### PR TITLE
TriggerDagRunOperator auto clearing support for failed child dag run tasks

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/dagrun.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/dagrun.py
@@ -30,9 +30,16 @@ class TriggerDAGRunPayload(StrictBaseModel):
     logical_date: UtcDateTime | None = None
     conf: dict = Field(default_factory=dict)
     reset_dag_run: bool = False
+    reset_mode: str = "all"
 
 
 class DagRunStateResponse(BaseModel):
     """Schema for DAG Run State response."""
 
     state: DagRunState
+
+
+class DAGRunClearPayload(StrictBaseModel):
+    """Schema for DAG Run Clear Body."""
+
+    only_failed: bool = False

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/dag_runs.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/dag_runs.py
@@ -27,7 +27,11 @@ from airflow.api.common.trigger_dag import trigger_dag
 from airflow.api_fastapi.common.dagbag import DagBagDep, get_dag_for_run
 from airflow.api_fastapi.common.db.common import SessionDep
 from airflow.api_fastapi.common.types import UtcDateTime
-from airflow.api_fastapi.execution_api.datamodels.dagrun import DagRunStateResponse, TriggerDAGRunPayload
+from airflow.api_fastapi.execution_api.datamodels.dagrun import (
+    DAGRunClearPayload,
+    DagRunStateResponse,
+    TriggerDAGRunPayload,
+)
 from airflow.api_fastapi.execution_api.datamodels.taskinstance import DagRun
 from airflow.exceptions import DagRunAlreadyExists
 from airflow.models.dag import DagModel
