### PR TITLE
Fix trigger rule error messages showing enum names instead of values

### DIFF
--- a/airflow-core/src/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow-core/src/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -475,7 +475,7 @@ class TriggerRuleDep(BaseTIDep):
                 if success <= 0:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{trigger_rule.value}' requires one upstream task success, "
+                            f"Task's trigger rule '{getattr(trigger_rule, 'value', trigger_rule)}' requires one upstream task success, "
                             f"but none were found. upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
                         )
@@ -484,7 +484,7 @@ class TriggerRuleDep(BaseTIDep):
                 if not failed and not upstream_failed:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{trigger_rule.value}' requires one upstream task failure, "
+                            f"Task's trigger rule '{getattr(trigger_rule, 'value', trigger_rule)}' requires one upstream task failure, "
                             f"but none were found. upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
                         )
@@ -493,7 +493,7 @@ class TriggerRuleDep(BaseTIDep):
                 if success + failed <= 0:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{trigger_rule.value}' "
+                            f"Task's trigger rule '{getattr(trigger_rule, 'value', trigger_rule)}' "
                             "requires at least one upstream task failure or success "
                             f"but none were failed or success. upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -506,7 +506,7 @@ class TriggerRuleDep(BaseTIDep):
                 if num_failures > 0:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{trigger_rule.value}' requires all upstream tasks to have "
+                            f"Task's trigger rule '{getattr(trigger_rule, 'value', trigger_rule)}' requires all upstream tasks to have "
                             f"succeeded, but found {num_failures} non-success(es). "
                             f"upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -519,7 +519,7 @@ class TriggerRuleDep(BaseTIDep):
                 if num_success > 0:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{trigger_rule.value}' requires all upstream tasks "
+                            f"Task's trigger rule '{getattr(trigger_rule, 'value', trigger_rule)}' requires all upstream tasks "
                             f"to have failed, but found {num_success} non-failure(s). "
                             f"upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -529,7 +529,7 @@ class TriggerRuleDep(BaseTIDep):
                 if not upstream_done:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{trigger_rule.value}' requires all upstream tasks to have "
+                            f"Task's trigger rule '{getattr(trigger_rule, 'value', trigger_rule)}' requires all upstream tasks to have "
                             f"completed, but found {len(upstream_tasks) - done} task(s) that were "
                             f"not done. upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -542,7 +542,7 @@ class TriggerRuleDep(BaseTIDep):
                 if num_failures > 0:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{trigger_rule.value}' requires all upstream tasks to have "
+                            f"Task's trigger rule '{getattr(trigger_rule, 'value', trigger_rule)}' requires all upstream tasks to have "
                             f"succeeded or been skipped, but found {num_failures} non-success(es). "
                             f"upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -552,7 +552,7 @@ class TriggerRuleDep(BaseTIDep):
                 if not upstream_done or (skipped > 0):
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{trigger_rule.value}' requires all upstream tasks to not "
+                            f"Task's trigger rule '{getattr(trigger_rule, 'value', trigger_rule)}' requires all upstream tasks to not "
                             f"have been skipped, but found {skipped} task(s) skipped. "
                             f"upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -563,7 +563,7 @@ class TriggerRuleDep(BaseTIDep):
                 if num_non_skipped > 0:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{trigger_rule.value}' requires all upstream tasks to have been "
+                            f"Task's trigger rule '{getattr(trigger_rule, 'value', trigger_rule)}' requires all upstream tasks to have been "
                             f"skipped, but found {num_non_skipped} task(s) in non skipped state. "
                             f"upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -573,7 +573,7 @@ class TriggerRuleDep(BaseTIDep):
                 if not upstream_done:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{trigger_rule.value}' requires all upstream tasks to have "
+                            f"Task's trigger rule '{getattr(trigger_rule, 'value', trigger_rule)}' requires all upstream tasks to have "
                             f"completed, but found {len(upstream_tasks) - done} task(s) that were not done. "
                             f"upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -582,7 +582,7 @@ class TriggerRuleDep(BaseTIDep):
                 elif upstream_setup and not success_setup:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{trigger_rule.value}' requires at least one upstream setup task "
+                            f"Task's trigger rule '{getattr(trigger_rule, 'value', trigger_rule)}' requires at least one upstream setup task "
                             f"be successful, but found {upstream_setup - success_setup} task(s) that were "
                             f"not. upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -599,7 +599,7 @@ class TriggerRuleDep(BaseTIDep):
                 if skipped > 0:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{trigger_rule.value}' requires all non-skipped upstream tasks to have "
