### PR TITLE
feature: Add OpenLineage support for pubsub create subscription operator - include inputs into OL

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/operators/pubsub.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/pubsub.py
@@ -409,13 +409,20 @@ class PubSubCreateSubscriptionOperator(GoogleCloudBaseOperator):
         from airflow.providers.common.compat.openlineage.facet import Dataset
         from airflow.providers.openlineage.extractors import OperatorLineage
 
-        project_id = self.subscription_project_id or self.project_id or self.pubsub_hook.project_id
+        topic_project_id = self.project_id or self.pubsub_hook.project_id
+        subscription_project_id = self.subscription_project_id or topic_project_id
 
-        output_dataset = [
-            Dataset(namespace="pubsub", name=f"subscription:{project_id}:{self._resolved_subscription_name}")
-        ]
-
-        return OperatorLineage(outputs=output_dataset)
+        return OperatorLineage(
+            inputs=[
+                Dataset(namespace="pubsub", name=f"topic:{topic_project_id}:{self.topic}")
+            ],
+            outputs=[
+                Dataset(
+                    namespace="pubsub",
+                    name=f"subscription:{subscription_project_id}:{self._resolved_subscription_name}"
+                )
+            ],
+        )
 
 
 class PubSubDeleteTopicOperator(GoogleCloudBaseOperator):

--- a/providers/google/src/airflow/providers/google/cloud/operators/pubsub.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/pubsub.py
@@ -413,13 +413,11 @@ class PubSubCreateSubscriptionOperator(GoogleCloudBaseOperator):
         subscription_project_id = self.subscription_project_id or topic_project_id
 
         return OperatorLineage(
-            inputs=[
-                Dataset(namespace="pubsub", name=f"topic:{topic_project_id}:{self.topic}")
-            ],
+            inputs=[Dataset(namespace="pubsub", name=f"topic:{topic_project_id}:{self.topic}")],
             outputs=[
                 Dataset(
                     namespace="pubsub",
-                    name=f"subscription:{subscription_project_id}:{self._resolved_subscription_name}"
+                    name=f"subscription:{subscription_project_id}:{self._resolved_subscription_name}",
                 )
             ],
         )

--- a/providers/google/tests/unit/google/cloud/operators/test_pubsub.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_pubsub.py
@@ -207,33 +207,54 @@ class TestPubSubSubscriptionCreateOperator:
         assert response == TEST_SUBSCRIPTION
 
     @pytest.mark.parametrize(
-        "subscription, project_id, subscription_project_id, expected_dataset",
+        "project_id, subscription, subscription_project_id, expected_input, expected_output",
         [
-            # 1. Subscription provided, project_id provided, subscription_project_id not provided
-            (TEST_SUBSCRIPTION, TEST_PROJECT, None, f"subscription:{TEST_PROJECT}:{TEST_SUBSCRIPTION}"),
-            # 2. Subscription provided, subscription_project_id provided
             (
-                TEST_SUBSCRIPTION,
                 TEST_PROJECT,
+                TEST_SUBSCRIPTION,
+                None,
+                f"topic:{TEST_PROJECT}:{TEST_TOPIC}",
+                f"subscription:{TEST_PROJECT}:{TEST_SUBSCRIPTION}",
+            ),
+            (
+                TEST_PROJECT,
+                TEST_SUBSCRIPTION,
                 "another-project",
+                f"topic:{TEST_PROJECT}:{TEST_TOPIC}",
                 f"subscription:another-project:{TEST_SUBSCRIPTION}",
             ),
-            # 3. Subscription not provided (generated), project_id provided
-            (None, TEST_PROJECT, None, f"subscription:{TEST_PROJECT}:generated"),
-            # 4. Subscription not provided, subscription_project_id provided
-            (None, TEST_PROJECT, "another-project", "subscription:another-project:generated"),
-            # 5. Neither subscription nor project_id provided (use project_id from connection)
-            (None, None, None, "subscription:connection-project:generated"),
+            (
+                TEST_PROJECT,
+                None,
+                None,
+                f"topic:{TEST_PROJECT}:{TEST_TOPIC}",
+                f"subscription:{TEST_PROJECT}:generated",
+            ),
+            (
+                TEST_PROJECT,
+                None,
+                "another-project",
+                f"topic:{TEST_PROJECT}:{TEST_TOPIC}",
+                "subscription:another-project:generated",
+            ),
+            (
+                None,
+                None,
+                None,
+                f"topic:connection-project:{TEST_TOPIC}",
+                "subscription:connection-project:generated",
+            ),
         ],
     )
     @mock.patch("airflow.providers.google.cloud.operators.pubsub.PubSubHook")
     def test_get_openlineage_facets(
         self,
         mock_hook,
-        subscription,
         project_id,
+        subscription,
         subscription_project_id,
-        expected_dataset,
+        expected_input,
+        expected_output,
     ):
         operator = PubSubCreateSubscriptionOperator(
             task_id=TASK_ID,
@@ -243,7 +264,7 @@ class TestPubSubSubscriptionCreateOperator:
             subscription_project_id=subscription_project_id,
         )
         mock_hook.return_value.create_subscription.return_value = subscription or "generated"
-        mock_hook.return_value.project_id = subscription_project_id or project_id or "connection-project"
+        mock_hook.return_value.project_id = project_id or "connection-project"
         context = mock.MagicMock()
         response = operator.execute(context=context)
         mock_hook.return_value.create_subscription.assert_called_once_with(
@@ -275,10 +296,12 @@ class TestPubSubSubscriptionCreateOperator:
         result = operator.get_openlineage_facets_on_complete(operator)
         assert not result.run_facets
         assert not result.job_facets
-        assert len(result.inputs) == 0
+        assert len(result.inputs) == 1
+        assert result.inputs[0].namespace == "pubsub"
+        assert result.inputs[0].name == expected_input
         assert len(result.outputs) == 1
         assert result.outputs[0].namespace == "pubsub"
-        assert result.outputs[0].name == expected_dataset
+        assert result.outputs[0].name == expected_output
 
 
 class TestPubSubSubscriptionDeleteOperator:


### PR DESCRIPTION
This PR adds inputs in OpenLineage for PubSubCreateSubscriptionOperator.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
