### PR TITLE
Change the interface by which Go tasks get access to variables etc.

### DIFF
--- a/go-sdk/.mockery.yml
+++ b/go-sdk/.mockery.yml
@@ -23,3 +23,6 @@ all: true
 recursive: true
 packages:
   github.com/apache/airflow/go-sdk:
+  github.com/apache/airflow/go-sdk/sdk:
+    config:
+      all: false

--- a/go-sdk/example/main.go
+++ b/go-sdk/example/main.go
@@ -56,9 +56,9 @@ func extract(ctx context.Context, log *slog.Logger) error {
 	return nil
 }
 
-func transform(ctx context.Context, log *slog.Logger) error {
+func transform(ctx context.Context, client sdk.Client, log *slog.Logger) error {
 	key := "my_variable"
-	val, err := sdk.VariableGet(ctx, key)
+	val, err := client.GetVariable(ctx, key)
 	if err != nil {
 		return err
 	}

--- a/go-sdk/example/main_test.go
+++ b/go-sdk/example/main_test.go
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package main
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/apache/airflow/go-sdk/sdk"
+)
+
+// This file serves as an example of how you could write unit tests against your own Go Tasks.
+// An example of how to write a test for a Task function!
+
+type mockVars struct{}
+
+// GetVariable implements sdk.VariableClient.
+func (m *mockVars) GetVariable(ctx context.Context, key string) (string, error) {
+	switch key {
+	case "my_variable":
+		return "value1", nil
+	default:
+		return "", sdk.VariableNotFound
+	}
+}
+
+// UnmarshalJSONVariable implements sdk.VariableClient.
+func (m *mockVars) UnmarshalJSONVariable(ctx context.Context, key string, pointer any) error {
+	panic("unimplemented")
+}
+
+var _ sdk.VariableClient = (*mockVars)(nil)
+
+func Test_transform(t *testing.T) {
+	log := slog.Default()
+	// This is not the best test, but it is a good proof of concept -- you can just call the function.
+	err := transform(context.Background(), &mockVars{}, log)
+	assert.NoError(t, err)
+}

--- a/go-sdk/sdk/client_test.go
+++ b/go-sdk/sdk/client_test.go
@@ -1,0 +1,100 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package sdk
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"resty.dev/v3"
+
+	"github.com/apache/airflow/go-sdk/pkg/api"
+	apiMock "github.com/apache/airflow/go-sdk/pkg/api/mocks"
+	"github.com/apache/airflow/go-sdk/pkg/sdkcontext"
+)
+
+type ClientSuite struct {
+	suite.Suite
+
+	apiClient       *apiMock.ClientInterface
+	variablesClient *apiMock.VariablesClient
+	ctx             context.Context
+}
+
+var AnyContext any = mock.MatchedBy(func(_ context.Context) bool { return true })
+
+func makeHTTPError(status int, statusMessage string) error {
+	return &api.GeneralHTTPError{
+		Response: &resty.Response{
+			RawResponse: &http.Response{
+				Status:     fmt.Sprintf("%d %s", status, statusMessage),
+				StatusCode: status,
+			},
+		},
+	}
+}
+
+func TestClientSuite(t *testing.T) {
+	suite.Run(t, &ClientSuite{})
+}
+
+func (s *ClientSuite) SetupTest() {
+	c := apiMock.NewClientInterface(s.T())
+	vars := apiMock.NewVariablesClient(s.T())
+	c.EXPECT().Variables().Maybe().Return(vars)
+
+	s.apiClient = c
+	s.variablesClient = vars
+	s.ctx = context.WithValue(context.Background(), sdkcontext.ApiClientContextKey, c)
+}
+
+func (s *ClientSuite) TestGetVariable() {
+	key := "my_var"
+	expected := `some"raw"value`
+	s.variablesClient.EXPECT().
+		Get(AnyContext, key).
+		Return(&api.VariableResponse{Value: &expected}, nil)
+
+	c := &client{}
+	val, err := c.GetVariable(s.ctx, key)
+	s.Require().NoError(err)
+	s.Assert().Equal(expected, val)
+}
+
+func (s *ClientSuite) TestGetVariable_404Error() {
+	key := "my_var"
+	s.variablesClient.EXPECT().Get(AnyContext, key).Return(nil, makeHTTPError(404, "Not Found"))
+
+	c := &client{}
+	_, err := c.GetVariable(s.ctx, key)
+	s.Assert().ErrorContainsf(err, `variable not found: "my_var"`, "")
+}
+
+func (s *ClientSuite) TestGetVariable_EnvFirst() {
+	s.T().Setenv("AIRFLOW_VAR_MY_VAR", "value1")
+
+	c := &client{}
+	val, err := c.GetVariable(s.ctx, "my_var")
+	s.Require().NoError(err)
+	s.Assert().Equal("value1", val)
+	s.variablesClient.AssertNotCalled(s.T(), "Get")
+}

