### PR TITLE
Make `batch_is_authorized_` methods team aware

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/import_error.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/import_error.py
@@ -179,19 +179,21 @@ def get_import_errors(
         limit=limit,
         session=session,
     )
-    import_errors_result: Iterable[tuple[ParseImportError, Iterable[str]]] = groupby(
+    import_errors_result: Iterable[tuple[ParseImportError, Iterable]] = groupby(
         session.execute(import_errors_select), itemgetter(0)
     )
 
     import_errors = []
     for import_error, file_dag_ids in import_errors_result:
+        dag_ids = [dag_id for _, dag_id in file_dag_ids]
+        teams = DagModel.get_bulk_team_name(dag_ids, session=session)
         # Check if user has read access to all the DAGs defined in the file
         requests: Sequence[IsAuthorizedDagRequest] = [
             {
                 "method": "GET",
-                "details": DagDetails(id=dag_id),
+                "details": DagDetails(id=dag_id, team_name=teams.get(dag_id)),
             }
-            for dag_id in file_dag_ids
+            for dag_id in dag_ids
         ]
         if not auth_manager.batch_is_authorized_dag(requests, user=user):
             session.expunge(import_error)

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/import_error.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/import_error.py
@@ -186,12 +186,12 @@ def get_import_errors(
     import_errors = []
     for import_error, file_dag_ids in import_errors_result:
         dag_ids = [dag_id for _, dag_id in file_dag_ids]
-        teams = DagModel.get_bulk_team_name(dag_ids, session=session)
+        dag_id_to_team = DagModel.get_dag_id_to_team_name_mapping(dag_ids, session=session)
         # Check if user has read access to all the DAGs defined in the file
         requests: Sequence[IsAuthorizedDagRequest] = [
             {
                 "method": "GET",
-                "details": DagDetails(id=dag_id, team_name=teams.get(dag_id)),
+                "details": DagDetails(id=dag_id, team_name=dag_id_to_team.get(dag_id)),
             }
             for dag_id in dag_ids
         ]

--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -601,7 +601,9 @@ class Connection(Base, LoggingMixin):
 
     @staticmethod
     @provide_session
-    def get_bulk_team_name(connection_ids: list[str], session=NEW_SESSION) -> dict[str, str | None]:
+    def get_conn_id_to_team_name_mapping(
+        connection_ids: list[str], session=NEW_SESSION
+    ) -> dict[str, str | None]:
         stmt = (
             select(Connection.conn_id, Team.name)
             .join(Team, Connection.team_id == Team.id)

--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -598,3 +598,13 @@ class Connection(Base, LoggingMixin):
             .where(Connection.conn_id == connection_id)
         )
         return session.scalar(stmt)
+
+    @staticmethod
+    @provide_session
+    def get_bulk_team_name(connection_ids: list[str], session=NEW_SESSION) -> dict[str, str | None]:
+        stmt = (
+            select(Connection.conn_id, Team.name)
+            .join(Team, Connection.team_id == Team.id)
+            .where(Connection.conn_id.in_(connection_ids))
+        )
+        return {conn_id: team_name for conn_id, team_name in session.execute(stmt)}

--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -699,7 +699,7 @@ class DagModel(Base):
 
     @staticmethod
     @provide_session
-    def get_bulk_team_name(dag_ids: list[str], session=NEW_SESSION) -> dict[str, str | None]:
+    def get_dag_id_to_team_name_mapping(dag_ids: list[str], session=NEW_SESSION) -> dict[str, str | None]:
         stmt = (
             select(DagModel.dag_id, Team.name)
             .join(DagBundleModel.teams)

--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -697,6 +697,17 @@ class DagModel(Base):
         )
         return session.scalar(stmt)
 
+    @staticmethod
+    @provide_session
+    def get_bulk_team_name(dag_ids: list[str], session=NEW_SESSION) -> dict[str, str | None]:
+        stmt = (
+            select(DagModel.dag_id, Team.name)
+            .join(DagBundleModel.teams)
+            .join(DagModel, DagModel.bundle_name == DagBundleModel.name)
+            .where(DagModel.dag_id.in_(dag_ids))
+        )
+        return {dag_id: team_name for dag_id, team_name in session.execute(stmt)}
+
 
 STATICA_HACK = True
 globals()["kcah_acitats"[::-1].upper()] = False

--- a/airflow-core/src/airflow/models/pool.py
+++ b/airflow-core/src/airflow/models/pool.py
@@ -359,3 +359,11 @@ class Pool(Base):
     def get_team_name(pool_name: str, session=NEW_SESSION) -> str | None:
         stmt = select(Team.name).join(Pool, Team.id == Pool.team_id).where(Pool.pool == pool_name)
         return session.scalar(stmt)
+
+    @staticmethod
+    @provide_session
+    def get_bulk_team_name(pool_names: list[str], session=NEW_SESSION) -> dict[str, str | None]:
+        stmt = (
+            select(Pool.pool, Team.name).join(Team, Pool.team_id == Team.id).where(Pool.pool.in_(pool_names))
+        )
+        return {pool: team_name for pool, team_name in session.execute(stmt)}

--- a/airflow-core/src/airflow/models/pool.py
+++ b/airflow-core/src/airflow/models/pool.py
@@ -362,7 +362,7 @@ class Pool(Base):
 
     @staticmethod
     @provide_session
-    def get_bulk_team_name(pool_names: list[str], session=NEW_SESSION) -> dict[str, str | None]:
+    def get_name_to_team_name_mapping(pool_names: list[str], session=NEW_SESSION) -> dict[str, str | None]:
         stmt = (
             select(Pool.pool, Team.name).join(Team, Pool.team_id == Team.id).where(Pool.pool.in_(pool_names))
         )

--- a/airflow-core/src/airflow/models/variable.py
+++ b/airflow-core/src/airflow/models/variable.py
@@ -465,7 +465,7 @@ class Variable(Base, LoggingMixin):
 
     @staticmethod
     @provide_session
-    def get_bulk_team_name(variable_keys: list[str], session=NEW_SESSION) -> dict[str, str | None]:
+    def get_key_to_team_name_mapping(variable_keys: list[str], session=NEW_SESSION) -> dict[str, str | None]:
         stmt = (
             select(Variable.key, Team.name)
             .join(Team, Variable.team_id == Team.id)

--- a/airflow-core/src/airflow/models/variable.py
+++ b/airflow-core/src/airflow/models/variable.py
@@ -462,3 +462,13 @@ class Variable(Base, LoggingMixin):
             select(Team.name).join(Variable, Team.id == Variable.team_id).where(Variable.key == variable_key)
         )
         return session.scalar(stmt)
+
+    @staticmethod
+    @provide_session
+    def get_bulk_team_name(variable_keys: list[str], session=NEW_SESSION) -> dict[str, str | None]:
+        stmt = (
+            select(Variable.key, Team.name)
+            .join(Team, Variable.team_id == Team.id)
+            .where(Variable.key.in_(variable_keys))
+        )
+        return {key: team_name for key, team_name in session.execute(stmt)}

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_import_error.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_import_error.py
@@ -22,6 +22,7 @@ from unittest import mock
 
 import pytest
 
+from airflow.api_fastapi.auth.managers.models.resource_details import DagDetails
 from airflow.models import DagModel
 from airflow.models.dagbundle import DagBundleModel
 from airflow.models.errors import ParseImportError
@@ -343,10 +344,19 @@ class TestGetImportErrors:
         assert response.status_code == 403
 
     @pytest.mark.parametrize(
-        "batch_is_authorized_dag_return_value, expected_stack_trace",
+        "team, batch_is_authorized_dag_return_value, expected_stack_trace",
         [
-            pytest.param(True, STACKTRACE1, id="user_has_read_access_to_all_dags_in_current_file"),
             pytest.param(
+                "test_team",
+                True,
+                STACKTRACE1,
+                id="user_has_read_access_to_all_dags_in_current_file_with_team",
+            ),
+            pytest.param(
+                None, True, STACKTRACE1, id="user_has_read_access_to_all_dags_in_current_file_without_team"
+            ),
+            pytest.param(
+                None,
                 False,
                 "REDACTED - you do not have read permission on all DAGs in the file",
                 id="user_does_not_have_read_access_to_all_dags_in_current_file",
@@ -354,21 +364,25 @@ class TestGetImportErrors:
         ],
     )
     @pytest.mark.usefixtures("permitted_dag_model")
+    @mock.patch.object(DagModel, "get_bulk_team_name")
     @mock.patch("airflow.api_fastapi.core_api.routes.public.import_error.get_auth_manager")
     def test_user_can_not_read_all_dags_in_file(
         self,
         mock_get_auth_manager,
+        mock_get_bulk_team_name,
         test_client,
+        team,
         batch_is_authorized_dag_return_value,
         expected_stack_trace,
         permitted_dag_model,
         import_errors,
     ):
+        mock_get_bulk_team_name.return_value = {permitted_dag_model.dag_id: team}
         set_mock_auth_manager__is_authorized_dag(mock_get_auth_manager)
         mock_get_authorized_dag_ids = set_mock_auth_manager__get_authorized_dag_ids(
             mock_get_auth_manager, {permitted_dag_model.dag_id}
         )
-        set_mock_auth_manager__batch_is_authorized_dag(
+        mock_batch_is_authorized_dag = set_mock_auth_manager__batch_is_authorized_dag(
             mock_get_auth_manager, batch_is_authorized_dag_return_value
         )
         # Act
@@ -389,6 +403,15 @@ class TestGetImportErrors:
                 }
             ],
         }
+        mock_batch_is_authorized_dag.assert_called_once_with(
+            [
+                {
+                    "method": "GET",
+                    "details": DagDetails(id=permitted_dag_model.dag_id, team_name=team),
+                }
+            ],
+            user=mock.ANY,
+        )
 
     @pytest.mark.usefixtures("permitted_dag_model")
     @mock.patch("airflow.api_fastapi.core_api.routes.public.import_error.get_auth_manager")

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_import_error.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_import_error.py
@@ -364,12 +364,12 @@ class TestGetImportErrors:
         ],
     )
     @pytest.mark.usefixtures("permitted_dag_model")
