### PR TITLE
Remove python_callable as string from mapped operator in serialized Dag

### DIFF
--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -1457,6 +1457,13 @@ class SerializedBaseOperator(DAGNode, BaseSerialization):
                     continue
                 serialized_op["partial_kwargs"].update({k: cls.serialize(v)})
 
+        # we want to store python_callable_name, not python_callable
+        python_callable = op.partial_kwargs.get("python_callable", None)
+        if python_callable:
+            callable_name = qualname(python_callable)
+            serialized_op["partial_kwargs"]["python_callable_name"] = callable_name
+            del serialized_op["partial_kwargs"]["python_callable"]
+
         serialized_op["_is_mapped"] = True
         return serialized_op
 

--- a/airflow-core/tests/unit/serialization/test_dag_serialization.py
+++ b/airflow-core/tests/unit/serialization/test_dag_serialization.py
@@ -3021,8 +3021,8 @@ def test_python_callable_in_partial_kwargs():
     assert serialized["partial_kwargs"]["python_callable_name"] == qualname(empty_function)
 
     deserialized = SerializedBaseOperator.deserialize_operator(serialized)
-    assert "python_callable" not in getattr(deserialized, "partial_kwargs")
-    assert getattr(deserialized, "partial_kwargs")["python_callable_name"] == qualname(empty_function)
+    assert "python_callable" not in deserialized.partial_kwargs
+    assert deserialized.partial_kwargs["python_callable_name"] == qualname(empty_function)
 
 
 def test_handle_v1_serdag():

--- a/airflow-core/tests/unit/serialization/test_dag_serialization.py
+++ b/airflow-core/tests/unit/serialization/test_dag_serialization.py
@@ -3004,6 +3004,27 @@ def test_mapped_task_with_operator_extra_links_property():
     assert mapped_task.extra_links == sorted({"airflow", "github"})
 
 
+def empty_function(*args, **kwargs):
+    """Empty function for testing."""
+
+
+def test_python_callable_in_partial_kwargs():
+    from airflow.providers.standard.operators.python import PythonOperator
+
+    operator = PythonOperator.partial(
+        task_id="task",
+        python_callable=empty_function,
+    ).expand(op_kwargs=[{"x": 1}])
+
+    serialized = SerializedBaseOperator.serialize_mapped_operator(operator)
+    assert "python_callable" not in serialized["partial_kwargs"]
+    assert serialized["partial_kwargs"]["python_callable_name"] == qualname(empty_function)
+
+    deserialized = SerializedBaseOperator.deserialize_operator(serialized)
+    assert "python_callable" not in getattr(deserialized, "partial_kwargs")
+    assert getattr(deserialized, "partial_kwargs")["python_callable_name"] == qualname(empty_function)
+
+
 def test_handle_v1_serdag():
     v1 = {
         "__version": 1,


### PR DESCRIPTION
Remove string serialization of python_callable in mapped tasks partial_kwargs. This reduces the serialized Dag size.