+                            f"Task's trigger rule '{getattr(trigger_rule, 'value', trigger_rule)}' requires all non-skipped upstream tasks to have "
                             f"completed, but found {skipped} skipped task(s). "
                             f"upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -608,7 +608,7 @@ class TriggerRuleDep(BaseTIDep):
                 elif non_skipped_done < non_skipped_upstream:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{trigger_rule.value}' requires all non-skipped upstream tasks to have "
+                            f"Task's trigger rule '{getattr(trigger_rule, 'value', trigger_rule)}' requires all non-skipped upstream tasks to have "
                             f"completed, but found {non_skipped_upstream - non_skipped_done} task(s) that were not done. "
                             f"upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -617,7 +617,7 @@ class TriggerRuleDep(BaseTIDep):
                 elif success == 0:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{trigger_rule.value}' requires all non-skipped upstream tasks to have "
+                            f"Task's trigger rule '{getattr(trigger_rule, 'value', trigger_rule)}' requires all non-skipped upstream tasks to have "
                             f"completed and at least one upstream task has succeeded, but found "
                             f"{success} successful task(s). upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"

--- a/airflow-core/src/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow-core/src/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -624,7 +624,6 @@ class TriggerRuleDep(BaseTIDep):
                         )
                     )
             else:
-                print("true rule not implemented:", trigger_rule)
                 yield self._failing_status(
                     reason=f"No strategy to evaluate trigger rule '{getattr(trigger_rule, 'value', trigger_rule)}'."
                 )

--- a/airflow-core/src/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow-core/src/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -475,7 +475,7 @@ class TriggerRuleDep(BaseTIDep):
                 if success <= 0:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{trigger_rule}' requires one upstream task success, "
+                            f"Task's trigger rule '{trigger_rule.value}' requires one upstream task success, "
                             f"but none were found. upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
                         )
@@ -484,7 +484,7 @@ class TriggerRuleDep(BaseTIDep):
                 if not failed and not upstream_failed:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{trigger_rule}' requires one upstream task failure, "
+                            f"Task's trigger rule '{trigger_rule.value}' requires one upstream task failure, "
                             f"but none were found. upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
                         )
@@ -493,7 +493,7 @@ class TriggerRuleDep(BaseTIDep):
                 if success + failed <= 0:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{trigger_rule}' "
+                            f"Task's trigger rule '{trigger_rule.value}' "
                             "requires at least one upstream task failure or success "
                             f"but none were failed or success. upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -506,7 +506,7 @@ class TriggerRuleDep(BaseTIDep):
                 if num_failures > 0:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{trigger_rule}' requires all upstream tasks to have "
+                            f"Task's trigger rule '{trigger_rule.value}' requires all upstream tasks to have "
                             f"succeeded, but found {num_failures} non-success(es). "
                             f"upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -519,7 +519,7 @@ class TriggerRuleDep(BaseTIDep):
                 if num_success > 0:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{trigger_rule}' requires all upstream tasks "
+                            f"Task's trigger rule '{trigger_rule.value}' requires all upstream tasks "
                             f"to have failed, but found {num_success} non-failure(s). "
                             f"upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -529,7 +529,7 @@ class TriggerRuleDep(BaseTIDep):
                 if not upstream_done:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{trigger_rule}' requires all upstream tasks to have "
+                            f"Task's trigger rule '{trigger_rule.value}' requires all upstream tasks to have "
                             f"completed, but found {len(upstream_tasks) - done} task(s) that were "
                             f"not done. upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -542,7 +542,7 @@ class TriggerRuleDep(BaseTIDep):
                 if num_failures > 0:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{trigger_rule}' requires all upstream tasks to have "
+                            f"Task's trigger rule '{trigger_rule.value}' requires all upstream tasks to have "
                             f"succeeded or been skipped, but found {num_failures} non-success(es). "
                             f"upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -552,7 +552,7 @@ class TriggerRuleDep(BaseTIDep):
                 if not upstream_done or (skipped > 0):
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{trigger_rule}' requires all upstream tasks to not "
+                            f"Task's trigger rule '{trigger_rule.value}' requires all upstream tasks to not "
                             f"have been skipped, but found {skipped} task(s) skipped. "
                             f"upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -563,7 +563,7 @@ class TriggerRuleDep(BaseTIDep):
                 if num_non_skipped > 0:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{trigger_rule}' requires all upstream tasks to have been "
