### PR TITLE
Retry on 409 conflict

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -373,7 +373,7 @@ class KubernetesExecutor(BaseExecutor):
                 except ApiException as e:
                     body = json.loads(e.body)
                     retries = self.task_publish_retries[key]
-                    # In case of exceeded quota errors, requeue the task as per the task_publish_max_retries
+                    # In case of exceeded quota or conflict errors, requeue the task as per the task_publish_max_retries
                     if (
                         (str(e.status) == "403" and "exceeded quota" in body["message"])
                         or (str(e.status) == "409" and "object has been modified" in body["message"])

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -377,8 +377,7 @@ class KubernetesExecutor(BaseExecutor):
                     if (
                         (str(e.status) == "403" and "exceeded quota" in body["message"])
                         or (str(e.status) == "409" and "object has been modified" in body["message"])
-                        and (self.task_publish_max_retries == -1 or retries < self.task_publish_max_retries)
-                    ):
+                    ) and (self.task_publish_max_retries == -1 or retries < self.task_publish_max_retries):
                         self.log.warning(
                             "[Try %s of %s] Kube ApiException for Task: (%s). Reason: %r. Message: %s",
                             self.task_publish_retries[key] + 1,

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -375,8 +375,8 @@ class KubernetesExecutor(BaseExecutor):
                     retries = self.task_publish_retries[key]
                     # In case of exceeded quota errors, requeue the task as per the task_publish_max_retries
                     if (
-                        str(e.status) == "403"
-                        and "exceeded quota" in body["message"]
+                        (str(e.status) == "403" and "exceeded quota" in body["message"])
+                        or (str(e.status) == "409" and "object has been modified" in body["message"])
                         and (self.task_publish_max_retries == -1 or retries < self.task_publish_max_retries)
                     ):
                         self.log.warning(

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -373,6 +373,13 @@ class TestKubernetesExecutor:
                 State.FAILED,
                 id="12345 fake-unhandled-reason (task_publish_max_retries=1) (retry failed)",
             ),
+            pytest.param(
+                HTTPResponse(body='{"message": "the object has been modified; please apply your changes to the latest version and try again"}', status=409),
+                1,
+                True,
+                State.SUCCESS,
+                id="409 conflict",
+            ),
         ],
     )
     @mock.patch("airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils.KubernetesJobWatcher")

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -374,7 +374,10 @@ class TestKubernetesExecutor:
                 id="12345 fake-unhandled-reason (task_publish_max_retries=1) (retry failed)",
             ),
             pytest.param(
-                HTTPResponse(body='{"message": "the object has been modified; please apply your changes to the latest version and try again"}', status=409),
+                HTTPResponse(
+                    body='{"message": "the object has been modified; please apply your changes to the latest version and try again"}',
+                    status=409,
+                ),
                 1,
                 True,
                 State.SUCCESS,


### PR DESCRIPTION
When running Airflow with the KubernetesExecutor (4 schedulers, kubernetes.worker_pods_creation_batch_size=16), pod creation occasionally fails with:

`Pod creation failed with reason 'Conflict'`


This happens because the namespace has a ResourceQuota. When multiple pods are created simultaneously, the quota controller must update the ResourceQuota object to reflect new usage. Concurrent updates cause a 409 Conflict, and the admission of some pods fails. As a result, the corresponding Airflow tasks are marked as failed even though there are still available resources under the quota.

This PR addresses the issue by adding a retry mechanism for pod creation when a 409 Conflict is encountered, ensuring tasks are not marked as failed due to transient quota update conflicts.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
