### PR TITLE
Remove state dependency from airflow core in sdk

### DIFF
--- a/providers/openlineage/docs/guides/developer.rst
+++ b/providers/openlineage/docs/guides/developer.rst
@@ -405,7 +405,8 @@ Writing a custom facet function
 .. code-block:: python
 
     import attrs
-    from airflow.models.taskinstance import TaskInstance, TaskInstanceState
+    from airflow.models.taskinstance import TaskInstance
+    from airflow.sdk import TaskInstanceState
     from airflow.providers.common.compat.openlineage.facet import RunFacet
 
 

--- a/providers/openlineage/docs/guides/developer.rst
+++ b/providers/openlineage/docs/guides/developer.rst
@@ -405,8 +405,7 @@ Writing a custom facet function
 .. code-block:: python
 
     import attrs
-    from airflow.models.taskinstance import TaskInstance
-    from airflow.sdk import TaskInstanceState
+    from airflow.models.taskinstance import TaskInstance, TaskInstanceState
     from airflow.providers.common.compat.openlineage.facet import RunFacet
 
 

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -39,6 +39,7 @@ from airflow.sdk.api.datamodels._generated import (
     DagRunStateResponse,
     HITLDetailResponse,
     HITLUser,
+    TerminalTIState,
     VariableResponse,
     XComResponse,
 )
@@ -52,7 +53,6 @@ from airflow.sdk.execution_time.comms import (
     RescheduleTask,
     TaskRescheduleStartDate,
 )
-from airflow.utils.state import TerminalTIState
 
 if TYPE_CHECKING:
     from time_machine import TimeMachineFixture

--- a/task-sdk/tests/task_sdk/bases/test_sensor.py
+++ b/task-sdk/tests/task_sdk/bases/test_sensor.py
@@ -34,12 +34,11 @@ from airflow.exceptions import (
 )
 from airflow.models.trigger import TriggerFailureReason
 from airflow.providers.standard.operators.empty import EmptyOperator
-from airflow.sdk import timezone
+from airflow.sdk import TaskInstanceState, timezone
 from airflow.sdk.bases.sensor import BaseSensorOperator, PokeReturnValue, poke_mode_only
 from airflow.sdk.definitions.dag import DAG
 from airflow.sdk.execution_time.comms import RescheduleTask, TaskRescheduleStartDate
 from airflow.sdk.timezone import datetime
-from airflow.utils.state import State
 
 if TYPE_CHECKING:
     from airflow.sdk.definitions.context import Context
@@ -172,7 +171,7 @@ class TestBaseSensor:
 
         state, msg, _ = run_task(task=sensor)
 
-        assert state == State.UP_FOR_RESCHEDULE
+        assert state == TaskInstanceState.UP_FOR_RESCHEDULE
         assert msg.reschedule_date == date1 + timedelta(seconds=sensor.poke_interval)
 
         # second poke returns False and task is re-scheduled
@@ -180,14 +179,14 @@ class TestBaseSensor:
         date2 = date1 + timedelta(seconds=sensor.poke_interval)
         state, msg, _ = run_task(task=sensor)
 
-        assert state == State.UP_FOR_RESCHEDULE
+        assert state == TaskInstanceState.UP_FOR_RESCHEDULE
         assert msg.reschedule_date == date2 + timedelta(seconds=sensor.poke_interval)
 
         # third poke returns True and task succeeds
         time_machine.coordinates.shift(sensor.poke_interval)
         state, _, _ = run_task(task=sensor)
 
-        assert state == State.SUCCESS
+        assert state == TaskInstanceState.SUCCESS
 
     def test_fail_with_reschedule(self, run_task, make_sensor, time_machine, mock_supervisor_comms):
         sensor = make_sensor(return_value=False, poke_interval=10, timeout=5, mode="reschedule")
@@ -198,7 +197,7 @@ class TestBaseSensor:
 
         state, msg, _ = run_task(task=sensor)
 
-        assert state == State.UP_FOR_RESCHEDULE
+        assert state == TaskInstanceState.UP_FOR_RESCHEDULE
         assert msg.reschedule_date == date1 + timedelta(seconds=sensor.poke_interval)
 
         # second poke returns False, timeout occurs
@@ -208,7 +207,7 @@ class TestBaseSensor:
         mock_supervisor_comms.send.return_value = TaskRescheduleStartDate(start_date=date1)
         state, msg, error = run_task(task=sensor, context_update={"task_reschedule_count": 1})
 
-        assert state == State.FAILED
+        assert state == TaskInstanceState.FAILED
         assert isinstance(error, AirflowSensorTimeout)
 
     def test_soft_fail_with_reschedule(self, run_task, make_sensor, time_machine, mock_supervisor_comms):
@@ -221,7 +220,7 @@ class TestBaseSensor:
         time_machine.move_to(date1, tick=False)
 
         state, msg, _ = run_task(task=sensor)
-        assert state == State.UP_FOR_RESCHEDULE
+        assert state == TaskInstanceState.UP_FOR_RESCHEDULE
 
         # second poke returns False, timeout occurs
         time_machine.coordinates.shift(sensor.poke_interval)
@@ -229,7 +228,7 @@ class TestBaseSensor:
         # Mocking values from DB/API-server
         mock_supervisor_comms.send.return_value = TaskRescheduleStartDate(start_date=date1)
         state, msg, _ = run_task(task=sensor, context_update={"task_reschedule_count": 1})
