### PR TITLE
Fix version_compat for Airflow 3.0.X

### DIFF
--- a/providers/docker/src/airflow/providers/docker/version_compat.py
+++ b/providers/docker/src/airflow/providers/docker/version_compat.py
@@ -35,14 +35,16 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 AIRFLOW_V_3_1_PLUS: bool = get_base_airflow_version_tuple() >= (3, 1, 0)
 
+# Version-compatible imports
+# BaseOperator: Use 3.1+ due to xcom_push method missing in SDK BaseOperator 3.0.x
+# This is needed for DecoratedOperator compatibility
 if AIRFLOW_V_3_1_PLUS:
-    from airflow.sdk import BaseHook
+    from airflow.sdk import (
+        BaseHook,
+        BaseOperator,
+    )
 else:
     from airflow.hooks.base import BaseHook  # type: ignore[attr-defined,no-redef]
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import BaseOperator
-else:
     from airflow.models import BaseOperator
 
 __all__ = [


### PR DESCRIPTION
The decorated operator for this provide fails with Airflow 3.0.X and provider version > 4.4.0. #52465 updated version_compat and the operator to use the BaseOperator from the Task SDK. However, this operator is missing the required `xcom_push` method in version 3.0.X.

This causes failures when using the decorater operator with AttributeError: '_DockerDecoratedOperator' object has no attribute 'xcom_push'.

Resolves #53077

Tested locally with DAG below:

 ```
from airflow.sdk import dag, task

@dag(
    schedule=None,
    start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
    catchup=False,
    tags=["example"],
)
def docker_test():

    @task.docker(image="python:3.10-slim")
    def hello_world():
        return "Hello, world!"

    hello_world()


docker_test()
```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
