### PR TITLE
Dev: Fix validation on dry-run with 'start-rc-process'

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_candidate_command.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_candidate_command.py
@@ -583,11 +583,13 @@ def publish_release_candidate(version, previous_version, task_sdk_version, githu
     os.chdir(AIRFLOW_ROOT_PATH)
     airflow_repo_root = os.getcwd()
 
-    validate_remote_tracks_apache_airflow(remote_name)
-    validate_git_status()
-    validate_version_branches_exist(version_branch, remote_name)
-    validate_tag_does_not_exist(version, remote_name)
-    validate_tag_does_not_exist(f"task-sdk/{task_sdk_version}", remote_name)
+    if not get_dry_run():
+        console_print("[info]Skipping validations in dry-run mode")
+        validate_remote_tracks_apache_airflow(remote_name)
+        validate_git_status()
+        validate_version_branches_exist(version_branch, remote_name)
+        validate_tag_does_not_exist(version, remote_name)
+        validate_tag_does_not_exist(f"task-sdk/{task_sdk_version}", remote_name)
 
     # List the above variables and ask for confirmation
     console_print()
@@ -610,7 +612,8 @@ def publish_release_candidate(version, previous_version, task_sdk_version, githu
     #
     # # Tag & clean the repo
     # Validate we're on the correct branch before tagging
-    validate_on_correct_branch_for_tagging(version_branch)
+    if not get_dry_run():
+        validate_on_correct_branch_for_tagging(version_branch)
     git_tag(version, f"Apache Airflow {version}")
     git_tag(f"task-sdk/{task_sdk_version}", f"Airflow Task SDK {task_sdk_version}")
     git_clean()


### PR DESCRIPTION
Example failure: https://github.com/apache/airflow/actions/runs/17308401766/job/49137091525

https://github.com/apache/airflow/issues/55025 didn't fully fix the CI failure

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
