### PR TITLE
Make jira provider notifier tests db independent

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -610,6 +610,7 @@ repos:
             ^providers/apprise/.*\.py$|
             ^providers/arangodb/.*\.py$|
             ^providers/asana/.*\.py$|
+            ^providers/atlassian/jira/.*\.py$|
             ^providers/cloudant/.*\.py$|
             ^providers/cohere/.*\.py$|
             ^providers/common/compat/.*\.py$|

--- a/providers/atlassian/jira/tests/unit/atlassian/jira/notifications/test_jira.py
+++ b/providers/atlassian/jira/tests/unit/atlassian/jira/notifications/test_jira.py
@@ -19,13 +19,8 @@ from __future__ import annotations
 
 from unittest import mock
 
-import pytest
-
 from airflow.providers.atlassian.jira.hooks.jira import JiraHook
 from airflow.providers.atlassian.jira.notifications.jira import JiraNotifier, send_jira_notification
-from airflow.providers.standard.operators.empty import EmptyOperator
-
-pytestmark = pytest.mark.db_test
 
 jira_create_issue_payload = dict(
     description="Test operator failed",
@@ -38,10 +33,7 @@ jira_create_issue_payload = dict(
 
 class TestJiraNotifier:
     @mock.patch.object(JiraHook, "get_conn")
-    def test_jira_notifier(self, mock_jira_hook, dag_maker):
-        with dag_maker("test_jira_notifier") as dag:
-            EmptyOperator(task_id="task1")
-
+    def test_jira_notifier(self, mock_jira_hook, create_dag_without_db):
         notifier = send_jira_notification(
             jira_conn_id="jira_default",
             project_id=10000,
@@ -50,14 +42,11 @@ class TestJiraNotifier:
             issue_type_id=10003,
             labels=["airflow-dag-failure"],
         )
-        notifier({"dag": dag})
+        notifier({"dag": create_dag_without_db("test_jira_notifier")})
         mock_jira_hook.return_value.create_issue.assert_called_once_with(jira_create_issue_payload)
 
     @mock.patch.object(JiraHook, "get_conn")
-    def test_jira_notifier_with_notifier_class(self, mock_jira_hook, dag_maker):
-        with dag_maker("test_jira_notifier") as dag:
-            EmptyOperator(task_id="task1")
-
+    def test_jira_notifier_with_notifier_class(self, mock_jira_hook, create_dag_without_db):
         notifier = JiraNotifier(
             jira_conn_id="jira_default",
             project_id=10000,
@@ -66,14 +55,11 @@ class TestJiraNotifier:
             issue_type_id=10003,
             labels=["airflow-dag-failure"],
         )
-        notifier({"dag": dag})
+        notifier({"dag": create_dag_without_db("test_jira_notifier")})
         mock_jira_hook.return_value.create_issue.assert_called_once_with(jira_create_issue_payload)
 
     @mock.patch.object(JiraHook, "get_conn")
-    def test_jira_notifier_templated(self, mock_jira_hook, dag_maker):
-        with dag_maker("test_jira_notifier") as dag:
-            EmptyOperator(task_id="task1")
-
+    def test_jira_notifier_templated(self, mock_jira_hook, create_dag_without_db):
         notifier = send_jira_notification(
             jira_conn_id="jira_default",
             project_id=10000,
@@ -82,7 +68,7 @@ class TestJiraNotifier:
             issue_type_id=10003,
             labels=["airflow-dag-failure"],
         )
-        notifier({"dag": dag})
+        notifier({"dag": create_dag_without_db("test_jira_notifier")})
         mock_jira_hook.return_value.create_issue.assert_called_once_with(
             dict(
                 description="Test operator failed for dag: test_jira_notifier.",


### PR DESCRIPTION
Why:

Making it db independent jira provider tests. These tests not required db init and creating runs.

Part of this https://github.com/apache/airflow/issues/42632 to switch completely provider tests db independent

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
