### PR TITLE
Decouple `Param` and `ParamsDict` from SDK during deserialization

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dags.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import inspect
 from collections import abc
 from datetime import datetime, timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from itsdangerous import URLSafeSerializer
 from pendulum.tz.timezone import FixedTimezone, Timezone
@@ -36,6 +36,9 @@ from airflow.api_fastapi.core_api.datamodels.dag_tags import DagTagResponse
 from airflow.api_fastapi.core_api.datamodels.dag_versions import DagVersionResponse
 from airflow.configuration import conf
 from airflow.models.dag_version import DagVersion
+
+if TYPE_CHECKING:
+    from airflow.serialization.definitions.param import SerializedParamsDict
 
 DAG_ALIAS_MAPPING: dict[str, str] = {
     # The keys are the names in the response, the values are the original names in the model
@@ -177,11 +180,11 @@ class DAGDetailsResponse(DAGResponse):
 
     @field_validator("params", mode="before")
     @classmethod
-    def get_params(cls, params: abc.Mapping | None) -> dict | None:
+    def get_params(cls, params: SerializedParamsDict | None) -> dict | None:
         """Convert params attribute to dict representation."""
         if params is None:
             return None
-        return {k: v.dump() for k, v in params.items()}
+        return {k: v.resolve(suppress_exception=True) for k, v in params.items()}
 
     # Mypy issue https://github.com/python/mypy/issues/1362
     @computed_field(deprecated=True)  # type: ignore[prop-decorator]

--- a/airflow-core/src/airflow/models/mappedoperator.py
+++ b/airflow-core/src/airflow/models/mappedoperator.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
     from airflow.models.expandinput import SchedulerExpandInput
     from airflow.sdk import BaseOperatorLink, Context
     from airflow.sdk.definitions.operator_resources import Resources
-    from airflow.sdk.definitions.param import ParamsDict
+    from airflow.serialization.definitions.param import SerializedParamsDict
     from airflow.serialization.serialized_objects import SerializedDAG
     from airflow.task.trigger_rule import TriggerRule
     from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
@@ -92,7 +92,7 @@ class MappedOperator(DAGNode):
 
     # Needed for serialization.
     task_id: str
-    params: ParamsDict | dict = attrs.field(init=False, factory=dict)
+    params: SerializedParamsDict | dict = attrs.field(init=False, factory=dict)
     operator_extra_links: Collection[BaseOperatorLink]
     template_ext: Sequence[str]
     template_fields: Collection[str]

--- a/airflow-core/src/airflow/models/mappedoperator.py
+++ b/airflow-core/src/airflow/models/mappedoperator.py
@@ -32,6 +32,7 @@ from airflow.exceptions import AirflowException, NotMapped
 from airflow.sdk import BaseOperator as TaskSDKBaseOperator
 from airflow.sdk.definitions._internal.node import DAGNode
 from airflow.sdk.definitions.mappedoperator import MappedOperator as TaskSDKMappedOperator
+from airflow.serialization.definitions.param import SerializedParamsDict
 from airflow.serialization.definitions.taskgroup import SerializedMappedTaskGroup, SerializedTaskGroup
 from airflow.serialization.enums import DagAttributeTypes
 from airflow.serialization.serialized_objects import DEFAULT_OPERATOR_DEPS, SerializedBaseOperator
@@ -47,7 +48,6 @@ if TYPE_CHECKING:
     from airflow.models.expandinput import SchedulerExpandInput
     from airflow.sdk import BaseOperatorLink, Context
     from airflow.sdk.definitions.operator_resources import Resources
-    from airflow.serialization.definitions.param import SerializedParamsDict
     from airflow.serialization.serialized_objects import SerializedDAG
     from airflow.task.trigger_rule import TriggerRule
     from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
@@ -92,7 +92,7 @@ class MappedOperator(DAGNode):
 
     # Needed for serialization.
     task_id: str
-    params: SerializedParamsDict | dict = attrs.field(init=False, factory=dict)
+    params: SerializedParamsDict = attrs.field(init=False, factory=SerializedParamsDict)
     operator_extra_links: Collection[BaseOperatorLink]
     template_ext: Sequence[str]
     template_fields: Collection[str]

--- a/airflow-core/src/airflow/serialization/definitions/notset.py
+++ b/airflow-core/src/airflow/serialization/definitions/notset.py
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from airflow.sdk.definitions._internal.types import NOTSET, ArgNotSet
+
+# TODO (GH-52141): Have different NOTSET and ArgNotSet in the scheduler.
+__all__ = ["NOTSET", "ArgNotSet"]

--- a/airflow-core/src/airflow/serialization/definitions/param.py
+++ b/airflow-core/src/airflow/serialization/definitions/param.py
@@ -1,0 +1,98 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from collections.abc import Collection, Iterator, Mapping
+from typing import Any
+
+NOTSET = object()
+
+
+class SerializedParam:
+    """Server-side Param class for deserialization."""
+
+    def __init__(self, default=None, description: str | None = None, **schema):
+        # No validation needed - the SDK already validated during serialization
+        # NOTSET is converted to None during serialization, so we only see None here
+        self.value = default
+        self.description = description
+        self.schema = schema
+
+    def resolve(self, value: Any = NOTSET, suppress_exception: bool = False) -> Any:
+        """Return the default value for compatibility."""
+        return self.value if value is NOTSET else value
+
+    def dump(self) -> Any:
+        """Return the parameter value for API responses."""
+        return self.value
+
+
+def _collect_params(container: Mapping[str, Any] | None) -> Iterator[tuple[str, SerializedParam]]:
+    if not container:
+        return
+    for k, v in container.items():
+        if isinstance(v, SerializedParam):
+            yield k, v
+        else:
+            yield k, SerializedParam(v)
+
+
+class SerializedParamsDict:
+    """Server-side ParamsDict class for deserialization."""
+
+    __dict: dict[str, SerializedParam]
+
+    def __init__(self, container: Mapping[str, Any] | None = None) -> None:
+        self.__dict = dict(_collect_params(container))
+
+    def __eq__(self, other: Any) -> bool:
+        """Compare ParamsDict objects using their dumped content, matching SDK behavior."""
+        if hasattr(other, "dump"):  # ParamsDict or SerializedParamsDict
+            return self.dump() == other.dump()
+        if isinstance(other, Mapping):
+            return self.dump() == other
+        return NotImplemented
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.__dict
+
+    def __len__(self) -> int:
+        return len(self.__dict)
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.__dict)
+
+    def __getitem__(self, key: str) -> Any:
+        """
+        Get the resolved value for this key.
+
+        This matches SDK ParamsDict behavior.
+        """
+        return self.__dict[key].value
+
+    def items(self) -> Collection[tuple[str, SerializedParam]]:
+        return self.__dict.items()
+
+    def get_param(self, key: str) -> SerializedParam:
+        """Get the internal SerializedParam object for this key."""
+        return self.__dict[key]
+
+    def dump(self) -> Mapping[str, Any]:
+        """Dump the resolved values as a mapping."""
+        return {k: v.value for k, v in self.__dict.items()}