-        assert state == State.SKIPPED
+        assert state == TaskInstanceState.SKIPPED
 
     def test_ok_with_reschedule_and_exponential_backoff(
         self, run_task, make_sensor, time_machine, mock_supervisor_comms
@@ -261,7 +260,7 @@ class TestBaseSensor:
             curr_date = curr_date + timedelta(seconds=new_interval)
             time_machine.coordinates.shift(new_interval)
             state, msg, _ = run_task(sensor, context_update={"task_reschedule_count": _poke_count})
-            assert state == State.UP_FOR_RESCHEDULE
+            assert state == TaskInstanceState.UP_FOR_RESCHEDULE
             old_interval = new_interval
             new_interval = sensor._get_next_poke_interval(task_start_date, run_duration, _poke_count)
             assert old_interval < new_interval  # actual test
@@ -272,7 +271,7 @@ class TestBaseSensor:
         time_machine.coordinates.shift(new_interval)
 
         state, msg, _ = run_task(sensor, context_update={"task_reschedule_count": false_count + 1})
-        assert state == State.SUCCESS
+        assert state == TaskInstanceState.SUCCESS
 
     def test_invalid_mode(self):
         with pytest.raises(AirflowException):
@@ -291,7 +290,7 @@ class TestBaseSensor:
         with time_machine.travel(date1, tick=False):
             state, msg, error = run_task(sensor)
 
-        assert state == State.UP_FOR_RESCHEDULE
+        assert state == TaskInstanceState.UP_FOR_RESCHEDULE
         assert isinstance(msg, RescheduleTask)
         assert msg.reschedule_date == date2
 
@@ -299,14 +298,14 @@ class TestBaseSensor:
         with time_machine.travel(date2, tick=False):
             state, msg, error = run_task(sensor)
 
-        assert state == State.UP_FOR_RESCHEDULE
+        assert state == TaskInstanceState.UP_FOR_RESCHEDULE
         assert isinstance(msg, RescheduleTask)
         assert msg.reschedule_date == date3
 
         # third poke returns True and task succeeds
         with time_machine.travel(date3, tick=False):
             state, _, _ = run_task(sensor)
-        assert state == State.SUCCESS
+        assert state == TaskInstanceState.SUCCESS
 
     def test_sensor_with_invalid_poke_interval(self):
         negative_poke_interval = -10
@@ -523,36 +522,36 @@ class TestBaseSensor:
                 context_update={"task_reschedule_count": test_state["task_reschedule_count"]},
             )
 
-            if state == State.UP_FOR_RESCHEDULE:
+            if state == TaskInstanceState.UP_FOR_RESCHEDULE:
                 test_state["task_reschedule_count"] += 1
                 # Only set first_reschedule_date on the first successful reschedule
                 if test_state["first_reschedule_date"] is None:
                     test_state["first_reschedule_date"] = test_state["current_time"]
-            elif state == State.UP_FOR_RETRY:
+            elif state == TaskInstanceState.UP_FOR_RETRY:
                 test_state["try_number"] += 1
             return state, msg, error
 
         # Phase 1: Initial execution until failure
         # First poke - should reschedule
         state, _, _ = _run_task()
-        assert state == State.UP_FOR_RESCHEDULE
+        assert state == TaskInstanceState.UP_FOR_RESCHEDULE
 
         # Second poke - should raise RuntimeError and retry
         test_state["current_time"] += timedelta(seconds=sensor.poke_interval)
         state, _, error = _run_task()
-        assert state == State.UP_FOR_RETRY
+        assert state == TaskInstanceState.UP_FOR_RETRY
         assert isinstance(error, RuntimeError)
 
         # Third poke - should reschedule again
         test_state["current_time"] += sensor.retry_delay + timedelta(seconds=1)
         state, _, _ = _run_task()
-        assert state == State.UP_FOR_RESCHEDULE
+        assert state == TaskInstanceState.UP_FOR_RESCHEDULE
 
         # Fourth poke - should timeout
         test_state["current_time"] += timedelta(seconds=sensor.poke_interval)
         state, _, error = _run_task()
         assert isinstance(error, AirflowSensorTimeout)
-        assert state == State.FAILED
+        assert state == TaskInstanceState.FAILED
 
         # Phase 2: After clearing the failed sensor
         # Reset supervisor comms to return None, simulating a fresh start after clearing
@@ -564,13 +563,13 @@ class TestBaseSensor:
         for _ in range(3):
             test_state["current_time"] += timedelta(seconds=sensor.poke_interval)
             state, _, _ = _run_task()
-            assert state == State.UP_FOR_RESCHEDULE
+            assert state == TaskInstanceState.UP_FOR_RESCHEDULE
 
         # Final poke - should timeout
         test_state["current_time"] += timedelta(seconds=sensor.poke_interval)
         state, _, error = _run_task()
         assert isinstance(error, AirflowSensorTimeout)
-        assert state == State.FAILED
+        assert state == TaskInstanceState.FAILED
 
     def test_sensor_with_xcom(self, make_sensor):
         xcom_value = "TestValue"
@@ -615,7 +614,7 @@ class TestBaseSensor:
         state, _, error = run_task(task=task, dag_id=f"test_sensor_timeout_{mode}_{retries}")
 
         assert isinstance(error, AirflowSensorTimeout)
-        assert state == State.FAILED
+        assert state == TaskInstanceState.FAILED
 
 
 @poke_mode_only


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
The task-sdk was importing and using the `State` class from `airflow.utils.state`, creating an unnecessary dependency on airflow-core utils

This PR replaces all `State` class usage with equivalent enums from the Execution API:

- **`TaskInstanceState`** - For task instance states (SUCCESS, FAILED, QUEUED, etc.)
- **`DagRunState`** - For DAG run states  
- **`TerminalTIState`** - For terminal task instance states

closes: [#55166](https://github.com/apache/airflow/issues/55166)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
