### PR TITLE
Block access to multi-team config

### DIFF
--- a/airflow-core/src/airflow/executors/executor_loader.py
+++ b/airflow-core/src/airflow/executors/executor_loader.py
@@ -164,7 +164,7 @@ class ExecutorLoader:
         executor_config = conf.get_mandatory_value("core", "executor")
         if not executor_config:
             raise AirflowConfigException(
-                "The 'executor' key in the 'coe' section of the configuration is mandatory and cannot be empty"
+                "The 'executor' key in the 'core' section of the configuration is mandatory and cannot be empty"
             )
         configs: list[tuple[str | None, list[str]]] = []
         # The executor_config can look like a few things. One is just a single executor name, such as
@@ -182,6 +182,7 @@ class ExecutorLoader:
                 # Split by comma to get the individual executor names and strip spaces off of them
                 configs.append((None, [name.strip() for name in team_executor_config.split(",")]))
             else:
+                cls.block_use_of_multi_team()
                 team_name, executor_names = team_executor_config.split("=")
                 configs.append((team_name, [name.strip() for name in executor_names.split(",")]))
         return configs

--- a/devel-common/src/tests_common/test_utils/executor_loader.py
+++ b/devel-common/src/tests_common/test_utils/executor_loader.py
@@ -29,6 +29,6 @@ def clean_executor_loader_module():
     """Clean the executor_loader state, as it stores global variables in the module, causing side effects for some tests."""
     executor_loader._alias_to_executors: dict[str, ExecutorName] = {}
     executor_loader._module_to_executors: dict[str, ExecutorName] = {}
-    executor_loader._team_id_to_executors: dict[str | None, ExecutorName] = {}
+    executor_loader._team_name_to_executors: dict[str | None, ExecutorName] = {}
     executor_loader._classname_to_executors: dict[str, ExecutorName] = {}
     executor_loader._executor_names: list[ExecutorName] = []


### PR DESCRIPTION
Currently it is technically possible to add multi-team related config for executors in airflow cfg, and have it read by the executor loader.

This should be blocked in 3.1 as the multi team feature is not completed.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
