### PR TITLE
Remove unneeded isort skip comments

### DIFF
--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -2269,8 +2269,6 @@ def _has_kubernetes() -> bool:
 
         globals()["k8s"] = k8s
         globals()["PodGenerator"] = PodGenerator
-
-        # isort: on
         HAS_KUBERNETES = True
     except ImportError:
         HAS_KUBERNETES = False

--- a/devel-common/src/docs/build_docs.py
+++ b/devel-common/src/docs/build_docs.py
@@ -15,11 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""
-Builds documentation and runs spell checking
-
-# isort:skip_file (needed to workaround isort bug)
-"""
+"""Builds documentation and runs spell checking."""
 
 from __future__ import annotations
 

--- a/devel-common/src/sphinx_exts/docs_build/dev_index_generator.py
+++ b/devel-common/src/sphinx_exts/docs_build/dev_index_generator.py
@@ -23,11 +23,8 @@ from pathlib import Path
 
 import jinja2
 
-# isort:off (needed to workaround isort bug)
 from sphinx_exts.docs_build.code_utils import AIRFLOW_CONTENT_ROOT_PATH
 from sphinx_exts.provider_yaml_utils import load_package_data
-
-# isort:on (needed to workaround isort bug)
 
 CURRENT_DIR = Path(os.path.dirname(__file__)).resolve()
 GENERATED_BUILD_DOCS_PATH = AIRFLOW_CONTENT_ROOT_PATH / "generated" / "_build" / "docs"

--- a/devel-common/src/sphinx_exts/docs_build/errors.py
+++ b/devel-common/src/sphinx_exts/docs_build/errors.py
@@ -24,9 +24,7 @@ from typing import NamedTuple
 from rich.console import Console
 
 from airflow.utils.code_utils import prepare_code_snippet
-
-from sphinx_exts.docs_build.code_utils import CONSOLE_WIDTH  # isort:skip (needed to workaround isort bug)
-
+from sphinx_exts.docs_build.code_utils import CONSOLE_WIDTH
 
 CURRENT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__)))
 DOCS_DIR = os.path.abspath(os.path.join(CURRENT_DIR, os.pardir, os.pardir))

--- a/devel-common/src/tests_common/pytest_plugin.py
+++ b/devel-common/src/tests_common/pytest_plugin.py
@@ -234,10 +234,7 @@ ALLOWED_TRACE_SQL_COLUMNS = ["num", "time", "trace", "sql", "parameters", "count
 @pytest.fixture(autouse=True)
 def trace_sql(request):
     try:
-        from tests_common.test_utils.perf.perf_kit.sqlalchemy import (  # isort: skip
-            count_queries,
-            trace_queries,
-        )
+        from tests_common.test_utils.perf.perf_kit.sqlalchemy import count_queries, trace_queries
     except ImportError:
         yield
         return

--- a/docker-tests/tests/docker_tests/test_docker_compose_quick_start.py
+++ b/docker-tests/tests/docker_tests/test_docker_compose_quick_start.py
@@ -28,13 +28,10 @@ from python_on_whales import DockerClient, docker
 from python_on_whales.exceptions import DockerException
 from rich.console import Console
 
-# isort:off (needed to workaround isort bug)
 from docker_tests.command_utils import run_command
 from docker_tests.constants import AIRFLOW_ROOT_PATH
 
 from tests_common.test_utils.api_client_helpers import generate_access_token
-
-# isort:on (needed to workaround isort bug)
 
 console = Console(width=400, color_system="standard")
 

--- a/docker-tests/tests/docker_tests/test_examples_of_prod_image_building.py
+++ b/docker-tests/tests/docker_tests/test_examples_of_prod_image_building.py
@@ -26,11 +26,8 @@ import pytest
 import requests
 from python_on_whales import docker
 
-# isort:off (needed to workaround isort bug)
 from docker_tests.command_utils import run_command
 from docker_tests.constants import AIRFLOW_ROOT_PATH
-
-# isort:on (needed to workaround isort bug)
 
 DOCKER_EXAMPLES_DIR = AIRFLOW_ROOT_PATH / "docker-stack-docs" / "docker-examples"
 QUARANTINED_DOCKER_EXAMPLES: dict[str, str] = {

--- a/kubernetes-tests/tests/kubernetes_tests/test_kubernetes_executor.py
+++ b/kubernetes-tests/tests/kubernetes_tests/test_kubernetes_executor.py
@@ -25,10 +25,7 @@ if TYPE_CHECKING:
     from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import FailureDetails
 
 from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import KubernetesResults
-from kubernetes_tests.test_base import (
-    EXECUTOR,
-    BaseK8STest,  # isort:skip (needed to workaround isort bug)
-)
+from kubernetes_tests.test_base import EXECUTOR, BaseK8STest
 
 
 @pytest.mark.skipif(EXECUTOR != "KubernetesExecutor", reason="Only runs on KubernetesExecutor")

--- a/kubernetes-tests/tests/kubernetes_tests/test_other_executors.py
+++ b/kubernetes-tests/tests/kubernetes_tests/test_other_executors.py
@@ -18,10 +18,7 @@ from __future__ import annotations
 
 import pytest
 
-from kubernetes_tests.test_base import (
-    EXECUTOR,
-    BaseK8STest,  # isort:skip (needed to workaround isort bug)
-)
+from kubernetes_tests.test_base import EXECUTOR, BaseK8STest
 
 
 # These tests are here because only KubernetesExecutor can run the tests in

--- a/providers/common/sql/src/airflow/providers/common/sql/dialects/dialect.pyi
+++ b/providers/common/sql/src/airflow/providers/common/sql/dialects/dialect.pyi
@@ -28,8 +28,8 @@
 # You can read more in the README_API.md file
 #
 """