--- a/go-sdk/sdk/errors.go
+++ b/go-sdk/sdk/errors.go
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package sdk
+
+import (
+	"errors"
+)
+
+// VariableNotFound is an error value used to signal that a variable could not be found (and that there were
+// no communication issues to the API server.
+//
+// See the “GetVariable“ method of [VariableClient] for an example
+var VariableNotFound = errors.New("variable not found")

--- a/go-sdk/sdk/errors.go
+++ b/go-sdk/sdk/errors.go
@@ -22,7 +22,7 @@ import (
 )
 
 // VariableNotFound is an error value used to signal that a variable could not be found (and that there were
-// no communication issues to the API server.
+// no communication issues to the API server).
 //
 // See the “GetVariable“ method of [VariableClient] for an example
 var VariableNotFound = errors.New("variable not found")

--- a/go-sdk/sdk/sdk.go
+++ b/go-sdk/sdk/sdk.go
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/*
+Package sdk provides access to the Airflow objects (Variables, Connection, XCom etc) during run time for tasks.
+*/
+package sdk
+
+import (
+	"context"
+)
+
+const (
+	VariableEnvPrefix   = "AIRFLOW_VAR_"
+	ConnectionEnvPrefix = "AIRFLOW_CONN_"
+)
+
+type VariableClient interface {
+	// GetVariable returns the value of an Airflow Variable.
+	//
+	// It will first look in the os.environ for the appropriately named variable, and if not found there will
+	// fallback to asking the API server
+	//
+	// If the variable is not found error will be a wrapped ``VariableNotFound``:
+	//
+	//		val, err := client.GetVariable(ctx, "my-var")
+	//		if errors.Is(err, VariableNotFound) {
+	//				// Handle not found, set default, return custom error etc
+	//		} else {
+	//				// Other errors here, such as http network timeouts etc.
+	//		}
+	GetVariable(ctx context.Context, key string) (string, error)
+	UnmarshalJSONVariable(ctx context.Context, key string, pointer any) error
+}
+
+type Client interface {
+	VariableClient
+}


### PR DESCRIPTION
The previous approach (of a module function, and pulling the API client out of
context) was sort of thrown together, but on coming back to it with fresh eyes
I didn't like it for a couple of reasons:

1. It makes it harder to library consumers (i.e. Go task authors) to write
   unit tests of their task functions.

   Instead of being able to simply call the function with a mock that
   implements the right interface, they would have had to create a mock of the
   API client (which is lower level) and then put that in the context under
   the right Key -- all of which is too tightly coupled to the current
   implementation and shouldn't be exposed to users.

2. It was essentially using global variables.

   Now, we are still pulling the HTTP API client out of the Context, but that
   could very easily be changed in future to be stored as a field on the
   `client` struct.

3. By having the function accept an argument of Client interface it is much
   clearer what the function needs, and what it's doing.

   It is already an accepted pattern in Python that task functions get called
   with values for function arguments of "special" names (`ti` for example in
   python), so this is not a new pattern for us. This is similar to how
   Temporal support [passing arguments][1] to Activities (= our Tasks)

This PR doesn't introduce any new features, but sets us up to be add
Connection and XCom support in a future PR.

[1]: https://docs.temporal.io/develop/go/core-application#activity-parameters