--- a/airflow-core/src/airflow/serialization/definitions/param.py
+++ b/airflow-core/src/airflow/serialization/definitions/param.py
@@ -18,58 +18,108 @@
 
 from __future__ import annotations
 
-from collections.abc import Collection, Iterator, Mapping
-from typing import Any
+import collections.abc
+import copy
+import json
+from typing import TYPE_CHECKING, Any
 
-NOTSET = object()
+from airflow.exceptions import ParamValidationError
+from airflow.serialization.definitions.notset import NOTSET, ArgNotSet
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Mapping
+
+
+def _check_json(value):
+    try:
+        json.dumps(value)
+    except Exception:
+        raise ParamValidationError(
+            f"All provided parameters must be JSON-serializable. The value '{value}' is not."
+        )
 
 
 class SerializedParam:
     """Server-side Param class for deserialization."""
 
-    def __init__(self, default=None, description: str | None = None, **schema):
-        # No validation needed - the SDK already validated during serialization
-        # NOTSET is converted to None during serialization, so we only see None here
+    def __init__(self, default: Any = None, description: str | None = None, **schema):
+        # No validation needed - the SDK already validated the default.
         self.value = default
         self.description = description
         self.schema = schema
 
     def resolve(self, value: Any = NOTSET, suppress_exception: bool = False) -> Any:
-        """Return the default value for compatibility."""
-        return self.value if value is NOTSET else value
+        """
+        Run the validations and returns the Param's final value.
 
-    def dump(self) -> Any:
-        """Return the parameter value for API responses."""
-        return self.value
+        May raise ValueError on failed validations, or TypeError
+        if no value is passed and no value already exists.
+        We first check that value is json-serializable; if not, warn.
+        In future release we will require the value to be json-serializable.
+
+        :param value: The value to be updated for the Param
+        :param suppress_exception: To raise an exception or not when validation
+            fails. If true and validations fails, *None* is returned.
+        """
+        import jsonschema
+        from jsonschema import FormatChecker
+        from jsonschema.exceptions import ValidationError
+
+        if not isinstance(value, ArgNotSet):
+            try:
+                _check_json(value)
+            except ParamValidationError:
+                if suppress_exception:
+                    return None
+                raise
+            final_val = value
+        elif isinstance(self.value, ArgNotSet):
+            if suppress_exception:
+                return None
+            raise ParamValidationError("No value passed and Param has no default value")
+        else:
+            final_val = self.value
+        try:
+            jsonschema.validate(final_val, self.schema, format_checker=FormatChecker())
+        except ValidationError as err:
+            if suppress_exception:
+                return None
+            raise ParamValidationError(err) from None
+        self.value = final_val
+        return final_val
+
+
+def _coerce_param(v: Any) -> SerializedParam:
+    if isinstance(v, SerializedParam):
+        return v
+    return SerializedParam(v)
 
 
 def _collect_params(container: Mapping[str, Any] | None) -> Iterator[tuple[str, SerializedParam]]:
     if not container:
         return
     for k, v in container.items():
-        if isinstance(v, SerializedParam):
-            yield k, v
-        else:
-            yield k, SerializedParam(v)
+        yield k, _coerce_param(v)
 
 
-class SerializedParamsDict:
+class SerializedParamsDict(collections.abc.Mapping[str, Any]):
     """Server-side ParamsDict class for deserialization."""
 
     __dict: dict[str, SerializedParam]
 
-    def __init__(self, container: Mapping[str, Any] | None = None) -> None:
-        self.__dict = dict(_collect_params(container))
+    def __init__(self, d: Mapping[str, Any] | None = None, *, suppress_exception: bool = False) -> None:
+        self.__dict = dict(_collect_params(d))
+        self.suppress_exception = suppress_exception
 
     def __eq__(self, other: Any) -> bool:
         """Compare ParamsDict objects using their dumped content, matching SDK behavior."""
         if hasattr(other, "dump"):  # ParamsDict or SerializedParamsDict
             return self.dump() == other.dump()
-        if isinstance(other, Mapping):
+        if isinstance(other, collections.abc.Mapping):
             return self.dump() == other
         return NotImplemented
 
-    def __contains__(self, key: str) -> bool:
+    def __contains__(self, key: object) -> bool:
         return key in self.__dict
 
     def __len__(self) -> int:
@@ -86,13 +136,41 @@ class SerializedParamsDict:
         """
         return self.__dict[key].value
 
-    def items(self) -> Collection[tuple[str, SerializedParam]]:
-        return self.__dict.items()
-
     def get_param(self, key: str) -> SerializedParam:
         """Get the internal SerializedParam object for this key."""
         return self.__dict[key]
 
+    def items(self):
+        return collections.abc.ItemsView(self.__dict)
+
+    def values(self):
+        return collections.abc.ValuesView(self.__dict)
+
+    def validate(self) -> dict[str, Any]:
+        """Validate & returns all the Params object stored in the dictionary."""
+
+        def _validate_one(k: str, v: SerializedParam):
+            try:
+                return v.resolve(suppress_exception=self.suppress_exception)
+            except ParamValidationError as e:
+                raise ParamValidationError(f"Invalid input for param {k}: {e}") from None
+
+        return {k: _validate_one(k, v) for k, v in self.__dict.items()}
+
     def dump(self) -> Mapping[str, Any]:
         """Dump the resolved values as a mapping."""
-        return {k: v.value for k, v in self.__dict.items()}
+        return {k: v.resolve(suppress_exception=True) for k, v in self.__dict.items()}
+
+    def deep_merge(self, data: Mapping[str, Any] | None) -> SerializedParamsDict:
+        """Create a new params dict by merging incoming data into this params dict."""
+        params = copy.deepcopy(self)
+        if not data:
+            return params
+        for k, v in data.items():
+            if k not in params:
+                params.__dict[k] = _coerce_param(v)
+            elif isinstance(v, SerializedParam):
+                params.__dict[k] = v
+            else:
+                params.__dict[k].value = v
+        return params

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -93,6 +93,7 @@ from airflow.sdk.definitions.taskgroup import MappedTaskGroup, TaskGroup
 from airflow.sdk.definitions.xcom_arg import serialize_xcom_arg
 from airflow.sdk.execution_time.context import OutletEventAccessor, OutletEventAccessors
 from airflow.serialization.dag_dependency import DagDependency
+from airflow.serialization.definitions.param import SerializedParam, SerializedParamsDict
 from airflow.serialization.definitions.taskgroup import SerializedMappedTaskGroup, SerializedTaskGroup
 from airflow.serialization.enums import DagAttributeTypes as DAT, Encoding
 from airflow.serialization.helpers import serialize_template_field
@@ -1028,16 +1029,14 @@ class BaseSerialization:
         }
 
     @classmethod
-    def _deserialize_param(cls, param_dict: dict):
+    def _deserialize_param(cls, param_dict: dict) -> SerializedParam:
         """
