### PR TITLE
fix: Set triggered_by='ui' for DAG runs triggered from UI

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -21,7 +21,7 @@ import textwrap
 from typing import Annotated, Literal, cast
 
 import structlog
-from fastapi import Depends, HTTPException, Query, status
+from fastapi import Depends, HTTPException, Query, Request, status
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import StreamingResponse
 from pydantic import ValidationError
@@ -407,6 +407,7 @@ def trigger_dag_run(
     dag_bag: DagBagDep,
     user: GetUserDep,
     session: SessionDep,
+    request: Request,
 ) -> DAGRunResponse:
     """Trigger a DAG."""
     dm = session.scalar(select(DagModel).where(~DagModel.is_stale, DagModel.dag_id == dag_id).limit(1))
@@ -419,6 +420,12 @@ def trigger_dag_run(
             f"DAG with dag_id: '{dag_id}' has import errors and cannot be triggered",
         )
 
+    referer = request.headers.get("referer")
+    if referer:
+        triggered_by = DagRunTriggeredByType.UI
+    else:
+        triggered_by = DagRunTriggeredByType.REST_API
+
     try:
         dag = get_latest_version_of_dag(dag_bag, dag_id, session)
         params = body.validate_context(dag)
@@ -430,7 +437,7 @@ def trigger_dag_run(
             run_after=params["run_after"],
             conf=params["conf"],
             run_type=DagRunType.MANUAL,
-            triggered_by=DagRunTriggeredByType.REST_API,
+            triggered_by=triggered_by,
             triggering_user_name=user.get_name(),
             state=DagRunState.QUEUED,
             session=session,


### PR DESCRIPTION
This closes triggered_by is set to "rest_api" for dag runs that are triggered via the UI #53767
closes: #53767 

### What happened
DAG runs triggered manually from the Airflow UI are incorrectly marked as `triggered_by="rest_api"` when retrieved via the REST API.

### Root cause
The endpoint that creates DAG runs does not differentiate between UI and API requests. By default, all runs were marked as `rest_api`.

### The fix
This PR updates the logic to check the `Referer` header in the request and accordingly set the triggered_by field.