### PR TITLE
Fix Outlet Event Extra Data is Empty in Task Instance Success Listener

### DIFF
--- a/scripts/ci/prek/check_template_context_variable_in_sync.py
+++ b/scripts/ci/prek/check_template_context_variable_in_sync.py
@@ -83,17 +83,25 @@ def _iter_template_context_keys_from_original_return() -> typing.Iterator[str]:
             yield key.value
 
     # Extract keys from the main `context` dictionary assignment
-    context_assignment = next(
+    context_assignment: ast.AnnAssign = next(
         stmt
         for stmt in fn_get_template_context.body
         if isinstance(stmt, ast.AnnAssign)
-        and isinstance(stmt.target, ast.Name)
-        and stmt.target.id == "context"
+        and isinstance(stmt.target, ast.Attribute)
+        and isinstance(stmt.target.value, ast.Name)
+        and stmt.target.value.id == "self"
+        and stmt.target.attr == "_context"
     )
 
-    if not isinstance(context_assignment.value, ast.Dict):
+    if not isinstance(context_assignment.value, ast.BoolOp):
+        raise TypeError("Expected a BoolOp like 'self._context or {...}'.")
+
+    context_assignment_op = context_assignment.value
+    _, context_assignment_value = context_assignment_op.values
+
+    if not isinstance(context_assignment_value, ast.Dict):
         raise ValueError("'context' is not assigned a dictionary literal")
-    yield from extract_keys_from_dict(context_assignment.value)
+    yield from extract_keys_from_dict(context_assignment_value)
 
     # Handle keys added conditionally in `if from_server`
     for stmt in fn_get_template_context.body:

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -129,6 +129,9 @@ class RuntimeTaskInstance(TaskInstance):
 
     task: BaseOperator
     bundle_instance: BaseDagBundle
+    _context: Context | None = None
+    """The Task Instance context."""
+
     _ti_context_from_server: Annotated[TIRunContext | None, Field(repr=False)] = None
     """The Task Instance context from the API server, if any."""
 
@@ -173,7 +176,9 @@ class RuntimeTaskInstance(TaskInstance):
 
         validated_params = process_params(self.task.dag, self.task, dag_run_conf, suppress_exception=False)
 
-        context: Context = {
+        # Cache the context object, which ensures that all calls to get_template_context
+        # are operating on the same context object.
+        self._context: Context = self._context or {
             # From the Task Execution interface
             "dag": self.task.dag,
             "inlets": self.task.inlets,
@@ -215,7 +220,7 @@ class RuntimeTaskInstance(TaskInstance):
                     lambda: coerce_datetime(get_previous_dagrun_success(self.id).end_date)
                 ),
             }
-            context.update(context_from_server)
+            self._context.update(context_from_server)
 
             if logical_date := coerce_datetime(dag_run.logical_date):
                 if TYPE_CHECKING:
@@ -226,7 +231,7 @@ class RuntimeTaskInstance(TaskInstance):
                 ts_nodash = logical_date.strftime("%Y%m%dT%H%M%S")
                 ts_nodash_with_tz = ts.replace("-", "").replace(":", "")
                 # logical_date and data_interval either coexist or be None together
-                context.update(
+                self._context.update(
                     {
                         # keys that depend on logical_date
                         "logical_date": logical_date,
@@ -253,7 +258,7 @@ class RuntimeTaskInstance(TaskInstance):
                 # existence. Should this be a private attribute on RuntimeTI instead perhaps?
                 setattr(self, "_upstream_map_indexes", from_server.upstream_map_indexes)
 
-        return context
+        return self._context
 
     def render_templates(
         self, context: Context | None = None, jinja_env: jinja2.Environment | None = None

--- a/task-sdk/tests/task_sdk/execution_time/test_context.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_context.py
@@ -154,26 +154,6 @@ class TestAirflowContextHelpers:
             "AIRFLOW_CTX_DAG_EMAIL": "email1@test.com",
         }
 
-    def test_get_template_context_return_same_context_object(self, create_runtime_ti):
-        task = BaseOperator(
-            task_id="test_context_vars",
-            owner=["owner1", "owner2"],
-            email="email1@test.com",
-        )
-
-        rti = create_runtime_ti(
-            task=task,
-            dag_id="dag_id",
-            run_id="dag_run_id",
-            logical_date="2017-05-21T00:00:00Z",
-            try_number=1,
-        )
-
-        c1 = rti.get_template_context()
-        c2 = rti.get_template_context()
-
-        assert c2 is c1
-
     def test_context_to_airflow_vars_from_policy(self):
         with mock.patch("airflow.settings.get_airflow_context_vars") as mock_method:
             airflow_cluster = "cluster-a"

--- a/task-sdk/tests/task_sdk/execution_time/test_context.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_context.py
@@ -154,6 +154,26 @@ class TestAirflowContextHelpers:
             "AIRFLOW_CTX_DAG_EMAIL": "email1@test.com",
         }
 
+    def test_get_template_context_return_same_context_object(self, create_runtime_ti):
+        task = BaseOperator(
+            task_id="test_context_vars",
+            owner=["owner1", "owner2"],
+            email="email1@test.com",
+        )
+
+        rti = create_runtime_ti(
+            task=task,
+            dag_id="dag_id",
+            run_id="dag_run_id",
+            logical_date="2017-05-21T00:00:00Z",
+            try_number=1,
+        )
+
+        c1 = rti.get_template_context()
+        c2 = rti.get_template_context()
+
+        assert c2 is c1
+
     def test_context_to_airflow_vars_from_policy(self):
         with mock.patch("airflow.settings.get_airflow_context_vars") as mock_method:
             airflow_cluster = "cluster-a"

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -64,7 +64,7 @@ from airflow.sdk.api.datamodels._generated import (
 )
 from airflow.sdk.bases.xcom import BaseXCom
 from airflow.sdk.definitions._internal.types import NOTSET, SET_DURING_EXECUTION, ArgNotSet
-from airflow.sdk.definitions.asset import Asset, AssetAlias, Dataset, Model
+from airflow.sdk.definitions.asset import Asset, AssetAlias, AssetUniqueKey, Dataset, Model
 from airflow.sdk.definitions.param import DagParam
 from airflow.sdk.exceptions import ErrorType
 from airflow.sdk.execution_time.comms import (
@@ -2502,6 +2502,32 @@ class TestTaskRunnerCallsListeners:
         def before_stopping(self, component):
             self.component = component
 
+    class CustomOutletEventsListener:
+        def __init__(self):
+            self.outlet_events = []
+            self.error = None
+
+        def _add_outlet_events(self, context):
+            outlets = context["outlets"]
+            for outlet in outlets:
+                self.outlet_events.append(context["outlet_events"][outlet])
+
+        @hookimpl
+        def on_task_instance_running(self, previous_state, task_instance):
+            context = task_instance.get_template_context()
+            self._add_outlet_events(context)
+
+        @hookimpl
+        def on_task_instance_success(self, previous_state, task_instance):
+            context = task_instance.get_template_context()
+            self._add_outlet_events(context)
+
+        @hookimpl
+        def on_task_instance_failed(self, previous_state, task_instance, error):
+            context = task_instance.get_template_context()
+            self._add_outlet_events(context)
+            self.error = error
+
     @pytest.fixture(autouse=True)
     def clean_listener_manager(self):
         lm = get_listener_manager()
@@ -2620,6 +2646,118 @@ class TestTaskRunnerCallsListeners:
         finalize(runtime_ti, state, context, log, error)
 
         assert listener.state == [TaskInstanceState.RUNNING, TaskInstanceState.FAILED]
+        assert listener.error == error
+
+    def test_listener_access_outlet_event_on_running_and_success(self, mocked_parse, mock_supervisor_comms):
+        """Test listener can access outlet events through invoking get_template_context() while task running and success"""
+        listener = self.CustomOutletEventsListener()
+        get_listener_manager().add_listener(listener)
+
+        test_asset = Asset("test-asset")
+        test_key = AssetUniqueKey(name="test-asset", uri="test-asset")
+        test_extra = {"name1": "value1", "nested_obj": {"name2": "value2"}}
+
+        class Producer(BaseOperator):
+            def execute(self, context):
+                outlet_events = context["outlet_events"]
+                outlet_events[test_asset].extra = {"name1": "value1", "nested_obj": {"name2": "value2"}}
+
+        task = Producer(
+            task_id="test_listener_access_outlet_event_on_running_and_success", outlets=[test_asset]
+        )
+        dag = get_inline_dag(dag_id="test_dag", task=task)
+        ti = TaskInstance(
+            id=uuid7(),
+            task_id=task.task_id,
+            dag_id=dag.dag_id,
+            run_id="test_run",
+            try_number=1,
+            dag_version_id=uuid7(),
+        )
+
+        runtime_ti = RuntimeTaskInstance.model_construct(
+            **ti.model_dump(exclude_unset=True), task=task, start_date=timezone.utcnow()
+        )
+
+        log = mock.MagicMock()
+        context = runtime_ti.get_template_context()
+
+        with mock.patch(
+            "airflow.sdk.execution_time.task_runner._validate_task_inlets_and_outlets"
+        ) as validate_mock:
+            state, _, _ = run(runtime_ti, context, log)
+
+        validate_mock.assert_called_once()
+
+        outlet_event_accessor = listener.outlet_events.pop()
+        assert outlet_event_accessor.key == test_key
+        assert outlet_event_accessor.extra == test_extra
+
+        finalize(runtime_ti, state, context, log)
+
+        outlet_event_accessor = listener.outlet_events.pop()
+        assert outlet_event_accessor.key == test_key
+        assert outlet_event_accessor.extra == test_extra
+
+    @pytest.mark.parametrize(
+        "exception",
+        [
+            ValueError("oops"),
+            SystemExit("oops"),
+            AirflowException("oops"),
+        ],
+        ids=["ValueError", "SystemExit", "AirflowException"],
+    )
+    def test_listener_access_outlet_event_on_failed(self, mocked_parse, mock_supervisor_comms, exception):
+        """Test listener can access outlet events through invoking get_template_context() while task failed"""
+        listener = self.CustomOutletEventsListener()
+        get_listener_manager().add_listener(listener)
+
+        test_asset = Asset("test-asset")
+        test_key = AssetUniqueKey(name="test-asset", uri="test-asset")
+        test_extra = {"name1": "value1", "nested_obj": {"name2": "value2"}}
+
+        class Producer(BaseOperator):
+            def execute(self, context):
+                outlet_events = context["outlet_events"]
+                outlet_events[test_asset].extra = {"name1": "value1", "nested_obj": {"name2": "value2"}}
+                raise exception
+
+        task = Producer(task_id="test_listener_access_outlet_event_on_failed", outlets=[test_asset])
+        dag = get_inline_dag(dag_id="test_dag", task=task)
+        ti = TaskInstance(
+            id=uuid7(),
+            task_id=task.task_id,
+            dag_id=dag.dag_id,
+            run_id="test_run",
+            try_number=1,
+            dag_version_id=uuid7(),
+        )
+
+        runtime_ti = RuntimeTaskInstance.model_construct(
+            **ti.model_dump(exclude_unset=True), task=task, start_date=timezone.utcnow()
+        )
+
+        log = mock.MagicMock()
+        context = runtime_ti.get_template_context()
+
+        with mock.patch(
+            "airflow.sdk.execution_time.task_runner._validate_task_inlets_and_outlets"
+        ) as validate_mock:
+            state, _, error = run(runtime_ti, context, log)
+
+        validate_mock.assert_called_once()
+
+        outlet_event_accessor = listener.outlet_events.pop()
+        assert outlet_event_accessor.key == test_key
+        assert outlet_event_accessor.extra == test_extra
+
+        finalize(runtime_ti, state, context, log, error)
+
+        outlet_event_accessor = listener.outlet_events.pop()
+        assert outlet_event_accessor.key == test_key
+        assert outlet_event_accessor.extra == test_extra
+
         assert listener.error == error
 
 

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -2660,7 +2660,7 @@ class TestTaskRunnerCallsListeners:
         class Producer(BaseOperator):
             def execute(self, context):
                 outlet_events = context["outlet_events"]
-                outlet_events[test_asset].extra = {"name1": "value1", "nested_obj": {"name2": "value2"}}
+                outlet_events[test_asset].extra = test_extra
 
         task = Producer(
             task_id="test_listener_access_outlet_event_on_running_and_success", outlets=[test_asset]
@@ -2720,7 +2720,7 @@ class TestTaskRunnerCallsListeners:
         class Producer(BaseOperator):
             def execute(self, context):
                 outlet_events = context["outlet_events"]
-                outlet_events[test_asset].extra = {"name1": "value1", "nested_obj": {"name2": "value2"}}
+                outlet_events[test_asset].extra = test_extra
                 raise exception
 
         task = Producer(task_id="test_listener_access_outlet_event_on_failed", outlets=[test_asset])


### PR DESCRIPTION
Close: #52574 

As discussed in #52574 , the outlet event extra data is empty because the task runner does not commit the asset changes to the database before calling the callbacks and the listeners. Also, every call to the `get_template_context` method create and return a new `Context` object, which might not persist the changes made during the task execution. Therefore, a method to fix this issue is to add a cache to the `get_template_context` method, ensuring all calls are operating on the same context object.

Since `RuntimeTaskInstance` is a unhashable type, `@functools.cache` doesn't work in this case. As an alternative, we probably can convert the `context` into a property, and the runtime task instance will operate on the property `context`. However, this implementation breaks the pre-commit hook `check-template-context-variable-in-sync`.

https://github.com/apache/airflow/blob/d4f4b22bbee25d58d56e2363bd68aaf4c9ac9093/scripts/ci/pre_commit/check_template_context_variable_in_sync.py#L81-L88

Any feedback regarding how to improve the current implementation for fixing the issue would be appreciated.

### manual functional testing
Before making the change, on log line 9, the bottom of the screenshot. The extra field is empty
<img width="961" height="781" alt="Screenshot from 2025-08-15 23-15-08" src="https://github.com/user-attachments/assets/feea5b57-4601-4268-ba7c-352a79e042af" />

After making the change, on log line 9, the bottom of the screenshot. The extra field contains the asset event extra.
<img width="961" height="781" alt="Screenshot from 2025-08-16 00-08-50" src="https://github.com/user-attachments/assets/e0ef56c3-4862-49ae-b121-ecc9dc953669" />


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
