### PR TITLE
Remove db dependency for apprise notifier tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -614,6 +614,7 @@ repos:
             ^providers/apache/flink/.*\.py$|
             ^providers/apache/iceberg/.*\.py$|
             ^providers/apache/kafka/.*\.py$|
+            ^providers/apprise/.*\.py$|
             ^providers/arangodb/.*\.py$|
             ^providers/asana/.*\.py$|
             ^providers/cloudant/.*\.py$|

--- a/providers/apprise/tests/unit/apprise/notifications/test_apprise.py
+++ b/providers/apprise/tests/unit/apprise/notifications/test_apprise.py
@@ -22,69 +22,79 @@ from unittest import mock
 import pytest
 from apprise import NotifyFormat, NotifyType
 
+from airflow.models import Connection
 from airflow.providers.apprise.notifications.apprise import (
     AppriseNotifier,
     send_apprise_notification,
 )
-from airflow.providers.standard.operators.empty import EmptyOperator
-
-pytestmark = pytest.mark.db_test
 
 
 class TestAppriseNotifier:
+    @pytest.fixture(autouse=True)
+    def setup_connections(self, create_connection_without_db):
+        extra = {"config": {"path": "http://some_path_that_dont_exist/", "tag": "alert"}}
+        create_connection_without_db(
+            Connection(
+                conn_id="apprise_default",
+                conn_type="apprise",
+                extra=extra,
+            )
+        )
+
     @mock.patch("airflow.providers.apprise.notifications.apprise.AppriseHook")
-    def test_notifier(self, mock_apprise_hook, dag_maker):
-        with dag_maker("test_notifier") as dag:
-            EmptyOperator(task_id="task1")
+    def test_notifier(self, mock_apprise_hook, create_dag_without_db):
         notifier = send_apprise_notification(body="DISK at 99%", notify_type=NotifyType.FAILURE)
-        notifier({"dag": dag})
-        mock_apprise_hook.return_value.notify.assert_called_once_with(
-            body="DISK at 99%",
-            notify_type=NotifyType.FAILURE,
-            title=None,
-            body_format=NotifyFormat.TEXT,
-            tag="all",
-            attach=None,
-            interpret_escapes=None,
-            config=None,
-        )
+        notifier({"dag": create_dag_without_db("test_notifier")})
+        call_args = mock_apprise_hook.return_value.notify.call_args.kwargs
+
+        assert call_args == {
+            "body": "DISK at 99%",
+            "notify_type": NotifyType.FAILURE,
+            "title": None,
+            "body_format": NotifyFormat.TEXT,
+            "tag": "all",
+            "attach": None,
+            "interpret_escapes": None,
+            "config": None,
+        }
+        mock_apprise_hook.return_value.notify.assert_called_once()
 
     @mock.patch("airflow.providers.apprise.notifications.apprise.AppriseHook")
-    def test_notifier_with_notifier_class(self, mock_apprise_hook, dag_maker):
-        with dag_maker("test_notifier") as dag:
-            EmptyOperator(task_id="task1")
+    def test_notifier_with_notifier_class(self, mock_apprise_hook, create_dag_without_db):
         notifier = AppriseNotifier(body="DISK at 99%", notify_type=NotifyType.FAILURE)
-        notifier({"dag": dag})
-        mock_apprise_hook.return_value.notify.assert_called_once_with(
-            body="DISK at 99%",
-            notify_type=NotifyType.FAILURE,
-            title=None,
-            body_format=NotifyFormat.TEXT,
-            tag="all",
-            attach=None,
-            interpret_escapes=None,
-            config=None,
-        )
+        notifier({"dag": create_dag_without_db("test_notifier")})
+        call_args = mock_apprise_hook.return_value.notify.call_args.kwargs
+
+        assert call_args == {
+            "body": "DISK at 99%",
+            "notify_type": NotifyType.FAILURE,
+            "title": None,
+            "body_format": NotifyFormat.TEXT,
+            "tag": "all",
+            "attach": None,
+            "interpret_escapes": None,
+            "config": None,
+        }
+        mock_apprise_hook.return_value.notify.assert_called_once()
 
     @mock.patch("airflow.providers.apprise.notifications.apprise.AppriseHook")
-    def test_notifier_templated(self, mock_apprise_hook, dag_maker):
-        with dag_maker("test_notifier") as dag:
-            EmptyOperator(task_id="task1")
-
+    def test_notifier_templated(self, mock_apprise_hook, create_dag_without_db):
         notifier = AppriseNotifier(
             notify_type=NotifyType.FAILURE,
             title="DISK at 99% {{dag.dag_id}}",
             body="System can crash soon {{dag.dag_id}}",
         )
-        context = {"dag": dag}
+        context = {"dag": create_dag_without_db("test_notifier")}
         notifier(context)
-        mock_apprise_hook.return_value.notify.assert_called_once_with(
-            notify_type=NotifyType.FAILURE,
-            title="DISK at 99% test_notifier",
-            body="System can crash soon test_notifier",
-            body_format=NotifyFormat.TEXT,
-            tag="all",
-            attach=None,
-            interpret_escapes=None,
-            config=None,
-        )
+        call_args = mock_apprise_hook.return_value.notify.call_args.kwargs
+        assert call_args == {
+            "body": "System can crash soon test_notifier",
+            "title": "DISK at 99% test_notifier",
+            "notify_type": NotifyType.FAILURE,
+            "body_format": NotifyFormat.TEXT,
+            "tag": "all",
+            "attach": None,
+            "interpret_escapes": None,
+            "config": None,
+        }
+        mock_apprise_hook.return_value.notify.assert_called_once()


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
