### PR TITLE
Fix Airflow 2 reference in README/index of providers

### DIFF
--- a/dev/breeze/src/airflow_breeze/templates/PROVIDER_INDEX_TEMPLATE.rst.jinja2
+++ b/dev/breeze/src/airflow_breeze/templates/PROVIDER_INDEX_TEMPLATE.rst.jinja2
@@ -57,7 +57,7 @@ All classes for this package are included in the ``{{FULL_PACKAGE_NAME}}`` pytho
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install {{PACKAGE_PIP_NAME}}``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/dev/breeze/src/airflow_breeze/templates/PROVIDER_README_TEMPLATE.rst.jinja2
+++ b/dev/breeze/src/airflow_breeze/templates/PROVIDER_README_TEMPLATE.rst.jinja2
@@ -70,7 +70,7 @@ in the `documentation <https://airflow.apache.org/docs/{{ PACKAGE_PIP_NAME }}/{{
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install {{PACKAGE_PIP_NAME}}``
 

--- a/providers/airbyte/README.rst
+++ b/providers/airbyte/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-airbyte``
 

--- a/providers/airbyte/docs/index.rst
+++ b/providers/airbyte/docs/index.rst
@@ -89,7 +89,7 @@ All classes for this package are included in the ``airflow.providers.airbyte`` p
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-airbyte``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/alibaba/README.rst
+++ b/providers/alibaba/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-alibaba``
 

--- a/providers/alibaba/docs/index.rst
+++ b/providers/alibaba/docs/index.rst
@@ -90,7 +90,7 @@ All classes for this package are included in the ``airflow.providers.alibaba`` p
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-alibaba``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/amazon/README.rst
+++ b/providers/amazon/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-amazon``
 

--- a/providers/amazon/docs/index.rst
+++ b/providers/amazon/docs/index.rst
@@ -100,7 +100,7 @@ All classes for this package are included in the ``airflow.providers.amazon`` py
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-amazon``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/apache/beam/README.rst
+++ b/providers/apache/beam/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-apache-beam``
 

--- a/providers/apache/beam/docs/index.rst
+++ b/providers/apache/beam/docs/index.rst
@@ -88,7 +88,7 @@ All classes for this package are included in the ``airflow.providers.apache.beam
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-apache-beam``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/apache/beam/src/airflow/providers/apache/beam/README.md
+++ b/providers/apache/beam/src/airflow/providers/apache/beam/README.md
@@ -39,7 +39,7 @@ are in `airflow.providers.apache.beam` python package.
 
 ## Installation
 
-You can install this package on top of an existing airflow 2.* installation via
+You can install this package on top of an existing Airflow.* installation via
 `pip install apache-airflow-providers-apache-beam`
 
 ## Cross provider package dependencies

--- a/providers/apache/cassandra/README.rst
+++ b/providers/apache/cassandra/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-apache-cassandra``
 

--- a/providers/apache/cassandra/docs/index.rst
+++ b/providers/apache/cassandra/docs/index.rst
@@ -89,7 +89,7 @@ All classes for this package are included in the ``airflow.providers.apache.cass
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-apache-cassandra``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/apache/drill/README.rst
+++ b/providers/apache/drill/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-apache-drill``
 

--- a/providers/apache/drill/docs/index.rst
+++ b/providers/apache/drill/docs/index.rst
@@ -89,7 +89,7 @@ All classes for this package are included in the ``airflow.providers.apache.dril
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-apache-drill``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/apache/druid/README.rst
+++ b/providers/apache/druid/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-apache-druid``
 

--- a/providers/apache/druid/docs/index.rst
+++ b/providers/apache/druid/docs/index.rst
@@ -89,7 +89,7 @@ All classes for this package are included in the ``airflow.providers.apache.drui
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-apache-druid``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/apache/flink/README.rst
+++ b/providers/apache/flink/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-apache-flink``
 

--- a/providers/apache/flink/docs/index.rst
+++ b/providers/apache/flink/docs/index.rst
@@ -81,7 +81,7 @@ All classes for this package are included in the ``airflow.providers.apache.flin
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-apache-flink``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/apache/hdfs/README.rst
+++ b/providers/apache/hdfs/README.rst
@@ -43,7 +43,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-apache-hdfs``
 

--- a/providers/apache/hdfs/docs/index.rst
+++ b/providers/apache/hdfs/docs/index.rst
@@ -78,7 +78,7 @@ All classes for this package are included in the ``airflow.providers.apache.hdfs
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-apache-hdfs``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/apache/hive/README.rst
+++ b/providers/apache/hive/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-apache-hive``
 

--- a/providers/apache/hive/docs/index.rst
+++ b/providers/apache/hive/docs/index.rst
@@ -92,7 +92,7 @@ All classes for this package are included in the ``airflow.providers.apache.hive
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-apache-hive``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/apache/iceberg/README.rst
+++ b/providers/apache/iceberg/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-apache-iceberg``
 

--- a/providers/apache/iceberg/docs/index.rst
+++ b/providers/apache/iceberg/docs/index.rst
@@ -86,7 +86,7 @@ All classes for this package are included in the ``airflow.providers.apache.iceb
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-apache-iceberg``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/apache/impala/README.rst
+++ b/providers/apache/impala/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-apache-impala``
 

--- a/providers/apache/impala/docs/index.rst
+++ b/providers/apache/impala/docs/index.rst
@@ -97,7 +97,7 @@ All classes for this package are included in the ``airflow.providers.apache.impa
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-apache-impala``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/apache/kafka/README.rst
+++ b/providers/apache/kafka/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-apache-kafka``
 

--- a/providers/apache/kafka/docs/index.rst
+++ b/providers/apache/kafka/docs/index.rst
@@ -96,7 +96,7 @@ All classes for this package are included in the ``airflow.providers.apache.kafk
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-apache-kafka``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/apache/kylin/README.rst
+++ b/providers/apache/kylin/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-apache-kylin``
 

--- a/providers/apache/kylin/docs/index.rst
+++ b/providers/apache/kylin/docs/index.rst
@@ -90,7 +90,7 @@ All classes for this package are included in the ``airflow.providers.apache.kyli
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-apache-kylin``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/apache/livy/README.rst
+++ b/providers/apache/livy/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-apache-livy``
 

--- a/providers/apache/livy/docs/index.rst
+++ b/providers/apache/livy/docs/index.rst
@@ -89,7 +89,7 @@ All classes for this package are included in the ``airflow.providers.apache.livy
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-apache-livy``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/apache/pig/README.rst
+++ b/providers/apache/pig/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-apache-pig``
 

--- a/providers/apache/pig/docs/index.rst
+++ b/providers/apache/pig/docs/index.rst
@@ -88,7 +88,7 @@ All classes for this package are included in the ``airflow.providers.apache.pig`
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-apache-pig``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/apache/pinot/README.rst
+++ b/providers/apache/pinot/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-apache-pinot``
 