+                            f"Task's trigger rule '{trigger_rule.value}' requires all upstream tasks to have been "
                             f"skipped, but found {num_non_skipped} task(s) in non skipped state. "
                             f"upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -573,7 +573,7 @@ class TriggerRuleDep(BaseTIDep):
                 if not upstream_done:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{trigger_rule}' requires all upstream tasks to have "
+                            f"Task's trigger rule '{trigger_rule.value}' requires all upstream tasks to have "
                             f"completed, but found {len(upstream_tasks) - done} task(s) that were not done. "
                             f"upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -582,7 +582,7 @@ class TriggerRuleDep(BaseTIDep):
                 elif upstream_setup and not success_setup:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{trigger_rule}' requires at least one upstream setup task "
+                            f"Task's trigger rule '{trigger_rule.value}' requires at least one upstream setup task "
                             f"be successful, but found {upstream_setup - success_setup} task(s) that were "
                             f"not. upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -599,7 +599,7 @@ class TriggerRuleDep(BaseTIDep):
                 if skipped > 0:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{trigger_rule}' requires all non-skipped upstream tasks to have "
+                            f"Task's trigger rule '{trigger_rule.value}' requires all non-skipped upstream tasks to have "
                             f"completed, but found {skipped} skipped task(s). "
                             f"upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -608,7 +608,7 @@ class TriggerRuleDep(BaseTIDep):
                 elif non_skipped_done < non_skipped_upstream:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{trigger_rule}' requires all non-skipped upstream tasks to have "
+                            f"Task's trigger rule '{trigger_rule.value}' requires all non-skipped upstream tasks to have "
                             f"completed, but found {non_skipped_upstream - non_skipped_done} task(s) that were not done. "
                             f"upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -617,14 +617,17 @@ class TriggerRuleDep(BaseTIDep):
                 elif success == 0:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{trigger_rule}' requires all non-skipped upstream tasks to have "
+                            f"Task's trigger rule '{trigger_rule.value}' requires all non-skipped upstream tasks to have "
                             f"completed and at least one upstream task has succeeded, but found "
                             f"{success} successful task(s). upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
                         )
                     )
             else:
-                yield self._failing_status(reason=f"No strategy to evaluate trigger rule '{trigger_rule}'.")
+                print("true rule not implemented:", trigger_rule)
+                yield self._failing_status(
+                    reason=f"No strategy to evaluate trigger rule '{getattr(trigger_rule, 'value', trigger_rule)}'."
+                )
 
         if TYPE_CHECKING:
             assert ti.task


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


Main's broken with errors like:
```
FAILED airflow-core/tests/unit/ti_deps/deps/test_trigger_rule_dep.py::TestTriggerRuleDepSetupConstraint::test_setup_constraint_will_fail_or_skip_fast[skipped-skipped] - assert False
 +  where False = <built-in method startswith of str object at 0xffc9b0b154d0>("Task's trigger rule 'all_success' requires")
 +    where <built-in method startswith of str object at 0xffc9b0b154d0> = "Task's trigger rule 'TriggerRule.ALL_SUCCESS' requires all upstream tasks to have succeeded, but found 2 non-success(...d=1, failed=0, upstream_failed=0, removed=0, done=1, success_setup=0, skipped_setup=1), upstream_task_ids={'s2', 's1'}".startswith
 +      where "Task's trigger rule 'TriggerRule.ALL_SUCCESS' requires all upstream tasks to have succeeded, but found 2 non-success(...d=1, failed=0, upstream_failed=0, removed=0, done=1, success_setup=0, skipped_setup=1), upstream_task_ids={'s2', 's1'}" = TIDepStatus(dep_name='Trigger Rule', passed=False, reason="Task's trigger rule 'TriggerRule.ALL_SUCCESS' requires all ...=1, failed=0, upstream_failed=0, removed=0, done=1, success_setup=0, skipped_setup=1), upstream_task_ids={'s2', 's1'}").reason
```

Example: https://github.com/apache/airflow/actions/runs/17122995052/job/48568924487

Due to recent merge of: https://github.com/apache/airflow/pull/53389, i wonder why no test caught this.

Just replaced all the occurecnes with `getattr`, reason being:

* task-sdk TriggerRule has no `__str__`, therefore, f"{trigger_rule}" → "TriggerRule.ALL_SUCCESS"
* airflow-core TriggerRule has `__str__` and it behaves like f"{trigger_rule}" → "all_success"

That's why getattr(trigger_rule, 'value', trigger_rule) works for all cases:
Enum objects: Uses .value => "all_success"
String objects: Falls back to string => "unknown_status"


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
