### PR TITLE
Fix: fix indentation errors when rendering multi-line property value

### DIFF
--- a/airflow-core/src/airflow/cli/commands/task_command.py
+++ b/airflow-core/src/airflow/cli/commands/task_command.py
@@ -440,9 +440,9 @@ def task_render(args, dag: DAG | None = None) -> None:
                 f"""        # ----------------------------------------------------------
         # property: {attr}
         # ----------------------------------------------------------
-        {getattr(ti.task, attr)}
         """
             )
+            + str(getattr(ti.task, attr))
         )
 
 

--- a/airflow-core/tests/unit/cli/commands/test_task_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_task_command.py
@@ -414,6 +414,19 @@ class TestCliTasks:
                 )
             )
 
+    def test_task_render_for_multi_line_properties(self, dag_maker):
+        """
+        tasks render should render and displays templated fields for a given task
+        """
+        with redirect_stdout(io.StringIO()) as stdout:
+            task_command.task_render(
+                self.parser.parse_args(["tasks", "render", "tutorial", "templated", "2016-01-01"])
+            )
+
+        output = stdout.getvalue()
+        # no indentation before property name
+        assert "# property: bash_command" in output.split("\n")
+
 
 def _set_state_and_try_num(ti, session):
     ti.state = TaskInstanceState.QUEUED


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #54581

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
## Overview
`textwrap.dedent`  is used to handle indentation for command `airflow task render`. It will not works for multi line value and there are will be a error indentation just like the red box in image:
<img width="1056" height="394" alt="error_indent" src="https://github.com/user-attachments/assets/b892df63-2493-4ba6-bcc9-17838a29c95c" />
related: #54581
## Root Cause
`textwrap.dedent` can only handle **common leading whitespace** and mulit line vaule will break this constraint.  Below code use f-string to concat property name with property vaule then try to dedent it. 
https://github.com/apache/airflow/blob/6b22dedc4721d8b1f8f6e8a271c64a18724ddd77/airflow-core/src/airflow/cli/commands/task_command.py#L438-L444

Given the property name and property vaule:
property name 
```
    # ----------------------------------------------------------
    # property: xxx
    # ----------------------------------------------------------
```
property vaule
```
this is the first line
this is the second line
```
The result of f-string just like below and `textwrap.dedent`  can not handle
```
    # ----------------------------------------------------------
    # property: xxx
    # ----------------------------------------------------------
    this is the first line
this is the second
```
## Solution
Only use `textwrap.dedent` to handle property name:
```python
        print(
            textwrap.dedent(
                f"""        # ----------------------------------------------------------
        # property: {attr}
        # ----------------------------------------------------------
        """
            )
            + str(getattr(ti.task, attr))
        )
```
## Result
before
<img width="1056" height="394" alt="error_indent" src="https://github.com/user-attachments/assets/b892df63-2493-4ba6-bcc9-17838a29c95c" />
after
<img width="1831" height="768" alt="image" src="https://github.com/user-attachments/assets/c495b17e-7e60-4e3f-9d84-6510cf33c34d" />


**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
