### PR TITLE
Handle task-sdk connection retrieval import error in BaseHook

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -621,7 +621,13 @@ class AwsGenericHook(BaseHook, Generic[BaseAwsConnection]):
                 self.log.warning(
                     "Unable to find AWS Connection ID '%s', switching to empty.", self.aws_conn_id
                 )
-
+            # In the TaskSDK's BaseHook, it only retrieves the connection via task-sdk. Since the AWS system testing infrastructure
+            # doesn't use task-sdk, this leads to an error which we handle below.
+            except ImportError as e:
+                if "SUPERVISOR_COMMS" in str(e):
+                    self.log.exception(e)
+                else:
+                    raise
         return AwsConnectionWrapper(
             conn=connection,
             region_name=self._region_name,


### PR DESCRIPTION
When these lines were merged from https://github.com/apache/airflow/pull/54083:

https://github.com/apache/airflow/pull/54083/files/5f2f2d8c95dfc4bf9bc98c7f9c3bb97f34062da6#diff-acfa34467241916c1189174e98f87a4094e8cbf58d391fa084e6afb2594decbcL61-L71

The Amazon provider system tests all started failing because the testing infrastructure does not use task-sdk. An ImportError is thrown when the testing infrastructure tries to retrieve the connection via task-sdk. In this PR, we handle this import error and the testing infrastructure then falls back to the default connection, which is the standard way the tests are run. With this change, the tests work.