### PR TITLE
Fix XCom deletion failure for mapped task instances

### DIFF
--- a/task-sdk/src/airflow/sdk/bases/xcom.py
+++ b/task-sdk/src/airflow/sdk/bases/xcom.py
@@ -376,5 +376,6 @@ class BaseXCom:
                 dag_id=dag_id,
                 task_id=task_id,
                 run_id=run_id,
+                map_index=map_index,
             ),
         )

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -905,6 +905,7 @@ def run(
                     dag_id=ti.dag_id,
                     task_id=ti.task_id,
                     run_id=ti.run_id,
+                    map_index=ti.map_index,
                 )
 
         with set_current_context(context):

--- a/task-sdk/tests/task_sdk/bases/test_xcom.py
+++ b/task-sdk/tests/task_sdk/bases/test_xcom.py
@@ -1,0 +1,72 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from airflow.sdk.bases.xcom import BaseXCom
+from airflow.sdk.execution_time.comms import DeleteXCom, XComResult
+
+
+class TestBaseXCom:
+    @pytest.mark.parametrize(
+        "map_index",
+        [
+            pytest.param(None, id="map_index_none"),
+            pytest.param(-1, id="map_index_negative_one"),
+            pytest.param(0, id="map_index_zero"),
+            pytest.param(5, id="map_index_positive"),
+        ],
+    )
+    def test_delete_includes_map_index_in_delete_xcom_message(self, map_index, mock_supervisor_comms):
+        """Test that BaseXCom.delete properly passes map_index to the DeleteXCom message."""
+        with mock.patch.object(
+            BaseXCom, "_get_xcom_db_ref", return_value=XComResult(key="test_key", value="test_value")
+        ) as mock_get_ref:
+            with mock.patch.object(BaseXCom, "purge") as mock_purge:
+                BaseXCom.delete(
+                    key="test_key",
+                    task_id="test_task",
+                    dag_id="test_dag",
+                    run_id="test_run",
+                    map_index=map_index,
+                )
+
+            mock_get_ref.assert_called_once_with(
+                key="test_key",
+                dag_id="test_dag",
+                task_id="test_task",
+                run_id="test_run",
+                map_index=map_index,
+            )
+
+            # Verify purge was called
+            mock_purge.assert_called_once()
+
+            # Verify DeleteXCom message was sent with map_index
+            mock_supervisor_comms.send.assert_called_once()
+            sent_message = mock_supervisor_comms.send.call_args[0][0]
+
+            assert isinstance(sent_message, DeleteXCom)
+            assert sent_message.key == "test_key"
+            assert sent_message.dag_id == "test_dag"
+            assert sent_message.task_id == "test_task"
+            assert sent_message.run_id == "test_run"
+            assert sent_message.map_index == map_index


### PR DESCRIPTION
XCom deletion was not working properly for mapped task instances due to missing map_index parameter in the deletion request. This caused XCom data to persist incorrectly when attempting to clear XComs from specific mapped task executions.

Add test to prevent regression of this fix.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
