### PR TITLE
Workable compat between task sdk 1.0.4 and server 3.1.0

### DIFF
--- a/airflow-core/src/airflow/configuration.py
+++ b/airflow-core/src/airflow/configuration.py
@@ -860,14 +860,14 @@ class AirflowConfigParser(ConfigParser):
         )
 
     def mask_secrets(self):
-        from airflow._shared.secrets_masker import mask_secret as mask_secret_core
-
         try:
+            from airflow._shared.secrets_masker import mask_secret as mask_secret_core
             from airflow.sdk.log import mask_secret as mask_secret_sdk
         except ImportError:
             # Fallback for older Airflow versions where the SDK secret masker
             # lived under `sdk.execution_time.secrets_masker`. Kept for
             # backward compatibility.
+            mask_secret_core = None
             mask_secret_sdk = None
 
         for section, key in self.sensitive_config_values:
@@ -882,7 +882,7 @@ class AirflowConfigParser(ConfigParser):
                 )
                 continue
             mask_secret_core(value)
-            if mask_secret_sdk:
+            if mask_secret_sdk is not None:
                 mask_secret_sdk(value)
 
     def _env_var_name(self, section: str, key: str) -> str:

--- a/airflow-core/src/airflow/dag_processing/processor.py
+++ b/airflow-core/src/airflow/dag_processing/processor.py
@@ -438,7 +438,7 @@ class DagFileProcessorProcess(WatchedSubprocess):
                 # lived under `sdk.execution_time.secrets_masker`. Kept for
                 # backward compatibility.
                 from airflow.sdk.execution_time.secrets_masker import (
-                    mask_secret,  # type: ignore[attr-defined]
+                    mask_secret,  # type: ignore[no-redef]
                 )
             mask_secret(msg.value, msg.name)
         else:

--- a/airflow-core/src/airflow/dag_processing/processor.py
+++ b/airflow-core/src/airflow/dag_processing/processor.py
@@ -431,8 +431,15 @@ class DagFileProcessorProcess(WatchedSubprocess):
             dump_opts = {"exclude_unset": True}
         elif isinstance(msg, MaskSecret):
             # Use sdk masker in dag processor and triggerer because those use the task sdk machinery
-            from airflow.sdk.log import mask_secret
-
+            try:
+                from airflow.sdk.log import mask_secret
+            except ImportError:
+                # Fallback for older Airflow versions where the SDK secret masker
+                # lived under `sdk.execution_time.secrets_masker`. Kept for
+                # backward compatibility.
+                from airflow.sdk.execution_time.secrets_masker import (
+                    mask_secret,  # type: ignore[attr-defined]
+                )
             mask_secret(msg.value, msg.name)
         else:
             log.error("Unhandled request", msg=msg)

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -445,8 +445,9 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
                         # lived under `sdk.execution_time.secrets_masker`. Kept for
                         # backward compatibility.
                         from airflow.sdk.execution_time.secrets_masker import (
-                            mask_secret,  # type: ignore[attr-defined]
+                            mask_secret,  # type: ignore[no-redef]
                         )
+                    mask_secret(var.value, var.key)
                 var_result = VariableResult.from_variable_response(var)
                 resp = var_result
                 dump_opts = {"exclude_unset": True}
@@ -517,11 +518,14 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
         elif isinstance(msg, MaskSecret):
             try:
                 from airflow.sdk.log import mask_secret
-
-                mask_secret(msg.value, msg.name)
             except ImportError:
-                # SDK version doesn't have mask_secret (< 1.1.0), skip masking
-                pass
+                # Fallback for older Airflow versions where the SDK secret masker
+                # lived under `sdk.execution_time.secrets_masker`. Kept for
+                # backward compatibility.
+                from airflow.sdk.execution_time.secrets_masker import (
+                    mask_secret,  # type: ignore[no-redef]
+                )
+            mask_secret(msg.value, msg.name)
         else:
             raise ValueError(f"Unknown message type {type(msg)}")
 

--- a/airflow-core/src/airflow/models/dagbag.py
+++ b/airflow-core/src/airflow/models/dagbag.py
@@ -63,11 +63,6 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.types import NOTSET
 
-try:
-    from airflow.sdk.exceptions import AirflowDagCycleException
-except ImportError:
-    from airflow.exceptions import AirflowDagCycleException  # type: ignore[no-redef]
-
 if TYPE_CHECKING:
     from collections.abc import Generator
 
@@ -538,6 +533,11 @@ class DagBag(LoggingMixin):
         except Exception as e:
             self.log.exception(e)
             raise AirflowClusterPolicyError(e)
+
+        try:
+            from airflow.sdk.exceptions import AirflowDagCycleException
+        except ImportError:
+            from airflow.exceptions import AirflowDagCycleException  # type: ignore[no-redef]
 
         try:
             prev_dag = self.dags.get(dag.dag_id)

--- a/airflow-core/tests/unit/cli/commands/test_task_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_task_command.py
@@ -174,8 +174,13 @@ class TestCliTasks:
         Output should be filtered by SecretsMasker.
         """
         # TODO: revisit during https://github.com/apache/airflow/issues/54658
-        from airflow.sdk.log import mask_secret
-
+        try:
+            from airflow.sdk.log import mask_secret
+        except ImportError:
+            # Fallback for older Airflow versions where the SDK secret masker
+            # lived under `sdk.execution_time.secrets_masker`. Kept for
+            # backward compatibility.
+            from airflow.sdk.execution_time.secrets_masker import mask_secret  # type: ignore[attr-defined]
         password = "somepassword1234!"
         mask_secret(password)
 

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -656,8 +656,13 @@ class CustomTrigger(BaseTrigger):
         from airflow.sdk import Variable
         from airflow.sdk.execution_time.xcom import XCom
 
-        # Use sdk masker in dag processor and triggerer because those use the task sdk machinery
-        from airflow.sdk.log import mask_secret
+        try:
+            from airflow.sdk.log import mask_secret
+        except ImportError:
+            # Fallback for older Airflow versions where the SDK secret masker
+            # lived under `sdk.execution_time.secrets_masker`. Kept for
+            # backward compatibility.
+            from airflow.sdk.execution_time.secrets_masker import mask_secret  # type: ignore[attr-defined]
 
         conn = await sync_to_async(BaseHook.get_connection)("test_connection")
         self.log.info("Loaded conn %s", conn.conn_id)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Couple of things seem to be broken:
*  `mask_secret_sdk` cannot be used with old sdk and need not be used too because 3.1 introduced a shared secrets masker but before that it was a global masker
* Similarly, `AirflowDagCycleException` being a bit of a pain because it was imported globally.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
