### PR TITLE
Fix bulk operation permissions for connection, pool and variable

### DIFF
--- a/airflow-core/docs/core-concepts/auth-manager/index.rst
+++ b/airflow-core/docs/core-concepts/auth-manager/index.rst
@@ -178,7 +178,10 @@ Optional methods recommended to override for optimization
 
 The following methods aren't required to override to have a functional Airflow auth manager. However, it is recommended to override these to make your auth manager faster (and potentially less costly):
 
+* ``batch_is_authorized_connection``: Batch version of ``is_authorized_connection``. If not overridden, it will call ``is_authorized_connection`` for every single item.
 * ``batch_is_authorized_dag``: Batch version of ``is_authorized_dag``. If not overridden, it will call ``is_authorized_dag`` for every single item.
+* ``batch_is_authorized_pool``: Batch version of ``is_authorized_pool``. If not overridden, it will call ``is_authorized_pool`` for every single item.
+* ``batch_is_authorized_variable``: Batch version of ``is_authorized_variable``. If not overridden, it will call ``is_authorized_variable`` for every single item.
 * ``get_authorized_dag_ids``: Return the list of Dag IDs the user has access to.  If not overridden, it will call ``is_authorized_dag`` for every single Dag available in the environment.
 
   * Note: To filter the results of ``get_authorized_dag_ids``, it is recommended that you define the filtering logic in your ``filter_authorized_dag_ids`` method. For example, this may be useful if you rely on per-Dag access controls derived from one or more fields on a given Dag (e.g. Dag tags).

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/models/batch_apis.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/models/batch_apis.py
@@ -22,9 +22,19 @@ from typing import TYPE_CHECKING, TypedDict
 if TYPE_CHECKING:
     from airflow.api_fastapi.auth.managers.base_auth_manager import ResourceMethod
     from airflow.api_fastapi.auth.managers.models.resource_details import (
+        ConnectionDetails,
         DagAccessEntity,
         DagDetails,
+        PoolDetails,
+        VariableDetails,
     )
+
+
+class IsAuthorizedConnectionRequest(TypedDict, total=False):
+    """Represent the parameters of ``is_authorized_connection`` API in the auth manager."""
+
+    method: ResourceMethod
+    details: ConnectionDetails | None
 
 
 class IsAuthorizedDagRequest(TypedDict, total=False):
@@ -33,3 +43,17 @@ class IsAuthorizedDagRequest(TypedDict, total=False):
     method: ResourceMethod
     access_entity: DagAccessEntity | None
     details: DagDetails | None
