### PR TITLE
Make slack providers tests db independent

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -650,6 +650,7 @@ repos:
             ^providers/segment/.*\.py$|
             ^providers/sendgrid/.*\.py$|
             ^providers/singularity/.*\.py$|
+            ^providers/slack/.*\.py$|
             ^providers/tableau/.*\.py$|
             ^providers/teradata/.*\.py$|
             ^providers/trino/.*\.py$|

--- a/providers/slack/tests/unit/slack/notifications/test_slack.py
+++ b/providers/slack/tests/unit/slack/notifications/test_slack.py
@@ -22,9 +22,6 @@ from unittest import mock
 import pytest
 
 from airflow.providers.slack.notifications.slack import SlackNotifier, send_slack_notification
-from airflow.providers.standard.operators.empty import EmptyOperator
-
-pytestmark = pytest.mark.db_test
 
 DEFAULT_HOOKS_PARAMETERS = {"base_url": None, "timeout": None, "proxy": None, "retry_handlers": None}
 
@@ -52,12 +49,9 @@ class TestSlackNotifier:
             ),
         ],
     )
-    def test_slack_notifier(self, mock_slack_hook, dag_maker, extra_kwargs, hook_extra_kwargs):
-        with dag_maker("test_slack_notifier") as dag:
-            EmptyOperator(task_id="task1")
-
+    def test_slack_notifier(self, mock_slack_hook, create_dag_without_db, extra_kwargs, hook_extra_kwargs):
         notifier = send_slack_notification(slack_conn_id="test_conn_id", text="test", **extra_kwargs)
