### PR TITLE
added DBT job run id to XCom in DbtCloudRunJobOperator

### DIFF
--- a/providers/dbt/cloud/src/airflow/providers/dbt/cloud/operators/dbt.py
+++ b/providers/dbt/cloud/src/airflow/providers/dbt/cloud/operators/dbt.py
@@ -192,9 +192,11 @@ class DbtCloudRunJobOperator(BaseOperator):
             self.run_id = trigger_job_response.json()["data"]["id"]
             job_run_url = trigger_job_response.json()["data"]["href"]
 
-        # Push the ``job_run_url`` value to XCom regardless of what happens during execution so that the job
-        # run can be monitored via the operator link.
+        # Push the ``job_run_url`` and ``job_run_id`` value to XCom regardless of what happens during execution.
+        # This enables job monitoring via the operator link and provides direct access
+        # to the job run ID without requiring users to parse the URL manually
         context["ti"].xcom_push(key="job_run_url", value=job_run_url)
+        context["ti"].xcom_push(key="job_run_id", value=self.run_id)
 
         if self.wait_for_termination and isinstance(self.run_id, int):
             if self.deferrable is False:


### PR DESCRIPTION
# Summary
Modified `DbtCloudRunJobOperator` to push both `run_job_id` and `run_job_url` to XCom.

## Problem
Currently, DBT job run ID is only returned as the operator result when the task completes successfully. To obtain the ID from a failed task, users must parse it from the `run_job_url`.

## Solution
The operator now automatically pushes run_job_id to XCom regardless of task outcome, making it accessible for downstream operations even when the `DbtCloudRunJobOperator` fails.

## Benefits
- Eliminates need for manual URL parsing to extract run job ID
- Enables downstream tasks to operate on the run job ID even after task failures

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
