### PR TITLE
Dev: Remove `dry_run` overrides on some command for CI

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_candidate_command.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_candidate_command.py
@@ -41,7 +41,6 @@ def validate_remote_tracks_apache_airflow(remote_name):
         check=False,
         capture_output=True,
         text=True,
-        dry_run_override=False,
     )
 
     if result.returncode != 0:
@@ -93,7 +92,7 @@ def validate_git_status():
     console_print("[success]Working directory is clean")
 
 
-def validate_version_branches_exist(version_branch, remote_name, dry_run=False):
+def validate_version_branches_exist(version_branch, remote_name):
     """Validate that the required version branches exist."""
     console_print(f"[info]Validating version branches exist for {version_branch}...")
 
@@ -110,7 +109,6 @@ def validate_version_branches_exist(version_branch, remote_name, dry_run=False):
         check=True,
         capture_output=True,
         text=True,
-        dry_run_override=False,
     )
     remote_branches = result.stdout
 
@@ -118,30 +116,18 @@ def validate_version_branches_exist(version_branch, remote_name, dry_run=False):
     stable_branch_exists = f"{remote_name}/{stable_branch}" in remote_branches
 
     if not test_branch_exists:
-        if dry_run:
-            console_print(
-                f"[warning]Not validating presence of test branch: '{remote_name}/{test_branch}' since its a dry-run"
-            )
-        else:
-            console_print(f"[error]Test branch '{remote_name}/{test_branch}' does not exist!")
-            console_print("Available remote branches:")
-            run_command(["git", "branch", "-r"])
-            exit(1)
-    else:
-        console_print(f"[success]Test branch '{remote_name}/{test_branch}' exists")
+        console_print(f"[error]Test branch '{remote_name}/{test_branch}' does not exist!")
+        console_print("Available remote branches:")
+        run_command(["git", "branch", "-r"])
+        exit(1)
+    console_print(f"[success]Test branch '{remote_name}/{test_branch}' exists")
 
     if not stable_branch_exists:
-        if dry_run:
-            console_print(
-                f"[warning]Not validating presence of stable branch: '{remote_name}/{stable_branch}' since its a dry-run)"
-            )
-        else:
-            console_print(f"[error]Stable branch '{remote_name}/{stable_branch}' does not exist!")
-            console_print("Available remote branches:")
-            run_command(["git", "branch", "-r"])
-            exit(1)
-    else:
-        console_print(f"[success]Stable branch '{remote_name}/{stable_branch}' exists")
+        console_print(f"[error]Stable branch '{remote_name}/{stable_branch}' does not exist!")
+        console_print("Available remote branches:")
+        run_command(["git", "branch", "-r"])
+        exit(1)
+    console_print(f"[success]Stable branch '{remote_name}/{stable_branch}' exists")
 
 
 def validate_tag_does_not_exist(version, remote_name):
@@ -190,10 +176,6 @@ def validate_on_correct_branch_for_tagging(version_branch):
     """Validate that we're on the correct branch for tagging (stable branch)."""
     console_print("[info]Validating we're on the correct branch for tagging...")
 
-    if get_dry_run():
-        console_print(f"Not really validating we're on branch: v{version_branch}-stable, dry-run mode")
-        return
-
     expected_branch = f"v{version_branch}-stable"
 
     # Check current branch
@@ -202,7 +184,6 @@ def validate_on_correct_branch_for_tagging(version_branch):
         check=True,
         capture_output=True,
         text=True,
-        dry_run_override=False,
     )
     current_branch = result.stdout.strip()
 
@@ -216,11 +197,6 @@ def validate_on_correct_branch_for_tagging(version_branch):
 
 def merge_pr(version_branch, remote_name):
     if confirm_action("Do you want to merge the Sync PR?"):
-        if get_dry_run():
-            console_print(
-                f"We would merge Sync PR for version branch: {version_branch}, but not doing it because of dry-run mode"
-            )
-            return
         run_command(
             [
                 "git",
@@ -609,7 +585,7 @@ def publish_release_candidate(version, previous_version, task_sdk_version, githu
 
     validate_remote_tracks_apache_airflow(remote_name)
     validate_git_status()
-    validate_version_branches_exist(version_branch, remote_name, dry_run=get_dry_run())
+    validate_version_branches_exist(version_branch, remote_name)
     validate_tag_does_not_exist(version, remote_name)
     validate_tag_does_not_exist(f"task-sdk/{task_sdk_version}", remote_name)
 


### PR DESCRIPTION
https://github.com/apache/airflow/pull/55011/ attempted at it but it wasn't a bug it was by desin since without it the other command would not run.

For now, temporarily removing the override to keep CI happy.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
