### PR TITLE
helm: statsd deployment volume mount without subpath for live reloading

### DIFF
--- a/chart/templates/statsd/statsd-deployment.yaml
+++ b/chart/templates/statsd/statsd-deployment.yaml
@@ -130,8 +130,8 @@ spec:
             timeoutSeconds: 5
           volumeMounts:
             - name: config
-              mountPath: /etc/statsd-exporter/mappings.yml
-              subPath: mappings.yml
+              mountPath: /etc/statsd-exporter
+              readOnly: true
       volumes:
         - name: config
           configMap:

--- a/helm-tests/tests/helm_tests/other/test_statsd.py
+++ b/helm-tests/tests/helm_tests/other/test_statsd.py
@@ -38,8 +38,8 @@ class TestStatsd:
 
         assert {
             "name": "config",
-            "mountPath": "/etc/statsd-exporter/mappings.yml",
-            "subPath": "mappings.yml",
+            "mountPath": "/etc/statsd-exporter",
+            "readOnly": True,
         } in jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
 
         default_args = ["--statsd.mapping-config=/etc/statsd-exporter/mappings.yml"]
@@ -62,8 +62,8 @@ class TestStatsd:
 
         assert {
             "name": "config",
-            "mountPath": "/etc/statsd-exporter/mappings.yml",
-            "subPath": "mappings.yml",
+            "mountPath": "/etc/statsd-exporter",
+            "readOnly": True,
         } in jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
 
     def test_should_add_volume_and_volume_mount_when_exist_override_mappings(self):
@@ -83,8 +83,8 @@ class TestStatsd:
 
         assert {
             "name": "config",
-            "mountPath": "/etc/statsd-exporter/mappings.yml",
-            "subPath": "mappings.yml",
+            "mountPath": "/etc/statsd-exporter",
+            "readOnly": True,
         } in jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
Whenever the `statsd_exporter`'s mapping is changed, the deployment will need to restart. This loses some metrics. The `statsd_exporter` exposes a lifecycle API: https://github.com/prometheus/statsd_exporter?tab=readme-ov-file#lifecycle-api in order to reload the mapping.

This is great, because we can reload mappings without losing metrics and downtime. However, quoting the Kubernetes documentation:

> A container using a ConfigMap as a [subPath](https://kubernetes.io/docs/concepts/storage/volumes/#using-subpath) volume mount will not receive updates when the ConfigMap changes.

In this MR we resolve it, by mounting all files from the Statsd ConfigMap in the `/etc/statsd-exporter`. This results in the same end result in the container filesystem, as it only contains a single file (`mappings.yml`).


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
