### PR TITLE
Remove references of `render_template_to_string` in sdk from core

### DIFF
--- a/airflow-core/src/airflow/utils/helpers.py
+++ b/airflow-core/src/airflow/utils/helpers.py
@@ -357,7 +357,7 @@ def __getattr__(name: str):
 
         warnings.warn(
             "airflow.utils.helpers.render_template_to_string is deprecated. "
-            "Use airflow.sdk.definitions.context.render_template_as_native instead.",
+            "Use airflow.sdk.definitions.context.render_template_to_string instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/airflow-core/src/airflow/utils/helpers.py
+++ b/airflow-core/src/airflow/utils/helpers.py
@@ -147,6 +147,16 @@ def log_filename_template_renderer() -> Callable[..., str]:
     return f_str_format
 
 
+def _render_template_to_string(template: jinja2.Template, context: Context) -> str:
+    """
+    Render a Jinja template to string using the provided context.
+
+    This is a private utility function specifically for log filename rendering.
+    It ensures templates are rendered as strings rather than native Python objects.
+    """
+    return render_template(template, cast("MutableMapping[str, Any]", context), native=False)
+
+
 def render_log_filename(ti: TaskInstance, try_number, filename_template) -> str:
     """
     Given task instance, try_number, filename_template, return the rendered log filename.
@@ -160,7 +170,7 @@ def render_log_filename(ti: TaskInstance, try_number, filename_template) -> str:
     if filename_jinja_template:
         jinja_context = ti.get_template_context()
         jinja_context["try_number"] = try_number
-        return render_template_to_string(filename_jinja_template, jinja_context)
+        return _render_template_to_string(filename_jinja_template, jinja_context)
 
     return filename_template.format(
         dag_id=ti.dag_id,
@@ -237,11 +247,6 @@ def render_template(template: Any, context: MutableMapping[str, Any], *, native:
 
         return jinja2.nativetypes.native_concat(nodes)
     return "".join(nodes)
-
-
-def render_template_to_string(template: jinja2.Template, context: Context) -> str:
-    """Shorthand to ``render_template(native=False)`` with better typing support."""
-    return render_template(template, cast("MutableMapping[str, Any]", context), native=False)
 
 
 def exactly_one(*args) -> bool:
@@ -344,5 +349,18 @@ def __getattr__(name: str):
             stacklevel=2,
         )
         return prevent_duplicates
+
+    if name == "render_template_to_string":
+        import warnings
+
+        from airflow.sdk.definitions.context import render_template_as_native
+
+        warnings.warn(
+            "airflow.utils.helpers.render_template_to_string is deprecated. "
+            "Use airflow.sdk.definitions.context.render_template_as_native instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return render_template_as_native
 
     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/airflow-core/src/airflow/utils/log/task_handler_with_custom_formatter.py
+++ b/airflow-core/src/airflow/utils/log/task_handler_with_custom_formatter.py
@@ -22,7 +22,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from airflow.configuration import conf
-from airflow.utils.helpers import parse_template_string, render_template_to_string
+from airflow.utils.helpers import _render_template_to_string, parse_template_string
 
 if TYPE_CHECKING:
     from jinja2 import Template
@@ -62,6 +62,6 @@ class TaskHandlerWithCustomFormatter(logging.StreamHandler):
     def _render_prefix(self, ti: TaskInstance) -> str:
         if self.prefix_jinja_template:
             jinja_context = ti.get_template_context()
-            return render_template_to_string(self.prefix_jinja_template, jinja_context)
+            return _render_template_to_string(self.prefix_jinja_template, jinja_context)
         logger.warning("'task_log_prefix_template' is in invalid format, ignoring the variable value")
         return ""

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1169,8 +1169,7 @@ def _get_email_subject_content(
     :meta private:
     """
     from airflow.sdk.definitions._internal.templater import SandboxedEnvironment
-    from airflow.sdk.definitions.context import Context
-    from airflow.utils.helpers import render_template_to_string
+    from airflow.sdk.definitions.context import Context, render_template_to_string
 
     exception_html = str(exception).replace("\n", "<br>")
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


closes: https://github.com/apache/airflow/issues/54711


Tested deprecation warning:
```
(airflow) ➜  airflow git:(remove-render-template) ✗ python
Python 3.12.9 (main, Feb  4 2025, 14:38:38) [Clang 16.0.0 (clang-1600.0.26.6)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> 
>>> 
>>> from airflow.sdk.definitions.context import render_template_to_string
>>> 
>>> 
>>> 
>>> from airflow.utils.helpers import render_template_to_string
<stdin>:1 DeprecationWarning: airflow.utils.helpers.render_template_to_string is deprecated. Use airflow.sdk.definitions.context.render_template_to_string instead.

```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
