### PR TITLE
Revert "Added support for Windows paths in SambaHook"

### DIFF
--- a/providers/samba/docs/connections.rst
+++ b/providers/samba/docs/connections.rst
@@ -42,6 +42,3 @@ Login
 
 Password
     The password of the user that will be used for authentication against the Samba server.
-
-Share Type
-    The share OS type (``posix`` or ``windows``). Used to determine the formatting of file and folder paths.

--- a/providers/samba/tests/unit/samba/hooks/test_samba.py
+++ b/providers/samba/tests/unit/samba/hooks/test_samba.py
@@ -148,38 +148,14 @@ class TestSambaHook:
             assert dict(kwargs, **connection_settings) == p_kwargs
 
     @pytest.mark.parametrize(
-        "path, path_type, full_path",
+        "path, full_path",
         [
-            # Linux path -> Linux path, no path_type (default)
-            ("/start/path/with/slash", None, "//ip/share/start/path/with/slash"),
-            ("start/path/without/slash", None, "//ip/share/start/path/without/slash"),
-            # Linux path -> Linux path, explicit path_type (posix)
-            ("/start/path/with/slash/posix", "posix", "//ip/share/start/path/with/slash/posix"),
-            ("start/path/without/slash/posix", "posix", "//ip/share/start/path/without/slash/posix"),
-            # Linux path -> Windows path, explicit path_type (windows)
-            ("/start/path/with/slash/windows", "windows", r"\\ip\share\start\path\with\slash\windows"),
-            ("start/path/without/slash/windows", "windows", r"\\ip\share\start\path\without\slash\windows"),
-            # Windows path -> Windows path, explicit path_type (windows)
-            (
-                r"\start\path\with\backslash\windows",
-                "windows",
-                r"\\ip\share\start\path\with\backslash\windows",
-            ),
-            (
-                r"start\path\without\backslash\windows",
-                "windows",
-                r"\\ip\share\start\path\without\backslash\windows",
-            ),
+            ("/start/path/with/slash", "//ip/share/start/path/with/slash"),
+            ("start/path/without/slash", "//ip/share/start/path/without/slash"),
         ],
     )
     @mock.patch(f"{BASEHOOK_PATCH_PATH}.get_connection")
-    def test__join_path(
-        self,
-        get_conn_mock,
-        path,
-        path_type,
-        full_path,
-    ):
+    def test__join_path(self, get_conn_mock, path, full_path):
         CONNECTION = Connection(
             host="ip",
             schema="share",
@@ -188,7 +164,7 @@ class TestSambaHook:
         )
 
         get_conn_mock.return_value = CONNECTION
-        hook = SambaHook("samba_default", share_type=path_type)
+        hook = SambaHook("samba_default")
         assert hook._join_path(path) == full_path
 
     @mock.patch("airflow.providers.samba.hooks.samba.smbclient.open_file", return_value=mock.Mock())


### PR DESCRIPTION
Reverts apache/airflow#54459

failing on CI https://github.com/apache/airflow/actions/runs/17003892508/job/48210865456

I think it needs proper handling for python 3.12 onwards :)