### PR TITLE
Add run type and triggering user filters to grid view

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/common/parameters.py
+++ b/airflow-core/src/airflow/api_fastapi/common/parameters.py
@@ -786,6 +786,10 @@ QueryDagRunRunTypesFilter = Annotated[
     ),
 ]
 
+QueryDagRunTriggeringUserSearch = Annotated[
+    _SearchParam, Depends(search_param_factory(DagRun.triggering_user_name, "triggering_user"))
+]
+
 # DagTags
 QueryDagTagPatternSearch = Annotated[
     _SearchParam, Depends(search_param_factory(DagTag.name, "tag_name_pattern"))

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -660,6 +660,18 @@ paths:
           items:
             type: string
           title: Run Type
+      - name: triggering_user
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: "SQL LIKE expression \u2014 use `%` / `_` wildcards (e.g. `%customer_%`).\
+            \ Regular expressions are **not** supported."
+          title: Triggering User
+        description: "SQL LIKE expression \u2014 use `%` / `_` wildcards (e.g. `%customer_%`).\
+          \ Regular expressions are **not** supported."
       responses:
         '200':
           description: Successful Response
@@ -775,6 +787,18 @@ paths:
           items:
             type: string
           title: Run Type
+      - name: triggering_user
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: "SQL LIKE expression \u2014 use `%` / `_` wildcards (e.g. `%customer_%`).\
+            \ Regular expressions are **not** supported."
+          title: Triggering User
+        description: "SQL LIKE expression \u2014 use `%` / `_` wildcards (e.g. `%customer_%`).\
+          \ Regular expressions are **not** supported."
       responses:
         '200':
           description: Successful Response

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -652,6 +652,14 @@ paths:
             format: date-time
           - type: 'null'
           title: Run After Lt
+      - name: run_type
+        in: query
+        required: false
+        schema:
+          type: array
+          items:
+            type: string
+          title: Run Type
       responses:
         '200':
           description: Successful Response
@@ -759,6 +767,14 @@ paths:
             format: date-time
           - type: 'null'
           title: Run After Lt
+      - name: run_type
+        in: query
+        required: false
+        schema:
+          type: array
+          items:
+            type: string
+          title: Run Type
       responses:
         '200':
           description: Successful Response

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/grid.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/grid.py
@@ -28,6 +28,7 @@ from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessE
 from airflow.api_fastapi.common.db.common import SessionDep, paginated_select
 from airflow.api_fastapi.common.parameters import (
     QueryDagRunRunTypesFilter,
+    QueryDagRunTriggeringUserSearch,
     QueryLimit,
     QueryOffset,
     RangeFilter,
@@ -120,6 +121,7 @@ def get_dag_structure(
     ],
     run_after: Annotated[RangeFilter, Depends(datetime_range_filter_factory("run_after", DagRun))],
     run_type: QueryDagRunRunTypesFilter,
+    triggering_user: QueryDagRunTriggeringUserSearch,
 ) -> list[GridNodeResponse]:
     """Return dag structure for grid view."""
     latest_serdag = _get_latest_serdag(dag_id, session)
@@ -138,7 +140,7 @@ def get_dag_structure(
         statement=base_query,
         order_by=order_by,
         offset=offset,
-        filters=[run_after, run_type],
+        filters=[run_after, run_type, triggering_user],
         limit=limit,
     )
     run_ids = list(session.scalars(dag_runs_select_filter))
@@ -217,6 +219,7 @@ def get_grid_runs(
     ],
     run_after: Annotated[RangeFilter, Depends(datetime_range_filter_factory("run_after", DagRun))],
     run_type: QueryDagRunRunTypesFilter,
+    triggering_user: QueryDagRunTriggeringUserSearch,
 ) -> list[GridRunsResponse]:
     """Get info about a run for the grid."""
     # Retrieve, sort the previous DAG Runs
@@ -244,7 +247,7 @@ def get_grid_runs(
         statement=base_query,
         order_by=order_by,
         offset=offset,
-        filters=[run_after, run_type],
+        filters=[run_after, run_type, triggering_user],
         limit=limit,
     )
     return session.execute(dag_runs_select_filter)

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/grid.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/grid.py
@@ -27,6 +27,7 @@ from sqlalchemy import select
 from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity
 from airflow.api_fastapi.common.db.common import SessionDep, paginated_select
 from airflow.api_fastapi.common.parameters import (
+    QueryDagRunRunTypesFilter,
     QueryLimit,
     QueryOffset,
     RangeFilter,
@@ -118,6 +119,7 @@ def get_dag_structure(
         Depends(SortParam(["run_after", "logical_date", "start_date", "end_date"], DagRun).dynamic_depends()),
     ],
     run_after: Annotated[RangeFilter, Depends(datetime_range_filter_factory("run_after", DagRun))],
+    run_type: QueryDagRunRunTypesFilter,
 ) -> list[GridNodeResponse]:
     """Return dag structure for grid view."""
     latest_serdag = _get_latest_serdag(dag_id, session)
@@ -136,7 +138,7 @@ def get_dag_structure(
         statement=base_query,
         order_by=order_by,
         offset=offset,
-        filters=[run_after],
+        filters=[run_after, run_type],
         limit=limit,
     )
     run_ids = list(session.scalars(dag_runs_select_filter))
@@ -214,6 +216,7 @@ def get_grid_runs(
         ),
     ],
     run_after: Annotated[RangeFilter, Depends(datetime_range_filter_factory("run_after", DagRun))],
+    run_type: QueryDagRunRunTypesFilter,
 ) -> list[GridRunsResponse]:
     """Get info about a run for the grid."""
     # Retrieve, sort the previous DAG Runs
