### PR TITLE
Fix:added none to lastupdated Date if event is not in queue

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/assets.py
@@ -88,7 +88,7 @@ def next_run_assets(
     ]
 
     for event in events:
-        if not event.pop('queued', None):
+        if not event.pop("queued", None):
             event["lastUpdate"] = None
 
     data = {"asset_expression": dag_model.asset_expression, "events": events}

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/assets.py
@@ -87,11 +87,9 @@ def next_run_assets(
         )
     ]
 
-    for ev in events:
-        queued = ev.get("queued")
-        if not queued:
-            ev["lastUpdate"] = None
-        ev.pop("queued", None)
+    for event in events:
+        if not event.pop('queued', None):
+            event["lastUpdate"] = None
 
     data = {"asset_expression": dag_model.asset_expression, "events": events}
     return data

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_assets.py
@@ -18,10 +18,13 @@ from __future__ import annotations
 
 from unittest import mock
 
+import pendulum
 import pytest
 
+from airflow.models.asset import AssetDagRunQueue, AssetEvent, AssetModel
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.sdk.definitions.asset import Asset
+from airflow.utils.session import create_session
 
 from tests_common.test_utils.db import clear_db_dags, clear_db_serialized_dags
 
@@ -74,3 +77,128 @@ class TestNextRunAssets:
     def test_should_respond_403(self, unauthorized_test_client):
         response = unauthorized_test_client.get("/next_run_assets/upstream")
         assert response.status_code == 403
+
+    def test_should_set_last_update_only_for_queued_and_hide_flag(self, test_client, dag_maker):
+        with dag_maker(
+            dag_id="two_assets_equal",
+            schedule=[
+                Asset(uri="s3://bucket/A", name="A"),
+                Asset(uri="s3://bucket/B", name="B"),
+            ],
+            serialized=True,
+        ):
+            EmptyOperator(task_id="t")
+
+        dr = dag_maker.create_dagrun()
+        dag_maker.sync_dagbag_to_db()
+
+        with create_session() as session:
+            assets = {
+                a.uri: a
+                for a in session.query(AssetModel).filter(
+                    AssetModel.uri.in_(["s3://bucket/A", "s3://bucket/B"])
+                )
+            }
+            # Queue and add an event only for A
+            session.add(
+                AssetDagRunQueue(asset_id=assets["s3://bucket/A"].id, target_dag_id="two_assets_equal")
+            )
+            session.add(
+                AssetEvent(asset_id=assets["s3://bucket/A"].id, timestamp=dr.logical_date or pendulum.now())
+            )
+            session.commit()
+
+        response = test_client.get("/next_run_assets/two_assets_equal")
+        assert response.status_code == 200
+        assert response.json() == {
+            "asset_expression": {
+                "all": [
+                    {
+                        "asset": {
+                            "uri": "s3://bucket/A",
+                            "name": "A",
+                            "group": "asset",
+                            "id": mock.ANY,
+                        }
+                    },
+                    {
+                        "asset": {
+                            "uri": "s3://bucket/B",
+                            "name": "B",
+                            "group": "asset",
+                            "id": mock.ANY,
+                        }
+                    },
+                ]
+            },
+            # events are ordered by uri
+            "events": [
+                {"id": mock.ANY, "uri": "s3://bucket/A", "name": "A", "lastUpdate": mock.ANY},
+                {"id": mock.ANY, "uri": "s3://bucket/B", "name": "B", "lastUpdate": None},
+            ],
+        }
+
+    def test_two_assets_only_one_queued_last_update_norm(self, test_client, dag_maker):
+        with dag_maker(
+            dag_id="two_assets",
+            schedule=[
+                Asset(uri="s3://bucket/A", name="A"),
+                Asset(uri="s3://bucket/B", name="B"),
+            ],
+            serialized=True,
+        ):
+            EmptyOperator(task_id="t")
+
+        dr = dag_maker.create_dagrun()
+        dag_maker.sync_dagbag_to_db()
+
+        with create_session() as session:
+            assets = {
+                a.uri: a
+                for a in session.query(AssetModel).filter(
+                    AssetModel.uri.in_(["s3://bucket/A", "s3://bucket/B"])
+                )
+            }
+            session.add(AssetDagRunQueue(asset_id=assets["s3://bucket/A"].id, target_dag_id="two_assets"))
+            session.add(
+                AssetEvent(asset_id=assets["s3://bucket/A"].id, timestamp=dr.logical_date or pendulum.now())
+            )
+            session.commit()
+
+        resp = test_client.get("/next_run_assets/two_assets")
+        assert resp.status_code == 200
+        events = resp.json()["events"]
+        # ordered by uri => A then B
+        assert events[0]["uri"] == "s3://bucket/A"
+        assert events[0]["lastUpdate"] is not None
+        assert "queued" not in events[0]
+        assert events[1]["uri"] == "s3://bucket/B"
+        assert events[1]["lastUpdate"] is None
+        assert "queued" not in events[1]
+
+    def test_last_update_respects_latest_run_filter(self, test_client, dag_maker):
+        with dag_maker(
+            dag_id="filter_run",
+            schedule=[Asset(uri="s3://bucket/F", name="F")],
+            serialized=True,
+        ):
+            EmptyOperator(task_id="t")
+
+        dr = dag_maker.create_dagrun()
+        dag_maker.sync_dagbag_to_db()
+
+        with create_session() as session:
+            asset = session.query(AssetModel).filter(AssetModel.uri == "s3://bucket/F").one()
+            session.add(AssetDagRunQueue(asset_id=asset.id, target_dag_id="filter_run"))
+            # event before latest_run should be ignored
+            ts_base = dr.logical_date or pendulum.now()
+            session.add(AssetEvent(asset_id=asset.id, timestamp=ts_base.subtract(minutes=10)))
+            # event after latest_run counts
+            session.add(AssetEvent(asset_id=asset.id, timestamp=ts_base.add(minutes=10)))
+            session.commit()
+
+        resp = test_client.get("/next_run_assets/filter_run")
+        assert resp.status_code == 200
+        ev = resp.json()["events"][0]
+        assert ev["lastUpdate"] is not None
+        assert "queued" not in ev

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_assets.py
@@ -132,7 +132,6 @@ class TestNextRunAssets:
             ],
         }
 
