### PR TITLE
Make StreamCaptureManager reset logging handlers on Python 3.13

### DIFF
--- a/devel-common/src/tests_common/test_utils/stream_capture_manager.py
+++ b/devel-common/src/tests_common/test_utils/stream_capture_manager.py
@@ -89,15 +89,12 @@ class StreamCaptureManager(ExitStack):
         original_handlers = list(root_logger.handlers)
 
         def reset_handlers():
-            from logging import _acquireLock, _releaseLock
+            from logging import _lock
 
             root_logger = logging.getLogger()
 
-            _acquireLock()
-            try:
+            with _lock:
                 root_logger.handlers = original_handlers
-            finally:
-                _releaseLock()
 
         self.callback(reset_handlers)
 


### PR DESCRIPTION
The approach I used worked up until 3.12, but the "with lock" approach works
all the way back to at least 3.9, and likely much further.

The price way pay for grubbing around in low level details of Logging module.

Follow up to #55153 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
