### PR TITLE
Go SDK: add tests to the task function reflection code

### DIFF
--- a/go-sdk/worker/task_test.go
+++ b/go-sdk/worker/task_test.go
@@ -1,0 +1,99 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package worker
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/apache/airflow/go-sdk/pkg/logging"
+)
+
+type TaskSuite struct {
+	suite.Suite
+}
+
+func TestTaskSuite(t *testing.T) {
+	suite.Run(t, &TaskSuite{})
+}
+
+func (s *TaskSuite) TestReturnValidation() {
+	cases := map[string]struct {
+		fn          any
+		errContains string
+	}{
+		"no-ret-values": {
+			func() {},
+			`func\d+ has 0 return values, must be`,
+		},
+		"too-many-ret-values": {
+			func() (a, b, c int) { return },
+			`func\d+ has 3 return values, must be`,
+		},
+		"invalid-ret": {
+			func() (c chan int) { return },
+			`func\d+ last return value to return error but found chan`,
+		},
+	}
+
+	for name, tt := range cases {
+		s.Run(name, func() {
+			_, err := NewTaskFunction(tt.fn)
+			if s.Assert().Error(err) {
+				s.Assert().Regexp(tt.errContains, err.Error())
+			}
+		})
+	}
+}
+
+func (s *TaskSuite) TestArgumentBinding() {
+	cases := map[string]struct {
+		fn any
+	}{
+		"no-args": {
+			func() error { return nil },
+		},
+		"context": {
+			func(ctx context.Context) error {
+				s.Assert().Equal("def", ctx.Value("abc"))
+				return nil
+			},
+		},
+		"context-and-logger": {
+			func(ctx context.Context, logger *slog.Logger) error {
+				s.Assert().Equal("def", ctx.Value("abc"))
+				s.Assert().NotNil(logger)
+				return nil
+			},
+		},
+	}
+
+	for name, tt := range cases {
+		s.Run(name, func() {
+			task, err := NewTaskFunction(tt.fn)
+			s.Require().NoError(err)
+
+			ctx := context.WithValue(context.Background(), "abc", "def")
+			logger := slog.New(logging.NewTeeLogger())
+			task.Execute(ctx, logger)
+		})
+	}
+}


### PR DESCRIPTION
This is an important part of the GoSDK as it is what lets us call the user's
task function with the right arguments. In future this will be extended to let
us pass arguments from XCom etc too!

A small pr as part of a larger work to make it easier to review.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
