### PR TITLE
[docs][provider:keycloak] Fix Installation text (Airflow 2 -> Airflow 3) 

### DIFF
--- a/providers/keycloak/docs/index.rst
+++ b/providers/keycloak/docs/index.rst
@@ -91,9 +91,13 @@ All classes for this package are included in the ``airflow.providers.keycloak`` 
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing **Airflow 3** installation via
 ``pip install apache-airflow-providers-keycloak``.
 For the minimum Airflow version supported, see ``Requirements`` below.
+
+.. note::
+This provider requires **Apache Airflow >= 3.0.0**. Installing it on Airflow 2.x is not supported and
+will raise a ``RuntimeError`` at import time.
 
 Requirements
 ------------


### PR DESCRIPTION
docs(keycloak): fix contradictory Installation text

- Replace "install on Airflow 2" with "Airflow 3" in the provider's Installation
  page to match the stated minimum requirement (>= 3.0.0) and runtime guard.
- Add a note clarifying that installing on Airflow 2.x is unsupported and raises
  RuntimeError.

Refs:
- https://airflow.apache.org/docs/apache-airflow-providers-keycloak/0.0.1/#installation
- airflow/providers/keycloak/__init__.py version check (requires >=3.0.0)