### PR TITLE
fix: Inherit ssl_ca_cert from KubernetesExecutor in KubernetesPodOperator

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -382,7 +382,13 @@ class KubernetesPodOperator(BaseOperator):
         self.secrets = secrets or []
         self.in_cluster = in_cluster
         self.cluster_context = cluster_context
-        self.ssl_ca_cert = ssl_ca_cert
+        # Only set ssl_ca_cert as instance attribute if not already defined as property.
+        # This prevents "can't set attribute" error when GKE operators inherit from both
+        # GKEOperatorMixin (ssl_ca_cert as @property) and KubernetesPodOperator (ssl_ca_cert as attribute).
+        if not hasattr(type(self), "ssl_ca_cert") or not isinstance(
+            getattr(type(self), "ssl_ca_cert"), property
+        ):
+            self.ssl_ca_cert = ssl_ca_cert
         self.reattach_on_restart = reattach_on_restart
         self.get_logs = get_logs
         # Fallback to the class variable BASE_CONTAINER_NAME here instead of via default argument value

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -295,6 +295,7 @@ class KubernetesPodOperator(BaseOperator):
         secrets: list[Secret] | None = None,
         in_cluster: bool | None = None,
         cluster_context: str | None = None,
+        ssl_ca_cert: str | None = None,
         labels: dict | None = None,
         reattach_on_restart: bool = True,
         startup_timeout_seconds: int = 120,
@@ -381,6 +382,7 @@ class KubernetesPodOperator(BaseOperator):
         self.secrets = secrets or []
         self.in_cluster = in_cluster
         self.cluster_context = cluster_context
+        self.ssl_ca_cert = ssl_ca_cert
         self.reattach_on_restart = reattach_on_restart
         self.get_logs = get_logs
         # Fallback to the class variable BASE_CONTAINER_NAME here instead of via default argument value
@@ -543,6 +545,7 @@ class KubernetesPodOperator(BaseOperator):
             in_cluster=self.in_cluster,
             config_file=self.config_file,
             cluster_context=self.cluster_context,
+            ssl_ca_cert=self.ssl_ca_cert,
         )
         return hook
 
@@ -857,6 +860,7 @@ class KubernetesPodOperator(BaseOperator):
                 cluster_context=self.cluster_context,
                 config_dict=self._config_dict,
                 in_cluster=self.in_cluster,
+                ssl_ca_cert=self.ssl_ca_cert,
                 poll_interval=self.poll_interval,
                 get_logs=self.get_logs,
                 startup_timeout=self.startup_timeout_seconds,

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
@@ -89,6 +89,7 @@ class KubernetesPodTrigger(BaseTrigger):
         cluster_context: str | None = None,
         config_dict: dict | None = None,
         in_cluster: bool | None = None,
+        ssl_ca_cert: str | None = None,
         get_logs: bool = True,
         startup_timeout: int = 120,
         startup_check_interval: int = 5,
@@ -107,6 +108,7 @@ class KubernetesPodTrigger(BaseTrigger):
         self.cluster_context = cluster_context
         self.config_dict = config_dict
         self.in_cluster = in_cluster
+        self.ssl_ca_cert = ssl_ca_cert
         self.get_logs = get_logs
         self.startup_timeout = startup_timeout
         self.startup_check_interval = startup_check_interval
@@ -130,6 +132,7 @@ class KubernetesPodTrigger(BaseTrigger):
                 "cluster_context": self.cluster_context,
                 "config_dict": self.config_dict,
                 "in_cluster": self.in_cluster,
+                "ssl_ca_cert": self.ssl_ca_cert,
                 "get_logs": self.get_logs,
                 "startup_timeout": self.startup_timeout,
                 "startup_check_interval": self.startup_check_interval,
@@ -285,6 +288,7 @@ class KubernetesPodTrigger(BaseTrigger):
             in_cluster=self.in_cluster,
             config_dict=self.config_dict,
             cluster_context=self.cluster_context,
+            ssl_ca_cert=self.ssl_ca_cert,
         )
 
     def define_container_state(self, pod: V1Pod) -> ContainerState:

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/decorators/test_kubernetes.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/decorators/test_kubernetes.py
@@ -59,6 +59,7 @@ class TestKubernetesDecorator(TestKubernetesDecoratorsBase):
             in_cluster=False,
             cluster_context="default",
             config_file="/tmp/fake_file",
+            ssl_ca_cert=None,
         )
         assert self.mock_create_pod.call_count == 1
 
@@ -105,6 +106,7 @@ class TestKubernetesDecorator(TestKubernetesDecoratorsBase):
             in_cluster=False,
             cluster_context="default",
             config_file="/tmp/fake_file",
+            ssl_ca_cert=None,
         )
         assert self.mock_hook.return_value.get_xcom_sidecar_container_image.call_count == 1
         assert self.mock_hook.return_value.get_xcom_sidecar_container_resources.call_count == 1

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/decorators/test_kubernetes_cmd.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/decorators/test_kubernetes_cmd.py
@@ -64,6 +64,7 @@ class TestKubernetesCmdDecorator(TestKubernetesDecoratorsBase):
             in_cluster=False,
             cluster_context="default",
             config_file="/tmp/fake_file",
