### PR TITLE
Fix lock map_index_template when running mapped task

### DIFF
--- a/airflow-core/src/airflow/models/mappedoperator.py
+++ b/airflow-core/src/airflow/models/mappedoperator.py
@@ -173,6 +173,10 @@ class MappedOperator(DAGNode):
         return self.partial_kwargs.get("doc_md")
 
     @property
+    def map_index_template(self) -> str | None:
+        return self.partial_kwargs.get("map_index_template")
+
+    @property
     def inherits_from_empty_operator(self) -> bool:
         """Implementing an empty Operator."""
         return self._is_empty


### PR DESCRIPTION


  Fixes a bug where the scheduler would crash when trying to expand a mapped task. The MappedOperator object in the scheduler was missing the map_index_template attribute, leading to an
  AttributeError.

 # Problem

   - When the scheduler prepares a mapped task for execution, it builds a template context for the task instance.
   - This process involves accessing the map_index_template attribute on the task object.
   - The MappedOperator object used by the scheduler was missing this attribute, causing the scheduler to fail with an AttributeError: 'MappedOperator' object has no attribute 'map_index_template'.

 # Solution

   - Add the map_index_template property to the MappedOperator class located in airflow-core/src/airflow/models/mappedoperator.py.
   - This property now correctly retrieves the value from the operator's partial_kwargs, ensuring the attribute is available to the scheduler at runtime.

 # Testing

   - The fix was validated by ensuring the scheduler no longer crashes when running DAGs with mapped tasks in the local environment
   - Manual inspection confirms the map_index_template attribute is now correctly accessed.
<img width="1446" height="660" alt="image" src="https://github.com/user-attachments/assets/9644e9fc-818e-4506-a008-d885084c083a" />


reproduce :
<img width="1205" height="679" alt="image" src="https://github.com/user-attachments/assets/5b098af0-10f5-4375-a26b-853c942d34c0" />


  Related Issues

  Closes #54627



<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
