### PR TITLE
Catch Exception in git hook instantiation

### DIFF
--- a/providers/git/src/airflow/providers/git/bundles/git.py
+++ b/providers/git/src/airflow/providers/git/bundles/git.py
@@ -80,7 +80,7 @@ class GitDagBundle(BaseDagBundle):
         self.hook: GitHook | None = None
         try:
             self.hook = GitHook(git_conn_id=git_conn_id or "git_default")
-        except AirflowException as e:
+        except Exception as e:
             self._log.warning("Could not create GitHook", conn_id=git_conn_id, exc=e)
 
         if not repo_url and self.hook and self.hook.repo_url:


### PR DESCRIPTION
It won't always be AirflowException here.  It could be ImportError, or other such things.  Not catching an exception here could cause the dag processor to halt.
