### PR TITLE
Persist TI tabs in dag view

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridTI.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridTI.tsx
@@ -18,14 +18,15 @@
  */
 import { Badge, Flex } from "@chakra-ui/react";
 import type { MouseEvent } from "react";
-import React from "react";
+import React, { useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { Link, useParams } from "react-router-dom";
+import { Link, useLocation, useParams } from "react-router-dom";
 
 import type { LightGridTaskInstanceSummary } from "openapi/requests/types.gen";
 import { StateIcon } from "src/components/StateIcon";
 import Time from "src/components/Time";
 import { Tooltip } from "src/components/ui";
+import { buildTaskInstanceUrl } from "src/utils/links";
 
 type Props = {
   readonly dagId: string;
@@ -58,6 +59,20 @@ const onMouseLeave = (event: MouseEvent<HTMLDivElement>) => {
 const Instance = ({ dagId, instance, isGroup, isMapped, onClick, runId, search, taskId }: Props) => {
   const { groupId: selectedGroupId, taskId: selectedTaskId } = useParams();
   const { t: translate } = useTranslation();
+  const location = useLocation();
+
+  const getTaskUrl = useCallback(
+    () =>
+      buildTaskInstanceUrl({
+        currentPathname: location.pathname,
+        dagId,
+        isGroup,
+        isMapped: Boolean(isMapped),
+        runId,
+        taskId,
+      }),
+    [dagId, isGroup, isMapped, location.pathname, runId, taskId],
+  );
 
   return (
     <Flex
@@ -79,7 +94,7 @@ const Instance = ({ dagId, instance, isGroup, isMapped, onClick, runId, search, 
         onClick={onClick}
         replace
         to={{
-          pathname: `/dags/${dagId}/runs/${runId}/tasks/${isGroup ? "group/" : ""}${taskId}${isMapped ? "/mapped" : ""}`,
+          pathname: getTaskUrl(),
           search,
         }}
       >

--- a/airflow-core/src/airflow/ui/src/pages/HITLTaskInstances/HITLTaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/HITLTaskInstances/HITLTaskInstances.tsx
@@ -84,17 +84,9 @@ const taskInstanceColumns = ({
     : [
         {
           accessorKey: "run_after",
-          // If we don't show the taskId column, make the dag run a link to the task instance
-          cell: ({ row: { original } }: TaskInstanceRow) =>
-            Boolean(taskId) ? (
-              <Link asChild color="fg.info" fontWeight="bold">
-                <RouterLink to={getTaskInstanceLink(original.task_instance)}>
-                  <Time datetime={original.task_instance.run_after} />
-                </RouterLink>
-              </Link>
-            ) : (
-              <Time datetime={original.task_instance.run_after} />
-            ),
+          cell: ({ row: { original } }: TaskInstanceRow) => (
+            <Time datetime={original.task_instance.run_after} />
+          ),
           header: translate("common:dagRun.runAfter"),
         },
       ]),

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/TaskInstance.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/TaskInstance.tsx
@@ -17,12 +17,12 @@
  * under the License.
  */
 import { ReactFlowProvider } from "@xyflow/react";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { FiCode, FiDatabase, FiUser } from "react-icons/fi";
 import { MdDetails, MdOutlineEventNote, MdOutlineTask, MdReorder, MdSyncAlt } from "react-icons/md";
 import { PiBracketsCurlyBold } from "react-icons/pi";
-import { useParams } from "react-router-dom";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
 
 import {
   useHumanInTheLoopServiceGetHitlDetails,
@@ -38,7 +38,8 @@ import { Header } from "./Header";
 export const TaskInstance = () => {
   const { t: translate } = useTranslation("dag");
   const { dagId = "", mapIndex = "-1", runId = "", taskId = "" } = useParams();
-
+  const navigate = useNavigate();
+  const location = useLocation();
   // Get external views with task_instance destination
   const externalTabs = usePluginTabs("task_instance");
 
@@ -79,7 +80,7 @@ export const TaskInstance = () => {
 
   const { data: gridTISummaries } = useGridTiSummaries({ dagId, runId });
 
-  const { data: hitlDetails } = useHumanInTheLoopServiceGetHitlDetails(
+  const { data: hitlDetails, isLoading: isLoadingHitl } = useHumanInTheLoopServiceGetHitlDetails(
     {
       dagId,
       dagRunId: runId,
@@ -127,6 +128,12 @@ export const TaskInstance = () => {
 
     return true;
   });
+
+  useEffect(() => {
+    if (!hasHitlForTask && !isLoadingHitl && location.pathname.includes("required_actions")) {
+      navigate(`/dags/${dagId}/runs/${runId}/tasks/${taskId}`);
+    }
+  }, [dagId, error, hasHitlForTask, isLoadingHitl, location.pathname, navigate, runId, taskId]);
 
   return (
     <ReactFlowProvider>

--- a/airflow-core/src/airflow/ui/src/pages/XCom/XCom.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/XCom/XCom.tsx
@@ -28,7 +28,7 @@ import { useTableURLState } from "src/components/DataTable/useTableUrlState";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import { TruncatedText } from "src/components/TruncatedText";
 import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searchParams";
-import { getTaskInstanceLinkFromObj } from "src/utils/links";
+import { getTaskInstanceLink } from "src/utils/links";
 
 import { XComEntry } from "./XComEntry";
 import { XComFilters } from "./XComFilters";
@@ -74,7 +74,7 @@ const columns = (translate: (key: string) => string): Array<ColumnDef<XComRespon
     cell: ({ row: { original } }: { row: { original: XComResponse } }) => (
       <Link asChild color="fg.info" fontWeight="bold">
         <RouterLink
-          to={getTaskInstanceLinkFromObj({
+          to={getTaskInstanceLink({
             dagId: original.dag_id,
             dagRunId: original.run_id,
             mapIndex: original.map_index,

--- a/airflow-core/src/airflow/ui/src/router.tsx
+++ b/airflow-core/src/airflow/ui/src/router.tsx
@@ -68,8 +68,8 @@ const pluginRoute = {
   path: "plugin/:page",
 };
 
-const taskInstanceRoutes = [
-  { element: <Logs />, index: true },
+export const taskInstanceRoutes = [
+  { element: <Logs />, index: true, path: undefined },
   { element: <Events />, path: "events" },
   { element: <XCom />, path: "xcom" },
   { element: <Code />, path: "code" },

--- a/airflow-core/src/airflow/ui/src/utils/links.test.ts
+++ b/airflow-core/src/airflow/ui/src/utils/links.test.ts
@@ -1,0 +1,248 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { describe, it, expect } from "vitest";
+
+import type { TaskInstanceResponse } from "openapi/requests/types.gen";
+
+import { buildTaskInstanceUrl, getTaskInstanceAdditionalPath, getTaskInstanceLink } from "./links";
+
+describe("getTaskInstanceLink", () => {
+  const testCases = [
+    // Individual parameters tests
+    {
+      description: "individual parameters without map index",
+      expected: "/dags/my_dag/runs/run_123/tasks/task_1",
+      input: { dagId: "my_dag", dagRunId: "run_123", mapIndex: -1, taskId: "task_1" },
+    },
+    {
+      description: "individual parameters with map index",
+      expected: "/dags/my_dag/runs/run_123/tasks/task_1/mapped/5",
+      input: { dagId: "my_dag", dagRunId: "run_123", mapIndex: 5, taskId: "task_1" },
+    },
+    {
+      description: "individual parameters with map index of 0",
+      expected: "/dags/test_dag/runs/test_run/tasks/mapped_task/mapped/0",
+      input: { dagId: "test_dag", dagRunId: "test_run", mapIndex: 0, taskId: "mapped_task" },
+    },
+    {
+      description: "individual parameters without mapIndex property (defaults to -1)",
+      expected: "/dags/my_dag/runs/run_123/tasks/task_1",
+      input: { dagId: "my_dag", dagRunId: "run_123", taskId: "task_1" },
+    },
+    // TaskInstanceResponse object tests
+    {
+      description: "TaskInstanceResponse object without map index",
+      expected: "/dags/my_dag/runs/run_123/tasks/task_1",
+      input: {
+        dag_id: "my_dag",
+        dag_run_id: "run_123",
+        map_index: -1,
+        task_id: "task_1",
+      } as TaskInstanceResponse,
+    },
+    {
+      description: "TaskInstanceResponse object with map index",
+      expected: "/dags/my_dag/runs/run_123/tasks/task_1/mapped/5",
+      input: {
+        dag_id: "my_dag",
+        dag_run_id: "run_123",
+        map_index: 5,
+        task_id: "task_1",
+      } as TaskInstanceResponse,
+    },
+    {
+      description: "TaskInstanceResponse object with map index of 0",
+      expected: "/dags/test_dag/runs/test_run/tasks/mapped_task/mapped/0",
+      input: {
+        dag_id: "test_dag",
+        dag_run_id: "test_run",
+        map_index: 0,
+        task_id: "mapped_task",
+      } as TaskInstanceResponse,
+    },
+  ];
+
+  it.each(testCases)("should handle $description", ({ expected, input }) => {
+    const result = getTaskInstanceLink(input);
+
+    expect(result).toBe(expected);
+  });
+});
+
+describe("getTaskInstanceAdditionalPath", () => {
+  it("should return empty string for basic task path", () => {
+    const result = getTaskInstanceAdditionalPath("/dags/my_dag/runs/run_1/tasks/task_1");
+
+    expect(result).toBe("");
+  });
+
+  it("should extract sub-route from regular task path", () => {
+    const result = getTaskInstanceAdditionalPath("/dags/my_dag/runs/run_1/tasks/task_1/details");
+
+    expect(result).toBe("/details");
+  });
+
+  it("should extract sub-route from group task path", () => {
+    const result = getTaskInstanceAdditionalPath("/dags/my_dag/runs/run_1/tasks/group/my_group/xcom");
+
+    expect(result).toBe("/xcom");
+  });
+
+  it("should extract sub-route from mapped task with index", () => {
+    const result = getTaskInstanceAdditionalPath("/dags/my_dag/runs/run_1/tasks/task_1/mapped/5/events");
+
+    expect(result).toBe("/events");
+  });
+
+  it("should handle all known task instance routes", () => {
+    const knownRoutes = [
+      "events",
+      "xcom",
+      "code",
+      "details",
+      "rendered_templates",
+      "task_instances",
+      "asset_events",
+      "required_actions",
+    ];
+
+    for (const route of knownRoutes) {
+      const result = getTaskInstanceAdditionalPath(`/dags/test/runs/run_1/tasks/task_1/${route}`);
+
+      expect(result).toBe(`/${route}`);
+    }
+  });
+
+  it("should handle various path scenarios", () => {
+    // Plugin routes
+    expect(getTaskInstanceAdditionalPath("/dags/my_dag/runs/run_1/tasks/task_1/plugin/custom-view")).toBe(
+      "/plugin/custom-view",
+    );
+
+    // Unknown sub-routes should return empty
+    expect(getTaskInstanceAdditionalPath("/dags/my_dag/runs/run_1/tasks/task_1/unknown_route")).toBe("");
+
+    // Complex plugin paths
+    expect(
+      getTaskInstanceAdditionalPath("/dags/test/runs/run_1/tasks/group/group_1/plugin/my-plugin/nested/path"),
+    ).toBe("/plugin/my-plugin/nested/path");
+
+    // Routes with special characters
+    expect(
+      getTaskInstanceAdditionalPath("/dags/my-dag_v2/runs/run_1-test/tasks/task.1/rendered_templates"),
+    ).toBe("/rendered_templates");
+  });
+});
+
+describe("buildTaskInstanceUrl", () => {
+  it("should build basic URL types", () => {
+    // Basic task instance URL
+    expect(
+      buildTaskInstanceUrl({
+        currentPathname: "/dags/other_dag/runs/other_run/tasks/other_task",
+        dagId: "my_dag",
+        runId: "run_123",
+        taskId: "task_1",
+      }),
+    ).toBe("/dags/my_dag/runs/run_123/tasks/task_1");
+
+    // Group task instance URL
+    expect(
+      buildTaskInstanceUrl({
+        currentPathname: "/some/path",
+        dagId: "my_dag",
+        isGroup: true,
+        runId: "run_123",
+        taskId: "group_1",
+      }),
+    ).toBe("/dags/my_dag/runs/run_123/tasks/group/group_1");
+
+    // Mapped task without map index
+    expect(
+      buildTaskInstanceUrl({
+        currentPathname: "/some/path",
+        dagId: "my_dag",
+        isMapped: true,
+        runId: "run_123",
+        taskId: "mapped_task",
+      }),
+    ).toBe("/dags/my_dag/runs/run_123/tasks/mapped_task/mapped");
+
+    // Mapped task with map index
+    expect(
+      buildTaskInstanceUrl({
+        currentPathname: "/some/path",
+        dagId: "my_dag",
+        isMapped: true,
+        mapIndex: "5",
+        runId: "run_123",
+        taskId: "mapped_task",
+      }),
+    ).toBe("/dags/my_dag/runs/run_123/tasks/mapped_task/mapped/5");
+  });
+
+  it("should handle advanced scenarios", () => {
+    // Preserve sub-routes from current pathname
+    expect(
+      buildTaskInstanceUrl({
+        currentPathname: "/dags/old_dag/runs/old_run/tasks/old_task/details",
+        dagId: "new_dag",
+        runId: "new_run",
+        taskId: "new_task",
+      }),
+    ).toBe("/dags/new_dag/runs/new_run/tasks/new_task/details");
+
+    // Preserve sub-routes for mapped tasks
+    expect(
+      buildTaskInstanceUrl({
+        currentPathname: "/dags/old_dag/runs/old_run/tasks/old_task/mapped/2/xcom",
+        dagId: "new_dag",
+        isMapped: true,
+        mapIndex: "7",
+        runId: "new_run",
+        taskId: "new_task",
+      }),
+    ).toBe("/dags/new_dag/runs/new_run/tasks/new_task/mapped/7/xcom");
+
+    // Handle mapIndex of -1
+    expect(
+      buildTaskInstanceUrl({
+        currentPathname: "/some/path",
+        dagId: "my_dag",
+        isMapped: true,
+        mapIndex: "-1",
+        runId: "run_123",
+        taskId: "mapped_task",
+      }),
+    ).toBe("/dags/my_dag/runs/run_123/tasks/mapped_task/mapped");
+
+    // Complex: group + mapped + sub-routes
+    expect(
+      buildTaskInstanceUrl({
+        currentPathname: "/dags/old/runs/old/tasks/group/old_group/events",
+        dagId: "new_dag",
+        isGroup: true,
+        isMapped: true,
+        mapIndex: "3",
+        runId: "new_run",
+        taskId: "new_group",
+      }),
+    ).toBe("/dags/new_dag/runs/new_run/tasks/group/new_group/mapped/3/events");
+  });
+});

--- a/airflow-core/src/airflow/ui/src/utils/links.ts
+++ b/airflow-core/src/airflow/ui/src/utils/links.ts
@@ -17,25 +17,83 @@
  * under the License.
  */
 import type { TaskInstanceResponse } from "openapi/requests/types.gen";
+import { taskInstanceRoutes } from "src/router";
 
-export const getTaskInstanceLink = (ti: TaskInstanceResponse) =>
-  `/dags/${ti.dag_id}/runs/${ti.dag_run_id}/tasks/${ti.task_id}${ti.map_index >= 0 ? `/mapped/${ti.map_index}` : ""}`;
+export const getTaskInstanceLink = (
+  tiOrParams:
+    | TaskInstanceResponse
+    | {
+        dagId: string;
+        dagRunId: string;
+        mapIndex?: number;
+        taskId: string;
+      },
+): string => {
+  if ("dag_id" in tiOrParams) {
+    return `/dags/${tiOrParams.dag_id}/runs/${tiOrParams.dag_run_id}/tasks/${tiOrParams.task_id}${
+      tiOrParams.map_index >= 0 ? `/mapped/${tiOrParams.map_index}` : ""
+    }`;
+  }
 
-export const getTaskInstanceLinkFromObj = ({
-  dagId,
-  dagRunId,
-  mapIndex = -1,
-  taskId,
-}: {
-  dagId: string;
-  dagRunId: string;
-  mapIndex: number;
-  taskId: string;
-}) => `/dags/${dagId}/runs/${dagRunId}/tasks/${taskId}${mapIndex >= 0 ? `/mapped/${mapIndex}` : ""}`;
+  const { dagId, dagRunId, mapIndex = -1, taskId } = tiOrParams;
+
+  return `/dags/${dagId}/runs/${dagRunId}/tasks/${taskId}${mapIndex >= 0 ? `/mapped/${mapIndex}` : ""}`;
+};
 
 export const getRedirectPath = (targetPath: string): string => {
   const baseHref = document.querySelector("head > base")?.getAttribute("href") ?? "";
   const baseUrl = new URL(baseHref, globalThis.location.origin);
 
   return new URL(targetPath, baseUrl).pathname;
+};
+
+export const getTaskInstanceAdditionalPath = (pathname: string): string => {
+  const subRoutes = taskInstanceRoutes.filter((route) => route.path !== undefined).map((route) => route.path);
+  // Look for patterns like /tasks/{taskId}/mapped/{mapIndex}/{sub-route}
+  const mappedRegex = /\/tasks\/[^/]+\/mapped\/[^/]+\/(?<subRoute>.+)$/u;
+  const mappedMatch = mappedRegex.exec(pathname);
+
+  if (mappedMatch?.groups?.subRoute !== undefined) {
+    return `/${mappedMatch.groups.subRoute}`;
+  }
+
+  // Look for patterns like /tasks/{taskId}/{sub-route} or /tasks/group/{groupId}/{sub-route}
+  const taskRegex = /\/tasks\/(?:group\/)?[^/]+\/(?<subRoute>.+)$/u;
+  const taskMatch = taskRegex.exec(pathname);
+
+  if (taskMatch?.groups?.subRoute !== undefined) {
+    const { subRoute } = taskMatch.groups;
+
+    // Only preserve if it's a known task instance route or plugin route
+    if (subRoutes.includes(subRoute) || subRoute.startsWith("plugin/")) {
+      return `/${subRoute}`;
+    }
+  }
+
+  return "";
+};
+
+export const buildTaskInstanceUrl = (params: {
+  currentPathname: string;
+  dagId: string;
+  isGroup?: boolean;
+  isMapped?: boolean;
+  mapIndex?: string;
+  runId: string;
+  taskId: string;
+}): string => {
+  const { currentPathname, dagId, isGroup = false, isMapped = false, mapIndex, runId, taskId } = params;
+  const groupPath = isGroup ? "group/" : "";
+  const additionalPath = getTaskInstanceAdditionalPath(currentPathname);
+
+  let basePath = `/dags/${dagId}/runs/${runId}/tasks/${groupPath}${taskId}`;
+
+  if (isMapped) {
+    basePath += `/mapped`;
+    if (mapIndex !== undefined && mapIndex !== "-1") {
+      basePath += `/${mapIndex}`;
+    }
+  }
+
+  return `${basePath}${additionalPath}`;
 };


### PR DESCRIPTION
Persist the tab when paging between Task Instance views. Especially useful when checking different HITL actions. Revert to logs if the TI doesn't have that tab

![gif](https://github.com/user-attachments/assets/57f37e55-c8c7-4e1e-8aa1-d52b62963102)

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
