### PR TITLE
Fixup to structlog migration - logging folder not being created correctly.

### DIFF
--- a/airflow-core/src/airflow/logging_config.py
+++ b/airflow-core/src/airflow/logging_config.py
@@ -85,7 +85,7 @@ def load_logging_config() -> tuple[dict[str, Any], str]:
 
 
 def configure_logging():
-    from airflow._shared.logging.structlog import configure_logging
+    from airflow._shared.logging import configure_logging, init_log_folder
 
     logging_config, logging_class_path = load_logging_config()
     try:
@@ -99,6 +99,18 @@ def configure_logging():
         raise e
 
     validate_logging_config()
+
+    new_folder_permissions = int(
+        conf.get("logging", "file_task_handler_new_folder_permissions", fallback="0o775"),
+        8,
+    )
+
+    base_log_folder = conf.get("logging", "base_log_folder")
+
+    return init_log_folder(
+        base_log_folder,
+        new_folder_permissions=new_folder_permissions,
+    )
 
     return logging_class_path
 

--- a/shared/logging/src/airflow_shared/logging/__init__.py
+++ b/shared/logging/src/airflow_shared/logging/__init__.py
@@ -16,4 +16,10 @@
 # under the License.
 from __future__ import annotations
 
-from .structlog import configure_logging as configure_logging
+__all__ = [
+    "configure_logging",
+    "init_log_file",
+    "init_log_folder",
+]
+
+from .structlog import configure_logging, init_log_file, init_log_folder


### PR DESCRIPTION
This was broken in #52651 with our move away from FileTaskHandler, and hidden
when running in Breeze due to the default logs folder already existing.
