### PR TITLE
Make opsgenie tests db independent

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -639,6 +639,7 @@ repos:
             ^providers/odbc/.*\.py$|
             ^providers/openai/.*\.py$|
             ^providers/openfaas/.*\.py$|
+            ^providers/opsgenie/.*\.py$|
             ^providers/oracle/.*\.py$|
             ^providers/pagerduty/.*\.py$|
             ^providers/pgvector/.*\.py$|

--- a/devel-common/src/tests_common/pytest_plugin.py
+++ b/devel-common/src/tests_common/pytest_plugin.py
@@ -2583,3 +2583,13 @@ def _import_timezone():
         except ModuleNotFoundError:
             from airflow.utils import timezone
     return timezone
+
+
+@pytest.fixture
+def create_dag_without_db():
+    def create_dag(dag_id: str):
+        from airflow.models.dag import DAG
+
+        return DAG(dag_id=dag_id, schedule=None, render_template_as_native_obj=True)
+
+    return create_dag

--- a/providers/opsgenie/tests/unit/opsgenie/hooks/test_opsgenie.py
+++ b/providers/opsgenie/tests/unit/opsgenie/hooks/test_opsgenie.py
@@ -106,7 +106,8 @@ class TestOpsgenieAlertHook:
             == "eb243592-faa2-4ba2-a551q-1afdf565c889"
         )
 
-    def test_create_alert_api_key_not_set(self, create_connection_without_db):
+    @mock.patch.object(AlertApi, "create_alert")
+    def test_create_alert_api_key_not_set(self, mock_create_alert, create_connection_without_db):
         create_connection_without_db(
             Connection(
                 conn_id="opsgenie_without_api_key",
@@ -114,6 +115,7 @@ class TestOpsgenieAlertHook:
                 host="https://api.opsgenie.com/",
             )
         )
+        mock_create_alert.side_effect = AuthenticationException
         hook = OpsgenieAlertHook(opsgenie_conn_id="opsgenie_without_api_key")
         with pytest.raises(AuthenticationException):
             hook.create_alert(payload=self._create_alert_payload)


### PR DESCRIPTION
This is free from db usage.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
