### PR TITLE
54527 simple extra link in dag

### DIFF
--- a/airflow-core/docs/templates-ref.rst
+++ b/airflow-core/docs/templates-ref.rst
@@ -67,6 +67,7 @@ Variable                                    Type                  Description
 ``{{ params }}``                            dict[str, Any]        | The user-defined params. This can be overridden by the mapping
                                                                   | passed to ``trigger_dag -c`` if ``dag_run_conf_overrides_params``
                                                                   | is enabled in ``airflow.cfg``.
+``{{ extra_links }}``                       dict[str, str]        Extra operator links available in the task. Keys are link names, values are URLs.
 ``{{ var.value }}``                                               Airflow variables. See `Airflow Variables in Templates`_ below.
 ``{{ var.json }}``                                                Airflow variables. See `Airflow Variables in Templates`_ below.
 ``{{ conn }}``                                                    Airflow connections. See `Airflow Connections in Templates`_ below.

--- a/airflow-core/src/airflow/utils/context.py
+++ b/airflow-core/src/airflow/utils/context.py
@@ -86,6 +86,7 @@ KNOWN_CONTEXT_KEYS: set[str] = {
     "ts_nodash_with_tz",
     "try_number",
     "var",
+    "extra_links",
 }
 
 

--- a/providers/standard/src/airflow/providers/standard/operators/python.py
+++ b/providers/standard/src/airflow/providers/standard/operators/python.py
@@ -421,6 +421,7 @@ class _BasePythonVirtualenvOperator(PythonOperator, metaclass=ABCMeta):
         "task",
         "params",
         "triggering_asset_events",
+        "extra_links",
         # The following should be removed when Airflow 2 support is dropped.
         "triggering_dataset_events",
     }

--- a/task-sdk/src/airflow/sdk/definitions/context.py
+++ b/task-sdk/src/airflow/sdk/definitions/context.py
@@ -81,6 +81,7 @@ class Context(TypedDict, total=False):
     ts_nodash: str
     ts_nodash_with_tz: str
     var: Any
+    extra_links: dict[str, str]
 
 
 KNOWN_CONTEXT_KEYS: set[str] = set(Context.__annotations__.keys())

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -196,6 +196,7 @@ class RuntimeTaskInstance(TaskInstance):
                 "value": VariableAccessor(deserialize_json=False),
             },
             "conn": ConnectionAccessor(),
+            "extra_links": {},
         }
         if from_server:
             dag_run = from_server.dag_run
@@ -1377,6 +1378,15 @@ def finalize(
         link, xcom_key = oe.get_link(operator=task, ti_key=ti), oe.xcom_key  # type: ignore[arg-type]
         log.debug("Setting xcom for operator extra link", link=link, xcom_key=xcom_key)
         _xcom_push_to_db(ti, key=xcom_key, value=link)
+
+    if context.get("extra_links"):
+        for link_name, url in context["extra_links"].items():
+            log.debug("Setting xcom for context extra link", link_name=link_name, url=url)
+            _xcom_push_to_db(
+                ti,
+                key=f"extra_link:{link_name}",
+                value=url,
+            )
 
     if getattr(ti.task, "overwrite_rtif_after_execution", False):
         log.debug("Overwriting Rendered template fields.")

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -1251,6 +1251,7 @@ class TestRuntimeTaskInstance:
                 "value": VariableAccessor(deserialize_json=False),
             },
             "conn": ConnectionAccessor(),
+            "extra_links": {},
             "dag": runtime_ti.task.dag,
             "inlets": task.inlets,
             "inlet_events": InletEventsAccessors(inlets=[]),
@@ -1284,6 +1285,7 @@ class TestRuntimeTaskInstance:
         )
 
         context = runtime_ti.get_template_context()
+        print(context, "++++++++++++++++++++++++++++++++++++++++++++")
 
         assert context == {
             "params": {},
@@ -1292,6 +1294,7 @@ class TestRuntimeTaskInstance:
                 "value": VariableAccessor(deserialize_json=False),
             },
             "conn": ConnectionAccessor(),
+            "extra_links": {},
             "dag": runtime_ti.task.dag,
             "inlets": task.inlets,
             "inlet_events": InletEventsAccessors(inlets=[]),


### PR DESCRIPTION
#### Feature

Add support for defining extra links directly within TaskFlow DAGs.

Currently, extra links require creating a custom operator and defining a BaseOperatorLink. This is too heavy for one-off tasks where authors just want to expose a useful URL (e.g., an API endpoint, a dashboard).

With this feature, DAG authors can set extra links in @task functions, and they will behave like operator extra links in the UI.

#### Changes Made
- Added support for storing extra links directly in task context (context["extra_links"]).
- Implemented logic to persist extra links into XCom (extra_link:<name> keys).
- Updated template context to include extra_links dictionary.
- Loaded extra links from XCom back into task context for UI/API visibility.
- Added test cases for the new feature.

#### Tests Added
- `test_parameterized_extra_links_dag`
- `test_context_based_extra_links_dag`

#### Sample dag files and screeshots

- DAG demonstrating extra links added via context dictionary.

``` python
from airflow.sdk import get_current_context, dag, task
from datetime import datetime, timedelta
import requests


@dag(
    start_date=datetime.now() - timedelta(days=1),
    schedule=None,
    catchup=False,
    tags=["extra_links_example"],
)
def example_extra_links_dag():
    @task
    def get_api_resource():
        context = get_current_context()
        rsp = requests.get("https://www.google.com", timeout=10)
        context.setdefault("extra_links", {})
        context["extra_links"]["Google"] = "https://www.google.com"
        return {"status_code": rsp.status_code}
    get_api_resource()


example_extra_links_dag()
```
<img width="1706" height="887" alt="image" src="https://github.com/user-attachments/assets/a576c158-4f12-4a0a-8e4b-57174c2fa7db" />

<img width="1853" height="862" alt="image" src="https://github.com/user-attachments/assets/7f5f3dc9-6192-4ceb-8d71-e16bdbffc698" />


- Support adding extra links to DAG tasks via parameters

``` python
from airflow.sdk import get_current_context, dag, task
from datetime import datetime, timedelta
import requests


@dag(
    start_date=datetime.now() - timedelta(days=1),
    schedule=None,
    catchup=False,
    tags=["extra_links_dag"],
)
def extra_links_dag():
    @task
    def get_api_resource(extra_links: dict[str, str]):
        rsp = requests.get("https://www.google.com", timeout=10)
        extra_links["Google"] = "https://www.google.com"
        return {"status_code": rsp.status_code}

    get_api_resource(extra_links={})

extra_links_dag()
```
<img width="1721" height="896" alt="image" src="https://github.com/user-attachments/assets/0f70a6b3-d7fd-445c-b686-bcdccfa096f1" />


<img width="1853" height="862" alt="image" src="https://github.com/user-attachments/assets/63e1dfaa-0b38-456d-b6ed-5634cc0f5943" />

closes: #54527
related: #54527