### PR TITLE
Alias `task_display_name` for `EventLogResponse`

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/event_logs.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/event_logs.py
@@ -41,6 +41,9 @@ class EventLogResponse(BaseModel):
     dag_display_name: str | None = Field(
         validation_alias=AliasPath("dag_model", "dag_display_name"), default=None
     )
+    task_display_name: str | None = Field(
+        validation_alias=AliasPath("task_instance", "task_display_name"), default=None
+    )
 
 
 class EventLogCollectionResponse(BaseModel):

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -10761,6 +10761,11 @@ components:
           - type: string
           - type: 'null'
           title: Dag Display Name
+        task_display_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Task Display Name
       type: object
       required:
       - event_log_id

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/event_logs.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/event_logs.py
@@ -21,6 +21,7 @@ from typing import Annotated
 
 from fastapi import Depends, HTTPException, status
 from sqlalchemy import select
+from sqlalchemy.orm import joinedload
 
 from airflow.api_fastapi.common.db.common import (
     SessionDep,
@@ -57,7 +58,9 @@ def get_event_log(
     event_log_id: int,
     session: SessionDep,
 ) -> EventLogResponse:
-    event_log = session.scalar(select(Log).where(Log.id == event_log_id))
+    event_log = session.scalar(
+        select(Log).where(Log.id == event_log_id).options(joinedload(Log.task_instance))
+    )
     if event_log is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"The Event Log with id: `{event_log_id}` not found")
     return event_log

--- a/airflow-core/src/airflow/models/log.py
+++ b/airflow-core/src/airflow/models/log.py
@@ -61,7 +61,7 @@ class Log(Base):
         viewonly=True,
         foreign_keys=[task_id],
         primaryjoin="Log.task_id == TaskInstance.task_id",
-        lazy="selectin",
+        lazy="noload",
     )
 
     __table_args__ = (

--- a/airflow-core/src/airflow/models/log.py
+++ b/airflow-core/src/airflow/models/log.py
@@ -56,6 +56,14 @@ class Log(Base):
         primaryjoin="Log.dag_id == DagModel.dag_id",
     )
 
+    task_instance = relationship(
+        "TaskInstance",
+        viewonly=True,
+        foreign_keys=[task_id],
+        primaryjoin="Log.task_id == TaskInstance.task_id",
+        lazy="selectin",
+    )
+
     __table_args__ = (
         Index("idx_log_dttm", dttm),
         Index("idx_log_event", event),

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -3363,6 +3363,17 @@ export const $EventLogResponse = {
                 }
             ],
             title: 'Dag Display Name'
+        },
+        task_display_name: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Task Display Name'
         }
     },
     type: 'object',

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -873,6 +873,7 @@ export type EventLogResponse = {
     owner: string | null;
     extra: string | null;
     dag_display_name?: string | null;
+    task_display_name?: string | null;
 };
 
 /**

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_event_logs.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_event_logs.py
@@ -32,6 +32,7 @@ DAG_ID = "TEST_DAG_ID"
 DAG_DISPLAY_NAME = "TEST_DAG_ID"
 DAG_RUN_ID = "TEST_DAG_RUN_ID"
 TASK_ID = "TEST_TASK_ID"
+TASK_DISPLAY_NAME = "TEST_TASK_ID"
 DAG_EXECUTION_DATE = datetime(2024, 6, 15, 0, 0, tzinfo=timezone.utc)
 OWNER = "TEST_OWNER"
 OWNER_DISPLAY_NAME = "Test Owner"
@@ -135,6 +136,7 @@ class TestGetEventLog(TestEventLogsEndpoint):
                     "owner": OWNER_AIRFLOW,
                     "run_id": DAG_RUN_ID,
                     "task_id": TASK_ID,
+                    "task_display_name": TASK_DISPLAY_NAME,
                 },
             ),
             (
@@ -148,6 +150,7 @@ class TestGetEventLog(TestEventLogsEndpoint):
                     "owner": OWNER,
                     "run_id": DAG_RUN_ID,
                     "task_id": TASK_ID,
+                    "task_display_name": TASK_DISPLAY_NAME,
                     "try_number": 0,
                 },
             ),
@@ -168,6 +171,7 @@ class TestGetEventLog(TestEventLogsEndpoint):
             "dag_display_name": expected_body.get("dag_display_name"),
             "dag_id": expected_body.get("dag_id"),
             "task_id": expected_body.get("task_id"),
+            "task_display_name": expected_body.get("task_display_name"),
             "run_id": expected_body.get("run_id"),
             "map_index": event_log.map_index,
             "try_number": event_log.try_number,

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -456,6 +456,7 @@ class EventLogResponse(BaseModel):
     owner: Annotated[str | None, Field(title="Owner")] = None
     extra: Annotated[str | None, Field(title="Extra")] = None
     dag_display_name: Annotated[str | None, Field(title="Dag Display Name")] = None
+    task_display_name: Annotated[str | None, Field(title="Task Display Name")] = None
 
 
 class ExternalLogUrlResponse(BaseModel):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Related Issue

#46730

## How

- alias the `task_display_name` for `EventLogResponse`
- update related tests

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
