### PR TITLE
fix(cli): escape MySQL password in db shell and add unit tests

### DIFF
--- a/airflow-core/src/airflow/cli/commands/db_command.py
+++ b/airflow-core/src/airflow/cli/commands/db_command.py
@@ -220,10 +220,11 @@ def check_migrations(args):
     db.check_migrations(timeout=args.migration_wait_timeout)
 
 
-def _quote_mysql_password_for_cnf(password: str | None) -> str:
+def _quote_mysql_password_for_cnf(password: str | None | None) -> str:
     """Escape and quote MySQL password for use in my.cnf option file."""
-    val = password or ""
-    val = val.replace("\\", "\\\\").replace('"', '\\"')
+    if password is None or password == "":
+        return ""
+    val = password.replace("\\", "\\\\").replace('"', '\\"')
     return f'"{val}"'
 
 

--- a/airflow-core/src/airflow/cli/commands/db_command.py
+++ b/airflow-core/src/airflow/cli/commands/db_command.py
@@ -220,6 +220,13 @@ def check_migrations(args):
     db.check_migrations(timeout=args.migration_wait_timeout)
 
 
+def _quote_mysql_password_for_cnf(password: str | None) -> str:
+    """Escape and quote MySQL password for use in my.cnf option file."""
+    val = password or ""
+    val = val.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{val}"'
+
+
 @cli_utils.action_cli(check_db=False)
 @providers_configuration_loaded
 def shell(args):
@@ -232,11 +239,11 @@ def shell(args):
             content = textwrap.dedent(
                 f"""
                 [client]
-                host     = {url.host}
-                user     = {url.username}
-                password = {url.password or ""}
+                host     = {(url.host or "")}
+                user     = {(url.username or "")}
+                password = {_quote_mysql_password_for_cnf(url.password)}
                 port     = {url.port or "3306"}
-                database = {url.database}
+                database = {(url.database or "")}
                 """
             ).strip()
             f.write(content.encode())

--- a/airflow-core/tests/unit/cli/commands/test_db_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_db_command.py
@@ -726,3 +726,17 @@ def test_get_version_revision():
     assert db_command._get_version_revision("2.11.1", heads) == "5f2621c13b39"
     assert db_command._get_version_revision("2.10.1", heads) == "22ed7efa9da2"
     assert db_command._get_version_revision("2.0.0", heads) is None
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("pa!sw0rd#", '"pa!sw0rd#"'),
+        ('he"llo', '"he\\"llo"'),
+        ("path\\file", '"path\\\\file"'),
+        (None, '""'),
+    ],
+)
+def test_quote_mysql_password_for_cnf(raw, expected):
+    password = db_command._quote_mysql_password_for_cnf(raw)
+    assert password == expected

--- a/airflow-core/tests/unit/cli/commands/test_db_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_db_command.py
@@ -734,7 +734,7 @@ def test_get_version_revision():
         ("pa!sw0rd#", '"pa!sw0rd#"'),
         ('he"llo', '"he\\"llo"'),
         ("path\\file", '"path\\\\file"'),
-        (None, '""'),
+        (None, ""),
     ],
 )
 def test_quote_mysql_password_for_cnf(raw, expected):


### PR DESCRIPTION
### Summary
Fix password escaping in `airflow db shell`.

### What was changed
- Added helper function `_quote_mysql_password_for_cnf`
- Updated `shell` command to use it
- Added unit tests

### Why it matters
Before this fix, `airflow db shell` failed with special characters in password.

### Checklist
- [x] Unit tests added and passing
- [x] Static checks passed (`prek run --all-files`)
- [x] Commit message follows guidelines
