### PR TITLE
[v3-0-test] Resolve serialization for numpy bool 1.x and 2.x compatib…

### DIFF
--- a/airflow-core/src/airflow/serialization/serializers/numpy.py
+++ b/airflow-core/src/airflow/serialization/serializers/numpy.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from airflow.utils.module_loading import import_string, qualname
+from airflow.utils.module_loading import qualname
 
 # lazy loading for performance reasons
 serializers = [
@@ -31,11 +31,13 @@ serializers = [
     "numpy.uint16",
     "numpy.uint32",
     "numpy.uint64",
-    "numpy.bool_",
     "numpy.float64",
+    "numpy.float32",
     "numpy.float16",
     "numpy.complex128",
     "numpy.complex64",
+    "numpy.bool",
+    "numpy.bool_",
 ]
 
 if TYPE_CHECKING:
@@ -53,6 +55,7 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
         return "", "", 0, False
 
     name = qualname(o)
+    metadata = (name, __version__, True)
     if isinstance(
         o,
         (
@@ -69,24 +72,19 @@ def serialize(o: object) -> tuple[U, str, int, bool]:
             np.uint64,
         ),
     ):
-        return int(o), name, __version__, True
+        return int(o), *metadata
 
-    if isinstance(o, np.bool_):
-        return bool(np), name, __version__, True
+    if hasattr(np, "bool") and isinstance(o, np.bool) or isinstance(o, np.bool_):
+        return bool(o), *metadata
 
-    if isinstance(
-        o, (np.float_, np.float16, np.float32, np.float64, np.complex_, np.complex64, np.complex128)
-    ):
-        return float(o), name, __version__, True
+    if isinstance(o, (np.float16, np.float32, np.float64, np.complex64, np.complex128)):
+        return float(o), *metadata
 
     return "", "", 0, False
 
 
-def deserialize(classname: str, version: int, data: str) -> Any:
+def deserialize(cls: type, version: int, data: str) -> Any:
     if version > __version__:
         raise TypeError("serialized version is newer than class version")
 
-    if classname not in deserializers:
-        raise TypeError(f"unsupported {classname} found for numpy deserialization")
-
-    return import_string(classname)(data)
+    return cls(data)

--- a/airflow-core/tests/unit/serialization/test_serde.py
+++ b/airflow-core/tests/unit/serialization/test_serde.py
@@ -18,13 +18,15 @@ from __future__ import annotations
 
 import datetime
 import enum
+import textwrap
 from collections import namedtuple
 from dataclasses import dataclass
-from importlib import import_module
+from importlib import import_module, metadata
 from typing import ClassVar
 
 import attr
 import pytest
+from packaging import version
 from pydantic import BaseModel
 
 from airflow.sdk.definitions.asset import Asset
@@ -59,6 +61,67 @@ def recalculate_patterns():
         _get_regexp_patterns.cache_clear()
         _match_glob.cache_clear()
         _match_regexp.cache_clear()
+
+
+def generate_serializers_importable_tests():
+    """
+    Generate test cases for `test_serializers_importable_and_str`.
+
+    The function iterates through all the modules defined under `airflow.serialization.serializers`. It loads
+    the import strings defined in the `serializers` from each module, and create a test case to verify that the
+    serializer is importable.
+    """
+    import airflow.serialization.serializers
+
+    NUMPY_VERSION = version.parse(metadata.version("numpy"))
+
+    serializer_tests = []
+
+    for _, name, _ in iter_namespace(airflow.serialization.serializers):
+        ############################################################
+        # Handle compatibility / optional dependency at module level
+        ############################################################
+        # https://github.com/apache/airflow/pull/37320
+        if name == "airflow.serialization.serializers.iceberg":
+            try:
+                import pyiceberg  # noqa: F401
+            except ImportError:
+                continue
+        # https://github.com/apache/airflow/pull/38074
+        if name == "airflow.serialization.serializers.deltalake":
+            try:
+                import deltalake  # noqa: F401
+            except ImportError:
+                continue
+        mod = import_module(name)
+        for s in getattr(mod, "serializers", list()):
+            ############################################################
+            # Handle compatibility issue at serializer level
+            ############################################################
+            if s == "numpy.bool" and NUMPY_VERSION.major < 2:
+                reason = textwrap.dedent(f"""\
+                    Current NumPy version: {NUMPY_VERSION}
+
+                    In NumPy 1.20, `numpy.bool` was deprecated as an alias for the built-in `bool`.
+                    For NumPy versions <= 1.26, attempting to import `numpy.bool` raises an ImportError.
+                    Starting with NumPy 2.0, `numpy.bool` is reintroduced as the NumPy scalar type,
+                    and `numpy.bool_` becomes an alias for `numpy.bool`.
+
+                    The serializers are loaded lazily at runtime. As a result:
+                    - With NumPy <= 1.26, only `numpy.bool_` is loaded.
+                    - With NumPy >= 2.0, only `numpy.bool` is loaded.
+
+                    This test case deliberately attempts to import both `numpy.bool` and `numpy.bool_`,
+                    regardless of the installed NumPy version. Therefore, when NumPy <= 1.26 is installed,
+                    importing `numpy.bool` will raise an ImportError.
+                """)
+                serializer_tests.append(pytest.param(name, s, marks=pytest.mark.skip(reason=reason)))
+            else:
+                serializer_tests.append(pytest.param(name, s))
+    return serializer_tests
+
+
+SERIALIZER_TESTS = generate_serializers_importable_tests()
 
 
 class Z:
@@ -371,29 +434,15 @@ class TestSerDe:
         obj = deserialize(serialize(asset))
         assert asset.uri == obj.uri
 
-    def test_serializers_importable_and_str(self):
+    @pytest.mark.parametrize("name, s", SERIALIZER_TESTS)
+    def test_serializers_importable_and_str(self, name, s):
         """Test if all distributed serializers are lazy loading and can be imported"""
-        import airflow.serialization.serializers
-
-        for _, name, _ in iter_namespace(airflow.serialization.serializers):
-            if name == "airflow.serialization.serializers.iceberg":
-                try:
-                    import pyiceberg  # noqa: F401
-                except ImportError:
-                    continue
-            if name == "airflow.serialization.serializers.deltalake":
-                try:
-                    import deltalake  # noqa: F401
-                except ImportError:
-                    continue
-            mod = import_module(name)
-            for s in getattr(mod, "serializers", list()):
-                if not isinstance(s, str):
-                    raise TypeError(f"{s} is not of type str. This is required for lazy loading")
-                try:
-                    import_string(s)
-                except ImportError:
-                    raise AttributeError(f"{s} cannot be imported (located in {name})")
+        if not isinstance(s, str):
+            raise TypeError(f"{s} is not of type str. This is required for lazy loading")
+        try:
+            import_string(s)
+        except ImportError:
+            raise AttributeError(f"{s} cannot be imported (located in {name})")
 
     def test_stringify(self):
         i = V(W(10), ["l1", "l2"], (1, 2), 10)


### PR DESCRIPTION
…ility (#53690)

* fix serialization for np.bool in numpy 2.x

get update from main

* update serializers importable test case to handle numpy bool compatibility between v1 and v2

* use pytest xfail to capture np.bool import error in numpy version less than 2

* parameterize the serializers importable test, so xfail can be applied individually to numpy bool

* add textwrap dedent for message

* add np.float32 to serializer and improve test description (cherry picked from commit 5babf15bb4289419e3326aded0670883113d01c0)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
