### PR TITLE
Improve contrast in Clear Task Instance dialog selectors

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/ui/SegmentedControl.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ui/SegmentedControl.tsx
@@ -61,6 +61,8 @@ const SegmentedControl = ({ defaultValues, multiple = false, onChange, options }
         <Button
           _hover={{ backgroundColor: "bg.emphasized" }}
           bg={selectedOptions.includes(value) ? "bg.panel" : undefined}
+          borderColor={selectedOptions.includes(value) ? "border.emphasized" : "transparent"}
+          borderWidth={selectedOptions.includes(value) ? 1 : 0}
           disabled={disabled}
           key={value}
           onClick={() => onClick(value)}


### PR DESCRIPTION
Add borders to selected options in SegmentedControl component to enhance visual distinction between selected and unselected. These are hard to read earlier. 

Old:
<img width="1120" height="552" alt="Add border old" src="https://github.com/user-attachments/assets/7b437fc9-510d-4cce-acd2-a998e2a0cbc5" />

New:
<img width="1117" height="555" alt="Add border new" src="https://github.com/user-attachments/assets/461ee115-cff2-44ab-abeb-ea8f2110ecb7" />
