### PR TITLE
Fix Python 3.11 work from sources in CI image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -197,7 +197,6 @@ function link_python() {
     # Links in /usr/local/bin are needed for tools that expect python to be there
     # Links in /usr/python/bin are needed for tools that are detecting home of python installation including
     # lib/site-packages. The /usr/python/bin should be first in PATH in order to help with the last part.
-    ldconfig
     for dst in pip3 python3 python3-config; do
         src="$(echo "${dst}" | tr -d 3)"
         echo "Linking ${dst} in /usr/local/bin and /usr/python/bin"
@@ -209,6 +208,16 @@ function link_python() {
             fi
         done
     done
+    for dst in /usr/python/lib/*
+    do
+        src="/usr/local/lib/$(basename "${dst}")"
+        if [[ -e "${src}" ]]; then
+            rm -rf "${src}"
+        fi
+        echo "Linking ${dst} to ${src}"
+        ln -sv "${dst}" "${src}"
+    done
+    ldconfig
 }
 
 function install_debian_runtime_dependencies() {
@@ -1558,11 +1567,9 @@ SHELL ["/bin/bash", "-o", "pipefail", "-o", "errexit", "-o", "nounset", "-o", "n
 ARG BASE_IMAGE
 
 # Make sure noninteractive debian install is used and language variables set
-# as well as LD_LIBRARY_PATH to /usr/local/lib and /usr/python/lib is set, so that
-# shared libraries installed there are found
 ENV BASE_IMAGE=${BASE_IMAGE} \
     DEBIAN_FRONTEND=noninteractive LANGUAGE=C.UTF-8 LANG=C.UTF-8 LC_ALL=C.UTF-8 \
-    LC_CTYPE=C.UTF-8 LC_MESSAGES=C.UTF-8 LD_LIBRARY_PATH=/usr/python/lib:/usr/local/lib \
+    LC_CTYPE=C.UTF-8 LC_MESSAGES=C.UTF-8 \
     PIP_CACHE_DIR=/tmp/.cache/pip \
     UV_CACHE_DIR=/tmp/.cache/uv
 
@@ -1794,11 +1801,9 @@ LABEL org.apache.airflow.distro="debian" \
 ARG BASE_IMAGE
 
 # Make sure noninteractive debian install is used and language variables set
-# as well as LD_LIBRARY_PATH to /usr/local/lib and /usr/python/lib is set, so that
-# shared libraries installed there are found
 ENV BASE_IMAGE=${BASE_IMAGE} \
     DEBIAN_FRONTEND=noninteractive LANGUAGE=C.UTF-8 LANG=C.UTF-8 LC_ALL=C.UTF-8 \
-    LC_CTYPE=C.UTF-8 LC_MESSAGES=C.UTF-8 LD_LIBRARY_PATH=/usr/python/lib:/usr/local/lib \
+    LC_CTYPE=C.UTF-8 LC_MESSAGES=C.UTF-8 \
     PIP_CACHE_DIR=/tmp/.cache/pip \
     UV_CACHE_DIR=/tmp/.cache/uv
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -137,7 +137,6 @@ function link_python() {
     # Links in /usr/local/bin are needed for tools that expect python to be there
     # Links in /usr/python/bin are needed for tools that are detecting home of python installation including
     # lib/site-packages. The /usr/python/bin should be first in PATH in order to help with the last part.
-    ldconfig
     for dst in pip3 python3 python3-config; do
         src="$(echo "${dst}" | tr -d 3)"
         echo "Linking ${dst} in /usr/local/bin and /usr/python/bin"
@@ -149,6 +148,16 @@ function link_python() {
             fi
         done
     done
+    for dst in /usr/python/lib/*
+    do
+        src="/usr/local/lib/$(basename "${dst}")"
+        if [[ -e "${src}" ]]; then
+            rm -rf "${src}"
+        fi
+        echo "Linking ${dst} to ${src}"
+        ln -sv "${dst}" "${src}"
+    done
+    ldconfig
 }
 
 function install_debian_runtime_dependencies() {
@@ -1365,11 +1374,9 @@ ARG AIRFLOW_IMAGE_REPOSITORY="https://github.com/apache/airflow"
 ARG DEPENDENCIES_EPOCH_NUMBER="15"
 
 # Make sure noninteractive debian install is used and language variables set
-# As well as LD_LIBRARY_PATH to /usr/local/lib and /usr/python/lib is set, so that
-# shared libraries installed there are found
 ENV BASE_IMAGE=${BASE_IMAGE} \
     DEBIAN_FRONTEND=noninteractive LANGUAGE=C.UTF-8 LANG=C.UTF-8 LC_ALL=C.UTF-8 \
-    LC_CTYPE=C.UTF-8 LC_MESSAGES=C.UTF-8 LD_LIBRARY_PATH=/usr/python/lib:/usr/local/lib \
+    LC_CTYPE=C.UTF-8 LC_MESSAGES=C.UTF-8 \
     DEPENDENCIES_EPOCH_NUMBER=${DEPENDENCIES_EPOCH_NUMBER} \
     INSTALL_MYSQL_CLIENT="true" \
     INSTALL_MSSQL_CLIENT="true" \

--- a/scripts/docker/install_os_dependencies.sh
+++ b/scripts/docker/install_os_dependencies.sh
@@ -119,7 +119,6 @@ function link_python() {
     # Links in /usr/local/bin are needed for tools that expect python to be there
     # Links in /usr/python/bin are needed for tools that are detecting home of python installation including
     # lib/site-packages. The /usr/python/bin should be first in PATH in order to help with the last part.
-    ldconfig
     for dst in pip3 python3 python3-config; do
         src="$(echo "${dst}" | tr -d 3)"
         echo "Linking ${dst} in /usr/local/bin and /usr/python/bin"
@@ -131,6 +130,16 @@ function link_python() {
             fi
         done
     done
+    for dst in /usr/python/lib/*
+    do
+        src="/usr/local/lib/$(basename "${dst}")"
+        if [[ -e "${src}" ]]; then
+            rm -rf "${src}"
+        fi
+        echo "Linking ${dst} to ${src}"
+        ln -sv "${dst}" "${src}"
+    done
+    ldconfig
 }
 
 function install_debian_runtime_dependencies() {


### PR DESCRIPTION
The #53770 changed the way how we build our Python image - we build python from released packages. We are building python - in order to be able to copy it between build and main images in PROD image in a separate /usr/python/ path and then we symbolically link it from /usr/local/lib for cpmpatibility with the original Python base images we used before.

Python in /usr/python is the first on the path so Python shoudl be used from there by default.

However in Python 3.11 (and only in Python 3.11) when hatch build backend build the package, apparently python is used from /usr/local/lib and there (even if LD_LIBRARY_PATH is properly set), python 3.11 run from /usr/local/lib, even if it is a symlink to the /usr/python/bin, expects to find dynamically linked python libraries in /usr/local/lib.

We also remove LD_LIBRARY_PATH that was set before to handle it (but not completely). Having symbolic links defined for lib entries in both places is a more complete solution with less side effects.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
