### PR TITLE
Mock AWS during Athena tests

### DIFF
--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_athena.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_athena.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from unittest import mock
 
 import pytest
+from moto import mock_aws
 
 from airflow.providers.amazon.aws.hooks.athena import (
     MULTI_LINE_QUERY_LOG_PREFIX,
@@ -58,8 +59,9 @@ MOCK_QUERY_EXECUTION_OUTPUT = {
 }
 
 
+@mock_aws
 class TestAthenaHook:
-    def setup_method(self):
+    def setup_method(self, _):
         self.athena = AthenaHook()
 
     def test_init(self):

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_athena.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_athena.py
@@ -43,6 +43,8 @@ try:
     from airflow.sdk import timezone
 except ImportError:
     from airflow.utils import timezone  # type: ignore[attr-defined,no-redef]
+from moto import mock_aws
+
 from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunType
 
@@ -67,6 +69,7 @@ query_context = {"Database": MOCK_DATA["database"], "Catalog": MOCK_DATA["catalo
 result_configuration = {"OutputLocation": MOCK_DATA["outputLocation"]}
 
 
+@mock_aws
 class TestAthenaOperator:
     @pytest.fixture(autouse=True)
     def _setup_test_cases(self):

--- a/providers/amazon/tests/unit/amazon/aws/sensors/test_athena.py
+++ b/providers/amazon/tests/unit/amazon/aws/sensors/test_athena.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from unittest import mock
 
 import pytest
+from moto import mock_aws
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.athena import AthenaHook
@@ -32,8 +33,9 @@ def mock_poll_query_status():
         yield m
 
 
+@mock_aws
 class TestAthenaSensor:
-    def setup_method(self):
+    def setup_method(self, _):
         self.default_op_kwargs = dict(
             task_id="test_athena_sensor",
             query_execution_id="abc",


### PR DESCRIPTION
The Athena tests were actually connecting to AWS during the run, but it should not be necessary at all. We are mocking AWS tests so that the calls to AWS apis are handled locally with moto.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