@@ -241,7 +244,7 @@ def get_grid_runs(
         statement=base_query,
         order_by=order_by,
         offset=offset,
-        filters=[run_after],
+        filters=[run_after, run_type],
         limit=limit,
     )
     return session.execute(dag_runs_select_filter)

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/common.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/common.ts
@@ -791,7 +791,7 @@ export const UseStructureServiceStructureDataKeyFn = ({ dagId, externalDependenc
 export type GridServiceGetDagStructureDefaultResponse = Awaited<ReturnType<typeof GridService.getDagStructure>>;
 export type GridServiceGetDagStructureQueryResult<TData = GridServiceGetDagStructureDefaultResponse, TError = unknown> = UseQueryResult<TData, TError>;
 export const useGridServiceGetDagStructureKey = "GridServiceGetDagStructure";
-export const UseGridServiceGetDagStructureKeyFn = ({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte }: {
+export const UseGridServiceGetDagStructureKeyFn = ({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }: {
   dagId: string;
   limit?: number;
   offset?: number;
@@ -800,11 +800,12 @@ export const UseGridServiceGetDagStructureKeyFn = ({ dagId, limit, offset, order
   runAfterGte?: string;
   runAfterLt?: string;
   runAfterLte?: string;
-}, queryKey?: Array<unknown>) => [useGridServiceGetDagStructureKey, ...(queryKey ?? [{ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte }])];
+  runType?: string[];
+}, queryKey?: Array<unknown>) => [useGridServiceGetDagStructureKey, ...(queryKey ?? [{ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }])];
 export type GridServiceGetGridRunsDefaultResponse = Awaited<ReturnType<typeof GridService.getGridRuns>>;
 export type GridServiceGetGridRunsQueryResult<TData = GridServiceGetGridRunsDefaultResponse, TError = unknown> = UseQueryResult<TData, TError>;
 export const useGridServiceGetGridRunsKey = "GridServiceGetGridRuns";
-export const UseGridServiceGetGridRunsKeyFn = ({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte }: {
+export const UseGridServiceGetGridRunsKeyFn = ({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }: {
   dagId: string;
   limit?: number;
   offset?: number;
@@ -813,7 +814,8 @@ export const UseGridServiceGetGridRunsKeyFn = ({ dagId, limit, offset, orderBy, 
   runAfterGte?: string;
   runAfterLt?: string;
   runAfterLte?: string;
-}, queryKey?: Array<unknown>) => [useGridServiceGetGridRunsKey, ...(queryKey ?? [{ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte }])];
+  runType?: string[];
+}, queryKey?: Array<unknown>) => [useGridServiceGetGridRunsKey, ...(queryKey ?? [{ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }])];
 export type GridServiceGetGridTiSummariesDefaultResponse = Awaited<ReturnType<typeof GridService.getGridTiSummaries>>;
 export type GridServiceGetGridTiSummariesQueryResult<TData = GridServiceGetGridTiSummariesDefaultResponse, TError = unknown> = UseQueryResult<TData, TError>;
 export const useGridServiceGetGridTiSummariesKey = "GridServiceGetGridTiSummaries";

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/common.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/common.ts
@@ -791,7 +791,7 @@ export const UseStructureServiceStructureDataKeyFn = ({ dagId, externalDependenc
 export type GridServiceGetDagStructureDefaultResponse = Awaited<ReturnType<typeof GridService.getDagStructure>>;
 export type GridServiceGetDagStructureQueryResult<TData = GridServiceGetDagStructureDefaultResponse, TError = unknown> = UseQueryResult<TData, TError>;
 export const useGridServiceGetDagStructureKey = "GridServiceGetDagStructure";
-export const UseGridServiceGetDagStructureKeyFn = ({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }: {
+export const UseGridServiceGetDagStructureKeyFn = ({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType, triggeringUser }: {
   dagId: string;
   limit?: number;
   offset?: number;
@@ -801,11 +801,12 @@ export const UseGridServiceGetDagStructureKeyFn = ({ dagId, limit, offset, order
   runAfterLt?: string;
   runAfterLte?: string;
   runType?: string[];
-}, queryKey?: Array<unknown>) => [useGridServiceGetDagStructureKey, ...(queryKey ?? [{ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }])];
+  triggeringUser?: string;
+}, queryKey?: Array<unknown>) => [useGridServiceGetDagStructureKey, ...(queryKey ?? [{ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType, triggeringUser }])];
 export type GridServiceGetGridRunsDefaultResponse = Awaited<ReturnType<typeof GridService.getGridRuns>>;
 export type GridServiceGetGridRunsQueryResult<TData = GridServiceGetGridRunsDefaultResponse, TError = unknown> = UseQueryResult<TData, TError>;
 export const useGridServiceGetGridRunsKey = "GridServiceGetGridRuns";
-export const UseGridServiceGetGridRunsKeyFn = ({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }: {
+export const UseGridServiceGetGridRunsKeyFn = ({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType, triggeringUser }: {
   dagId: string;
   limit?: number;
   offset?: number;
@@ -815,7 +816,8 @@ export const UseGridServiceGetGridRunsKeyFn = ({ dagId, limit, offset, orderBy, 
   runAfterLt?: string;
   runAfterLte?: string;
   runType?: string[];
-}, queryKey?: Array<unknown>) => [useGridServiceGetGridRunsKey, ...(queryKey ?? [{ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }])];
+  triggeringUser?: string;
+}, queryKey?: Array<unknown>) => [useGridServiceGetGridRunsKey, ...(queryKey ?? [{ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType, triggeringUser }])];
 export type GridServiceGetGridTiSummariesDefaultResponse = Awaited<ReturnType<typeof GridService.getGridTiSummaries>>;
 export type GridServiceGetGridTiSummariesQueryResult<TData = GridServiceGetGridTiSummariesDefaultResponse, TError = unknown> = UseQueryResult<TData, TError>;
 export const useGridServiceGetGridTiSummariesKey = "GridServiceGetGridTiSummaries";

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/ensureQueryData.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/ensureQueryData.ts
@@ -1504,10 +1504,11 @@ export const ensureUseStructureServiceStructureDataData = (queryClient: QueryCli
 * @param data.runAfterGt
 * @param data.runAfterLte
 * @param data.runAfterLt
+* @param data.runType
 * @returns GridNodeResponse Successful Response
 * @throws ApiError
 */
-export const ensureUseGridServiceGetDagStructureData = (queryClient: QueryClient, { dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte }: {
+export const ensureUseGridServiceGetDagStructureData = (queryClient: QueryClient, { dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }: {
   dagId: string;
   limit?: number;
   offset?: number;
@@ -1516,7 +1517,8 @@ export const ensureUseGridServiceGetDagStructureData = (queryClient: QueryClient
   runAfterGte?: string;
   runAfterLt?: string;
   runAfterLte?: string;
-}) => queryClient.ensureQueryData({ queryKey: Common.UseGridServiceGetDagStructureKeyFn({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte }), queryFn: () => GridService.getDagStructure({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte }) });
+  runType?: string[];
+}) => queryClient.ensureQueryData({ queryKey: Common.UseGridServiceGetDagStructureKeyFn({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }), queryFn: () => GridService.getDagStructure({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }) });
 /**
 * Get Grid Runs
 * Get info about a run for the grid.
@@ -1529,10 +1531,11 @@ export const ensureUseGridServiceGetDagStructureData = (queryClient: QueryClient
 * @param data.runAfterGt
 * @param data.runAfterLte
 * @param data.runAfterLt
+* @param data.runType
 * @returns GridRunsResponse Successful Response
 * @throws ApiError
 */
-export const ensureUseGridServiceGetGridRunsData = (queryClient: QueryClient, { dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte }: {
+export const ensureUseGridServiceGetGridRunsData = (queryClient: QueryClient, { dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }: {
   dagId: string;
   limit?: number;
   offset?: number;
@@ -1541,7 +1544,8 @@ export const ensureUseGridServiceGetGridRunsData = (queryClient: QueryClient, { 
   runAfterGte?: string;
   runAfterLt?: string;
   runAfterLte?: string;
-}) => queryClient.ensureQueryData({ queryKey: Common.UseGridServiceGetGridRunsKeyFn({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte }), queryFn: () => GridService.getGridRuns({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte }) });
+  runType?: string[];
+}) => queryClient.ensureQueryData({ queryKey: Common.UseGridServiceGetGridRunsKeyFn({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }), queryFn: () => GridService.getGridRuns({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }) });
 /**
 * Get Grid Ti Summaries
 * Get states for TIs / "groups" of TIs.

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/ensureQueryData.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/ensureQueryData.ts
@@ -1505,10 +1505,11 @@ export const ensureUseStructureServiceStructureDataData = (queryClient: QueryCli
 * @param data.runAfterLte
 * @param data.runAfterLt
 * @param data.runType
+* @param data.triggeringUser SQL LIKE expression — use `%` / `_` wildcards (e.g. `%customer_%`). Regular expressions are **not** supported.
 * @returns GridNodeResponse Successful Response
 * @throws ApiError
 */
-export const ensureUseGridServiceGetDagStructureData = (queryClient: QueryClient, { dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }: {
+export const ensureUseGridServiceGetDagStructureData = (queryClient: QueryClient, { dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType, triggeringUser }: {
   dagId: string;
   limit?: number;
   offset?: number;
@@ -1518,7 +1519,8 @@ export const ensureUseGridServiceGetDagStructureData = (queryClient: QueryClient
   runAfterLt?: string;
   runAfterLte?: string;
   runType?: string[];
-}) => queryClient.ensureQueryData({ queryKey: Common.UseGridServiceGetDagStructureKeyFn({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }), queryFn: () => GridService.getDagStructure({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }) });
+  triggeringUser?: string;
+}) => queryClient.ensureQueryData({ queryKey: Common.UseGridServiceGetDagStructureKeyFn({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType, triggeringUser }), queryFn: () => GridService.getDagStructure({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType, triggeringUser }) });
 /**
 * Get Grid Runs
 * Get info about a run for the grid.
@@ -1532,10 +1534,11 @@ export const ensureUseGridServiceGetDagStructureData = (queryClient: QueryClient
 * @param data.runAfterLte
 * @param data.runAfterLt
 * @param data.runType
+* @param data.triggeringUser SQL LIKE expression — use `%` / `_` wildcards (e.g. `%customer_%`). Regular expressions are **not** supported.
 * @returns GridRunsResponse Successful Response
 * @throws ApiError
 */
-export const ensureUseGridServiceGetGridRunsData = (queryClient: QueryClient, { dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }: {
+export const ensureUseGridServiceGetGridRunsData = (queryClient: QueryClient, { dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType, triggeringUser }: {
   dagId: string;
   limit?: number;
   offset?: number;
@@ -1545,7 +1548,8 @@ export const ensureUseGridServiceGetGridRunsData = (queryClient: QueryClient, { 
   runAfterLt?: string;
   runAfterLte?: string;
   runType?: string[];
-}) => queryClient.ensureQueryData({ queryKey: Common.UseGridServiceGetGridRunsKeyFn({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }), queryFn: () => GridService.getGridRuns({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }) });
+  triggeringUser?: string;
+}) => queryClient.ensureQueryData({ queryKey: Common.UseGridServiceGetGridRunsKeyFn({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType, triggeringUser }), queryFn: () => GridService.getGridRuns({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType, triggeringUser }) });
 /**
 * Get Grid Ti Summaries
 * Get states for TIs / "groups" of TIs.

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -1504,10 +1504,11 @@ export const prefetchUseStructureServiceStructureData = (queryClient: QueryClien
 * @param data.runAfterGt
 * @param data.runAfterLte
 * @param data.runAfterLt
+* @param data.runType
 * @returns GridNodeResponse Successful Response
 * @throws ApiError
 */
-export const prefetchUseGridServiceGetDagStructure = (queryClient: QueryClient, { dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte }: {
+export const prefetchUseGridServiceGetDagStructure = (queryClient: QueryClient, { dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }: {
   dagId: string;
   limit?: number;
   offset?: number;
@@ -1516,7 +1517,8 @@ export const prefetchUseGridServiceGetDagStructure = (queryClient: QueryClient, 
   runAfterGte?: string;
   runAfterLt?: string;
   runAfterLte?: string;
-}) => queryClient.prefetchQuery({ queryKey: Common.UseGridServiceGetDagStructureKeyFn({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte }), queryFn: () => GridService.getDagStructure({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte }) });
+  runType?: string[];
+}) => queryClient.prefetchQuery({ queryKey: Common.UseGridServiceGetDagStructureKeyFn({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }), queryFn: () => GridService.getDagStructure({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }) });
 /**
 * Get Grid Runs
 * Get info about a run for the grid.
@@ -1529,10 +1531,11 @@ export const prefetchUseGridServiceGetDagStructure = (queryClient: QueryClient, 
 * @param data.runAfterGt
 * @param data.runAfterLte
 * @param data.runAfterLt
+* @param data.runType
 * @returns GridRunsResponse Successful Response
 * @throws ApiError
 */
-export const prefetchUseGridServiceGetGridRuns = (queryClient: QueryClient, { dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte }: {
+export const prefetchUseGridServiceGetGridRuns = (queryClient: QueryClient, { dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }: {
   dagId: string;
   limit?: number;
   offset?: number;
@@ -1541,7 +1544,8 @@ export const prefetchUseGridServiceGetGridRuns = (queryClient: QueryClient, { da
   runAfterGte?: string;
   runAfterLt?: string;
   runAfterLte?: string;
-}) => queryClient.prefetchQuery({ queryKey: Common.UseGridServiceGetGridRunsKeyFn({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte }), queryFn: () => GridService.getGridRuns({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte }) });
+  runType?: string[];
+}) => queryClient.prefetchQuery({ queryKey: Common.UseGridServiceGetGridRunsKeyFn({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }), queryFn: () => GridService.getGridRuns({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }) });
 /**
 * Get Grid Ti Summaries
 * Get states for TIs / "groups" of TIs.

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -1505,10 +1505,11 @@ export const prefetchUseStructureServiceStructureData = (queryClient: QueryClien
 * @param data.runAfterLte
 * @param data.runAfterLt
 * @param data.runType
+* @param data.triggeringUser SQL LIKE expression — use `%` / `_` wildcards (e.g. `%customer_%`). Regular expressions are **not** supported.
 * @returns GridNodeResponse Successful Response
 * @throws ApiError
 */
-export const prefetchUseGridServiceGetDagStructure = (queryClient: QueryClient, { dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }: {
+export const prefetchUseGridServiceGetDagStructure = (queryClient: QueryClient, { dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType, triggeringUser }: {
   dagId: string;
   limit?: number;
   offset?: number;
@@ -1518,7 +1519,8 @@ export const prefetchUseGridServiceGetDagStructure = (queryClient: QueryClient, 
   runAfterLt?: string;
   runAfterLte?: string;
   runType?: string[];
-}) => queryClient.prefetchQuery({ queryKey: Common.UseGridServiceGetDagStructureKeyFn({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }), queryFn: () => GridService.getDagStructure({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }) });
+  triggeringUser?: string;
+}) => queryClient.prefetchQuery({ queryKey: Common.UseGridServiceGetDagStructureKeyFn({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType, triggeringUser }), queryFn: () => GridService.getDagStructure({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType, triggeringUser }) });
 /**
 * Get Grid Runs
 * Get info about a run for the grid.
@@ -1532,10 +1534,11 @@ export const prefetchUseGridServiceGetDagStructure = (queryClient: QueryClient, 
 * @param data.runAfterLte
 * @param data.runAfterLt
 * @param data.runType
+* @param data.triggeringUser SQL LIKE expression — use `%` / `_` wildcards (e.g. `%customer_%`). Regular expressions are **not** supported.
 * @returns GridRunsResponse Successful Response
 * @throws ApiError
 */
-export const prefetchUseGridServiceGetGridRuns = (queryClient: QueryClient, { dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }: {
+export const prefetchUseGridServiceGetGridRuns = (queryClient: QueryClient, { dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType, triggeringUser }: {
   dagId: string;
   limit?: number;
   offset?: number;
@@ -1545,7 +1548,8 @@ export const prefetchUseGridServiceGetGridRuns = (queryClient: QueryClient, { da
   runAfterLt?: string;
   runAfterLte?: string;
   runType?: string[];
-}) => queryClient.prefetchQuery({ queryKey: Common.UseGridServiceGetGridRunsKeyFn({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }), queryFn: () => GridService.getGridRuns({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }) });
+  triggeringUser?: string;
+}) => queryClient.prefetchQuery({ queryKey: Common.UseGridServiceGetGridRunsKeyFn({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType, triggeringUser }), queryFn: () => GridService.getGridRuns({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType, triggeringUser }) });
 /**
 * Get Grid Ti Summaries
 * Get states for TIs / "groups" of TIs.

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/queries.ts
@@ -1505,10 +1505,11 @@ export const useStructureServiceStructureData = <TData = Common.StructureService
 * @param data.runAfterLte
 * @param data.runAfterLt
 * @param data.runType
+* @param data.triggeringUser SQL LIKE expression — use `%` / `_` wildcards (e.g. `%customer_%`). Regular expressions are **not** supported.
 * @returns GridNodeResponse Successful Response
 * @throws ApiError
 */
-export const useGridServiceGetDagStructure = <TData = Common.GridServiceGetDagStructureDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }: {
+export const useGridServiceGetDagStructure = <TData = Common.GridServiceGetDagStructureDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType, triggeringUser }: {
   dagId: string;
   limit?: number;
   offset?: number;
@@ -1518,7 +1519,8 @@ export const useGridServiceGetDagStructure = <TData = Common.GridServiceGetDagSt
   runAfterLt?: string;
   runAfterLte?: string;
   runType?: string[];
-}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useQuery<TData, TError>({ queryKey: Common.UseGridServiceGetDagStructureKeyFn({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }, queryKey), queryFn: () => GridService.getDagStructure({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }) as TData, ...options });
+  triggeringUser?: string;
+}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useQuery<TData, TError>({ queryKey: Common.UseGridServiceGetDagStructureKeyFn({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType, triggeringUser }, queryKey), queryFn: () => GridService.getDagStructure({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType, triggeringUser }) as TData, ...options });
 /**
 * Get Grid Runs
 * Get info about a run for the grid.
@@ -1532,10 +1534,11 @@ export const useGridServiceGetDagStructure = <TData = Common.GridServiceGetDagSt
 * @param data.runAfterLte
 * @param data.runAfterLt
 * @param data.runType
+* @param data.triggeringUser SQL LIKE expression — use `%` / `_` wildcards (e.g. `%customer_%`). Regular expressions are **not** supported.
 * @returns GridRunsResponse Successful Response
 * @throws ApiError
 */
-export const useGridServiceGetGridRuns = <TData = Common.GridServiceGetGridRunsDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }: {
+export const useGridServiceGetGridRuns = <TData = Common.GridServiceGetGridRunsDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType, triggeringUser }: {
   dagId: string;
   limit?: number;
   offset?: number;
@@ -1545,7 +1548,8 @@ export const useGridServiceGetGridRuns = <TData = Common.GridServiceGetGridRunsD
   runAfterLt?: string;
   runAfterLte?: string;
   runType?: string[];
-}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useQuery<TData, TError>({ queryKey: Common.UseGridServiceGetGridRunsKeyFn({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }, queryKey), queryFn: () => GridService.getGridRuns({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }) as TData, ...options });
+  triggeringUser?: string;
+}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useQuery<TData, TError>({ queryKey: Common.UseGridServiceGetGridRunsKeyFn({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType, triggeringUser }, queryKey), queryFn: () => GridService.getGridRuns({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType, triggeringUser }) as TData, ...options });
 /**
 * Get Grid Ti Summaries
 * Get states for TIs / "groups" of TIs.

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/queries.ts
@@ -1504,10 +1504,11 @@ export const useStructureServiceStructureData = <TData = Common.StructureService
 * @param data.runAfterGt
 * @param data.runAfterLte
 * @param data.runAfterLt
+* @param data.runType
 * @returns GridNodeResponse Successful Response
 * @throws ApiError
 */
-export const useGridServiceGetDagStructure = <TData = Common.GridServiceGetDagStructureDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte }: {
+export const useGridServiceGetDagStructure = <TData = Common.GridServiceGetDagStructureDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }: {
   dagId: string;
   limit?: number;
   offset?: number;
@@ -1516,7 +1517,8 @@ export const useGridServiceGetDagStructure = <TData = Common.GridServiceGetDagSt
   runAfterGte?: string;
   runAfterLt?: string;
   runAfterLte?: string;
-}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useQuery<TData, TError>({ queryKey: Common.UseGridServiceGetDagStructureKeyFn({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte }, queryKey), queryFn: () => GridService.getDagStructure({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte }) as TData, ...options });
+  runType?: string[];
+}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useQuery<TData, TError>({ queryKey: Common.UseGridServiceGetDagStructureKeyFn({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }, queryKey), queryFn: () => GridService.getDagStructure({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }) as TData, ...options });
 /**
 * Get Grid Runs
 * Get info about a run for the grid.
@@ -1529,10 +1531,11 @@ export const useGridServiceGetDagStructure = <TData = Common.GridServiceGetDagSt
 * @param data.runAfterGt
 * @param data.runAfterLte
 * @param data.runAfterLt
+* @param data.runType
 * @returns GridRunsResponse Successful Response
 * @throws ApiError
 */
-export const useGridServiceGetGridRuns = <TData = Common.GridServiceGetGridRunsDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte }: {
+export const useGridServiceGetGridRuns = <TData = Common.GridServiceGetGridRunsDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }: {
   dagId: string;
   limit?: number;
   offset?: number;
@@ -1541,7 +1544,8 @@ export const useGridServiceGetGridRuns = <TData = Common.GridServiceGetGridRunsD
   runAfterGte?: string;
   runAfterLt?: string;
   runAfterLte?: string;
-}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useQuery<TData, TError>({ queryKey: Common.UseGridServiceGetGridRunsKeyFn({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte }, queryKey), queryFn: () => GridService.getGridRuns({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte }) as TData, ...options });
+  runType?: string[];
+}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useQuery<TData, TError>({ queryKey: Common.UseGridServiceGetGridRunsKeyFn({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }, queryKey), queryFn: () => GridService.getGridRuns({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }) as TData, ...options });
 /**
 * Get Grid Ti Summaries
 * Get states for TIs / "groups" of TIs.

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/suspense.ts
@@ -1504,10 +1504,11 @@ export const useStructureServiceStructureDataSuspense = <TData = Common.Structur
 * @param data.runAfterGt
 * @param data.runAfterLte
 * @param data.runAfterLt
+* @param data.runType
 * @returns GridNodeResponse Successful Response
 * @throws ApiError
 */
-export const useGridServiceGetDagStructureSuspense = <TData = Common.GridServiceGetDagStructureDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte }: {
+export const useGridServiceGetDagStructureSuspense = <TData = Common.GridServiceGetDagStructureDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }: {
   dagId: string;
   limit?: number;
   offset?: number;
@@ -1516,7 +1517,8 @@ export const useGridServiceGetDagStructureSuspense = <TData = Common.GridService
   runAfterGte?: string;
   runAfterLt?: string;
   runAfterLte?: string;
-}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useSuspenseQuery<TData, TError>({ queryKey: Common.UseGridServiceGetDagStructureKeyFn({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte }, queryKey), queryFn: () => GridService.getDagStructure({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte }) as TData, ...options });
+  runType?: string[];
+}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useSuspenseQuery<TData, TError>({ queryKey: Common.UseGridServiceGetDagStructureKeyFn({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }, queryKey), queryFn: () => GridService.getDagStructure({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }) as TData, ...options });
 /**
 * Get Grid Runs
 * Get info about a run for the grid.
@@ -1529,10 +1531,11 @@ export const useGridServiceGetDagStructureSuspense = <TData = Common.GridService
 * @param data.runAfterGt
 * @param data.runAfterLte
 * @param data.runAfterLt
+* @param data.runType
 * @returns GridRunsResponse Successful Response
 * @throws ApiError
 */
-export const useGridServiceGetGridRunsSuspense = <TData = Common.GridServiceGetGridRunsDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte }: {
+export const useGridServiceGetGridRunsSuspense = <TData = Common.GridServiceGetGridRunsDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }: {
   dagId: string;
   limit?: number;
   offset?: number;
@@ -1541,7 +1544,8 @@ export const useGridServiceGetGridRunsSuspense = <TData = Common.GridServiceGetG
   runAfterGte?: string;
   runAfterLt?: string;
   runAfterLte?: string;
-}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useSuspenseQuery<TData, TError>({ queryKey: Common.UseGridServiceGetGridRunsKeyFn({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte }, queryKey), queryFn: () => GridService.getGridRuns({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte }) as TData, ...options });
+  runType?: string[];
+}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useSuspenseQuery<TData, TError>({ queryKey: Common.UseGridServiceGetGridRunsKeyFn({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }, queryKey), queryFn: () => GridService.getGridRuns({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }) as TData, ...options });
 /**
 * Get Grid Ti Summaries
 * Get states for TIs / "groups" of TIs.

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/suspense.ts
@@ -1505,10 +1505,11 @@ export const useStructureServiceStructureDataSuspense = <TData = Common.Structur
 * @param data.runAfterLte
 * @param data.runAfterLt
 * @param data.runType
+* @param data.triggeringUser SQL LIKE expression — use `%` / `_` wildcards (e.g. `%customer_%`). Regular expressions are **not** supported.
 * @returns GridNodeResponse Successful Response
 * @throws ApiError
 */
-export const useGridServiceGetDagStructureSuspense = <TData = Common.GridServiceGetDagStructureDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }: {
+export const useGridServiceGetDagStructureSuspense = <TData = Common.GridServiceGetDagStructureDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType, triggeringUser }: {
   dagId: string;
   limit?: number;
   offset?: number;
@@ -1518,7 +1519,8 @@ export const useGridServiceGetDagStructureSuspense = <TData = Common.GridService
   runAfterLt?: string;
   runAfterLte?: string;
   runType?: string[];
-}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useSuspenseQuery<TData, TError>({ queryKey: Common.UseGridServiceGetDagStructureKeyFn({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }, queryKey), queryFn: () => GridService.getDagStructure({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }) as TData, ...options });
+  triggeringUser?: string;
+}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useSuspenseQuery<TData, TError>({ queryKey: Common.UseGridServiceGetDagStructureKeyFn({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType, triggeringUser }, queryKey), queryFn: () => GridService.getDagStructure({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType, triggeringUser }) as TData, ...options });
 /**
 * Get Grid Runs
 * Get info about a run for the grid.
@@ -1532,10 +1534,11 @@ export const useGridServiceGetDagStructureSuspense = <TData = Common.GridService
 * @param data.runAfterLte
 * @param data.runAfterLt
 * @param data.runType
+* @param data.triggeringUser SQL LIKE expression — use `%` / `_` wildcards (e.g. `%customer_%`). Regular expressions are **not** supported.
 * @returns GridRunsResponse Successful Response
 * @throws ApiError
 */
-export const useGridServiceGetGridRunsSuspense = <TData = Common.GridServiceGetGridRunsDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }: {
+export const useGridServiceGetGridRunsSuspense = <TData = Common.GridServiceGetGridRunsDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType, triggeringUser }: {
   dagId: string;
   limit?: number;
   offset?: number;
@@ -1545,7 +1548,8 @@ export const useGridServiceGetGridRunsSuspense = <TData = Common.GridServiceGetG
   runAfterLt?: string;
   runAfterLte?: string;
   runType?: string[];
-}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useSuspenseQuery<TData, TError>({ queryKey: Common.UseGridServiceGetGridRunsKeyFn({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }, queryKey), queryFn: () => GridService.getGridRuns({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType }) as TData, ...options });
+  triggeringUser?: string;
+}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useSuspenseQuery<TData, TError>({ queryKey: Common.UseGridServiceGetGridRunsKeyFn({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType, triggeringUser }, queryKey), queryFn: () => GridService.getGridRuns({ dagId, limit, offset, orderBy, runAfterGt, runAfterGte, runAfterLt, runAfterLte, runType, triggeringUser }) as TData, ...options });
 /**
 * Get Grid Ti Summaries
 * Get states for TIs / "groups" of TIs.

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -3882,6 +3882,7 @@ export class GridService {
      * @param data.runAfterGt
      * @param data.runAfterLte
      * @param data.runAfterLt
+     * @param data.runType
      * @returns GridNodeResponse Successful Response
      * @throws ApiError
      */
@@ -3899,7 +3900,8 @@ export class GridService {
                 run_after_gte: data.runAfterGte,
                 run_after_gt: data.runAfterGt,
                 run_after_lte: data.runAfterLte,
-                run_after_lt: data.runAfterLt
+                run_after_lt: data.runAfterLt,
+                run_type: data.runType
             },
             errors: {
                 400: 'Bad Request',
@@ -3921,6 +3923,7 @@ export class GridService {
      * @param data.runAfterGt
      * @param data.runAfterLte
      * @param data.runAfterLt
+     * @param data.runType
      * @returns GridRunsResponse Successful Response
      * @throws ApiError
      */
@@ -3938,7 +3941,8 @@ export class GridService {
                 run_after_gte: data.runAfterGte,
                 run_after_gt: data.runAfterGt,
                 run_after_lte: data.runAfterLte,
-                run_after_lt: data.runAfterLt
+                run_after_lt: data.runAfterLt,
+                run_type: data.runType
             },
             errors: {
                 400: 'Bad Request',

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -3883,6 +3883,7 @@ export class GridService {
      * @param data.runAfterLte
      * @param data.runAfterLt
      * @param data.runType
+     * @param data.triggeringUser SQL LIKE expression — use `%` / `_` wildcards (e.g. `%customer_%`). Regular expressions are **not** supported.
      * @returns GridNodeResponse Successful Response
      * @throws ApiError
      */
@@ -3901,7 +3902,8 @@ export class GridService {
                 run_after_gt: data.runAfterGt,
                 run_after_lte: data.runAfterLte,
                 run_after_lt: data.runAfterLt,
-                run_type: data.runType
+                run_type: data.runType,
+                triggering_user: data.triggeringUser
             },
             errors: {
                 400: 'Bad Request',
@@ -3924,6 +3926,7 @@ export class GridService {
      * @param data.runAfterLte
      * @param data.runAfterLt
      * @param data.runType
+     * @param data.triggeringUser SQL LIKE expression — use `%` / `_` wildcards (e.g. `%customer_%`). Regular expressions are **not** supported.
      * @returns GridRunsResponse Successful Response
      * @throws ApiError
      */
@@ -3942,7 +3945,8 @@ export class GridService {
                 run_after_gt: data.runAfterGt,
                 run_after_lte: data.runAfterLte,
                 run_after_lt: data.runAfterLt,
-                run_type: data.runType
+                run_type: data.runType,
+                triggering_user: data.triggeringUser
             },
             errors: {
                 400: 'Bad Request',

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -3164,6 +3164,7 @@ export type GetDagStructureData = {
     runAfterGte?: string | null;
     runAfterLt?: string | null;
     runAfterLte?: string | null;
+    runType?: Array<(string)>;
 };
 
 export type GetDagStructureResponse = Array<GridNodeResponse>;
@@ -3177,6 +3178,7 @@ export type GetGridRunsData = {
     runAfterGte?: string | null;
     runAfterLt?: string | null;
     runAfterLte?: string | null;
+    runType?: Array<(string)>;
 };
 
 export type GetGridRunsResponse = Array<GridRunsResponse>;

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -3165,6 +3165,10 @@ export type GetDagStructureData = {
     runAfterLt?: string | null;
     runAfterLte?: string | null;
     runType?: Array<(string)>;
+    /**
+     * SQL LIKE expression — use `%` / `_` wildcards (e.g. `%customer_%`). Regular expressions are **not** supported.
+     */
+    triggeringUser?: string | null;
 };
 
 export type GetDagStructureResponse = Array<GridNodeResponse>;
@@ -3179,6 +3183,10 @@ export type GetGridRunsData = {
     runAfterLt?: string | null;
     runAfterLte?: string | null;
     runType?: Array<(string)>;
+    /**
+     * SQL LIKE expression — use `%` / `_` wildcards (e.g. `%customer_%`). Regular expressions are **not** supported.
+     */
+    triggeringUser?: string | null;
 };
 
 export type GetGridRunsResponse = Array<GridRunsResponse>;

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
@@ -101,7 +101,8 @@
     "runAfterFromPlaceholder": "Run After From",
     "runAfterToPlaceholder": "Run After To",
     "runIdPlaceholder": "Filter by Run ID",
-    "taskIdPlaceholder": "Filter by Task ID"
+    "taskIdPlaceholder": "Filter by Task ID",
+    "triggeringUserPlaceholder": "Filter by triggering user"
   },
   "logicalDate": "Logical Date",
   "logout": "Logout",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
@@ -109,6 +109,9 @@
     },
     "graphDirection": {
       "label": "Graph Direction"
+    },
+    "runTypeFilter": {
+      "label": "Run Type Filter"
     }
   },
   "paramsFailed": "Failed to load params",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
@@ -112,6 +112,10 @@
     },
     "runType": {
       "label": "Run Type"
+    },
+    "triggeringUser": {
+      "label": "Triggering User Name",
+      "placeholder": "Enter user name to filter..."
     }
   },
   "paramsFailed": "Failed to load params",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
@@ -109,13 +109,6 @@
     },
     "graphDirection": {
       "label": "Graph Direction"
-    },
-    "runType": {
-      "label": "Run Type"
-    },
-    "triggeringUser": {
-      "label": "Triggering User Name",
-      "placeholder": "Enter user name to filter..."
     }
   },
   "paramsFailed": "Failed to load params",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
@@ -110,8 +110,8 @@
     "graphDirection": {
       "label": "Graph Direction"
     },
-    "runTypeFilter": {
-      "label": "Run Type Filter"
+    "runType": {
+      "label": "Run Type"
     }
   },
   "paramsFailed": "Failed to load params",

--- a/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -64,6 +64,10 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
     `run_type_filter-${dagId}`,
     null,
   );
+  const [triggeringUserFilter, setTriggeringUserFilter] = useLocalStorage<string | null>(
+    `triggering_user_filter-${dagId}`,
+    null,
+  );
 
   const [showGantt, setShowGantt] = useLocalStorage<boolean>(`show_gantt-${dagId}`, true);
   const { fitView, getZoom } = useReactFlow();
@@ -133,13 +137,20 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
                 setLimit={setLimit}
                 setRunTypeFilter={setRunTypeFilter}
                 setShowGantt={setShowGantt}
+                setTriggeringUserFilter={setTriggeringUserFilter}
                 showGantt={showGantt}
+                triggeringUserFilter={triggeringUserFilter}
               />
               {dagView === "graph" ? (
                 <Graph />
               ) : (
                 <HStack gap={0}>
-                  <Grid limit={limit} runType={runTypeFilter} showGantt={Boolean(runId) && showGantt} />
+                  <Grid
+                    limit={limit}
+                    runType={runTypeFilter}
+                    showGantt={Boolean(runId) && showGantt}
+                    triggeringUser={triggeringUserFilter}
+                  />
                   {showGantt ? <Gantt limit={limit} /> : undefined}
                 </HStack>
               )}

--- a/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -28,6 +28,7 @@ import { Outlet, useParams } from "react-router-dom";
 import { useLocalStorage } from "usehooks-ts";
 
 import { useDagServiceGetDag, useDagWarningServiceListDagWarnings } from "openapi/queries";
+import type { DagRunType } from "openapi/requests/types.gen";
 import BackfillBanner from "src/components/Banner/BackfillBanner";
 import { SearchDagsButton } from "src/components/SearchDags";
 import TriggerDAGButton from "src/components/TriggerDag/TriggerDAGButton";
@@ -59,6 +60,10 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
   const panelGroupRef = useRef(null);
   const [dagView, setDagView] = useLocalStorage<"graph" | "grid">(`dag_view-${dagId}`, defaultDagView);
   const [limit, setLimit] = useLocalStorage<number>(`dag_runs_limit-${dagId}`, 10);
+  const [runTypeFilter, setRunTypeFilter] = useLocalStorage<Array<DagRunType> | null>(
+    `run_type_filter-${dagId}`,
+    null,
+  );
 
   const [showGantt, setShowGantt] = useLocalStorage<boolean>(`show_gantt-${dagId}`, true);
   const { fitView, getZoom } = useReactFlow();
@@ -123,8 +128,10 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
                 dagView={dagView}
                 limit={limit}
                 panelGroupRef={panelGroupRef}
+                runTypeFilter={runTypeFilter}
                 setDagView={setDagView}
                 setLimit={setLimit}
+                setRunTypeFilter={setRunTypeFilter}
                 setShowGantt={setShowGantt}
                 showGantt={showGantt}
               />
@@ -132,7 +139,7 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
                 <Graph />
               ) : (
                 <HStack gap={0}>
-                  <Grid limit={limit} showGantt={Boolean(runId) && showGantt} />
+                  <Grid limit={limit} runType={runTypeFilter} showGantt={Boolean(runId) && showGantt} />
                   {showGantt ? <Gantt limit={limit} /> : undefined}
                 </HStack>
               )}

--- a/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -60,13 +60,13 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
   const panelGroupRef = useRef(null);
   const [dagView, setDagView] = useLocalStorage<"graph" | "grid">(`dag_view-${dagId}`, defaultDagView);
   const [limit, setLimit] = useLocalStorage<number>(`dag_runs_limit-${dagId}`, 10);
-  const [runTypeFilter, setRunTypeFilter] = useLocalStorage<Array<DagRunType> | null>(
+  const [runTypeFilter, setRunTypeFilter] = useLocalStorage<DagRunType | undefined>(
     `run_type_filter-${dagId}`,
-    null,
+    undefined,
   );
-  const [triggeringUserFilter, setTriggeringUserFilter] = useLocalStorage<string | null>(
+  const [triggeringUserFilter, setTriggeringUserFilter] = useLocalStorage<string | undefined>(
     `triggering_user_filter-${dagId}`,
-    null,
+    undefined,
   );
 
   const [showGantt, setShowGantt] = useLocalStorage<boolean>(`show_gantt-${dagId}`, true);

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Grid.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Grid.tsx
@@ -43,9 +43,10 @@ type Props = {
   readonly limit: number;
   readonly runType?: Array<DagRunType> | null;
   readonly showGantt?: boolean;
+  readonly triggeringUser?: string | null;
 };
 
-export const Grid = ({ limit, runType, showGantt }: Props) => {
+export const Grid = ({ limit, runType, showGantt, triggeringUser }: Props) => {
   const { t: translate } = useTranslation("dag");
   const gridRef = useRef<HTMLDivElement>(null);
 
@@ -54,7 +55,7 @@ export const Grid = ({ limit, runType, showGantt }: Props) => {
   const { openGroupIds, toggleGroupId } = useOpenGroups();
   const { dagId = "", runId = "" } = useParams();
 
-  const { data: gridRuns, isLoading } = useGridRuns({ limit, runType });
+  const { data: gridRuns, isLoading } = useGridRuns({ limit, runType, triggeringUser });
 
   // Check if the selected dag run is inside of the grid response, if not, we'll update the grid filters
   // Eventually we should redo the api endpoint to make this work better
@@ -78,7 +79,7 @@ export const Grid = ({ limit, runType, showGantt }: Props) => {
     }
   }, [gridRuns, setHasActiveRun]);
 
-  const { data: dagStructure } = useGridStructure({ hasActiveRun, limit, runType });
+  const { data: dagStructure } = useGridStructure({ hasActiveRun, limit, runType, triggeringUser });
   // calculate dag run bar heights relative to max
 
   const max = Math.max.apply(

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Grid.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Grid.tsx
@@ -41,9 +41,9 @@ dayjs.extend(dayjsDuration);
 
 type Props = {
   readonly limit: number;
-  readonly runType?: Array<DagRunType> | null;
+  readonly runType?: DagRunType | undefined;
   readonly showGantt?: boolean;
-  readonly triggeringUser?: string | null;
+  readonly triggeringUser?: string | undefined;
 };
 
 export const Grid = ({ limit, runType, showGantt, triggeringUser }: Props) => {

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Grid.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Grid.tsx
@@ -24,7 +24,7 @@ import { useTranslation } from "react-i18next";
 import { FiChevronsRight } from "react-icons/fi";
 import { Link, useParams } from "react-router-dom";
 
-import type { GridRunsResponse } from "openapi/requests";
+import type { DagRunType, GridRunsResponse } from "openapi/requests";
 import { useOpenGroups } from "src/context/openGroups";
 import { useNavigation } from "src/hooks/navigation";
 import { useGridRuns } from "src/queries/useGridRuns.ts";
@@ -41,10 +41,11 @@ dayjs.extend(dayjsDuration);
 
 type Props = {
   readonly limit: number;
+  readonly runType?: Array<DagRunType> | null;
   readonly showGantt?: boolean;
 };
 
-export const Grid = ({ limit, showGantt }: Props) => {
+export const Grid = ({ limit, runType, showGantt }: Props) => {
   const { t: translate } = useTranslation("dag");
   const gridRef = useRef<HTMLDivElement>(null);
 
@@ -53,7 +54,7 @@ export const Grid = ({ limit, showGantt }: Props) => {
   const { openGroupIds, toggleGroupId } = useOpenGroups();
   const { dagId = "", runId = "" } = useParams();
 
-  const { data: gridRuns, isLoading } = useGridRuns({ limit });
+  const { data: gridRuns, isLoading } = useGridRuns({ limit, runType });
 
   // Check if the selected dag run is inside of the grid response, if not, we'll update the grid filters
   // Eventually we should redo the api endpoint to make this work better
@@ -77,7 +78,7 @@ export const Grid = ({ limit, showGantt }: Props) => {
     }
   }, [gridRuns, setHasActiveRun]);
 
-  const { data: dagStructure } = useGridStructure({ hasActiveRun, limit });
+  const { data: dagStructure } = useGridStructure({ hasActiveRun, limit, runType });
   // calculate dag run bar heights relative to max
 
   const max = Math.max.apply(

--- a/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
@@ -30,6 +30,7 @@ import {
   VStack,
   Text,
   Box,
+  Input,
 } from "@chakra-ui/react";
 import { useReactFlow } from "@xyflow/react";
 import { useHotkeys } from "react-hotkeys-hook";
@@ -60,7 +61,9 @@ type Props = {
   readonly setLimit: React.Dispatch<React.SetStateAction<number>>;
   readonly setRunTypeFilter: React.Dispatch<React.SetStateAction<Array<DagRunType> | null>>;
   readonly setShowGantt: React.Dispatch<React.SetStateAction<boolean>>;
+  readonly setTriggeringUserFilter: React.Dispatch<React.SetStateAction<string | null>>;
   readonly showGantt: boolean;
+  readonly triggeringUserFilter: string | null;
 };
 
 const getOptions = (translate: (key: string) => string) =>
@@ -96,7 +99,9 @@ export const PanelButtons = ({
   setLimit,
   setRunTypeFilter,
   setShowGantt,
+  setTriggeringUserFilter,
   showGantt,
+  triggeringUserFilter,
 }: Props) => {
   const { t: translate } = useTranslation(["components", "dag"]);
   const { dagId = "", runId } = useParams();
@@ -137,6 +142,12 @@ export const PanelButtons = ({
     } else {
       setRunTypeFilter([val as DagRunType]);
     }
+  };
+
+  const handleTriggeringUserChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value.trim();
+
+    setTriggeringUserFilter(value === "" ? null : value);
   };
 
   const handleFocus = (view: string) => {
@@ -343,6 +354,17 @@ export const PanelButtons = ({
                             </Select.Content>
                           </Select.Positioner>
                         </Select.Root>
+                        <VStack alignItems="flex-start">
+                          <Text fontSize="xs" mb={1}>
+                            {translate("dag:panel.triggeringUser.label")}
+                          </Text>
+                          <Input
+                            onChange={handleTriggeringUserChange}
+                            placeholder={translate("dag:panel.triggeringUser.placeholder")}
+                            size="sm"
+                            value={triggeringUserFilter ?? ""}
+                          />
+                        </VStack>
                         {shouldShowToggleButtons ? (
                           <VStack alignItems="flex-start" px={1}>
                             <Checkbox checked={showGantt} onChange={() => setShowGantt(!showGantt)} size="sm">

--- a/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
@@ -30,7 +30,6 @@ import {
   VStack,
   Text,
   Box,
-  Input,
 } from "@chakra-ui/react";
 import { useReactFlow } from "@xyflow/react";
 import { useHotkeys } from "react-hotkeys-hook";
@@ -45,6 +44,7 @@ import type { DagRunType } from "openapi/requests/types.gen";
 import { DagVersionSelect } from "src/components/DagVersionSelect";
 import { directionOptions, type Direction } from "src/components/Graph/useGraphLayout";
 import { RunTypeIcon } from "src/components/RunTypeIcon";
+import { SearchBar } from "src/components/SearchBar";
 import { Button, Tooltip } from "src/components/ui";
 import { Checkbox } from "src/components/ui/Checkbox";
 import { dagRunTypeOptions } from "src/constants/stateOptions";
@@ -56,14 +56,14 @@ type Props = {
   readonly dagView: string;
   readonly limit: number;
   readonly panelGroupRef: React.RefObject<{ setLayout?: (layout: Array<number>) => void } & HTMLDivElement>;
-  readonly runTypeFilter: Array<DagRunType> | null;
+  readonly runTypeFilter: DagRunType | undefined;
   readonly setDagView: (x: "graph" | "grid") => void;
   readonly setLimit: React.Dispatch<React.SetStateAction<number>>;
-  readonly setRunTypeFilter: React.Dispatch<React.SetStateAction<Array<DagRunType> | null>>;
+  readonly setRunTypeFilter: React.Dispatch<React.SetStateAction<DagRunType | undefined>>;
   readonly setShowGantt: React.Dispatch<React.SetStateAction<boolean>>;
-  readonly setTriggeringUserFilter: React.Dispatch<React.SetStateAction<string | null>>;
+  readonly setTriggeringUserFilter: React.Dispatch<React.SetStateAction<string | undefined>>;
   readonly showGantt: boolean;
-  readonly triggeringUserFilter: string | null;
+  readonly triggeringUserFilter: string | undefined;
 };
 
 const getOptions = (translate: (key: string) => string) =>
@@ -134,20 +134,20 @@ export const PanelButtons = ({
     }
   };
 
-  const handleRunTypeChange = (event: SelectValueChangeDetails<{ label: string; value: Array<string> }>) => {
+  const handleRunTypeChange = (event: SelectValueChangeDetails<string>) => {
     const [val] = event.value;
 
     if (val === undefined || val === "all") {
-      setRunTypeFilter(null);
+      setRunTypeFilter(undefined);
     } else {
-      setRunTypeFilter([val as DagRunType]);
+      setRunTypeFilter(val as DagRunType);
     }
   };
 
-  const handleTriggeringUserChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const value = event.target.value.trim();
+  const handleTriggeringUserChange = (value: string) => {
+    const trimmedValue = value.trim();
 
-    setTriggeringUserFilter(value === "" ? null : value);
+    setTriggeringUserFilter(trimmedValue === "" ? undefined : trimmedValue);
   };
 
   const handleFocus = (view: string) => {
@@ -326,24 +326,23 @@ export const PanelButtons = ({
                           data-testid="run-type-filter"
                           onValueChange={handleRunTypeChange}
                           size="sm"
-                          value={[runTypeFilter?.[0] ?? "all"]}
+                          value={[runTypeFilter ?? "all"]}
                         >
                           <Select.Label>{translate("common:dagRun.runType")}</Select.Label>
                           <Select.Control>
                             <Select.Trigger>
                               <Select.ValueText>
-                                {(runTypeFilter?.[0] ?? "all") === "all"
-                                  ? translate("dags:filters.allRunTypes")
-                                  : runTypeFilter?.[0] !== undefined && (
-                                      <Flex gap={1}>
-                                        <RunTypeIcon runType={runTypeFilter[0]} />
-                                        {translate(
-                                          dagRunTypeOptions.items.find(
-                                            (item) => item.value === runTypeFilter[0],
-                                          )?.label ?? "",
-                                        )}
-                                      </Flex>
+                                {(runTypeFilter ?? "all") === "all" ? (
+                                  translate("dags:filters.allRunTypes")
+                                ) : (
+                                  <Flex gap={1}>
+                                    <RunTypeIcon runType={runTypeFilter!} />
+                                    {translate(
+                                      dagRunTypeOptions.items.find((item) => item.value === runTypeFilter)
+                                        ?.label ?? "",
                                     )}
+                                  </Flex>
+                                )}
                               </Select.ValueText>
                             </Select.Trigger>
                             <Select.IndicatorGroup>
@@ -371,11 +370,12 @@ export const PanelButtons = ({
                           <Text fontSize="xs" mb={1}>
                             {translate("common:dagRun.triggeringUser")}
                           </Text>
-                          <Input
+                          <SearchBar
+                            defaultValue={triggeringUserFilter ?? ""}
+                            hideAdvanced
+                            hotkeyDisabled
                             onChange={handleTriggeringUserChange}
-                            placeholder={translate("common:filters.triggeringUserPlaceholder")}
-                            size="sm"
-                            value={triggeringUserFilter ?? ""}
+                            placeHolder={translate("common:filters.triggeringUserPlaceholder")}
                           />
                         </VStack>
                         {shouldShowToggleButtons ? (

--- a/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
@@ -331,7 +331,20 @@ export const PanelButtons = ({
                           <Select.Label>{translate("dag:panel.runType.label")}</Select.Label>
                           <Select.Control>
                             <Select.Trigger>
-                              <Select.ValueText />
+                              <Select.ValueText>
+                                {(runTypeFilter?.[0] ?? "all") === "all"
+                                  ? translate("dags:filters.allRunTypes")
+                                  : runTypeFilter?.[0] !== undefined && (
+                                      <Flex gap={1}>
+                                        <RunTypeIcon runType={runTypeFilter[0]} />
+                                        {translate(
+                                          dagRunTypeOptions.items.find(
+                                            (item) => item.value === runTypeFilter[0],
+                                          )?.label ?? "",
+                                        )}
+                                      </Flex>
+                                    )}
+                              </Select.ValueText>
                             </Select.Trigger>
                             <Select.IndicatorGroup>
                               <Select.Indicator />

--- a/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
@@ -40,10 +40,13 @@ import { MdOutlineAccountTree } from "react-icons/md";
 import { useParams } from "react-router-dom";
 import { useLocalStorage } from "usehooks-ts";
 
+import type { DagRunType } from "openapi/requests/types.gen";
 import { DagVersionSelect } from "src/components/DagVersionSelect";
 import { directionOptions, type Direction } from "src/components/Graph/useGraphLayout";
+import { RunTypeIcon } from "src/components/RunTypeIcon";
 import { Button, Tooltip } from "src/components/ui";
 import { Checkbox } from "src/components/ui/Checkbox";
+import { dagRunTypeOptions } from "src/constants/stateOptions";
 
 import { DagRunSelect } from "./DagRunSelect";
 import { ToggleGroups } from "./ToggleGroups";
@@ -52,8 +55,10 @@ type Props = {
   readonly dagView: string;
   readonly limit: number;
   readonly panelGroupRef: React.RefObject<{ setLayout?: (layout: Array<number>) => void } & HTMLDivElement>;
+  readonly runTypeFilter: Array<DagRunType> | null;
   readonly setDagView: (x: "graph" | "grid") => void;
   readonly setLimit: React.Dispatch<React.SetStateAction<number>>;
+  readonly setRunTypeFilter: React.Dispatch<React.SetStateAction<Array<DagRunType> | null>>;
   readonly setShowGantt: React.Dispatch<React.SetStateAction<boolean>>;
   readonly showGantt: boolean;
 };
@@ -86,8 +91,10 @@ export const PanelButtons = ({
   dagView,
   limit,
   panelGroupRef,
+  runTypeFilter,
   setDagView,
   setLimit,
+  setRunTypeFilter,
   setShowGantt,
   showGantt,
 }: Props) => {
@@ -119,6 +126,16 @@ export const PanelButtons = ({
   ) => {
     if (event.value[0] !== undefined) {
       setDirection(event.value[0] as Direction);
+    }
+  };
+
+  const handleRunTypeChange = (event: SelectValueChangeDetails<{ label: string; value: Array<string> }>) => {
+    const [val] = event.value;
+
+    if (val === undefined || val === "all") {
+      setRunTypeFilter(null);
+    } else {
+      setRunTypeFilter([val as DagRunType]);
     }
   };
 
@@ -287,6 +304,40 @@ export const PanelButtons = ({
                               {displayRunOptions.items.map((option) => (
                                 <Select.Item item={option} key={option.value}>
                                   {option.label}
+                                </Select.Item>
+                              ))}
+                            </Select.Content>
+                          </Select.Positioner>
+                        </Select.Root>
+                        <Select.Root
+                          // @ts-expect-error The expected option type is incorrect
+                          collection={dagRunTypeOptions}
+                          data-testid="run-type-filter"
+                          onValueChange={handleRunTypeChange}
+                          size="sm"
+                          value={[runTypeFilter?.[0] ?? "all"]}
+                        >
+                          <Select.Label>{translate("dag:panel.runTypeFilter.label")}</Select.Label>
+                          <Select.Control>
+                            <Select.Trigger>
+                              <Select.ValueText />
+                            </Select.Trigger>
+                            <Select.IndicatorGroup>
+                              <Select.Indicator />
+                            </Select.IndicatorGroup>
+                          </Select.Control>
+                          <Select.Positioner>
+                            <Select.Content>
+                              {dagRunTypeOptions.items.map((option) => (
+                                <Select.Item item={option} key={option.value}>
+                                  {option.value === "all" ? (
+                                    translate(option.label)
+                                  ) : (
+                                    <Flex gap={1}>
+                                      <RunTypeIcon runType={option.value as DagRunType} />
+                                      {translate(option.label)}
+                                    </Flex>
+                                  )}
                                 </Select.Item>
                               ))}
                             </Select.Content>

--- a/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
@@ -328,7 +328,7 @@ export const PanelButtons = ({
                           size="sm"
                           value={[runTypeFilter?.[0] ?? "all"]}
                         >
-                          <Select.Label>{translate("dag:panel.runType.label")}</Select.Label>
+                          <Select.Label>{translate("common:dagRun.runType")}</Select.Label>
                           <Select.Control>
                             <Select.Trigger>
                               <Select.ValueText>
@@ -369,11 +369,11 @@ export const PanelButtons = ({
                         </Select.Root>
                         <VStack alignItems="flex-start">
                           <Text fontSize="xs" mb={1}>
-                            {translate("dag:panel.triggeringUser.label")}
+                            {translate("common:dagRun.triggeringUser")}
                           </Text>
                           <Input
                             onChange={handleTriggeringUserChange}
-                            placeholder={translate("dag:panel.triggeringUser.placeholder")}
+                            placeholder={translate("common:filters.triggeringUserPlaceholder")}
                             size="sm"
                             value={triggeringUserFilter ?? ""}
                           />

--- a/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
@@ -317,7 +317,7 @@ export const PanelButtons = ({
                           size="sm"
                           value={[runTypeFilter?.[0] ?? "all"]}
                         >
-                          <Select.Label>{translate("dag:panel.runTypeFilter.label")}</Select.Label>
+                          <Select.Label>{translate("dag:panel.runType.label")}</Select.Label>
                           <Select.Control>
                             <Select.Trigger>
                               <Select.ValueText />

--- a/airflow-core/src/airflow/ui/src/queries/useGridRuns.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useGridRuns.ts
@@ -28,8 +28,8 @@ export const useGridRuns = ({
   triggeringUser,
 }: {
   limit: number;
-  runType?: Array<DagRunType> | null;
-  triggeringUser?: string | null;
+  runType?: DagRunType | undefined;
+  triggeringUser?: string | undefined;
 }) => {
   const { dagId = "" } = useParams();
 
@@ -40,7 +40,7 @@ export const useGridRuns = ({
       dagId,
       limit,
       orderBy: ["-run_after"],
-      runType: runType ?? undefined,
+      runType: runType ? [runType] : undefined,
       triggeringUser: triggeringUser ?? undefined,
     },
     undefined,

--- a/airflow-core/src/airflow/ui/src/queries/useGridRuns.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useGridRuns.ts
@@ -19,9 +19,10 @@
 import { useParams } from "react-router-dom";
 
 import { useGridServiceGetGridRuns } from "openapi/queries";
+import type { DagRunType } from "openapi/requests/types.gen";
 import { isStatePending, useAutoRefresh } from "src/utils";
 
-export const useGridRuns = ({ limit }: { limit: number }) => {
+export const useGridRuns = ({ limit, runType }: { limit: number; runType?: Array<DagRunType> | null }) => {
   const { dagId = "" } = useParams();
 
   const defaultRefetchInterval = useAutoRefresh({ dagId });
@@ -31,6 +32,7 @@ export const useGridRuns = ({ limit }: { limit: number }) => {
       dagId,
       limit,
       orderBy: ["-run_after"],
+      runType: runType ?? undefined,
     },
     undefined,
     {

--- a/airflow-core/src/airflow/ui/src/queries/useGridRuns.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useGridRuns.ts
@@ -22,7 +22,15 @@ import { useGridServiceGetGridRuns } from "openapi/queries";
 import type { DagRunType } from "openapi/requests/types.gen";
 import { isStatePending, useAutoRefresh } from "src/utils";
 
-export const useGridRuns = ({ limit, runType }: { limit: number; runType?: Array<DagRunType> | null }) => {
+export const useGridRuns = ({
+  limit,
+  runType,
+  triggeringUser,
+}: {
+  limit: number;
+  runType?: Array<DagRunType> | null;
+  triggeringUser?: string | null;
+}) => {
   const { dagId = "" } = useParams();
 
   const defaultRefetchInterval = useAutoRefresh({ dagId });
@@ -33,6 +41,7 @@ export const useGridRuns = ({ limit, runType }: { limit: number; runType?: Array
       limit,
       orderBy: ["-run_after"],
       runType: runType ?? undefined,
+      triggeringUser: triggeringUser ?? undefined,
     },
     undefined,
     {

--- a/airflow-core/src/airflow/ui/src/queries/useGridStructure.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useGridStructure.ts
@@ -19,14 +19,17 @@
 import { useParams } from "react-router-dom";
 
 import { useGridServiceGetDagStructure } from "openapi/queries";
+import type { DagRunType } from "openapi/requests/types.gen";
 import { useAutoRefresh } from "src/utils";
 
 export const useGridStructure = ({
   hasActiveRun = undefined,
   limit,
+  runType,
 }: {
   hasActiveRun?: boolean;
   limit?: number;
+  runType?: Array<DagRunType> | null;
 }) => {
   const { dagId = "" } = useParams();
   const refetchInterval = useAutoRefresh({ dagId });
@@ -37,6 +40,7 @@ export const useGridStructure = ({
       dagId,
       limit,
       orderBy: ["-run_after"],
+      runType: runType ?? undefined,
     },
     undefined,
     {

--- a/airflow-core/src/airflow/ui/src/queries/useGridStructure.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useGridStructure.ts
@@ -30,8 +30,8 @@ export const useGridStructure = ({
 }: {
   hasActiveRun?: boolean;
   limit?: number;
-  runType?: Array<DagRunType> | null;
-  triggeringUser?: string | null;
+  runType?: DagRunType | undefined;
+  triggeringUser?: string | undefined;
 }) => {
   const { dagId = "" } = useParams();
   const refetchInterval = useAutoRefresh({ dagId });
@@ -42,7 +42,7 @@ export const useGridStructure = ({
       dagId,
       limit,
       orderBy: ["-run_after"],
-      runType: runType ?? undefined,
+      runType: runType ? [runType] : undefined,
       triggeringUser: triggeringUser ?? undefined,
     },
     undefined,

--- a/airflow-core/src/airflow/ui/src/queries/useGridStructure.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useGridStructure.ts
@@ -26,10 +26,12 @@ export const useGridStructure = ({
   hasActiveRun = undefined,
   limit,
   runType,
+  triggeringUser,
 }: {
   hasActiveRun?: boolean;
   limit?: number;
   runType?: Array<DagRunType> | null;
+  triggeringUser?: string | null;
 }) => {
   const { dagId = "" } = useParams();
   const refetchInterval = useAutoRefresh({ dagId });
@@ -41,6 +43,7 @@ export const useGridStructure = ({
       limit,
       orderBy: ["-run_after"],
       runType: runType ?? undefined,
+      triggeringUser: triggeringUser ?? undefined,
     },
     undefined,
     {

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_grid.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_grid.py
@@ -496,47 +496,34 @@ class TestGetGridDataEndpoint:
             },
         ]
 
-    def test_get_grid_runs_filter_by_run_type_scheduled(self, session, test_client):
+    @pytest.mark.parametrize(
+        "endpoint,run_type,expected",
+        [
+            ("runs", "scheduled", [GRID_RUN_1]),
+            ("runs", "manual", [GRID_RUN_2]),
+            ("structure", "scheduled", GRID_NODES),
+            ("structure", "manual", GRID_NODES),
+        ],
+    )
+    def test_filter_by_run_type(self, session, test_client, endpoint, run_type, expected):
         session.commit()
-        response = test_client.get(f"/grid/runs/{DAG_ID}?run_type=scheduled")
+        response = test_client.get(f"/grid/{endpoint}/{DAG_ID}?run_type={run_type}")
         assert response.status_code == 200
-        assert response.json() == [GRID_RUN_1]
+        assert response.json() == expected
 
-    def test_get_grid_runs_filter_by_run_type_manual(self, session, test_client):
+    @pytest.mark.parametrize(
+        "endpoint,triggering_user,expected",
+        [
+            ("runs", "user2", [GRID_RUN_2]),
+            ("runs", "nonexistent", []),
+            ("structure", "user2", GRID_NODES),
+        ],
+    )
+    def test_filter_by_triggering_user(self, session, test_client, endpoint, triggering_user, expected):
         session.commit()
-        response = test_client.get(f"/grid/runs/{DAG_ID}?run_type=manual")
+        response = test_client.get(f"/grid/{endpoint}/{DAG_ID}?triggering_user={triggering_user}")
         assert response.status_code == 200
-        assert response.json() == [GRID_RUN_2]
-
-    def test_get_dag_structure_filter_by_run_type_scheduled(self, session, test_client):
-        session.commit()
-        response = test_client.get(f"/grid/structure/{DAG_ID}?run_type=scheduled")
-        assert response.status_code == 200
-        assert response.json() == GRID_NODES
-
-    def test_get_dag_structure_filter_by_run_type_manual(self, session, test_client):
-        session.commit()
-        response = test_client.get(f"/grid/structure/{DAG_ID}?run_type=manual")
-        assert response.status_code == 200
-        assert response.json() == GRID_NODES
-
-    def test_get_grid_runs_filter_by_triggering_user(self, session, test_client):
-        session.commit()
-        response = test_client.get(f"/grid/runs/{DAG_ID}?triggering_user=user2")
-        assert response.status_code == 200
-        assert response.json() == [GRID_RUN_2]
-
-    def test_get_grid_runs_filter_by_triggering_user_nonexistent(self, session, test_client):
-        session.commit()
-        response = test_client.get(f"/grid/runs/{DAG_ID}?triggering_user=nonexistent")
-        assert response.status_code == 200
-        assert response.json() == []
-
-    def test_get_dag_structure_filter_by_triggering_user(self, session, test_client):
-        session.commit()
-        response = test_client.get(f"/grid/structure/{DAG_ID}?triggering_user=user2")
-        assert response.status_code == 200
-        assert response.json() == GRID_NODES
+        assert response.json() == expected
 
     def test_get_grid_runs_filter_by_run_type_and_triggering_user(self, session, test_client):
         session.commit()


### PR DESCRIPTION
  ## Summary
  This PR adds two new filtering capabilities to the DAG grid view:

  1. **Run Type Filter**: Filter DAG runs by run type (scheduled, manual, backfill, asset_triggered)
  2. **Triggering User Filter**: Filter DAG runs by the user who triggered them

  ### Key Features
  - **Persistent Filters**: Filter settings are saved per DAG and restored on page reload
  - **Real-time Search**: Triggering user filter applies as you type
  - **Visual Indicators**: Run type filter shows proper icons and translated text
  - **Combined Filtering**: Both filters work together to refine results
  - **Responsive UI**: Filters integrate seamlessly into existing grid options panel

  ## Usage
  1. Navigate to any DAG's grid view
  2. Click "Options" button to access the filter panel
  3. Select run types from the dropdown or enter a username to filter by triggering user
  4. Filters are automatically applied and saved per DAG

<img width="699" height="415" alt="image" src="https://github.com/user-attachments/assets/ddf8c1db-e282-4bc4-8dcf-4098d73e176a" />


https://github.com/user-attachments/assets/cd8613af-f805-48b0-90fb-b73f4c1ecc26

cc: @jscheffl 
