### PR TITLE
Stabilising shared timezone tests and running them in CI

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -104,6 +104,24 @@ jobs:
       - name: "Run shared secrets masker tests"
         run: uv run --group dev pytest --color=yes
         working-directory: ./shared/secrets_masker/
+  tests-shared-timezones:
+    timeout-minutes: 10
+    name: Shared timezone tests
+    runs-on: ${{ fromJSON(inputs.runners) }}
+    steps:
+      - name: "Cleanup repo"
+        shell: bash
+        run: docker run -v "${GITHUB_WORKSPACE}:/workspace" -u 0:0 bash -c "rm -rf /workspace/*"
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          persist-credentials: false
+      - name: "Prepare and cleanup runner"
+        run: ./scripts/ci/prepare_and_cleanup_runner.sh
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
+      - name: "Run shared timezone tests"
+        run: uv run --group dev pytest --color=yes
+        working-directory: ./shared/timezones/
   tests-ui:
     timeout-minutes: 15
     name: React UI tests

--- a/shared/timezones/tests/conftest.py
+++ b/shared/timezones/tests/conftest.py
@@ -14,40 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
-[project]
-name = "apache-airflow-shared-timezones"
-description = "Shared timezone code for Airflow distributions"
-version = "0.0"
-classifiers = [
-    "Private :: Do Not Upload",
-]
+import os
 
-dependencies = [
-    "pendulum>=3.1.0",
-    "methodtools>=0.4.7",
-]
-
-[dependency-groups]
-dev = [
-    "apache-airflow-devel-common",
-]
-
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[tool.hatch.build.targets.wheel]
-packages = ["src/airflow_shared"]
-
-[tool.ruff]
-extend = "../../pyproject.toml"
-src = ["src"]
-
-[tool.ruff.lint.per-file-ignores]
-# Ignore Doc rules et al for anything outside of tests
-"!src/*" = ["D", "S101", "TRY002"]
-
-[tool.ruff.lint.flake8-tidy-imports]
-# Override the workspace level default
-ban-relative-imports = "parents"
+os.environ["_AIRFLOW__AS_LIBRARY"] = "true"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

The shared timezone tests had errors when I tried to run them independently (as they will when there is a separate distribution), fixing those errors and adding those tests in the CI to run as well.


Testing:

