### PR TITLE
Support templated extra in outlets assets

### DIFF
--- a/airflow-core/docs/authoring-and-scheduling/assets.rst
+++ b/airflow-core/docs/authoring-and-scheduling/assets.rst
@@ -104,6 +104,27 @@ If needed, you can include an extra dictionary in an asset:
 
 This can be used to supply custom description to the asset, such as who has ownership to the target file, or what the file is for. The extra information does not affect an asset's identity.
 
+You can also use Jinja templating in the extra dictionary to enrich the asset with runtime information, such as the execution date of the task that emits events of the asset:
+
+.. code-block::
+
+    BashOperator(
+        task_id="write_example_asset",
+        bash_command="echo 'writing...'",
+        outlets=Asset(
+            "asset_example",
+            extra={
+                "static_extra": "value",
+                "dag_id": "{{ dag.dag_id }}",
+                "nested_extra": {
+                    "run_id": "{{ run_id }}",
+                    "logical_date": "{{ ds }}",
+                }
+            }
+        ),
+    )
+
+
 .. note:: **Security Note:** Asset URI and extra fields are not encrypted, they are stored in cleartext in Airflow's metadata database. Do NOT store any sensitive values, especially credentials, in either asset URIs or extra key values!
 
 Creating a task to emit asset events

--- a/task-sdk/src/airflow/sdk/definitions/_internal/templater.py
+++ b/task-sdk/src/airflow/sdk/definitions/_internal/templater.py
@@ -89,7 +89,7 @@ class Templater:
 
     def resolve_template_files(self) -> None:
         """Get the content of files for template_field / template_ext."""
-        if hasattr(self, "template_ext") and self.template_ext:
+        if getattr(self, "template_ext", None):
             for field in self.template_fields:
                 content = getattr(self, field, None)
                 if isinstance(content, str) and content.endswith(tuple(self.template_ext)):

--- a/task-sdk/src/airflow/sdk/definitions/_internal/templater.py
+++ b/task-sdk/src/airflow/sdk/definitions/_internal/templater.py
@@ -89,7 +89,7 @@ class Templater:
 
     def resolve_template_files(self) -> None:
         """Get the content of files for template_field / template_ext."""
-        if self.template_ext:
+        if hasattr(self, "template_ext") and self.template_ext:
             for field in self.template_fields:
                 content = getattr(self, field, None)
                 if isinstance(content, str) and content.endswith(tuple(self.template_ext)):
@@ -170,7 +170,7 @@ class Templater:
             jinja_env = self.get_template_env()
 
         if isinstance(value, str):
-            if value.endswith(tuple(self.template_ext)):  # A filepath.
+            if hasattr(self, "template_ext") and value.endswith(tuple(self.template_ext)):  # A filepath.
                 template = jinja_env.get_template(value)
             else:
                 template = jinja_env.from_string(value)

--- a/task-sdk/src/airflow/sdk/definitions/asset/__init__.py
+++ b/task-sdk/src/airflow/sdk/definitions/asset/__init__.py
@@ -23,19 +23,23 @@ import operator
 import os
 import urllib.parse
 import warnings
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, overload
 
 import attrs
 
 from airflow.sdk.api.datamodels._generated import AssetProfile
+from airflow.sdk.definitions._internal.templater import Templater
 from airflow.serialization.dag_dependency import DagDependency
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
     from urllib.parse import SplitResult
 
+    import jinja2
+
     from airflow.models.asset import AssetModel
+    from airflow.sdk import Context
     from airflow.sdk.io.path import ObjectStoragePath
     from airflow.serialization.serialized_objects import SerializedAssetWatcher
     from airflow.triggers.base import BaseEventTrigger
@@ -305,7 +309,7 @@ class AssetWatcher:
 
 
 @attrs.define(init=False, unsafe_hash=False)
