### PR TITLE
fix: Outgoing graph edges should exit opposite of incoming edges

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/Graph/useGraphLayout.ts
+++ b/airflow-core/src/airflow/ui/src/components/Graph/useGraphLayout.ts
@@ -164,6 +164,7 @@ const generateElkGraph = ({
         label: node.label,
         layoutOptions: {
           "elk.padding": "[top=80,left=15,bottom=15,right=15]",
+          "elk.portConstraints": "FIXED_SIDE",
         },
       };
     }
@@ -214,6 +215,7 @@ const generateElkGraph = ({
       isGroup: Boolean(node.children),
       isMapped: node.is_mapped === null ? undefined : node.is_mapped,
       label: node.label,
+      layoutOptions: { "elk.portConstraints": "FIXED_SIDE" },
       operator: node.operator,
       setupTeardownType: node.setup_teardown_type,
       type: node.type,


### PR DESCRIPTION
Outgoing edges from collapsed task groups do not always originate from the side of the graph node that opposes the destination of incoming edges.  For example:  In a left-to-right layout, predecessor edges should have a destination on the left side of the node while successor edges should originate on the right side of the node.  This constraint is not enforced, so there are cases in which incoming and outgoing edges on a task group may be destined and originate from the same side of the node.  When rendered, this depicts two edges between two nodes with no directionality, given the absence of end markers.

For example, note the edges between tg1 and tg2:
<img width="300"  alt="image" src="https://github.com/user-attachments/assets/85c757aa-ca5c-49e2-96d7-3f92b5a91f53" />

This fix applies port constraints to ensure edges enter and exit from opposing sides of task group nodes in all orientations:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/25d62d77-1ea4-44c6-968f-6514717efae5" />

Alternative proposal (not in this commit) could include the use of edge markers for directional clarity and shorter edge paths:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/3bfb1b8c-fba2-422e-91e9-42863b4b79f0" />

Code to reproduce this issue:
```
from typing import Any
import pendulum

from airflow.sdk import dag, task, task_group

@dag(
    dag_id="port_test",
    start_date=pendulum.datetime(2025,1,1,tz="US/Eastern"),
    schedule=None,
)
def _dag() -> None:
    _tasks: dict[str, Any] = {}

    @task_group
    def tg0() -> None:
        @task
        def start() -> None:
            pass

        _tasks['start'] = start()

    @task_group
    def tg1() -> None:
        @task
        def tg1_task1() -> None:
            pass

        @task
        def tg1_task2() -> None:
            pass

        @task
        def tg1_task3() -> None:
            pass

        _tasks['tg1_task1'] = tg1_task1()
        _tasks['tg1_task2'] = tg1_task2()
        _tasks['tg1_task3'] = tg1_task3()


    @task_group
    def tg2() -> None:
        @task
        def tg2_task1() -> None:
            pass

        @task
        def tg2_task2() -> None:
            pass
        
        @task
        def tg2_task3() -> None:
            pass


        _tasks['tg2_task1'] = tg2_task1()
        _tasks['tg2_task2'] = tg2_task2()
        _tasks['tg2_task3'] = tg2_task3()

    @task_group
    def tg3() -> None:
        @task
        def end() -> None:
            pass
        _tasks['end'] = end()

    tg0()
    tg1()
    tg2()
    tg3()

    _tasks['start'] >> [_tasks['tg1_task1'],_tasks['tg1_task2']]
    _tasks['tg1_task1'] >> _tasks['tg2_task1']
    _tasks['tg1_task2'] >> _tasks['tg2_task2']
    _tasks['tg2_task2'] >> _tasks['tg1_task3']
    _tasks['tg1_task3'] >> _tasks['tg2_task3']
    [_tasks['tg2_task1'], _tasks['tg2_task3']] >> _tasks['end']

_dag()
```