-    @mock.patch.object(DagModel, "get_bulk_team_name")
+    @mock.patch.object(DagModel, "get_dag_id_to_team_name_mapping")
     @mock.patch("airflow.api_fastapi.core_api.routes.public.import_error.get_auth_manager")
     def test_user_can_not_read_all_dags_in_file(
         self,
         mock_get_auth_manager,
-        mock_get_bulk_team_name,
+        mock_get_dag_id_to_team_name_mapping,
         test_client,
         team,
         batch_is_authorized_dag_return_value,
@@ -377,7 +377,7 @@ class TestGetImportErrors:
         permitted_dag_model,
         import_errors,
     ):
-        mock_get_bulk_team_name.return_value = {permitted_dag_model.dag_id: team}
+        mock_get_dag_id_to_team_name_mapping.return_value = {permitted_dag_model.dag_id: team}
         set_mock_auth_manager__is_authorized_dag(mock_get_auth_manager)
         mock_get_authorized_dag_ids = set_mock_auth_manager__get_authorized_dag_ids(
             mock_get_auth_manager, {permitted_dag_model.dag_id}

--- a/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
@@ -106,7 +106,7 @@ class TestFastApiSecurity:
 
     @pytest.mark.db_test
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
-    async def test_requires_access_dag_authorized(self, mock_get_auth_manager):
+    def test_requires_access_dag_authorized(self, mock_get_auth_manager):
         auth_manager = Mock()
         auth_manager.is_authorized_dag.return_value = True
         mock_get_auth_manager.return_value = auth_manager
@@ -119,7 +119,7 @@ class TestFastApiSecurity:
 
     @pytest.mark.db_test
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
-    async def test_requires_access_dag_unauthorized(self, mock_get_auth_manager):
+    def test_requires_access_dag_unauthorized(self, mock_get_auth_manager):
         auth_manager = Mock()
         auth_manager.is_authorized_dag.return_value = False
         mock_get_auth_manager.return_value = auth_manager
@@ -169,7 +169,7 @@ class TestFastApiSecurity:
     )
     @patch.object(Connection, "get_team_name")
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
-    async def test_requires_access_connection(self, mock_get_auth_manager, mock_get_team_name, team_name):
+    def test_requires_access_connection(self, mock_get_auth_manager, mock_get_team_name, team_name):
         auth_manager = Mock()
         auth_manager.is_authorized_connection.return_value = True
         mock_get_auth_manager.return_value = auth_manager