--- a/providers/apache/pinot/docs/index.rst
+++ b/providers/apache/pinot/docs/index.rst
@@ -83,7 +83,7 @@ All classes for this package are included in the ``airflow.providers.apache.pino
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-apache-pinot``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/apache/spark/README.rst
+++ b/providers/apache/spark/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-apache-spark``
 

--- a/providers/apache/spark/docs/index.rst
+++ b/providers/apache/spark/docs/index.rst
@@ -90,7 +90,7 @@ All classes for this package are included in the ``airflow.providers.apache.spar
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-apache-spark``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/apache/tinkerpop/README.rst
+++ b/providers/apache/tinkerpop/README.rst
@@ -44,7 +44,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-apache-tinkerpop``
 

--- a/providers/apache/tinkerpop/docs/index.rst
+++ b/providers/apache/tinkerpop/docs/index.rst
@@ -91,7 +91,7 @@ All classes for this package are included in the ``airflow.providers.apache.tink
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-apache-tinkerpop``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/apprise/README.rst
+++ b/providers/apprise/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-apprise``
 

--- a/providers/apprise/docs/index.rst
+++ b/providers/apprise/docs/index.rst
@@ -77,7 +77,7 @@ All classes for this package are included in the ``airflow.providers.apprise`` p
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-apprise``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/arangodb/README.rst
+++ b/providers/arangodb/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-arangodb``
 

