### PR TITLE
Relax Catalan plural rules

### DIFF
--- a/dev/i18n/check_translations_completeness.py
+++ b/dev/i18n/check_translations_completeness.py
@@ -51,7 +51,7 @@ MOST_COMMON_PLURAL_SUFFIXES = ["_one", "_other"]
 # You can check the rules for your language at https://jsfiddle.net/6bpxsgd4
 PLURAL_SUFFIXES = {
     "ar": ["_zero", "_one", "_two", "_few", "_many", "_other"],
-    "ca": ["_one", "_many", "_other"],
+    "ca": MOST_COMMON_PLURAL_SUFFIXES,
     "de": MOST_COMMON_PLURAL_SUFFIXES,
     "en": MOST_COMMON_PLURAL_SUFFIXES,
     "es": ["_one", "_many", "_other"],


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

@potiuk I propose to keep Catalan with only MOST_COMMON_PLURAL_SUFFIXES, since we only have 1 plural. I believe Spanish should fall under the same rule, but I'm not so sure as in Catalan.

I tried the page you mentioned in the PR where you introduced the checks and it says there are 2 plurals, but the example is only for 1 plural (https://github.com/apache/airflow/pull/55352#issuecomment-3263939033). I guess i18next has a bug somewhere.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
