### PR TITLE
Alias `task_display_name` for `XCom`

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/xcom.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/xcom.py
@@ -35,6 +35,7 @@ class XComResponse(BaseModel):
     dag_id: str
     run_id: str
     dag_display_name: str = Field(validation_alias=AliasPath("dag_run", "dag_model", "dag_display_name"))
+    task_display_name: str = Field(validation_alias=AliasPath("task", "task_display_name"))
 
 
 class XComResponseNative(XComResponse):

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -12579,6 +12579,9 @@ components:
         dag_display_name:
           type: string
           title: Dag Display Name
+        task_display_name:
+          type: string
+          title: Task Display Name
       type: object
       required:
       - key
@@ -12589,6 +12592,7 @@ components:
       - dag_id
       - run_id
       - dag_display_name
+      - task_display_name
       title: XComResponse
       description: Serializer for a xcom item.
     XComResponseNative:
@@ -12621,6 +12625,9 @@ components:
         dag_display_name:
           type: string
           title: Dag Display Name
+        task_display_name:
+          type: string
+          title: Task Display Name
         value:
           title: Value
       type: object
@@ -12633,6 +12640,7 @@ components:
       - dag_id
       - run_id
       - dag_display_name
+      - task_display_name
       - value
       title: XComResponseNative
       description: XCom response serializer with native return type.
@@ -12666,6 +12674,9 @@ components:
         dag_display_name:
           type: string
           title: Dag Display Name
+        task_display_name:
+          type: string
+          title: Task Display Name
         value:
           anyOf:
           - type: string
@@ -12681,6 +12692,7 @@ components:
       - dag_id
       - run_id
       - dag_display_name
+      - task_display_name
       - value
       title: XComResponseString
       description: XCom response serializer with string return type.

--- a/airflow-core/src/airflow/models/xcom.py
+++ b/airflow-core/src/airflow/models/xcom.py
@@ -104,6 +104,12 @@ class XComModel(TaskInstanceDependencies):
     )
     logical_date = association_proxy("dag_run", "logical_date")
 
+    task = relationship(
+        "TaskInstance",
+        viewonly=True,
+        lazy="selectin",
+    )
+
     @classmethod
     @provide_session
     def clear(

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -6348,10 +6348,14 @@ export const $XComResponse = {
         dag_display_name: {
             type: 'string',
             title: 'Dag Display Name'
+        },
+        task_display_name: {
+            type: 'string',
+            title: 'Task Display Name'
         }
     },
     type: 'object',
-    required: ['key', 'timestamp', 'logical_date', 'map_index', 'task_id', 'dag_id', 'run_id', 'dag_display_name'],
+    required: ['key', 'timestamp', 'logical_date', 'map_index', 'task_id', 'dag_id', 'run_id', 'dag_display_name', 'task_display_name'],
     title: 'XComResponse',
     description: 'Serializer for a xcom item.'
 } as const;
@@ -6399,12 +6403,16 @@ export const $XComResponseNative = {
             type: 'string',
             title: 'Dag Display Name'
         },
+        task_display_name: {
+            type: 'string',
+            title: 'Task Display Name'
+        },
         value: {
             title: 'Value'
         }
     },
     type: 'object',
-    required: ['key', 'timestamp', 'logical_date', 'map_index', 'task_id', 'dag_id', 'run_id', 'dag_display_name', 'value'],
+    required: ['key', 'timestamp', 'logical_date', 'map_index', 'task_id', 'dag_id', 'run_id', 'dag_display_name', 'task_display_name', 'value'],
     title: 'XComResponseNative',
     description: 'XCom response serializer with native return type.'
 } as const;
@@ -6452,6 +6460,10 @@ export const $XComResponseString = {
             type: 'string',
             title: 'Dag Display Name'
         },
