### PR TITLE
fix helm schema validation for executor value

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -687,7 +687,7 @@
             "type": "string",
             "x-docsSection": "Common",
             "default": "CeleryExecutor",
-            "pattern": "^(([a-zA-Z_][a-zA-Z0-9_]*.)*[A-Z][a-zA-Z0-9]*Executor)(,(([a-zA-Z_][a-zA-Z0-9_]*.)*[A-Z][a-zA-Z0-9]*Executor))*$"
+            "pattern": "^(([a-zA-Z_][a-zA-Z0-9_]*.)*[A-Z][a-zA-Z0-9]+Executor)(,(([a-zA-Z_][a-zA-Z0-9_]*.)*[A-Z][a-zA-Z0-9]+Executor))*$"
         },
         "allowPodLaunching": {
             "description": "Whether various Airflow components launch pods.",

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -687,7 +687,7 @@
             "type": "string",
             "x-docsSection": "Common",
             "default": "CeleryExecutor",
-            "pattern": "^(LocalExecutor|LocalKubernetesExecutor|CeleryExecutor|KubernetesExecutor|CeleryKubernetesExecutor|airflow.providers.edge3.executors.EdgeExecutor|airflow.providers.amazon.aws.executors.batch.AwsBatchExecutor|airflow.providers.amazon.aws.executors.ecs.AwsEcsExecutor)(,(LocalExecutor|LocalKubernetesExecutor|CeleryExecutor|KubernetesExecutor|CeleryKubernetesExecutor|airflow.providers.edge3.executors.EdgeExecutor|airflow.providers.amazon.aws.executors.batch.AwsBatchExecutor|airflow.providers.amazon.aws.executors.ecs.AwsEcsExecutor))*$"
+            "pattern": "^(([a-zA-Z_][a-zA-Z0-9_]*.)*[A-Z][a-zA-Z0-9]*Executor)(,(([a-zA-Z_][a-zA-Z0-9_]*.)*[A-Z][a-zA-Z0-9]*Executor))*$"
         },
         "allowPodLaunching": {
             "description": "Whether various Airflow components launch pods.",

--- a/helm-tests/tests/helm_tests/airflow_aux/test_basic_helm_chart.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_basic_helm_chart.py
@@ -613,6 +613,9 @@ class TestBaseChartTest:
             "airflow.providers.amazon.aws.executors.batch.AwsBatchExecutor",
             "airflow.providers.amazon.aws.executors.ecs.AwsEcsExecutor",
             "CeleryExecutor,KubernetesExecutor",
+            "CustomExecutor",
+            "my.org.CustomExecutor",
+            "CeleryExecutor,CustomExecutor",
         ],
     )
     def test_supported_executor(self, executor):
@@ -623,12 +626,20 @@ class TestBaseChartTest:
             },
         )
 
-    def test_unsupported_executor(self):
+    @pytest.mark.parametrize(
+        "invalid_executor",
+        [
+            "Executor",       # class name must include more than just Executor
+            "ExecutorCustom", # class name must end with Executor
+            "Customexecutor", # lowercase Executor is disallowed
+        ],
+    )
+    def test_unsupported_executor(self, invalid_executor):
         with pytest.raises(CalledProcessError):
             render_chart(
                 "test-basic",
                 {
-                    "executor": "SequentialExecutor",  # just keeping this one here as its an incompatible one
+                    "executor": invalid_executor,
                 },
             )
 

--- a/helm-tests/tests/helm_tests/airflow_aux/test_basic_helm_chart.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_basic_helm_chart.py
@@ -629,7 +629,7 @@ class TestBaseChartTest:
     @pytest.mark.parametrize(
         "invalid_executor",
         [
-            "Executor",       # class name must include more than just Executor
+            "Executor", # class name must include more than just Executor
             "ExecutorCustom", # class name must end with Executor
             "Customexecutor", # lowercase Executor is disallowed
         ],

--- a/helm-tests/tests/helm_tests/airflow_aux/test_basic_helm_chart.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_basic_helm_chart.py
@@ -629,9 +629,9 @@ class TestBaseChartTest:
     @pytest.mark.parametrize(
         "invalid_executor",
         [
-            "Executor", # class name must include more than just Executor
-            "ExecutorCustom", # class name must end with Executor
-            "Customexecutor", # lowercase Executor is disallowed
+            "Executor",  # class name must include more than just Executor
+            "ExecutorCustom",  # class name must end with Executor
+            "Customexecutor",  # lowercase Executor is disallowed
         ],
     )
     def test_unsupported_executor(self, invalid_executor):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Closes: #54673.

Updating the Airflow Helm Chart schema validation for the `executor` field to allow custom executors to be specified along with the existing officially supported Airflow executors. 

This regex change checks each supplied executor in the list to ensure it matches the following:

`<optional.python.package.path.><RequiredExecutorName>Executor`

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
