### PR TITLE
Fix process leaks in `GitDagBundle` repository management

### DIFF
--- a/providers/git/tests/unit/git/bundles/test_git.py
+++ b/providers/git/tests/unit/git/bundles/test_git.py
@@ -68,6 +68,14 @@ def git_repo(tmp_path_factory):
     return (directory, repo)
 
 
+def assert_repo_is_closed(bundle: GitDagBundle):
+    # cat-file processes get left around if the repo is not closed, so check it was
+    assert bundle.repo.git.cat_file_all is None
+    assert bundle.bare_repo.git.cat_file_all is None
+    assert bundle.repo.git.cat_file_header is None
+    assert bundle.bare_repo.git.cat_file_header is None
+
+
 class TestGitDagBundle:
     @classmethod
     def teardown_class(cls) -> None:
@@ -137,6 +145,8 @@ class TestGitDagBundle:
 
         assert bundle.get_current_version() == repo.head.commit.hexsha
 
+        assert_repo_is_closed(bundle)
+
     @mock.patch("airflow.providers.git.bundles.git.GitHook")
     def test_get_specific_version(self, mock_githook, git_repo):
         repo_path, repo = git_repo
@@ -162,6 +172,8 @@ class TestGitDagBundle:
 
         files_in_repo = {f.name for f in bundle.path.iterdir() if f.is_file()}
         assert {"test_dag.py"} == files_in_repo
+
+        assert_repo_is_closed(bundle)
 
     @mock.patch("airflow.providers.git.bundles.git.GitHook")
     def test_get_tag_version(self, mock_githook, git_repo):
@@ -211,6 +223,8 @@ class TestGitDagBundle:
         files_in_repo = {f.name for f in bundle.path.iterdir() if f.is_file()}
         assert {"test_dag.py", "new_test.py"} == files_in_repo
 
+        assert_repo_is_closed(bundle)
+
     @pytest.mark.parametrize(
         "amend",
         [
@@ -249,6 +263,8 @@ class TestGitDagBundle:
 
         files_in_repo = {f.name for f in bundle.path.iterdir() if f.is_file()}
         assert {"test_dag.py", "new_test.py"} == files_in_repo
+
+        assert_repo_is_closed(bundle)
 
     @mock.patch("airflow.providers.git.bundles.git.GitHook")
     def test_refresh_tag(self, mock_githook, git_repo):


### PR DESCRIPTION
Fix leftover git cat-file processes from GitDagBundle. GitDagBundle was leaving behind `git cat-file --batch-check` processes after operations, causing process accumulation over time. This occurred because Git repository objects were not being properly closed after repo operations.