### PR TITLE
[v3-0-test] Optimize task instance API queries by removing redundant …

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
@@ -94,7 +94,6 @@ def get_task_instance(
     query = (
         select(TI)
         .where(TI.dag_id == dag_id, TI.run_id == dag_run_id, TI.task_id == task_id)
-        .join(TI.dag_run)
         .options(joinedload(TI.rendered_task_instance_fields))
         .options(joinedload(TI.dag_version))
     )
@@ -356,7 +355,6 @@ def get_mapped_task_instance(
     query = (
         select(TI)
         .where(TI.dag_id == dag_id, TI.run_id == dag_run_id, TI.task_id == task_id, TI.map_index == map_index)
-        .join(TI.dag_run)
         .options(joinedload(TI.rendered_task_instance_fields))
         .options(joinedload(TI.dag_version))
     )
@@ -532,7 +530,7 @@ def get_task_instances_batch(
         TI,
     ).set_value(body.order_by)
 
-    query = select(TI).join(TI.dag_run)
+    query = select(TI)
     task_instance_select, total_entries = paginated_select(
         statement=query,
         filters=[

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
@@ -320,7 +320,7 @@ class TestXComsGetEndpoint:
         )
         assert response.status_code == 200
 
-        assert response.json() == expected_xcoms
+        assert set(response.json()) == set(expected_xcoms)
 
 
 class TestXComsSetEndpoint:


### PR DESCRIPTION
…JOINs (#54363)

* Optimize task instance API queries by removing redundant JOINs

Remove duplicate `.join(TI.dag_run)` calls in task instance API endpoints that were redundant with `joinedload(TI.dag_run)` options, resulting in cleaner SQL execution.

- GET `/dagRuns/{dag_run_id}/taskInstances/{task_id}`
- GET `/dagRuns/{dag_run_id}/taskInstances/{task_id}/{map_index}`
- POST `/dagRuns/~/taskInstances/list`

❌ Before (Redundant):
```python
query = (
    select(TI)
    .join(TI.dag_run)                               # Explicit JOIN
    .options(joinedload(TI.dag_run))               # Creates ANOTHER JOIN!
)
```

✅ After:
```python
query = (
    select(TI)
    .options(joinedload(TI.dag_run))               # Single efficient JOIN
)
```

**Before (with redundant JOINs):**
```sql
FROM task_instance
JOIN dag_run ON dag_run.dag_id = task_instance.dag_id AND dag_run.run_id = task_instance.run_id
JOIN dag_run AS dag_run_1 ON dag_run_1.dag_id = task_instance.dag_id AND dag_run_1.run_id = task_instance.run_id
LEFT OUTER JOIN dag AS dag_1 ON dag_run_1.dag_id = dag_1.dag_id
```

**After:**
```sql
FROM task_instance
JOIN dag_run AS dag_run_1 ON dag_run_1.dag_id = task_instance.dag_id AND dag_run_1.run_id = task_instance.run_id
LEFT OUTER JOIN dag AS dag_1 ON dag_run_1.dag_id = dag_1.dag_id
```

Tested using SQLAlchemy query compilation with PostgreSQL to confirm:
- 2 → 1 dag_run JOINs per endpoint
- Maintained all required relationship loading
- No import or syntax errors introduced

* Make test_xcom_get_slice_accepts_include_prior_dates test more resilient (cherry picked from commit e796bc23ad373d161bd52ec01f006c1c2cbdf0af)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
