### PR TITLE
Fix: Cannot set operator_extra_links in __init__ for dynamically-mapped operators (#54778)

### DIFF
--- a/devel-common/src/tests_common/test_utils/mock_operators.py
+++ b/devel-common/src/tests_common/test_utils/mock_operators.py
@@ -198,3 +198,22 @@ class GithubLink(BaseOperatorLink):
 
     def get_link(self, operator, *, ti_key):
         return "https://github.com/apache/airflow"
+
+
+class InitCustomLink(BaseOperatorLink):
+    name = "Google"
+
+    def get_link(self, operator, ti_key):
+        return "https://www.google.com"
+
+
+class InitExtraLinksOperator(BaseOperator):
+    """Custom operator to test operator_extra_links defined in __init__."""
+
+    def __init__(self, value=None, **kwargs):
+        super().__init__(**kwargs)
+        self.value = value
+        self.operator_extra_links = (InitCustomLink(),)
+
+    def execute(self, context):
+        pass


### PR DESCRIPTION
### What this PR does
Fixes an issue where operator extra links defined dynamically inside
`__init__` were not available in the `/links` API or the UI, because
they weren’t included in the serialized DAG.

This change makes the API fall back to runtime XCom entries
(`_link_*` keys) whenever links are missing or `None` in the task
definition.

### Why this change is needed
Before:
- Operators that defined `self.operator_extra_links = (...)` in
  `__init__` did not display links in the Task Instance details page
  or API.
- Dynamically-mapped tasks were particularly affected, as they never
  serialized these links.

After:
- Links defined in `__init__` are correctly retrieved from XCom and
  displayed in both the API and the UI.
- Works for both single tasks and dynamically-mapped tasks.

### Tests added
- `test_should_fallback_to_xcom_for_init_defined_links`
- `test_should_fallback_to_xcom_for_init_defined_links_mapped`

These confirm that runtime XCom links are returned correctly for both
single and mapped operators.

### Related issue
Closes https://github.com/apache/airflow/issues/54778


### Below find the screenshots

<img width="1777" height="539" alt="Screenshot from 2025-09-03 02-49-40" src="https://github.com/user-attachments/assets/f858cf2e-d921-4c5f-8ae4-85ef78d93fe7" />


<img width="1777" height="539" alt="Screenshot from 2025-09-03 02-49-50" src="https://github.com/user-attachments/assets/8f85b3e5-1c72-4b89-ba7e-72fdeddac89c" />


<img width="1777" height="539" alt="Screenshot from 2025-09-03 02-50-07" src="https://github.com/user-attachments/assets/dc5866f9-93ff-497d-8c9b-e6a0e9ec13f9" />


<img width="1777" height="539" alt="Screenshot from 2025-09-03 02-50-18" src="https://github.com/user-attachments/assets/104da985-ba8e-4e28-a9fa-27bd78ea960b" />

