### PR TITLE
Make AWS notifier tests db independent

### DIFF
--- a/providers/amazon/tests/unit/amazon/aws/notifications/test_chime.py
+++ b/providers/amazon/tests/unit/amazon/aws/notifications/test_chime.py
@@ -24,9 +24,6 @@ import pytest
 from airflow.models import Connection
 from airflow.providers.amazon.aws.hooks.chime import ChimeWebhookHook
 from airflow.providers.amazon.aws.notifications.chime import ChimeNotifier, send_chime_notification
-from airflow.providers.standard.operators.empty import EmptyOperator
-
-pytestmark = pytest.mark.db_test
 
 
 class TestChimeNotifier:
@@ -44,34 +41,25 @@ class TestChimeNotifier:
         )
 
     @mock.patch.object(ChimeWebhookHook, "send_message")
-    def test_chime_notifier(self, mock_chime_hook, dag_maker):
-        with dag_maker("test_chime_notifier") as dag:
-            EmptyOperator(task_id="task1")
-
+    def test_chime_notifier(self, mock_chime_hook, create_dag_without_db):
         notifier = send_chime_notification(
             chime_conn_id="default-chime-webhook", message="Chime Test Message"
         )
-        notifier({"dag": dag})
+        notifier({"dag": create_dag_without_db("test_chime_notifier")})
         mock_chime_hook.assert_called_once_with(message="Chime Test Message")
 
     @mock.patch.object(ChimeWebhookHook, "send_message")
-    def test_chime_notifier_with_notifier_class(self, mock_chime_hook, dag_maker):
-        with dag_maker("test_chime_notifier") as dag:
-            EmptyOperator(task_id="task1")
-
+    def test_chime_notifier_with_notifier_class(self, mock_chime_hook, create_dag_without_db):
         notifier = ChimeNotifier(
             chime_conn_id="default-chime-webhook", message="Test Chime Message for Class"
         )
-        notifier({"dag": dag})
+        notifier({"dag": create_dag_without_db("test_chime_notifier")})
         mock_chime_hook.assert_called_once_with(message="Test Chime Message for Class")
 
     @mock.patch.object(ChimeWebhookHook, "send_message")
-    def test_chime_notifier_templated(self, mock_chime_hook, dag_maker):
-        with dag_maker("test_chime_notifier") as dag:
-            EmptyOperator(task_id="task1")
-
+    def test_chime_notifier_templated(self, mock_chime_hook, create_dag_without_db):
         notifier = send_chime_notification(
             chime_conn_id="default-chime-webhook", message="Test Chime Message. Dag is {{ dag.dag_id }}."
         )
-        notifier({"dag": dag})
+        notifier({"dag": create_dag_without_db("test_chime_notifier")})
         mock_chime_hook.assert_called_once_with(message="Test Chime Message. Dag is test_chime_notifier.")


### PR DESCRIPTION
Removing db dependency for notifier tests.

Part of this https://github.com/apache/airflow/issues/42632 to switch completely provider tests db independent 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
