### PR TITLE
Configure logging for Triggerer

### DIFF
--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -710,6 +710,10 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
         import msgspec
         from structlog.stdlib import NAME_TO_LEVEL
 
+        from airflow.sdk.log import configure_logging
+
+        configure_logging()
+
         fallback_log = structlog.get_logger(logger_name=__name__)
 
         from airflow.sdk.log import logging_processors

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -1145,14 +1145,3 @@ def test_update_triggers_prevents_duplicate_creation_queue_entries_with_multiple
     trigger_ids = {trigger.id for trigger in supervisor.creating_triggers}
     assert trigger_orm1.id in trigger_ids
     assert trigger_orm2.id in trigger_ids
-
-
-@patch("airflow.sdk.log.configure_logging")
-def test_process_log_messages_configures_logging(mock_configure_logging, supervisor_builder):
-    supervisor = supervisor_builder()
-
-    # Create the generator (this triggers the configuration reading)
-    log_processor_gen = supervisor._process_log_messages_from_subprocess()
-    next(log_processor_gen)  # Initialize the generator
-
-    assert mock_configure_logging.call_count == 1

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -1145,3 +1145,14 @@ def test_update_triggers_prevents_duplicate_creation_queue_entries_with_multiple
     trigger_ids = {trigger.id for trigger in supervisor.creating_triggers}
     assert trigger_orm1.id in trigger_ids
     assert trigger_orm2.id in trigger_ids
+
+
+@patch("airflow.sdk.log.configure_logging")
+def test_process_log_messages_configures_logging(mock_configure_logging, supervisor_builder):
+    supervisor = supervisor_builder()
+
+    # Create the generator (this triggers the configuration reading)
+    log_processor_gen = supervisor._process_log_messages_from_subprocess()
+    next(log_processor_gen)  # Initialize the generator
+
+    assert mock_configure_logging.call_count == 1


### PR DESCRIPTION
This will ensure logging configuration such as colored_console_log are respected by the Triggerer processes.

The way this was detected was Trigger logs not respecting the `logging.colored_console_log` config (see #54962). With this change the logs now respect that setting:

<img width="1913" height="1152" alt="Screenshot from 2025-08-27 11-16-40" src="https://github.com/user-attachments/assets/d311c6b6-80cd-4b81-bd04-0edbb4832e44" />


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
