### PR TITLE
Fix ``BranchPythonOperator`` execution failure when callable returns `None`

### DIFF
--- a/providers/standard/src/airflow/providers/standard/operators/branch.py
+++ b/providers/standard/src/airflow/providers/standard/operators/branch.py
@@ -37,11 +37,17 @@ if TYPE_CHECKING:
 class BranchMixIn(SkipMixin):
     """Utility helper which handles the branching as one-liner."""
 
-    def do_branch(self, context: Context, branches_to_execute: str | Iterable[str]) -> str | Iterable[str]:
+    def do_branch(
+        self, context: Context, branches_to_execute: str | Iterable[str] | None
+    ) -> str | Iterable[str] | None:
         """Implement the handling of branching including logging."""
         self.log.info("Branch into %s", branches_to_execute)
-        branch_task_ids = self._expand_task_group_roots(context["ti"], branches_to_execute)
-        self.skip_all_except(context["ti"], branch_task_ids)
+        if branches_to_execute is None:
+            # When None is returned, skip all downstream tasks
+            self.skip_all_except(context["ti"], None)
+        else:
+            branch_task_ids = self._expand_task_group_roots(context["ti"], branches_to_execute)
+            self.skip_all_except(context["ti"], branch_task_ids)
         return branches_to_execute
 
     def _expand_task_group_roots(
@@ -86,13 +92,13 @@ class BaseBranchOperator(BaseOperator, BranchMixIn):
 
     inherits_from_skipmixin = True
 
-    def choose_branch(self, context: Context) -> str | Iterable[str]:
+    def choose_branch(self, context: Context) -> str | Iterable[str] | None:
         """
         Abstract method to choose which branch to run.
 
         Subclasses should implement this, running whatever logic is
         necessary to choose a branch and returning a task_id or list of
-        task_ids.
+        task_ids. If None is returned, all downstream tasks will be skipped.
 
         :param context: Context dictionary as passed to execute()
         """


### PR DESCRIPTION
`BranchPythonOperator` now properly handles callables that return None by skipping all downstream tasks, instead of throwing an execution error. This restores the expected behavior for users who rely on None returns to skip branches conditionally.

Fixes #54340

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