+        task_display_name: {
+            type: 'string',
+            title: 'Task Display Name'
+        },
         value: {
             anyOf: [
                 {
@@ -6465,7 +6477,7 @@ export const $XComResponseString = {
         }
     },
     type: 'object',
-    required: ['key', 'timestamp', 'logical_date', 'map_index', 'task_id', 'dag_id', 'run_id', 'dag_display_name', 'value'],
+    required: ['key', 'timestamp', 'logical_date', 'map_index', 'task_id', 'dag_id', 'run_id', 'dag_display_name', 'task_display_name', 'value'],
     title: 'XComResponseString',
     description: 'XCom response serializer with string return type.'
 } as const;

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -1571,6 +1571,7 @@ export type XComResponse = {
     dag_id: string;
     run_id: string;
     dag_display_name: string;
+    task_display_name: string;
 };
 
 /**
@@ -1585,6 +1586,7 @@ export type XComResponseNative = {
     dag_id: string;
     run_id: string;
     dag_display_name: string;
+    task_display_name: string;
     value: unknown;
 };
 
@@ -1600,6 +1602,7 @@ export type XComResponseString = {
     dag_id: string;
     run_id: string;
     dag_display_name: string;
+    task_display_name: string;
     value: string | null;
 };
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_xcom.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_xcom.py
@@ -50,11 +50,13 @@ TEST_XCOM_KEY_2 = "test_xcom_key_non_existing"
 TEST_DAG_ID = "test-dag-id"
 TEST_DAG_DISPLAY_NAME = "test-dag-id"
 TEST_TASK_ID = "test-task-id"
+TEST_TASK_DISPLAY_NAME = "test-task-id"
 TEST_EXECUTION_DATE = "2005-04-02T00:00:00+00:00"
 
 TEST_DAG_ID_2 = "test-dag-id-2"
 TEST_DAG_DISPLAY_NAME_2 = "test-dag-id-2"
 TEST_TASK_ID_2 = "test-task-id-2"
+TEST_TASK_DISPLAY_NAME_2 = "test-task-id-2"
 
 logical_date_parsed = timezone.parse(TEST_EXECUTION_DATE)
 logical_date_formatted = logical_date_parsed.strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -133,6 +135,7 @@ class TestGetXComEntry(TestXComEndpoint):
             "run_id": run_id,
             "key": TEST_XCOM_KEY,
             "task_id": TEST_TASK_ID,
+            "task_display_name": TEST_TASK_DISPLAY_NAME,
             "map_index": -1,
             "timestamp": current_data["timestamp"],
             "value": json.dumps(TEST_XCOM_VALUE),
@@ -216,6 +219,7 @@ class TestGetXComEntries(TestXComEndpoint):
                     "run_id": run_id,
                     "key": f"{TEST_XCOM_KEY}-0",
                     "task_id": TEST_TASK_ID,
+                    "task_display_name": TEST_TASK_DISPLAY_NAME,
                     "timestamp": "TIMESTAMP",
                     "map_index": -1,
                 },
@@ -226,6 +230,7 @@ class TestGetXComEntries(TestXComEndpoint):
                     "run_id": run_id,
                     "key": f"{TEST_XCOM_KEY}-1",
                     "task_id": TEST_TASK_ID,
+                    "task_display_name": TEST_TASK_DISPLAY_NAME,
                     "timestamp": "TIMESTAMP",
                     "map_index": -1,
                 },
@@ -253,6 +258,7 @@ class TestGetXComEntries(TestXComEndpoint):
                     "run_id": run_id,
                     "key": f"{TEST_XCOM_KEY}-0",
                     "task_id": TEST_TASK_ID,
+                    "task_display_name": TEST_TASK_DISPLAY_NAME,
                     "timestamp": "TIMESTAMP",
                     "map_index": -1,
                 },
@@ -263,6 +269,7 @@ class TestGetXComEntries(TestXComEndpoint):
                     "run_id": run_id,
                     "key": f"{TEST_XCOM_KEY}-1",
                     "task_id": TEST_TASK_ID,
+                    "task_display_name": TEST_TASK_DISPLAY_NAME,
                     "timestamp": "TIMESTAMP",
                     "map_index": -1,
                 },
@@ -273,6 +280,7 @@ class TestGetXComEntries(TestXComEndpoint):
                     "run_id": run_id,
                     "key": f"{TEST_XCOM_KEY}-0",
                     "task_id": TEST_TASK_ID_2,
+                    "task_display_name": TEST_TASK_DISPLAY_NAME_2,
                     "timestamp": "TIMESTAMP",
                     "map_index": -1,
                 },
@@ -283,6 +291,7 @@ class TestGetXComEntries(TestXComEndpoint):
                     "run_id": run_id,
                     "key": f"{TEST_XCOM_KEY}-1",
                     "task_id": TEST_TASK_ID_2,
+                    "task_display_name": TEST_TASK_DISPLAY_NAME_2,
                     "timestamp": "TIMESTAMP",
                     "map_index": -1,
                 },
@@ -311,6 +320,7 @@ class TestGetXComEntries(TestXComEndpoint):
                     "run_id": run_id,
                     "key": TEST_XCOM_KEY,
                     "task_id": TEST_TASK_ID,
+                    "task_display_name": TEST_TASK_DISPLAY_NAME,
                     "timestamp": "TIMESTAMP",
                     "map_index": idx,
                 }
@@ -325,6 +335,7 @@ class TestGetXComEntries(TestXComEndpoint):
                     "run_id": run_id,
                     "key": TEST_XCOM_KEY,
                     "task_id": TEST_TASK_ID,
+                    "task_display_name": TEST_TASK_DISPLAY_NAME,
                     "timestamp": "TIMESTAMP",
                     "map_index": map_index,
                 }
@@ -349,6 +360,7 @@ class TestGetXComEntries(TestXComEndpoint):
                         "run_id": run_id,
                         "key": TEST_XCOM_KEY,
                         "task_id": TEST_TASK_ID,
+                        "task_display_name": TEST_TASK_DISPLAY_NAME,
                         "timestamp": "TIMESTAMP",
                         "map_index": 0,
                     },
@@ -359,6 +371,7 @@ class TestGetXComEntries(TestXComEndpoint):
                         "run_id": run_id,
                         "key": TEST_XCOM_KEY,
                         "task_id": TEST_TASK_ID,
+                        "task_display_name": TEST_TASK_DISPLAY_NAME,
                         "timestamp": "TIMESTAMP",
                         "map_index": 1,
                     },

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -955,6 +955,7 @@ class XComResponse(BaseModel):
     dag_id: Annotated[str, Field(title="Dag Id")]
     run_id: Annotated[str, Field(title="Run Id")]
     dag_display_name: Annotated[str, Field(title="Dag Display Name")]
+    task_display_name: Annotated[str, Field(title="Task Display Name")]
 
 
 class XComResponseNative(BaseModel):
@@ -970,6 +971,7 @@ class XComResponseNative(BaseModel):
     dag_id: Annotated[str, Field(title="Dag Id")]
     run_id: Annotated[str, Field(title="Run Id")]
     dag_display_name: Annotated[str, Field(title="Dag Display Name")]
+    task_display_name: Annotated[str, Field(title="Task Display Name")]
     value: Annotated[Any, Field(title="Value")]
 
 
@@ -986,6 +988,7 @@ class XComResponseString(BaseModel):
     dag_id: Annotated[str, Field(title="Dag Id")]
     run_id: Annotated[str, Field(title="Run Id")]
     dag_display_name: Annotated[str, Field(title="Dag Display Name")]
+    task_display_name: Annotated[str, Field(title="Task Display Name")]
     value: Annotated[str | None, Field(title="Value")] = None
 
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Related Issue

#46730

## How

- alias the `task_display_name` for `XComModel`
- update tests to validate `task_display_name`

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
