### PR TITLE
Improve state handling UI for pending required actions

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/HITLTaskInstances/HITLResponseForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/HITLTaskInstances/HITLResponseForm.tsx
@@ -65,6 +65,8 @@ export const HITLResponseForm = ({ hitlDetail }: HITLResponseFormProps) => {
   const shouldRenderOptionButton =
     hitlDetail.options.length < 4 && !hitlDetail.multiple && preloadedHITLOptions.length === 0;
 
+  const isPending = hitlDetail.task_instance.state === "deferred";
+
   const { updateHITLResponse } = useUpdateHITLDetail({
     dagId: hitlDetail.task_instance.dag_id,
     dagRunId: hitlDetail.task_instance.dag_run_id,
@@ -107,7 +109,7 @@ export const HITLResponseForm = ({ hitlDetail }: HITLResponseFormProps) => {
         variant="enclosed"
       >
         <FlexibleForm
-          disabled={hitlDetail.response_received}
+          disabled={!isPending || hitlDetail.response_received}
           flexFormDescription={hitlDetail.body ?? undefined}
           flexibleFormDefaultSection={hitlDetail.subject}
           initialParamsDict={{
@@ -127,7 +129,7 @@ export const HITLResponseForm = ({ hitlDetail }: HITLResponseFormProps) => {
             hitlDetail.options.map((option) => (
               <Button
                 colorPalette={isHighlightOption(option, hitlDetail, preloadedHITLOptions) ? "blue" : "gray"}
-                disabled={errors || isSubmitting || hitlDetail.response_received}
+                disabled={errors || isSubmitting || !isPending || hitlDetail.response_received}
                 key={option}
                 onClick={() => handleSubmit(option)}
                 variant={isHighlightOption(option, hitlDetail, preloadedHITLOptions) ? "solid" : "subtle"}

--- a/airflow-core/src/airflow/ui/src/pages/HITLTaskInstances/HITLTaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/HITLTaskInstances/HITLTaskInstances.tsx
@@ -129,6 +129,7 @@ export const HITLTaskInstances = () => {
     offset: pagination.pageIndex * pagination.pageSize,
     orderBy: sort ? [`${sort.desc ? "-" : ""}${sort.id}`] : [],
     responseReceived: Boolean(responseReceived) ? responseReceived === "true" : undefined,
+    state: responseReceived === "false" ? ["deferred"] : undefined,
     taskId,
   });
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Why

1. The form allowed interaction with tasks regardless of their state. Users would attempt to respond to tasks that are no longer in pending.
2. The "pending" filter was showing all tasks with responseReceived: false, regardless of their actual state. Users couldn't distinguish which one is truly needed action and be confused.

cc @Lee-W @bbovenzi 

## How

- Disabled the form and buttons when task is not pending
<img width="3024" height="1810" alt="image" src="https://github.com/user-attachments/assets/c04c467a-c587-44d3-a602-b4387faff26e" />


- Only shows deferred tasks when "pending" is selected, otherwise shows all tasks
<img width="3024" height="1810" alt="image" src="https://github.com/user-attachments/assets/c05cb157-c068-4d22-8f8b-b0abc08e9c93" />
<img width="3024" height="1810" alt="image" src="https://github.com/user-attachments/assets/f47a4db8-41a8-4913-b6f0-c5453c4cdeb6" />



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
