### PR TITLE
Fix typo in documentation building doc

### DIFF
--- a/contributing-docs/11_documentation_building.rst
+++ b/contributing-docs/11_documentation_building.rst
@@ -117,8 +117,8 @@ Building the documentation
 
 In Airflow 3 the documentation is placed closely to where source code is placed (in most distribution
 packages it is in the ``doc`` subfolder of a distribution you want to build the documentation for.
-Some distributions do not have ``docs``subfolder - when they are ``doc-only``. The ``build-doc`` script
-is installed automatically from ``devel-common` distribution and available to run using ``uv run``
+Some distributions do not have ``docs`` subfolder - when they are ``doc-only``. The ``build-doc`` script
+is installed automatically from ``devel-common`` distribution and available to run using ``uv run``
 command (or directly ``build-docs`` inside the ``breeze`` container). This script will automatically
 detect which distribution you are in and build the documentation for it.
 


### PR DESCRIPTION
Fix some small typo in the contributing doc. 

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
