### PR TITLE
Adding validation for missing connection type while constructing connections

### DIFF
--- a/task-sdk/src/airflow/sdk/definitions/connection.py
+++ b/task-sdk/src/airflow/sdk/definitions/connection.py
@@ -257,6 +257,12 @@ class Connection:
     @classmethod
     def from_json(cls, value, conn_id=None) -> Connection:
         kwargs = json.loads(value)
+        conn_type = kwargs.get("conn_type", None)
+        if not conn_type:
+            raise ValueError(
+                "Connection type (conn_type) is required but missing from connection configuration. "
+                "Please add 'conn_type' field to your connection definition."
+            )
         extra = kwargs.pop("extra", None)
         if extra:
             kwargs["extra"] = extra if isinstance(extra, str) else json.dumps(extra)

--- a/task-sdk/tests/task_sdk/definitions/test_connections.py
+++ b/task-sdk/tests/task_sdk/definitions/test_connections.py
@@ -190,6 +190,23 @@ class TestConnections:
         assert connection.host == "localhost"
         assert connection.port == 5432
 
+    def test_from_json_missing_conn_type(self):
+        """Test that missing conn_type throws an error while using from_json."""
+        import re
+
+        json_data = {
+            "host": "localhost",
+            "port": "5432",
+        }
+
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "Connection type (conn_type) is required but missing from connection configuration. Please add 'conn_type' field to your connection definition."
+            ),
+        ):
+            Connection.from_json(json.dumps(json_data), conn_id="test_conn")
+
     def test_extra_dejson_property(self, patched_secrets_masker):
         """Test that extra_dejson property correctly deserializes JSON extra field."""
         connection = Connection(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

On a similar vein as https://github.com/apache/airflow/pull/54681, after merging the recent change: https://github.com/apache/airflow/pull/53870, `conn_type` is a mandatory field and it would be nice to have a better error thrown to users instead of the non friendly:
```
FAILED providers/git/tests/unit/git/bundles/test_git.py::TestGitDagBundle::test_repo_url_access_missing_connection_doesnt_error[my_test_git-GitHook] - TypeError: Connection.__init__() missing 2 required positional arguments: 'conn_id' and 'conn_type'
```

When in fact the conn_id is present.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
