### PR TITLE
Fix missing 'ti_successes' and related metrics in Airflow 3.0 Task SDK

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1027,7 +1027,7 @@ def _handle_current_task_success(
     end_date = datetime.now(tz=timezone.utc)
     ti.end_date = end_date
 
-    # Record success metrics
+    # Record operator and task instance success metrics
     operator = ti.task.__class__.__name__
     stats_tags = {"dag_id": ti.dag_id, "task_id": ti.task_id}
 
@@ -1397,7 +1397,7 @@ def finalize(
     if ti.start_date and ti.end_date:
         duration_ms = (ti.end_date - ti.start_date).total_seconds() * 1000
         stats_tags = {"dag_id": ti.dag_id, "task_id": ti.task_id}
-        # Legacy format and new format with tags (following same pattern as queued_duration/scheduled_duration)
+
         Stats.timing(f"dag.{ti.dag_id}.{ti.task_id}.duration", duration_ms)
         Stats.timing("task.duration", duration_ms, tags=stats_tags)
 

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -106,6 +106,7 @@ from airflow.sdk.execution_time.context import (
 )
 from airflow.sdk.execution_time.xcom import XCom
 from airflow.sdk.timezone import coerce_datetime
+from airflow.stats import Stats
 
 if TYPE_CHECKING:
     import jinja2
@@ -1025,6 +1026,16 @@ def _handle_current_task_success(
 ) -> tuple[SucceedTask, TaskInstanceState]:
     end_date = datetime.now(tz=timezone.utc)
     ti.end_date = end_date
+
+    # Record success metrics - following the same pattern as ti_failures in airflow-core
+    operator = ti.task.__class__.__name__
+    stats_tags = {"dag_id": ti.dag_id, "task_id": ti.task_id}
+
+    Stats.incr(f"operator_successes_{operator}", tags=stats_tags)
+    # Same metric with tagging
+    Stats.incr("operator_successes", tags={**stats_tags, "operator": operator})
+    Stats.incr("ti_successes", tags=stats_tags)
+
     task_outlets = list(_build_asset_profiles(ti.task.outlets))
     outlet_events = list(_serialize_outlet_events(context["outlet_events"]))
     msg = SucceedTask(
@@ -1382,6 +1393,14 @@ def finalize(
     log: Logger,
     error: BaseException | None = None,
 ):
+    # Record task duration metrics for all terminal states
+    if ti.start_date and ti.end_date:
+        duration_ms = (ti.end_date - ti.start_date).total_seconds() * 1000
+        stats_tags = {"dag_id": ti.dag_id, "task_id": ti.task_id}
+        # Legacy format and new format with tags (following same pattern as queued_duration/scheduled_duration)
+        Stats.timing(f"dag.{ti.dag_id}.{ti.task_id}.duration", duration_ms)
+        Stats.timing("task.duration", duration_ms, tags=stats_tags)
+
     task = ti.task
     # Pushing xcom for each operator extra links defined on the operator only.
     for oe in task.operator_extra_links:

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1027,7 +1027,7 @@ def _handle_current_task_success(
     end_date = datetime.now(tz=timezone.utc)
     ti.end_date = end_date
 
-    # Record success metrics - following the same pattern as ti_failures in airflow-core
+    # Record success metrics
     operator = ti.task.__class__.__name__
     stats_tags = {"dag_id": ti.dag_id, "task_id": ti.task_id}
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
## Description
This PR addresses issue #52336 by implementing missing task success and duration metrics in the Airflow 3.0 Task SDK.

**Metrics Restored**
This PR restores the following metrics that were missing in Airflow 3.0:
- **Counter**
  - `ti_successes`: Task instance success count with dag_id and task_id tags
  - `operator_successes_{operator_name}`: Legacy format operator success count
  - `operator_successes`: Tagged format operator success count
- **Timers**  
  - `dag.{dag_id}.{task_id}.duration`: Legacy format task duration timing
  - `task.duration`: Tagged format task duration timing

## Changes Made
1. Added Success Metrics in `_handle_current_task_success()`
This function is only called when a task genuinely succeeds, ensuring metrics are recorded only for actual successes.
https://github.com/apache/airflow/blob/8d7cc721dad900453d9068c399c9827f4610065d/task-sdk/src/airflow/sdk/execution_time/task_runner.py#L1022

2. Added Duration Metrics in `finalize()`
The `finalize()` function is called regardless of task outcome (success, failure, skip), ensuring comprehensive duration tracking.
https://github.com/apache/airflow/blob/8d7cc721dad900453d9068c399c9827f4610065d/task-sdk/src/airflow/sdk/execution_time/task_runner.py#L1378

Closes: #52336 

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