-class Asset(os.PathLike, BaseAsset):
+class Asset(os.PathLike, BaseAsset, Templater):
     """A representation of data asset dependencies between workflows."""
 
     name: str = attrs.field(
@@ -329,6 +333,8 @@ class Asset(os.PathLike, BaseAsset):
 
     asset_type: ClassVar[str] = "asset"
     __version__: ClassVar[int] = 1
+
+    template_ext: Sequence[str] = ()
 
     @overload
     def __init__(
@@ -488,6 +494,22 @@ class Asset(os.PathLike, BaseAsset):
         :meta private:
         """
         return AssetProfile(name=self.name or None, uri=self.uri or None, type=Asset.__name__)
+
+    def render_extra_field(
+        self,
+        context: Context,
+        jinja_env: jinja2.Environment | None = None,
+    ) -> None:
+        """
+        Template extra attribute.
+
+        :param context: Context dict with values to apply on content.
+        :param jinja_env: Jinja environment to use for rendering.
+        """
+        dag = context["dag"]
+        if not jinja_env:
+            jinja_env = self.get_template_env(dag=dag)
+        self._do_render_template_fields(self, ("extra",), context, jinja_env, set())
 
 
 class AssetRef(BaseAsset, AttrsInstance):

--- a/task-sdk/src/airflow/sdk/definitions/asset/__init__.py
+++ b/task-sdk/src/airflow/sdk/definitions/asset/__init__.py
@@ -23,7 +23,7 @@ import operator
 import os
 import urllib.parse
 import warnings
-from collections.abc import Callable, Sequence
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, overload
 
 import attrs
@@ -333,8 +333,6 @@ class Asset(os.PathLike, BaseAsset, Templater):
 
     asset_type: ClassVar[str] = "asset"
     __version__: ClassVar[int] = 1
-
-    template_ext: Sequence[str] = ()
 
     @overload
     def __init__(

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1270,6 +1270,11 @@ def _execute_task(context: Context, ti: RuntimeTaskInstance, log: Logger):
 
     outlet_events = context_get_outlet_events(context)
 
+    for outlet in task.outlets or ():
+        if isinstance(outlet, Asset):
+            outlet.render_extra_field(context, jinja_env=task.dag.get_template_env())
+            outlet_events[outlet].extra.update(outlet.extra)
+
     if (pre_execute_hook := task._pre_execute_hook) is not None:
         create_executable_runner(pre_execute_hook, outlet_events, logger=log).run(context)
     if getattr(pre_execute_hook := task.pre_execute, "__func__", None) is not BaseOperator.pre_execute:

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -942,9 +942,37 @@ def test_dag_parsing_context(make_ti_context, mock_supervisor_comms, monkeypatch
                 task_outlets=[
                     AssetProfile(name="s3://bucket/my-task", uri="s3://bucket/my-task", type="Asset")
                 ],
-                outlet_events=[],
+                outlet_events=[
+                    {
+                        "dest_asset_key": {"name": "s3://bucket/my-task", "uri": "s3://bucket/my-task"},
+                        "extra": {},
+                    }
+                ],
             ),
             id="asset",
+        ),
+        pytest.param(
+            [
+                Asset(
+                    name="s3://bucket/my-task",
+                    uri="s3://bucket/my-task",
+                    extra={"task_id": "{{ task.task_id }}"},
+                )
+            ],
+            SucceedTask(
+                state="success",
+                end_date=timezone.datetime(2024, 12, 3, 10, 0),
+                task_outlets=[
+                    AssetProfile(name="s3://bucket/my-task", uri="s3://bucket/my-task", type="Asset")
+                ],
+                outlet_events=[
+                    {
+                        "dest_asset_key": {"name": "s3://bucket/my-task", "uri": "s3://bucket/my-task"},
+                        "extra": {"task_id": "asset-outlet-task"},
+                    }
+                ],
+            ),
+            id="asset_with_template_extra",
         ),
         pytest.param(
             [Dataset(name="s3://bucket/my-task", uri="s3://bucket/my-task")],
@@ -954,9 +982,37 @@ def test_dag_parsing_context(make_ti_context, mock_supervisor_comms, monkeypatch
                 task_outlets=[
                     AssetProfile(name="s3://bucket/my-task", uri="s3://bucket/my-task", type="Asset")
                 ],
-                outlet_events=[],
+                outlet_events=[
+                    {
+                        "dest_asset_key": {"name": "s3://bucket/my-task", "uri": "s3://bucket/my-task"},
+                        "extra": {},
+                    }
+                ],
             ),
             id="dataset",
+        ),
+        pytest.param(
+            [
+                Dataset(
+                    name="s3://bucket/my-task",
+                    uri="s3://bucket/my-task",
+                    extra={"task_id": "{{ task.task_id }}"},
+                )
+            ],
+            SucceedTask(
+                state="success",
+                end_date=timezone.datetime(2024, 12, 3, 10, 0),
+                task_outlets=[
+                    AssetProfile(name="s3://bucket/my-task", uri="s3://bucket/my-task", type="Asset")
+                ],
+                outlet_events=[
+                    {
+                        "dest_asset_key": {"name": "s3://bucket/my-task", "uri": "s3://bucket/my-task"},
+                        "extra": {"task_id": "asset-outlet-task"},
+                    }
+                ],
+            ),
+            id="dataset_with_template_extra",
         ),
         pytest.param(
             [Model(name="s3://bucket/my-task", uri="s3://bucket/my-task")],
@@ -966,9 +1022,37 @@ def test_dag_parsing_context(make_ti_context, mock_supervisor_comms, monkeypatch
                 task_outlets=[
                     AssetProfile(name="s3://bucket/my-task", uri="s3://bucket/my-task", type="Asset")
                 ],
-                outlet_events=[],
+                outlet_events=[
+                    {
+                        "dest_asset_key": {"name": "s3://bucket/my-task", "uri": "s3://bucket/my-task"},
+                        "extra": {},
+                    }
+                ],
             ),
             id="model",
+        ),
+        pytest.param(
+            [
+                Model(
+                    name="s3://bucket/my-task",
+                    uri="s3://bucket/my-task",
+                    extra={"task_id": "{{ task.task_id }}"},
+                )
+            ],
+            SucceedTask(
+                state="success",
+                end_date=timezone.datetime(2024, 12, 3, 10, 0),
+                task_outlets=[
+                    AssetProfile(name="s3://bucket/my-task", uri="s3://bucket/my-task", type="Asset")
+                ],
+                outlet_events=[
+                    {
+                        "dest_asset_key": {"name": "s3://bucket/my-task", "uri": "s3://bucket/my-task"},
+                        "extra": {"task_id": "asset-outlet-task"},
+                    }
+                ],
+            ),
+            id="model_with_template_extra",
         ),
         pytest.param(
             [Asset.ref(name="s3://bucket/my-task")],


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This PR adds support for Jinja templates in outlet assets, which will be rendered in the emitted events.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
