### PR TITLE
Add queued DAGs filter button to DAGs page

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/DagsFilters.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/DagsFilters.tsx
@@ -53,6 +53,7 @@ export const DagsFilters = () => {
   const isAll = state === null;
   const isRunning = state === "running";
   const isFailed = state === "failed";
+  const isQueued = state === "queued";
   const isSuccess = state === "success";
 
   const [pattern, setPattern] = useState("");
@@ -178,6 +179,7 @@ export const DagsFilters = () => {
         <StateFilters
           isAll={isAll}
           isFailed={isFailed}
+          isQueued={isQueued}
           isRunning={isRunning}
           isSuccess={isSuccess}
           onStateChange={handleStateChange}

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/StateFilters.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/StateFilters.tsx
@@ -25,12 +25,13 @@ import { StateBadge } from "src/components/StateBadge";
 type Props = {
   readonly isAll: boolean;
   readonly isFailed: boolean;
+  readonly isQueued: boolean;
   readonly isRunning: boolean;
   readonly isSuccess: boolean;
   readonly onStateChange: React.MouseEventHandler<HTMLButtonElement>;
 };
 
-export const StateFilters = ({ isAll, isFailed, isRunning, isSuccess, onStateChange }: Props) => {
+export const StateFilters = ({ isAll, isFailed, isQueued, isRunning, isSuccess, onStateChange }: Props) => {
   const { t: translate } = useTranslation(["dags", "common"]);
 
   return (
@@ -46,6 +47,15 @@ export const StateFilters = ({ isAll, isFailed, isRunning, isSuccess, onStateCha
       >
         <StateBadge state="failed" />
         {translate("common:states.failed")}
+      </QuickFilterButton>
+      <QuickFilterButton
+        data-testid="dags-queued-filter"
+        isActive={isQueued}
+        onClick={onStateChange}
+        value="queued"
+      >
+        <StateBadge state="queued" />
+        {translate("common:states.queued")}
       </QuickFilterButton>
       <QuickFilterButton
         data-testid="dags-running-filter"


### PR DESCRIPTION
The homepage had a "Queued DAGs" card that linked to the DAGs page with queued filter, but the DAGs page itself was missing a dedicated queued filter button. This change adds the missing "Queued" filter button to the state filters on the DAGs page, allowing users to easily filter for queued DAGs directly from the page interface.

<img width="1916" height="737" alt="image" src="https://github.com/user-attachments/assets/cc5e6eb5-0025-4d7e-8310-d1ab4904e2b3" />
