### PR TITLE
Fix prek teething errors for canary builds

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -257,12 +257,14 @@ jobs:
         with:
           python-version: ${{steps.breeze.outputs.host-python-version}}
           skip-prek-hooks: ${{ inputs.skip-prek-hooks }}
-      - name: "Autoupdate all prek hooks"
-        run: prek autoupdate --freeze
-      - name: "Autoupdate Lucas-C hooks to bleeding edge"
-        run: prek autoupdate --bleeding-edge --freeze --repo https://github.com/Lucas-C/pre-commit-hooks
-      - name: "Check if there are any changes in pre-commit hooks"
-        run: git diff --exit-code
+      # TODO(potiuk): enable this once prek supports automatic upgrade of hooks
+      #               after https://github.com/j178/prek/issues/35 is implemented§
+      # - name: "Autoupdate all prek hooks"
+      #   run: prek autoupdate --freeze
+      # - name: "Autoupdate Lucas-C hooks to bleeding edge"
+      #   run: prek autoupdate --bleeding-edge --freeze --repo https://github.com/Lucas-C/pre-commit-hooks
+      # - name: "Check if there are any changes in pre-commit hooks"
+      #   run: git diff --exit-code
       - name: "Run automated upgrade for black"
         run: >
           prek

--- a/.github/workflows/ci-image-checks.yml
+++ b/.github/workflows/ci-image-checks.yml
@@ -151,7 +151,7 @@ jobs:
         if: inputs.canary-run == 'true'
       - name: "Prepare .tar file from prek cache"
         run: |
-          tar -C ~ -czf /tmp/cache-prek.tar.gz .cache/prek .cache/uv
+          tar -C ~ -czf /tmp/cache-prek.tar.gz .cache/prek
         shell: bash
         if: inputs.canary-run == 'true'
       - name: "Save prek cache"


### PR DESCRIPTION
After switching to prek in #54258 there are still few small things thet were only discovered in our canary builds:

* installation of prek hooks does not necessarily create uv cache
* autoupgrade is not yet implemented in prek

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
