### PR TITLE
Add options_mapping support to HITLBranchOperator

### DIFF
--- a/providers/standard/src/airflow/providers/standard/operators/hitl.py
+++ b/providers/standard/src/airflow/providers/standard/operators/hitl.py
@@ -359,9 +359,7 @@ class HITLBranchOperator(HITLOperator, BranchMixIn):
         self.validate_options_mapping()
 
     def validate_options_mapping(self) -> None:
-        """
-        Ensure provided options_mapping keys are valid option labels and values are strings.
-        """
+        """Ensure provided options_mapping keys are valid option labels and values are strings."""
         if not self.options_mapping:
             return
 

--- a/providers/standard/src/airflow/providers/standard/operators/hitl.py
+++ b/providers/standard/src/airflow/providers/standard/operators/hitl.py
@@ -18,8 +18,6 @@ from __future__ import annotations
 
 import logging
 
-from hatch.cli import self
-
 from airflow.exceptions import AirflowOptionalProviderFeatureException
 from airflow.providers.standard.version_compat import AIRFLOW_V_3_1_PLUS
 

--- a/providers/standard/src/airflow/providers/standard/operators/hitl.py
+++ b/providers/standard/src/airflow/providers/standard/operators/hitl.py
@@ -351,15 +351,30 @@ class HITLBranchOperator(HITLOperator, BranchMixIn):
     inherits_from_skipmixin = True
 
     def __init__(self, *, options_mapping: dict[str, str] | None = None, **kwargs) -> None:
-        super().__init__(
-            **kwargs,
-        )
-        self.options_mapping = options_mapping or {}
+        """
+        Initialize HITLBranchOperator.
 
+        Args:
+            options_mapping:
+                A dictionary mapping option labels (must match entries in `self.options`)
+                to string values (e.g., task IDs). Defaults to an empty dict if not provided.
+
+        Raises:
+            ValueError:
+                - If `options_mapping` contains keys not present in `self.options`.
+                - If any value in `options_mapping` is not a string.
+        """
+        super().__init__(**kwargs)
+        self.options_mapping = options_mapping or {}
         self.validate_options_mapping()
 
     def validate_options_mapping(self) -> None:
-        """Ensure provided options_mapping keys are valid option labels and values are strings."""
+        """
+        Validate that `options_mapping` keys match `self.options` and all values are strings.
+
+        Raises:
+            ValueError: If any key is not in `self.options` or any value is not a string.
+        """
         if not self.options_mapping:
             return
 

--- a/providers/standard/tests/unit/standard/operators/test_hitl.py
+++ b/providers/standard/tests/unit/standard/operators/test_hitl.py
@@ -31,7 +31,7 @@ from urllib.parse import parse_qs, urlparse
 import pytest
 from sqlalchemy import select
 
-from airflow.exceptions import DownstreamTasksSkipped, AirflowException
+from airflow.exceptions import AirflowException, DownstreamTasksSkipped
 from airflow.models import TaskInstance, Trigger
 from airflow.models.hitl import HITLDetail
 from airflow.providers.standard.operators.empty import EmptyOperator
@@ -576,7 +576,7 @@ class TestHITLBranchOperator:
         assert set(exc.value.tasks) == {("branch_1", -1)}
 
     def test_error_if_mapped_branch_not_direct_downstream(self, dag_maker):
-        # Don’t add the mapped task downstream → expect a clean error
+        # Don't add the mapped task downstream → expect a clean error
         with dag_maker("hitl_map_dag", serialized=True):
             op = HITLBranchOperator(
                 task_id="choose",

--- a/providers/standard/tests/unit/standard/operators/test_hitl.py
+++ b/providers/standard/tests/unit/standard/operators/test_hitl.py
@@ -31,7 +31,7 @@ from urllib.parse import parse_qs, urlparse
 import pytest
 from sqlalchemy import select
 
-from airflow.exceptions import DownstreamTasksSkipped
+from airflow.exceptions import DownstreamTasksSkipped, AirflowException
 from airflow.models import TaskInstance, Trigger
 from airflow.models.hitl import HITLDetail
 from airflow.providers.standard.operators.empty import EmptyOperator
@@ -505,3 +505,111 @@ class TestHITLBranchOperator:
                 },
             )
         assert set(exc_info.value.tasks) == set((f"branch_{i}", -1) for i in range(4, 6))
