### PR TITLE
Refactor trigger rule string extraction in ``TriggerRuleDep``

### DIFF
--- a/airflow-core/src/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow-core/src/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -359,6 +359,7 @@ class TriggerRuleDep(BaseTIDep):
             task = ti.task
             upstream_tasks = {t.task_id: t for t in task.upstream_list}
             trigger_rule = task.trigger_rule
+            trigger_rule_str = getattr(trigger_rule, "value", trigger_rule)
 
             finished_upstream_tis = (
                 finished_ti
@@ -475,7 +476,7 @@ class TriggerRuleDep(BaseTIDep):
                 if success <= 0:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{getattr(trigger_rule, 'value', trigger_rule)}' requires one upstream task success, "
+                            f"Task's trigger rule '{trigger_rule_str}' requires one upstream task success, "
                             f"but none were found. upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
                         )
@@ -484,7 +485,7 @@ class TriggerRuleDep(BaseTIDep):
                 if not failed and not upstream_failed:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{getattr(trigger_rule, 'value', trigger_rule)}' requires one upstream task failure, "
+                            f"Task's trigger rule '{trigger_rule_str}' requires one upstream task failure, "
                             f"but none were found. upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
                         )
@@ -493,7 +494,7 @@ class TriggerRuleDep(BaseTIDep):
                 if success + failed <= 0:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{getattr(trigger_rule, 'value', trigger_rule)}' "
+                            f"Task's trigger rule '{trigger_rule_str}' "
                             "requires at least one upstream task failure or success "
                             f"but none were failed or success. upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -506,7 +507,7 @@ class TriggerRuleDep(BaseTIDep):
                 if num_failures > 0:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{getattr(trigger_rule, 'value', trigger_rule)}' requires all upstream tasks to have "
+                            f"Task's trigger rule '{trigger_rule_str}' requires all upstream tasks to have "
                             f"succeeded, but found {num_failures} non-success(es). "
                             f"upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -519,7 +520,7 @@ class TriggerRuleDep(BaseTIDep):
                 if num_success > 0:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{getattr(trigger_rule, 'value', trigger_rule)}' requires all upstream tasks "
+                            f"Task's trigger rule '{trigger_rule_str}' requires all upstream tasks "
                             f"to have failed, but found {num_success} non-failure(s). "
                             f"upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -529,7 +530,7 @@ class TriggerRuleDep(BaseTIDep):
                 if not upstream_done:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{getattr(trigger_rule, 'value', trigger_rule)}' requires all upstream tasks to have "
+                            f"Task's trigger rule '{trigger_rule_str}' requires all upstream tasks to have "
                             f"completed, but found {len(upstream_tasks) - done} task(s) that were "
                             f"not done. upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -542,7 +543,7 @@ class TriggerRuleDep(BaseTIDep):
                 if num_failures > 0:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{getattr(trigger_rule, 'value', trigger_rule)}' requires all upstream tasks to have "
+                            f"Task's trigger rule '{trigger_rule_str}' requires all upstream tasks to have "
                             f"succeeded or been skipped, but found {num_failures} non-success(es). "
                             f"upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -552,7 +553,7 @@ class TriggerRuleDep(BaseTIDep):
                 if not upstream_done or (skipped > 0):
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{getattr(trigger_rule, 'value', trigger_rule)}' requires all upstream tasks to not "
+                            f"Task's trigger rule '{trigger_rule_str}' requires all upstream tasks to not "
                             f"have been skipped, but found {skipped} task(s) skipped. "
                             f"upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -563,7 +564,7 @@ class TriggerRuleDep(BaseTIDep):
                 if num_non_skipped > 0:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{getattr(trigger_rule, 'value', trigger_rule)}' requires all upstream tasks to have been "
+                            f"Task's trigger rule '{trigger_rule_str}' requires all upstream tasks to have been "
                             f"skipped, but found {num_non_skipped} task(s) in non skipped state. "
                             f"upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -573,7 +574,7 @@ class TriggerRuleDep(BaseTIDep):
                 if not upstream_done:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{getattr(trigger_rule, 'value', trigger_rule)}' requires all upstream tasks to have "
+                            f"Task's trigger rule '{trigger_rule_str}' requires all upstream tasks to have "
                             f"completed, but found {len(upstream_tasks) - done} task(s) that were not done. "
                             f"upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -582,7 +583,7 @@ class TriggerRuleDep(BaseTIDep):
                 elif upstream_setup and not success_setup:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{getattr(trigger_rule, 'value', trigger_rule)}' requires at least one upstream setup task "
+                            f"Task's trigger rule '{trigger_rule_str}' requires at least one upstream setup task "
                             f"be successful, but found {upstream_setup - success_setup} task(s) that were "
                             f"not. upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -599,7 +600,7 @@ class TriggerRuleDep(BaseTIDep):
                 if skipped > 0:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{getattr(trigger_rule, 'value', trigger_rule)}' requires all non-skipped upstream tasks to have "
+                            f"Task's trigger rule '{trigger_rule_str}' requires all non-skipped upstream tasks to have "
                             f"completed, but found {skipped} skipped task(s). "
                             f"upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -608,7 +609,7 @@ class TriggerRuleDep(BaseTIDep):
                 elif non_skipped_done < non_skipped_upstream:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{getattr(trigger_rule, 'value', trigger_rule)}' requires all non-skipped upstream tasks to have "
+                            f"Task's trigger rule '{trigger_rule_str}' requires all non-skipped upstream tasks to have "
                             f"completed, but found {non_skipped_upstream - non_skipped_done} task(s) that were not done. "
                             f"upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -617,7 +618,7 @@ class TriggerRuleDep(BaseTIDep):
                 elif success == 0:
                     yield self._failing_status(
                         reason=(
-                            f"Task's trigger rule '{getattr(trigger_rule, 'value', trigger_rule)}' requires all non-skipped upstream tasks to have "
+                            f"Task's trigger rule '{trigger_rule_str}' requires all non-skipped upstream tasks to have "
                             f"completed and at least one upstream task has succeeded, but found "
                             f"{success} successful task(s). upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
@@ -625,7 +626,7 @@ class TriggerRuleDep(BaseTIDep):
                     )
             else:
                 yield self._failing_status(
-                    reason=f"No strategy to evaluate trigger rule '{getattr(trigger_rule, 'value', trigger_rule)}'."
+                    reason=f"No strategy to evaluate trigger rule '{trigger_rule_str}'."
                 )
 
         if TYPE_CHECKING:


### PR DESCRIPTION
Extract repeated `getattr(trigger_rule, 'value', trigger_rule)` pattern into a single variable `trigger_rule_str` to reduce duplication in error messages.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
