### PR TITLE
fix: Add more security options for the JWT token cookie

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/routes/login.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/routes/login.py
@@ -95,6 +95,7 @@ def login_all_admins(request: Request) -> RedirectResponse:
         SimpleAuthManagerLogin.create_token_all_admins(),
         secure=secure,
         http_only=True,
+        expires=300,  # 5 minutes should be more than enough for JWT token exchange
     )
     return response
 

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/routes/login.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/routes/login.py
@@ -94,6 +94,7 @@ def login_all_admins(request: Request) -> RedirectResponse:
         COOKIE_NAME_JWT_TOKEN,
         SimpleAuthManagerLogin.create_token_all_admins(),
         secure=secure,
+        http_only=True,
     )
     return response
 


### PR DESCRIPTION
The JWT token cookie `_token` is short-lived and only for token exchange with the UI, according to the doc: https://github.com/apache/airflow/blob/2997d8b6dadc56053bb0e9a6ff4fb673caadaa24/airflow-core/docs/core-concepts/auth-manager/index.rst?plain=1#L151

The secure flag is already set based on the configuration `[api] base_url`. It will be more secure with HttpOnly and an expiration set.

This PR adds two things to this the `_token` cookie:

1. Set `HttpOnly = true`
2. Set an expiration of 5 minutes, which should be sufficient for the token exchange with the UI.

