### PR TITLE
Remove duplicate "concurrency" from dag details

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dags.py
@@ -186,7 +186,11 @@ class DAGDetailsResponse(DAGResponse):
     @computed_field  # type: ignore[prop-decorator]
     @property
     def concurrency(self) -> int:
-        """Return max_active_tasks as concurrency."""
+        """
+        Return max_active_tasks as concurrency.
+
+        Deprecated: Use max_active_tasks instead.
+        """
         return self.max_active_tasks
 
     # Mypy issue https://github.com/python/mypy/issues/1362

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -9156,7 +9156,10 @@ components:
         concurrency:
           type: integer
           title: Concurrency
-          description: Return max_active_tasks as concurrency.
+          description: 'Return max_active_tasks as concurrency.
+
+
+            Deprecated: Use max_active_tasks instead.'
           readOnly: true
         latest_dag_version:
           anyOf:

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -1950,7 +1950,9 @@ export const $DAGDetailsResponse = {
         concurrency: {
             type: 'integer',
             title: 'Concurrency',
-            description: 'Return max_active_tasks as concurrency.',
+            description: `Return max_active_tasks as concurrency.
+
+Deprecated: Use max_active_tasks instead.`,
             readOnly: true
         },
         latest_dag_version: {

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -541,6 +541,8 @@ export type DAGDetailsResponse = {
     readonly file_token: string;
     /**
      * Return max_active_tasks as concurrency.
+     *
+     * Deprecated: Use max_active_tasks instead.
      */
     readonly concurrency: number;
     /**

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ar/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ar/common.json
@@ -45,7 +45,6 @@
   "dag_zero": "لا يوجد أي Dag",
   "dagDetails": {
     "catchup": "إلحاق",
-    "concurrency": "تزامن",
     "dagRunTimeout": "مهلة تشغيل الDag",
     "defaultArgs": "متغيرات افتراضية",
     "description": "وصف",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/de/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/de/common.json
@@ -25,7 +25,6 @@
   "dag_other": "Dags",
   "dagDetails": {
     "catchup": "Nachgeholt",
-    "concurrency": "Parallelität",
     "dagRunTimeout": "Dag Lauf Zeitüberschreitung",
     "defaultArgs": "Standard-Parameter",
     "description": "Beschreibung",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
@@ -25,7 +25,6 @@
   "dag_other": "Dags",
   "dagDetails": {
     "catchup": "Catchup",
-    "concurrency": "Concurrency",
     "dagRunTimeout": "Dag Run Timeout",
     "defaultArgs": "Default Args",
     "description": "Description",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/es/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/es/common.json
@@ -24,7 +24,6 @@
   "dag_other": "Dags",
   "dagDetails": {
     "catchup": "Catchup",
-    "concurrency": "Concurrencia",
     "dagRunTimeout": "Tiempo de Ejecución del Dag",
     "defaultArgs": "Argumentos por Defecto",
     "description": "Descripción",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/common.json
@@ -23,7 +23,6 @@
   "dag_other": "Dags",
   "dagDetails": {
     "catchup": "Rattrapage",
-    "concurrency": "Concurrence",
     "dagRunTimeout": "Délai d'exécution du Dag",
     "defaultArgs": "Arguments par défaut",
     "description": "Description",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/he/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/he/common.json
@@ -25,7 +25,6 @@
   "dag_other": "Dags",
   "dagDetails": {
     "catchup": "השלמה אוטומטית",
-    "concurrency": "מספר הרצות מקבילות",
     "dagRunTimeout": "זמן תפוגה להרצת Dag",
     "defaultArgs": "פרמטרי ברירת מחדל",
     "description": "תיאור",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/common.json
@@ -25,7 +25,6 @@
   "dag_other": "Dags",
   "dagDetails": {
     "catchup": "캐치업",
-    "concurrency": "동시 샐행 수",
     "dagRunTimeout": "Dag 실행 제한 시간",
     "defaultArgs": "기본 인자",
     "description": "설명",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/nl/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/nl/common.json
@@ -25,7 +25,6 @@
   "dag_other": "Dags",
   "dagDetails": {
     "catchup": "Catchup",
-    "concurrency": "Concurrency",
     "dagRunTimeout": "Dag Run timeout",
     "defaultArgs": "Standaard argumenten",
     "description": "Omschrijving",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/common.json
@@ -35,7 +35,6 @@
   "dag_other": "Dagi",
   "dagDetails": {
     "catchup": "Nadrabianie zaległości",
-    "concurrency": "Współbieżność",
     "dagRunTimeout": "Limit czasu wykonania",
     "defaultArgs": "Domyślne argumenty",
     "description": "Opis",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/tr/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/tr/common.json
@@ -25,7 +25,6 @@
   "dag_other": "Dag'ler",
   "dagDetails": {
     "catchup": "Yakalama",
-    "concurrency": "Eş Zamanlılık",
     "dagRunTimeout": "Dag Çalıştırma Zaman Aşımı",
     "defaultArgs": "Varsayılan Argümanlar",
     "description": "Açıklama",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/common.json
@@ -25,7 +25,6 @@
   "dag_other": "Dags",
   "dagDetails": {
     "catchup": "自動回填",
-    "concurrency": "並行數",
     "dagRunTimeout": "Dag 執行超時",
     "defaultArgs": "預設參數",
     "description": "描述",

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Details.tsx
@@ -97,10 +97,6 @@ export const Details = () => {
               </Table.Cell>
             </Table.Row>
             <Table.Row>
-              <Table.Cell>{translate("dagDetails.concurrency")}</Table.Cell>
-              <Table.Cell>{dag.concurrency}</Table.Cell>
-            </Table.Row>
-            <Table.Row>
               <Table.Cell>{translate("dagDetails.hasTaskConcurrencyLimits")}</Table.Cell>
               <Table.Cell>{dag.has_task_concurrency_limits.toString()}</Table.Cell>
             </Table.Row>

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -1252,7 +1252,11 @@ class DAGDetailsResponse(BaseModel):
     owner_links: Annotated[dict[str, str] | None, Field(title="Owner Links")] = None
     file_token: Annotated[str, Field(description="Return file token.", title="File Token")]
     concurrency: Annotated[
-        int, Field(description="Return max_active_tasks as concurrency.", title="Concurrency")
+        int,
+        Field(
+            description="Return max_active_tasks as concurrency.\n\nDeprecated: Use max_active_tasks instead.",
+            title="Concurrency",
+        ),
     ]
     latest_dag_version: Annotated[
         DagVersionResponse | None, Field(description="Return the latest DagVersion.")


### PR DESCRIPTION
"Concurrency" is [the same](https://github.com/apache/airflow/blob/b48260dff095f4ddc4657a5c6714588cb3ec61d9/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dags.py#L185-L190) as "Max Active Tasks", but is less clear what it actually means, so I've removed it.

<img width="567" height="318" alt="Screenshot 2025-08-21 at 2 27 11 PM" src="https://github.com/user-attachments/assets/2f1af8c1-18f4-44b1-ac55-0fc0fddd42a7" />


New deprecation warning in api docs:
<img width="617" height="100" alt="Screenshot 2025-08-22 at 1 51 43 PM" src="https://github.com/user-attachments/assets/8c8bf226-d6f7-4746-803c-d724f4984a5a" />