+
+
+class IsAuthorizedPoolRequest(TypedDict, total=False):
+    """Represent the parameters of ``is_authorized_pool`` API in the auth manager."""
+
+    method: ResourceMethod
+    details: PoolDetails | None
+
+
+class IsAuthorizedVariableRequest(TypedDict, total=False):
+    """Represent the parameters of ``is_authorized_variable`` API in the auth manager."""
+
+    method: ResourceMethod
+    details: VariableDetails | None

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/connections.py
@@ -43,7 +43,7 @@ from airflow.api_fastapi.core_api.datamodels.connections import (
     ConnectionTestResponse,
 )
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
-from airflow.api_fastapi.core_api.security import requires_access_connection
+from airflow.api_fastapi.core_api.security import requires_access_connection, requires_access_connection_bulk
 from airflow.api_fastapi.core_api.services.public.connections import (
     BulkConnectionService,
     update_orm_from_pydantic,
@@ -157,7 +157,7 @@ def post_connection(
 
 
 @connections_router.patch(
-    "", dependencies=[Depends(requires_access_connection(method="PUT")), Depends(action_logging())]
+    "", dependencies=[Depends(requires_access_connection_bulk()), Depends(action_logging())]
 )
 def bulk_connections(
     request: BulkBody[ConnectionBody],

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/pools.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/pools.py
@@ -40,7 +40,7 @@ from airflow.api_fastapi.core_api.datamodels.pools import (
     PoolResponse,
 )
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
-from airflow.api_fastapi.core_api.security import requires_access_pool
+from airflow.api_fastapi.core_api.security import requires_access_pool, requires_access_pool_bulk
 from airflow.api_fastapi.core_api.services.public.pools import BulkPoolService
 from airflow.api_fastapi.logging.decorators import action_logging
 from airflow.models.pool import Pool
@@ -197,7 +197,7 @@ def post_pool(
 
 @pools_router.patch(
     "",
-    dependencies=[Depends(requires_access_pool(method="PUT")), Depends(action_logging())],
+    dependencies=[Depends(requires_access_pool_bulk()), Depends(action_logging())],
 )
 def bulk_pools(
     request: BulkBody[PoolBody],

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/variables.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/variables.py
@@ -38,7 +38,7 @@ from airflow.api_fastapi.core_api.datamodels.variables import (
     VariableResponse,
 )
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
-from airflow.api_fastapi.core_api.security import requires_access_variable
+from airflow.api_fastapi.core_api.security import requires_access_variable, requires_access_variable_bulk
 from airflow.api_fastapi.core_api.services.public.variables import BulkVariableService
 from airflow.api_fastapi.logging.decorators import action_logging
 from airflow.models.variable import Variable
@@ -192,7 +192,7 @@ def post_variable(
 
 
 @variables_router.patch(
-    "", dependencies=[Depends(action_logging()), Depends(requires_access_variable("DELETE"))]
+    "", dependencies=[Depends(action_logging()), Depends(requires_access_variable_bulk())]
 )
 def bulk_variables(
     request: BulkBody[VariableBody],

--- a/airflow-core/tests/unit/api_fastapi/auth/managers/test_base_auth_manager.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/managers/test_base_auth_manager.py
@@ -249,6 +249,28 @@ class TestBaseAuthManager:
             ([True, True], True),
         ],
     )
+    @patch.object(EmptyAuthManager, "is_authorized_connection")
+    def test_batch_is_authorized_connection(
+        self, mock_is_authorized_connection, auth_manager, return_values, expected
+    ):
+        mock_is_authorized_connection.side_effect = return_values
+        result = auth_manager.batch_is_authorized_connection(
+            [
+                {"method": "GET", "details": ConnectionDetails(conn_id="conn1")},
+                {"method": "GET", "details": ConnectionDetails(conn_id="conn2")},
+            ],
+            user=Mock(),
+        )
+        assert result == expected
+
+    @pytest.mark.parametrize(
+        "return_values, expected",
+        [
+            ([False, False], False),
+            ([True, False], False),
+            ([True, True], True),
+        ],
+    )
     @patch.object(EmptyAuthManager, "is_authorized_dag")
     def test_batch_is_authorized_dag(self, mock_is_authorized_dag, auth_manager, return_values, expected):
         mock_is_authorized_dag.side_effect = return_values
@@ -256,6 +278,48 @@ class TestBaseAuthManager:
             [
                 {"method": "GET", "details": DagDetails(id="dag1")},
                 {"method": "GET", "details": DagDetails(id="dag2")},
+            ],
+            user=Mock(),
+        )
+        assert result == expected
+
+    @pytest.mark.parametrize(
+        "return_values, expected",
+        [
+            ([False, False], False),
+            ([True, False], False),
+            ([True, True], True),
+        ],
+    )
+    @patch.object(EmptyAuthManager, "is_authorized_pool")
+    def test_batch_is_authorized_pool(self, mock_is_authorized_pool, auth_manager, return_values, expected):
+        mock_is_authorized_pool.side_effect = return_values
+        result = auth_manager.batch_is_authorized_pool(
+            [
+                {"method": "GET", "details": PoolDetails(name="pool1")},
+                {"method": "GET", "details": PoolDetails(name="pool2")},
+            ],
+            user=Mock(),
+        )
+        assert result == expected
+
+    @pytest.mark.parametrize(
+        "return_values, expected",
+        [
+            ([False, False], False),
+            ([True, False], False),
+            ([True, True], True),
+        ],
+    )
+    @patch.object(EmptyAuthManager, "is_authorized_variable")
+    def test_batch_is_authorized_variable(
+        self, mock_is_authorized_variable, auth_manager, return_values, expected
+    ):
+        mock_is_authorized_variable.side_effect = return_values
+        result = auth_manager.batch_is_authorized_variable(
+            [
+                {"method": "GET", "details": VariableDetails(key="var1")},
+                {"method": "GET", "details": VariableDetails(key="var2")},
             ],
             user=Mock(),
         )

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
@@ -1244,7 +1244,19 @@ class TestBulkConnections(TestConnectionEndpoint):
         assert response.status_code == 401
 
     def test_should_respond_403(self, unauthorized_test_client):
-        response = unauthorized_test_client.patch("/connections", json={})
+        response = unauthorized_test_client.patch(
+            "/connections",
+            json={
+                "actions": [
+                    {
+                        "action": "create",
+                        "entities": [
+                            {"connection_id": "test1", "conn_type": "test1"},
+                        ],
+                    },
+                ]
+            },
+        )
         assert response.status_code == 403
 
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py
@@ -831,5 +831,17 @@ class TestBulkPools(TestPoolsEndpoint):
         assert response.status_code == 401
 
     def test_should_respond_403(self, unauthorized_test_client):
-        response = unauthorized_test_client.patch("/pools", json={})
+        response = unauthorized_test_client.patch(
+            "/pools",
+            json={
+                "actions": [
+                    {
+                        "action": "create",
+                        "entities": [
+                            {"pool": "pool1", "slots": 1},
+                        ],
+                    },
+                ]
+            },
+        )
         assert response.status_code == 403

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py
@@ -1114,5 +1114,17 @@ class TestBulkVariables(TestVariableEndpoint):
         assert response.status_code == 401
 
     def test_bulk_variables_should_respond_403(self, unauthorized_test_client):
-        response = unauthorized_test_client.patch("/variables", json={})
+        response = unauthorized_test_client.patch(
+            "/variables",
+            json={
+                "actions": [
+                    {
+                        "action": "create",
+                        "entities": [
+                            {"key": "var1", "value": "value1"},
+                        ],
+                    },
+                ]
+            },
+        )
         assert response.status_code == 403


### PR DESCRIPTION
In Airflow, connections, pools and variables have bulk APIs. Through these APIs, you can create, edit and delete a same kind of resource (connection, pool or variable) within a same request.

However, these APIs have bad authorization checks. For example, `bulk_connections` has `requires_access_connection(method="PUT")` as access control. That means, anyone having `PUT` (edit) access on connections, can create, edit or delete a connection using the bulk API. And this is true for pools and variables as well.

Since these APIs are different from the others, I built specific access control decorators to check the user has access to all resources and operations they are trying to do within the request.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
