### PR TITLE
Remove setting of headers in OTLPSpanExporter and OTLPMetricExporter in Airflow 2.11.0

### DIFF
--- a/airflow/metrics/otel_logger.py
+++ b/airflow/metrics/otel_logger.py
@@ -419,10 +419,7 @@ def get_otel_logger(cls) -> SafeOtelLogger:
     log.info("[Metric Exporter] Connecting to OpenTelemetry Collector at %s", endpoint)
     readers = [
         PeriodicExportingMetricReader(
-            OTLPMetricExporter(
-                endpoint=endpoint,
-                headers={"Content-Type": "application/json"},
-            ),
+            OTLPMetricExporter(endpoint=endpoint),
             export_interval_millis=interval,
         )
     ]

--- a/airflow/traces/otel_tracer.py
+++ b/airflow/traces/otel_tracer.py
@@ -269,7 +269,7 @@ def get_otel_tracer(cls) -> OtelTrace:
         endpoint = f"{protocol}://{host}:{port}/v1/traces"
         log.info("[OTLPSpanExporter] Connecting to OpenTelemetry Collector at %s", endpoint)
         return OtelTrace(
-            span_exporter=OTLPSpanExporter(endpoint=endpoint, headers={"Content-Type": "application/json"}),
+            span_exporter=OTLPSpanExporter(endpoint=endpoint),
             tag_string=tag_string,
         )
 


### PR DESCRIPTION
This PR fixes an issue in the Airflow 2.11.0 stable branch where headers were hardcoded in OTLPSpanExporter and OTLPMetricExporter, preventing users from properly configuring authentication via custom headers.

By removing the hardcoded headers, this change enables users to add necessary authentication information when exporting spans using OTLPSpanExporter.

This issue is specific to Airflow 2.x; while Airflow 3.0.x have breaking changes, many users still rely on Airflow 2.11.0 for production environments and require this bugfix.

related: PR[#44346](https://github.com/apache/airflow/pull/44346)