### PR TITLE
Improved observability of deadline callbacks

### DIFF
--- a/airflow-core/src/airflow/models/deadline.py
+++ b/airflow-core/src/airflow/models/deadline.py
@@ -86,6 +86,7 @@ class DeadlineCallbackState(str, Enum):
     """
 
     QUEUED = "queued"
+    RUNNING = "running"
     SUCCESS = "success"
     FAILED = "failed"
 
@@ -223,9 +224,11 @@ class Deadline(Base):
         if (status := event.payload.get(PAYLOAD_STATUS_KEY)) and status in {
             DeadlineCallbackState.SUCCESS,
             DeadlineCallbackState.FAILED,
+            DeadlineCallbackState.RUNNING,
         }:
-            self.trigger = None
-            self.callback_state = event.payload[PAYLOAD_STATUS_KEY]
+            self.callback_state = status
+            if status != DeadlineCallbackState.RUNNING:
+                self.trigger = None
             session.add(self)
         else:
             logger.error("Unexpected event received: %s", event.payload)

--- a/airflow-core/src/airflow/triggers/deadline.py
+++ b/airflow-core/src/airflow/triggers/deadline.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import logging
+import traceback
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -49,17 +50,21 @@ class DeadlineCallbackTrigger(BaseTrigger):
 
         try:
             callback = import_string(self.callback_path)
+            yield TriggerEvent({PAYLOAD_STATUS_KEY: DeadlineCallbackState.RUNNING})
             result = await callback(**self.callback_kwargs)
             log.info("Deadline callback completed with return value: %s", result)
             yield TriggerEvent({PAYLOAD_STATUS_KEY: DeadlineCallbackState.SUCCESS, PAYLOAD_BODY_KEY: result})
         except Exception as e:
             if isinstance(e, ImportError):
-                message = "Could not import deadline callback on the triggerer"
+                message = "Failed to import this deadline callback on the triggerer"
             elif isinstance(e, TypeError) and "await" in str(e):
-                message = "Deadline callback not awaitable"
+                message = "Failed to run this deadline callback because it is not awaitable"
             else:
-                message = "An error occurred while executing deadline callback"
-            log.exception("%s: %s", message, e)
+                message = "An error occurred during execution of this deadline callback"
+            log.exception("%s: %s; kwargs: %s\n%s", message, self.callback_path, self.callback_kwargs, e)
             yield TriggerEvent(
-                {PAYLOAD_STATUS_KEY: DeadlineCallbackState.FAILED, PAYLOAD_BODY_KEY: f"{message}: {e}"}
+                {
+                    PAYLOAD_STATUS_KEY: DeadlineCallbackState.FAILED,
+                    PAYLOAD_BODY_KEY: f"{message}: {traceback.format_exception(e)}",
+                }
             )

--- a/airflow-core/tests/unit/models/test_deadline.py
+++ b/airflow-core/tests/unit/models/test_deadline.py
@@ -236,6 +236,11 @@ class TestDeadline:
                 id="failed_event",
             ),
             pytest.param(
+                TriggerEvent({PAYLOAD_STATUS_KEY: DeadlineCallbackState.RUNNING}),
+                False,
+                id="running_event",
+            ),
+            pytest.param(
                 TriggerEvent({PAYLOAD_STATUS_KEY: DeadlineCallbackState.QUEUED, PAYLOAD_BODY_KEY: ""}),
                 False,
                 id="invalid_event",


### PR DESCRIPTION
- Add a new RUNNING state for Deadline callbacks
- Include tracebacks in failure `TriggerEvent`
- Make the exception message more clear
- Include details about the callback in the exception string

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