-        Workaround to serialize Param on older versions.
+        Deserialize Param using server-side class to avoid SDK coupling.
 
         In 2.2.0, Param attrs were assumed to be json-serializable and were not run through
         this class's ``serialize`` method.  So before running through ``deserialize``,
         we first verify that it's necessary to do.
         """
-        class_name = param_dict["__class"]
-        class_: type[Param] = import_string(class_name)
         attrs = ("default", "description", "schema")
         kwargs = {}
 
@@ -1054,7 +1053,11 @@ class BaseSerialization:
                 if is_serialized(val):
                     val = cls.deserialize(val)
                 kwargs[attr] = val
-        return class_(**kwargs)
+
+        # Use server-side class instead of SDK class
+        return SerializedParam(
+            default=kwargs.get("default"), description=kwargs.get("description"), **kwargs.get("schema", {})
+        )
 
     @classmethod
     def _serialize_params_dict(cls, params: ParamsDict | dict) -> list[tuple[str, dict]]:
@@ -1076,8 +1079,8 @@ class BaseSerialization:
         return serialized_params
 
     @classmethod
-    def _deserialize_params_dict(cls, encoded_params: list[tuple[str, dict]]) -> ParamsDict:
-        """Deserialize a DAG's Params dict."""
+    def _deserialize_params_dict(cls, encoded_params: list[tuple[str, dict]]) -> SerializedParamsDict:
+        """Deserialize a DAG's Params dict using server-side classes."""
         if isinstance(encoded_params, collections.abc.Mapping):
             # in 2.9.2 or earlier params were serialized as JSON objects
             encoded_param_pairs: Iterable[tuple[str, dict]] = encoded_params.items()
@@ -1089,10 +1092,10 @@ class BaseSerialization:
             if isinstance(v, dict) and "__class" in v:
                 op_params[k] = cls._deserialize_param(v)
             else:
-                # Old style params, convert it
-                op_params[k] = Param(v)
+                # Old style params, convert it using server-side class
+                op_params[k] = SerializedParam(v)
 
-        return ParamsDict(op_params)
+        return SerializedParamsDict(op_params)
 
     @classmethod
     @lru_cache(maxsize=4)  # Cache for "operator", "dag", and a few others
@@ -1284,6 +1287,7 @@ class SerializedBaseOperator(DAGNode, BaseSerialization):
 
     outlets: Sequence = []
     owner: str = "airflow"
+    params: SerializedParamsDict | dict[str, Any] = SerializedParamsDict()
     pool: str = "default_pool"
     pool_slots: int = 1
     priority_weight: int = 1
@@ -1317,18 +1321,11 @@ class SerializedBaseOperator(DAGNode, BaseSerialization):
 
     is_mapped = False
 
-    def __init__(
-        self,
-        *,
-        task_id: str,
-        params: Mapping[str, Any] | None = None,
-        _airflow_from_mapped: bool = False,
-    ) -> None:
+    def __init__(self, *, task_id: str, _airflow_from_mapped: bool = False) -> None:
         super().__init__()
 
         self._BaseOperator__from_mapped = _airflow_from_mapped
         self.task_id = task_id