--- a/providers/arangodb/docs/index.rst
+++ b/providers/arangodb/docs/index.rst
@@ -83,7 +83,7 @@ All classes for this package are included in the ``airflow.providers.arangodb`` 
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-arangodb``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/asana/README.rst
+++ b/providers/asana/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-asana``
 

--- a/providers/asana/docs/index.rst
+++ b/providers/asana/docs/index.rst
@@ -90,7 +90,7 @@ All classes for this package are included in the ``airflow.providers.asana`` pyt
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-asana``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/atlassian/jira/README.rst
+++ b/providers/atlassian/jira/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-atlassian-jira``
 

--- a/providers/atlassian/jira/docs/index.rst
+++ b/providers/atlassian/jira/docs/index.rst
@@ -82,7 +82,7 @@ All classes for this package are included in the ``airflow.providers.atlassian.j
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-atlassian-jira``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/celery/README.rst
+++ b/providers/celery/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-celery``
 

--- a/providers/celery/docs/index.rst
+++ b/providers/celery/docs/index.rst
@@ -80,7 +80,7 @@ All classes for this package are included in the ``airflow.providers.celery`` py
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-celery``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/cloudant/README.rst
+++ b/providers/cloudant/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-cloudant``
 

--- a/providers/cloudant/docs/index.rst
+++ b/providers/cloudant/docs/index.rst
@@ -68,7 +68,7 @@ All classes for this package are included in the ``airflow.providers.cloudant`` 
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-cloudant``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/cncf/kubernetes/README.rst
+++ b/providers/cncf/kubernetes/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-cncf-kubernetes``
 

--- a/providers/cncf/kubernetes/docs/index.rst
+++ b/providers/cncf/kubernetes/docs/index.rst
@@ -100,7 +100,7 @@ All classes for this package are included in the ``airflow.providers.cncf.kubern
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-cncf-kubernetes``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/cohere/README.rst
+++ b/providers/cohere/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-cohere``
 

--- a/providers/cohere/docs/index.rst
+++ b/providers/cohere/docs/index.rst
@@ -84,7 +84,7 @@ All classes for this package are included in the ``airflow.providers.cohere`` py
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-cohere``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/common/compat/README.rst
+++ b/providers/common/compat/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-common-compat``
 

--- a/providers/common/compat/docs/index.rst
+++ b/providers/common/compat/docs/index.rst
@@ -75,7 +75,7 @@ All classes for this package are included in the ``airflow.providers.common.comp
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-common-compat``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/common/io/README.rst
+++ b/providers/common/io/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-common-io``
 

--- a/providers/common/io/docs/index.rst
+++ b/providers/common/io/docs/index.rst
@@ -92,7 +92,7 @@ All classes for this package are included in the ``airflow.providers.common.io``
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-common-io``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/common/messaging/README.rst
+++ b/providers/common/messaging/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-common-messaging``
 

--- a/providers/common/messaging/docs/index.rst
+++ b/providers/common/messaging/docs/index.rst
@@ -90,7 +90,7 @@ All classes for this package are included in the ``airflow.providers.common.mess
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-common-messaging``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/common/sql/README.rst
+++ b/providers/common/sql/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-common-sql``
 

--- a/providers/common/sql/docs/index.rst
+++ b/providers/common/sql/docs/index.rst
@@ -92,7 +92,7 @@ All classes for this package are included in the ``airflow.providers.common.sql`
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-common-sql``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/databricks/README.rst
+++ b/providers/databricks/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-databricks``
 

--- a/providers/databricks/docs/index.rst
+++ b/providers/databricks/docs/index.rst
@@ -91,7 +91,7 @@ All classes for this package are included in the ``airflow.providers.databricks`
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-databricks``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/datadog/README.rst
+++ b/providers/datadog/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-datadog``
 

--- a/providers/datadog/docs/index.rst
+++ b/providers/datadog/docs/index.rst
@@ -81,7 +81,7 @@ All classes for this package are included in the ``airflow.providers.datadog`` p
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-datadog``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/dbt/cloud/README.rst
+++ b/providers/dbt/cloud/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-dbt-cloud``
 

