### PR TITLE
Adding a compat shim for secrets_masker that was moved to shared

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/secrets_masker.py
+++ b/task-sdk/src/airflow/sdk/execution_time/secrets_masker.py
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Compatibility module for secrets_masker.
+
+This module provides backward compatibility for providers that still import
+from airflow.sdk.execution_time.secrets_masker. The actual implementation
+has been moved to airflow.sdk._shared.secrets_masker.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+warnings.warn(
+    "Importing from 'airflow.sdk.execution_time.secrets_masker' is deprecated. "
+    "Please use 'airflow.sdk._shared.secrets_masker' instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+
+def __getattr__(name: str):
+    """Dynamically import attributes from the shared secrets_masker location."""
+    try:
+        import airflow.sdk._shared.secrets_masker as new_module
+
+        return getattr(new_module, name)
+    except AttributeError:
+        raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/task-sdk/src/airflow/sdk/execution_time/secrets_masker.py
+++ b/task-sdk/src/airflow/sdk/execution_time/secrets_masker.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import warnings
 
 warnings.warn(
-    "Importing from 'airflow.sdk.execution_time.secrets_masker' is deprecated. "
+    "Importing from 'airflow.sdk.execution_time.secrets_masker' is deprecated and will be removed in a future version. "
     "Please use 'airflow.sdk._shared.secrets_masker' instead.",
     DeprecationWarning,
     stacklevel=2,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

After the merge of #54449, we nuked the `airflow.sdk.execution_time.secrets_masker` path, but it is possible that some provider etc would be using this since it is public API in their code which would break.

Adding a compat shim for that so that those code paths to continue working and providing them some time to migrate till the next release probably.

Before changes:
```
(airflow) ➜  airflow git:(compat-module-for-secrets-masker) ✗ git checkout main                                                               
Switched to branch 'main'
Your branch is up to date with 'origin/main'.
(airflow) ➜  airflow git:(main) ✗ python           
Python 3.12.9 (main, Feb  4 2025, 14:38:38) [Clang 16.0.0 (clang-1600.0.26.6)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from airflow.sdk.execution_time.secrets_masker import Redactable, Redacted, SecretsMasker, should_hide_value_for_key
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'airflow.sdk.execution_time.secrets_masker'

```

After changes:
```
(airflow) ➜  airflow git:(compat-module-for-secrets-masker) ✗ python
Python 3.12.9 (main, Feb  4 2025, 14:38:38) [Clang 16.0.0 (clang-1600.0.26.6)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from airflow.sdk.execution_time.secrets_masker import Redactable, Redacted, SecretsMasker, should_hide_value_for_key
<stdin>:1 DeprecationWarning: Importing from 'airflow.sdk.execution_time.secrets_masker' is deprecated and will be removed in a future version. Please use 'airflow.sdk._shared.secrets_masker' instead.

```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
