### PR TITLE
Doc: Add DAG bundles triggerer limitation

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -600,6 +600,10 @@ Airflow 3.0 introduces native DAG versioning. DAG structure changes (e.g., renam
 tracked directly in the metadata database. This allows users to inspect historical DAG structures through the UI and API,
 and lays the foundation for safer backfills, improved observability, and runtime-determined DAG logic.
 
+**Note**: DAG bundles are not initialized in the triggerer. In practice, this means that triggers cannot come from a
+DAG bundle. This is because the triggerer does not deal with changes in trigger code over time, as everything happens
+in the main process. Triggers can come from anywhere else on ``sys.path`` instead.
+
 React UI Rewrite (AIP-38, AIP-84)
 """""""""""""""""""""""""""""""""
 
@@ -1023,6 +1027,16 @@ been **moved to the new ``[api]`` section**. The following configuration keys ha
 - ``[webserver] web_server_ssl_cert`` → ``[api] ssl_cert``
 - ``[webserver] web_server_ssl_key`` → ``[api] ssl_key``
 - ``[webserver] access_logfile`` → ``[api] access_logfile``
+
+The following DAG parsing configuration options were **moved to the new ``[dag_processor]`` section**:
+
+- ``[core] dag_file_processor_timeout`` → ``[dag_processor] dag_file_processor_timeout``
+- ``[scheduler] parsing_processes`` → ``[dag_processor] parsing_processes``
+- ``[scheduler] file_parsing_sort_mode`` → ``[dag_processor] file_parsing_sort_mode``
+- ``[scheduler] max_callbacks_per_loop`` → ``[dag_processor] max_callbacks_per_loop``
+- ``[scheduler] min_file_process_interval`` → ``[dag_processor] min_file_process_interval``
+- ``[scheduler] stale_dag_threshold`` → ``[dag_processor] stale_dag_threshold``
+- ``[scheduler] print_stats_interval`` → ``[dag_processor] print_stats_interval``
 
 Users should review their ``airflow.cfg`` files or use the ``airflow config lint`` command to identify outdated or
 removed options.

--- a/airflow-core/docs/administration-and-deployment/dag-bundles.rst
+++ b/airflow-core/docs/administration-and-deployment/dag-bundles.rst
@@ -165,3 +165,8 @@ Other Considerations
 - **Concurrency**: Workers may create many bundles simultaneously, and does nothing to serialize calls to the bundle objects. Thus, the bundle class must handle locking if
   that is problematic for the underlying technology. For example, if you are cloning a git repo, the bundle class is responsible for locking to ensure only 1 bundle
   object is cloning at a time. There is a ``lock`` method in the base class that can be used for this purpose, if necessary.
+
+- **Triggerer Limitation**: DAG bundles are not initialized in the triggerer component. In practice, this means that triggers cannot come from a DAG bundle.
+  This is because the triggerer does not deal with changes in trigger code over time, as everything happens in the main process.
+  Triggers can come from anywhere else on ``sys.path`` instead. If you need to use custom triggers, ensure they are available in the Python environment's
+  ``sys.path`` rather than being sourced from DAG bundles.

--- a/reproducible_build.yaml
+++ b/reproducible_build.yaml
@@ -1,2 +1,2 @@
-release-notes-hash: 81e41c5508d536a674c6ebdced78aeaf
-source-date-epoch: 1756547695
+release-notes-hash: 5608b8ff344d72dd3417308a3d711c8a
+source-date-epoch: 1756939245


### PR DESCRIPTION
Document that DAG bundles are not initialized in triggerer and added DAG processor configuration section movements to release notes.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
