### PR TITLE
Fix task_queued_timeout not working after first DAG run

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2055,6 +2055,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             .values(
                 state=TaskInstanceState.SCHEDULED,
                 queued_dttm=None,
+                queued_by_job_id=None,
                 scheduled_dttm=timezone.utcnow(),
             )
             .execution_options(synchronize_session=False)


### PR DESCRIPTION
Tasks queued longer than task_queued_timeout were not being terminated by the Airflow scheduler, leading to accumulation of stale queued tasks over several days.

<img width="1689" height="730" alt="task_queue_timeout_bad" src="https://github.com/user-attachments/assets/6e9ea5f2-339b-4d72-9caa-880689ac7344" />

Root Cause:
The queued_by_job_id field was not being reset to None, which prevented the scheduler from recognizing that the task was eligible for termination due to timeout.

Fix:
Reset queued_by_job_id when rescheduling stuck tasks to ensure timeout monitoring works correctly across multiple DAG runs.

<img width="1913" height="937" alt="task_queue_timeout_fixed" src="https://github.com/user-attachments/assets/0c8d928b-9563-45e6-b861-e69f11c66199" />



