### PR TITLE
Fix SMTP email template when mark_success_url is undefined for RuntimeTaskInstance objects

### DIFF
--- a/providers/smtp/src/airflow/providers/smtp/notifications/templates/email.html
+++ b/providers/smtp/src/airflow/providers/smtp/notifications/templates/email.html
@@ -27,10 +27,12 @@
             <td>Log Link:</td>
             <td><a href="{{ ti.log_url }}" style="text-decoration:underline;">{{ ti.log_url }}</a></td>
         </tr>
+        {% if ti.mark_success_url is defined %}
         <tr>
             <td>Mark Success Link:</td>
             <td><a href="{{ ti.mark_success_url }}" style="text-decoration:underline;">{{ ti.mark_success_url }}</a></td>
         </tr>
+        {% endif %}
         {% elif slas is defined %}
         <tr>
             <td>Dag:</td>


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/53135

Added an existence check for `mark_success_url` in the default SMTP html template.
The `TaskInstance` class properly defines a `mark_success_url` property, while the `RuntimeTaskInstance` class used during task execution does not. This results in an `UndefinedError` when the email template tries to access `ti.mark_success_url` on a `RuntimeTaskInstance` object.

This change makes sure:
- The link is displayed when using `TaskInstance` objects (which have the property)
- No error occurs when using `RuntimeTaskInstance` objects (which don't have the property)
