### PR TITLE
Fixing typo in upgrade checks CI script

### DIFF
--- a/scripts/ci/prek/upgrade_important_versions.py
+++ b/scripts/ci/prek/upgrade_important_versions.py
@@ -50,7 +50,7 @@ FILES_TO_UPDATE: list[tuple[Path, bool]] = [
         False,
     ),
     (AIRFLOW_ROOT_PATH / ".github" / "actions" / "install-prek" / "action.yml", False),
-    (AIRFLOW_ROOT_PATH / ".github" / "workflows" / "basic-test.yml", False),
+    (AIRFLOW_ROOT_PATH / ".github" / "workflows" / "basic-tests.yml", False),
     (AIRFLOW_ROOT_PATH / "dev" / "breeze" / "doc" / "ci" / "02_images.md", True),
     (AIRFLOW_ROOT_PATH / "dev" / "breeze" / "pyproject.toml", False),
     (AIRFLOW_ROOT_PATH / ".pre-commit-config.yaml", False),


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

CI fails with:
```
  Latest setuptools version: 80.9.0
  Latest Node LTS version: 22.18.0
  Latest hatch version: 1.14.1
  Latest PyYAML version: 6.0.2
  Latest GitPython version: 3.1.45
  Latest rich version: 14.1.0
  Updating /home/runner/work/airflow/airflow/.github/workflows/basic-test.yml
  Traceback (most recent call last):
    File "/home/runner/work/airflow/airflow/scripts/ci/prek/upgrade_important_versions.py", line 260, in <module>
      file_content = file.read_text()
    File "/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/pathlib.py", line 1134, in read_text
      with self.open(mode='r', encoding=encoding, errors=errors) as f:
    File "/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/pathlib.py", line 1119, in open
      return self._accessor.open(self, mode, buffering, encoding, errors,
  FileNotFoundError: [Errno 2] No such file or directory: '/home/runner/work/airflow/airflow/.github/workflows/basic-test.yml'
All changes made by hooks:
```

Example: https://github.com/apache/airflow/actions/runs/17176074490/job/48732154042

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
