### PR TITLE
Manual Backport 54462: Filter out empty logs in useLogs

### DIFF
--- a/airflow-core/src/airflow/ui/src/queries/useLogs.tsx
+++ b/airflow-core/src/airflow/ui/src/queries/useLogs.tsx
@@ -57,17 +57,19 @@ const parseLogs = ({ data, logLevelFilters, sourceFilters, taskInstance, tryNumb
   const logLink = taskInstance ? `${getTaskInstanceLink(taskInstance)}?try_number=${tryNumber}` : "";
 
   try {
-    parsedLines = data.map((datum, index) => {
-      if (typeof datum !== "string" && "logger" in datum) {
-        const source = datum.logger as string;
+    parsedLines = data
+      .map((datum, index) => {
+        if (typeof datum !== "string" && "logger" in datum) {
+          const source = datum.logger as string;
 
-        if (!sources.includes(source)) {
-          sources.push(source);
+          if (!sources.includes(source)) {
+            sources.push(source);
+          }
         }
-      }
 
-      return renderStructuredLog({ index, logLevelFilters, logLink, logMessage: datum, sourceFilters });
-    });
+        return renderStructuredLog({ index, logLevelFilters, logLink, logMessage: datum, sourceFilters });
+      })
+      .filter((parsedLine) => parsedLine !== "");
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : "An error occurred.";
 


### PR DESCRIPTION
Manual backport for #54462: Filter out empty logs in useLogs


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
