### PR TITLE
Add `LIST` scope in Keycloak auth manager

### DIFF
--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/cli/commands.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/cli/commands.py
@@ -114,7 +114,7 @@ def _get_client_uuid(args):
 
 def _create_scopes(client: KeycloakAdmin, client_uuid: str):
     scopes = [{"name": method} for method in get_args(ResourceMethod)]
-    scopes.append({"name": "MENU"})
+    scopes.extend([{"name": "MENU"}, {"name": "LIST"}])
     for scope in scopes:
         client.create_client_authz_scopes(client_id=client_uuid, payload=scope)
 
@@ -126,7 +126,7 @@ def _create_resources(client: KeycloakAdmin, client_uuid: str):
     scopes = [
         {"id": scope["id"], "name": scope["name"]}
         for scope in all_scopes
-        if scope["name"] in ["GET", "POST", "PUT", "DELETE"]
+        if scope["name"] in ["GET", "POST", "PUT", "DELETE", "LIST"]
     ]
 
     for resource in KeycloakResource:
@@ -166,7 +166,7 @@ def _create_permissions(client: KeycloakAdmin, client_uuid: str):
 
 def _create_read_only_permission(client: KeycloakAdmin, client_uuid: str):
     all_scopes = client.get_client_authz_scopes(client_uuid)
-    scopes = [scope["id"] for scope in all_scopes if scope["name"] in ["GET", "MENU"]]
+    scopes = [scope["id"] for scope in all_scopes if scope["name"] in ["GET", "MENU", "LIST"]]
     payload = {
         "name": "ReadOnly",
         "type": "scope",

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
@@ -286,6 +286,8 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
         context_attributes = prune_dict(attributes or {})
         if resource_id:
             context_attributes[RESOURCE_ID_ATTRIBUTE_NAME] = resource_id
+        elif method == "GET":
+            method = "LIST"
 
         resp = requests.post(
             self._get_token_url(server_url, realm),

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
@@ -112,7 +112,7 @@ class TestKeycloakAuthManager:
                 "Configuration#GET",
                 {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
             ],
-            ["is_authorized_configuration", "GET", None, "Configuration#GET", None],
+            ["is_authorized_configuration", "GET", None, "Configuration#LIST", None],
             [
                 "is_authorized_configuration",
                 "PUT",
@@ -127,7 +127,7 @@ class TestKeycloakAuthManager:
                 "Connection#DELETE",
                 {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
             ],
-            ["is_authorized_connection", "GET", None, "Connection#GET", {}],
+            ["is_authorized_connection", "GET", None, "Connection#LIST", {}],
             [
                 "is_authorized_backfill",
                 "POST",
@@ -135,7 +135,7 @@ class TestKeycloakAuthManager:
                 "Backfill#POST",
                 {RESOURCE_ID_ATTRIBUTE_NAME: "1"},
             ],
-            ["is_authorized_backfill", "GET", None, "Backfill#GET", {}],
+            ["is_authorized_backfill", "GET", None, "Backfill#LIST", {}],
             [
                 "is_authorized_asset",
                 "GET",
@@ -143,7 +143,7 @@ class TestKeycloakAuthManager:
                 "Asset#GET",
                 {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
             ],
-            ["is_authorized_asset", "GET", None, "Asset#GET", {}],
+            ["is_authorized_asset", "GET", None, "Asset#LIST", {}],
             [
                 "is_authorized_asset_alias",
                 "GET",
@@ -151,7 +151,7 @@ class TestKeycloakAuthManager:
                 "AssetAlias#GET",
                 {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
             ],
-            ["is_authorized_asset_alias", "GET", None, "AssetAlias#GET", {}],
+            ["is_authorized_asset_alias", "GET", None, "AssetAlias#LIST", {}],
             [
                 "is_authorized_variable",
                 "PUT",
@@ -159,7 +159,7 @@ class TestKeycloakAuthManager:
                 "Variable#PUT",
                 {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
             ],
-            ["is_authorized_variable", "GET", None, "Variable#GET", {}],
+            ["is_authorized_variable", "GET", None, "Variable#LIST", {}],
             [
                 "is_authorized_pool",
                 "POST",
@@ -167,7 +167,7 @@ class TestKeycloakAuthManager:
                 "Pool#POST",
                 {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
             ],
-            ["is_authorized_pool", "GET", None, "Pool#GET", {}],
+            ["is_authorized_pool", "GET", None, "Pool#LIST", {}],
         ],
     )
     @pytest.mark.parametrize(
@@ -257,7 +257,7 @@ class TestKeycloakAuthManager:
                 "GET",
                 None,
                 None,
-                "Dag#GET",
+                "Dag#LIST",
                 {},
             ],
             [
@@ -278,7 +278,7 @@ class TestKeycloakAuthManager:
                 "GET",
                 DagAccessEntity.TASK_INSTANCE,
                 None,
-                "Dag#GET",
+                "Dag#LIST",
                 {"dag_entity": "TASK_INSTANCE"},
             ],
         ],


### PR DESCRIPTION
Similar of #54987 and #54926 but for Keycloak auth manager.

The current logic to list resources (e.g. list Dags) is a bit wrong in auth managers. Let's take an example. If a user is authorized to access only the Dag test, with the Keycloak auth manager today, the list Dags API returns access denied because we are checking whether the user has access to all Dags.

To fix that, I introduce a new action LIST so that admins can easily give LIST access to all Dags but GET access only on few Dags.



<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
