### PR TITLE
Add ability to return number of affected rows to SpannerQueryDatabaseInstanceOperator

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/operators/spanner.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/spanner.py
@@ -280,8 +280,8 @@ class SpannerQueryDatabaseInstanceOperator(GoogleCloudBaseOperator):
             self.instance_id,
             self.database_id,
         )
-        self.log.info(queries)
-        hook.execute_dml(
+        self.log.info("Executing queries: %s", queries)
+        result_rows_count_per_query = hook.execute_dml(
             project_id=self.project_id,
             instance_id=self.instance_id,
             database_id=self.database_id,
@@ -293,6 +293,7 @@ class SpannerQueryDatabaseInstanceOperator(GoogleCloudBaseOperator):
             database_id=self.database_id,
             project_id=self.project_id or hook.project_id,
         )
+        return result_rows_count_per_query
 
     @staticmethod
     def sanitize_queries(queries: list[str]) -> None:

--- a/providers/google/tests/unit/google/cloud/hooks/test_spanner.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_spanner.py
@@ -17,9 +17,11 @@
 # under the License.
 from __future__ import annotations
 
+from collections import OrderedDict
 from unittest import mock
 from unittest.mock import MagicMock, PropertyMock
 
+import pytest
 import sqlalchemy
 
 from airflow.providers.google.cloud.hooks.spanner import SpannerHook
@@ -405,14 +407,14 @@ class TestGcpSpannerHookDefaultProjectId:
         res = self.spanner_hook_default_project_id.execute_dml(
             instance_id=SPANNER_INSTANCE,
             database_id=SPANNER_DATABASE,
-            queries="",
+            queries=[""],
             project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST,
         )
         get_client.assert_called_once_with(project_id="example-project")
         instance_method.assert_called_once_with(instance_id="instance")
         database_method.assert_called_once_with(database_id="database-name")
         run_in_transaction_method.assert_called_once_with(mock.ANY)
-        assert res is None
+        assert res == []
 
     @mock.patch("airflow.providers.google.cloud.hooks.spanner.SpannerHook._get_client")
     def test_execute_dml_overridden_project_id(self, get_client):
@@ -422,13 +424,75 @@ class TestGcpSpannerHookDefaultProjectId:
         database_method = instance_method.return_value.database
         run_in_transaction_method = database_method.return_value.run_in_transaction
         res = self.spanner_hook_default_project_id.execute_dml(
-            project_id="new-project", instance_id=SPANNER_INSTANCE, database_id=SPANNER_DATABASE, queries=""
+            project_id="new-project", instance_id=SPANNER_INSTANCE, database_id=SPANNER_DATABASE, queries=[""]
         )
         get_client.assert_called_once_with(project_id="new-project")
         instance_method.assert_called_once_with(instance_id="instance")
         database_method.assert_called_once_with(database_id="database-name")
         run_in_transaction_method.assert_called_once_with(mock.ANY)
-        assert res is None
+        assert res == []
+
+    @mock.patch("airflow.providers.google.cloud.hooks.spanner.SpannerHook._get_client")
+    def test_execute_dml_oqueries_row_count(self, get_client):
+        pass
+
+    @pytest.mark.parametrize(
+        "returned_items, expected_counts",
+        [
+            pytest.param(
+                [
+                    ("DELETE FROM T WHERE archived = TRUE", 5),
+                    ("SELECT * FROM T", 42),
+                    ("UPDATE U SET flag = FALSE WHERE x = 1", 3),
+                ],
+                [5, 3],
+            ),
+            pytest.param(
+                [
+                    ("DELETE FROM Logs WHERE created_at < '2024-01-01'", 7),
+                ],
+                [7],
+            ),
+            pytest.param(
+                [
+                    (
+                        "UPDATE Accounts SET active=false WHERE last_login < DATE_SUB(CURRENT_DATE(), INTERVAL 365 DAY)",
+                        11,
+                    ),
+                    ("DELETE FROM Sessions WHERE expires_at < CURRENT_TIMESTAMP()", 23),
+                ],
+                [11, 23],
+            ),
+            pytest.param(
+                [
+                    ("SELECT COUNT(*) FROM Users", 50000),
+                    ("SELECT * FROM BigTable", 123456),
+                ],
+                [],
+            ),
+            pytest.param(
+                [],
+                [],
+            ),
+        ],
+    )
+    @mock.patch("airflow.providers.google.cloud.hooks.spanner.SpannerHook._get_client")
+    def test_execute_dml_parametrized(self, get_client, returned_items, expected_counts):
+        instance_method = get_client.return_value.instance
+        database_method = instance_method.return_value.database
+        run_in_tx = database_method.return_value.run_in_transaction
+
+        returned_mapping = OrderedDict(returned_items)
+        run_in_tx.return_value = returned_mapping
+
+        res = self.spanner_hook_default_project_id.execute_dml(
+            instance_id=SPANNER_INSTANCE,
+            database_id=SPANNER_DATABASE,
+            queries=[sql for sql, _ in returned_items],
+            project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST,
+        )
+
+        assert res == expected_counts
 
     def test_get_uri(self):
         self.spanner_hook_default_project_id._get_conn_params = MagicMock(return_value=SPANNER_CONN_PARAMS)
@@ -682,13 +746,13 @@ class TestGcpSpannerHookNoDefaultProjectID:
             project_id=GCP_PROJECT_ID_HOOK_UNIT_TEST,
             instance_id=SPANNER_INSTANCE,
             database_id=SPANNER_DATABASE,
-            queries="",
+            queries=[""],
         )
         get_client.assert_called_once_with(project_id="example-project")
         instance_method.assert_called_once_with(instance_id="instance")
         database_method.assert_called_once_with(database_id="database-name")
         run_in_transaction_method.assert_called_once_with(mock.ANY)
