### PR TITLE
Add "No Response Received" required action state

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/_freeze_exemptions.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/_freeze_exemptions.json
@@ -7,6 +7,10 @@
   "dag": {},
   "dags": {},
   "dashboard": {},
-  "hitl": {},
+  "hitl": {
+    "state": {
+      "noResponseReceived": "No Response Received"
+    }
+  },
   "tasks": {}
 }

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/hitl.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/hitl.json
@@ -16,6 +16,7 @@
     "approvalRequired": "需要核准",
     "choiceReceived": "已選擇",
     "choiceRequired": "需要選擇",
+    "noResponseReceived": "未收到回應",
     "rejectionReceived": "已拒絕",
     "responseReceived": "已回應",
     "responseRequired": "需要回應"

--- a/airflow-core/src/airflow/ui/src/pages/HITLTaskInstances/HITLTaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/HITLTaskInstances/HITLTaskInstances.tsx
@@ -114,7 +114,7 @@ const taskInstanceColumns = ({
 ];
 
 export const HITLTaskInstances = () => {
-  const { t: translate } = useTranslation("hitl");
+  const { t: translate } = useTranslation(["hitl", "_freeze_exemptions"]);
   const { dagId, runId, taskId } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
   const { setTableURLState, tableURLState } = useTableURLState();

--- a/airflow-core/src/airflow/ui/src/utils/hitl.ts
+++ b/airflow-core/src/airflow/ui/src/utils/hitl.ts
@@ -167,9 +167,22 @@ export const getHITLFormData = (paramsDict: ParamsSpec, option?: string): HITLRe
 };
 
 export const getHITLState = (translate: TFunction, hitlDetail: HITLDetail) => {
-  const { chosen_options: chosenOptions, options, params, response_received: responseReceived } = hitlDetail;
+  const {
+    chosen_options: chosenOptions,
+    options,
+    params,
+    response_received: responseReceived,
+    task_instance: { state: taskInstanceState },
+  } = hitlDetail;
+
+  const isNotDeferred = taskInstanceState !== "deferred";
 
   let stateType: [string, string] = ["responseRequired", "responseReceived"];
+
+  if (!responseReceived && isNotDeferred) {
+    // need to update this after unfreezing hitl.json
+    return translate("_freeze_exemptions:hitl.state.noResponseReceived");
+  }
 
   if (options.length === 2 && options.includes("Approve") && options.includes("Reject")) {
     // If options contain only "Approve" and "Reject" -> approval task

--- a/airflow-core/src/airflow/ui/src/utils/hitl.ts
+++ b/airflow-core/src/airflow/ui/src/utils/hitl.ts
@@ -180,7 +180,7 @@ export const getHITLState = (translate: TFunction, hitlDetail: HITLDetail) => {
   let stateType: [string, string] = ["responseRequired", "responseReceived"];
 
   if (!responseReceived && isNotDeferred) {
-    // need to update this after unfreezing hitl.json
+    // TODO: update this after unfreezing hitl.json
     return translate("_freeze_exemptions:hitl.state.noResponseReceived");
   }
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Why

The required action needed better user feedback when it is not deferred and no response is received from the backend. Users were experiencing unclear states when the system couldn't retrieve task instance data, leading to confusion about whether the system was still loading or had encountered an error.

## How

- Added "No Response Received" to provide clear user feedback
- Updated HITL state logic to handle and display the "no response" state appropriately
<img width="3024" height="1810" alt="image" src="https://github.com/user-attachments/assets/cc5634d0-1b04-4bcf-9988-8af042e282ed" />


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