-        self.params = ParamsDict(params)
         # Move class attributes into object attributes.
         self.deps = DEFAULT_OPERATOR_DEPS
         self._operator_name: str | None = None
@@ -1603,9 +1600,6 @@ class SerializedBaseOperator(DAGNode, BaseSerialization):
 
             elif k == "params":
                 v = cls._deserialize_params_dict(v)
-                if op.params:  # Merge existing params if needed.
-                    v, new = op.params, v
-                    v.update(new)
             elif k == "partial_kwargs":
                 # Use unified deserializer that supports both encoded and non-encoded values
                 v = cls._deserialize_partial_kwargs(v, client_defaults)
@@ -3257,11 +3251,6 @@ class SerializedDAG(BaseSerialization):
 
         # todo: AIP-78 add verification that if run type is backfill then we have a backfill id
 
-        # create a copy of params before validating
-        copied_params = copy.deepcopy(self.params)
-        if conf:
-            copied_params.update(conf)
-        copied_params.validate()
         orm_dagrun = _create_orm_dagrun(
             dag=self,
             run_id=run_id,

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py
@@ -861,14 +861,7 @@ class TestDagDetails(TestDagEndpoint):
             "next_dagrun_run_after": None,
             "owners": ["airflow"],
             "owner_links": {},
-            "params": {
-                "foo": {
-                    "__class": "airflow.sdk.definitions.param.Param",
-                    "description": None,
-                    "schema": {},
-                    "value": 1,
-                }
-            },
+            "params": {"foo": 1},
             "relative_fileloc": "test_dags.py",
             "render_template_as_native_obj": False,
             "timetable_summary": None,
@@ -957,14 +950,7 @@ class TestDagDetails(TestDagEndpoint):
             "next_dagrun_run_after": None,
             "owners": ["airflow"],
             "owner_links": {},
-            "params": {
-                "foo": {
-                    "__class": "airflow.sdk.definitions.param.Param",
-                    "description": None,
-                    "schema": {},
-                    "value": 1,
-                }
-            },
+            "params": {"foo": 1},
             "relative_fileloc": "test_dags.py",
             "render_template_as_native_obj": False,
             "timetable_summary": None,

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_tasks.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_tasks.py
@@ -101,14 +101,7 @@ class TestGetTask(TestTaskEndpoint):
             "extra_links": [],
             "operator_name": "EmptyOperator",
             "owner": "airflow",
-            "params": {
-                "foo": {
-                    "__class": "airflow.sdk.definitions.param.Param",
-                    "value": "bar",
-                    "description": None,
-                    "schema": {},
-                }
-            },
+            "params": {"foo": "bar"},
             "pool": "default_pool",
             "pool_slots": 1.0,
             "priority_weight": 1.0,
@@ -186,14 +179,7 @@ class TestGetTask(TestTaskEndpoint):
             "extra_links": [],
             "operator_name": "EmptyOperator",
             "owner": "airflow",
-            "params": {
-                "is_unscheduled": {
-                    "__class": "airflow.sdk.definitions.param.Param",
-                    "value": True,
-                    "description": None,
-                    "schema": {},
-                }
-            },
+            "params": {"is_unscheduled": True},
             "pool": "default_pool",
             "pool_slots": 1.0,
             "priority_weight": 1.0,
@@ -252,14 +238,7 @@ class TestGetTask(TestTaskEndpoint):
             "extra_links": [],
             "operator_name": "EmptyOperator",
             "owner": "airflow",
-            "params": {
-                "foo": {
-                    "__class": "airflow.sdk.definitions.param.Param",
-                    "value": "bar",
-                    "description": None,
-                    "schema": {},
-                }
-            },
+            "params": {"foo": "bar"},
             "pool": "default_pool",
             "pool_slots": 1.0,
             "priority_weight": 1.0,
@@ -324,14 +303,7 @@ class TestGetTasks(TestTaskEndpoint):
                     "extra_links": [],
                     "operator_name": "EmptyOperator",
                     "owner": "airflow",
-                    "params": {
-                        "foo": {
-                            "__class": "airflow.sdk.definitions.param.Param",
-                            "value": "bar",
-                            "description": None,
-                            "schema": {},
-                        }
-                    },
+                    "params": {"foo": "bar"},
                     "pool": "default_pool",
                     "pool_slots": 1.0,
                     "priority_weight": 1.0,
@@ -483,14 +455,7 @@ class TestGetTasks(TestTaskEndpoint):
                     "extra_links": [],
                     "operator_name": "EmptyOperator",
                     "owner": "airflow",
-                    "params": {
-                        "is_unscheduled": {
-                            "__class": "airflow.sdk.definitions.param.Param",
-                            "value": True,
-                            "description": None,
-                            "schema": {},
-                        }
-                    },
+                    "params": {"is_unscheduled": True},
                     "pool": "default_pool",
                     "pool_slots": 1.0,
                     "priority_weight": 1.0,

--- a/airflow-core/tests/unit/serialization/test_dag_serialization.py
+++ b/airflow-core/tests/unit/serialization/test_dag_serialization.py
@@ -74,6 +74,7 @@ from airflow.serialization.serialized_objects import (
     BaseSerialization,
     SerializedBaseOperator,
     SerializedDAG,
+    SerializedParam,
     XComOperatorLink,
 )
 from airflow.task.priority_strategy import _AbsolutePriorityWeightStrategy, _DownstreamPriorityWeightStrategy
@@ -1183,7 +1184,7 @@ class TestStringifiedDAGs:
 
         assert dag.params.get_param("my_param").value == param.value
         observed_param = dag.params.get_param("my_param")
-        assert isinstance(observed_param, Param)
+        assert isinstance(observed_param, SerializedParam)
         assert observed_param.description == param.description
         assert observed_param.schema == param.schema
 
@@ -2333,7 +2334,8 @@ class TestStringifiedDAGs:
         dag = SerializedDAG.from_dict(serialized)
 
         assert dag.params["none"] is None
-        assert isinstance(dag.params.get_param("none"), Param)
+        # After decoupling, server-side deserialization uses SerializedParam
+        assert isinstance(dag.params.get_param("none"), SerializedParam)
         assert dag.params["str"] == "str"
 
     def test_params_serialization_from_dict_upgrade(self):
@@ -2359,7 +2361,8 @@ class TestStringifiedDAGs:
         dag = SerializedDAG.from_dict(serialized)
 
         param = dag.params.get_param("my_param")
-        assert isinstance(param, Param)
+        # After decoupling, server-side deserialization uses SerializedParam
+        assert isinstance(param, SerializedParam)
         assert param.value == "str"
 
     def test_params_serialize_default_2_2_0(self):
@@ -2381,7 +2384,8 @@ class TestStringifiedDAGs:
         SerializedDAG.validate_schema(serialized)
         dag = SerializedDAG.from_dict(serialized)
 
-        assert isinstance(dag.params.get_param("str"), Param)
+        # After decoupling, server-side deserialization uses SerializedParam
+        assert isinstance(dag.params.get_param("str"), SerializedParam)
         assert dag.params["str"] == "str"
 
     def test_params_serialize_default(self):
@@ -2410,7 +2414,8 @@ class TestStringifiedDAGs:
 
         assert dag.params["my_param"] == "a string value"
         param = dag.params.get_param("my_param")
-        assert isinstance(param, Param)
+        # After decoupling, server-side deserialization uses SerializedParam
+        assert isinstance(param, SerializedParam)
         assert param.description == "hello"
         assert param.schema == {"type": "string"}
 

--- a/task-sdk/tests/task_sdk/definitions/test_param.py
+++ b/task-sdk/tests/task_sdk/definitions/test_param.py
@@ -22,6 +22,7 @@ import pytest
 
 from airflow.exceptions import ParamValidationError
 from airflow.sdk.definitions.param import Param, ParamsDict
+from airflow.serialization.definitions.param import SerializedParam
 from airflow.serialization.serialized_objects import BaseSerialization
 
 
@@ -231,7 +232,7 @@ class TestParam:
         restored_param: Param = serializer.deserialize(serialized_param)
 
         assert restored_param.value == param.value
-        assert isinstance(restored_param, Param)
+        assert isinstance(restored_param, SerializedParam)
         assert restored_param.description == param.description
         assert restored_param.schema == param.schema
 


### PR DESCRIPTION
Introduces server-side `SerializedParam` and `SerializedParamsDict` classes to eliminate SDK dependencies during DAG deserialization. This change ensures the scheduler and API server can deserialize DAGs without importing Task SDK modules.

Part of https://github.com/apache/airflow/issues/52141

TODO:
- [x] Param Validation

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
