### PR TITLE
Add hotkey shortcut to toggle between grid and graph views.

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
@@ -92,8 +92,8 @@
     "buttons": {
       "options": "Options",
       "showGantt": "Show Gantt",
-      "showGraph": "Show Graph",
-      "showGrid": "Show Grid"
+      "showGraphShortcut": "Show Graph (Press g)",
+      "showGridShortcut": "Show Grid (Press g)"
     },
     "dagRuns": {
       "label": "Number of Dag Runs"

--- a/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
@@ -158,7 +158,7 @@ export const PanelButtons = ({
       <Flex flexWrap="wrap" justifyContent="space-between">
         <ButtonGroup attached size="sm" variant="outline">
           <IconButton
-            aria-label={translate("dag:panel.buttons.showGrid")}
+            aria-label={translate("dag:panel.buttons.showGridShortcut")}
             colorPalette="blue"
             onClick={() => {
               setDagView("grid");
@@ -166,13 +166,13 @@ export const PanelButtons = ({
                 handleFocus("grid");
               }
             }}
-            title={translate("dag:panel.buttons.showGrid")}
+            title={translate("dag:panel.buttons.showGridShortcut")}
             variant={dagView === "grid" ? "solid" : "outline"}
           >
             <FiGrid />
           </IconButton>
           <IconButton
-            aria-label={translate("dag:panel.buttons.showGraph")}
+            aria-label={translate("dag:panel.buttons.showGraphShortcut")}
             colorPalette="blue"
             onClick={() => {
               setDagView("graph");
@@ -180,7 +180,7 @@ export const PanelButtons = ({
                 handleFocus("graph");
               }
             }}
-            title={translate("dag:panel.buttons.showGraph")}
+            title={translate("dag:panel.buttons.showGraphShortcut")}
             variant={dagView === "graph" ? "solid" : "outline"}
           >
             <MdOutlineAccountTree />

--- a/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
@@ -32,6 +32,7 @@ import {
   Box,
 } from "@chakra-ui/react";
 import { useReactFlow } from "@xyflow/react";
+import { useHotkeys } from "react-hotkeys-hook";
 import { useTranslation } from "react-i18next";
 import { FiChevronDown, FiGrid } from "react-icons/fi";
 import { LuKeyboard } from "react-icons/lu";
@@ -136,6 +137,21 @@ export const PanelButtons = ({
       }
     }
   };
+
+  useHotkeys(
+    "g",
+    () => {
+      if (dagView === "graph") {
+        setDagView("grid");
+        handleFocus("grid");
+      } else {
+        setDagView("graph");
+        handleFocus("graph");
+      }
+    },
+    [dagView],
+    { preventDefault: true },
+  );
 
   return (
     <Box position="absolute" top={1} width="100%" zIndex={1}>


### PR DESCRIPTION
 Add <kbd>g</kbd> as hotkey shortcut key to toggle between the grid and graph view. This needs to discoverable so this can be shown along with "show grid" tooltip like "show grid (press g)" . I am not sure how translations are handled for this.