### PR TITLE
Update templating support in Deadline Alert docs

### DIFF
--- a/airflow-core/docs/core-concepts/dags.rst
+++ b/airflow-core/docs/core-concepts/dags.rst
@@ -857,8 +857,8 @@ Here's a simple example using the existing email Notifier:
             interval=timedelta(minutes=30),
             callback=SmtpNotifier(
                 to="team@example.com",
-                subject="[Alert] Dag {{ dag.dag_id }} exceeded time threshold",
-                html_content="The Dag has been running for more than 30 minutes since being queued.",
+                subject="🚨 Dag {{ dag_run.dag_id }} missed deadline at {{ deadline.deadline_time }}",
+                html_content="The Dag Run {{ dag_run.dag_run_id }} has been running for more than 30 minutes since being queued.",
             ),
         ),
     ):

--- a/airflow-core/docs/howto/deadline-alerts.rst
+++ b/airflow-core/docs/howto/deadline-alerts.rst
@@ -64,7 +64,9 @@ Below is an example Dag implementation. If the Dag has not finished 15 minutes a
             interval=timedelta(minutes=15),
             callback=AsyncCallback(
                 SlackWebhookNotifier,
-                kwargs={"text": "Dag 'slack_deadline_alert' still running after 30 minutes."},
+                kwargs={
+                    "text": "🚨 Dag {{ dag_run.dag_id }} missed deadline at {{ deadline.deadline_time }}. DagRun: {{ dag_run }}"
+                },
             ),
         ),
     ):
@@ -108,7 +110,9 @@ Here's an example using a fixed datetime:
             interval=timedelta(minutes=-30),  # Alert 30 minutes before the reference.
             callback=AsyncCallback(
                 SlackWebhookNotifier,
-                kwargs={"text": "Dag 'slack_deadline_alert' still running after 30 minutes."},
+                kwargs={
+                    "text": "🚨 Dag {{ dag_run.dag_id }} missed deadline at {{ deadline.deadline_time }}. DagRun: {{ dag_run }}"
+                },
             ),
         ),
     ):
@@ -128,9 +132,10 @@ The timeline for this example would look like this:
 Using Callbacks
 ---------------
 
-When a deadline is exceeded, the callback is executed. You can use an existing :doc:`Notifier </howto/notifications>`
-or create a custom callback function.  A callback must be an :class:`~airflow.sdk.definitions.deadline.AsyncCallback`,
-with support coming soon for :class:`~airflow.sdk.definitions.deadline.SyncCallback`.
+When a deadline is exceeded, the callback's callable is executed with the specified kwargs. You can use an
+existing :doc:`Notifier </howto/notifications>` or create a custom callable.  A callback must be an
+:class:`~airflow.sdk.definitions.deadline.AsyncCallback`, with support coming soon for
+:class:`~airflow.sdk.definitions.deadline.SyncCallback`.
 
 Using Built-in Notifiers
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -146,7 +151,9 @@ Here's an example using the Slack Notifier if the Dag run has not finished withi
             interval=timedelta(minutes=30),
             callback=AsyncCallback(
                 SlackWebhookNotifier,
-                kwargs={"text": "Dag 'slack_deadline_alert' still running after 30 minutes."},
+                kwargs={
+                    "text": "🚨 Dag {{ dag_run.dag_id }} missed deadline at {{ deadline.deadline_time }}. DagRun: {{ dag_run }}"
+                },
             ),
         ),
     ):
@@ -155,7 +162,7 @@ Here's an example using the Slack Notifier if the Dag run has not finished withi
 Creating Custom Callbacks
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You can create custom callbacks for more complex handling. If ``kwargs`` are specified in the ``Callback``,
+You can create custom callables for more complex handling. If ``kwargs`` are specified in the ``Callback``,
 they are passed to the callback function. **Asynchronous callbacks** must be defined somewhere in the
 Triggerer's system path.
 
@@ -163,7 +170,8 @@ Triggerer's system path.
     Regarding Async Custom Deadline callbacks:
 
     * Async callbacks are executed by the Triggerer, so users must ensure they are importable by the Triggerer.
-    * One easy way to do this is to place the callback as a top-level method in a new file in the plugins folder.
+    * One easy way to do this is to place the callable as a top-level method in a new file in the plugins folder.
+      Nested callables are not currently supported.
     * The Triggerer will need to be restarted when a callback is added or changed in order to reload the file.
 
 
@@ -175,7 +183,9 @@ A **custom asynchronous callback** might look like this:
 
     async def custom_async_callback(**kwargs):
         """Handle deadline violation with custom logic."""
-        print(f"Deadline exceeded for Dag {kwargs.get("dag_id")}!")
+        context = kwargs.get("context", {})
+        print(f"Deadline exceeded for Dag {context.get("dag_run", {}).get("dag_id")}!")
+        print(f"Context: {context}")
         print(f"Alert type: {kwargs.get("alert_type")}")
         # Additional custom handling here
 
@@ -199,12 +209,21 @@ A **custom asynchronous callback** might look like this:
             interval=timedelta(minutes=15),
             callback=AsyncCallback(
                 custom_async_callback,
-                kwargs={"alert_type": "time_exceeded", "dag_id": "custom_deadline_alert"},
+                kwargs={"alert_type": "time_exceeded"},
             ),
         ),
     ):
         EmptyOperator(task_id="example_task")
 
+Templating and Context
+^^^^^^^^^^^^^^^^^^^^^^
+
+Currently, a relatively simple version of the Airflow context is passed to callables and Airflow does not run
+:ref:`concepts:jinja-templating` on the kwargs. However, ``Notifier``s already run templating with the
+provided context as part of their execution. This means that templating can be used when using a ``Notifier``
+as long as the variables being templated are included in the simplified context. This currently includes the
+ID and the calculated deadline time of the Deadline Alert as well as the data included in the ``GET`` REST API
+response for Dag Run. Support for more comprehensive context and templating will be added in future versions.
 
 Deadline Calculation
 ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
There were some recent changes in templating/context for Deadline Alert callbacks. This updates the docs to reflect those changes.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
