### PR TITLE
🚧 [AIP-94] Add support for read-only sql_alchemy sessions

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -544,6 +544,27 @@ database:
       sensitive: true
       example: "postgresql+asyncpg://postgres:airflow@postgres/airflow"
       default: ~
+    sql_alchemy_conn_readonly:
+      description: |
+        The SQLAlchemy connection string to a read-only replica of the metadata database.
+        This is used for read-heavy operations to offload traffic from the master database.
+        If not set, read operations will use the same connection as ``sql_alchemy_conn``.
+        The read-only database should be a replica or read-only instance of the master database.
+      version_added: 3.1.0
+      type: string
+      sensitive: true
+      example: "postgresql://postgres:airflow@postgres-readonly/airflow"
+      default: ~
+    sql_alchemy_conn_readonly_async:
+      description: |
+        The SQLAlchemy connection string to a read-only replica of the metadata database for async connections.
+        If not set, Airflow will automatically derive this from ``sql_alchemy_conn_readonly`` if available,
+        or fall back to ``sql_alchemy_conn_async``.
+      version_added: 3.1.0
+      type: string
+      sensitive: true
+      example: "postgresql+asyncpg://postgres:airflow@postgres-readonly/airflow"
+      default: ~
     sql_alchemy_engine_args:
       description: |
         Extra engine specific keyword args passed to SQLAlchemy's create_engine, as a JSON-encoded value

--- a/airflow-core/src/airflow/models/deadline.py
+++ b/airflow-core/src/airflow/models/deadline.py
@@ -38,7 +38,7 @@ from airflow.serialization.serde import deserialize, serialize
 from airflow.settings import json
 from airflow.triggers.deadline import PAYLOAD_STATUS_KEY, DeadlineCallbackTrigger
 from airflow.utils.log.logging_mixin import LoggingMixin
-from airflow.utils.session import provide_session
+from airflow.utils.session import provide_session, provide_readonly_session
 from airflow.utils.sqlalchemy import UtcDateTime
 
 if TYPE_CHECKING:
@@ -356,7 +356,7 @@ class ReferenceModels:
 DeadlineReferenceType = ReferenceModels.BaseDeadlineReference
 
 
-@provide_session
+@provide_readonly_session
 def _fetch_from_db(model_reference: Column, session=None, **conditions) -> datetime:
     """
     Fetch a datetime value from the database using the provided model reference and filtering conditions.

--- a/airflow-core/src/airflow/models/serialized_dag.py
+++ b/airflow-core/src/airflow/models/serialized_dag.py
@@ -48,7 +48,7 @@ from airflow.serialization.dag_dependency import DagDependency
 from airflow.serialization.serialized_objects import SerializedDAG
 from airflow.settings import COMPRESS_SERIALIZED_DAGS, json
 from airflow.utils.hashlib_wrapper import md5
-from airflow.utils.session import NEW_SESSION, provide_session
+from airflow.utils.session import NEW_SESSION, NEW_READONLY_SESSION, provide_session, provide_readonly_session
 from airflow.utils.sqlalchemy import UtcDateTime
 
 if TYPE_CHECKING:
@@ -472,9 +472,9 @@ class SerializedDagModel(Base):
         return select(cls).where(cls.dag_id == dag_id).order_by(cls.created_at.desc()).limit(1)
 
     @classmethod
-    @provide_session
+    @provide_readonly_session
     def get_latest_serialized_dags(
-        cls, *, dag_ids: list[str], session: Session = NEW_SESSION
+        cls, *, dag_ids: list[str], session: Session = NEW_READONLY_SESSION
     ) -> list[SerializedDagModel]:
         """
         Get the latest serialized dags of given DAGs.
@@ -501,8 +501,8 @@ class SerializedDagModel(Base):
         return latest_serdags or []
 
     @classmethod
-    @provide_session
-    def read_all_dags(cls, session: Session = NEW_SESSION) -> dict[str, SerializedDAG]:
+    @provide_readonly_session
+    def read_all_dags(cls, session: Session = NEW_READONLY_SESSION) -> dict[str, SerializedDAG]:
         """
         Read all DAGs in serialized_dag table.
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

Added support for specifying and connecting to read-only database connections. This feature would be very useful for orgs that are running Airflow at a huge scale and would need to safeguard their database's master node from a very high QPS. 


**Key Features**
Automatic Fallback
If read-only database is not configured or unavailable, operations seamlessly fall back to the master database.
Session Type Safety
The implementation maintains type safety with NEW_READONLY_SESSION constant that follows the same pattern as NEW_SESSION.

**Performance Benefits**
Offloads read-heavy operations from master database
Enables horizontal scaling of read capacity
Reduces contention on master database

**Easy Adoption**
Drop-in replacement: Change @provide_session to @provide_readonly_session
Context managers available for manual session management
Backward compatible - existing code continues to work

PS: This diff is not in the final phase yet and needs to add unit tests and documentation. 


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
