### PR TITLE
Fix timezone conversion in datetime trigger parameters

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/DateTimeInput.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DateTimeInput.tsx
@@ -17,42 +17,26 @@
  * under the License.
  */
 import { Input, type InputProps } from "@chakra-ui/react";
-import dayjs from "dayjs";
-import tz from "dayjs/plugin/timezone";
 import { forwardRef } from "react";
-
-import { useTimezone } from "src/context/timezone";
-
-dayjs.extend(tz);
 
 type Props = {
   readonly value: string;
 } & InputProps;
 
-export const DateTimeInput = forwardRef<HTMLInputElement, Props>(({ onChange, value, ...rest }, ref) => {
-  const { selectedTimezone } = useTimezone();
-
-  // Make the value timezone-aware
-  const date = dayjs(value).tz(selectedTimezone).format("YYYY-MM-DDTHH:mm:ss.SSS");
-
-  return (
-    <Input
-      onChange={(event) =>
-        onChange?.({
-          ...event,
-          target: {
-            ...event.target,
-            // Return a timezone-aware ISO string
-            value: dayjs(event.target.value).isValid()
-              ? dayjs(event.target.value).tz(selectedTimezone, true).toISOString()
-              : "",
-          },
-        })
-      }
-      ref={ref}
-      type="datetime-local"
-      value={date}
-      {...rest}
-    />
-  );
-});
+export const DateTimeInput = forwardRef<HTMLInputElement, Props>(({ onChange, value, ...rest }, ref) => (
+  <Input
+    onChange={(event) =>
+      onChange?.({
+        ...event,
+        target: {
+          ...event.target,
+          value: event.target.value,
+        },
+      })
+    }
+    ref={ref}
+    type="datetime-local"
+    value={value}
+    {...rest}
+  />
+));

