### PR TITLE
FIX: incorrect access of logical_date in google bigquery operator and google workflow operator

### DIFF
--- a/providers/apache/hive/src/airflow/providers/apache/hive/operators/hive.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/operators/hive.py
@@ -146,10 +146,10 @@ class HiveOperator(BaseOperator):
             logical_date = context.get("logical_date", None)
             if logical_date is None:
                 raise RuntimeError(
-                    "logical_date is not available. Please make sure the task is not used in an asset-triggered dag. "
-                    "HiveOperator was designed to work with timetable scheduled dags, "
-                    "and an asset-triggered dag run does not have a logical_date. "
-                    "If you need to use HiveOperator with an asset-triggered dag,"
+                    "logical_date is not available. Please make sure the task is not used in an asset-triggered Dag. "
+                    "HiveOperator was designed to work with timetable scheduled Dags, "
+                    "and an asset-triggered Dag run does not have a logical_date. "
+                    "If you need to use HiveOperator in an asset-triggered Dag,"
                     "please open an issue on the Airflow project."
                 )
             hostname = ti.hostname or ""

--- a/providers/apache/hive/src/airflow/providers/apache/hive/operators/hive.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/operators/hive.py
@@ -146,11 +146,11 @@ class HiveOperator(BaseOperator):
             logical_date = context.get("logical_date", None)
             if logical_date is None:
                 raise RuntimeError(
-                    "logical_date is None. Please make sure the task is not used in an asset-triggered DAG. "
-                    "HiveOperator was designed to work with timetable scheduled DAGs, "
-                    "and asset-triggered DAGs do not have logical_date. "
-                    "if asset-triggered HiveOperator is a required use case, "
-                    "please open an issue on the airflow project."
+                    "logical_date is None. Please make sure the task is not used in an asset-triggered Dag. "
+                    "HiveOperator was designed to work with timetable scheduled Dags, "
+                    "and asset-triggered Dags do not have logical_date. "
+                    "If asset-triggered HiveOperator is a required use case, "
+                    "please open an issue on the Airflow project."
                 )
             hostname = ti.hostname or ""
             self.hook.mapred_job_name = self.mapred_job_name_template.format(

--- a/providers/apache/hive/src/airflow/providers/apache/hive/operators/hive.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/operators/hive.py
@@ -146,10 +146,10 @@ class HiveOperator(BaseOperator):
             logical_date = context.get("logical_date", None)
             if logical_date is None:
                 raise RuntimeError(
-                    "logical_date is None. Please make sure the task is not used in an asset-triggered Dag. "
-                    "HiveOperator was designed to work with timetable scheduled Dags, "
-                    "and asset-triggered Dags do not have logical_date. "
-                    "If asset-triggered HiveOperator is a required use case, "
+                    "logical_date is not available. Please make sure the task is not used in an asset-triggered dag. "
+                    "HiveOperator was designed to work with timetable scheduled dags, "
+                    "and an asset-triggered dag run does not have a logical_date. "
+                    "If you need to use HiveOperator with an asset-triggered dag,"
                     "please open an issue on the Airflow project."
                 )
             hostname = ti.hostname or ""

--- a/providers/apache/hive/src/airflow/providers/apache/hive/operators/hive.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/operators/hive.py
@@ -145,7 +145,13 @@ class HiveOperator(BaseOperator):
             ti = context["ti"]
             logical_date = context.get("logical_date", None)
             if logical_date is None:
-                raise RuntimeError("logical_date is None")
+                raise RuntimeError(
+                    "logical_date is None. Please make sure the task is not used in an asset-triggered DAG. "
+                    "HiveOperator was designed to work with timetable scheduled DAGs, "
+                    "and asset-triggered DAGs do not have logical_date. "
+                    "if asset-triggered HiveOperator is a required use case, "
+                    "please open an issue on the airflow project."
+                )
             hostname = ti.hostname or ""
             self.hook.mapred_job_name = self.mapred_job_name_template.format(
                 dag_id=ti.dag_id,

--- a/providers/apache/hive/src/airflow/providers/apache/hive/operators/hive.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/operators/hive.py
@@ -143,7 +143,7 @@ class HiveOperator(BaseOperator):
         # set the mapred_job_name if it's not set with dag, task, execution time info
         if not self.mapred_job_name:
             ti = context["ti"]
-            logical_date = context["logical_date"]
+            logical_date = context.get("logical_date", None)
             if logical_date is None:
                 raise RuntimeError("logical_date is None")
             hostname = ti.hostname or ""

--- a/providers/google/src/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/bigquery.py
@@ -89,10 +89,7 @@ if TYPE_CHECKING:
     from google.api_core.retry import Retry
     from requests import Session
 
-    if AIRFLOW_V_3_0_PLUS:
-        from airflow.sdk.definitions.context import Context
-    else:
-        from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 log = logging.getLogger(__name__)
 

--- a/providers/google/src/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/bigquery.py
@@ -1283,7 +1283,14 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         return job_api_repr
 
     def generate_job_id(
-        self, job_id, dag_id, task_id, logical_date, configuration, run_after=None, force_rerun=False
+        self,
+        job_id: str | None,
+        dag_id: str,
+        task_id: str,
+        logical_date: datetime | None,
+        configuration: dict,
+        run_after: pendulum.DateTime | None = None,
+        force_rerun: bool = False
     ) -> str:
         if force_rerun:
             hash_base = str(uuid.uuid4())

--- a/providers/google/src/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/bigquery.py
@@ -1290,7 +1290,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         logical_date: datetime | None,
         configuration: dict,
         run_after: pendulum.DateTime | None = None,
-        force_rerun: bool = False
+        force_rerun: bool = False,
     ) -> str:
         if force_rerun:
             hash_base = str(uuid.uuid4())

--- a/providers/google/src/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/bigquery.py
@@ -1296,11 +1296,12 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
             return f"{job_id}_{uniqueness_suffix}"
 
         if logical_date is not None:
-            warnings.warn(
-                "The 'logical_date' parameter is deprecated. Please use 'run_after' instead.",
-                AirflowProviderDeprecationWarning,
-                stacklevel=1,
-            )
+            if AIRFLOW_V_3_0_PLUS:
+                warnings.warn(
+                    "The 'logical_date' parameter is deprecated. Please use 'run_after' instead.",
+                    AirflowProviderDeprecationWarning,
+                    stacklevel=1,
+                )
             job_id_timestamp = logical_date
         elif run_after is not None:
             job_id_timestamp = run_after

--- a/providers/google/src/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/bigquery.py
@@ -1299,8 +1299,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
     def get_exec_date(self, context: Context) -> pendulum.DateTime:
         date = context.get("logical_date", None)
         if AIRFLOW_V_3_0_PLUS and date is None:
-            dag_run = context.get("dag_run")
-            if dag_run and hasattr(dag_run, "run_after"):
+            if dag_run := context.get("dag_run"):
                 date = pendulum.instance(dag_run.run_after)
         return date if date is not None else pendulum.now("UTC")
 

--- a/providers/google/src/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/bigquery.py
@@ -1313,11 +1313,16 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
 
     def get_run_after_or_logical_date(self, context: Context) -> pendulum.DateTime:
         if AIRFLOW_V_3_0_PLUS:
-            dag_run = context.get("dag_run")
-            run_after = pendulum.instance(dag_run.run_after)
+            if dag_run := context.get("dag_run"):
+                run_after = pendulum.instance(dag_run.run_after)
+            else:
+                run_after = pendulum.now("UTC")
         else:
-            run_after = context.get("logical_date", None)
-        return run_after if run_after is not None else pendulum.now("UTC")
+            if logical_date := context.get("logical_date"):
+                run_after = logical_date
+            else:
+                run_after = pendulum.now("UTC")
+        return run_after
 
     def split_tablename(
         self, table_input: str, default_project_id: str, var_name: str | None = None

--- a/providers/google/src/airflow/providers/google/cloud/operators/bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/bigquery.py
@@ -2370,14 +2370,6 @@ class BigQueryInsertJobOperator(GoogleCloudBaseOperator, _BigQueryInsertJobOpera
         if self.project_id is None:
             self.project_id = hook.project_id
 
-        # Handle missing logical_date. Example: asset-triggered DAGs (Airflow 3)
-        logical_date = context.get("logical_date")
-        if logical_date is None:
-            # Use dag_run.run_after as fallback when logical_date is not available
-            dag_run = context.get("dag_run")
-            if dag_run and hasattr(dag_run, "run_after"):
-                logical_date = dag_run.run_after
-
         self.job_id = hook.generate_job_id(
             job_id=self.job_id,
             dag_id=self.dag_id,

--- a/providers/google/src/airflow/providers/google/cloud/operators/bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/bigquery.py
@@ -2382,7 +2382,7 @@ class BigQueryInsertJobOperator(GoogleCloudBaseOperator, _BigQueryInsertJobOpera
             job_id=self.job_id,
             dag_id=self.dag_id,
             task_id=self.task_id,
-            logical_date=logical_date,
+            date=hook.get_exec_date(context),
             configuration=self.configuration,
             force_rerun=self.force_rerun,
         )

--- a/providers/google/src/airflow/providers/google/cloud/operators/bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/bigquery.py
@@ -2374,8 +2374,9 @@ class BigQueryInsertJobOperator(GoogleCloudBaseOperator, _BigQueryInsertJobOpera
             job_id=self.job_id,
             dag_id=self.dag_id,
             task_id=self.task_id,
-            date=hook.get_exec_date(context),
+            logical_date=None,
             configuration=self.configuration,
+            run_after=hook.get_run_after_or_logical_date(context),
             force_rerun=self.force_rerun,
         )
 

--- a/providers/google/src/airflow/providers/google/cloud/operators/workflows.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/workflows.py
@@ -43,10 +43,7 @@ if TYPE_CHECKING:
     from google.api_core.retry import Retry
     from google.protobuf.field_mask_pb2 import FieldMask
 
-    if AIRFLOW_V_3_0_PLUS:
-        from airflow.sdk.definitions.context import Context
-    else:
-        from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 from airflow.utils.hashlib_wrapper import md5
 

--- a/providers/google/src/airflow/providers/google/cloud/operators/workflows.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/workflows.py
@@ -121,15 +121,15 @@ class WorkflowsCreateWorkflowOperator(GoogleCloudBaseOperator):
         # we use hash of whole information
         if AIRFLOW_V_3_0_PLUS:
             if dag_run := context.get("dag_run"):
-                logical_date_or_run_after = pendulum.instance(dag_run.run_after)
+                run_after = pendulum.instance(dag_run.run_after)
             else:
-                logical_date_or_run_after = pendulum.now("UTC")
+                run_after = pendulum.now("UTC")
         else:
             if logical_date := context.get("logical_date"):
-                logical_date_or_run_after = pendulum.instance(logical_date)
+                run_after = pendulum.instance(logical_date)
             else:
-                logical_date_or_run_after = pendulum.now("UTC")
-        base = f"airflow_{self.dag_id}_{self.task_id}_{logical_date_or_run_after.isoformat()}_{hash_base}"
+                run_after = pendulum.now("UTC")
+        base = f"airflow_{self.dag_id}_{self.task_id}_{run_after.isoformat()}_{hash_base}"
         workflow_id = md5(base.encode()).hexdigest()
         return re.sub(r"[:\-+.]", "_", workflow_id)
 

--- a/providers/google/src/airflow/providers/google/cloud/operators/workflows.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/workflows.py
@@ -121,9 +121,8 @@ class WorkflowsCreateWorkflowOperator(GoogleCloudBaseOperator):
         # we use hash of whole information
         date = context.get("logical_date", None)
         if AIRFLOW_V_3_0_PLUS and date is None:
-            if dr := context.get("dag_run"):
-                if dr.run_after:
-                    date = pendulum.instance(dr.run_after)
+            if dag_run := context.get("dag_run"):
+                date = pendulum.instance(dag_run.run_after)
         exec_date = date if date is not None else datetime.datetime.now(tz=datetime.timezone.utc)
         exec_date_iso = exec_date.isoformat()
         base = f"airflow_{self.dag_id}_{self.task_id}_{exec_date_iso}_{hash_base}"

--- a/providers/google/src/airflow/providers/google/cloud/operators/workflows.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/workflows.py
@@ -106,7 +106,7 @@ class WorkflowsCreateWorkflowOperator(GoogleCloudBaseOperator):
         self.impersonation_chain = impersonation_chain
         self.force_rerun = force_rerun
 
-    def _workflow_id(self, context: Context):
+    def _workflow_id(self, context: Context) -> str:
         if self.workflow_id and not self.force_rerun:
             # If users provide workflow id then assuring the idempotency
             # is on their side
@@ -119,13 +119,13 @@ class WorkflowsCreateWorkflowOperator(GoogleCloudBaseOperator):
 
         # We are limited by allowed length of workflow_id so
         # we use hash of whole information
-        date = context.get("logical_date", None)
-        if AIRFLOW_V_3_0_PLUS and date is None:
+        logical_date_or_run_after = context.get("logical_date", None)
+        if AIRFLOW_V_3_0_PLUS and logical_date_or_run_after is None:
             if dag_run := context.get("dag_run"):
-                date = pendulum.instance(dag_run.run_after)
-        exec_date = date if date is not None else datetime.datetime.now(tz=datetime.timezone.utc)
-        exec_date_iso = exec_date.isoformat()
-        base = f"airflow_{self.dag_id}_{self.task_id}_{exec_date_iso}_{hash_base}"
+                logical_date_or_run_after = pendulum.instance(dag_run.run_after)
+        if logical_date_or_run_after is None:
+            logical_date_or_run_after = datetime.datetime.now(tz=datetime.timezone.utc)
+        base = f"airflow_{self.dag_id}_{self.task_id}_{logical_date_or_run_after.isoformat()}_{hash_base}"
         workflow_id = md5(base.encode()).hexdigest()
         return re.sub(r"[:\-+.]", "_", workflow_id)
 

--- a/providers/google/src/airflow/providers/google/cloud/sensors/cloud_composer.py
+++ b/providers/google/src/airflow/providers/google/cloud/sensors/cloud_composer.py
@@ -113,9 +113,9 @@ class CloudComposerDAGRunSensor(BaseSensorOperator):
         logical_date = context.get("logical_date", None)
         if logical_date is None:
             raise RuntimeError(
-                "logical_date is None. Please make sure the sensor is not used in an asset-triggered DAG. "
-                "CloudComposerDAGRunSensor was designed to be used in time-based scheduled DAGs only, "
-                "and asset-triggered DAGs do not have logical_date. "
+                "logical_date is None. Please make sure the sensor is not used in an asset-triggered Dag. "
+                "CloudComposerDAGRunSensor was designed to be used in time-based scheduled Dags only, "
+                "and asset-triggered Dags do not have logical_date. "
             )
         if isinstance(self.execution_range, timedelta):
             if self.execution_range < timedelta(0):

--- a/providers/google/src/airflow/providers/google/cloud/sensors/cloud_composer.py
+++ b/providers/google/src/airflow/providers/google/cloud/sensors/cloud_composer.py
@@ -110,15 +110,22 @@ class CloudComposerDAGRunSensor(BaseSensorOperator):
         self.poll_interval = poll_interval
 
     def _get_logical_dates(self, context) -> tuple[datetime, datetime]:
+        logical_date = context.get("logical_date", None)
+        if logical_date is None:
+            raise RuntimeError(
+                "logical_date is None. Please make sure the sensor is not used in an asset-triggered DAG. "
+                "CloudComposerDAGRunSensor was designed to be used in time-based scheduled DAGs only, "
+                "and asset-triggered DAGs do not have logical_date. "
+            )
         if isinstance(self.execution_range, timedelta):
             if self.execution_range < timedelta(0):
-                return context["logical_date"], context["logical_date"] - self.execution_range
-            return context["logical_date"] - self.execution_range, context["logical_date"]
+                return logical_date, logical_date - self.execution_range
+            return logical_date - self.execution_range, logical_date
         if isinstance(self.execution_range, list) and len(self.execution_range) > 0:
             return self.execution_range[0], self.execution_range[1] if len(
                 self.execution_range
-            ) > 1 else context["logical_date"]
-        return context["logical_date"] - timedelta(1), context["logical_date"]
+            ) > 1 else logical_date
+        return logical_date - timedelta(1), logical_date
 
     def poke(self, context: Context) -> bool:
         start_date, end_date = self._get_logical_dates(context)

--- a/providers/google/src/airflow/providers/google/cloud/transfers/bigquery_to_gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/bigquery_to_gcs.py
@@ -215,8 +215,9 @@ class BigQueryToGCSOperator(BaseOperator):
             job_id=self.job_id,
             dag_id=self.dag_id,
             task_id=self.task_id,
-            date=hook.get_exec_date(context),
+            logical_date=None,
             configuration=configuration,
+            run_after=hook.get_run_after_or_logical_date(context),
             force_rerun=self.force_rerun,
         )
 

--- a/providers/google/src/airflow/providers/google/cloud/transfers/bigquery_to_gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/bigquery_to_gcs.py
@@ -215,7 +215,7 @@ class BigQueryToGCSOperator(BaseOperator):
             job_id=self.job_id,
             dag_id=self.dag_id,
             task_id=self.task_id,
-            logical_date=context["logical_date"],
+            date=hook.get_exec_date(context),
             configuration=configuration,
             force_rerun=self.force_rerun,
         )

--- a/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -337,8 +337,9 @@ class GCSToBigQueryOperator(BaseOperator):
             job_id=self.job_id,
             dag_id=self.dag_id,
             task_id=self.task_id,
-            date=hook.get_exec_date(context),
+            logical_date=None,
             configuration=self.configuration,
+            run_after=hook.get_run_after_or_logical_date(context),
             force_rerun=self.force_rerun,
         )
 

