### PR TITLE
Fix external_links for plugins, url_route undefined

### DIFF
--- a/airflow-core/src/airflow/plugins_manager.py
+++ b/airflow-core/src/airflow/plugins_manager.py
@@ -393,8 +393,10 @@ def initialize_ui_plugins():
 
     for plugin in plugins:
         for external_view in plugin.external_views:
-            url_route = external_view["url_route"]
-            if url_route is not None and url_route in seen_url_route:
+            url_route = external_view.get("url_route")
+            if url_route is None:
+                continue
+            if url_route in seen_url_route:
                 log.warning(
                     "Plugin '%s' has an external view with an URL route '%s' "
                     "that conflicts with another plugin '%s'. The view will not be loaded.",
@@ -411,8 +413,10 @@ def initialize_ui_plugins():
             seen_url_route[url_route] = plugin.name
 
         for react_app in plugin.react_apps:
-            url_route = react_app["url_route"]
-            if url_route is not None and url_route in seen_url_route:
+            url_route = react_app.get("url_route")
+            if url_route is None:
+                continue
+            if url_route in seen_url_route:
                 log.warning(
                     "Plugin '%s' has a React App with an URL route '%s' "
                     "that conflicts with another plugin '%s'. The React App will not be loaded.",

--- a/airflow-core/tests/unit/plugins/test_plugins_manager.py
+++ b/airflow-core/tests/unit/plugins/test_plugins_manager.py
@@ -161,7 +161,7 @@ class TestPluginsManager:
         class TestPluginA(AirflowPlugin):
             name = "test_plugin_a"
 
-            external_views = [{"url_route": "/test_route"}]
+            external_views = [{"url_route": "/test_route"}, {"wrong_view": "/no_url_route"}]
 
         class TestPluginB(AirflowPlugin):
             name = "test_plugin_b"


### PR DESCRIPTION
If the `url_route` is missing, it shouldn't crash the api server, but be considered as an 'external_link', similarly to `"url_route": None`.

This fixes that.

Related: https://github.com/apache/airflow/issues/55142