### PR TITLE
Potential fix for code scanning alert no. 519: Clear-text logging of sensitive information

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -2193,7 +2193,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
     def oauth_token_getter():
         """Get authentication (OAuth) token."""
         token = session.get("oauth")
-        log.debug("Token Get: %s", token)
+        log.debug("OAuth token retrieved from session.")
         return token
 
     @staticmethod


### PR DESCRIPTION
Potential fix for [https://github.com/apache/airflow/security/code-scanning/519](https://github.com/apache/airflow/security/code-scanning/519)

To fix the problem, we should avoid logging the OAuth token in clear text. Instead, we can log that a token was retrieved, without including its value. If necessary for debugging, we could log only non-sensitive metadata (such as the type or length of the token), or redact the token value (e.g., log only the first few characters, or a hash). The best fix is to remove the token value from the log message entirely, replacing it with a generic message indicating that the token was accessed. This change should be made in the `oauth_token_getter` static method, specifically on line 2196. No new imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
