### PR TITLE
Fix: Consistent no-log handling for tasks with try_number=0 in API and UI (#54749)

### DIFF
--- a/airflow-core/src/airflow/utils/log/log_reader.py
+++ b/airflow-core/src/airflow/utils/log/log_reader.py
@@ -19,11 +19,13 @@ from __future__ import annotations
 import logging
 import time
 from collections.abc import Generator, Iterator
+from datetime import datetime, timezone
 from functools import cached_property
 from typing import TYPE_CHECKING
 
 from airflow.configuration import conf
 from airflow.utils.helpers import render_log_filename
+from airflow.utils.log.file_task_handler import StructuredLogMessage
 from airflow.utils.log.logging_mixin import ExternalLoggingMixin
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import TaskInstanceState
@@ -51,6 +53,24 @@ class TaskLogReader:
     STREAM_LOOP_STOP_AFTER_EMPTY_ITERATIONS = 10
     """Number of empty loop iterations before stopping the stream"""
 
+    @staticmethod
+    def get_no_log_state_message(ti: TaskInstance | TaskInstanceHistory) -> Iterator[StructuredLogMessage]:
+        """Yield standardized no-log messages for a given TI state."""
+        msg = {
+            TaskInstanceState.SKIPPED: "Task was skipped — no logs available.",
+            TaskInstanceState.UPSTREAM_FAILED: "Task did not run because upstream task(s) failed.",
+        }.get(ti.state, "No logs available for this task.")
+
+        yield StructuredLogMessage(
+            timestamp=None,
+            event="::group::Log message source details",
+        )
+        yield StructuredLogMessage(timestamp=None, event="::endgroup::")
+        yield StructuredLogMessage(
+            timestamp=ti.updated_at or datetime.now(timezone.utc),
+            event=msg,
+        )
+
     def read_log_chunks(
         self,
         ti: TaskInstance | TaskInstanceHistory,
@@ -75,6 +95,11 @@ class TaskLogReader:
         contain information about the task log which can enable you read logs to the
         end.
         """
+        if try_number == 0:
+            msg = self.get_no_log_state_message(ti)  # returns StructuredLogMessage
+            # one message + tell the caller it's the end so stream stops
+            return msg, {"end_of_log": True}
+
         return self.log_handler.read(ti, try_number, metadata=metadata)
 
     def read_log_stream(
@@ -92,6 +117,12 @@ class TaskLogReader:
         """
         if try_number is None:
             try_number = ti.try_number
+
+        # Handle skipped / upstream_failed case directly
+        if try_number == 0:
+            for msg in self.get_no_log_state_message(ti):
+                yield f"{msg.model_dump_json()}\n"
+            return
 
         for key in ("end_of_log", "max_offset", "offset", "log_pos"):
             # https://mypy.readthedocs.io/en/stable/typed_dict.html#supported-operations


### PR DESCRIPTION
### Summary
This PR ensures consistent handling of **no-log cases** for tasks when `try_number=0`.  
Instead of returning empty or confusing responses, the system now provides clear, structured messages across both **UI** and **API** log views.

### Implementation Details
- Added a check for `try_number=0` before calling `read_log_chunks`.
- Introduced fallback structured log responses for specific states:
  - **SKIPPED** → "Task was skipped — no logs available."
  - **UPSTREAM_FAILED** → "Task did not run because upstream task(s) failed."
  - Others → "No logs available for this task."
- Reused structured log format to match API/UI expectations (timestamp, event, level, sources).
- Ensured this logic is applied consistently in log streaming and API responses.

### Testing
- Verified DAG runs where tasks were **SKIPPED** and **UPSTREAM_FAILED**.
- Confirmed that API responses now return structured fallback logs instead of empty logs.
- Checked that UI log viewer shows the same messages, ensuring consistency.

### Why
Previously, tasks with `try_number=0` produced inconsistent log responses:
- API often returned empty logs.
- UI displayed misleading or missing messages.

This change standardizes the behavior, improving observability and debugging for users.

### Related Issue

Closes https://github.com/apache/airflow/issues/54749


### Below find the screenshots

<img width="1231" height="354" alt="Screenshot from 2025-09-01 01-00-59" src="https://github.com/user-attachments/assets/86d1552f-8fb2-4a3d-802d-b7d9b5ce7545" />


<img width="1231" height="354" alt="Screenshot from 2025-09-01 01-01-09" src="https://github.com/user-attachments/assets/495b73b4-8ea7-4cd4-9cb9-4d4f2f1eccab" />

