### PR TITLE
Add guards for registering middlewares from plugins on non callable objects

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/app.py
+++ b/airflow-core/src/airflow/api_fastapi/app.py
@@ -200,5 +200,9 @@ def init_plugins(app: FastAPI) -> None:
             log.error("'middleware' key is missing for the fastapi middleware: %s", name)
             continue
 
+        if not callable(middleware):
+            log.error("'middleware' value for %s is should be callable: %s", name, middleware)
+            continue
+
         log.debug("Adding root middleware %s", name)
         app.add_middleware(middleware, *args, **kwargs)


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/55176