--- a/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -337,7 +337,7 @@ class GCSToBigQueryOperator(BaseOperator):
             job_id=self.job_id,
             dag_id=self.dag_id,
             task_id=self.task_id,
-            logical_date=context["logical_date"],
+            date=hook.get_exec_date(context),
             configuration=self.configuration,
             force_rerun=self.force_rerun,
         )

--- a/providers/google/tests/unit/google/cloud/hooks/test_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_bigquery.py
@@ -685,15 +685,12 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
     def test_get_run_after_or_logical_date(self):
         if AIRFLOW_V_3_0_PLUS:
             from airflow.models import DagRun
-            from airflow.sdk.definitions.context import Context
 
             ctx = Context(dag_run=DagRun(run_after=pendulum.datetime(2025, 1, 1)))
-            assert self.hook.get_run_after_or_logical_date(ctx) == pendulum.datetime(2025, 1, 1)
         else:
-            from airflow.utils.context import Context
-
             ctx = Context(logical_date=pendulum.datetime(2025, 1, 1))
-            assert self.hook.get_run_after_or_logical_date(ctx) == pendulum.datetime(2025, 1, 1)
+
+        assert self.hook.get_run_after_or_logical_date(ctx) == pendulum.datetime(2025, 1, 1)
 
     @mock.patch(
         "airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_job",

--- a/providers/google/tests/unit/google/cloud/hooks/test_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_bigquery.py
@@ -22,6 +22,7 @@ from unittest import mock
 from unittest.mock import AsyncMock
 
 import google.auth
+import pendulum
 import pytest
 from gcloud.aio.bigquery import Job, Table as Table_async
 from google.api_core import page_iterator
@@ -682,8 +683,6 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
         assert job_id == expected_job_id
 
     def test_get_run_after_or_logical_date(self):
-        import pendulum
-
         if AIRFLOW_V_3_0_PLUS:
             from airflow.models import DagRun
             from airflow.sdk.definitions.context import Context

--- a/providers/google/tests/unit/google/cloud/hooks/test_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_bigquery.py
@@ -51,6 +51,7 @@ from airflow.providers.google.cloud.hooks.bigquery import (
     _validate_src_fmt_configs,
     _validate_value,
 )
+from airflow.sdk import Context
 
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 

--- a/providers/google/tests/unit/google/cloud/hooks/test_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_bigquery.py
@@ -51,9 +51,13 @@ from airflow.providers.google.cloud.hooks.bigquery import (
     _validate_src_fmt_configs,
     _validate_value,
 )
-from airflow.sdk import Context
 
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+
+if AIRFLOW_V_3_0_PLUS:
+    from airflow.sdk import Context
+else:
+    from airflow.utils.context import Context
 
 pytestmark = pytest.mark.filterwarnings("error::airflow.exceptions.AirflowProviderDeprecationWarning")
 

--- a/providers/google/tests/unit/google/cloud/hooks/test_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_bigquery.py
@@ -675,27 +675,26 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
             job_id=None,
             dag_id=test_dag_id,
             task_id="test_job_id",
-            date=datetime(2020, 1, 23),
+            logical_date=None,
             configuration=configuration,
+            run_after=datetime(2020, 1, 23),
         )
         assert job_id == expected_job_id
 
