### PR TITLE
Fix typo in `define-extra-link.rst`

### DIFF
--- a/airflow-core/docs/howto/define-extra-link.rst
+++ b/airflow-core/docs/howto/define-extra-link.rst
@@ -143,7 +143,7 @@ Console, but if we wanted to change that link we could do:
 
         name = "BigQuery Dataset"
         key = "bigquery_dataset"
-        format_str = BIGQUERY_DATASET_LINK
+        format_str = BIGQUERY_DATASET_LINK_FMT
 
         @staticmethod
         def persist(


### PR DESCRIPTION
The constant used to set the `format_str` class-level attribute did not exist. `BIGQUERY_JOB_DETAILS_LINK` needed to be updated to `BIGQUERY_JOB_DETAILS_LINK_FMT.

Search for `BIGQUERY_JOB_DETAILS_LINK` on this page (https://airflow.apache.org/docs/apache-airflow/stable/howto/define-extra-link.html) will show the mis-match.
