### PR TITLE
Use 'orient' kwarg in SalesforceHook

### DIFF
--- a/providers/salesforce/src/airflow/providers/salesforce/hooks/salesforce.py
+++ b/providers/salesforce/src/airflow/providers/salesforce/hooks/salesforce.py
@@ -343,9 +343,9 @@ class SalesforceHook(BaseHook):
             # write the dataframe
             df.to_csv(filename, index=False)
         elif fmt == "json":
-            df.to_json(filename, "records", date_unit="s")
+            df.to_json(filename, orient="records", date_unit="s")
         elif fmt == "ndjson":
-            df.to_json(filename, "records", lines=True, date_unit="s")
+            df.to_json(filename, orient="records", lines=True, date_unit="s")
 
         return df
 

--- a/providers/salesforce/tests/unit/salesforce/hooks/test_salesforce.py
+++ b/providers/salesforce/tests/unit/salesforce/hooks/test_salesforce.py
@@ -377,7 +377,9 @@ class TestSalesforceHook:
         )
 
         mock_describe_object.assert_called_once_with(obj_name)
-        mock_data_frame.return_value.to_json.assert_called_once_with(filename, "records", date_unit="s")
+        mock_data_frame.return_value.to_json.assert_called_once_with(
+            filename, orient="records", date_unit="s"
+        )
         pd.testing.assert_frame_equal(
             data_frame, pd.DataFrame({"test": [1, 2, 3], "field_1": [1.546301e09, 1.546387e09, 1.546474e09]})
         )
@@ -396,7 +398,7 @@ class TestSalesforceHook:
         )
 
         mock_data_frame.return_value.to_json.assert_called_once_with(
-            filename, "records", lines=True, date_unit="s"
+            filename, orient="records", lines=True, date_unit="s"
         )
         pd.testing.assert_frame_equal(
             data_frame,


### PR DESCRIPTION
Mypy started complaining about this somehow. This should be completely backward compatible.