### PR TITLE
remove mp_start_method remnants

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -159,18 +159,6 @@ core:
       type: integer
       example: ~
       default: "0"
-    mp_start_method:
-      description: |
-        The name of the method used in order to start Python processes via the multiprocessing module.
-        This corresponds directly with the options available in the Python docs:
-        `multiprocessing.set_start_method
-        <https://docs.python.org/3/library/multiprocessing.html#multiprocessing.set_start_method>`__
-        must be one of the values returned by `multiprocessing.get_all_start_methods()
-        <https://docs.python.org/3/library/multiprocessing.html#multiprocessing.get_all_start_methods>`__.
-      version_added: "2.0.0"
-      type: string
-      default: ~
-      example: "fork"
     load_examples:
       description: |
         Whether to load the DAG examples that ship with Airflow. It's good to

--- a/airflow-core/src/airflow/configuration.py
+++ b/airflow-core/src/airflow/configuration.py
@@ -22,7 +22,6 @@ import functools
 import itertools
 import json
 import logging
-import multiprocessing
 import os
 import pathlib
 import re
@@ -414,7 +413,6 @@ class AirflowConfigParser(ConfigParser):
     enums_options = {
         ("core", "default_task_weight_rule"): sorted(WeightRule.all_weight_rules()),
         ("core", "dag_ignore_file_syntax"): ["regexp", "glob"],
-        ("core", "mp_start_method"): multiprocessing.get_all_start_methods(),
         ("dag_processor", "file_parsing_sort_mode"): [
             "modified_time",
             "random_seeded_by_host",

--- a/devel-common/src/tests_common/pytest_plugin.py
+++ b/devel-common/src/tests_common/pytest_plugin.py
@@ -21,7 +21,6 @@ import importlib
 import itertools
 import json
 import os
-import platform
 import re
 import subprocess
 import sys
@@ -214,11 +213,6 @@ os.environ["AIRFLOW__CORE__DAGS_FOLDER"] = os.fspath(AIRFLOW_CORE_TESTS_PATH / "
 os.environ["AIRFLOW__CORE__UNIT_TEST_MODE"] = "True"
 os.environ["AWS_DEFAULT_REGION"] = os.environ.get("AWS_DEFAULT_REGION") or "us-east-1"
 os.environ["CREDENTIALS_DIR"] = os.environ.get("CREDENTIALS_DIR") or "/files/airflow-breeze-config/keys"
-
-if platform.system() == "Darwin":
-    # mocks from unittest.mock work correctly in subprocesses only if they are created by "fork" method
-    # but macOS uses "spawn" by default
-    os.environ["AIRFLOW__CORE__MP_START_METHOD"] = "fork"
 
 
 @pytest.fixture


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
the main core of this functionality was removed in 11acefa462b6, this is just removing what remains in config. Although multiprocessing is still used in some places python-daemon is now used as the main driver; if it makes sense it can be added back in the future.
closes: #54619 

**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
