### PR TITLE
Prevent register multiple FastAPI plugins using same name

### DIFF
--- a/airflow-core/src/airflow/plugins_manager.py
+++ b/airflow-core/src/airflow/plugins_manager.py
@@ -312,7 +312,7 @@ def load_plugins_from_plugin_directory():
                             f"Please set the 'name' attribute for the plugin class."
                         )
                     if plugin_name in plugin_names:
-                        raise AirflowPluginException("Duplicate plugin name found in {file_path}. ")
+                        raise AirflowPluginException(f"Duplicate plugin name found in {file_path}. ")
                     plugin_names[plugin_name] = plugin_class
                 
                 # Second pass: register all plugins

--- a/airflow-core/src/airflow/plugins_manager.py
+++ b/airflow-core/src/airflow/plugins_manager.py
@@ -300,7 +300,7 @@ def load_plugins_from_plugin_directory():
 
                 # First pass: collect all plugin classes in this file
                 plugin_classes = [m for m in mod.__dict__.values() if is_valid_plugin(m)]
-                
+
                 # Check for duplicate plugin names within the same file
                 plugin_names = {}
                 for plugin_class in plugin_classes:
@@ -314,7 +314,7 @@ def load_plugins_from_plugin_directory():
                     if plugin_name in plugin_names:
                         raise AirflowPluginException(f"Duplicate plugin name found in {file_path}. ")
                     plugin_names[plugin_name] = plugin_class
-                
+
                 # Second pass: register all plugins
                 for plugin_class in plugin_classes:
                     try:

--- a/airflow-core/tests/unit/plugins/test_plugins_manager.py
+++ b/airflow-core/tests/unit/plugins/test_plugins_manager.py
@@ -385,7 +385,7 @@ from airflow.plugins_manager import AirflowPlugin
 
 class FirstPlugin(AirflowPlugin):
     name = "test_duplicate_plugin"
-    
+
 class SecondPlugin(AirflowPlugin):
     name = "test_duplicate_plugin"
 """
@@ -401,11 +401,10 @@ class SecondPlugin(AirflowPlugin):
             assert "Duplicate plugin name found in" in received_logs
             assert str(plugin_file) in received_logs
             assert "test_duplicate_plugin" in received_logs
-                
             # Verify the error was added to import_errors
             assert any("Duplicate plugin name" in str(e) for e in plugins_manager.import_errors.values())
-                
-                          
+
+
 class TestPluginsDirectorySource:
     def test_should_return_correct_path_name(self):
         from airflow import plugins_manager

--- a/airflow-core/tests/unit/plugins/test_plugins_manager.py
+++ b/airflow-core/tests/unit/plugins/test_plugins_manager.py
@@ -375,7 +375,7 @@ class TestPluginsManager:
             plugins_manager.load_providers_plugins()
             assert len(plugins_manager.plugins) == 4
 
-    def test_duplicate_plugin_names_are_reported(self, tmp_path, caplog):
+    def test_duplicate_plugin_names_are_reported(self, caplog, tmp_path):
         """Test that duplicate plugin names are properly reported in logs and import_errors."""
         from airflow import plugins_manager
 
@@ -389,20 +389,21 @@ class FirstPlugin(AirflowPlugin):
 class SecondPlugin(AirflowPlugin):
     name = "test_duplicate_plugin"
 """
-        plugin_file = tmp_path / "test_duplicate_plugin.py"
-        plugin_file.write_text(plugin_content)
+        with mock.patch("airflow.plugins_manager.plugins", []):
+            plugin_file = tmp_path / "test_duplicate_plugin.py"
+            plugin_file.write_text(plugin_content)
 
-        with conf_vars({("core", "plugins_folder"): os.fspath(tmp_path)}):
-            with caplog.at_level(logging.ERROR, logger="airflow.plugins_manager"):
+            with conf_vars({("core", "plugins_folder"): os.fspath(tmp_path)}):
                 plugins_manager.load_plugins_from_plugin_directory()
 
-                # Verify the error was logged
-                assert "Duplicate plugin name found in" in caplog.text
-                assert str(plugin_file) in caplog.text
-                assert "test_duplicate_plugin" in caplog.text
+            received_logs = caplog.text
+            # Verify the error was logged
+            assert "Duplicate plugin name found in" in received_logs
+            assert str(plugin_file) in received_logs
+            assert "test_duplicate_plugin" in received_logs
                 
-                # Verify the error was added to import_errors
-                assert any("Duplicate plugin name" in str(e) for e in plugins_manager.import_errors.values())
+            # Verify the error was added to import_errors
+            assert any("Duplicate plugin name" in str(e) for e in plugins_manager.import_errors.values())
                 
                           
 class TestPluginsDirectorySource:


### PR DESCRIPTION
closes: #55140 
related: #55140 


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