@@ -106,6 +110,7 @@ def trigger_dag_run(
 def clear_dag_run(
     dag_id: str,
     run_id: str,
+    payload: DAGRunClearPayload | None,
     session: SessionDep,
     dag_bag: DagBagDep,
 ):
@@ -131,7 +136,9 @@ def clear_dag_run(
     )
     dag = get_dag_for_run(dag_bag, dag_run=dag_run, session=session)
 
-    dag.clear(run_id=run_id)
+    only_failed = payload.only_failed if payload else False
+
+    dag.clear(run_id=run_id, only_failed=only_failed)
 
 
 @router.get(

--- a/airflow-core/src/airflow/exceptions.py
+++ b/airflow-core/src/airflow/exceptions.py
@@ -370,6 +370,7 @@ class DagRunTriggerException(AirflowException):
         conf: dict | None,
         logical_date: datetime | None,
         reset_dag_run: bool,
+        reset_mode: str = "all",
         skip_when_already_exists: bool,
         wait_for_completion: bool,
         allowed_states: list[str | DagRunState],
@@ -383,6 +384,7 @@ class DagRunTriggerException(AirflowException):
         self.conf = conf
         self.logical_date = logical_date
         self.reset_dag_run = reset_dag_run
+        self.reset_mode = reset_mode
         self.skip_when_already_exists = skip_when_already_exists
         self.wait_for_completion = wait_for_completion
         self.allowed_states = allowed_states

--- a/providers/standard/src/airflow/providers/standard/operators/trigger_dagrun.py
+++ b/providers/standard/src/airflow/providers/standard/operators/trigger_dagrun.py
@@ -130,6 +130,8 @@ class TriggerDagRunOperator(BaseOperator):
         DAG run conf is immutable and will not be reset on rerun of an existing DAG run.
         When reset_dag_run=False and dag run exists, DagRunAlreadyExists will be raised.
         When reset_dag_run=True and dag run exists, existing DAG run will be cleared to rerun.
+    :param reset_mode: Defines the reset behavior for the dag run — whether to reset all tasks or only those that have failed.
+        Input options - all or only_failed
     :param wait_for_completion: Whether or not wait for DAG run completion. (default: False)
     :param poke_interval: Poke interval to check DAG run status when wait_for_completion=True.
         (default: 60)
@@ -166,6 +168,7 @@ class TriggerDagRunOperator(BaseOperator):
         conf: dict | None = None,
         logical_date: str | datetime.datetime | None | ArgNotSet = NOTSET,
         reset_dag_run: bool = False,
+        reset_mode: str = "all",
         wait_for_completion: bool = False,
         poke_interval: int = 60,
         allowed_states: list[str | DagRunState] | None = None,
@@ -202,6 +205,9 @@ class TriggerDagRunOperator(BaseOperator):
             raise TypeError(
                 f"Expected str, datetime.datetime, or None for parameter 'logical_date'. Got {type(logical_date).__name__}"
             )
+        if reset_mode not in ["all", "only_failed"]:
+            raise ValueError("reset_mode must be one of 'all', 'only_failed'")
+        self.reset_mode = reset_mode
 
     def execute(self, context: Context):
         if self.logical_date is NOTSET:
@@ -250,6 +256,7 @@ class TriggerDagRunOperator(BaseOperator):
             conf=self.conf,
             logical_date=parsed_logical_date,
             reset_dag_run=self.reset_dag_run,
+            reset_mode=self.reset_mode,
             skip_when_already_exists=self.skip_when_already_exists,
             wait_for_completion=self.wait_for_completion,
             allowed_states=self.allowed_states,

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -102,6 +102,17 @@ class ConnectionResponse(BaseModel):
     extra: Annotated[str | None, Field(title="Extra")] = None
 
 
+class DAGRunClearPayload(BaseModel):
+    """
+    Schema for DAG Run Clear Body.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    only_failed: Annotated[bool | None, Field(title="Only Failed")] = False
+
+
 class DagRunAssetReference(BaseModel):
     """
     DagRun serializer for asset responses.
@@ -332,6 +343,7 @@ class TriggerDAGRunPayload(BaseModel):
     logical_date: Annotated[AwareDatetime | None, Field(title="Logical Date")] = None
     conf: Annotated[dict[str, Any] | None, Field(title="Conf")] = None
     reset_dag_run: Annotated[bool | None, Field(title="Reset Dag Run")] = False
+    reset_mode: Annotated[str | None, Field(title="Reset Mode")] = "all"
 
 
 class UpdateHITLDetailPayload(BaseModel):

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -1287,6 +1287,7 @@ class ActivitySubprocess(WatchedSubprocess):
                 msg.conf,
                 msg.logical_date,
                 msg.reset_dag_run,
+                msg.reset_mode,
             )
         elif isinstance(msg, GetDagRunState):
             dr_resp = self.client.dag_runs.get_state(msg.dag_id, msg.run_id)

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1057,6 +1057,7 @@ def _handle_trigger_dag_run(
             logical_date=drte.logical_date,
             conf=drte.conf,
             reset_dag_run=drte.reset_dag_run,
+            reset_mode=drte.reset_mode,
         ),
     )
 

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -1799,7 +1799,7 @@ REQUEST_TEST_CASES = [
         expected_body={"ok": True, "type": "OKResponse"},
         client_mock=ClientMock(
             method_path="dag_runs.trigger",
-            args=("test_dag", "test_run", {"key": "value"}, timezone.datetime(2025, 1, 1), True),
+            args=("test_dag", "test_run", {"key": "value"}, timezone.datetime(2025, 1, 1), True, "all"),
             response=OKResponse(ok=True),
         ),
         test_id="dag_run_trigger",
@@ -1809,7 +1809,7 @@ REQUEST_TEST_CASES = [
         expected_body={"error": "DAGRUN_ALREADY_EXISTS", "detail": None, "type": "ErrorResponse"},
         client_mock=ClientMock(
             method_path="dag_runs.trigger",
-            args=("test_dag", "test_run", None, None, False),
+            args=("test_dag", "test_run", None, None, False, "all"),
             response=ErrorResponse(error=ErrorType.DAGRUN_ALREADY_EXISTS),
         ),
         test_id="dag_run_trigger_already_exists",


### PR DESCRIPTION
This PR is to support auto clearing failed dag run tasks for TriggerDagRunOperator.

Related Issue : #53402 