### PR TITLE
Nuke `patched_secrets_masker` fixture and its usages

### DIFF
--- a/task-sdk/tests/conftest.py
+++ b/task-sdk/tests/conftest.py
@@ -20,7 +20,6 @@ import logging
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn, Protocol
-from unittest.mock import patch
 
 import pytest
 
@@ -273,12 +272,3 @@ def make_ti_context_dict(make_ti_context: MakeTIContextCallable) -> MakeTIContex
         return context.model_dump(exclude_unset=True, mode="json")
 
     return _make_context_dict
-
-
-@pytest.fixture
-def patched_secrets_masker():
-    from airflow.sdk._shared.secrets_masker import SecretsMasker
-
-    secrets_masker = SecretsMasker()
-    with patch("airflow.sdk._shared.secrets_masker._secrets_masker", return_value=secrets_masker):
-        yield secrets_masker

--- a/task-sdk/tests/task_sdk/definitions/test_connections.py
+++ b/task-sdk/tests/task_sdk/definitions/test_connections.py
@@ -207,7 +207,7 @@ class TestConnections:
         ):
             Connection.from_json(json.dumps(json_data), conn_id="test_conn")
 
-    def test_extra_dejson_property(self, patched_secrets_masker):
+    def test_extra_dejson_property(self):
         """Test that extra_dejson property correctly deserializes JSON extra field."""
         connection = Connection(
             conn_id="test_conn",

--- a/task-sdk/tests/task_sdk/definitions/test_variables.py
+++ b/task-sdk/tests/task_sdk/definitions/test_variables.py
@@ -91,7 +91,7 @@ class TestVariables:
 
 
 class TestVariableFromSecrets:
-    def test_var_get_from_secrets_found(self, mock_supervisor_comms, patched_secrets_masker, tmp_path):
+    def test_var_get_from_secrets_found(self, mock_supervisor_comms, tmp_path):
         """Tests getting a variable from secrets backend."""
         path = tmp_path / "var.env"
         path.write_text("VAR_A=some_value")
@@ -109,9 +109,7 @@ class TestVariableFromSecrets:
             assert retrieved_var is not None
             assert retrieved_var == "some_value"
 
-    def test_var_get_from_secrets_found_with_deserialize(
-        self, mock_supervisor_comms, tmp_path, patched_secrets_masker
-    ):
+    def test_var_get_from_secrets_found_with_deserialize(self, mock_supervisor_comms, tmp_path):
         """Tests getting a variable from secrets backend when deserialize_json is provided."""
         path = tmp_path / "var.json"
         dict_data = {"num1": 23, "num2": 42}
@@ -156,7 +154,7 @@ class TestVariableFromSecrets:
             mock_mask_secret.assert_called_with("super-secret", "secret")
 
     @mock.patch("airflow.secrets.environment_variables.EnvironmentVariablesBackend.get_variable")
-    def test_get_variable_env_var(self, mock_env_get, mock_supervisor_comms, patched_secrets_masker):
+    def test_get_variable_env_var(self, mock_env_get, mock_supervisor_comms):
         """Tests getting a variable from environment variable."""
         mock_env_get.return_value = "fake_value"
         Variable.get(key="fake_var_key")
@@ -172,9 +170,7 @@ class TestVariableFromSecrets:
         "airflow.secrets.local_filesystem.LocalFilesystemBackend.get_variable",
     )
     @mock.patch("airflow.secrets.environment_variables.EnvironmentVariablesBackend.get_variable")
-    def test_backend_fallback_to_env_var(
-        self, mock_get_variable, mock_env_get, mock_supervisor_comms, patched_secrets_masker
-    ):
+    def test_backend_fallback_to_env_var(self, mock_get_variable, mock_env_get, mock_supervisor_comms):
         """Tests if variable retrieval falls back to environment variable backend if not found in secrets backend."""
         mock_get_variable.return_value = None
         mock_env_get.return_value = "fake_value"

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -181,7 +181,6 @@ class TestSupervisor:
     )
     def test_supervise(
         self,
-        patched_secrets_masker,
         server,
         dry_run,
         expectation,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

After https://github.com/apache/airflow/pull/54449/files, there is no need to patch a secrets masker, as it will return a "real" new object as required instead of hunting for it in the logging filters. This makes unwanted mocks unnecessary and those can be safely removed along with the fixture in our tests and keep them cleaner.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