```
cd shared/timezones
➜  timezones git:(fix-tests-shared-timezone) ✗ uv sync                  
Resolved 866 packages in 13.23s
warning: The package `pandas==2.1.4` does not have an extra named `postgres`
      Built apache-airflow-shared-timezones @ file:///Users/amoghdesai/Documents/OSS/repos/airflow/shared/timezones
Prepared 1 package in 319ms
warning: Failed to uninstall package at /Users/amoghdesai/Documents/OSS/repos/airflow/.venv/lib/python3.13/site-packages/cfn_lint-1.38.2.dist-info due to missing `RECORD` file. Installation may result in an incomplete environment.
Uninstalled 2 packages in 1ms
Installed 3 packages in 3ms
 ~ apache-airflow-shared-timezones==0.0 (from file:///Users/amoghdesai/Documents/OSS/repos/airflow/shared/timezones)
 - cfn-lint==1.38.2
 + methodtools==0.4.7
 + wirerope==1.0.0
➜  timezones git:(fix-tests-shared-timezone) ✗ uv run pytest --color=yes
================================================================================================================================================ test session starts ================================================================================================================================================
platform darwin -- Python 3.13.3, pytest-8.4.1, pluggy-1.6.0 -- /Users/amoghdesai/Documents/OSS/repos/airflow/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /Users/amoghdesai/Documents/OSS/repos/airflow
configfile: pyproject.toml
plugins: unordered-0.7.0, instafail-0.5.0, timeouts-1.2.1, asyncio-1.1.0, xdist-3.8.0, custom-exit-code-0.3.0, icdiff-0.9, rerunfailures-15.1, cov-6.2.1, kgb-7.2, mock-3.14.1, time-machine-2.17.0, requests-mock-1.12.1
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
setup timeout: 0.0s, execution timeout: 0.0s, teardown timeout: 0.0s
collected 30 items                                                                                                                                                                                                                                                                                                  

tests/timezones/test_timezone.py::TestTimezone::test_is_aware PASSED                                                                                                                                                                                                                                          [  3%]
tests/timezones/test_timezone.py::TestTimezone::test_is_naive PASSED                                                                                                                                                                                                                                          [  6%]
tests/timezones/test_timezone.py::TestTimezone::test_utcnow PASSED                                                                                                                                                                                                                                            [ 10%]
tests/timezones/test_timezone.py::TestTimezone::test_convert_to_utc PASSED                                                                                                                                                                                                                                    [ 13%]
tests/timezones/test_timezone.py::TestTimezone::test_make_naive PASSED                                                                                                                                                                                                                                        [ 16%]
tests/timezones/test_timezone.py::TestTimezone::test_make_aware PASSED                                                                                                                                                                                                                                        [ 20%]
tests/timezones/test_timezone.py::TestTimezone::test_td_format PASSED                                                                                                                                                                                                                                         [ 23%]
tests/timezones/test_timezone.py::test_coerce_datetime[None datetime] PASSED                                                                                                                                                                                                                                  [ 26%]
tests/timezones/test_timezone.py::test_coerce_datetime[Non aware pendulum Datetime] PASSED                                                                                                                                                                                                                    [ 30%]
tests/timezones/test_timezone.py::test_coerce_datetime[Aware pendulum Datetime] PASSED                                                                                                                                                                                                                        [ 33%]
tests/timezones/test_timezone.py::test_coerce_datetime[Non aware datetime] PASSED                                                                                                                                                                                                                             [ 36%]
tests/timezones/test_timezone.py::test_coerce_datetime[Aware datetime] PASSED                                                                                                                                                                                                                                 [ 40%]
tests/timezones/test_timezone.py::test_parse_timezone_iana[CET] PASSED                                                                                                                                                                                                                                        [ 43%]
tests/timezones/test_timezone.py::test_parse_timezone_iana[EAT] PASSED                                                                                                                                                                                                                                        [ 46%]
tests/timezones/test_timezone.py::test_parse_timezone_iana[ICT] PASSED                                                                                                                                                                                                                                        [ 50%]
tests/timezones/test_timezone.py::test_parse_timezone_utc[utc] PASSED                                                                                                                                                                                                                                         [ 53%]
tests/timezones/test_timezone.py::test_parse_timezone_utc[UTC] PASSED                                                                                                                                                                                                                                         [ 56%]
tests/timezones/test_timezone.py::test_parse_timezone_utc[uTc] PASSED                                                                                                                                                                                                                                         [ 60%]
tests/timezones/test_timezone.py::test_parse_timezone_offset[zero-offset] PASSED                                                                                                                                                                                                                              [ 63%]
tests/timezones/test_timezone.py::test_parse_timezone_offset[1-hour-behind] PASSED                                                                                                                                                                                                                            [ 66%]
tests/timezones/test_timezone.py::test_parse_timezone_offset[5.5-hours-ahead] PASSED                                                                                                                                                                                                                          [ 70%]
tests/timezones/test_timezone.py::test_from_timestamp_utc[implicit] PASSED                                                                                                                                                                                                                                    [ 73%]
tests/timezones/test_timezone.py::test_from_timestamp_utc[explicit] PASSED                                                                                                                                                                                                                                    [ 76%]
tests/timezones/test_timezone.py::test_from_timestamp_utc[utc-literal] PASSED                                                                                                                                                                                                                                 [ 80%]
tests/timezones/test_timezone.py::test_from_timestamp_local[local] PASSED                                                                                                                                                                                                                                     [ 83%]
tests/timezones/test_timezone.py::test_from_timestamp_local[LOCAL] PASSED                                                                                                                                                                                                                                     [ 86%]
tests/timezones/test_timezone.py::test_from_timestamp_iana_timezones[pendulum-timezone] PASSED                                                                                                                                                                                                                [ 90%]
tests/timezones/test_timezone.py::test_from_timestamp_iana_timezones[IANA-timezone] PASSED                                                                                                                                                                                                                    [ 93%]
tests/timezones/test_timezone.py::test_from_timestamp_fixed_timezone[3600] PASSED                                                                                                                                                                                                                             [ 96%]
tests/timezones/test_timezone.py::test_from_timestamp_fixed_timezone[-7200] PASSED                                                                                                                                                                                                                            [100%]

=========================================================================================================================================== 30 passed, 1 warning in 0.50s ===========================================================================================================================================
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
