### PR TITLE
Fix k8s pod yaml test to expect redacted sensitive data

### DIFF
--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/test_template_rendering.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/test_template_rendering.py
@@ -205,47 +205,37 @@ def test_get_k8s_pod_yaml(render_k8s_pod_yaml, dag_maker, session):
     Test that k8s_pod_yaml is rendered correctly, stored in the Database,
     and are correctly fetched using RTIF.get_k8s_pod_yaml
     """
-    from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS
+    with dag_maker("test_get_k8s_pod_yaml") as dag:
+        task = BashOperator(task_id="test", bash_command="echo hi")
+    dr = dag_maker.create_dagrun()
+    dag.fileloc = "/test_get_k8s_pod_yaml.py"
 
-    if AIRFLOW_V_3_1_PLUS:
-        target = "airflow._shared.secrets_masker.redact"
-    elif AIRFLOW_V_3_0_PLUS:
-        target = "airflow.sdk.execution_time.secrets_masker.redact"
-    else:
-        target = "airflow.utils.log.secrets_masker.redact"
-    with mock.patch(target, side_effect=lambda item, *args, **kwargs: item) as redact:
-        with dag_maker("test_get_k8s_pod_yaml") as dag:
-            task = BashOperator(task_id="test", bash_command="echo hi")
-        dr = dag_maker.create_dagrun()
-        dag.fileloc = "/test_get_k8s_pod_yaml.py"
+    ti = dr.task_instances[0]
+    ti.task = task
 
-        ti = dr.task_instances[0]
-        ti.task = task
+    render_k8s_pod_yaml.return_value = {"I'm a": "pod", "secret": "password123"}
 
-        render_k8s_pod_yaml.return_value = {"I'm a": "pod"}
+    rtif = RTIF(ti=ti)
 
-        rtif = RTIF(ti=ti)
+    assert ti.dag_id == rtif.dag_id
+    assert ti.task_id == rtif.task_id
+    assert ti.run_id == rtif.run_id
 
-        assert ti.dag_id == rtif.dag_id
-        assert ti.task_id == rtif.task_id
-        assert ti.run_id == rtif.run_id
+    # Expect redacted version
+    expected_pod_yaml = {"I'm a": "pod", "secret": "***"}
 
-        expected_pod_yaml = {"I'm a": "pod"}
+    assert rtif.k8s_pod_yaml == expected_pod_yaml
 
-        assert rtif.k8s_pod_yaml == render_k8s_pod_yaml.return_value
-        # K8s pod spec dict was passed to redact
-        redact.assert_any_call(rtif.k8s_pod_yaml)
+    with create_session() as session:
+        session.add(rtif)
+        session.flush()
 
-        with create_session() as session:
-            session.add(rtif)
-            session.flush()
+        assert expected_pod_yaml == RTIF.get_k8s_pod_yaml(ti=ti, session=session)
+        make_transient(ti)
+        # "Delete" it from the DB
+        session.rollback()
 
-            assert expected_pod_yaml == RTIF.get_k8s_pod_yaml(ti=ti, session=session)
-            make_transient(ti)
-            # "Delete" it from the DB
-            session.rollback()
-
-            # Test the else part of get_k8s_pod_yaml
-            # i.e. for the TIs that are not stored in RTIF table
-            # Fetching them will return None
-            assert RTIF.get_k8s_pod_yaml(ti=ti, session=session) is None
+        # Test the else part of get_k8s_pod_yaml
+        # i.e. for the TIs that are not stored in RTIF table
+        # Fetching them will return None
+        assert RTIF.get_k8s_pod_yaml(ti=ti, session=session) is None


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Remove unnecessary mocks from the `test_get_k8s_pod_yaml` test and update test assertion to expect redacted secret values instead of original sensitive data when redaction is enabled. This ensures the
test properly validates that sensitive information is masked.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
