### PR TITLE
Update TelegramHook, added escaping for kwargs["text"]

### DIFF
--- a/providers/telegram/src/airflow/providers/telegram/hooks/telegram.py
+++ b/providers/telegram/src/airflow/providers/telegram/hooks/telegram.py
@@ -156,6 +156,12 @@ class TelegramHook(BaseHook):
         if kwargs.get("chat_id") is None:
             raise AirflowException("'chat_id' must be provided for telegram message")
 
+        if kwargs["parse_mode"] == telegram.constants.ParseMode.HTML:
+            kwargs["text"] = telegram.helpers.escape(kwargs["text"])
+        else:
+            kwargs["text"] = telegram.helpers.escape_markdown(
+                kwargs["text"], 2 if kwargs["parse_mode"] == telegram.constants.ParseMode.MARKDOWN_V2 else 1)
+
         response = asyncio.run(self.connection.send_message(**kwargs))
         self.log.debug(response)
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
Added escape for kwargs["text"] via telegram.helpers.escape and telegram.helpers.escape_markdown

**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