-Definition of the public interface for airflow.providers.common.sql.src.airflow.providers.common.sql.dialects.dialect
-isort:skip_file
+Definition of the public interface for
+airflow.providers.common.sql.src.airflow.providers.common.sql.dialects.dialect.
 """
 
 from collections.abc import Callable, Iterable, Mapping

--- a/providers/common/sql/src/airflow/providers/common/sql/get_provider_info.pyi
+++ b/providers/common/sql/src/airflow/providers/common/sql/get_provider_info.pyi
@@ -28,8 +28,8 @@
 # You can read more in the README_API.md file
 #
 """
-Definition of the public interface for airflow.providers.common.sql.src.airflow.providers.common.sql.get_provider_info
-isort:skip_file
+Definition of the public interface for
+airflow.providers.common.sql.src.airflow.providers.common.sql.get_provider_info.
 """
 
 def get_provider_info() -> None: ...

--- a/providers/common/sql/src/airflow/providers/common/sql/hooks/handlers.pyi
+++ b/providers/common/sql/src/airflow/providers/common/sql/hooks/handlers.pyi
@@ -28,8 +28,8 @@
 # You can read more in the README_API.md file
 #
 """
-Definition of the public interface for airflow.providers.common.sql.src.airflow.providers.common.sql.hooks.handlers
-isort:skip_file
+Definition of the public interface for
+airflow.providers.common.sql.src.airflow.providers.common.sql.hooks.handlers.
 """
 
 from collections.abc import Iterable

--- a/providers/common/sql/src/airflow/providers/common/sql/hooks/sql.pyi
+++ b/providers/common/sql/src/airflow/providers/common/sql/hooks/sql.pyi
@@ -28,8 +28,8 @@
 # You can read more in the README_API.md file
 #
 """
-Definition of the public interface for airflow.providers.common.sql.src.airflow.providers.common.sql.hooks.sql
-isort:skip_file
+Definition of the public interface for
+airflow.providers.common.sql.src.airflow.providers.common.sql.hooks.sql.
 """
 
 from collections.abc import Callable, Generator, Iterable, Mapping, MutableMapping, Sequence

--- a/providers/common/sql/src/airflow/providers/common/sql/operators/generic_transfer.pyi
+++ b/providers/common/sql/src/airflow/providers/common/sql/operators/generic_transfer.pyi
@@ -27,10 +27,7 @@
 #
 # You can read more in the README_API.md file
 #
-"""
-Definition of the public interface for airflow.providers.common.sql.operators.generic_transfer
-isort:skip_file
-"""
+"""Definition of the public interface for airflow.providers.common.sql.operators.generic_transfer."""
 
 from collections.abc import Sequence
 from functools import cached_property as cached_property

--- a/providers/common/sql/src/airflow/providers/common/sql/sensors/sql.pyi
+++ b/providers/common/sql/src/airflow/providers/common/sql/sensors/sql.pyi
@@ -28,8 +28,8 @@
 # You can read more in the README_API.md file
 #
 """
