### PR TITLE
Show collapsible plugin menu when plugins more than or equal 2

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.tsx
@@ -139,8 +139,6 @@ export const Nav = () => {
       bg="blue.muted"
       height="100%"
       justifyContent="space-between"
-      overflowX="hidden"
-      overflowY="auto"
       position="fixed"
       py={3}
       top={0}

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.tsx
@@ -139,6 +139,8 @@ export const Nav = () => {
       bg="blue.muted"
       height="100%"
       justifyContent="space-between"
+      overflowX="hidden"
+      overflowY="auto"
       position="fixed"
       py={3}
       top={0}

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/PluginMenus.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/PluginMenus.tsx
@@ -49,8 +49,8 @@ export const PluginMenus = ({ navItems }: { readonly navItems: Array<NavItemResp
     return undefined;
   }
 
-  // Show plugins in menu if there are more than 2
-  return navItems.length > 2 ? (
+  // Show plugins in menu if there are more than or equal to 2
+  return navItems.length >= 2 ? (
     <Menu.Root positioning={{ placement: "right" }}>
       <Menu.Trigger>
         <NavButton as={Box} icon={<LuPlug />} title={translate("nav.plugins")} />


### PR DESCRIPTION
## Description

This PR addresses an issue where the left-hand sidebar would truncate navigation items when there has 2 plugins were registered. Currently, the sidebar has a fixed height with no scroll support, so items that extend beyond the viewport are inaccessible to users.

## Screenshots

<img width="513" height="777" alt="image" src="https://github.com/user-attachments/assets/74436480-276f-4603-8174-975dbaff6a4d" />


## Related Issue

resolves: #55131 