+            ssl_ca_cert=None,
         )
         assert self.mock_create_pod.call_count == 1
 
@@ -155,6 +156,7 @@ class TestKubernetesCmdDecorator(TestKubernetesDecoratorsBase):
             in_cluster=False,
             cluster_context="default",
             config_file="/tmp/fake_file",
+            ssl_ca_cert=None,
         )
         assert self.mock_create_pod.call_count == 1
         assert self.mock_hook.return_value.get_xcom_sidecar_container_image.call_count == 1
@@ -277,6 +279,7 @@ class TestKubernetesCmdDecorator(TestKubernetesDecoratorsBase):
             in_cluster=False,
             cluster_context="default",
             config_file="/tmp/fake_file",
+            ssl_ca_cert=None,
         )
         containers = self.mock_create_pod.call_args.kwargs["pod"].spec.containers
         assert len(containers) == 1
@@ -308,6 +311,7 @@ class TestKubernetesCmdDecorator(TestKubernetesDecoratorsBase):
             in_cluster=False,
             cluster_context="default",
             config_file="/tmp/fake_file",
+            ssl_ca_cert=None,
         )
         containers = self.mock_create_pod.call_args.kwargs["pod"].spec.containers
         assert len(containers) == 1
@@ -339,6 +343,7 @@ class TestKubernetesCmdDecorator(TestKubernetesDecoratorsBase):
             in_cluster=False,
             cluster_context="default",
             config_file="/tmp/fake_file",
+            ssl_ca_cert=None,
         )
         containers = self.mock_create_pod.call_args.kwargs["pod"].spec.containers
         assert len(containers) == 1
@@ -371,6 +376,7 @@ class TestKubernetesCmdDecorator(TestKubernetesDecoratorsBase):
             in_cluster=False,
             cluster_context="default",
             config_file="/tmp/fake_file",
+            ssl_ca_cert=None,
         )
         containers = self.mock_create_pod.call_args.kwargs["pod"].spec.containers
         assert len(containers) == 1

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -294,6 +294,7 @@ class TestKubernetesPodOperator:
             conn_id="kubernetes_default",
             config_file=file_path,
             in_cluster=None,
+            ssl_ca_cert=None,
         )
 
     @pytest.mark.parametrize(

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/triggers/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/triggers/test_pod.py
@@ -104,6 +104,7 @@ class TestKubernetesPodTrigger:
             "cluster_context": CLUSTER_CONTEXT,
             "config_dict": CONFIG_DICT,
             "in_cluster": IN_CLUSTER,
+            "ssl_ca_cert": None,
             "get_logs": GET_LOGS,
             "startup_timeout": STARTUP_TIMEOUT_SECS,
             "startup_check_interval": 5,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
## Description
The existing `ssl_ca_cert` setting is only supported within the `kubernetes_executor` configuration, and its scope does not extend to the `KubernetesPodOperator`.
https://github.com/apache/airflow/blob/7ef251d0b62ba0abc186061413ee33da3af3d548/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/kube_client.py#L151-L153

> **Problem**: The current implementation of the KubernetesPodOperator does not inherit SSL configurations from its parent executor or environment variables

## Solution
The KubernetesPodOperator operates in two primary modes to handle synchronous and asynchronous tasks:
1. **deferrable=False**
   - KubernetesPodOperator -> KubernetesHook -> Kubernetes API
2. **deferrable=True**
   - KubernetesPodOperator -> KubernetesPodTrigger -> AsyncKubernetesHook -> Kubernetes API

**Enhancements**
1. Extend `KubernetesPodOperator` to Support `ssl_ca_cert`
2. Enhance `KubernetesHook` for Proper SSL CA Configuration
3. Define a Clear Inheritance Order
   1. **KubernetesPodOperator's ssl_ca_cert parameter**
   This will be the primary source for the CA certificate path.
      ```yaml
      airflow.cfg
      [kubernetes_executor]
      ssl_ca_cert = /etc/ssl/certs/ca.crt
      ```

      ```python
      # The Pod will automatically use [kubernetes_executor] ssl_ca_cert = /etc/ssl/certs/ca.crt
      pod_operator = KubernetesPodOperator(
          task_id="my_task",
          image="my-image",
          # ssl_ca_cert is not specified, so it uses the executor's setting
      )
      ```


   2. **kubernetes_executor.ssl_ca_cert setting**: 
   If the `KubernetesPodOperator parameter` is not provided, the system will automatically fall back to the setting defined in the `kubernetes_executor` configuration.

      ```python
      # The Pod will use /custom/path/ca.crt, ignoring the executor's setting
      pod_operator = KubernetesPodOperator(
          task_id="my_task",
          image="my-image",
          ssl_ca_cert="/custom/path/ca.crt"  # Overrides the global setting
      )
      ```

close: #53192

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
