### PR TITLE
Improve duration chart

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/DurationChart.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DurationChart.tsx
@@ -184,7 +184,7 @@ export const DurationChart = ({
               label: translate("durationChart.runDuration"),
             },
           ],
-          labels: entries.map((entry: RunResponse) => dayjs(entry.run_after).format("YYYY-MM-DD HH:mm:ss")),
+          labels: entries.map((entry: RunResponse) => dayjs(entry.run_after).format(DEFAULT_DATETIME_FORMAT)),
         }}
         datasetIdKey="id"
         options={{

--- a/airflow-core/src/airflow/ui/src/components/DurationChart.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DurationChart.tsx
@@ -60,9 +60,11 @@ type RunResponse = GridRunsResponse | TaskInstanceResponse;
 const getDuration = (start: string, end: string | null) => dayjs.duration(dayjs(end).diff(start)).asSeconds();
 
 export const DurationChart = ({
+  autoRefreshEnabled,
   entries,
   kind,
 }: {
+  readonly autoRefreshEnabled?: boolean;
   readonly entries: Array<RunResponse> | undefined;
   readonly kind: "Dag Run" | "Task Instance";
 }) => {
@@ -161,10 +163,16 @@ export const DurationChart = ({
               label: translate("durationChart.runDuration"),
             },
           ],
-          labels: entries.map((entry: RunResponse) => dayjs(entry.run_after).format(DEFAULT_DATETIME_FORMAT)),
+          labels: entries.map((entry: RunResponse) => dayjs(entry.run_after).format("YYYY-MM-DD, hh:mm")),
         }}
         datasetIdKey="id"
         options={{
+          animation: {
+            delay: 0,
+            duration: autoRefreshEnabled ? 0 : 1000,
+            easing: "easeOutQuart",
+            loop: false,
+          },
           onClick: (_event, elements) => {
             const [element] = elements;
 

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Overview/Overview.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Overview/Overview.tsx
@@ -76,15 +76,13 @@ export const Overview = () => {
     timestampLte: endDate,
   });
 
-<<<<<<< HEAD
   const refetchInterval = useAutoRefresh({});
-=======
+  
   const autoRefreshEnabled =
     Boolean(useAutoRefresh({ dagId })) &&
     gridRuns &&
     gridRuns.length > 0 &&
     isStatePending(gridRuns[0]?.state);
->>>>>>> 9c73a294d3 (Improve duration chart)
 
   return (
     <Box m={4} spaceY={4}>

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Overview/Overview.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Overview/Overview.tsx
@@ -76,7 +76,15 @@ export const Overview = () => {
     timestampLte: endDate,
   });
 
+<<<<<<< HEAD
   const refetchInterval = useAutoRefresh({});
+=======
+  const autoRefreshEnabled =
+    Boolean(useAutoRefresh({ dagId })) &&
+    gridRuns &&
+    gridRuns.length > 0 &&
+    isStatePending(gridRuns[0]?.state);
+>>>>>>> 9c73a294d3 (Improve duration chart)
 
   return (
     <Box m={4} spaceY={4}>
@@ -130,7 +138,11 @@ export const Overview = () => {
           {isLoadingRuns ? (
             <Skeleton height="200px" w="full" />
           ) : (
-            <DurationChart entries={gridRuns?.slice().reverse()} kind="Dag Run" />
+            <DurationChart
+              autoRefreshEnabled={autoRefreshEnabled}
+              entries={gridRuns?.slice().reverse()}
+              kind="Dag Run"
+            />
           )}
         </Box>
         {assetEventsData && assetEventsData.total_entries > 0 ? (


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE

related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #54786 

Changes date format to remove :ss and prevents reanimating on auto-refresh


<!-- Please keep an empty line above the dashes. -->

---
This PR tackles the 2 improvements asked for [here](https://github.com/apache/airflow/issues/54786)

- The :ss is stripped from the DurationChart
- Auto refresh logic is copied from [here](https://github.com/apache/airflow/blob/main/airflow-core/src/airflow/ui/src/pages/Dag/Dag.tsx#L126) and used to determine whether we are auto-refreshing. Only animate if we are auto refreshing.

### Before changes - Graph re-animates on refresh

https://github.com/user-attachments/assets/9711ae37-04f8-4810-9cb3-c3fc586c99ae


### After changes - Graph updates without animating again (>1 day)

https://github.com/user-attachments/assets/2860b45d-9a69-49bd-a73c-f8c7030e0a24

### After changes - Graph updates without animating again (<1 day)


<img width="919" height="548" alt="Screenshot 2025-09-11 at 7 03 09 PM" src="https://github.com/user-attachments/assets/5f9ea7e1-693f-4751-8c12-e62b81aadd1e" />

### Full date on hover
<img width="923" height="551" alt="image" src="https://github.com/user-attachments/assets/60761518-79ea-40ba-abe8-32f598764afb" />
