### PR TITLE
add stable note to BatchExecutor

### DIFF
--- a/providers/amazon/docs/changelog.rst
+++ b/providers/amazon/docs/changelog.rst
@@ -32,6 +32,9 @@ Changelog
 
 Release Date: ``|PypiReleaseDate|``
 
+.. note::
+  * ``The experimental BatchExecutor added in 8.20.0 is now stable``
+
 Features
 ~~~~~~~~
 


### PR DESCRIPTION
looks like I lost the stable note in changelog during rebasing the release PR so adding it again.
I will rebuild the docs to include this commit during release