### PR TITLE
Align cards with stretch when translation adds a line wrap

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/DagActions/RunBackfillForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DagActions/RunBackfillForm.tsx
@@ -187,7 +187,7 @@ const RunBackfillForm = ({ dag, onClose }: RunBackfillFormProps) => {
               <RadioCardLabel fontSize="md" fontWeight="semibold" mb={3}>
                 {translate("backfill.reprocessBehavior")}
               </RadioCardLabel>
-              <HStack>
+              <HStack align="stretch">
                 {reprocessBehaviors.map((item) => (
                   <RadioCardItem
                     colorPalette="blue"


### PR DESCRIPTION
I just noticed a small nit that radio selection cards are not strech-aligned in the trigger form for backfill if translated text is not same length... what is happening in German as one example.

Checked other cases, this was the only HStack where "stretch" was missing.

Before:
<img width="896" height="818" alt="image" src="https://github.com/user-attachments/assets/3b474cae-6590-4fb0-afa3-a38087647532" />

After:
<img width="896" height="818" alt="image" src="https://github.com/user-attachments/assets/b3924f69-2c8a-4a22-889f-cf73f5cdf3e7" />