-
     def test_last_update_respects_latest_run_filter(self, test_client, dag_maker, session):
         with dag_maker(
             dag_id="filter_run",

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_assets.py
@@ -93,14 +93,10 @@ class TestNextRunAssets:
 
         assets = {
             a.uri: a
-            for a in session.query(AssetModel).filter(
-                AssetModel.uri.in_(["s3://bucket/A", "s3://bucket/B"])
-            )
+            for a in session.query(AssetModel).filter(AssetModel.uri.in_(["s3://bucket/A", "s3://bucket/B"]))
         }
         # Queue and add an event only for A
-        session.add(
-            AssetDagRunQueue(asset_id=assets["s3://bucket/A"].id, target_dag_id="two_assets_equal")
-        )
+        session.add(AssetDagRunQueue(asset_id=assets["s3://bucket/A"].id, target_dag_id="two_assets_equal"))
         session.add(
             AssetEvent(asset_id=assets["s3://bucket/A"].id, timestamp=dr.logical_date or pendulum.now())
         )
@@ -152,9 +148,7 @@ class TestNextRunAssets:
 
         assets = {
             a.uri: a
-            for a in session.query(AssetModel).filter(
-                AssetModel.uri.in_(["s3://bucket/A", "s3://bucket/B"])
-            )
+            for a in session.query(AssetModel).filter(AssetModel.uri.in_(["s3://bucket/A", "s3://bucket/B"]))
         }
         session.add(AssetDagRunQueue(asset_id=assets["s3://bucket/A"].id, target_dag_id="two_assets"))
         session.add(


### PR DESCRIPTION
closes: #53817
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



Summary of changes:

Display logic for "X of Y assets":

Y = total assets relevant to the DAG's asset_expression.

X = assets with lastUpdate > latestRunAfter (i.e., new events since last DAG run).

Introduced SQL-based computation of each asset’s "queued" status using a LEFT JOIN + MAX(CASE) approach.

Grouped and normalized the data so:

Non-queued assets have lastUpdate = None.

The internal queued field is removed from the final response payload for clarity.
