### PR TITLE
[KubernetesPodOperator] Add more robust reading of the container statuses

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -1102,7 +1102,7 @@ class KubernetesPodOperator(BaseOperator):
             pod_reason = getattr(remote_pod.status, "reason", None)
             self.log.info("Pod phase: %s, reason: %s", pod_phase, pod_reason)
 
-            container_statuses = getattr(remote_pod.status, "container_statuses", [])
+            container_statuses = getattr(remote_pod.status, "container_statuses", None) or []
             for status in container_statuses:
                 name = status.name
                 state = status.state


### PR DESCRIPTION
# Overview

We are encountering an issue where, when stopping a pod that is in the pending state, the operator attempts to access the container statuses. However, since no containers exist while the pod is pending, container_statuses is None. This leads to a crash when the code tries to iterate over the statuses in a for loop. To prevent this, a more robust approach to reading pod.container_statuses is needed.


# Details of change:
* Add more robust reading of container_statuses