### PR TITLE
README optional dependencies template

### DIFF
--- a/dev/breeze/src/airflow_breeze/templates/PROVIDER_README_TEMPLATE.rst.jinja2
+++ b/dev/breeze/src/airflow_breeze/templates/PROVIDER_README_TEMPLATE.rst.jinja2
@@ -102,6 +102,16 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 {{ CROSS_PROVIDERS_DEPENDENCIES_TABLE_RST | safe }}
 
 {%- endif %}
+{%- if OPTIONAL_DEPENDENCIES %}
+
+Optional dependencies
+----------------------
+
+{%- for extra_name, dependencies in OPTIONAL_DEPENDENCIES.items() %}
+``{{ extra_name }}`` : {{ ", ".join(dependencies) }}
+{%- endfor %}
+
+{%- endif %}
 
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/{{ PACKAGE_PIP_NAME }}/{{RELEASE}}/changelog.html>`_.

--- a/dev/breeze/src/airflow_breeze/templates/PROVIDER_README_TEMPLATE.rst.jinja2
+++ b/dev/breeze/src/airflow_breeze/templates/PROVIDER_README_TEMPLATE.rst.jinja2
@@ -107,9 +107,7 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 Optional dependencies
 ----------------------
 
-{%- for extra_name, dependencies in OPTIONAL_DEPENDENCIES.items() %}
-``{{ extra_name }}`` : {{ ", ".join(dependencies) }}
-{%- endfor %}
+{{ OPTIONAL_DEPENDENCIES_TABLE_RST | safe }}
 
 {%- endif %}
 

--- a/dev/breeze/src/airflow_breeze/utils/packages.py
+++ b/dev/breeze/src/airflow_breeze/utils/packages.py
@@ -292,6 +292,11 @@ def get_provider_requirements(provider_id: str) -> list[str]:
     return package_metadata["dependencies"] if package_metadata else []
 
 
+def get_provider_optional_dependencies(provider_id: str) -> dict[str, list[str]]:
+    package_metadata = get_provider_distributions_metadata().get(provider_id)
+    return package_metadata.get("optional-dependencies", {}) if package_metadata else {}
+
+
 @lru_cache
 def get_available_distributions(
     include_non_provider_doc_packages: bool = False,
@@ -679,6 +684,7 @@ def get_provider_jinja_context(
         ),
         "REQUIRES_PYTHON": requires_python_version,
         "EXTRA_PROJECT_METADATA": provider_details.extra_project_metadata,
+        "OPTIONAL_DEPENDENCIES": get_provider_optional_dependencies(provider_id),
     }
     return context
 

--- a/dev/breeze/src/airflow_breeze/utils/packages.py
+++ b/dev/breeze/src/airflow_breeze/utils/packages.py
@@ -631,6 +631,30 @@ def convert_cross_package_dependencies_to_table(
     return tabulate(table_data, headers=headers, tablefmt="pipe" if markdown else "rst")
 
 
+def convert_optional_dependencies_to_table(
+    optional_dependencies: dict[str, list[str]],
+    markdown: bool = True,
+) -> str:
+    """
+    Converts optional dependencies to a Markdown/RST table
+    :param optional_dependencies: dict of optional dependencies
+    :param markdown: if True, Markdown format is used else rst
+    :return: formatted table
+    """
+    import html
+
+    from tabulate import tabulate
+
+    headers = ["Extra", "Dependencies"]
+    table_data = []
+    for extra_name, dependencies in optional_dependencies.items():
+        decoded_deps = [html.unescape(dep) for dep in dependencies]
+        formatted_deps = ", ".join(f"`{dep}`" if markdown else f"``{dep}``" for dep in decoded_deps)
+        extra_col = f"`{extra_name}`" if markdown else f"``{extra_name}``"
+        table_data.append((extra_col, formatted_deps))
+    return tabulate(table_data, headers=headers, tablefmt="pipe" if markdown else "rst")
+
+
 def get_cross_provider_dependent_packages(provider_id: str) -> list[str]:
     if provider_id in get_removed_provider_ids():
         return []
@@ -685,6 +709,9 @@ def get_provider_jinja_context(
         "REQUIRES_PYTHON": requires_python_version,
         "EXTRA_PROJECT_METADATA": provider_details.extra_project_metadata,
         "OPTIONAL_DEPENDENCIES": get_provider_optional_dependencies(provider_id),
+        "OPTIONAL_DEPENDENCIES_TABLE_RST": convert_optional_dependencies_to_table(
+            get_provider_optional_dependencies(provider_id), markdown=False
+        ),
     }
     return context
 

--- a/providers/amazon/README.rst
+++ b/providers/amazon/README.rst
@@ -25,7 +25,6 @@ Package ``apache-airflow-providers-amazon``
 
 Release: ``9.12.0``
 
-Release Date: ``|PypiReleaseDate|``
 
 Amazon integration (including `Amazon Web Services (AWS) <https://aws.amazon.com/>`__).
 
