### PR TITLE
Check for Deprecated SQLA Query Class Usage in Prevent Deprecated SQLA Hook

### DIFF
--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -617,11 +617,7 @@ class DagRun(Base, LoggingMixin):
 
     @classmethod
     @retry_db_transaction
-<<<<<<< HEAD
     def get_queued_dag_runs_to_set_running(cls, session: Session) -> ScalarResult[DagRun]:
-=======
-    def get_queued_dag_runs_to_set_running(cls, session: Session) -> ScalarResult:
->>>>>>> 06560f82d6 (remove Query obj from dagrun.py)
         """
         Return the next queued DagRuns that the scheduler should attempt to schedule.
 

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -617,7 +617,11 @@ class DagRun(Base, LoggingMixin):
 
     @classmethod
     @retry_db_transaction
+<<<<<<< HEAD
     def get_queued_dag_runs_to_set_running(cls, session: Session) -> ScalarResult[DagRun]:
+=======
+    def get_queued_dag_runs_to_set_running(cls, session: Session) -> ScalarResult:
+>>>>>>> 06560f82d6 (remove Query obj from dagrun.py)
         """
         Return the next queued DagRuns that the scheduler should attempt to schedule.
 

--- a/airflow-core/src/airflow/models/pool.py
+++ b/airflow-core/src/airflow/models/pool.py
@@ -32,7 +32,6 @@ from airflow.utils.sqlalchemy import mapped_column, with_row_locks
 from airflow.utils.state import TaskInstanceState
 
 if TYPE_CHECKING:
-    from sqlalchemy.orm import Query
     from sqlalchemy.orm.session import Session
     from sqlalchemy.sql import Select
 
@@ -176,7 +175,7 @@ class Pool(Base):
         pools: dict[str, PoolStats] = {}
         pool_includes_deferred: dict[str, bool] = {}
 
-        query: Select[Any] | Query[Any] = select(Pool.pool, Pool.slots, Pool.include_deferred)
+        query: Select[Any] = select(Pool.pool, Pool.slots, Pool.include_deferred)
 
         if lock_rows:
             query = with_row_locks(query, session=session, nowait=True)

--- a/airflow-core/src/airflow/utils/sqlalchemy.py
+++ b/airflow-core/src/airflow/utils/sqlalchemy.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 
     from kubernetes.client.models.v1_pod import V1Pod
     from sqlalchemy.exc import OperationalError
-    from sqlalchemy.orm import Query, Session
+    from sqlalchemy.orm import Session
     from sqlalchemy.sql import Select
     from sqlalchemy.sql.elements import ColumnElement
     from sqlalchemy.types import TypeEngine

--- a/airflow-core/src/airflow/utils/sqlalchemy.py
+++ b/airflow-core/src/airflow/utils/sqlalchemy.py
@@ -42,10 +42,7 @@ if TYPE_CHECKING:
     from sqlalchemy.exc import OperationalError
     from sqlalchemy.orm import Query, Session
     from sqlalchemy.sql import Select
-<<<<<<< HEAD
     from sqlalchemy.sql.elements import ColumnElement
-=======
->>>>>>> bebf06f88e (Remove Query class)
     from sqlalchemy.types import TypeEngine
 
     from airflow.typing_compat import Self

--- a/airflow-core/src/airflow/utils/sqlalchemy.py
+++ b/airflow-core/src/airflow/utils/sqlalchemy.py
@@ -42,7 +42,10 @@ if TYPE_CHECKING:
     from sqlalchemy.exc import OperationalError
     from sqlalchemy.orm import Query, Session
     from sqlalchemy.sql import Select
+<<<<<<< HEAD
     from sqlalchemy.sql.elements import ColumnElement
+=======
+>>>>>>> bebf06f88e (Remove Query class)
     from sqlalchemy.types import TypeEngine
 
     from airflow.typing_compat import Self

--- a/airflow-core/src/airflow/utils/sqlalchemy.py
+++ b/airflow-core/src/airflow/utils/sqlalchemy.py
@@ -330,14 +330,14 @@ USE_ROW_LEVEL_LOCKING: bool = conf.getboolean("scheduler", "use_row_level_lockin
 
 
 def with_row_locks(
-    query: Query[Any] | Select[Any],
+    query: Select[Any],
     session: Session,
     *,
     nowait: bool = False,
     skip_locked: bool = False,
     key_share: bool = True,
     **kwargs,
-) -> Query[Any] | Select[Any]:
+) -> Select[Any]:
     """
     Apply with_for_update to the SQLAlchemy query if row level locking is in use.
 

--- a/scripts/ci/prek/prevent_deprecated_sqlalchemy_usage.py
+++ b/scripts/ci/prek/prevent_deprecated_sqlalchemy_usage.py
@@ -39,6 +39,17 @@ def check_session_query(mod: ast.Module, file_path: str) -> bool:
             if node.func.attr == "query":
                 console.print(f"Deprecated query-obj found at line {node.lineno} in {file_path}.")
                 errors = True
+        if isinstance(node, ast.ImportFrom):
+            if (
+                node.module == "sqlalchemy.orm.query"
+                or node.module == "sqlalchemy"
+                or node.module == "sqlalchemy.orm"
+            ):
+                for alias in node.names:
+                    if alias.name == "Query":
+                        console.print(f"Deprecated Query class found at line {node.lineno} in {file_path}.")
+                        errors = True
+
     return errors
 
 


### PR DESCRIPTION
This PR is part of the migration to SQLAlchemy 2.0

Previously, the hook only detected usage of `.query()` which returns a `Query` object. 
This update extends the check to also flag direct usage of the deprecated `Query` class itself

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!chl 

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
