### PR TITLE
Fix test_external_python tests setup

### DIFF
--- a/providers/standard/tests/unit/standard/decorators/test_external_python.py
+++ b/providers/standard/tests/unit/standard/decorators/test_external_python.py
@@ -33,7 +33,10 @@ if AIRFLOW_V_3_0_PLUS:
 else:
     from airflow.decorators import setup, task, teardown  # type: ignore[attr-defined,no-redef]
 
-from airflow.utils import timezone
+try:
+    from airflow.utils import timezone  # type: ignore[attr-defined]
+except AttributeError:
+    from airflow.sdk import timezone
 
 pytestmark = pytest.mark.db_test
 
@@ -67,7 +70,7 @@ def venv_python_with_cloudpickle_and_dill(tmp_path_factory):
     venv_dir = tmp_path_factory.mktemp("venv_serializers")
     venv.create(venv_dir, with_pip=True)
     python_path = (venv_dir / "bin" / "python").resolve(strict=True).as_posix()
-    subprocess.call([python_path, "-m", "pip", "install", "cloudpickle", "dill"])
+    subprocess.check_call([python_path, "-m", "pip", "install", "cloudpickle", "dill"])
     return python_path
 
 


### PR DESCRIPTION
There were two issues in this script:

* (less important) timezone had no airflow.sdk import
* (more important) the result of setting up of the venv has not been checked, so when the setup failed, the test continued (and failed much later with much less obvious reason why it failed).

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
