### PR TITLE
Fix type annotation for self.dialect in _UniqueConstraintErrorHandler

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/common/exceptions.py
+++ b/airflow-core/src/airflow/api_fastapi/common/exceptions.py
@@ -63,7 +63,7 @@ class _UniqueConstraintErrorHandler(BaseErrorHandler[IntegrityError]):
 
     def __init__(self):
         super().__init__(IntegrityError)
-        self.dialect: _DatabaseDialect.value | None = None
+        self.dialect: _DatabaseDialect | None = None
 
     def exception_handler(self, request: Request, exc: IntegrityError):
         """Handle IntegrityError exception."""


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Fix type annotation for self.dialect in _UniqueConstraintErrorHandler

This PR fixes the type annotation for `self.dialect` in the `_UniqueConstraintErrorHandler` class.

Previously, the annotation was set to `_DatabaseDialect.value | None`, which is not valid Python typing syntax. The `.value` attribute refers to the underlying string of the Enum, not the Enum member itself, and cannot be used in type hints.

The annotation is now updated to `_DatabaseDialect | None`, which correctly indicates that `self.dialect` can hold either a `_DatabaseDialect` enum member or `None`. This change resolves static type checking errors and improves code clarity.

### Summary of changes

- Update type annotation for `self.dialect` from `_DatabaseDialect.value | None` to `_DatabaseDialect | None` in `_UniqueConstraintErrorHandler`.

### Why this is needed

- Ensures proper type checking and avoids confusion regarding the type of `self.dialect`.
- Follows Python typing best practices for Enum

closes:  [ #53717](https://github.com/apache/airflow/issues/53717)

---