### PR TITLE
Fix KubernetesJobOperator ignoring on_finish_action parameter

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/job.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/job.py
@@ -42,7 +42,11 @@ from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import (
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator, merge_objects
 from airflow.providers.cncf.kubernetes.triggers.job import KubernetesJobTrigger
-from airflow.providers.cncf.kubernetes.utils.pod_manager import EMPTY_XCOM_RESULT, PodNotFoundException
+from airflow.providers.cncf.kubernetes.utils.pod_manager import (
+    EMPTY_XCOM_RESULT,
+    OnFinishAction,
+    PodNotFoundException,
+)
 from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_1_PLUS
 
 if AIRFLOW_V_3_1_PLUS:
@@ -243,6 +247,41 @@ class KubernetesJobOperator(KubernetesPodOperator):
                         containers=self.container_logs,
                         follow_logs=True,
                     )
+
+            # Handle Job cleanup based on on_finish_action
+            if self.wait_until_job_complete and self.job:
+                should_delete_job = self.on_finish_action == OnFinishAction.DELETE_POD or (
+                    self.on_finish_action == OnFinishAction.DELETE_SUCCEEDED_POD
+                    and not self.hook.is_job_failed(job=self.job)
+                )
+
+                if should_delete_job:
+                    self.log.info("Deleting job: %s", self.job.metadata.name)
+                    self.job_client.delete_namespaced_job(
+                        name=self.job.metadata.name,
+                        namespace=self.job.metadata.namespace,
+                        propagation_policy="Foreground",  # 確保 Pod 也被刪除
+                    )
+                else:
+                    # Only run pod cleanup if we're not deleting the job
+                    # (since job deletion will cascade delete the pods)
+                    if self.pods:
+                        for pod in self.pods:
+                            # Get the latest pod status
+                            try:
+                                remote_pod = self.pod_manager.read_pod(pod)
+                                if remote_pod:
+                                    pod = remote_pod
+                            except Exception as e:
+                                self.log.warning("Failed to refresh pod status: %s", e)
+
+                            # Execute cleanup logic including processing on_finish_action
+                            self.cleanup(
+                                pod=pod,
+                                remote_pod=pod,
+                                xcom_result=xcom_result[self.pods.index(pod)] if self.do_xcom_push else None,
+                                context=context,
+                            )
 
         ti.xcom_push(key="job", value=self.job.to_dict())
         if self.wait_until_job_complete:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->

## Description
This PR fixes a issue where `KubernetesJobOperator` was completely ignoring the `on_finish_action` parameter despite inheriting it from KubernetesPodOperator.

> **Problem**: This resulted in pods never being cleaned up regardless of the configured action.

## Solution
**Core Logic for Job and Pod Cleanup**
- **Job Deletion**: 
If the cleanup action requires deletion (`DELETE_POD` or `DELETE_SUCCEEDED_POD` for successful jobs), the entire Job is deleted.
  - Uses `propagation_policy="Foreground"` to ensure associated Pods are also deleted via cascading deletion.

- **Pod Cleanup**: 
If the Job is not deleted, terate through each Pod and execute the inherited `cleanup()` method for individual Pod processing. 
  - Handle Pod-level cleanup when the Job is not deleted.
  -  Decide whether to delete Pods based on `on_finish_action`.
https://github.com/apache/airflow/blob/69bdd6bc04db34f764f64c34b7d1cd79cc372e2b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py#L1017-L1023

- **OnFinishAction Classifications**
The `OnFinishAction` enum defines the possible actions to take when a Pod or Job completes:
  - `DELETE_POD`: Always deletes both job and associated pods
  - `DELETE_SUCCEEDED_POD`: Only deletes job and pods if the job succeeded
  - `KEEP_POD`: Never deletes the job, but calls cleanup() for pod management
https://github.com/apache/airflow/blob/69bdd6bc04db34f764f64c34b7d1cd79cc372e2b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py#L1019-L1024

Fixes: #55192

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
