### PR TITLE
feat(hitl): add fail_on_reject to ApprovalOperator

### DIFF
--- a/providers/standard/src/airflow/providers/standard/exceptions.py
+++ b/providers/standard/src/airflow/providers/standard/exceptions.py
@@ -63,3 +63,7 @@ class HITLTriggerEventError(Exception):
 
 class HITLTimeoutError(HITLTriggerEventError):
     """Raised when HITLOperator timeouts."""
+
+
+class HITLRejectException(AirflowException):
+    """Raised when an ApprovalOperator receives a "Reject" response when fail_on_reject is set to True."""

--- a/providers/standard/tests/unit/standard/operators/test_hitl.py
+++ b/providers/standard/tests/unit/standard/operators/test_hitl.py
@@ -46,11 +46,14 @@ from airflow.providers.standard.operators.hitl import (
 from airflow.sdk import Param, timezone
 from airflow.sdk.definitions.param import ParamsDict
 from airflow.sdk.execution_time.hitl import HITLUser
+from airflow.utils.context import Context
 
 from tests_common.test_utils.config import conf_vars
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
+
+    from airflow.sdk.definitions.context import Context
 
     from tests_common.pytest_plugin import DagMaker
 
@@ -75,6 +78,37 @@ def hitl_task_and_ti_for_generating_link(dag_maker: DagMaker) -> tuple[HITLOpera
         )
     dr = dag_maker.create_dagrun()
     return task, dag_maker.run_ti(task.task_id, dr)
+
+
+@pytest.fixture
+def get_context_from_model_ti(mock_supervisor_comms):
+    def _get_context(ti: TaskInstance) -> Context:
+        from airflow.api_fastapi.execution_api.datamodels.taskinstance import (
+            DagRun as DRDataModel,
+            TaskInstance as TIDataModel,
+            TIRunContext,
+        )
+        from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
+
+        # make mypy happy
+        assert ti is not None
+
+        dag_run = ti.dag_run
+        ti_model = TIDataModel.model_validate(ti, from_attributes=True)
+        runtime_ti = RuntimeTaskInstance.model_construct(
+            **ti_model.model_dump(exclude_unset=True),
+            task=ti.task,
+            _ti_context_from_server=TIRunContext(
+                dag_run=DRDataModel.model_validate(dag_run, from_attributes=True),
+                max_tries=ti.max_tries,
+                variables=[],
+                connections=[],
+                xcom_keys_to_clear=[],
+            ),
+        )
+        return runtime_ti.get_template_context()
+
+    return _get_context
 
 
 class TestHITLOperator:
@@ -451,7 +485,9 @@ class TestApprovalOperator:
             "responded_by_user": {"id": "test", "name": "test"},
         }
 
