### PR TITLE
Fix Graph View for DAGs with mapped operators

### DIFF
--- a/airflow-core/src/airflow/utils/dag_edges.py
+++ b/airflow-core/src/airflow/utils/dag_edges.py
@@ -18,13 +18,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, TypeAlias, cast
 
+from airflow.models.mappedoperator import MappedOperator
 from airflow.sdk.definitions._internal.abstractoperator import AbstractOperator
 from airflow.serialization.serialized_objects import SerializedBaseOperator
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    from airflow.models.mappedoperator import MappedOperator
     from airflow.sdk import DAG
 
     Operator: TypeAlias = MappedOperator | SerializedBaseOperator
@@ -65,7 +65,7 @@ def dag_edges(dag: DAG):
 
     def collect_edges(task_group):
         """Update edges_to_add and edges_to_skip according to TaskGroups."""
-        if isinstance(task_group, (AbstractOperator, SerializedBaseOperator)):
+        if isinstance(task_group, (AbstractOperator, SerializedBaseOperator, MappedOperator)):
             return
 
         for target_id in task_group.downstream_group_ids:

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_structure.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_structure.py
@@ -654,3 +654,71 @@ class TestStructureDataEndpoint:
             response.json()["detail"]
             == "Dag with id dag_with_multiple_versions and version number 999 was not found"
         )
+
+    def test_mapped_operator_graph_view(self, dag_maker, test_client, session):
+        """
+        Ensures structure_data endpoint handles MappedOperator without AttributeError.
+        """
+        from airflow.providers.standard.operators.bash import BashOperator
+
+        with dag_maker(
+            dag_id="test_mapped_operator_dag",
+            serialized=True,
+            session=session,
+            start_date=pendulum.DateTime(2023, 2, 1, 0, 0, 0, tzinfo=pendulum.UTC),
+        ):
+            task1 = EmptyOperator(task_id="task1")
+            mapped_task = BashOperator.partial(
+                task_id="mapped_bash_task",
+                do_xcom_push=False,
+            ).expand(bash_command=["echo 1", "echo 2", "echo 3"])
+            task2 = EmptyOperator(task_id="task2")
+
+            task1 >> mapped_task >> task2
+
+        dag_maker.sync_dagbag_to_db()
+        response = test_client.get("/structure/structure_data", params={"dag_id": "test_mapped_operator_dag"})
+        assert response.status_code == 200
+        data = response.json()
+
+        mapped_node = next(node for node in data["nodes"] if node["id"] == "mapped_bash_task")
+        assert mapped_node["is_mapped"] is True
+        assert mapped_node["operator"] == "BashOperator"
+        assert len(data["edges"]) == 2
+
+    def test_mapped_operator_in_task_group(self, dag_maker, test_client, session):
+        """
+        Test that mapped operators within task groups are handled correctly.
+        Specifically tests task_group_to_dict function with MappedOperator instances.
+        """
+        from airflow.providers.standard.operators.python import PythonOperator
+        from airflow.sdk.definitions.taskgroup import TaskGroup
+
+        with dag_maker(
+            dag_id="test_mapped_in_group_dag",
+            serialized=True,
+            session=session,
+            start_date=pendulum.DateTime(2023, 2, 1, 0, 0, 0, tzinfo=pendulum.UTC),
+        ):
+            with TaskGroup(group_id="processing_group"):
+                prep = EmptyOperator(task_id="prep")
+                mapped = PythonOperator.partial(
+                    task_id="process",
+                    python_callable=lambda x: print(f"Processing {x}"),
+                ).expand(op_args=[[1], [2], [3], [4]])
+
+                prep >> mapped
+
+        dag_maker.sync_dagbag_to_db()
+        response = test_client.get("/structure/structure_data", params={"dag_id": "test_mapped_in_group_dag"})
+
+        assert response.status_code == 200
+        data = response.json()
+        group_node = next(node for node in data["nodes"] if node["id"] == "processing_group")
+        assert group_node["children"] is not None
+
+        mapped_in_group = next(
+            child for child in group_node["children"] if child["id"] == "processing_group.process"
+        )
+        assert mapped_in_group["is_mapped"] is True
+        assert mapped_in_group["operator"] == "PythonOperator"

--- a/task-sdk/src/airflow/sdk/definitions/taskgroup.py
+++ b/task-sdk/src/airflow/sdk/definitions/taskgroup.py
@@ -686,11 +686,11 @@ def get_task_group_children_getter() -> Callable:
 
 def task_group_to_dict(task_item_or_group, parent_group_is_mapped=False):
     """Create a nested dict representation of this TaskGroup and its children used to construct the Graph."""
+    from airflow.models.mappedoperator import MappedOperator
     from airflow.sdk.definitions._internal.abstractoperator import AbstractOperator
-    from airflow.sdk.definitions.mappedoperator import MappedOperator
     from airflow.serialization.serialized_objects import SerializedBaseOperator
 
-    if isinstance(task := task_item_or_group, (AbstractOperator, SerializedBaseOperator)):
+    if isinstance(task := task_item_or_group, (AbstractOperator, SerializedBaseOperator, MappedOperator)):
         node_operator = {
             "id": task.task_id,
             "label": task.label,


### PR DESCRIPTION
__closes: #54753__
closes #54665

## Problem Description

The Airflow UI Graph View fails to display DAGs containing dynamically mapped operators (created with `.expand()`). When users try to view such DAGs in the Graph View, the page fails to load and shows a 500 Internal Server Error due to cascading errors in the UI rendering pipeline.

## Errors Observed

__First Error:__

```javascript
AttributeError: 'MappedOperator' object has no attribute 'topological_sort'
INFO: GET /ui/structure/structure_data?dag_id=integration_test HTTP/1.1" 500 Internal Server Error
```

__Subsequent Error (after fixing the first):__

```javascript
AttributeError: 'MappedOperator' object has no attribute 'downstream_group_ids'. Did you mean: 'downstream_task_ids'?
```

Both errors occur because `MappedOperator` instances are incorrectly treated as `TaskGroup` objects throughout the UI rendering pipeline, causing the system to call TaskGroup-specific methods that don't exist on `MappedOperator`.

## Proposed Solution

Updated both functions to properly recognize `MappedOperator` as a task-like object rather than a TaskGroup. These changes ensure `MappedOperator` instances are handled consistently as tasks throughout the entire UI rendering pipeline, preventing both the initial error and subsequent cascading failures.

## Testing

<img width="729" height="271" alt="Screenshot 2025-08-20 at 4 51 45 PM" src="https://github.com/user-attachments/assets/44e3f92d-113c-4ed7-9d3a-cef8f5a4bd40" />

- Verified Graph View now displays correctly for DAGs with mapped operators
- Tested with example DAGs containing `task.expand()` operations

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
