### PR TITLE
Fix Cloud Run async hooks (inc. unit tests) 

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/hooks/cloud_run.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/cloud_run.py
@@ -178,7 +178,7 @@ class CloudRunAsyncHook(GoogleBaseAsyncHook):
         account from the list granting this role to the originating account.
     """
 
-    sync_hook_class = GoogleBaseHook
+    sync_hook_class = CloudRunHook
 
     def __init__(
         self,
@@ -264,7 +264,7 @@ class CloudRunServiceHook(GoogleBaseHook):
         return operation.result()
 
 
-class CloudRunServiceAsyncHook(GoogleBaseHook):
+class CloudRunServiceAsyncHook(GoogleBaseAsyncHook):
     """
     Async hook for the Google Cloud Run services.
 
@@ -278,6 +278,8 @@ class CloudRunServiceAsyncHook(GoogleBaseHook):
         Service Account Token Creator IAM role to the directly preceding identity, with first
         account from the list granting this role to the originating account.
     """
+
+    sync_hook_class = CloudRunServiceHook
 
     def __init__(
         self,

--- a/providers/google/tests/unit/google/cloud/hooks/test_cloud_run.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_cloud_run.py
@@ -33,6 +33,7 @@ from google.cloud.run_v2 import (
     Service,
     UpdateJobRequest,
 )
+from google.longrunning import operations_pb2
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.cloud_run import (
@@ -43,6 +44,12 @@ from airflow.providers.google.cloud.hooks.cloud_run import (
 )
 
 from unit.google.cloud.utils.base_gcp_mock import mock_base_gcp_hook_default_project_id
+
+PROJECT_ID = "projectid"
+REGION = "region1"
+JOB_NAME = "job1"
+SERVICE_NAME = "service1"
+OPERATION_NAME = "operationname"
 
 
 @pytest.mark.db_test
@@ -62,13 +69,9 @@ class TestCloudRunHook:
     )
     @mock.patch("airflow.providers.google.cloud.hooks.cloud_run.JobsClient")
     def test_get_job(self, mock_batch_service_client, cloud_run_hook):
-        job_name = "job1"
-        region = "region1"
-        project_id = "projectid"
+        get_job_request = GetJobRequest(name=f"projects/{PROJECT_ID}/locations/{REGION}/jobs/{JOB_NAME}")
 
-        get_job_request = GetJobRequest(name=f"projects/{project_id}/locations/{region}/jobs/{job_name}")
-
-        cloud_run_hook.get_job(job_name=job_name, region=region, project_id=project_id)
+        cloud_run_hook.get_job(job_name=JOB_NAME, region=REGION, project_id=PROJECT_ID)
         cloud_run_hook._client.get_job.assert_called_once_with(get_job_request)
 
     @mock.patch(
@@ -77,17 +80,14 @@ class TestCloudRunHook:
     )
     @mock.patch("airflow.providers.google.cloud.hooks.cloud_run.JobsClient")
     def test_update_job(self, mock_batch_service_client, cloud_run_hook):
-        job_name = "job1"
-        region = "region1"
-        project_id = "projectid"
         job = Job()
-        job.name = f"projects/{project_id}/locations/{region}/jobs/{job_name}"
+        job.name = f"projects/{PROJECT_ID}/locations/{REGION}/jobs/{JOB_NAME}"
 
         update_request = UpdateJobRequest()
         update_request.job = job
 
         cloud_run_hook.update_job(
-            job=Job.to_dict(job), job_name=job_name, region=region, project_id=project_id
+            job=Job.to_dict(job), job_name=JOB_NAME, region=REGION, project_id=PROJECT_ID
         )
 
         cloud_run_hook._client.update_job.assert_called_once_with(update_request)
@@ -98,18 +98,15 @@ class TestCloudRunHook:
     )
     @mock.patch("airflow.providers.google.cloud.hooks.cloud_run.JobsClient")
     def test_create_job(self, mock_batch_service_client, cloud_run_hook):
-        job_name = "job1"
-        region = "region1"
-        project_id = "projectid"
         job = Job()
 
         create_request = CreateJobRequest()
         create_request.job = job
-        create_request.job_id = job_name
-        create_request.parent = f"projects/{project_id}/locations/{region}"
+        create_request.job_id = JOB_NAME
+        create_request.parent = f"projects/{PROJECT_ID}/locations/{REGION}"
 
         cloud_run_hook.create_job(
-            job=Job.to_dict(job), job_name=job_name, region=region, project_id=project_id
+            job=Job.to_dict(job), job_name=JOB_NAME, region=REGION, project_id=PROJECT_ID
         )
 
         cloud_run_hook._client.create_job.assert_called_once_with(create_request)
@@ -120,20 +117,17 @@ class TestCloudRunHook:
     )
     @mock.patch("airflow.providers.google.cloud.hooks.cloud_run.JobsClient")
     def test_execute_job(self, mock_batch_service_client, cloud_run_hook):
-        job_name = "job1"
-        region = "region1"
-        project_id = "projectid"
         overrides = {
             "container_overrides": [{"args": ["python", "main.py"]}],
             "task_count": 1,
             "timeout": "60s",
         }
         run_job_request = RunJobRequest(
-            name=f"projects/{project_id}/locations/{region}/jobs/{job_name}", overrides=overrides
+            name=f"projects/{PROJECT_ID}/locations/{REGION}/jobs/{JOB_NAME}", overrides=overrides
         )
 
         cloud_run_hook.execute_job(
-            job_name=job_name, region=region, project_id=project_id, overrides=overrides
+            job_name=JOB_NAME, region=REGION, project_id=PROJECT_ID, overrides=overrides
         )
         cloud_run_hook._client.run_job.assert_called_once_with(request=run_job_request)
 
@@ -260,13 +254,9 @@ class TestCloudRunHook:
 
     @mock.patch("airflow.providers.google.cloud.hooks.cloud_run.JobsClient")
     def test_delete_job(self, mock_batch_service_client, cloud_run_hook):
-        job_name = "job1"
-        region = "region1"
-        project_id = "projectid"
+        delete_request = DeleteJobRequest(name=f"projects/{PROJECT_ID}/locations/{REGION}/jobs/{JOB_NAME}")
 
-        delete_request = DeleteJobRequest(name=f"projects/{project_id}/locations/{region}/jobs/{job_name}")
-
-        cloud_run_hook.delete_job(job_name=job_name, region=region, project_id=project_id)
+        cloud_run_hook.delete_job(job_name=JOB_NAME, region=REGION, project_id=PROJECT_ID)
         cloud_run_hook._client.delete_job.assert_called_once_with(delete_request)
 
     def _mock_pager(self, number_of_jobs):
@@ -279,23 +269,13 @@ class TestCloudRunHook:
 
 class TestCloudRunAsyncHook:
     @pytest.mark.asyncio
-    @mock.patch(
-        "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
-        new=mock_base_gcp_hook_default_project_id,
-    )
-    @mock.patch("airflow.providers.google.cloud.hooks.cloud_run.JobsAsyncClient")
-    async def test_get_operation(self, mock_client):
-        expected_operation = {"name": "somename"}
-        operation_name = "operationname"
-        mock_client.return_value = mock.MagicMock()
-        mock_client.return_value.get_operation = self.mock_get_operation(expected_operation)
+    async def test_get_operation(self):
         hook = CloudRunAsyncHook()
-        hook.get_credentials = self._dummy_get_credentials
-
-        returned_operation = await hook.get_operation(operation_name=operation_name)
-
-        mock_client.return_value.get_operation.assert_called_once_with(mock.ANY, timeout=120)
-        assert returned_operation == expected_operation
+        hook.get_conn = mock.AsyncMock()
+        await hook.get_operation(operation_name=OPERATION_NAME)
+        hook.get_conn.return_value.get_operation.assert_called_once_with(
+            operations_pb2.GetOperationRequest(name=OPERATION_NAME), timeout=120
+        )
 
     def mock_get_operation(self, expected_operation):
         get_operation_mock = mock.AsyncMock()
@@ -318,58 +298,47 @@ class TestCloudRunServiceHook:
         return cloud_run_service_hook
 
     @mock.patch(
-        "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
+        "airflow.providers.google.common.hooks.base_google.GoogleBaseAsyncHook.__init__",
         new=mock_base_gcp_hook_default_project_id,
     )
     @mock.patch("airflow.providers.google.cloud.hooks.cloud_run.ServicesClient")
     def test_get_service(self, mock_batch_service_client, cloud_run_service_hook):
-        service_name = "service1"
-        region = "region1"
-        project_id = "projectid"
-
         get_service_request = GetServiceRequest(
-            name=f"projects/{project_id}/locations/{region}/services/{service_name}"
+            name=f"projects/{PROJECT_ID}/locations/{REGION}/services/{SERVICE_NAME}"
         )
 
-        cloud_run_service_hook.get_service(service_name=service_name, region=region, project_id=project_id)
+        cloud_run_service_hook.get_service(service_name=SERVICE_NAME, region=REGION, project_id=PROJECT_ID)
         cloud_run_service_hook._client.get_service.assert_called_once_with(get_service_request)
 
     @mock.patch(
-        "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
+        "airflow.providers.google.common.hooks.base_google.GoogleBaseAsyncHook.__init__",
         new=mock_base_gcp_hook_default_project_id,
     )
     @mock.patch("airflow.providers.google.cloud.hooks.cloud_run.ServicesClient")
     def test_create_service(self, mock_batch_service_client, cloud_run_service_hook):
-        service_name = "service1"
-        region = "region1"
-        project_id = "projectid"
         service = Service()
 
         create_request = CreateServiceRequest()
         create_request.service = service
-        create_request.service_id = service_name
-        create_request.parent = f"projects/{project_id}/locations/{region}"
+        create_request.service_id = SERVICE_NAME
+        create_request.parent = f"projects/{PROJECT_ID}/locations/{REGION}"
 
         cloud_run_service_hook.create_service(
-            service=service, service_name=service_name, region=region, project_id=project_id
+            service=service, service_name=SERVICE_NAME, region=REGION, project_id=PROJECT_ID
         )
         cloud_run_service_hook._client.create_service.assert_called_once_with(create_request)
 
     @mock.patch(
-        "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
+        "airflow.providers.google.common.hooks.base_google.GoogleBaseAsyncHook.__init__",
         new=mock_base_gcp_hook_default_project_id,
     )
     @mock.patch("airflow.providers.google.cloud.hooks.cloud_run.ServicesClient")
     def test_delete_service(self, mock_batch_service_client, cloud_run_service_hook):
-        service_name = "service1"
-        region = "region1"
-        project_id = "projectid"
-
         delete_request = DeleteServiceRequest(
-            name=f"projects/{project_id}/locations/{region}/services/{service_name}"
+            name=f"projects/{PROJECT_ID}/locations/{REGION}/services/{SERVICE_NAME}"
         )
 
-        cloud_run_service_hook.delete_service(service_name=service_name, region=region, project_id=project_id)
+        cloud_run_service_hook.delete_service(service_name=SERVICE_NAME, region=REGION, project_id=PROJECT_ID)
         cloud_run_service_hook._client.delete_service.assert_called_once_with(delete_request)
 
 
@@ -382,7 +351,7 @@ class TestCloudRunServiceAsyncHook:
 
     @pytest.mark.asyncio
     @mock.patch(
-        "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
+        "airflow.providers.google.common.hooks.base_google.GoogleBaseAsyncHook.__init__",
         new=mock_base_gcp_hook_default_project_id,
     )
     @mock.patch("airflow.providers.google.cloud.hooks.cloud_run.ServicesAsyncClient")
@@ -394,23 +363,23 @@ class TestCloudRunServiceAsyncHook:
         hook.get_credentials = self.dummy_get_credentials
 
         await hook.create_service(
-            service_name="service1",
+            service_name=SERVICE_NAME,
             service=Service(),
-            region="region1",
-            project_id="projectid",
+            region=REGION,
+            project_id=PROJECT_ID,
         )
 
         expected_request = CreateServiceRequest(
             service=Service(),
-            service_id="service1",
-            parent="projects/projectid/locations/region1",
+            service_id=SERVICE_NAME,
+            parent=f"projects/{PROJECT_ID}/locations/{REGION}",
         )
 
         mock_client.return_value.create_service.assert_called_once_with(expected_request)
 
     @pytest.mark.asyncio
     @mock.patch(
-        "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
+        "airflow.providers.google.common.hooks.base_google.GoogleBaseAsyncHook.__init__",
         new=mock_base_gcp_hook_default_project_id,
     )
     @mock.patch("airflow.providers.google.cloud.hooks.cloud_run.ServicesAsyncClient")
@@ -422,13 +391,13 @@ class TestCloudRunServiceAsyncHook:
         hook.get_credentials = self.dummy_get_credentials
 
         await hook.delete_service(
-            service_name="service1",
-            region="region1",
-            project_id="projectid",
+            service_name=SERVICE_NAME,
+            region=REGION,
+            project_id=PROJECT_ID,
         )
 
         expected_request = DeleteServiceRequest(
-            name="projects/projectid/locations/region1/services/service1",
+            name=f"projects/{PROJECT_ID}/locations/{REGION}/services/{SERVICE_NAME}",
         )
 
         mock_client.return_value.delete_service.assert_called_once_with(expected_request)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
related: #55316

cc: @morgan-dgk


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