-Definition of the public interface for airflow.providers.common.sql.src.airflow.providers.common.sql.sensors.sql
-isort:skip_file
+Definition of the public interface for
+airflow.providers.common.sql.src.airflow.providers.common.sql.sensors.sql.
 """
 
 from collections.abc import Callable, Mapping, Sequence

--- a/providers/common/sql/src/airflow/providers/common/sql/triggers/sql.pyi
+++ b/providers/common/sql/src/airflow/providers/common/sql/triggers/sql.pyi
@@ -27,10 +27,7 @@
 #
 # You can read more in the README_API.md file
 #
-"""
-Definition of the public interface for airflow.providers.common.sql.triggers.sql
-isort:skip_file
-"""
+"""Definition of the public interface for airflow.providers.common.sql.triggers.sql."""
 
 from collections.abc import AsyncIterator
 from typing import Any

--- a/providers/google/tests/system/google/cloud/vision/example_vision_annotate_image.py
+++ b/providers/google/tests/system/google/cloud/vision/example_vision_annotate_image.py
@@ -40,7 +40,7 @@ except ImportError:
     from airflow.utils.trigger_rule import TriggerRule  # type: ignore[no-redef,attr-defined]
 
 # [START howto_operator_vision_retry_import]
-from google.api_core.retry import Retry  # isort:skip
+from google.api_core.retry import Retry
 
 # [END howto_operator_vision_retry_import]
 

--- a/providers/google/tests/system/google/cloud/vision/example_vision_autogenerated.py
+++ b/providers/google/tests/system/google/cloud/vision/example_vision_autogenerated.py
@@ -47,11 +47,11 @@ except ImportError:
     from airflow.utils.trigger_rule import TriggerRule  # type: ignore[no-redef,attr-defined]
 
 # [START howto_operator_vision_retry_import]
-from google.api_core.retry import Retry  # isort:skip
+from google.api_core.retry import Retry
 
 # [END howto_operator_vision_retry_import]
 # [START howto_operator_vision_product_set_import]
-from google.cloud.vision_v1.types import ProductSet  # isort:skip
+from google.cloud.vision_v1.types import ProductSet
 
 # [END howto_operator_vision_product_set_import]
 # [START howto_operator_vision_product_import]
@@ -59,7 +59,7 @@ from google.cloud.vision_v1.types import Product  # isort:skip
 
 # [END howto_operator_vision_product_import]
 # [START howto_operator_vision_reference_image_import]
-from google.cloud.vision_v1.types import ReferenceImage  # isort:skip
+from google.cloud.vision_v1.types import ReferenceImage
 
 # [END howto_operator_vision_reference_image_import]
 # [START howto_operator_vision_enums_import]

--- a/providers/google/tests/system/google/cloud/vision/example_vision_explicit.py
+++ b/providers/google/tests/system/google/cloud/vision/example_vision_explicit.py
@@ -46,11 +46,11 @@ except ImportError:
     from airflow.utils.trigger_rule import TriggerRule  # type: ignore[no-redef,attr-defined]
 
 # [START howto_operator_vision_retry_import]
-from google.api_core.retry import Retry  # isort:skip
+from google.api_core.retry import Retry
 
 # [END howto_operator_vision_retry_import]
 # [START howto_operator_vision_product_set_import_2]
-from google.cloud.vision_v1.types import ProductSet  # isort:skip
+from google.cloud.vision_v1.types import ProductSet
 
 # [END howto_operator_vision_product_set_import_2]
 # [START howto_operator_vision_product_import_2]


### PR DESCRIPTION
We don't actually use isort now, and many of these workarounds are not needed anymore (probably also true for the actual isort too).