+
+    def test_mapping_applies_for_single_choice(self, dag_maker):
+        # ["Approve"]; map -> "publish"
+        with dag_maker("hitl_map_dag", serialized=True):
+            op = HITLBranchOperator(
+                task_id="choose",
+                subject="S",
+                options=["Approve", "Reject"],
+                options_mapping={"Approve": "publish"},
+            )
+            op >> [EmptyOperator(task_id="publish"), EmptyOperator(task_id="archive")]
+
+        dr = dag_maker.create_dagrun()
+        ti = dr.get_task_instance("choose")
+
+        with pytest.raises(DownstreamTasksSkipped) as exc:
+            op.execute_complete(
+                context={"ti": ti, "task": ti.task},
+                event={"chosen_options": ["Approve"], "params_input": {}},
+            )
+        # checks to see that the "archive" task was skipped
+        assert set(exc.value.tasks) == {("archive", -1)}
+
+    def test_mapping_with_multiple_choices(self, dag_maker):
+        # multiple=True; mapping applied per option; no dedup implied
+        with dag_maker("hitl_map_dag", serialized=True):
+            op = HITLBranchOperator(
+                task_id="choose",
+                subject="S",
+                multiple=True,
+                options=["Approve", "KeepAsIs"],
+                options_mapping={"Approve": "publish", "KeepAsIs": "keep"},
+            )
+            op >> [
+                EmptyOperator(task_id="publish"),
+                EmptyOperator(task_id="keep"),
+                EmptyOperator(task_id="other"),
+            ]
+
+        dr = dag_maker.create_dagrun()
+        ti = dr.get_task_instance("choose")
+
+        with pytest.raises(DownstreamTasksSkipped) as exc:
+            op.execute_complete(
+                context={"ti": ti, "task": ti.task},
+                event={"chosen_options": ["Approve", "KeepAsIs"], "params_input": {}},
+            )
+        # publish + keep chosen → only "other" skipped
+        assert set(exc.value.tasks) == {("other", -1)}
+
+    def test_fallback_to_option_when_not_mapped(self, dag_maker):
+        # No mapping: option must match downstream task_id
+        with dag_maker("hitl_map_dag", serialized=True):
+            op = HITLBranchOperator(
+                task_id="choose",
+                subject="S",
+                options=["branch_1", "branch_2"],  # no mapping for branch_2
+            )
+            op >> [EmptyOperator(task_id="branch_1"), EmptyOperator(task_id="branch_2")]
+
+        dr = dag_maker.create_dagrun()
+        ti = dr.get_task_instance("choose")
+
+        with pytest.raises(DownstreamTasksSkipped) as exc:
+            op.execute_complete(
+                context={"ti": ti, "task": ti.task},
+                event={"chosen_options": ["branch_2"], "params_input": {}},
+            )
+        assert set(exc.value.tasks) == {("branch_1", -1)}
+
+    def test_error_if_mapped_branch_not_direct_downstream(self, dag_maker):
+        # Don’t add the mapped task downstream → expect a clean error
+        with dag_maker("hitl_map_dag", serialized=True):
+            op = HITLBranchOperator(
+                task_id="choose",
+                subject="S",
+                options=["Approve"],
+                options_mapping={"Approve": "not_a_downstream"},
+            )
+            # Intentionally no downstream "not_a_downstream"
+
+        dr = dag_maker.create_dagrun()
+        ti = dr.get_task_instance("choose")
+
+        with pytest.raises(AirflowException, match="downstream|not found"):
+            op.execute_complete(
+                context={"ti": ti, "task": ti.task},
+                event={"chosen_options": ["Approve"], "params_input": {}},
+            )
+
+    @pytest.mark.parametrize("bad", [123, ["publish"], {"x": "y"}, b"publish"])
+    def test_options_mapping_non_string_value_raises(self, bad):
+        with pytest.raises(ValueError, match=r"values must be strings \(task_ids\)"):
+            HITLBranchOperator(
+                task_id="choose",
+                subject="S",
+                options=["Approve"],
+                options_mapping={"Approve": bad},
+            )
+
+    def test_options_mapping_key_not_in_options_raises(self):
+        with pytest.raises(ValueError, match="contains keys that are not in `options`"):
+            HITLBranchOperator(
+                task_id="choose",
+                subject="S",
+                options=["Approve", "Reject"],
+                options_mapping={"NotAnOption": "publish"},
+            )


### PR DESCRIPTION
This PR enhances `HITLBranchOperator` to accept an optional `options_mapping` dict that maps human-facing option labels to downstream `task_ids`. Previously, HITL branching required users to select raw `task_ids`, which isn’t user-friendly in business-facing workflows. With this change, a workflow can present clearer options (e.g., “Full Deploy” / “Canary”) while still resolving to valid downstream tasks.

**Changes**

- New parameter: options_mapping: dict[str, str] | None
  - Keys: option labels (same as what's provided to `options`)
  - Values: `task_ids` of valid downstream tasks
- Validation:
  - Ensures keys are valid options
  - Ensures values are strings (task_ids)
- Execution:
  - Normalizes chosen options and applies mapping before branching
  - Falls back to the raw option if no mapping is provided
- Tests:
  - Single and multiple mapped choices
  - Fallback to unmapped options
  - Error when mapping points to non-downstream tasks (`AirflowException`)
  - Error on invalid keys
  - Error on non-string mapping values

**Rationale**
This improves HITL usability for end-users by decoupling the labels people choose from the `task_ids` Airflow needs that may not necessarily be known by the approver, while keeping strong validation in place.

Example
```
op = HITLBranchOperator(
    task_id="choose",
    subject="Approval required",
    options=["Approve", "Reject"],
    options_mapping={"Approve": "publish", "Reject": "archive"},
)
op >> [EmptyOperator(task_id="publish"), EmptyOperator(task_id="archive")]
```
If the user selects Approve, the operator branches to the `publish` task.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