-        notifier({"dag": dag})
+        notifier({"dag": create_dag_without_db("test_slack_notifier")})
         mock_slack_hook.return_value.call.assert_called_once_with(
             "chat.postMessage",
             json={
@@ -75,12 +69,9 @@ class TestSlackNotifier:
         mock_slack_hook.assert_called_once_with(slack_conn_id="test_conn_id", **hook_extra_kwargs)
 
     @mock.patch("airflow.providers.slack.notifications.slack.SlackHook")
-    def test_slack_notifier_with_notifier_class(self, mock_slack_hook, dag_maker):
-        with dag_maker("test_slack_notifier") as dag:
-            EmptyOperator(task_id="task1")
-
+    def test_slack_notifier_with_notifier_class(self, mock_slack_hook, create_dag_without_db):
         notifier = SlackNotifier(text="test")
-        notifier({"dag": dag})
+        notifier({"dag": create_dag_without_db("test_slack_notifier")})
         mock_slack_hook.return_value.call.assert_called_once_with(
             "chat.postMessage",
             json={
@@ -97,16 +88,13 @@ class TestSlackNotifier:
         )
 
     @mock.patch("airflow.providers.slack.notifications.slack.SlackHook")
-    def test_slack_notifier_templated(self, mock_slack_hook, dag_maker):
-        with dag_maker("test_slack_notifier") as dag:
-            EmptyOperator(task_id="task1")
-
+    def test_slack_notifier_templated(self, mock_slack_hook, create_dag_without_db):
         notifier = send_slack_notification(
             text="test {{ username }}",
             channel="#test-{{dag.dag_id}}",
             attachments=[{"image_url": "{{ dag.dag_id }}.png"}],
         )
-        context = {"dag": dag}
+        context = {"dag": create_dag_without_db("test_slack_notifier")}
         notifier(context)
         mock_slack_hook.return_value.call.assert_called_once_with(
             "chat.postMessage",
@@ -124,16 +112,13 @@ class TestSlackNotifier:
         )
 
     @mock.patch("airflow.providers.slack.notifications.slack.SlackHook")
-    def test_slack_notifier_unfurl_options(self, mock_slack_hook, dag_maker):
-        with dag_maker("test_slack_notifier_unfurl_options") as dag:
-            EmptyOperator(task_id="task1")
-
+    def test_slack_notifier_unfurl_options(self, mock_slack_hook, create_dag_without_db):
         notifier = send_slack_notification(
             text="test",
             unfurl_links=False,
             unfurl_media=False,
         )
-        notifier({"dag": dag})
+        notifier({"dag": create_dag_without_db("test_slack_notifier")})
         mock_slack_hook.return_value.call.assert_called_once_with(
             "chat.postMessage",
             json={

--- a/providers/slack/tests/unit/slack/transfers/test_sql_to_slack_webhook.py
+++ b/providers/slack/tests/unit/slack/transfers/test_sql_to_slack_webhook.py
@@ -23,7 +23,11 @@ import pytest
 
 from airflow.models import Connection
 from airflow.providers.slack.transfers.sql_to_slack_webhook import SqlToSlackWebhookOperator
-from airflow.utils import timezone
+
+try:
+    from airflow.sdk import timezone
+except ImportError:
+    from airflow.utils import timezone  # type: ignore[attr-defined,no-redef]
 
 TEST_DAG_ID = "sql_to_slack_unit_test"
 TEST_TASK_ID = "sql_to_slack_unit_test_task"
@@ -36,8 +40,17 @@ def mocked_hook():
         yield m
 
 
-@pytest.mark.db_test
 class TestSqlToSlackWebhookOperator:
+    @pytest.fixture(autouse=True)
+    def setup_connections(self, create_connection_without_db):
+        create_connection_without_db(
+            Connection(
+                conn_id="slack_connection",
+                conn_type="slackwebhook",
+                password="xoxb-1234567890123-09876543210987-AbCdEfGhIjKlMnOpQrStUvWx",
+            )
+        )
+
     def setup_method(self):
         self.default_hook_parameters = {"timeout": None, "proxy": None, "retry_handlers": None}
 
@@ -59,31 +72,27 @@ class TestSqlToSlackWebhookOperator:
             ),
         ],
     )
-    def test_rendering_and_message_execution(
-        self, slack_op_kwargs, hook_extra_kwargs, mocked_hook, dag_maker
-    ):
+    def test_rendering_and_message_execution(self, slack_op_kwargs, hook_extra_kwargs, mocked_hook):
         mock_dbapi_hook = mock.Mock()
 
         test_df = pd.DataFrame({"a": "1", "b": "2"}, index=[0, 1])
         get_df_mock = mock_dbapi_hook.return_value.get_df
         get_df_mock.return_value = test_df
 
-        with dag_maker(dag_id=TEST_DAG_ID, start_date=DEFAULT_DATE):
-            operator_args = {
-                "sql_conn_id": "snowflake_connection",
-                "slack_webhook_conn_id": "slack_connection",
-                "slack_message": "message: {{ ds }}, {{ results_df }}",
-                "slack_channel": "#test",
-                "sql": "sql {{ ds }}",
-                **slack_op_kwargs,
-            }
-            sql_to_slack_operator = self._construct_operator(**operator_args)
+        operator_args = {
+            "sql_conn_id": "snowflake_connection",
+            "slack_webhook_conn_id": "slack_connection",
+            "slack_message": "message: {{ ds }}, {{ results_df }}",
+            "slack_channel": "#test",
+            "sql": "sql {{ ds }}",
+            **slack_op_kwargs,
+        }
+        sql_to_slack_operator = self._construct_operator(**operator_args)
 
         slack_webhook_hook = mocked_hook.return_value
         sql_to_slack_operator._get_hook = mock_dbapi_hook
-
-        ti = dag_maker.create_dagrun().task_instances[0]
-        ti.run()
+        sql_to_slack_operator.render_template_fields({"ds": "2017-01-01"})
+        sql_to_slack_operator.execute({"ds": "2017-01-01"})
 
         # Test that the Slack hook is instantiated with the right parameters
         mocked_hook.assert_called_once_with(slack_webhook_conn_id="slack_connection", **hook_extra_kwargs)
@@ -94,28 +103,27 @@ class TestSqlToSlackWebhookOperator:
             channel="#test",
         )
 
-    def test_rendering_and_message_execution_with_slack_hook(self, mocked_hook, dag_maker):
+    def test_rendering_and_message_execution_with_slack_hook(self, mocked_hook):
         mock_dbapi_hook = mock.Mock()
 
         test_df = pd.DataFrame({"a": "1", "b": "2"}, index=[0, 1])
         get_df_mock = mock_dbapi_hook.return_value.get_df
         get_df_mock.return_value = test_df
 
-        with dag_maker(dag_id=TEST_DAG_ID, start_date=DEFAULT_DATE):
-            operator_args = {
-                "sql_conn_id": "snowflake_connection",
-                "slack_webhook_conn_id": "slack_connection",
-                "slack_message": "message: {{ ds }}, {{ results_df }}",
-                "slack_channel": "#test",
-                "sql": "sql {{ ds }}",
-            }
-            sql_to_slack_operator = self._construct_operator(**operator_args)
+        operator_args = {
+            "sql_conn_id": "snowflake_connection",
+            "slack_webhook_conn_id": "slack_connection",
+            "slack_message": "message: {{ ds }}, {{ results_df }}",
+            "slack_channel": "#test",
+            "sql": "sql {{ ds }}",
+        }
+        sql_to_slack_operator = self._construct_operator(**operator_args)
 
         slack_webhook_hook = mocked_hook.return_value
         sql_to_slack_operator._get_hook = mock_dbapi_hook
 
-        ti = dag_maker.create_dagrun().task_instances[0]
-        ti.run()
+        sql_to_slack_operator.render_template_fields({"ds": "2017-01-01"})
+        sql_to_slack_operator.execute({"ds": "2017-01-01"})
 
         # Test that the Slack hook is instantiated with the right parameters
         mocked_hook.assert_called_once_with(
@@ -157,29 +165,28 @@ class TestSqlToSlackWebhookOperator:
         with pytest.raises(ValueError, match="Got an empty `slack_webhook_conn_id` value"):
             self._construct_operator(**operator_args)
 
-    def test_rendering_custom_df_name_message_execution(self, mocked_hook, dag_maker):
+    def test_rendering_custom_df_name_message_execution(self, mocked_hook):
         mock_dbapi_hook = mock.Mock()
 
         test_df = pd.DataFrame({"a": "1", "b": "2"}, index=[0, 1])
         get_df_mock = mock_dbapi_hook.return_value.get_df
         get_df_mock.return_value = test_df
 
-        with dag_maker(dag_id=TEST_DAG_ID, start_date=DEFAULT_DATE):
-            operator_args = {
-                "sql_conn_id": "snowflake_connection",
-                "slack_webhook_conn_id": "slack_connection",
-                "slack_message": "message: {{ ds }}, {{ testing }}",
-                "slack_channel": "#test",
-                "sql": "sql {{ ds }}",
-                "results_df_name": "testing",
-            }
-            sql_to_slack_operator = self._construct_operator(**operator_args)
+        operator_args = {
+            "sql_conn_id": "snowflake_connection",
+            "slack_webhook_conn_id": "slack_connection",
+            "slack_message": "message: {{ ds }}, {{ testing }}",
+            "slack_channel": "#test",
+            "sql": "sql {{ ds }}",
+            "results_df_name": "testing",
+        }
+        sql_to_slack_operator = self._construct_operator(**operator_args)
 
         slack_webhook_hook = mocked_hook.return_value
         sql_to_slack_operator._get_hook = mock_dbapi_hook
 
-        ti = dag_maker.create_dagrun().task_instances[0]
-        ti.run()
+        sql_to_slack_operator.render_template_fields({"ds": "2017-01-01"})
+        sql_to_slack_operator.execute({"ds": "2017-01-01"})
 
         # Test that the Slack hook is instantiated with the right parameters
         mocked_hook.assert_called_once_with(


### PR DESCRIPTION
Making it db independent slack provider tests. These tests not required db init and creating runs. we can use mocked connections and dag class initialisation 

Part of this https://github.com/apache/airflow/issues/42632 to switch completely provider tests db independent

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
