### PR TITLE
feature: Add OpenLineage support for OracleToGCSOperator

### DIFF
--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -1943,7 +1943,7 @@ def test_expected_output_push(
             {
                 "selected-providers-list-as-string": "amazon common.compat common.io common.sql "
                 "databricks dbt.cloud ftp google microsoft.mssql mysql "
-                "openlineage postgres sftp snowflake trino",
+                "openlineage oracle postgres sftp snowflake trino",
                 "all-python-versions": f"['{DEFAULT_PYTHON_MAJOR_MINOR_VERSION}']",
                 "all-python-versions-list-as-string": DEFAULT_PYTHON_MAJOR_MINOR_VERSION,
                 "ci-image-build": "true",
@@ -1954,7 +1954,7 @@ def test_expected_output_push(
                 "docs-build": "true",
                 "docs-list-as-string": "apache-airflow task-sdk amazon common.compat common.io common.sql "
                 "databricks dbt.cloud ftp google microsoft.mssql mysql "
-                "openlineage postgres sftp snowflake trino",
+                "openlineage oracle postgres sftp snowflake trino",
                 "skip-prek-hooks": ALL_SKIPPED_COMMITS_ON_NO_CI_IMAGE,
                 "run-kubernetes-tests": "false",
                 "upgrade-to-newer-dependencies": "false",
@@ -1964,7 +1964,7 @@ def test_expected_output_push(
                         {
                             "description": "amazon...google",
                             "test_types": "Providers[amazon] Providers[common.compat,common.io,common.sql,"
-                            "databricks,dbt.cloud,ftp,microsoft.mssql,mysql,openlineage,"
+                            "databricks,dbt.cloud,ftp,microsoft.mssql,mysql,openlineage,oracle,"
                             "postgres,sftp,snowflake,trino] Providers[google]",
                         }
                     ]

--- a/providers/google/tests/unit/google/cloud/transfers/test_oracle_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_oracle_to_gcs.py
@@ -18,11 +18,11 @@
 from __future__ import annotations
 
 from unittest import mock
+from unittest.mock import MagicMock
 
 import oracledb
 import pytest
 
-from unittest.mock import MagicMock, patch
 from airflow.models import Connection
 from airflow.providers.common.compat.openlineage.facet import (
     OutputDataset,
@@ -159,7 +159,9 @@ class TestOracleToGoogleCloudStorageOperator:
             (None, "SID", 1234, 1521, 1234),
         ],
     )
-    def test_execute_openlineage_events(self, input_service_name, input_sid, connection_port, default_port, expected_port):
+    def test_execute_openlineage_events(
+        self, input_service_name, input_sid, connection_port, default_port, expected_port
+    ):
         class DBApiHookForTests(DbApiHook):
             conn_name_attr = "sql_default"
             get_conn = MagicMock(name="conn")
@@ -183,9 +185,7 @@ class TestOracleToGoogleCloudStorageOperator:
                 return dbapi_hook
 
         sql = """SELECT employee_id, first_name FROM hr.employees"""
-        op = OracleToGCSOperatorForTest(
-            task_id=TASK_ID, sql=sql, bucket="bucket", filename="dir/file{}.csv"
-        )
+        op = OracleToGCSOperatorForTest(task_id=TASK_ID, sql=sql, bucket="bucket", filename="dir/file{}.csv")
         DB_SCHEMA_NAME = "HR"
         rows = [
             (DB_SCHEMA_NAME, "employees", "employee_id", 1, "NUMBER"),

--- a/providers/google/tests/unit/google/cloud/transfers/test_oracle_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_oracle_to_gcs.py
@@ -20,7 +20,15 @@ from __future__ import annotations
 from unittest import mock
 
 import oracledb
+import pytest
 
+from unittest.mock import MagicMock, patch
+from airflow.models import Connection
+from airflow.providers.common.compat.openlineage.facet import (
+    OutputDataset,
+    SchemaDatasetFacetFields,
+)
+from airflow.providers.common.sql.hooks.sql import DbApiHook
 from airflow.providers.google.cloud.transfers.oracle_to_gcs import OracleToGCSOperator
 
 TASK_ID = "test-oracle-to-gcs"
@@ -141,3 +149,71 @@ class TestOracleToGoogleCloudStorageOperator:
 
         # once for the file and once for the schema
         assert gcs_hook_mock.upload.call_count == 2
+
+    @pytest.mark.parametrize(
+        "input_service_name, input_sid, connection_port, default_port, expected_port",
+        [
+            ("ServiceName", None, None, 1521, 1521),
+            (None, "SID", None, 1521, 1521),
+            (None, "SID", 1234, None, 1234),
+            (None, "SID", 1234, 1521, 1234),
+        ],
+    )
+    def test_execute_openlineage_events(self, input_service_name, input_sid, connection_port, default_port, expected_port):
+        class DBApiHookForTests(DbApiHook):
+            conn_name_attr = "sql_default"
+            get_conn = MagicMock(name="conn")
+            get_connection = MagicMock()
+            service_name = input_service_name
+            sid = input_sid
+
+            def get_openlineage_database_info(self, connection):
+                from airflow.providers.openlineage.sqlparser import DatabaseInfo
+
+                return DatabaseInfo(
+                    scheme="oracle",
+                    authority=DbApiHook.get_openlineage_authority_part(connection, default_port=default_port),
+                )
+
+        dbapi_hook = DBApiHookForTests()
+
+        class OracleToGCSOperatorForTest(OracleToGCSOperator):
+            @property
+            def db_hook(self):
+                return dbapi_hook
+
+        sql = """SELECT employee_id, first_name FROM hr.employees"""
+        op = OracleToGCSOperatorForTest(
+            task_id=TASK_ID, sql=sql, bucket="bucket", filename="dir/file{}.csv"
+        )
+        DB_SCHEMA_NAME = "HR"
+        rows = [
+            (DB_SCHEMA_NAME, "employees", "employee_id", 1, "NUMBER"),
+            (DB_SCHEMA_NAME, "employees", "first_name", 2, "VARCHAR2"),
+            (DB_SCHEMA_NAME, "employees", "age", 3, "NUMBER"),
+        ]
+        dbapi_hook.get_connection.return_value = Connection(
+            conn_id="sql_default", conn_type="oracle", host="host", port=connection_port
+        )
+        dbapi_hook.get_conn.return_value.cursor.return_value.fetchall.side_effect = [rows, []]
+
+        lineage = op.get_openlineage_facets_on_start()
+        assert len(lineage.inputs) == 1
+        assert lineage.inputs[0].namespace == f"oracle://host:{expected_port}"
+        assert lineage.inputs[0].name == f"{input_service_name or input_sid}.HR.employees"
+        assert len(lineage.inputs[0].facets) == 1
+        assert lineage.inputs[0].facets["schema"].fields == [
+            SchemaDatasetFacetFields(name="employee_id", type="NUMBER"),
+            SchemaDatasetFacetFields(name="first_name", type="VARCHAR2"),
+            SchemaDatasetFacetFields(name="age", type="NUMBER"),
+        ]
+        assert lineage.outputs == [
+            OutputDataset(
+                namespace="gs://bucket",
+                name="dir",
+            )
+        ]
+
+        assert len(lineage.job_facets) == 1
+        assert lineage.job_facets["sql"].query == sql
+        assert lineage.run_facets == {}

--- a/providers/oracle/pyproject.toml
+++ b/providers/oracle/pyproject.toml
@@ -71,6 +71,9 @@ dependencies = [
     "numpy>=1.26.0; python_version=='3.12'",
     "numpy>=2.1.0; python_version>='3.13'",
 ]
+"openlineage" = [
+    "apache-airflow-providers-openlineage"
+]
 
 [dependency-groups]
 dev = [
@@ -78,6 +81,7 @@ dev = [
     "apache-airflow-task-sdk",
     "apache-airflow-devel-common",
     "apache-airflow-providers-common-sql",
+    "apache-airflow-providers-openlineage",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
     "numpy>=1.22.4; python_version<'3.11'",
     "numpy>=1.23.2; python_version=='3.11'",

--- a/providers/oracle/src/airflow/providers/oracle/hooks/oracle.py
+++ b/providers/oracle/src/airflow/providers/oracle/hooks/oracle.py
@@ -24,6 +24,11 @@ from typing import Any
 
 import oracledb
 
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from airflow.models.connection import Connection
+    from airflow.providers.openlineage.sqlparser import DatabaseInfo
+
 from airflow.providers.common.sql.hooks.sql import DbApiHook
 
 DEFAULT_DB_PORT = 1521

--- a/providers/oracle/src/airflow/providers/oracle/hooks/oracle.py
+++ b/providers/oracle/src/airflow/providers/oracle/hooks/oracle.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import math
 import warnings
 from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import oracledb
 

--- a/providers/oracle/src/airflow/providers/oracle/hooks/oracle.py
+++ b/providers/oracle/src/airflow/providers/oracle/hooks/oracle.py
@@ -116,6 +116,21 @@ class OracleHook(DbApiHook):
         self.thick_mode_config_dir = thick_mode_config_dir
         self.fetch_decimals = fetch_decimals
         self.fetch_lobs = fetch_lobs
+        self._service_name: str | None = None
+        self._sid: str | None = None
+
+    @property
+    def service_name(self) -> str | None:
+        if self._service_name is None:
+            self._service_name = self.get_connection(self.get_conn_id()).extra_dejson.get("service_name")
+        return self._service_name
+
+    @property
+    def sid(self) -> str | None:
+        if self._sid is None:
+            self._sid = self.get_connection(self.get_conn_id()).extra_dejson.get("sid")
+        return self._sid
+
 
     def get_conn(self) -> oracledb.Connection:
         """
@@ -447,6 +462,33 @@ class OracleHook(DbApiHook):
         )
 
         return result
+
+    def get_openlineage_database_info(self, connection: Connection) -> DatabaseInfo:
+        """Return Oracle specific information for OpenLineage."""
+        from airflow.providers.openlineage.sqlparser import DatabaseInfo
+
+        return DatabaseInfo(
+            scheme=self.get_openlineage_database_dialect(connection),
+            authority=DbApiHook.get_openlineage_authority_part(connection, default_port=DEFAULT_DB_PORT),
+            information_schema_table_name="ALL_TAB_COLUMNS",
+            information_schema_columns=[
+                "owner",
+                "table_name",
+                "column_name",
+                "column_id",
+                "data_type",
+            ],
+            database=self.service_name or self.sid,
+            normalize_name_method=lambda name: name.upper(),
+        )
+
+    def get_openlineage_database_dialect(self, _) -> str:
+        """Return database dialect."""
+        return "oracle"
+
+    def get_openlineage_default_schema(self) -> str | None:
+        """Return current schema."""
+        return self.get_first("SELECT SYS_CONTEXT('USERENV', 'CURRENT_SCHEMA') FROM dual")[0]
 
     def get_uri(self) -> str:
         """Get the URI for the Oracle connection."""

--- a/providers/oracle/src/airflow/providers/oracle/hooks/oracle.py
+++ b/providers/oracle/src/airflow/providers/oracle/hooks/oracle.py
@@ -24,7 +24,6 @@ from typing import TYPE_CHECKING, Any
 
 import oracledb
 
-from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from airflow.models.connection import Connection
     from airflow.providers.openlineage.sqlparser import DatabaseInfo

--- a/providers/oracle/src/airflow/providers/oracle/hooks/oracle.py
+++ b/providers/oracle/src/airflow/providers/oracle/hooks/oracle.py
@@ -131,7 +131,6 @@ class OracleHook(DbApiHook):
             self._sid = self.get_connection(self.get_conn_id()).extra_dejson.get("sid")
         return self._sid
 
-
     def get_conn(self) -> oracledb.Connection:
         """
         Get an Oracle connection object.

--- a/providers/oracle/tests/unit/oracle/hooks/test_oracle.py
+++ b/providers/oracle/tests/unit/oracle/hooks/test_oracle.py
@@ -525,3 +525,44 @@ class TestOracleHook:
         self.cur.execute.assert_called_once_with("select 1 from dual")
         assert status is True
         assert message == "Connection successfully tested"
+
+    def test_get_openlineage_database_info_with_service_name(self):
+        conn = Connection(
+            conn_id="oracle_default",
+            conn_type="oracle",
+            host="localhost",
+            port=1521,
+            extra='{"service_name": "ORCLPDB1"}',
+        )
+        hook = OracleHook(oracle_conn_id="oracle_default")
+        hook.get_connection = lambda _: conn
+
+        assert hook.service_name == "ORCLPDB1"
+        db_info = hook.get_openlineage_database_info(conn)
+        assert db_info.scheme == "oracle"
+        assert db_info.authority == "localhost:1521"
+        assert db_info.database == "ORCLPDB1"
+        assert db_info.normalize_name_method("employees") == "EMPLOYEES"
+        assert db_info.information_schema_table_name == "ALL_TAB_COLUMNS"
+        assert "owner" in db_info.information_schema_columns
+
+
+    def test_get_openlineage_database_info_with_sid(self):
+        conn = Connection(
+            conn_id="oracle_default",
+            conn_type="oracle",
+            host="dbhost",
+            port=1521,
+            extra='{"sid": "XE"}',
+        )
+        hook = OracleHook(oracle_conn_id="oracle_default")
+        hook.get_connection = lambda _: conn
+
+        assert hook.sid == "XE"
+        db_info = hook.get_openlineage_database_info(conn)
+        assert db_info.scheme == "oracle"
+        assert db_info.authority == "dbhost:1521"
+        assert db_info.database == "XE"
+        assert db_info.normalize_name_method("employees") == "EMPLOYEES"
+        assert db_info.information_schema_table_name == "ALL_TAB_COLUMNS"
+        assert "owner" in db_info.information_schema_columns

--- a/providers/oracle/tests/unit/oracle/hooks/test_oracle.py
+++ b/providers/oracle/tests/unit/oracle/hooks/test_oracle.py
@@ -546,7 +546,6 @@ class TestOracleHook:
         assert db_info.information_schema_table_name == "ALL_TAB_COLUMNS"
         assert "owner" in db_info.information_schema_columns
 
-
     def test_get_openlineage_database_info_with_sid(self):
         conn = Connection(
             conn_id="oracle_default",


### PR DESCRIPTION
This PR adds OpenLineage support for OracleToGCSOperator.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