--- a/providers/dbt/cloud/docs/index.rst
+++ b/providers/dbt/cloud/docs/index.rst
@@ -94,7 +94,7 @@ All classes for this package are included in the ``airflow.providers.dbt.cloud``
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-dbt-cloud``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/dingding/README.rst
+++ b/providers/dingding/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-dingding``
 

--- a/providers/dingding/docs/index.rst
+++ b/providers/dingding/docs/index.rst
@@ -89,7 +89,7 @@ All classes for this package are included in the ``airflow.providers.dingding`` 
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-dingding``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/discord/README.rst
+++ b/providers/discord/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-discord``
 

--- a/providers/discord/docs/index.rst
+++ b/providers/discord/docs/index.rst
@@ -75,7 +75,7 @@ All classes for this package are included in the ``airflow.providers.discord`` p
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-discord``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/docker/README.rst
+++ b/providers/docker/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-docker``
 

--- a/providers/docker/docs/index.rst
+++ b/providers/docker/docs/index.rst
@@ -83,7 +83,7 @@ All classes for this package are included in the ``airflow.providers.docker`` py
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-docker``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/edge3/README.rst
+++ b/providers/edge3/README.rst
@@ -54,7 +54,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-edge3``
 

--- a/providers/edge3/docs/index.rst
+++ b/providers/edge3/docs/index.rst
@@ -103,7 +103,7 @@ All classes for this package are included in the ``airflow.providers.edge3`` pyt
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-edge3``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/elasticsearch/README.rst
+++ b/providers/elasticsearch/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-elasticsearch``
 

--- a/providers/elasticsearch/docs/index.rst
+++ b/providers/elasticsearch/docs/index.rst
@@ -92,7 +92,7 @@ All classes for this package are included in the ``airflow.providers.elasticsear
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-elasticsearch``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/exasol/README.rst
+++ b/providers/exasol/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-exasol``
 

--- a/providers/exasol/docs/index.rst
+++ b/providers/exasol/docs/index.rst
@@ -88,7 +88,7 @@ All classes for this package are included in the ``airflow.providers.exasol`` py
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-exasol``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/fab/README.rst
+++ b/providers/fab/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-fab``
 

--- a/providers/fab/docs/index.rst
+++ b/providers/fab/docs/index.rst
@@ -97,7 +97,7 @@ All classes for this package are included in the ``airflow.providers.fab`` pytho
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-fab``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/facebook/README.rst
+++ b/providers/facebook/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-facebook``
 

--- a/providers/facebook/docs/index.rst
+++ b/providers/facebook/docs/index.rst
@@ -74,7 +74,7 @@ All classes for this package are included in the ``airflow.providers.facebook`` 
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-facebook``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/ftp/README.rst
+++ b/providers/ftp/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-ftp``
 

--- a/providers/ftp/docs/index.rst
+++ b/providers/ftp/docs/index.rst
@@ -97,7 +97,7 @@ All classes for this package are included in the ``airflow.providers.ftp`` pytho
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-ftp``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/git/README.rst
+++ b/providers/git/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-git``
 

--- a/providers/git/docs/index.rst
+++ b/providers/git/docs/index.rst
@@ -85,7 +85,7 @@ All classes for this package are included in the ``airflow.providers.git`` pytho
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-git``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/github/README.rst
+++ b/providers/github/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-github``
 

--- a/providers/github/docs/index.rst
+++ b/providers/github/docs/index.rst
@@ -90,7 +90,7 @@ All classes for this package are included in the ``airflow.providers.github`` py
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-github``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/google/README.rst
+++ b/providers/google/README.rst
@@ -49,7 +49,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-google``
 

--- a/providers/google/docs/index.rst
+++ b/providers/google/docs/index.rst
@@ -101,7 +101,7 @@ All classes for this package are included in the ``airflow.providers.google`` py
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-google``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/grpc/README.rst
+++ b/providers/grpc/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-grpc``
 