-    def test_get_exec_date(self):
+    def test_get_run_after_or_logical_date(self):
         import pendulum
 
         if AIRFLOW_V_3_0_PLUS:
             from airflow.models import DagRun
             from airflow.sdk.definitions.context import Context
 
-            ctx = Context(logical_date=pendulum.datetime(2025, 1, 1))
-            assert self.hook.get_exec_date(ctx) == pendulum.datetime(2025, 1, 1)
             ctx = Context(dag_run=DagRun(run_after=pendulum.datetime(2025, 1, 1)))
-            assert self.hook.get_exec_date(ctx) == pendulum.datetime(2025, 1, 1)
+            assert self.hook.get_run_after_or_logical_date(ctx) == pendulum.datetime(2025, 1, 1)
         else:
             from airflow.utils.context import Context
 
             ctx = Context(logical_date=pendulum.datetime(2025, 1, 1))
-            assert self.hook.get_exec_date(ctx) == pendulum.datetime(2025, 1, 1)
+            assert self.hook.get_run_after_or_logical_date(ctx) == pendulum.datetime(2025, 1, 1)
 
     @mock.patch(
         "airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_job",

--- a/providers/google/tests/unit/google/cloud/operators/test_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_bigquery.py
@@ -1595,7 +1595,7 @@ class TestBigQueryInsertJobOperator:
             job_id=job_id,
             dag_id="adhoc_airflow",
             task_id="insert_query_job",
-            logical_date=ANY,
+            date=ANY,
             configuration=configuration,
             force_rerun=True,
         )