@@ -103,6 +102,26 @@ Dependent package                                                               
 `apache-airflow-providers-salesforce <https://airflow.apache.org/docs/apache-airflow-providers-salesforce>`_              ``salesforce``
 `apache-airflow-providers-ssh <https://airflow.apache.org/docs/apache-airflow-providers-ssh>`_                            ``ssh``
 ========================================================================================================================  ====================
+
+Optional dependencies
+----------------------
+``aiobotocore`` : aiobotocore[boto3]&gt;=2.21.1
+``cncf.kubernetes`` : apache-airflow-providers-cncf-kubernetes&gt;=7.2.0
+``s3fs`` : s3fs&gt;=2023.10.0
+``python3-saml`` : python3-saml&gt;=1.16.0; python_version &lt; &#39;3.13&#39;, xmlsec&gt;=1.3.14; python_version &lt; &#39;3.13&#39;, lxml&gt;=6.0.0; python_version &lt; &#39;3.13&#39;
+``apache.hive`` : apache-airflow-providers-apache-hive
+``exasol`` : apache-airflow-providers-exasol
+``fab`` : apache-airflow-providers-fab&gt;=2.2.0; python_version &lt; &#39;3.13&#39;
+``ftp`` : apache-airflow-providers-ftp
+``google`` : apache-airflow-providers-google
+``imap`` : apache-airflow-providers-imap
+``microsoft.azure`` : apache-airflow-providers-microsoft-azure
+``mongo`` : apache-airflow-providers-mongo
+``openlineage`` : apache-airflow-providers-openlineage&gt;=2.3.0
+``salesforce`` : apache-airflow-providers-salesforce
+``ssh`` : apache-airflow-providers-ssh
+``standard`` : apache-airflow-providers-standard
+``common.messaging`` : apache-airflow-providers-common-messaging&gt;=1.0.3
 
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-amazon/9.12.0/changelog.html>`_.

--- a/providers/amazon/README.rst
+++ b/providers/amazon/README.rst
@@ -105,23 +105,28 @@ Dependent package                                                               
 
 Optional dependencies
 ----------------------
-``aiobotocore`` : aiobotocore[boto3]&gt;=2.21.1
-``cncf.kubernetes`` : apache-airflow-providers-cncf-kubernetes&gt;=7.2.0
-``s3fs`` : s3fs&gt;=2023.10.0
-``python3-saml`` : python3-saml&gt;=1.16.0; python_version &lt; &#39;3.13&#39;, xmlsec&gt;=1.3.14; python_version &lt; &#39;3.13&#39;, lxml&gt;=6.0.0; python_version &lt; &#39;3.13&#39;
-``apache.hive`` : apache-airflow-providers-apache-hive
-``exasol`` : apache-airflow-providers-exasol
-``fab`` : apache-airflow-providers-fab&gt;=2.2.0; python_version &lt; &#39;3.13&#39;
-``ftp`` : apache-airflow-providers-ftp
-``google`` : apache-airflow-providers-google
-``imap`` : apache-airflow-providers-imap
-``microsoft.azure`` : apache-airflow-providers-microsoft-azure
-``mongo`` : apache-airflow-providers-mongo
-``openlineage`` : apache-airflow-providers-openlineage&gt;=2.3.0
-``salesforce`` : apache-airflow-providers-salesforce
-``ssh`` : apache-airflow-providers-ssh
-``standard`` : apache-airflow-providers-standard
-``common.messaging`` : apache-airflow-providers-common-messaging&gt;=1.0.3
+
+====================  ========================================================================================================================================
+Extra                 Dependencies
+====================  ========================================================================================================================================
+``aiobotocore``       ``aiobotocore[boto3]>=2.21.1``
+``cncf.kubernetes``   ``apache-airflow-providers-cncf-kubernetes>=7.2.0``
+``s3fs``              ``s3fs>=2023.10.0``
+``python3-saml``      ``python3-saml>=1.16.0; python_version < '3.13'``, ``xmlsec>=1.3.14; python_version < '3.13'``, ``lxml>=6.0.0; python_version < '3.13'``
+``apache.hive``       ``apache-airflow-providers-apache-hive``
+``exasol``            ``apache-airflow-providers-exasol``
+``fab``               ``apache-airflow-providers-fab>=2.2.0; python_version < '3.13'``
+``ftp``               ``apache-airflow-providers-ftp``
+``google``            ``apache-airflow-providers-google``
+``imap``              ``apache-airflow-providers-imap``
+``microsoft.azure``   ``apache-airflow-providers-microsoft-azure``
+``mongo``             ``apache-airflow-providers-mongo``
+``openlineage``       ``apache-airflow-providers-openlineage>=2.3.0``
+``salesforce``        ``apache-airflow-providers-salesforce``
+``ssh``               ``apache-airflow-providers-ssh``
+``standard``          ``apache-airflow-providers-standard``
+``common.messaging``  ``apache-airflow-providers-common-messaging>=1.0.3``
+====================  ========================================================================================================================================
 
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-amazon/9.12.0/changelog.html>`_.


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/55207
Changed provider template to reflect optional dependencies with upper limit for READMEs
Only generated amazon provider assuming all are re-generated during CI/CD (?)