-    def test_execute_complete_with_downstream_tasks(self, dag_maker: DagMaker) -> None:
+    def test_execute_complete_with_downstream_tasks(
+        self, dag_maker: DagMaker, get_context_from_model_ti
+    ) -> None:
         with dag_maker("hitl_test_dag", serialized=True):
             hitl_op = ApprovalOperator(
                 task_id="hitl_test",
@@ -461,10 +497,9 @@ class TestApprovalOperator:
 
         dr = dag_maker.create_dagrun()
         ti = dr.get_task_instance("hitl_test")
-
         with pytest.raises(DownstreamTasksSkipped) as exc_info:
             hitl_op.execute_complete(
-                context={"ti": ti, "task": ti.task},
+                context=get_context_from_model_ti(ti),
                 event={
                     "chosen_options": ["Reject"],
                     "params_input": {},
@@ -474,18 +509,24 @@ class TestApprovalOperator:
             )
         assert set(exc_info.value.tasks) == {"op1"}
 
-    def test_execute_complete_with_fail_on_reject_set_to_true(self, dag_maker: DagMaker) -> None:
+    def test_execute_complete_with_fail_on_reject_set_to_true(
+        self, dag_maker: DagMaker, get_context_from_model_ti
+    ) -> None:
         with dag_maker("hitl_test_dag", serialized=True):
             hitl_op = ApprovalOperator(task_id="hitl_test", subject="This is subject", fail_on_reject=True)
             (hitl_op >> EmptyOperator(task_id="op1"))
 
         dr = dag_maker.create_dagrun()
         ti = dr.get_task_instance("hitl_test")
-
         with pytest.raises(HITLRejectException):
             hitl_op.execute_complete(
-                context={"ti": ti, "task": ti.task},
-                event={"chosen_options": ["Reject"], "params_input": {}},
+                context=get_context_from_model_ti(ti),
+                event={
+                    "chosen_options": ["Reject"],
+                    "params_input": {},
+                    "responded_at": timezone.utcnow(),
+                    "responded_by_user": {"id": "test", "name": "test"},
+                },
             )
 
 
@@ -527,7 +568,7 @@ class TestHITLEntryOperator:
 
 
 class TestHITLBranchOperator:
-    def test_execute_complete(self, dag_maker: DagMaker) -> None:
+    def test_execute_complete(self, dag_maker: DagMaker, get_context_from_model_ti) -> None:
         with dag_maker("hitl_test_dag", serialized=True):
             branch_op = HITLBranchOperator(
                 task_id="make_choice",
@@ -541,7 +582,7 @@ class TestHITLBranchOperator:
         ti = dr.get_task_instance("make_choice")
         with pytest.raises(DownstreamTasksSkipped) as exc_info:
             branch_op.execute_complete(
-                context={"ti": ti, "task": ti.task},
+                context=get_context_from_model_ti(ti),
                 event={
                     "chosen_options": ["branch_1"],
                     "params_input": {},
@@ -551,7 +592,9 @@ class TestHITLBranchOperator:
             )
         assert set(exc_info.value.tasks) == set((f"branch_{i}", -1) for i in range(2, 6))
 
-    def test_execute_complete_with_multiple_branches(self, dag_maker: DagMaker) -> None:
+    def test_execute_complete_with_multiple_branches(
+        self, dag_maker: DagMaker, get_context_from_model_ti
+    ) -> None:
         with dag_maker("hitl_test_dag", serialized=True):
             branch_op = HITLBranchOperator(
                 task_id="make_choice",
@@ -568,7 +611,7 @@ class TestHITLBranchOperator:
         ti = dr.get_task_instance("make_choice")
         with pytest.raises(DownstreamTasksSkipped) as exc_info:
             branch_op.execute_complete(
-                context={"ti": ti, "task": ti.task},
+                context=get_context_from_model_ti(ti),
                 event={
                     "chosen_options": [f"branch_{i}" for i in range(1, 4)],
                     "params_input": {},
@@ -578,7 +621,7 @@ class TestHITLBranchOperator:
             )
         assert set(exc_info.value.tasks) == set((f"branch_{i}", -1) for i in range(4, 6))
 
-    def test_mapping_applies_for_single_choice(self, dag_maker: DagMaker) -> None:
+    def test_mapping_applies_for_single_choice(self, dag_maker: DagMaker, get_context_from_model_ti) -> None:
         # ["Approve"]; map -> "publish"
         with dag_maker("hitl_map_dag", serialized=True):
             op = HITLBranchOperator(
@@ -594,7 +637,7 @@ class TestHITLBranchOperator:
 
         with pytest.raises(DownstreamTasksSkipped) as exc:
             op.execute_complete(
-                context={"ti": ti, "task": ti.task},
+                context=get_context_from_model_ti(ti),
                 event={
                     "chosen_options": ["Approve"],
                     "params_input": {},
@@ -605,7 +648,7 @@ class TestHITLBranchOperator:
         # checks to see that the "archive" task was skipped
         assert set(exc.value.tasks) == {("archive", -1)}
 
-    def test_mapping_with_multiple_choices(self, dag_maker: DagMaker) -> None:
+    def test_mapping_with_multiple_choices(self, dag_maker: DagMaker, get_context_from_model_ti) -> None:
         # multiple=True; mapping applied per option; no dedup implied
         with dag_maker("hitl_map_dag", serialized=True):
             op = HITLBranchOperator(
@@ -626,7 +669,7 @@ class TestHITLBranchOperator:
 
         with pytest.raises(DownstreamTasksSkipped) as exc:
             op.execute_complete(
-                context={"ti": ti, "task": ti.task},
+                context=get_context_from_model_ti(ti),
                 event={
                     "chosen_options": ["Approve", "KeepAsIs"],
                     "params_input": {},
@@ -637,7 +680,7 @@ class TestHITLBranchOperator:
         # publish + keep chosen → only "other" skipped
         assert set(exc.value.tasks) == {("other", -1)}
 
-    def test_fallback_to_option_when_not_mapped(self, dag_maker: DagMaker) -> None:
+    def test_fallback_to_option_when_not_mapped(self, dag_maker: DagMaker, get_context_from_model_ti) -> None:
         # No mapping: option must match downstream task_id
         with dag_maker("hitl_map_dag", serialized=True):
             op = HITLBranchOperator(
@@ -652,7 +695,7 @@ class TestHITLBranchOperator:
 
         with pytest.raises(DownstreamTasksSkipped) as exc:
             op.execute_complete(
-                context={"ti": ti, "task": ti.task},
+                context=get_context_from_model_ti(ti),
                 event={
                     "chosen_options": ["branch_2"],
                     "params_input": {},
@@ -662,7 +705,9 @@ class TestHITLBranchOperator:
             )
         assert set(exc.value.tasks) == {("branch_1", -1)}
 
-    def test_error_if_mapped_branch_not_direct_downstream(self, dag_maker: DagMaker):
+    def test_error_if_mapped_branch_not_direct_downstream(
+        self, dag_maker: DagMaker, get_context_from_model_ti
+    ):
         # Don't add the mapped task downstream → expect a clean error
         with dag_maker("hitl_map_dag", serialized=True):
             op = HITLBranchOperator(
@@ -678,7 +723,7 @@ class TestHITLBranchOperator:
 
         with pytest.raises(AirflowException, match="downstream|not found"):
             op.execute_complete(
-                context={"ti": ti, "task": ti.task},
+                context=get_context_from_model_ti(ti),
                 event={
                     "chosen_options": ["Approve"],
                     "params_input": {},

--- a/providers/standard/tests/unit/standard/operators/test_hitl.py
+++ b/providers/standard/tests/unit/standard/operators/test_hitl.py
@@ -527,7 +527,7 @@ class TestHITLEntryOperator:
 
 
 class TestHITLBranchOperator:
-    def test_execute_complete(self, dag_maker) -> None:
+    def test_execute_complete(self, dag_maker: DagMaker) -> None:
         with dag_maker("hitl_test_dag", serialized=True):
             branch_op = HITLBranchOperator(
                 task_id="make_choice",
@@ -551,7 +551,7 @@ class TestHITLBranchOperator:
             )
         assert set(exc_info.value.tasks) == set((f"branch_{i}", -1) for i in range(2, 6))
 
-    def test_execute_complete_with_multiple_branches(self, dag_maker) -> None:
+    def test_execute_complete_with_multiple_branches(self, dag_maker: DagMaker) -> None:
         with dag_maker("hitl_test_dag", serialized=True):
             branch_op = HITLBranchOperator(
                 task_id="make_choice",
@@ -578,7 +578,7 @@ class TestHITLBranchOperator:
             )
         assert set(exc_info.value.tasks) == set((f"branch_{i}", -1) for i in range(4, 6))
 
-    def test_mapping_applies_for_single_choice(self, dag_maker):
+    def test_mapping_applies_for_single_choice(self, dag_maker: DagMaker) -> None:
         # ["Approve"]; map -> "publish"
         with dag_maker("hitl_map_dag", serialized=True):
             op = HITLBranchOperator(
@@ -605,7 +605,7 @@ class TestHITLBranchOperator:
         # checks to see that the "archive" task was skipped
         assert set(exc.value.tasks) == {("archive", -1)}
 
-    def test_mapping_with_multiple_choices(self, dag_maker):
+    def test_mapping_with_multiple_choices(self, dag_maker: DagMaker) -> None:
         # multiple=True; mapping applied per option; no dedup implied
         with dag_maker("hitl_map_dag", serialized=True):
             op = HITLBranchOperator(
@@ -637,7 +637,7 @@ class TestHITLBranchOperator:
         # publish + keep chosen → only "other" skipped
         assert set(exc.value.tasks) == {("other", -1)}
 
-    def test_fallback_to_option_when_not_mapped(self, dag_maker):
+    def test_fallback_to_option_when_not_mapped(self, dag_maker: DagMaker) -> None:
         # No mapping: option must match downstream task_id
         with dag_maker("hitl_map_dag", serialized=True):
             op = HITLBranchOperator(
@@ -662,7 +662,7 @@ class TestHITLBranchOperator:
             )
         assert set(exc.value.tasks) == {("branch_1", -1)}
 
-    def test_error_if_mapped_branch_not_direct_downstream(self, dag_maker):
+    def test_error_if_mapped_branch_not_direct_downstream(self, dag_maker: DagMaker):
         # Don't add the mapped task downstream → expect a clean error
         with dag_maker("hitl_map_dag", serialized=True):
             op = HITLBranchOperator(


### PR DESCRIPTION
## Why
Closes: https://github.com/apache/airflow/issues/55065

## What
Add argument `fail_on_reject` to `ApprovalOperator` to fail a task upon receiving "Reject" forcly

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