--- a/providers/grpc/docs/index.rst
+++ b/providers/grpc/docs/index.rst
@@ -81,7 +81,7 @@ All classes for this package are included in the ``airflow.providers.grpc`` pyth
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-grpc``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/hashicorp/README.rst
+++ b/providers/hashicorp/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-hashicorp``
 

--- a/providers/hashicorp/docs/index.rst
+++ b/providers/hashicorp/docs/index.rst
@@ -82,7 +82,7 @@ All classes for this package are included in the ``airflow.providers.hashicorp``
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-hashicorp``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/http/README.rst
+++ b/providers/http/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-http``
 

--- a/providers/http/docs/index.rst
+++ b/providers/http/docs/index.rst
@@ -90,7 +90,7 @@ All classes for this package are included in the ``airflow.providers.http`` pyth
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-http``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/imap/README.rst
+++ b/providers/imap/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-imap``
 

--- a/providers/imap/docs/index.rst
+++ b/providers/imap/docs/index.rst
@@ -76,7 +76,7 @@ All classes for this package are included in the ``airflow.providers.imap`` pyth
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-imap``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/influxdb/README.rst
+++ b/providers/influxdb/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-influxdb``
 

--- a/providers/influxdb/docs/index.rst
+++ b/providers/influxdb/docs/index.rst
@@ -90,7 +90,7 @@ All classes for this package are included in the ``airflow.providers.influxdb`` 
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-influxdb``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/jdbc/README.rst
+++ b/providers/jdbc/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-jdbc``
 

--- a/providers/jdbc/docs/index.rst
+++ b/providers/jdbc/docs/index.rst
@@ -91,7 +91,7 @@ All classes for this package are included in the ``airflow.providers.jdbc`` pyth
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-jdbc``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/jenkins/README.rst
+++ b/providers/jenkins/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-jenkins``
 

--- a/providers/jenkins/docs/index.rst
+++ b/providers/jenkins/docs/index.rst
@@ -89,7 +89,7 @@ All classes for this package are included in the ``airflow.providers.jenkins`` p
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-jenkins``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/keycloak/README.rst
+++ b/providers/keycloak/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-keycloak``
 

--- a/providers/keycloak/docs/index.rst
+++ b/providers/keycloak/docs/index.rst
@@ -91,7 +91,7 @@ All classes for this package are included in the ``airflow.providers.keycloak`` 
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-keycloak``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/microsoft/azure/README.rst
+++ b/providers/microsoft/azure/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-microsoft-azure``
 

--- a/providers/microsoft/azure/docs/index.rst
+++ b/providers/microsoft/azure/docs/index.rst
@@ -95,7 +95,7 @@ All classes for this package are included in the ``airflow.providers.microsoft.a
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-microsoft-azure``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/microsoft/mssql/README.rst
+++ b/providers/microsoft/mssql/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-microsoft-mssql``
 

--- a/providers/microsoft/mssql/docs/index.rst
+++ b/providers/microsoft/mssql/docs/index.rst
@@ -91,7 +91,7 @@ All classes for this package are included in the ``airflow.providers.microsoft.m
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-microsoft-mssql``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/microsoft/psrp/README.rst
+++ b/providers/microsoft/psrp/README.rst
@@ -44,7 +44,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-microsoft-psrp``
 

--- a/providers/microsoft/psrp/docs/index.rst
+++ b/providers/microsoft/psrp/docs/index.rst
@@ -83,7 +83,7 @@ All classes for this package are included in the ``airflow.providers.microsoft.p
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-microsoft-psrp``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/microsoft/winrm/README.rst
+++ b/providers/microsoft/winrm/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-microsoft-winrm``
 

--- a/providers/microsoft/winrm/docs/index.rst
+++ b/providers/microsoft/winrm/docs/index.rst
@@ -89,7 +89,7 @@ All classes for this package are included in the ``airflow.providers.microsoft.w
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-microsoft-winrm``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/mongo/README.rst
+++ b/providers/mongo/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-mongo``
 

--- a/providers/mongo/docs/index.rst
+++ b/providers/mongo/docs/index.rst
@@ -75,7 +75,7 @@ All classes for this package are included in the ``airflow.providers.mongo`` pyt
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-mongo``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/mysql/README.rst
+++ b/providers/mysql/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-mysql``
 

