### PR TITLE
Only redirect on the dag detail page

### DIFF
--- a/airflow-core/src/airflow/ui/src/queries/useTrigger.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useTrigger.ts
@@ -19,7 +19,7 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
 import {
   UseDagRunServiceGetDagRunsKeyFn,
@@ -37,6 +37,7 @@ export const useTrigger = ({ dagId, onSuccessConfirm }: { dagId: string; onSucce
   const [error, setError] = useState<unknown>(undefined);
   const { t: translate } = useTranslation("components");
   const navigate = useNavigate();
+  const { dagId: selectedDagId } = useParams();
 
   const onSuccess = async (dagRun: TriggerDagRunResponse) => {
     const queryKeys = [
@@ -55,7 +56,10 @@ export const useTrigger = ({ dagId, onSuccessConfirm }: { dagId: string; onSucce
     });
     onSuccessConfirm();
 
-    navigate(`/dags/${dagRun.dag_id}/runs/${dagRun.dag_run_id}`);
+    // Only redirect if we're already on the dag page
+    if (selectedDagId === dagRun.dag_id) {
+      navigate(`/dags/${dagRun.dag_id}/runs/${dagRun.dag_run_id}`);
+    }
   };
 
   const onError = (_error: unknown) => {


### PR DESCRIPTION
It makes sense to redirect the dag detail selection to the dag run you just triggered but not to navigate away from any other page a user may be triggering a dag from.


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
