### PR TITLE
Small adjustments to Audit Logs filtering

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Events/EventsFilters.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Events/EventsFilters.tsx
@@ -27,6 +27,8 @@ import { SearchBar } from "src/components/SearchBar";
 import { ResetButton } from "src/components/ui";
 import { SearchParamsKeys } from "src/constants/searchParams";
 
+import { getFilterCount } from "./filterUtils";
+
 const {
   AFTER: AFTER_PARAM,
   BEFORE: BEFORE_PARAM,
@@ -82,11 +84,19 @@ export const EventsFilters = ({ urlDagId, urlRunId, urlTaskId }: EventsFiltersPr
     [resetPagination, searchParams, setSearchParams],
   );
 
-  const handleClearFilters = useCallback(() => {
-    // Clear all URL params
+  const onClearFilters = useCallback(() => {
+    searchParams.delete(AFTER_PARAM);
+    searchParams.delete(BEFORE_PARAM);
+    searchParams.delete(DAG_ID_PARAM);
+    searchParams.delete(EVENT_TYPE_PARAM);
+    searchParams.delete(MAP_INDEX_PARAM);
+    searchParams.delete(RUN_ID_PARAM);
+    searchParams.delete(TASK_ID_PARAM);
+    searchParams.delete(TRY_NUMBER_PARAM);
+    searchParams.delete(USER_PARAM);
     resetPagination();
-    setSearchParams(new URLSearchParams());
-  }, [resetPagination, setSearchParams]);
+    setSearchParams(searchParams);
+  }, [resetPagination, searchParams, setSearchParams]);
 
   const handleSearchChange = useCallback(
     (paramName: string) => (value: string) => {
@@ -104,10 +114,20 @@ export const EventsFilters = ({ urlDagId, urlRunId, urlTaskId }: EventsFiltersPr
     [updateSearchParams],
   );
 
-  const filterCount = searchParams.size;
+  const filterCount = getFilterCount({
+    after: afterFilter,
+    before: beforeFilter,
+    dagId: dagIdFilter,
+    eventType: eventTypeFilter,
+    mapIndex: mapIndexFilter,
+    runId: runIdFilter,
+    taskId: taskIdFilter,
+    tryNumber: tryNumberFilter,
+    user: userFilter,
+  });
 
   return (
-    <HStack justifyContent="space-between">
+    <HStack alignItems="end" justifyContent="space-between">
       <HStack alignItems="end" gap={4}>
         {/* Timestamp Range Filters */}
         <VStack alignItems="flex-start" gap={1}>
@@ -225,7 +245,7 @@ export const EventsFilters = ({ urlDagId, urlRunId, urlTaskId }: EventsFiltersPr
       </HStack>
 
       <Box>
-        <ResetButton filterCount={filterCount} onClearFilters={handleClearFilters} />
+        <ResetButton filterCount={filterCount} onClearFilters={onClearFilters} />
       </Box>
     </HStack>
   );

--- a/airflow-core/src/airflow/ui/src/pages/Events/filterUtils.ts
+++ b/airflow-core/src/airflow/ui/src/pages/Events/filterUtils.ts
@@ -1,0 +1,73 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+export type FilterOptions = {
+  after: string | null;
+  before: string | null;
+  dagId: string | null;
+  eventType: string | null;
+  mapIndex: string | null;
+  runId: string | null;
+  taskId: string | null;
+  tryNumber: string | null;
+  user: string | null;
+};
+
+export const getFilterCount = ({
+  after,
+  before,
+  dagId,
+  eventType,
+  mapIndex,
+  runId,
+  taskId,
+  tryNumber,
+  user,
+}: FilterOptions) => {
+  let count = 0;
+
+  if (after !== null) {
+    count += 1;
+  }
+  if (before !== null) {
+    count += 1;
+  }
+  if (dagId !== null) {
+    count += 1;
+  }
+  if (eventType !== null) {
+    count += 1;
+  }
+  if (mapIndex !== null) {
+    count += 1;
+  }
+  if (runId !== null) {
+    count += 1;
+  }
+  if (taskId !== null) {
+    count += 1;
+  }
+  if (tryNumber !== null) {
+    count += 1;
+  }
+  if (user !== null) {
+    count += 1;
+  }
+
+  return count;
+};


### PR DESCRIPTION
Follow up of https://github.com/apache/airflow/pull/54210

This mimics what we have for DagFilters, mainly to not lose ordering while clearing the 'filters' and also not display the 'clear filter' button when only ordering is specified. (There is no filters to clear).

Also fix a small alignment issue.


#### Before

https://github.com/user-attachments/assets/7ff74c44-1983-4b76-b6b0-e7434b58674d





#### After

https://github.com/user-attachments/assets/cbc1fcf7-ad1c-4c2c-a90f-c96559cdc4d1

