### PR TITLE
Fix XCom ``include_prior_dates`` API versioning coverage

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2025_08_10.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2025_08_10.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from cadwyn import ResponseInfo, VersionChange, convert_response_to_previous_version_for, endpoint, schema
 
 from airflow.api_fastapi.execution_api.datamodels.taskinstance import DagRun, TIRunContext
-from airflow.api_fastapi.execution_api.routes.xcoms import GetXComSliceFilterParams
+from airflow.api_fastapi.execution_api.routes.xcoms import GetXcomFilterParams, GetXComSliceFilterParams
 
 
 class AddDagRunStateFieldAndPreviousEndpoint(VersionChange):
@@ -41,10 +41,11 @@ class AddDagRunStateFieldAndPreviousEndpoint(VersionChange):
 
 
 class AddIncludePriorDatesToGetXComSlice(VersionChange):
-    """Add the `include_prior_dates` field to GetXComSliceFilterParams."""
+    """Add the `include_prior_dates` field to GetXComSliceFilterParams and GetXcomFilterParams."""
 
     description = __doc__
 
     instructions_to_migrate_to_previous_version = (
         schema(GetXComSliceFilterParams).field("include_prior_dates").didnt_exist,
+        schema(GetXcomFilterParams).field("include_prior_dates").didnt_exist,
     )


### PR DESCRIPTION
Extend `AddIncludePriorDatesToGetXComSlice` version change to include `GetXcomFilterParams` in addition to `GetXComSliceFilterParams`.

This ensures that the include_prior_dates field is properly handled in API version migrations for both XCom endpoints:
- GET /xcoms/{dag_id}/{run_id}/{task_id}/{key} (single XCom)
- GET /xcoms/{dag_id}/{run_id}/{task_id}/{key}/slice (XCom slice)

This was missed in https://github.com/apache/airflow/pull/53809

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
