### PR TITLE
Adding a backcompat shim layer for `JobState`

### DIFF
--- a/airflow-core/src/airflow/utils/__init__.py
+++ b/airflow-core/src/airflow/utils/__init__.py
@@ -55,9 +55,6 @@ __deprecated_classes = {
         "DB_SAFE_MAXIMUM": "airflow.sdk.bases.operator.DB_SAFE_MAXIMUM",
         "db_safe_priority": "airflow.sdk.bases.operator.db_safe_priority",
     },
-    __name__: {
-        "JobState": "airflow.jobs.job.JobState",
-    },
 }
 
 add_deprecated_classes(__deprecated_classes, __name__)

--- a/airflow-core/src/airflow/utils/state.py
+++ b/airflow-core/src/airflow/utils/state.py
@@ -214,3 +214,21 @@ class State:
     A list of states indicating that a task can be adopted or reset by a scheduler job
     if it was queued by another scheduler job that is not running anymore.
     """
+
+
+def __getattr__(name: str):
+    """Provide backward compatibility for moved classes."""
+    if name == "JobState":
+        import warnings
+
+        from airflow.jobs.job import JobState
+
+        warnings.warn(
+            "The `airflow.utils.state.JobState` attribute is deprecated and will be removed in a future version. "
+            "Please use `airflow.jobs.job.JobState` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return JobState
+
+    raise AttributeError(f"module 'airflow.utils.state' has no attribute '{name}'")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


Backcompat was attempted in https://github.com/apache/airflow/pull/53387/files#diff-09ccc0b988660a1f363f98722a724541b07ab7b61ba17274a0f36611bde985e2R57-R59, but turns out the `add_deprecated_classes` cannot handle partial module moves. ie, some part of a module is moved to a new location but the module itself stays.

The reason for that is probably module loading order problems because:
```
import airflow.utils.state  # Loads real state.py first
# Later...
add_deprecated_classes({"state": {...}})  # Too late! Real module already loaded
```

In any case, that is a separate problem to introduce a feature for partial module moves in `add_deprecated_classes`


Earlier:
```
(airflow) ➜  airflow git:(main) ✗ python        
Python 3.12.9 (main, Feb  4 2025, 14:38:38) [Clang 16.0.0 (clang-1600.0.26.6)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> airflow.utils.state
KeyboardInterrupt
>>> from airflow.utils.state import JobState
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'JobState' from 'airflow.utils.state' (/Users/amoghdesai/Documents/OSS/repos/airflow/airflow-core/src/airflow/utils/state.py)
>>> exit()

```

Now:
```
(airflow) ➜  airflow git:(backcompat-jobstate) ✗ python
Python 3.12.9 (main, Feb  4 2025, 14:38:38) [Clang 16.0.0 (clang-1600.0.26.6)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from airflow.utils.state import JobState
<stdin>:1 DeprecationWarning: The `airflow.utils.state.JobState` attribute is deprecated and will be removed in a future version. Please use `airflow.jobs.job.JobState` instead.
>>> from airflow.jobs.job import JobState

```




<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