--- a/providers/mysql/docs/index.rst
+++ b/providers/mysql/docs/index.rst
@@ -90,7 +90,7 @@ All classes for this package are included in the ``airflow.providers.mysql`` pyt
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-mysql``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/neo4j/README.rst
+++ b/providers/neo4j/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-neo4j``
 

--- a/providers/neo4j/docs/index.rst
+++ b/providers/neo4j/docs/index.rst
@@ -90,7 +90,7 @@ All classes for this package are included in the ``airflow.providers.neo4j`` pyt
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-neo4j``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/odbc/README.rst
+++ b/providers/odbc/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-odbc``
 

--- a/providers/odbc/docs/index.rst
+++ b/providers/odbc/docs/index.rst
@@ -90,7 +90,7 @@ All classes for this package are included in the ``airflow.providers.odbc`` pyth
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-odbc``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/openai/README.rst
+++ b/providers/openai/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-openai``
 

--- a/providers/openai/docs/index.rst
+++ b/providers/openai/docs/index.rst
@@ -84,7 +84,7 @@ All classes for this package are included in the ``airflow.providers.openai`` py
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-openai``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/openfaas/README.rst
+++ b/providers/openfaas/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-openfaas``
 

--- a/providers/openfaas/docs/index.rst
+++ b/providers/openfaas/docs/index.rst
@@ -74,7 +74,7 @@ All classes for this package are included in the ``airflow.providers.openfaas`` 
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-openfaas``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/openlineage/README.rst
+++ b/providers/openlineage/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-openlineage``
 

--- a/providers/openlineage/docs/index.rst
+++ b/providers/openlineage/docs/index.rst
@@ -94,7 +94,7 @@ All classes for this package are included in the ``airflow.providers.openlineage
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-openlineage``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/opensearch/README.rst
+++ b/providers/opensearch/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-opensearch``
 

--- a/providers/opensearch/docs/index.rst
+++ b/providers/opensearch/docs/index.rst
@@ -91,7 +91,7 @@ All classes for this package are included in the ``airflow.providers.opensearch`
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-opensearch``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/opsgenie/README.rst
+++ b/providers/opsgenie/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-opsgenie``
 

--- a/providers/opsgenie/docs/index.rst
+++ b/providers/opsgenie/docs/index.rst
@@ -91,7 +91,7 @@ All classes for this package are included in the ``airflow.providers.opsgenie`` 
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-opsgenie``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/oracle/README.rst
+++ b/providers/oracle/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-oracle``
 

--- a/providers/oracle/docs/index.rst
+++ b/providers/oracle/docs/index.rst
@@ -90,7 +90,7 @@ All classes for this package are included in the ``airflow.providers.oracle`` py
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-oracle``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/pagerduty/README.rst
+++ b/providers/pagerduty/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-pagerduty``
 

--- a/providers/pagerduty/docs/index.rst
+++ b/providers/pagerduty/docs/index.rst
@@ -82,7 +82,7 @@ All classes for this package are included in the ``airflow.providers.pagerduty``
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-pagerduty``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/papermill/README.rst
+++ b/providers/papermill/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-papermill``
 

--- a/providers/papermill/docs/index.rst
+++ b/providers/papermill/docs/index.rst
@@ -90,7 +90,7 @@ All classes for this package are included in the ``airflow.providers.papermill``
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-papermill``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/pgvector/README.rst
+++ b/providers/pgvector/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-pgvector``
 

--- a/providers/pgvector/docs/index.rst
+++ b/providers/pgvector/docs/index.rst
@@ -92,7 +92,7 @@ All classes for this package are included in the ``airflow.providers.pgvector`` 
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-pgvector``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/pinecone/README.rst
+++ b/providers/pinecone/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-pinecone``
 

--- a/providers/pinecone/docs/index.rst
+++ b/providers/pinecone/docs/index.rst
@@ -84,7 +84,7 @@ All classes for this package are included in the ``airflow.providers.pinecone`` 
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-pinecone``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/postgres/README.rst
+++ b/providers/postgres/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-postgres``
 

--- a/providers/postgres/docs/index.rst
+++ b/providers/postgres/docs/index.rst
@@ -90,7 +90,7 @@ All classes for this package are included in the ``airflow.providers.postgres`` 
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-postgres``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/presto/README.rst
+++ b/providers/presto/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-presto``
 

--- a/providers/presto/docs/index.rst
+++ b/providers/presto/docs/index.rst
@@ -91,7 +91,7 @@ All classes for this package are included in the ``airflow.providers.presto`` py
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-presto``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/qdrant/README.rst
+++ b/providers/qdrant/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-qdrant``
 

--- a/providers/qdrant/docs/index.rst
+++ b/providers/qdrant/docs/index.rst
@@ -83,7 +83,7 @@ All classes for this package are included in the ``airflow.providers.qdrant`` py
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-qdrant``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/redis/README.rst
+++ b/providers/redis/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-redis``
 

--- a/providers/redis/docs/index.rst
+++ b/providers/redis/docs/index.rst
@@ -92,7 +92,7 @@ All classes for this package are included in the ``airflow.providers.redis`` pyt
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-redis``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/salesforce/README.rst
+++ b/providers/salesforce/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-salesforce``
 

--- a/providers/salesforce/docs/index.rst
+++ b/providers/salesforce/docs/index.rst
@@ -90,7 +90,7 @@ All classes for this package are included in the ``airflow.providers.salesforce`
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-salesforce``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/samba/README.rst
+++ b/providers/samba/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-samba``
 

