### PR TITLE
Fix dependabot groups for Edge React UI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,15 +50,17 @@ updates:
       core-ui-package-updates:
         patterns:
           - "*"
+
   - package-ecosystem: npm
     directories:
       - /providers/edge3/src/airflow/providers/edge3/plugins/www
     schedule:
       interval: daily
     groups:
-      fab-ui-package-updates:
+      edge-ui-package-updates:
         patterns:
           - "*"
+
   - package-ecosystem: npm
     directories:
       - /providers/fab/src/airflow/providers/fab/www


### PR DESCRIPTION
Just realized that I made a "wrong" group name in dependabot for React UI in Edge Provider. Made it "wrong" as copy & paste... sorry.