### PR TITLE
Improve test maintainability for supervisor request handling tests

### DIFF
--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -78,6 +78,7 @@ from airflow.sdk.execution_time.comms import (
     TaskRescheduleStartDate,
     TICount,
     UpdateHITLDetail,
+    XComCountResponse,
 )
 
 if TYPE_CHECKING:
@@ -414,7 +415,7 @@ class XComOperations:
     def __init__(self, client: Client):
         self.client = client
 
-    def head(self, dag_id: str, run_id: str, task_id: str, key: str) -> int:
+    def head(self, dag_id: str, run_id: str, task_id: str, key: str) -> XComCountResponse:
         """Get the number of mapped XCom values."""
         resp = self.client.head(f"xcoms/{dag_id}/{run_id}/{task_id}/{key}")
 
@@ -423,7 +424,7 @@ class XComOperations:
             "map_indexes "
         ):
             raise RuntimeError(f"Unable to parse Content-Range header from HEAD {resp.request.url}")
-        return int(content_range[len("map_indexes ") :])
+        return XComCountResponse(len=int(content_range[len("map_indexes ") :]))
 
     def get(
         self,

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -113,7 +113,6 @@ from airflow.sdk.execution_time.comms import (
     TriggerDagRun,
     ValidateInletsAndOutlets,
     VariableResult,
-    XComCountResponse,
     XComResult,
     XComSequenceIndexResult,
     XComSequenceSliceResult,
@@ -1202,8 +1201,7 @@ class ActivitySubprocess(WatchedSubprocess):
             xcom_result = XComResult.from_xcom_response(xcom)
             resp = xcom_result
         elif isinstance(msg, GetXComCount):
-            xcom_count = self.client.xcoms.head(msg.dag_id, msg.run_id, msg.task_id, msg.key)
-            resp = XComCountResponse(len=xcom_count)
+            resp = self.client.xcoms.head(msg.dag_id, msg.run_id, msg.task_id, msg.key)
         elif isinstance(msg, GetXComSequenceItem):
             xcom = self.client.xcoms.get_sequence_item(
                 msg.dag_id, msg.run_id, msg.task_id, msg.key, msg.offset


### PR DESCRIPTION
Refactor large parametrized test from individual parameters to dataclass structure for better readability and maintainability. The test now uses a `RequestTestCase` dataclass instead of 7 separate parameters, making it much easier to add new test cases and understand existing ones.

This change makes the test suite more maintainable for developers working on the supervisor communication protocol.

All the existing tests have been ported over.

Tests:

```
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[get_connection] PASSED                                                                                      [  2%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[get_connection_with_password] PASSED                                                                        [  4%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[get_connection_with_alias] PASSED                                                                           [  7%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[get_variable] PASSED                                                                                        [  9%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[set_variable] PASSED                                                                                        [ 12%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[delete_variable] PASSED                                                                                     [ 14%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[patch_task_instance_to_deferred] PASSED                                                                     [ 17%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[patch_task_instance_to_up_for_reschedule] PASSED                                                            [ 19%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[get_xcom] PASSED                                                                                            [ 21%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[get_xcom_map_index] PASSED                                                                                  [ 24%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[get_xcom_not_found] PASSED                                                                                  [ 26%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[get_xcom_include_prior_dates] PASSED                                                                        [ 29%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[set_xcom] PASSED                                                                                            [ 31%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[set_xcom_with_map_index] PASSED                                                                             [ 34%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[set_xcom_with_map_index_and_mapped_length] PASSED                                                           [ 36%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[delete_xcom] PASSED                                                                                         [ 39%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[up_for_retry] PASSED                                                                                        [ 41%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[set_rtif] PASSED                                                                                            [ 43%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[succeed_task] PASSED                                                                                        [ 46%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[get_asset_by_name] PASSED                                                                                   [ 48%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[get_asset_by_uri] PASSED                                                                                    [ 51%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[get_asset_events_by_uri_and_name] PASSED                                                                    [ 53%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[get_asset_events_by_uri] PASSED                                                                             [ 56%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[get_asset_events_by_name] PASSED                                                                            [ 58%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[get_asset_events_by_asset_alias] PASSED                                                                     [ 60%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[validate_inlets_and_outlets] PASSED                                                                         [ 63%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[get_prev_successful_dagrun] PASSED                                                                          [ 65%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[dag_run_trigger] PASSED                                                                                     [ 68%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[dag_run_trigger_already_exists] PASSED                                                                      [ 70%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[get_dag_run_state] PASSED                                                                                   [ 73%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[get_previous_dagrun] PASSED                                                                                 [ 75%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[get_previous_dagrun_with_state] PASSED                                                                      [ 78%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[get_task_reschedule_start_date] PASSED                                                                      [ 80%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[get_ti_count] PASSED                                                                                        [ 82%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[get_dr_count] PASSED                                                                                        [ 85%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[get_task_states] PASSED                                                                                     [ 87%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[get_xcom_seq_item] PASSED                                                                                   [ 90%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[get_xcom_seq_item_not_found] PASSED                                                                         [ 92%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[get_xcom_seq_slice] PASSED                                                                                  [ 95%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[patch_task_instance_to_skipped] PASSED                                                                      [ 97%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[create_hitl_detail_payload] PASSED                                                                          [100%]
```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
