### PR TITLE
Accept start_date as string in default_args when start_date is defined in dag constructor.

### DIFF
--- a/task-sdk/src/airflow/sdk/definitions/dag.py
+++ b/task-sdk/src/airflow/sdk/definitions/dag.py
@@ -458,7 +458,9 @@ class DAG:
     def __attrs_post_init__(self):
         from airflow.sdk import timezone
 
-        # Apply the timezone we settled on to end_date if it wasn't supplied
+        # Apply the timezone we settled on to start_date, end_date if it wasn't supplied
+        if isinstance(_start_date := self.default_args.get("start_date"), str):
+            self.default_args["start_date"] = timezone.parse(_start_date, timezone=self.timezone)
         if isinstance(_end_date := self.default_args.get("end_date"), str):
             self.default_args["end_date"] = timezone.parse(_end_date, timezone=self.timezone)
 

--- a/task-sdk/tests/task_sdk/definitions/test_dag.py
+++ b/task-sdk/tests/task_sdk/definitions/test_dag.py
@@ -73,7 +73,9 @@ class TestDag:
         DAG("DAG", schedule=None, default_args={"start_date": "2019-06-01"})
 
     def test_dag_naive_start_date_constructor_default_args_string(self):
-        DAG("DAG", start_date=DEFAULT_DATE, schedule=None, default_args={"start_date": "2019-06-01"})
+        dag = DAG("DAG", start_date=DEFAULT_DATE, schedule=None, default_args={"start_date": "2019-06-01"})
+
+        assert dag.start_date == DEFAULT_DATE
 
     def test_dag_naive_start_end_dates_strings(self):
         DAG("DAG", schedule=None, default_args={"start_date": "2019-06-01", "end_date": "2019-06-05"})

--- a/task-sdk/tests/task_sdk/definitions/test_dag.py
+++ b/task-sdk/tests/task_sdk/definitions/test_dag.py
@@ -72,6 +72,9 @@ class TestDag:
     def test_dag_naive_start_date_string(self):
         DAG("DAG", schedule=None, default_args={"start_date": "2019-06-01"})
 
+    def test_dag_naive_start_date_constructor_default_args_string(self):
+        DAG("DAG", start_date=DEFAULT_DATE, schedule=None, default_args={"start_date": "2019-06-01"})
+
     def test_dag_naive_start_end_dates_strings(self):
         DAG("DAG", schedule=None, default_args={"start_date": "2019-06-01", "end_date": "2019-06-05"})
 


### PR DESCRIPTION
Closes #55134 