### PR TITLE
fix unintended print of dag not found in serialised_dag table

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -909,13 +909,14 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 # Get task from the Serialized DAG
                 try:
                     dag = scheduler_dag_bag.get_dag_for_run(dag_run=ti.dag_run, session=session)
-                    cls.logger().error(
-                        "DAG '%s' for task instance %s not found in serialized_dag table",
-                        ti.dag_id,
-                        ti,
-                    )
-                    if TYPE_CHECKING:
-                        assert dag
+                    if not dag:
+                        cls.logger().error(
+                            "DAG '%s' for task instance %s not found in serialized_dag table",
+                            ti.dag_id,
+                            ti,
+                        )
+                        raise
+
                     # TODO (GH-52141): get_task in scheduler needs to return scheduler types
                     # instead, but currently it inherits SDK's DAG.
                     task = cast("MappedOperator | SerializedBaseOperator", dag.get_task(ti.task_id))

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -48,6 +48,7 @@ from airflow.callbacks.callback_requests import (
 )
 from airflow.configuration import conf
 from airflow.dag_processing.bundles.base import BundleUsageTrackingManager
+from airflow.exceptions import DagNotFound
 from airflow.executors import workloads
 from airflow.jobs.base_job_runner import BaseJobRunner
 from airflow.jobs.job import Job, JobState, perform_heartbeat
@@ -914,7 +915,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                             ti.dag_id,
                             ti,
                         )
-                        raise
+                        raise DagNotFound(f"DAG '{ti.dag_id}' not found in serialized_dag table")
 
                     task = dag.get_task(ti.task_id)
                 except Exception:


### PR DESCRIPTION
we are directly printing that serialised dag is not found without checking. This PR fixes it.