### PR TITLE
chore(cli): remove duplicate None in _quote_mysql_password_for_cnt

### DIFF
--- a/airflow-core/src/airflow/cli/commands/db_command.py
+++ b/airflow-core/src/airflow/cli/commands/db_command.py
@@ -220,7 +220,7 @@ def check_migrations(args):
     db.check_migrations(timeout=args.migration_wait_timeout)
 
 
-def _quote_mysql_password_for_cnf(password: str | None | None) -> str:
+def _quote_mysql_password_for_cnf(password: str | None) -> str:
     """Escape and quote MySQL password for use in my.cnf option file."""
     if password is None or password == "":
         return ""


### PR DESCRIPTION
What: Fix union type from str | None | None to str | None.
Why: Redundant None likely introduced during auto-rewrite/merge; no functional change.
Test: prek run --all-files / mypy-airflow-core passed.
Related: follow-up to #54892.