### PR TITLE
Fix `external_python` task failure when ``expect_airflow=False``

### DIFF
--- a/providers/standard/src/airflow/providers/standard/operators/python.py
+++ b/providers/standard/src/airflow/providers/standard/operators/python.py
@@ -1076,7 +1076,7 @@ class ExternalPythonOperator(_BasePythonVirtualenvOperator):
 
     def _iter_serializable_context_keys(self):
         yield from self.BASE_SERIALIZABLE_CONTEXT_KEYS
-        if self._get_airflow_version_from_target_env():
+        if self.expect_airflow and self._get_airflow_version_from_target_env():
             yield from self.AIRFLOW_SERIALIZABLE_CONTEXT_KEYS
             yield from self.PENDULUM_SERIALIZABLE_CONTEXT_KEYS
         elif self._is_pendulum_installed_in_target_env():

--- a/providers/standard/tests/unit/standard/operators/test_python.py
+++ b/providers/standard/tests/unit/standard/operators/test_python.py
@@ -1781,6 +1781,28 @@ class TestExternalPythonOperator(BaseTestPythonVirtualenvOperator):
             assert "Something went wrong" in caplog.text
             assert "returned non-zero exit status" in caplog.text
 
+    @mock.patch.object(ExternalPythonOperator, "_get_airflow_version_from_target_env")
+    def test_iter_serializable_context_keys_respects_expect_airflow_false(self, mock_get_airflow_version):
+        """Test that when expect_airflow=False, _get_airflow_version_from_target_env is not called."""
+
+        def f():
+            return 42
+
+        op = ExternalPythonOperator(
+            python_callable=f, task_id="task", python=sys.executable, expect_airflow=False
+        )
+
+        keys = set(op._iter_serializable_context_keys())
+
+        mock_get_airflow_version.assert_not_called()
+
+        # BASE keys should always be present
+        base_keys = set(op.BASE_SERIALIZABLE_CONTEXT_KEYS)
+        airflow_keys = set(op.AIRFLOW_SERIALIZABLE_CONTEXT_KEYS)
+
+        assert base_keys <= keys
+        assert not (airflow_keys & keys), "Airflow keys should not be present when expect_airflow=False"
+
 
 class BaseTestBranchPythonVirtualenvOperator(BaseTestPythonVirtualenvOperator):
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
Resolves issue where `@task.external_python` with `expect_airflow=False` would throw exceptions in Airflow 3.0.4+ when Airflow was not installed in the target environment, breaking functionality that worked in Airflow 2.9.1.

The `ExternalPythonOperator` now respects the `expect_airflow` flag and skips Airflow version checking when `expect_airflow=False`, preventing exceptions and allowing tasks to run successfully in environments without Airflow.

Closes https://github.com/apache/airflow/issues/54766

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