--- a/providers/samba/docs/index.rst
+++ b/providers/samba/docs/index.rst
@@ -89,7 +89,7 @@ All classes for this package are included in the ``airflow.providers.samba`` pyt
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-samba``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/segment/README.rst
+++ b/providers/segment/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-segment``
 

--- a/providers/segment/docs/index.rst
+++ b/providers/segment/docs/index.rst
@@ -74,7 +74,7 @@ All classes for this package are included in the ``airflow.providers.segment`` p
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-segment``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/sendgrid/README.rst
+++ b/providers/sendgrid/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-sendgrid``
 

--- a/providers/sendgrid/docs/index.rst
+++ b/providers/sendgrid/docs/index.rst
@@ -74,7 +74,7 @@ All classes for this package are included in the ``airflow.providers.sendgrid`` 
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-sendgrid``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/sftp/README.rst
+++ b/providers/sftp/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-sftp``
 

--- a/providers/sftp/docs/index.rst
+++ b/providers/sftp/docs/index.rst
@@ -83,7 +83,7 @@ All classes for this package are included in the ``airflow.providers.sftp`` pyth
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-sftp``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/singularity/README.rst
+++ b/providers/singularity/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-singularity``
 

--- a/providers/singularity/docs/index.rst
+++ b/providers/singularity/docs/index.rst
@@ -82,7 +82,7 @@ All classes for this package are included in the ``airflow.providers.singularity
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-singularity``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/slack/README.rst
+++ b/providers/slack/README.rst
@@ -45,7 +45,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-slack``
 

--- a/providers/slack/docs/index.rst
+++ b/providers/slack/docs/index.rst
@@ -94,7 +94,7 @@ All classes for this package are included in the ``airflow.providers.slack`` pyt
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-slack``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/smtp/README.rst
+++ b/providers/smtp/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-smtp``
 

--- a/providers/smtp/docs/index.rst
+++ b/providers/smtp/docs/index.rst
@@ -77,7 +77,7 @@ All classes for this package are included in the ``airflow.providers.smtp`` pyth
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-smtp``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/snowflake/README.rst
+++ b/providers/snowflake/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-snowflake``
 

--- a/providers/snowflake/docs/index.rst
+++ b/providers/snowflake/docs/index.rst
@@ -91,7 +91,7 @@ All classes for this package are included in the ``airflow.providers.snowflake``
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-snowflake``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/sqlite/README.rst
+++ b/providers/sqlite/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-sqlite``
 

--- a/providers/sqlite/docs/index.rst
+++ b/providers/sqlite/docs/index.rst
@@ -90,7 +90,7 @@ All classes for this package are included in the ``airflow.providers.sqlite`` py
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-sqlite``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/ssh/README.rst
+++ b/providers/ssh/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-ssh``
 

