### PR TITLE
Fix kpo log_events_on_failure logs warnings at warning level

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -1088,10 +1088,11 @@ class KubernetesPodOperator(BaseOperator):
         """Will fetch and emit events from pod."""
         with _optionally_suppress(reraise=reraise):
             for event in self.pod_manager.read_pod_events(pod).items:
-                if event.type == PodEventType.NORMAL.value:
-                    self.log.info("Pod Event: %s - %s", event.reason, event.message)
+                if event.type == PodEventType.WARNING.value:
+                    self.log.warning("Pod Event: %s - %s", event.reason, event.message)
                 else:
-                    self.log.error("Pod Event: %s - %s", event.reason, event.message)
+                    # events.k8s.io/v1 at this stage will always be Normal
+                    self.log.info("Pod Event: %s - %s", event.reason, event.message)
 
     def _read_pod_container_states(self, pod, *, reraise=True) -> None:
         """Log detailed container states of pod for debugging."""

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -2799,8 +2799,8 @@ def test_read_pod_events(mock_log, mock_pod_manager):
         mock_event_normal.reason,
         mock_event_normal.message,
     )
-    # Assert that event with type `Warning` is logged as error.
-    mock_log.error.assert_called_once_with(
+    # Assert that event with type `Warning` is logged as warning.
+    mock_log.warning.assert_called_once_with(
         "Pod Event: %s - %s",
         mock_event_error.reason,
         mock_event_error.message,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---

Resolves #54964 

[K8s pod events](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/event-v1/) of the `type=Warning` was reported to Airflow logs at the error level. This is too high of a level for the intention of the event type. I chose to report all warning as warning and everything else as info as I think this follows the purpose of K8s events documented as

> Events should be treated as informative, best-effort, supplemental data.

Most if not all the pod events are retryable within K8s' scheduler. I have seen these events being an error tricks pipeline users/operators into thinking the K8s scheduler is at fault it's likely pod TTL issues.

- Warning messages are logged as warning
- Normal messages are logged as info
- Any others are logged as info (v1 Event includes only Warning and Normal)

---

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
