### PR TITLE
docs: remove outdated directed acyclic graph description

### DIFF
--- a/airflow-core/docs/core-concepts/dags.rst
+++ b/airflow-core/docs/core-concepts/dags.rst
@@ -101,7 +101,7 @@ Dags are nothing without :doc:`tasks` to run, and those will usually come in the
 Task Dependencies
 ~~~~~~~~~~~~~~~~~
 
-A Task/Operator does not usually live alone; it has dependencies on other tasks (those *upstream* of it), and other tasks depend on it (those *downstream* of it). Declaring these dependencies between tasks is what makes up the Dag structure (the *edges* of the *directed acyclic graph*).
+A Task/Operator does not usually live alone; it has dependencies on other tasks (those *upstream* of it), and other tasks depend on it (those *downstream* of it). Declaring these dependencies between tasks is what makes up the Dag structure.
 
 There are two main ways to declare individual task dependencies. The recommended one is to use the ``>>`` and ``<<`` operators::
 

--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -302,7 +302,7 @@ def _convert_max_consecutive_failed_dag_runs(val: int) -> int:
 @attrs.define(hash=False, repr=False, eq=False, slots=False)
 class DAG(TaskSDKDag, LoggingMixin):
     """
-    A dag (directed acyclic graph) is a collection of tasks with directional dependencies.
+    A dag is a collection of tasks with directional dependencies.
 
     A dag also has a schedule, a start date and an end date (optional).  For each schedule,
     (say daily or hourly), the DAG needs to run each individual tasks as their dependencies

--- a/task-sdk/src/airflow/sdk/definitions/dag.py
+++ b/task-sdk/src/airflow/sdk/definitions/dag.py
@@ -250,7 +250,7 @@ def _default_task_group(instance: DAG) -> TaskGroup:
 @attrs.define(repr=False, field_transformer=_all_after_dag_id_to_kw_only, slots=False)
 class DAG:
     """
-    A dag (directed acyclic graph) is a collection of tasks with directional dependencies.
+    A dag is a collection of tasks with directional dependencies.
 
     A dag also has a schedule, a start date and an end date (optional).  For each schedule,
     (say daily or hourly), the DAG needs to run each individual tasks as their dependencies


### PR DESCRIPTION
## Why
A dag no longer relates to directed acyclic graph in airflow context

## What
remove related description
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