--- a/providers/google/tests/unit/google/cloud/operators/test_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_bigquery.py
@@ -1595,7 +1595,8 @@ class TestBigQueryInsertJobOperator:
             job_id=job_id,
             dag_id="adhoc_airflow",
             task_id="insert_query_job",
-            date=ANY,
+            logical_date=ANY,
+            run_after=ANY,
             configuration=configuration,
             force_rerun=True,
         )

--- a/providers/google/tests/unit/google/cloud/operators/test_workflows.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_workflows.py
@@ -41,7 +41,7 @@ from airflow.utils.hashlib_wrapper import md5
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk.definitions.context import Context
+    from airflow.sdk import Context
 else:
     from airflow.utils.context import Context
 

--- a/providers/google/tests/unit/google/cloud/operators/test_workflows.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_workflows.py
@@ -24,6 +24,7 @@ from unittest import mock
 import pendulum
 from google.protobuf.timestamp_pb2 import Timestamp
 
+from airflow.models.dagrun import DagRun
 from airflow.providers.google.cloud.operators.workflows import (
     WorkflowsCancelExecutionOperator,
     WorkflowsCreateExecutionOperator,
@@ -41,9 +42,7 @@ from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 if AIRFLOW_V_3_0_PLUS:
     from airflow.sdk.definitions.context import Context
-    from airflow.sdk.definitions.dagrun import DagRun
 else:
-    from airflow.models.dagrun import DagRun
     from airflow.utils.context import Context
 
 BASE_PATH = "airflow.providers.google.cloud.operators.workflows.{}"

--- a/providers/google/tests/unit/google/cloud/operators/test_workflows.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_workflows.py
@@ -21,6 +21,7 @@ import json
 import re
 from unittest import mock
 
+import pendulum
 from google.protobuf.timestamp_pb2 import Timestamp
 
 from airflow.providers.google.cloud.operators.workflows import (
@@ -35,6 +36,15 @@ from airflow.providers.google.cloud.operators.workflows import (
     WorkflowsUpdateWorkflowOperator,
 )
 from airflow.utils.hashlib_wrapper import md5
+
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+
+if AIRFLOW_V_3_0_PLUS:
+    from airflow.sdk.definitions.context import Context
+    from airflow.sdk.definitions.dagrun import DagRun
+else:
+    from airflow.models.dagrun import DagRun
+    from airflow.utils.context import Context
 
 BASE_PATH = "airflow.providers.google.cloud.operators.workflows.{}"
 LOCATION = "europe-west1"
@@ -90,16 +100,6 @@ class TestWorkflowsCreateWorkflowOperator:
         assert result == mock_object.to_dict.return_value
 
     def test_execute_without_workflow_id(self):
-        import pendulum
-
-        from airflow.models.dagrun import DagRun
-
-        from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
-
-        if AIRFLOW_V_3_0_PLUS:
-            from airflow.sdk.definitions.context import Context
-        else:
-            from airflow.utils.context import Context
         op = WorkflowsCreateWorkflowOperator(
             task_id="test_task",
             workflow=WORKFLOW,

--- a/providers/google/tests/unit/google/cloud/operators/test_workflows.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_workflows.py
@@ -89,7 +89,7 @@ class TestWorkflowsCreateWorkflowOperator:
 
         assert result == mock_object.to_dict.return_value
 
-    def test_execute_wihout_workflow_id(self):
+    def test_execute_without_workflow_id(self):
         import pendulum
 
         from airflow.models.dagrun import DagRun
@@ -115,6 +115,8 @@ class TestWorkflowsCreateWorkflowOperator:
         hash_base = json.dumps(WORKFLOW, sort_keys=True)
         date = pendulum.datetime(2025, 1, 1)
         ctx = Context(logical_date=date)
+        if AIRFLOW_V_3_0_PLUS:
+            ctx["dag_run"] = DagRun(run_after=date)
         expected = md5(f"airflow_{op.dag_id}_test_task_{date.isoformat()}_{hash_base}".encode()).hexdigest()
         assert op._workflow_id(ctx) == re.sub(r"[:\-+.]", "_", expected)
 

--- a/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_bigquery.py
@@ -1745,7 +1745,8 @@ class TestAsyncGCSToBigQueryOperator:
             job_id=None,
             dag_id="adhoc_airflow",
             task_id=TASK_ID,
-            date=hook.return_value.get_exec_date(),
+            logical_date=None,
+            run_after=hook.return_value.get_run_after_or_logical_date(),
             configuration={},
             force_rerun=True,
         )

--- a/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_bigquery.py
@@ -43,7 +43,6 @@ from airflow.providers.common.compat.openlineage.facet import (
 )
 from airflow.providers.google.cloud.transfers.gcs_to_bigquery import GCSToBigQueryOperator
 from airflow.utils.state import TaskInstanceState
-from airflow.utils.timezone import datetime
 
 TASK_ID = "test-gcs-to-bq-operator"
 TEST_EXPLICIT_DEST = "test-project.dataset.table"
@@ -1746,7 +1745,7 @@ class TestAsyncGCSToBigQueryOperator:
             job_id=None,
             dag_id="adhoc_airflow",
             task_id=TASK_ID,
-            logical_date=datetime(2016, 1, 1, 0, 0),
+            date=hook.return_value.get_exec_date(),
             configuration={},
             force_rerun=True,
         )


### PR DESCRIPTION
related: #53634 #55073 #55092

In airflow 3, logcial_date is not available for asset triggered DAG runs.
However, it was previously used for job ID generation in Bigquery and workflow ID for Workflows.

This PR proposes using dag_run.run_after as a substitute for asset triggered DAG runs.

In this PR, I propose to use dagrun.run_after for asset triggered dag run.

Summary of the PR

1. HiveOperator: raise error if logical_date is None (as is), and provide more information in the error message
2. GoogleCloudComposer: raise an error if logical_date is None
3. BigQueryHook.generate_job_id:
   - for airflow >= 3.0, add deprecated warning calls with logical_date is not None
   - add a new argument `run_after` with default value = None (for backwards compatibility)
4. Operators that use `BigqueryHook.generate_job_id`: for AIRFLOW_V_3_0_PLUS, use dag_run.run_after.

~~What Wasn't Fixed~~

~~The usage of `context["logical_date"]` in `providers/google/cloud/sensors/cloud_composer.py` remains unchangeed.~~

cc: @kaxil. this is related to #55073 but cover move on

- workflow
- gcs_to_bigquery
- bigquery_to_gcs