### PR TITLE
Add react-dom to default plugin external libraries

### DIFF
--- a/dev/react-plugin-tools/react_plugin_template/vite.config.ts
+++ b/dev/react-plugin-tools/react_plugin_template/vite.config.ts
@@ -42,6 +42,7 @@ export default defineConfig(({ command }) => {
         output: {
           globals: {
             react: "React",
+            "react-dom": "ReactDOM",
             "react/jsx-runtime": "ReactJSXRuntime",
           },
         },


### PR DESCRIPTION
Follow up of: https://github.com/apache/airflow/pull/55348

Adds `react-dom` to default external libraries when generating a react app plugin with the boostrapping tool.

Adding a modal is a fairly common use case and users shouldn't have to modify their vite config to achieve that.