### PR TITLE
Add hyperlink to triggering user name in DAG run header

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
@@ -16,10 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { HStack, Text, Box } from "@chakra-ui/react";
+import { HStack, Text, Box, Link } from "@chakra-ui/react";
 import { useCallback, useState, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { FiBarChart } from "react-icons/fi";
+import { Link as RouterLink } from "react-router-dom";
 
 import type { DAGRunResponse } from "openapi/requests/types.gen";
 import { ClearRunButton } from "src/components/Clear";
@@ -119,7 +120,15 @@ export const Header = ({
             : [
                 {
                   label: translate("dagRun.triggeringUser"),
-                  value: <Text>{dagRun.triggering_user_name}</Text>,
+                  value: (
+                    <Link asChild color="fg.info">
+                      <RouterLink
+                        to={`/dag_runs?triggering_user_name_pattern=${encodeURIComponent(dagRun.triggering_user_name)}`}
+                      >
+                        <Text>{dagRun.triggering_user_name}</Text>
+                      </RouterLink>
+                    </Link>
+                  ),
                 },
               ]),
           {


### PR DESCRIPTION
Links to dag_runs page with triggering_user_name_pattern filter to show all runs by that user.


https://github.com/user-attachments/assets/703e5e10-5993-49e6-9d5a-746b675cfbf3
