### PR TITLE
Fix Gantt chart no status color

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/Gantt.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/Gantt.tsx
@@ -178,7 +178,8 @@ export const Gantt = ({ limit }: Props) => {
         {
           backgroundColor: data.map(
             (dataItem) =>
-              system.tokens.categoryMap.get("colors")?.get(`${dataItem.state}.600`)?.value as string,
+              system.tokens.categoryMap.get("colors")?.get(`${dataItem.state ?? "none"}.600`)
+                ?.value as string,
           ),
           data,
           maxBarThickness: CHART_ROW_HEIGHT,


### PR DESCRIPTION
### Before:
<img width="1630" height="925" alt="Screenshot 2025-09-05 at 15 30 44" src="https://github.com/user-attachments/assets/a14b8f7f-d242-4951-b740-ffde3653587a" />



### After:
<img width="1747" height="776" alt="Screenshot 2025-09-05 at 15 30 21" src="https://github.com/user-attachments/assets/12fe241f-2ace-4039-801a-bbea737fd207" />
