### PR TITLE
Mark DagDetailsResponse.concurrency as deprecated

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dags.py
@@ -183,7 +183,7 @@ class DAGDetailsResponse(DAGResponse):
         return {k: v.dump() for k, v in params.items()}
 
     # Mypy issue https://github.com/python/mypy/issues/1362
-    @computed_field  # type: ignore[prop-decorator]
+    @computed_field(deprecated=True)  # type: ignore[prop-decorator]
     @property
     def concurrency(self) -> int:
         """

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -9684,6 +9684,7 @@ components:
 
 
             Deprecated: Use max_active_tasks instead.'
+          deprecated: true
           readOnly: true
         latest_dag_version:
           anyOf:

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -1953,6 +1953,7 @@ export const $DAGDetailsResponse = {
             description: `Return max_active_tasks as concurrency.
 
 Deprecated: Use max_active_tasks instead.`,
+            deprecated: true,
             readOnly: true
         },
         latest_dag_version: {

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -543,6 +543,7 @@ export type DAGDetailsResponse = {
      * Return max_active_tasks as concurrency.
      *
      * Deprecated: Use max_active_tasks instead.
+     * @deprecated
      */
     readonly concurrency: number;
     /**


### PR DESCRIPTION
Small follow up of https://github.com/apache/airflow/pull/54801

<img width="1737" height="698" alt="Screenshot 2025-09-01 at 17 27 43" src="https://github.com/user-attachments/assets/31db6fd4-1e06-40bb-b22e-dd41135e43a1" />