--- a/providers/ssh/docs/index.rst
+++ b/providers/ssh/docs/index.rst
@@ -81,7 +81,7 @@ All classes for this package are included in the ``airflow.providers.ssh`` pytho
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-ssh``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/standard/README.rst
+++ b/providers/standard/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-standard``
 

--- a/providers/standard/docs/index.rst
+++ b/providers/standard/docs/index.rst
@@ -79,7 +79,7 @@ All classes for this package are included in the ``airflow.providers.standard`` 
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-standard``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/tableau/README.rst
+++ b/providers/tableau/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-tableau``
 

--- a/providers/tableau/docs/index.rst
+++ b/providers/tableau/docs/index.rst
@@ -84,7 +84,7 @@ All classes for this package are included in the ``airflow.providers.tableau`` p
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-tableau``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/telegram/README.rst
+++ b/providers/telegram/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-telegram``
 

--- a/providers/telegram/docs/index.rst
+++ b/providers/telegram/docs/index.rst
@@ -90,7 +90,7 @@ All classes for this package are included in the ``airflow.providers.telegram`` 
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-telegram``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/teradata/README.rst
+++ b/providers/teradata/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-teradata``
 

--- a/providers/teradata/docs/index.rst
+++ b/providers/teradata/docs/index.rst
@@ -90,7 +90,7 @@ All classes for this package are included in the ``airflow.providers.teradata`` 
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-teradata``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/trino/README.rst
+++ b/providers/trino/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-trino``
 

--- a/providers/trino/docs/index.rst
+++ b/providers/trino/docs/index.rst
@@ -91,7 +91,7 @@ All classes for this package are included in the ``airflow.providers.trino`` pyt
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-trino``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/vertica/README.rst
+++ b/providers/vertica/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-vertica``
 

--- a/providers/vertica/docs/index.rst
+++ b/providers/vertica/docs/index.rst
@@ -91,7 +91,7 @@ All classes for this package are included in the ``airflow.providers.vertica`` p
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-vertica``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/weaviate/README.rst
+++ b/providers/weaviate/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-weaviate``
 

--- a/providers/weaviate/docs/index.rst
+++ b/providers/weaviate/docs/index.rst
@@ -92,7 +92,7 @@ All classes for this package are included in the ``airflow.providers.weaviate`` 
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-weaviate``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/yandex/README.rst
+++ b/providers/yandex/README.rst
@@ -44,7 +44,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-yandex``
 

--- a/providers/yandex/docs/index.rst
+++ b/providers/yandex/docs/index.rst
@@ -94,7 +94,7 @@ All classes for this package are included in the ``airflow.providers.yandex`` py
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-yandex``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/ydb/README.rst
+++ b/providers/ydb/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-ydb``
 

--- a/providers/ydb/docs/index.rst
+++ b/providers/ydb/docs/index.rst
@@ -90,7 +90,7 @@ All classes for this package are included in the ``airflow.providers.ydb`` pytho
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-ydb``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 

--- a/providers/zendesk/README.rst
+++ b/providers/zendesk/README.rst
@@ -42,7 +42,7 @@ in the `documentation <https://airflow.apache.org/docs/apache-airflow-providers-
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below
+You can install this package on top of an existing Airflow installation (see ``Requirements`` below
 for the minimum Airflow version supported) via
 ``pip install apache-airflow-providers-zendesk``
 

--- a/providers/zendesk/docs/index.rst
+++ b/providers/zendesk/docs/index.rst
@@ -89,7 +89,7 @@ All classes for this package are included in the ``airflow.providers.zendesk`` p
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2 installation via
+You can install this package on top of an existing Airflow installation via
 ``pip install apache-airflow-providers-zendesk``.
 For the minimum Airflow version supported, see ``Requirements`` below.
 


### PR DESCRIPTION
We should change it to just "Airflow" - we have some providers with Airflow 2+3, some with only 3 and in a few months there will be Airflow 3 only. So we should remove Airflow reference altogether, min version of airflow is explained in "Requirements" table below

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