@@ -187,11 +187,14 @@ class TestFastApiSecurity:
         )
         mock_get_team_name.assert_called_once_with("conn_id")
 
+    @patch.object(Connection, "get_bulk_team_name")
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
-    async def test_requires_access_connection_bulk(self, mock_get_auth_manager):
+    def test_requires_access_connection_bulk(self, mock_get_auth_manager, mock_get_bulk_team_name):
         auth_manager = Mock()
         auth_manager.batch_is_authorized_connection.return_value = True
         mock_get_auth_manager.return_value = auth_manager
+        mock_get_bulk_team_name.return_value = {"test1": "team1"}
+
         request = BulkBody[ConnectionBody].model_validate(
             {
                 "actions": [
@@ -216,7 +219,7 @@ class TestFastApiSecurity:
             requests=[
                 {
                     "method": "POST",
-                    "details": ConnectionDetails(conn_id="test1"),
+                    "details": ConnectionDetails(conn_id="test1", team_name="team1"),
                 },
                 {
                     "method": "POST",
@@ -237,7 +240,7 @@ class TestFastApiSecurity:
     )
     @patch.object(Variable, "get_team_name")
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
-    async def test_requires_access_variable(self, mock_get_auth_manager, mock_get_team_name, team_name):
+    def test_requires_access_variable(self, mock_get_auth_manager, mock_get_team_name, team_name):
         auth_manager = Mock()
         auth_manager.is_authorized_variable.return_value = True
         mock_get_auth_manager.return_value = auth_manager
@@ -255,11 +258,13 @@ class TestFastApiSecurity:
         )
         mock_get_team_name.assert_called_once_with("var_key")
 
+    @patch.object(Variable, "get_bulk_team_name")
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
-    async def test_requires_access_variable_bulk(self, mock_get_auth_manager):
+    def test_requires_access_variable_bulk(self, mock_get_auth_manager, mock_get_bulk_team_name):
         auth_manager = Mock()
         auth_manager.batch_is_authorized_variable.return_value = True
         mock_get_auth_manager.return_value = auth_manager
+        mock_get_bulk_team_name.return_value = {"var1": "team1", "dummy": "team2"}
         request = BulkBody[VariableBody].model_validate(
             {
                 "actions": [
@@ -284,7 +289,7 @@ class TestFastApiSecurity:
             requests=[
                 {
                     "method": "POST",
-                    "details": VariableDetails(key="var1"),
+                    "details": VariableDetails(key="var1", team_name="team1"),
                 },
                 {
                     "method": "POST",
@@ -305,7 +310,7 @@ class TestFastApiSecurity:
     )
     @patch.object(Pool, "get_team_name")
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
-    async def test_requires_access_pool(self, mock_get_auth_manager, mock_get_team_name, team_name):
+    def test_requires_access_pool(self, mock_get_auth_manager, mock_get_team_name, team_name):
         auth_manager = Mock()
         auth_manager.is_authorized_pool.return_value = True
         mock_get_auth_manager.return_value = auth_manager
@@ -323,11 +328,13 @@ class TestFastApiSecurity:
         )
         mock_get_team_name.assert_called_once_with("pool")
 
+    @patch.object(Pool, "get_bulk_team_name")
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
-    async def test_requires_access_pool_bulk(self, mock_get_auth_manager):
+    def test_requires_access_pool_bulk(self, mock_get_auth_manager, mock_get_bulk_team_name):
         auth_manager = Mock()
         auth_manager.batch_is_authorized_pool.return_value = True
         mock_get_auth_manager.return_value = auth_manager
+        mock_get_bulk_team_name.return_value = {"pool1": "team1"}
         request = BulkBody[PoolBody].model_validate(
             {
                 "actions": [
@@ -352,7 +359,7 @@ class TestFastApiSecurity:
             requests=[
                 {
                     "method": "POST",
-                    "details": PoolDetails(name="pool1"),
+                    "details": PoolDetails(name="pool1", team_name="team1"),
                 },
                 {
                     "method": "POST",

--- a/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
@@ -187,13 +187,15 @@ class TestFastApiSecurity:
         )
         mock_get_team_name.assert_called_once_with("conn_id")
 
-    @patch.object(Connection, "get_bulk_team_name")
+    @patch.object(Connection, "get_conn_id_to_team_name_mapping")
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
-    def test_requires_access_connection_bulk(self, mock_get_auth_manager, mock_get_bulk_team_name):
+    def test_requires_access_connection_bulk(
+        self, mock_get_auth_manager, mock_get_conn_id_to_team_name_mapping
+    ):
         auth_manager = Mock()
         auth_manager.batch_is_authorized_connection.return_value = True
         mock_get_auth_manager.return_value = auth_manager
-        mock_get_bulk_team_name.return_value = {"test1": "team1"}
+        mock_get_conn_id_to_team_name_mapping.return_value = {"test1": "team1"}
 
         request = BulkBody[ConnectionBody].model_validate(
             {
@@ -258,13 +260,13 @@ class TestFastApiSecurity:
         )
         mock_get_team_name.assert_called_once_with("var_key")
 
-    @patch.object(Variable, "get_bulk_team_name")
+    @patch.object(Variable, "get_key_to_team_name_mapping")
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
-    def test_requires_access_variable_bulk(self, mock_get_auth_manager, mock_get_bulk_team_name):
+    def test_requires_access_variable_bulk(self, mock_get_auth_manager, mock_get_key_to_team_name_mapping):
         auth_manager = Mock()
         auth_manager.batch_is_authorized_variable.return_value = True
         mock_get_auth_manager.return_value = auth_manager
-        mock_get_bulk_team_name.return_value = {"var1": "team1", "dummy": "team2"}
+        mock_get_key_to_team_name_mapping.return_value = {"var1": "team1", "dummy": "team2"}
         request = BulkBody[VariableBody].model_validate(
             {
                 "actions": [
@@ -328,13 +330,13 @@ class TestFastApiSecurity:
         )
         mock_get_team_name.assert_called_once_with("pool")
 
-    @patch.object(Pool, "get_bulk_team_name")
+    @patch.object(Pool, "get_name_to_team_name_mapping")
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
-    def test_requires_access_pool_bulk(self, mock_get_auth_manager, mock_get_bulk_team_name):
+    def test_requires_access_pool_bulk(self, mock_get_auth_manager, mock_get_name_to_team_name_mapping):
         auth_manager = Mock()
         auth_manager.batch_is_authorized_pool.return_value = True
         mock_get_auth_manager.return_value = auth_manager
-        mock_get_bulk_team_name.return_value = {"pool1": "team1"}
+        mock_get_name_to_team_name_mapping.return_value = {"pool1": "team1"}
         request = BulkBody[PoolBody].model_validate(
             {
                 "actions": [

--- a/airflow-core/tests/unit/models/test_connection.py
+++ b/airflow-core/tests/unit/models/test_connection.py
@@ -375,7 +375,7 @@ class TestConnection:
         clear_db_connections()
 
     @pytest.mark.db_test
-    def test_get_bulk_team_name(self, testing_team: Team, session: Session):
+    def test_get_conn_id_to_team_name_mapping(self, testing_team: Team, session: Session):
         clear_db_connections()
 
         connection1 = Connection(conn_id="test_conn1", conn_type="test_type", team_id=testing_team.id)
@@ -384,7 +384,7 @@ class TestConnection:
         session.add(connection2)
         session.flush()
 
-        assert Connection.get_bulk_team_name(["test_conn1", "test_conn2"], session=session) == {
+        assert Connection.get_conn_id_to_team_name_mapping(["test_conn1", "test_conn2"], session=session) == {
             "test_conn1": "testing"
         }
         clear_db_connections()

--- a/airflow-core/tests/unit/models/test_connection.py
+++ b/airflow-core/tests/unit/models/test_connection.py
@@ -373,3 +373,18 @@ class TestConnection:
 
         assert Connection.get_team_name("test_conn", session=session) == "testing"
         clear_db_connections()
+
+    @pytest.mark.db_test
+    def test_get_bulk_team_name(self, testing_team: Team, session: Session):
+        clear_db_connections()
+
+        connection1 = Connection(conn_id="test_conn1", conn_type="test_type", team_id=testing_team.id)
+        connection2 = Connection(conn_id="test_conn2", conn_type="test_type")
+        session.add(connection1)
+        session.add(connection2)
+        session.flush()
+
+        assert Connection.get_bulk_team_name(["test_conn1", "test_conn2"], session=session) == {
+            "test_conn1": "testing"
+        }
+        clear_db_connections()

--- a/airflow-core/tests/unit/models/test_dag.py
+++ b/airflow-core/tests/unit/models/test_dag.py
@@ -2299,7 +2299,7 @@ class TestDagModel:
         assert DagModel.get_dagmodel(dag_id) is not None
         assert DagModel.get_team_name(dag_id, session=session) is None
 
-    def test_get_bulk_team_name(self, testing_team):
+    def test_get_dag_id_to_team_name_mapping(self, testing_team):
         session = settings.Session()
         bundle1 = DagBundleModel(name="bundle1")
         bundle1.teams.append(testing_team)
@@ -2325,7 +2325,9 @@ class TestDagModel:
         session.add(orm_dag1)
         session.add(orm_dag2)
         session.flush()
-        assert DagModel.get_bulk_team_name([dag_id1, dag_id2], session=session) == {dag_id1: "testing"}
+        assert DagModel.get_dag_id_to_team_name_mapping([dag_id1, dag_id2], session=session) == {
+            dag_id1: "testing"
+        }
 
 
 class TestQueries:

--- a/airflow-core/tests/unit/models/test_dag.py
+++ b/airflow-core/tests/unit/models/test_dag.py
@@ -2281,6 +2281,52 @@ class TestDagModel:
         assert DagModel.get_dagmodel(dag_id) is not None
         assert DagModel.get_team_name(dag_id, session=session) == "testing"
 
+    def test_get_team_name_no_team(self, testing_team):
+        session = settings.Session()
+        dag_bundle = DagBundleModel(name="testing")
+        session.add(dag_bundle)
+        session.flush()
+
+        dag_id = "test_get_team_name_no_team"
+        dag = DAG(dag_id, schedule=None)
+        orm_dag = DagModel(
+            dag_id=dag.dag_id,
+            bundle_name="testing",
+            is_stale=False,
+        )
+        session.add(orm_dag)
+        session.flush()
+        assert DagModel.get_dagmodel(dag_id) is not None
+        assert DagModel.get_team_name(dag_id, session=session) is None
+
+    def test_get_bulk_team_name(self, testing_team):
+        session = settings.Session()
+        bundle1 = DagBundleModel(name="bundle1")
+        bundle1.teams.append(testing_team)
+        bundle2 = DagBundleModel(name="bundle2")
+        session.add(bundle1)
+        session.add(bundle2)
+        session.flush()
+
+        dag_id1 = "test_dag1"
+        dag1 = DAG(dag_id1, schedule=None)
+        orm_dag1 = DagModel(
+            dag_id=dag1.dag_id,
+            bundle_name="bundle1",
+            is_stale=False,
+        )
+        dag_id2 = "test_dag2"
+        dag2 = DAG(dag_id2, schedule=None)
+        orm_dag2 = DagModel(
+            dag_id=dag2.dag_id,
+            bundle_name="bundle2",
+            is_stale=False,
+        )
+        session.add(orm_dag1)
+        session.add(orm_dag2)
+        session.flush()
+        assert DagModel.get_bulk_team_name([dag_id1, dag_id2], session=session) == {dag_id1: "testing"}
+
 
 class TestQueries:
     def setup_method(self) -> None:

--- a/airflow-core/tests/unit/models/test_pool.py
+++ b/airflow-core/tests/unit/models/test_pool.py
@@ -333,11 +333,11 @@ class TestPool:
 
         assert Pool.get_team_name("test", session=session) == "testing"
 
-    def test_get_bulk_team_name(self, testing_team: Team, session: Session):
+    def test_get_name_to_team_name_mapping(self, testing_team: Team, session: Session):
         pool1 = Pool(pool="pool1", include_deferred=False, team_id=testing_team.id)
         pool2 = Pool(pool="pool2", include_deferred=False)
         session.add(pool1)
         session.add(pool2)
         session.flush()
 
-        assert Pool.get_bulk_team_name(["pool1", "pool2"], session=session) == {"pool1": "testing"}
+        assert Pool.get_name_to_team_name_mapping(["pool1", "pool2"], session=session) == {"pool1": "testing"}

--- a/airflow-core/tests/unit/models/test_pool.py
+++ b/airflow-core/tests/unit/models/test_pool.py
@@ -332,3 +332,12 @@ class TestPool:
         session.flush()
 
         assert Pool.get_team_name("test", session=session) == "testing"
+
+    def test_get_bulk_team_name(self, testing_team: Team, session: Session):
+        pool1 = Pool(pool="pool1", include_deferred=False, team_id=testing_team.id)
+        pool2 = Pool(pool="pool2", include_deferred=False)
+        session.add(pool1)
+        session.add(pool2)
+        session.flush()
+
+        assert Pool.get_bulk_team_name(["pool1", "pool2"], session=session) == {"pool1": "testing"}

--- a/airflow-core/tests/unit/models/test_variable.py
+++ b/airflow-core/tests/unit/models/test_variable.py
@@ -323,6 +323,15 @@ class TestVariable:
 
         assert Variable.get_team_name("key", session=session) == "testing"
 
+    def test_get_bulk_team_name(self, testing_team: Team, session: Session):
+        var1 = Variable(key="key1", val="value1", team_id=testing_team.id)
+        var2 = Variable(key="key2", val="value2")
+        session.add(var1)
+        session.add(var2)
+        session.flush()
+
+        assert Variable.get_bulk_team_name(["key1", "key2"], session=session) == {"key1": "testing"}
+
 
 @pytest.mark.parametrize(
     "variable_value, deserialize_json, expected_masked_values",

--- a/airflow-core/tests/unit/models/test_variable.py
+++ b/airflow-core/tests/unit/models/test_variable.py
@@ -323,14 +323,14 @@ class TestVariable:
 
         assert Variable.get_team_name("key", session=session) == "testing"
 
-    def test_get_bulk_team_name(self, testing_team: Team, session: Session):
+    def test_get_key_to_team_name_mapping(self, testing_team: Team, session: Session):
         var1 = Variable(key="key1", val="value1", team_id=testing_team.id)
         var2 = Variable(key="key2", val="value2")
         session.add(var1)
         session.add(var2)
         session.flush()
 
-        assert Variable.get_bulk_team_name(["key1", "key2"], session=session) == {"key1": "testing"}
+        assert Variable.get_key_to_team_name_mapping(["key1", "key2"], session=session) == {"key1": "testing"}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The same way some `is_authorized_` methods are team aware, the `batch_is_authorized_` methods need to be as well.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
