### PR TITLE
Refactor Kubernetes Executor Types to NamedTuples

### DIFF
--- a/kubernetes-tests/tests/kubernetes_tests/test_kubernetes_executor.py
+++ b/kubernetes-tests/tests/kubernetes_tests/test_kubernetes_executor.py
@@ -24,6 +24,7 @@ import pytest
 if TYPE_CHECKING:
     from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import FailureDetails
 
+from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import KubernetesResults
 from kubernetes_tests.test_base import (
     EXECUTOR,
     BaseK8STest,  # isort:skip (needed to workaround isort bug)
@@ -138,14 +139,18 @@ class TestKubernetesExecutor(BaseK8STest):
         # Create a test task key
         task_key = TaskInstanceKey(dag_id="test_dag", task_id="test_task", run_id="test_run", try_number=1)
 
-        # Call _change_state with FAILED status and failure details
-        executor._change_state(
+        # Create KubernetesResults object
+        results = KubernetesResults(
             key=task_key,
             state=TaskInstanceState.FAILED,
             pod_name="test-pod",
             namespace="test-namespace",
+            resource_version="123",
             failure_details=failure_details,
         )
+
+        # Call _change_state with KubernetesResults object
+        executor._change_state(results)
 
         # Verify that the warning log was called with expected parameters
         mock_log.warning.assert_called_once_with(
@@ -181,14 +186,18 @@ class TestKubernetesExecutor(BaseK8STest):
         # Create a test task key
         task_key = TaskInstanceKey(dag_id="test_dag", task_id="test_task", run_id="test_run", try_number=1)
 
-        # Call _change_state with FAILED status but no failure details
-        executor._change_state(
+        # Create KubernetesResults object without failure details
+        results = KubernetesResults(
             key=task_key,
             state=TaskInstanceState.FAILED,
             pod_name="test-pod",
             namespace="test-namespace",
+            resource_version="123",
             failure_details=None,
         )
+
+        # Call _change_state with KubernetesResults object
+        executor._change_state(results)
 
         # Verify that the warning log was called with the correct parameters
         mock_log.warning.assert_called_once_with(
@@ -214,10 +223,18 @@ class TestKubernetesExecutor(BaseK8STest):
         # Create a test task key
         task_key = TaskInstanceKey(dag_id="test_dag", task_id="test_task", run_id="test_run", try_number=1)
 
-        # Call _change_state with SUCCESS status
-        executor._change_state(
-            key=task_key, state=TaskInstanceState.SUCCESS, pod_name="test-pod", namespace="test-namespace"
+        # Create KubernetesResults object with SUCCESS state
+        results = KubernetesResults(
+            key=task_key,
+            state=TaskInstanceState.SUCCESS,
+            pod_name="test-pod",
+            namespace="test-namespace",
+            resource_version="123",
+            failure_details=None,
         )
+
+        # Call _change_state with KubernetesResults object
+        executor._change_state(results)
 
         # Verify that no failure logs were called
         mock_log.error.assert_not_called()

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -67,6 +67,8 @@ from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types impor
     ADOPTED,
     POD_EXECUTOR_DONE_KEY,
     FailureDetails,
+    KubernetesJob,
+    KubernetesResults,
 )
 from airflow.providers.cncf.kubernetes.kube_config import KubeConfig
 from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import annotations_to_key
@@ -86,10 +88,6 @@ if TYPE_CHECKING:
     from airflow.executors import workloads
     from airflow.models.taskinstance import TaskInstance
     from airflow.models.taskinstancekey import TaskInstanceKey
-    from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import (
-        KubernetesJobType,
-        KubernetesResultsType,
-    )
     from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils import (
         AirflowKubernetesScheduler,
     )
@@ -157,8 +155,8 @@ class KubernetesExecutor(BaseExecutor):
     def __init__(self):
         self.kube_config = KubeConfig()
         self._manager = multiprocessing.Manager()
-        self.task_queue: Queue[KubernetesJobType] = self._manager.Queue()
-        self.result_queue: Queue[KubernetesResultsType] = self._manager.Queue()
+        self.task_queue: Queue[KubernetesJob] = self._manager.Queue()
+        self.result_queue: Queue[KubernetesResults] = self._manager.Queue()
         self.kube_scheduler: AirflowKubernetesScheduler | None = None
         self.kube_client: client.CoreV1Api | None = None
         self.scheduler_job_id: str | None = None
@@ -280,7 +278,7 @@ class KubernetesExecutor(BaseExecutor):
         else:
             pod_template_file = None
         self.event_buffer[key] = (TaskInstanceState.QUEUED, self.scheduler_job_id)
-        self.task_queue.put((key, command, kube_executor_config, pod_template_file))
+        self.task_queue.put(KubernetesJob(key, command, kube_executor_config, pod_template_file))
         # We keep a temporary local record that we've handled this so we don't
         # try and remove it from the QUEUED state while we process it
         self.last_handled[key] = time.time()
@@ -331,17 +329,22 @@ class KubernetesExecutor(BaseExecutor):
             while True:
                 results = self.result_queue.get_nowait()
                 try:
-                    key, state, pod_name, namespace, resource_version, failure_details = results
-                    last_resource_version[namespace] = resource_version
-                    self.log.info("Changing state of %s to %s", results, state)
+                    last_resource_version[results.namespace] = results.resource_version
+                    self.log.info("Changing state of %s to %s", results, results.state)
                     try:
-                        self._change_state(key, state, pod_name, namespace, failure_details)
+                        self._change_state(
+                            results.key,
+                            results.state,
+                            results.pod_name,
+                            results.namespace,
+                            results.failure_details,
+                        )
                     except Exception as e:
                         self.log.exception(
                             "Exception: %s when attempting to change state of %s to %s, re-queueing.",
                             e,
                             results,
-                            state,
+                            results.state,
                         )
                         self.result_queue.put(results)
                 finally:
@@ -362,7 +365,7 @@ class KubernetesExecutor(BaseExecutor):
                 task = self.task_queue.get_nowait()
 
                 try:
-                    key, command, kube_executor_config, pod_template_file = task
+                    key = task.key
                     self.kube_scheduler.run_next(task)
                     self.task_publish_retries.pop(key, None)
                 except PodReconciliationError as e:
@@ -391,11 +394,11 @@ class KubernetesExecutor(BaseExecutor):
                         self.task_publish_retries[key] = retries + 1
                     else:
                         self.log.error("Pod creation failed with reason %r. Failing task", e.reason)
-                        key, _, _, _ = task
+                        key = task.key
                         self.fail(key, e)
                         self.task_publish_retries.pop(key, None)
                 except PodMutationHookException as e:
-                    key, _, _, _ = task
+                    key = task.key
                     self.log.error(
                         "Pod Mutation Hook failed for the task %s. Failing task. Details: %s",
                         key,
@@ -734,18 +737,26 @@ class KubernetesExecutor(BaseExecutor):
                 results = self.result_queue.get_nowait()
                 self.log.warning("Executor shutting down, flushing results=%s", results)
                 try:
-                    key, state, pod_name, namespace, resource_version, failure_details = results
                     self.log.info(
-                        "Changing state of %s to %s : resource_version=%d", results, state, resource_version
+                        "Changing state of %s to %s : resource_version=%s",
+                        results,
+                        results.state,
+                        results.resource_version,
                     )
                     try:
-                        self._change_state(key, state, pod_name, namespace, failure_details)
+                        self._change_state(
+                            results.key,
+                            results.state,
+                            results.pod_name,
+                            results.namespace,
+                            results.failure_details,
+                        )
                     except Exception as e:
                         self.log.exception(
                             "Ignoring exception: %s when attempting to change state of %s to %s.",
                             e,
                             results,
-                            state,
+                            results.state,
                         )
                 finally:
                     self.result_queue.task_done()

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -332,13 +332,7 @@ class KubernetesExecutor(BaseExecutor):
                     last_resource_version[results.namespace] = results.resource_version
                     self.log.info("Changing state of %s to %s", results, results.state)
                     try:
-                        self._change_state(
-                            results.key,
-                            results.state,
-                            results.pod_name,
-                            results.namespace,
-                            results.failure_details,
-                        )
+                        self._change_state(results)
                     except Exception as e:
                         self.log.exception(
                             "Exception: %s when attempting to change state of %s to %s, re-queueing.",
@@ -411,15 +405,18 @@ class KubernetesExecutor(BaseExecutor):
     @provide_session
     def _change_state(
         self,
-        key: TaskInstanceKey,
-        state: TaskInstanceState | str | None,
-        pod_name: str,
-        namespace: str,
-        failure_details: FailureDetails | None = None,
+        results: KubernetesResults,
         session: Session = NEW_SESSION,
     ) -> None:
+        """Change state of the task based on KubernetesResults."""
         if TYPE_CHECKING:
             assert self.kube_scheduler
+
+        key = results.key
+        state = results.state
+        pod_name = results.pod_name
+        namespace = results.namespace
+        failure_details = results.failure_details
 
         if state == TaskInstanceState.FAILED:
             # Use pre-collected failure details from the watcher to avoid additional API calls
@@ -744,13 +741,7 @@ class KubernetesExecutor(BaseExecutor):
                         results.resource_version,
                     )
                     try:
-                        self._change_state(
-                            results.key,
-                            results.state,
-                            results.pod_name,
-                            results.namespace,
-                            results.failure_details,
-                        )
+                        self._change_state(results)
                     except Exception as e:
                         self.log.exception(
                             "Ignoring exception: %s when attempting to change state of %s to %s.",

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -66,7 +66,6 @@ from airflow.providers.cncf.kubernetes.exceptions import PodMutationHookExceptio
 from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import (
     ADOPTED,
     POD_EXECUTOR_DONE_KEY,
-    FailureDetails,
     KubernetesJob,
     KubernetesResults,
 )

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_types.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_types.py
@@ -45,7 +45,7 @@ class FailureDetails(TypedDict, total=False):
 class KubernetesResults(NamedTuple):
     """Results from Kubernetes task execution."""
 
-    key: TaskInstanceKey  # 使用字符串引用
+    key: TaskInstanceKey
     state: TaskInstanceState | str | None
     pod_name: str
     namespace: str

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_types.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_types.py
@@ -16,7 +16,14 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, TypedDict
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypedDict
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from airflow.models.taskinstance import TaskInstanceKey
+    from airflow.utils.state import TaskInstanceState
+
 
 ADOPTED = "adopted"
 
@@ -35,27 +42,45 @@ class FailureDetails(TypedDict, total=False):
     container_name: str | None
 
 
-if TYPE_CHECKING:
-    from collections.abc import Sequence
+class KubernetesResults(NamedTuple):
+    """Results from Kubernetes task execution."""
 
-    from airflow.models.taskinstance import TaskInstanceKey
-    from airflow.utils.state import TaskInstanceState
+    key: TaskInstanceKey  # 使用字符串引用
+    state: TaskInstanceState | str | None
+    pod_name: str
+    namespace: str
+    resource_version: str
+    failure_details: FailureDetails | None
 
-    # TODO: Remove after Airflow 2 support is removed
-    CommandType = Sequence[str]
 
-    # TaskInstance key, command, configuration, pod_template_file
-    KubernetesJobType = tuple[TaskInstanceKey, CommandType, Any, str | None]
+class KubernetesWatch(NamedTuple):
+    """Watch event data from Kubernetes pods."""
 
-    # key, pod state, pod_name, namespace, resource_version, failure_details
-    KubernetesResultsType = tuple[
-        TaskInstanceKey, TaskInstanceState | str | None, str, str, str, FailureDetails | None
-    ]
+    pod_name: str
+    namespace: str
+    state: TaskInstanceState | str | None
+    annotations: dict[str, str]
+    resource_version: str
+    failure_details: FailureDetails | None
 
-    # pod_name, namespace, pod state, annotations, resource_version, failure_details
-    KubernetesWatchType = tuple[
-        str, str, TaskInstanceState | str | None, dict[str, str], str, FailureDetails | None
-    ]
+
+# TODO: Remove after Airflow 2 support is removed
+CommandType = "Sequence[str]"
+
+
+class KubernetesJob(NamedTuple):
+    """Job definition for Kubernetes execution."""
+
+    key: TaskInstanceKey
+    command: Sequence[str]
+    kube_executor_config: Any
+    pod_template_file: str | None
+
+
+# Keep legacy type alias for backward compatibility
+KubernetesJobType = KubernetesJob
+KubernetesResultsType = KubernetesResults
+KubernetesWatchType = KubernetesWatch
 
 ALL_NAMESPACES = "ALL_NAMESPACES"
 POD_EXECUTOR_DONE_KEY = "airflow_executor_done"

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_types.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_types.py
@@ -77,11 +77,6 @@ class KubernetesJob(NamedTuple):
     pod_template_file: str | None
 
 
-# Keep legacy type alias for backward compatibility
-KubernetesJobType = KubernetesJob
-KubernetesResultsType = KubernetesResults
-KubernetesWatchType = KubernetesWatch
-
 ALL_NAMESPACES = "ALL_NAMESPACES"
 POD_EXECUTOR_DONE_KEY = "airflow_executor_done"
 

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_utils.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_utils.py
@@ -53,10 +53,6 @@ from airflow.utils.state import TaskInstanceState
 if TYPE_CHECKING:
     from kubernetes.client import Configuration, models as k8s
 
-    # Use type aliases for the runtime types
-    KubernetesResultsType = KubernetesResults
-    KubernetesWatchType = KubernetesWatch
-
 
 class ResourceVersion(metaclass=Singleton):
     """Singleton for tracking resourceVersion from Kubernetes."""

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_utils.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_utils.py
@@ -35,6 +35,9 @@ from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types impor
     POD_EXECUTOR_DONE_KEY,
     POD_REVOKED_KEY,
     FailureDetails,
+    KubernetesJob,
+    KubernetesResults,
+    KubernetesWatch,
 )
 from airflow.providers.cncf.kubernetes.kube_client import get_kube_client
 from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import (
@@ -50,11 +53,9 @@ from airflow.utils.state import TaskInstanceState
 if TYPE_CHECKING:
     from kubernetes.client import Configuration, models as k8s
 
-    from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import (
-        KubernetesJobType,
-        KubernetesResultsType,
-        KubernetesWatchType,
-    )
+    # Use type aliases for the runtime types
+    KubernetesResultsType = KubernetesResults
+    KubernetesWatchType = KubernetesWatch
 
 
 class ResourceVersion(metaclass=Singleton):
@@ -69,7 +70,7 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
     def __init__(
         self,
         namespace: str,
-        watcher_queue: Queue[KubernetesWatchType],
+        watcher_queue: Queue[KubernetesWatch],
         resource_version: str | None,
         scheduler_job_id: str,
         kube_config: Configuration,
@@ -217,7 +218,9 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
             # So, there is no change in the pod state.
             # However, need to free the executor slot from the current executor.
             self.log.info("Event: pod %s adopted, annotations: %s", pod_name, annotations_string)
-            self.watcher_queue.put((pod_name, namespace, ADOPTED, annotations, resource_version, None))
+            self.watcher_queue.put(
+                KubernetesWatch(pod_name, namespace, ADOPTED, annotations, resource_version, None)
+            )
         elif hasattr(pod.status, "reason") and pod.status.reason == "ProviderFailed":
             # Most likely this happens due to Kubernetes setup (virtual kubelet, virtual nodes, etc.)
             key = annotations_to_key(annotations=annotations)
@@ -229,7 +232,7 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
                 annotations_string,
             )
             self.watcher_queue.put(
-                (
+                KubernetesWatch(
                     pod_name,
                     namespace,
                     TaskInstanceState.FAILED,
@@ -277,7 +280,7 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
                                 task_key_str,
                             )
                             self.watcher_queue.put(
-                                (
+                                KubernetesWatch(
                                     pod_name,
                                     namespace,
                                     TaskInstanceState.FAILED,
@@ -306,7 +309,7 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
                 "Event: %s Failed, task: %s, annotations: %s", pod_name, task_key_str, annotations_string
             )
             self.watcher_queue.put(
-                (
+                KubernetesWatch(
                     pod_name,
                     namespace,
                     TaskInstanceState.FAILED,
@@ -317,7 +320,9 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
             )
         elif status == "Succeeded":
             self.log.info("Event: %s Succeeded, annotations: %s", pod_name, annotations_string)
-            self.watcher_queue.put((pod_name, namespace, None, annotations, resource_version, None))
+            self.watcher_queue.put(
+                KubernetesWatch(pod_name, namespace, None, annotations, resource_version, None)
+            )
         elif status == "Running":
             # deletion_timestamp is set by kube server when a graceful deletion is requested.
             # since kube server have received request to delete pod set TI state failed
@@ -328,7 +333,7 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
                     annotations_string,
                 )
                 self.watcher_queue.put(
-                    (
+                    KubernetesWatch(
                         pod_name,
                         namespace,
                         TaskInstanceState.FAILED,
@@ -466,7 +471,7 @@ class AirflowKubernetesScheduler(LoggingMixin):
     def __init__(
         self,
         kube_config: Any,
-        result_queue: Queue[KubernetesResultsType],
+        result_queue: Queue[KubernetesResults],
         kube_client: client.CoreV1Api,
         scheduler_job_id: str,
     ):
@@ -540,9 +545,12 @@ class AirflowKubernetesScheduler(LoggingMixin):
                 ResourceVersion().resource_version[namespace] = "0"
                 self.kube_watchers[namespace] = self._make_kube_watcher(namespace)
 
-    def run_next(self, next_job: KubernetesJobType) -> None:
+    def run_next(self, next_job: KubernetesJob) -> None:
         """Receives the next job to run, builds the pod, and creates it."""
-        key, command, kube_executor_config, pod_template_file = next_job
+        key = next_job.key
+        command = next_job.command
+        kube_executor_config = next_job.kube_executor_config
+        pod_template_file = next_job.pod_template_file
 
         dag_id, task_id, run_id, try_number, map_index = key
         if len(command) == 1:
@@ -660,19 +668,27 @@ class AirflowKubernetesScheduler(LoggingMixin):
                 finally:
                     self.watcher_queue.task_done()
 
-    def process_watcher_task(self, task: KubernetesWatchType) -> None:
+    def process_watcher_task(self, task: KubernetesWatch) -> None:
         """Process the task by watcher."""
-        pod_name, namespace, state, annotations, resource_version, failure_details = task
         self.log.debug(
             "Attempting to finish pod; pod_name: %s; state: %s; annotations: %s",
-            pod_name,
-            state,
-            annotations_for_logging_task_metadata(annotations),
+            task.pod_name,
+            task.state,
+            annotations_for_logging_task_metadata(task.annotations),
         )
-        key = annotations_to_key(annotations=annotations)
+        key = annotations_to_key(annotations=task.annotations)
         if key:
-            self.log.debug("finishing job %s - %s (%s)", key, state, pod_name)
-            self.result_queue.put((key, state, pod_name, namespace, resource_version, failure_details))
+            self.log.debug("finishing job %s - %s (%s)", key, task.state, task.pod_name)
+            self.result_queue.put(
+                KubernetesResults(
+                    key,
+                    task.state,
+                    task.pod_name,
+                    task.namespace,
+                    task.resource_version,
+                    task.failure_details,
+                )
+            )
 
     def _flush_watcher_queue(self) -> None:
         self.log.debug("Executor shutting down, watcher_queue approx. size=%d", self.watcher_queue.qsize())

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -38,7 +38,7 @@ from airflow.providers.cncf.kubernetes.executors.kubernetes_executor import (
 )
 from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import (
     ADOPTED,
-    KubernetesWatchType,
+    KubernetesWatch,
 )
 from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils import (
     AirflowKubernetesScheduler,
@@ -1493,7 +1493,7 @@ class TestKubernetesJobWatcher:
 
     def assert_watcher_queue_called_once_with_state(self, state):
         self.watcher.watcher_queue.put.assert_called_once_with(
-            KubernetesWatchType(
+            KubernetesWatch(
                 self.pod.metadata.name,
                 self.watcher.namespace,
                 state,
@@ -1730,7 +1730,7 @@ class TestKubernetesJobWatcher:
 
         self._run()
         self.watcher.watcher_queue.put.assert_called_once_with(
-            KubernetesWatchType(
+            KubernetesWatch(
                 self.pod.metadata.name,
                 self.watcher.namespace,
                 ADOPTED,

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -38,6 +38,7 @@ from airflow.providers.cncf.kubernetes.executors.kubernetes_executor import (
 )
 from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import (
     ADOPTED,
+    KubernetesResults,
     KubernetesWatch,
 )
 from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils import (
@@ -693,7 +694,8 @@ class TestKubernetesExecutor:
         try:
             key = TaskInstanceKey(dag_id="dag_id", task_id="task_id", run_id="run_id", try_number=1)
             executor.running = {key}
-            executor._change_state(key, State.RUNNING, "pod_name", "default")
+            results = KubernetesResults(key, State.RUNNING, "pod_name", "default", "resource_version", None)
+            executor._change_state(results)
             assert executor.event_buffer[key][0] == State.RUNNING
             assert executor.running == {key}
         finally:
@@ -711,7 +713,8 @@ class TestKubernetesExecutor:
         try:
             key = TaskInstanceKey(dag_id="dag_id", task_id="task_id", run_id="run_id", try_number=2)
             executor.running = {key}
-            executor._change_state(key, State.SUCCESS, "pod_name", "default")
+            results = KubernetesResults(key, State.SUCCESS, "pod_name", "default", "resource_version", None)
+            executor._change_state(results)
             assert executor.event_buffer[key][0] == State.SUCCESS
             assert executor.running == set()
             mock_delete_pod.assert_called_once_with(pod_name="pod_name", namespace="default")
@@ -736,7 +739,8 @@ class TestKubernetesExecutor:
         try:
             key = TaskInstanceKey(dag_id="dag_id", task_id="task_id", run_id="run_id", try_number=3)
             executor.running = {key}
-            executor._change_state(key, State.FAILED, "pod_id", "test-namespace")
+            results = KubernetesResults(key, State.FAILED, "pod_id", "test-namespace", "resource_version", None)
+            executor._change_state(results)
             assert executor.event_buffer[key][0] == State.FAILED
             assert executor.running == set()
             mock_delete_pod.assert_not_called()
@@ -768,7 +772,8 @@ class TestKubernetesExecutor:
             ti = create_task_instance(state=ti_state)
             key = ti.key
             executor.running = {key}
-            executor._change_state(key, None, "pod_name", "default")
+            results = KubernetesResults(key, None, "pod_name", "default", "resource_version", None)
+            executor._change_state(results)
             assert executor.event_buffer[key][0] == ti_state
             assert executor.running == set()
             mock_delete_pod.assert_called_once_with(pod_name="pod_name", namespace="default")
@@ -787,7 +792,8 @@ class TestKubernetesExecutor:
         try:
             key = TaskInstanceKey(dag_id="dag_id", task_id="task_id", run_id="run_id", try_number=2)
             executor.running = {key}
-            executor._change_state(key, ADOPTED, "pod_name", "default")
+            results = KubernetesResults(key, ADOPTED, "pod_name", "default", "resource_version", None)
+            executor._change_state(results)
             assert len(executor.event_buffer) == 0
             assert len(executor.running) == 0
             mock_delete_pod.assert_not_called()
@@ -803,7 +809,8 @@ class TestKubernetesExecutor:
         try:
             key = TaskInstanceKey(dag_id="dag_id", task_id="task_id", run_id="run_id", try_number=1)
             executor.running = set()
-            executor._change_state(key, State.SUCCESS, "pod_name", "default")
+            results = KubernetesResults(key, State.SUCCESS, "pod_name", "default", "resource_version", None)
+            executor._change_state(results)
             assert executor.event_buffer.get(key) is None
             assert executor.running == set()
         finally:
@@ -851,7 +858,8 @@ class TestKubernetesExecutor:
         try:
             key = TaskInstanceKey(dag_id="dag_id", task_id="task_id", run_id="run_id", try_number=2)
             executor.running = {key}
-            executor._change_state(key, State.SUCCESS, "pod_name", "test-namespace")
+            results = KubernetesResults(key, State.SUCCESS, "pod_name", "test-namespace", "resource_version", None)
+            executor._change_state(results)
             assert executor.event_buffer[key][0] == State.SUCCESS
             assert executor.running == set()
             mock_delete_pod.assert_not_called()
@@ -877,7 +885,8 @@ class TestKubernetesExecutor:
         try:
             key = TaskInstanceKey(dag_id="dag_id", task_id="task_id", run_id="run_id", try_number=2)
             executor.running = {key}
-            executor._change_state(key, State.FAILED, "pod_name", "test-namespace")
+            results = KubernetesResults(key, State.FAILED, "pod_name", "test-namespace", "resource_version", None)
+            executor._change_state(results)
             assert executor.event_buffer[key][0] == State.FAILED
             assert executor.running == set()
             mock_delete_pod.assert_called_once_with(pod_name="pod_name", namespace="test-namespace")

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -739,7 +739,9 @@ class TestKubernetesExecutor:
         try:
             key = TaskInstanceKey(dag_id="dag_id", task_id="task_id", run_id="run_id", try_number=3)
             executor.running = {key}
-            results = KubernetesResults(key, State.FAILED, "pod_id", "test-namespace", "resource_version", None)
+            results = KubernetesResults(
+                key, State.FAILED, "pod_id", "test-namespace", "resource_version", None
+            )
             executor._change_state(results)
             assert executor.event_buffer[key][0] == State.FAILED
             assert executor.running == set()
@@ -858,7 +860,9 @@ class TestKubernetesExecutor:
         try:
             key = TaskInstanceKey(dag_id="dag_id", task_id="task_id", run_id="run_id", try_number=2)
             executor.running = {key}
-            results = KubernetesResults(key, State.SUCCESS, "pod_name", "test-namespace", "resource_version", None)
+            results = KubernetesResults(
+                key, State.SUCCESS, "pod_name", "test-namespace", "resource_version", None
+            )
             executor._change_state(results)
             assert executor.event_buffer[key][0] == State.SUCCESS
             assert executor.running == set()
@@ -885,7 +889,9 @@ class TestKubernetesExecutor:
         try:
             key = TaskInstanceKey(dag_id="dag_id", task_id="task_id", run_id="run_id", try_number=2)
             executor.running = {key}
-            results = KubernetesResults(key, State.FAILED, "pod_name", "test-namespace", "resource_version", None)
+            results = KubernetesResults(
+                key, State.FAILED, "pod_name", "test-namespace", "resource_version", None
+            )
             executor._change_state(results)
             assert executor.event_buffer[key][0] == State.FAILED
             assert executor.running == set()

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -38,6 +38,7 @@ from airflow.providers.cncf.kubernetes.executors.kubernetes_executor import (
 )
 from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import (
     ADOPTED,
+    KubernetesWatchType,
 )
 from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils import (
     AirflowKubernetesScheduler,
@@ -1492,7 +1493,7 @@ class TestKubernetesJobWatcher:
 
     def assert_watcher_queue_called_once_with_state(self, state):
         self.watcher.watcher_queue.put.assert_called_once_with(
-            (
+            KubernetesWatchType(
                 self.pod.metadata.name,
                 self.watcher.namespace,
                 state,
@@ -1729,7 +1730,7 @@ class TestKubernetesJobWatcher:
 
         self._run()
         self.watcher.watcher_queue.put.assert_called_once_with(
-            (
+            KubernetesWatchType(
                 self.pod.metadata.name,
                 self.watcher.namespace,
                 ADOPTED,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
### Description
When working on #54115, a good suggestion from @HTErik that we should refactors the Kubernetes executor type to make for better readability. 
This PR refactors the Kubernetes executor type system by converting simple tuple aliases to structured `NamedTuple` classes.

### Changes Made
- Type System Improvements
  - `KubernetesResultsType` → `KubernetesResults` (NamedTuple)
  - `KubernetesWatchType` → `KubernetesWatch` (NamedTuple)
  - `KubernetesJobType` → `KubernetesJob` (NamedTuple)

- Code Updates
  - Updated `kubernetes_executor_types.py`: Define new NamedTuple classes with proper typing
  - Updated `kubernetes_executor_utils.py`: Modify usage patterns to work with NamedTuples
  - Updated `kubernetes_executor.py`: Refactor result handling logic for new type structure
  - Updated `test_kubernetes_executor.py`: Adjust test assertions to work with named fields



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
