### PR TITLE
Pass team name information to `is_authorized_dag` method

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/models/resource_details.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/models/resource_details.py
@@ -42,6 +42,7 @@ class DagDetails:
     """Represents the details of a DAG."""
 
     id: str | None = None
+    team_name: str | None = None
 
 
 @dataclass

--- a/airflow-core/src/airflow/api_fastapi/core_api/security.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/security.py
@@ -103,10 +103,14 @@ def requires_access_dag(
         user: GetUserDep,
     ) -> None:
         dag_id: str | None = request.path_params.get("dag_id")
+        team_name = DagModel.get_team_name(dag_id) if dag_id else None
 
         _requires_access(
             is_authorized_callback=lambda: get_auth_manager().is_authorized_dag(
-                method=method, access_entity=access_entity, details=DagDetails(id=dag_id), user=user
+                method=method,
+                access_entity=access_entity,
+                details=DagDetails(id=dag_id, team_name=team_name),
+                user=user,
             )
         )
 

--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -76,6 +76,7 @@ from airflow.models.asset import (
 )
 from airflow.models.base import Base, StringID
 from airflow.models.dag_version import DagVersion
+from airflow.models.dagbundle import DagBundleModel
 from airflow.models.dagrun import RUN_ID_REGEX, DagRun
 from airflow.models.taskinstance import (
     TaskInstance,
@@ -83,6 +84,7 @@ from airflow.models.taskinstance import (
     clear_task_instances,
 )
 from airflow.models.tasklog import LogTemplate
+from airflow.models.team import Team
 from airflow.sdk import TaskGroup
 from airflow.sdk.definitions.asset import Asset, AssetAlias, AssetUniqueKey, BaseAsset
 from airflow.sdk.definitions.dag import DAG as TaskSDKDag, dag as task_sdk_dag_decorator
@@ -2268,6 +2270,18 @@ class DagModel(Base):
         # When an asset alias does not resolve into assets, get_asset_triggered_next_run_info returns
         # an empty dict as there's no asset info to get. This method should thus return None.
         return get_asset_triggered_next_run_info([self.dag_id], session=session).get(self.dag_id, None)
+
+    @staticmethod
+    @provide_session
+    def get_team_name(dag_id: str, session=NEW_SESSION) -> str | None:
+        """Return the potential team name associated to a Dag."""
+        stmt = (
+            select(Team.name)
+            .join(DagBundleModel.teams)
+            .join(DagModel, DagModel.bundle_name == DagBundleModel.name)
+            .where(DagModel.dag_id == dag_id)
+        )
+        return session.scalar(stmt)
 
 
 STATICA_HACK = True

--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -2274,7 +2274,7 @@ class DagModel(Base):
     @staticmethod
     @provide_session
     def get_team_name(dag_id: str, session=NEW_SESSION) -> str | None:
-        """Return the potential team name associated to a Dag."""
+        """Return the team name associated to a Dag or None if it is not owned by a specific team."""
         stmt = (
             select(Team.name)
             .join(DagBundleModel.teams)

--- a/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
@@ -84,6 +84,7 @@ class TestFastApiSecurity:
 
         auth_manager.get_user_from_token.assert_called_once_with(token_str)
 
+    @pytest.mark.db_test
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
     async def test_requires_access_dag_authorized(self, mock_get_auth_manager):
         auth_manager = Mock()
@@ -96,6 +97,7 @@ class TestFastApiSecurity:
 
         auth_manager.is_authorized_dag.assert_called_once()
 
+    @pytest.mark.db_test
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
     async def test_requires_access_dag_unauthorized(self, mock_get_auth_manager):
         auth_manager = Mock()

--- a/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
@@ -91,7 +91,7 @@ class TestFastApiSecurity:
         auth_manager.is_authorized_dag.return_value = True
         mock_get_auth_manager.return_value = auth_manager
         fastapi_request = Mock()
-        fastapi_request.path_params.return_value = {}
+        fastapi_request.path_params = {}
 
         requires_access_dag("GET", DagAccessEntity.CODE)(fastapi_request, Mock())
 
@@ -104,7 +104,7 @@ class TestFastApiSecurity:
         auth_manager.is_authorized_dag.return_value = False
         mock_get_auth_manager.return_value = auth_manager
         fastapi_request = Mock()
-        fastapi_request.path_params.return_value = {}
+        fastapi_request.path_params = {}
 
         mock_request = Mock()
         mock_request.path_params.return_value = {}

--- a/airflow-core/tests/unit/models/test_dag.py
+++ b/airflow-core/tests/unit/models/test_dag.py
@@ -21,6 +21,7 @@ import datetime
 import logging
 import os
 import pickle
+import uuid
 from datetime import timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -64,6 +65,7 @@ from airflow.models.dagbundle import DagBundleModel
 from airflow.models.dagrun import DagRun
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskinstance import TaskInstance as TI
+from airflow.models.team import Team
 from airflow.providers.standard.operators.bash import BashOperator
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.standard.operators.python import PythonOperator
@@ -92,6 +94,7 @@ from tests_common.test_utils.db import (
     clear_db_dags,
     clear_db_runs,
     clear_db_serialized_dags,
+    clear_db_teams,
 )
 from tests_common.test_utils.mapping import expand_mapped_task
 from tests_common.test_utils.mock_plugins import mock_plugin_manager
@@ -143,6 +146,18 @@ TEST_DAGS_FOLDER = Path(__file__).parents[1] / "dags"
 def test_dags_bundle(configure_testing_dag_bundle):
     with configure_testing_dag_bundle(TEST_DAGS_FOLDER):
         yield
+
+
+@pytest.fixture
+def testing_team():
+    from airflow.utils.session import create_session
+
+    with create_session() as session:
+        team = session.query(Team).filter_by(name="testing").one_or_none()
+        if not team:
+            team = Team(id=uuid.uuid4(), name="testing")
+            session.add(team)
+        yield team
 
 
 def _create_dagrun(
@@ -2086,6 +2101,8 @@ class TestDagModel:
         clear_db_dags()
         clear_db_assets()
         clear_db_runs()
+        clear_db_dag_bundles()
+        clear_db_teams()
 
     def setup_method(self):
         self._clean()
@@ -2521,6 +2538,25 @@ class TestDagModel:
                 {"alias": {"name": "test_name", "group": "test-group"}},
             ]
         }
+
+    def test_get_team_name(self, testing_team):
+        session = settings.Session()
+        dag_bundle = DagBundleModel(name="testing-team")
+        dag_bundle.teams.append(testing_team)
+        session.add(dag_bundle)
+        session.flush()
+
+        dag_id = "test_get_team_name"
+        dag = DAG(dag_id, schedule=None)
+        orm_dag = DagModel(
+            dag_id=dag.dag_id,
+            bundle_name="testing-team",
+            is_stale=False,
+        )
+        session.add(orm_dag)
+        session.flush()
+        assert DagModel.get_dagmodel(dag_id) is not None
+        assert DagModel.get_team_name(dag_id, session=session) == "testing"
 
 
 class TestQueries:

--- a/devel-common/src/tests_common/test_utils/db.py
+++ b/devel-common/src/tests_common/test_utils/db.py
@@ -355,6 +355,13 @@ def clear_db_dag_bundles():
         session.query(DagBundleModel).delete()
 
 
+def clear_db_teams():
+    with create_session() as session:
+        from airflow.models.team import Team
+
+        session.query(Team).delete()
+
+
 def clear_dag_specific_permissions():
     if "FabAuthManager" not in conf.get("core", "auth_manager"):
         return


### PR DESCRIPTION
The team name can be then used by the individual auth managers to make authorization decisions. I intend to do the similar to other resources such as connection, variable and pools but I wanted to make sure this is the correct approach first. I'll do all the other resources in a same follow-up PR.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
