### PR TITLE
fix: logical_date or run_after for google bigquery and workflow

### DIFF
--- a/providers/apache/hive/src/airflow/providers/apache/hive/operators/hive.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/operators/hive.py
@@ -143,7 +143,7 @@ class HiveOperator(BaseOperator):
         # set the mapred_job_name if it's not set with dag, task, execution time info
         if not self.mapred_job_name:
             ti = context["ti"]
-            logical_date = context["logical_date"]
+            logical_date = context.get("logical_date", None)
             if logical_date is None:
                 raise RuntimeError("logical_date is None")
             hostname = ti.hostname or ""

--- a/providers/google/src/airflow/providers/google/cloud/operators/bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/bigquery.py
@@ -2374,7 +2374,7 @@ class BigQueryInsertJobOperator(GoogleCloudBaseOperator, _BigQueryInsertJobOpera
             job_id=self.job_id,
             dag_id=self.dag_id,
             task_id=self.task_id,
-            logical_date=context["logical_date"],
+            date=hook.get_exec_date(context),
             configuration=self.configuration,
             force_rerun=self.force_rerun,
         )

--- a/providers/google/src/airflow/providers/google/cloud/transfers/bigquery_to_gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/bigquery_to_gcs.py
@@ -215,7 +215,7 @@ class BigQueryToGCSOperator(BaseOperator):
             job_id=self.job_id,
             dag_id=self.dag_id,
             task_id=self.task_id,
-            logical_date=context["logical_date"],
+            date=hook.get_exec_date(context),
             configuration=configuration,
             force_rerun=self.force_rerun,
         )

--- a/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -337,7 +337,7 @@ class GCSToBigQueryOperator(BaseOperator):
             job_id=self.job_id,
             dag_id=self.dag_id,
             task_id=self.task_id,
-            logical_date=context["logical_date"],
+            date=hook.get_exec_date(context),
             configuration=self.configuration,
             force_rerun=self.force_rerun,
         )

--- a/providers/google/tests/unit/google/cloud/operators/test_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_bigquery.py
@@ -1595,7 +1595,7 @@ class TestBigQueryInsertJobOperator:
             job_id=job_id,
             dag_id="adhoc_airflow",
             task_id="insert_query_job",
-            logical_date=ANY,
+            date=ANY,
             configuration=configuration,
             force_rerun=True,
         )

--- a/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_bigquery.py
@@ -43,7 +43,6 @@ from airflow.providers.common.compat.openlineage.facet import (
 )
 from airflow.providers.google.cloud.transfers.gcs_to_bigquery import GCSToBigQueryOperator
 from airflow.utils.state import TaskInstanceState
-from airflow.utils.timezone import datetime
 
 TASK_ID = "test-gcs-to-bq-operator"
 TEST_EXPLICIT_DEST = "test-project.dataset.table"
@@ -1746,7 +1745,7 @@ class TestAsyncGCSToBigQueryOperator:
             job_id=None,
             dag_id="adhoc_airflow",
             task_id=TASK_ID,
-            logical_date=datetime(2016, 1, 1, 0, 0),
+            date=hook.return_value.get_exec_date(),
             configuration={},
             force_rerun=True,
         )


### PR DESCRIPTION
related: #53634 #55073 #55092 

In airflow 3, `logcial_date` is not available for asset triggered DAG runs.
However, it was previously used for job ID generation in Bigquery and workflow ID for Workflows.

This PR proposes using `dag_run.run_after` as a substitute for asset triggered DAG runs.

In this PR, I propose to use dagrun.run_after for assert triggered dag run.


What Wasn't Fixed

The usage of `context["logical_date"]` in `providers/google/cloud/sensors/cloud_composer.py`
remains unchangeed.
