### PR TITLE
Fix dataflow java streaming operator infinite run

### DIFF
--- a/providers/apache/beam/src/airflow/providers/apache/beam/operators/beam.py
+++ b/providers/apache/beam/src/airflow/providers/apache/beam/operators/beam.py
@@ -620,6 +620,16 @@ class BeamRunJavaPipelineOperator(BeamBasePipelineOperator):
                 variables=self.pipeline_options,
                 location=self.dataflow_config.location,
             )
+            if is_running and self.pipeline_options.get("streaming"):
+                self.log.warning(
+                    "Stop execution, as dataflow streaming job name: %s is found in a state: RUNNING. "
+                    "If you want to submit a new job, please pass the dataflow config option"
+                    " check_if_running=False or another unique job_name.",
+                    self.dataflow_job_name,
+                )
+                # Since there is no way to get job_id, skip link construction.
+                self.operator_extra_links = ()
+                return {"dataflow_job_id": None}
 
         if not is_running:
             self.pipeline_options["jobName"] = self.dataflow_job_name

--- a/providers/apache/beam/tests/unit/apache/beam/operators/test_beam.py
+++ b/providers/apache/beam/tests/unit/apache/beam/operators/test_beam.py
@@ -495,6 +495,29 @@ class TestBeamRunJavaPipelineOperator:
 
         dataflow_cancel_job.assert_not_called()
 
+    @mock.patch(BEAM_OPERATOR_PATH.format("DataflowJobLink.persist"))
+    @mock.patch(BEAM_OPERATOR_PATH.format("BeamHook"))
+    @mock.patch(BEAM_OPERATOR_PATH.format("DataflowHook"))
+    @mock.patch(BEAM_OPERATOR_PATH.format("GCSHook"))
+    def test_dataflow_streaming_not_stuck(
+        self, gcs_hook, dataflow_hook_mock, beam_hook_mock, persist_link_mock
+    ):
+        """Check that start java streaming pipeline does not enter infinite loop,
+        when streaming pipeline with the same prefix is already running and check_is_running=True"""
+        dataflow_config = DataflowConfiguration()
+        op_kwargs = copy.deepcopy(self.default_op_kwargs)
+        op_kwargs["pipeline_options"]["streaming"] = True
+        dataflow_hook_mock.return_value.is_job_dataflow_running.return_value = True
+        start_java_mock = beam_hook_mock.return_value.start_java_pipeline
+
+        op = BeamRunJavaPipelineOperator(
+            **op_kwargs, dataflow_config=dataflow_config, runner="DataflowRunner"
+        )
+        res = op.execute({})
+
+        start_java_mock.assert_not_called()
+        assert res == {"dataflow_job_id": None}
+
 
 class TestBeamRunGoPipelineOperator:
     @pytest.fixture(autouse=True)

--- a/providers/google/tests/system/google/cloud/dataflow/example_dataflow_java_streaming.py
+++ b/providers/google/tests/system/google/cloud/dataflow/example_dataflow_java_streaming.py
@@ -129,7 +129,7 @@ with DAG(
             "streaming": True,
         },
         dataflow_config={
-            "job_name": f"java-streaming-job-{ENV_ID}",
+            "job_name": f"java-streaming-job-def-{ENV_ID}",
             "location": LOCATION,
         },
         deferrable=True,
@@ -164,13 +164,13 @@ with DAG(
         # TEST SETUP
         create_bucket
         >> download_file
-        >> create_output_pub_sub_topic
-        >> create_output_pub_sub_topic_2
+        >> [create_output_pub_sub_topic, create_output_pub_sub_topic_2]
         # TEST BODY
         >> start_java_streaming_job_dataflow
+        >> stop_dataflow_job
         >> start_java_streaming_job_dataflow_def
+        >> stop_dataflow_job_deferrable
         # TEST TEARDOWN
-        >> [stop_dataflow_job, stop_dataflow_job_deferrable]
         >> delete_topic
         >> delete_topic_2
         >> delete_bucket


### PR DESCRIPTION
- With previous implementation operator might end up with infinite execution: if the streaming job with the same prefix is already running, and the new one submitted with 'check_if_running=True' (by default).

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
