### PR TITLE
fix: provide correct extra to on_asset_changed listener

### DIFF
--- a/airflow-core/src/airflow/assets/manager.py
+++ b/airflow-core/src/airflow/assets/manager.py
@@ -198,7 +198,9 @@ class AssetManager(LoggingMixin):
             )
         )
 
-        cls.notify_asset_changed(asset=asset_model.to_public())
+        _asset = asset_model.to_public()
+        _asset.extra.update(extra or {})
+        cls.notify_asset_changed(asset=_asset)
 
         Stats.incr("asset.updates")
 

--- a/airflow-core/tests/unit/listeners/test_asset_listener.py
+++ b/airflow-core/tests/unit/listeners/test_asset_listener.py
@@ -21,6 +21,8 @@ import pytest
 from airflow.listeners.listener import get_listener_manager
 from airflow.models.asset import AssetModel
 from airflow.providers.standard.operators.empty import EmptyOperator
+from airflow.providers.standard.operators.python import PythonOperator
+from airflow.sdk import Metadata
 from airflow.sdk.definitions.asset import Asset
 from airflow.utils.session import provide_session
 
@@ -41,10 +43,10 @@ def clean_listener_manager():
 @pytest.mark.db_test
 @provide_session
 def test_asset_listener_on_asset_changed_gets_calls(create_task_instance_of_operator, session):
-    asset_uri = "test://asset/"
-    asset_name = "test_asset_uri"
+    asset_uri = "test://asset1/"
+    asset_name = "test_asset_uri1"
     asset_group = "test-group"
-    asset = Asset(uri=asset_uri, name=asset_name, group=asset_group)
+    asset = Asset(uri=asset_uri, name=asset_name, group=asset_group, extra={"key": "value"})
     asset_model = AssetModel(uri=asset_uri, name=asset_name, group=asset_group)
     session.add(asset_model)
 
@@ -63,3 +65,64 @@ def test_asset_listener_on_asset_changed_gets_calls(create_task_instance_of_oper
     assert asset_listener.changed[0].uri == asset_uri
     assert asset_listener.changed[0].name == asset_name
     assert asset_listener.changed[0].group == asset_group
+    assert asset_listener.changed[0].extra == {"key": "value"}
+
+
+@pytest.mark.db_test
+@provide_session
+def test_asset_listener_on_asset_changed_with_dynamic_extra(create_task_instance_of_operator, session):
+    asset_uri = "test://asset2/"
+    asset_name = "test_asset_uri2"
+    asset_group = "test-group"
+    asset = Asset(uri=asset_uri, name=asset_name, group=asset_group)
+    asset_model = AssetModel(uri=asset_uri, name=asset_name, group=asset_group)
+    session.add(asset_model)
+
+    session.flush()
+
+    def test_task_callable():
+        yield Metadata(Asset(uri=asset_uri, name=asset_name, group=asset_group), extra={"key": "value"})
+
+    ti = create_task_instance_of_operator(
+        operator_class=PythonOperator,
+        dag_id="producing_dag",
+        task_id="test_task",
+        session=session,
+        outlets=[asset],
+        python_callable=test_task_callable,
+    )
+    ti.run()
+
+    assert len(asset_listener.changed) == 1
+    assert asset_listener.changed[0].uri == asset_uri
+    assert asset_listener.changed[0].name == asset_name
+    assert asset_listener.changed[0].group == asset_group
+    assert asset_listener.changed[0].extra == {"key": "value"}
+
+
+@pytest.mark.db_test
+@provide_session
+def test_asset_listener_on_asset_changed_with_template_extra(create_task_instance_of_operator, session):
+    asset_uri = "test://asset3/"
+    asset_name = "test_asset_uri3"
+    asset_group = "test-group"
+    asset = Asset(uri=asset_uri, name=asset_name, group=asset_group, extra={"task_id": "{{ ti.task_id }}"})
+    asset_model = AssetModel(uri=asset_uri, name=asset_name, group=asset_group)
+    session.add(asset_model)
+
+    session.flush()
+
+    ti = create_task_instance_of_operator(
+        operator_class=EmptyOperator,
+        dag_id="producing_dag",
+        task_id="test_task",
+        session=session,
+        outlets=[asset],
+    )
+    ti.run()
+
+    assert len(asset_listener.changed) == 1
+    assert asset_listener.changed[0].uri == asset_uri
+    assert asset_listener.changed[0].name == asset_name
+    assert asset_listener.changed[0].group == asset_group
+    assert asset_listener.changed[0].extra == {"task_id": "test_task"}


### PR DESCRIPTION
Today, the `on_asset_changed` listener receives a copy of the asset loaded from the database. However, the extra metadata may be added or updated at runtime.

This PR updates the asset instance sent to the listener to ensure it includes the correct extra metadata.

## Summary of tests without the fix:
```
============================================================================= short test summary info =============================================================================
FAILED airflow-core/tests/unit/listeners/test_asset_listener.py::test_asset_listener_on_asset_changed_with_dynamic_extra - AssertionError: assert equals failed
  {}                 {'key': 'value'}
FAILED airflow-core/tests/unit/listeners/test_asset_listener.py::test_asset_listener_on_asset_changed_with_template_extra - AssertionError: assert equals failed
  {'task_id': '{{ ti.task_id }}'}   {'task_id': 'test_task'}
===================================================================== 2 failed, 1 passed, 1 warning in 6.51s ======================================================================
```