### PR TITLE
modify python path to sys executable

### DIFF
--- a/scripts/in_container/run_check_imports_in_providers.py
+++ b/scripts/in_container/run_check_imports_in_providers.py
@@ -36,7 +36,7 @@ def check_imports():
         "analyze",
         "graph",
         "--python",
-        "/usr/python/bin/python",
+        sys.executable,
     ]
     console.print("Cmd", cmd)
     import_tree_str = subprocess.check_output(cmd)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
When do 
```uv run prek run check-imports-in-providers --all-files```
if the python path not /usr/python/bin/python
will cause the following error
```
Cmd
  ['ruff', 'analyze', 'graph', '--python', '/usr/python/bin/python']
  warning: `ruff analyze graph` is experimental and may change without warning
  ruff failed
    Cause: Invalid `--python` argument `/usr/python/bin/python`: does not point to a Python executable or a directory on disk
    Cause: No such file or directory (os error 2)
  Traceback (most recent call last):
    File "/opt/airflow/scripts/in_container/run_check_imports_in_providers.py", line 85, in <module>
      check_imports()
    File "/opt/airflow/scripts/in_container/run_check_imports_in_providers.py", line 42, in check_imports
      import_tree_str = subprocess.check_output(cmd)
    File "/usr/local/lib/python3.10/subprocess.py", line 421, in check_output
      return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
    File "/usr/local/lib/python3.10/subprocess.py", line 526, in run
      raise CalledProcessError(retcode, process.args,
  subprocess.CalledProcessError: Command '['ruff', 'analyze', 'graph', '--python', '/usr/python/bin/python']' returned non-zero exit status 2.
```
To avoid this error, modify "/usr/python/bin/python" to sys.executable, which means current system python path.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---


**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