-        assert res is None
+        assert res == []
 
     def test_get_uri(self):
         self.spanner_hook_no_default_project_id._get_conn_params = MagicMock(return_value=SPANNER_CONN_PARAMS)

--- a/providers/google/tests/unit/google/cloud/operators/test_spanner.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_spanner.py
@@ -250,7 +250,7 @@ class TestCloudSpanner:
 
     @mock.patch("airflow.providers.google.cloud.operators.spanner.SpannerHook")
     def test_instance_query(self, mock_hook):
-        mock_hook.return_value.execute_sql.return_value = None
+        mock_hook.return_value.execute_dml.return_value = [3]
         op = SpannerQueryDatabaseInstanceOperator(
             project_id=PROJECT_ID,
             instance_id=INSTANCE_ID,
@@ -258,8 +258,7 @@ class TestCloudSpanner:
             query=INSERT_QUERY,
             task_id="id",
         )
-        context = mock.MagicMock()
-        result = op.execute(context=context)
+        result = op.execute(context=mock.MagicMock())
         mock_hook.assert_called_once_with(
             gcp_conn_id="google_cloud_default",
             impersonation_chain=None,
@@ -267,11 +266,11 @@ class TestCloudSpanner:
         mock_hook.return_value.execute_dml.assert_called_once_with(
             project_id=PROJECT_ID, instance_id=INSTANCE_ID, database_id=DB_ID, queries=[INSERT_QUERY]
         )
-        assert result is None
+        assert result == [3]
 
     @mock.patch("airflow.providers.google.cloud.operators.spanner.SpannerHook")
     def test_instance_query_missing_project_id(self, mock_hook):
-        mock_hook.return_value.execute_sql.return_value = None
+        mock_hook.return_value.execute_dml.return_value = [3]
         op = SpannerQueryDatabaseInstanceOperator(
             instance_id=INSTANCE_ID, database_id=DB_ID, query=INSERT_QUERY, task_id="id"
         )
@@ -284,7 +283,7 @@ class TestCloudSpanner:
         mock_hook.return_value.execute_dml.assert_called_once_with(
             project_id=None, instance_id=INSTANCE_ID, database_id=DB_ID, queries=[INSERT_QUERY]
         )
-        assert result is None
+        assert result == [3]
 
     @pytest.mark.parametrize(
         "project_id, instance_id, database_id, query, exp_msg",


### PR DESCRIPTION
The current set of Spanner Airflow operators support DDL and DML statements, but neither return values from e.g. INSERTS nor queries.
With this change now the user will be able to get number of affected rows by the query as a return value from the SpannerQueryDatabaseInstanceOperator.
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
