### PR TITLE
fix: skip scheduling for stale DAGs to prevent scheduler failures whe…

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -1837,6 +1837,12 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 self.log.error("Couldn't find DAG %s in DAG bag or database!", dag_run.dag_id)
                 return callback
 
+            # Handle stale DAGs (removed from filesystem but still have task instances in DB)
+            if dag_model.is_stale and not dag:
+                self.log.error("DAG %s is stale (removed from filesystem), skipping scheduling for DAG run %s",
+                    dag_run.dag_id, dag_run.run_id)
+                return callback
+
             if (
                 dag_run.start_date
                 and dag.dagrun_timeout


### PR DESCRIPTION
closes: #54932 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->

## Root Cause

- DAG removal marks `DagModel.is_stale=True` but doesn't handle existing task instances
- Scheduler's `_schedule_dag_run()` method calls `get_dag_for_run()` which returns `None` for removed DAGs  
- Current error handling logs the issue but continues processing, leading to repeated failures

## Solution

Added stale DAG detection in `_schedule_dag_run()` method in `scheduler_job_runner.py`:

1. **Check for stale DAGs**: Added condition `if dag_model.is_stale and not dag`
2. **Graceful handling**: Log warning and skip processing instead of failing
3. **Clean exit**: Return immediately to prevent scheduler errors