--- a/airflow-core/src/airflow/ui/src/components/DateTimeInput.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DateTimeInput.tsx
@@ -35,7 +35,7 @@ export const DateTimeInput = forwardRef<HTMLInputElement, Props>(({ onChange, va
   // Convert UTC value to local time for display
   const displayValue =
     Boolean(value) && dayjs(value).isValid()
-      ? dayjs(value).tz(selectedTimezone).format("YYYY-MM-DDTHH:mm")
+      ? dayjs(value).tz(selectedTimezone).format("YYYY-MM-DDTHH:mm:ss.SSS")
       : "";
 
   return (

--- a/airflow-core/src/airflow/ui/src/components/DateTimeInput.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DateTimeInput.tsx
@@ -32,7 +32,7 @@ type Props = {
 export const DateTimeInput = forwardRef<HTMLInputElement, Props>(({ onChange, value, ...rest }, ref) => {
   const { selectedTimezone } = useTimezone();
 
-  // Convert stored UTC value to local timezone for display
+  // Convert UTC value to local time for display
   const displayValue =
     Boolean(value) && dayjs(value).isValid()
       ? dayjs(value).tz(selectedTimezone).format("YYYY-MM-DDTHH:mm")
@@ -45,7 +45,6 @@ export const DateTimeInput = forwardRef<HTMLInputElement, Props>(({ onChange, va
           ...event,
           target: {
             ...event.target,
-            // Convert local time input to UTC for storage/API
             value: dayjs(event.target.value).isValid()
               ? dayjs(event.target.value).tz(selectedTimezone, true).toISOString()
               : "",

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDateTime.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDateTime.tsx
@@ -63,7 +63,7 @@ export const FieldDateTime = ({
         onChange={(event) => handleChange(event.target.value)}
         size="sm"
         value={
-          Boolean(param.value) && typeof param.value === "string"
+          typeof param.value === "string" && dayjs(param.value).isValid()
             ? dayjs(param.value).tz(selectedTimezone).format("YYYY-MM-DDTHH:mm")
             : ""
         }

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDateTime.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDateTime.tsx
@@ -33,8 +33,7 @@ export const FieldDateTime = ({
   const param = paramsDict[name] ?? paramPlaceholder;
   const handleChange = (value: string) => {
     if (paramsDict[name]) {
-      // DateTimeInput already returns UTC ISO string for datetime-local
-      paramsDict[name].value = value === "" ? null : value;
+      paramsDict[name].value = value === "" ? undefined : value;
     }
 
     setParamsDict(paramsDict);

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDateTime.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDateTime.tsx
@@ -32,8 +32,10 @@ export const FieldDateTime = ({
   const { disabled, paramsDict, setParamsDict } = useParamStore(namespace);
   const param = paramsDict[name] ?? paramPlaceholder;
   const handleChange = (value: string) => {
+    // "undefined" values are removed from params, so we set it to null to avoid falling back to DAG defaults.
     if (paramsDict[name]) {
-      paramsDict[name].value = value === "" ? undefined : value;
+      // eslint-disable-next-line unicorn/no-null
+      paramsDict[name].value = value === "" ? null : value;
     }
 
     setParamsDict(paramsDict);

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDateTime.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDateTime.tsx
@@ -17,16 +17,11 @@
  * under the License.
  */
 import { Input, type InputProps } from "@chakra-ui/react";
-import dayjs from "dayjs";
-import tz from "dayjs/plugin/timezone";
 
-import { useTimezone } from "src/context/timezone";
 import { paramPlaceholder, useParamStore } from "src/queries/useParamStore";
 
 import type { FlexibleFormElementProps } from ".";
 import { DateTimeInput } from "../DateTimeInput";
-
-dayjs.extend(tz);
 
 export const FieldDateTime = ({
   name,
@@ -35,19 +30,11 @@ export const FieldDateTime = ({
   ...rest
 }: FlexibleFormElementProps & InputProps) => {
   const { disabled, paramsDict, setParamsDict } = useParamStore(namespace);
-  const { selectedTimezone } = useTimezone();
   const param = paramsDict[name] ?? paramPlaceholder;
   const handleChange = (value: string) => {
     if (paramsDict[name]) {
-      if (rest.type === "datetime-local") {
-        // "undefined" values are removed from params, so we set it to null to avoid falling back to DAG defaults.
-        // eslint-disable-next-line unicorn/no-null
-        paramsDict[name].value = value === "" ? null : dayjs(value).tz(selectedTimezone).toISOString();
-      } else {
-        // "undefined" values are removed from params, so we set it to null to avoid falling back to DAG defaults.
-        // eslint-disable-next-line unicorn/no-null
-        paramsDict[name].value = value === "" ? null : value;
-      }
+      // DateTimeInput already returns UTC ISO string for datetime-local
+      paramsDict[name].value = value === "" ? null : value;
     }
 
     setParamsDict(paramsDict);
@@ -62,11 +49,7 @@ export const FieldDateTime = ({
         name={`element_${name}`}
         onChange={(event) => handleChange(event.target.value)}
         size="sm"
-        value={
-          typeof param.value === "string" && dayjs(param.value).isValid()
-            ? dayjs(param.value).tz(selectedTimezone).format("YYYY-MM-DDTHH:mm")
-            : ""
-        }
+        value={(param.value as string) || ""}
       />
     );
   }


### PR DESCRIPTION
## Summary

Fixes a bug where datetime parameter inputs in the Airflow UI were applying timezone conversion twice, causing incorrect scheduling times. When users selected a local time via the datetime picker, the actual trigger time would be offset by double the timezone difference.

## Problem
1. User picks "5:25 PM" local time (Pacific UTC-7)
2. DateTimeInput converts to UTC: "2025-08-17T00:25:00.000Z"
3. FieldDateTime adds fake UTC suffix: "2025-08-17T00:25:00.000Z:00+00:00"
4. This malformed string gets parsed incorrectly
5. Results in wrong final datetime (appeared like double conversion)
 
## Solution
`DateTimeInput` handles all conversions, other components pass UTC values unchanged

1. `DateTimeInput`: Maintains proper timezone conversion (local display -> UTC)
2. `FieldDateTime`: Removed faulty conditional that was adding fake UTC suffixes to already-converted values

## Testing
  - Manual testing with Pacific (UTC-7) timezone and verified DAG triggers execute at correct times
  - Confirmed no double conversion in browser console logs
  
## Related Issues
resolves #54466
