### PR TITLE
AIP-67 - Multi-team: Update executor loader cache

### DIFF
--- a/airflow-core/tests/integration/otel/test_otel.py
+++ b/airflow-core/tests/integration/otel/test_otel.py
@@ -709,7 +709,9 @@ class TestOtelIntegration:
             module_path="airflow.providers.celery.executors.celery_executor.CeleryExecutor",
             alias="CeleryExecutor",
         )
-        monkeypatch.setattr(executor_loader, "_alias_to_executors", {"CeleryExecutor": executor_name})
+        monkeypatch.setattr(
+            executor_loader, "_alias_to_executors_per_team", {None: {"CeleryExecutor": executor_name}}
+        )
 
     @pytest.fixture(autouse=True)
     def cleanup_control_file_if_needed(self):

--- a/devel-common/src/tests_common/test_utils/executor_loader.py
+++ b/devel-common/src/tests_common/test_utils/executor_loader.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+from collections import defaultdict
 from typing import TYPE_CHECKING
 
 import airflow.executors.executor_loader as executor_loader
@@ -27,8 +28,14 @@ if TYPE_CHECKING:
 
 def clean_executor_loader_module():
     """Clean the executor_loader state, as it stores global variables in the module, causing side effects for some tests."""
-    executor_loader._alias_to_executors: dict[str, ExecutorName] = {}
-    executor_loader._module_to_executors: dict[str, ExecutorName] = {}
-    executor_loader._team_name_to_executors: dict[str | None, ExecutorName] = {}
-    executor_loader._classname_to_executors: dict[str, ExecutorName] = {}
+    executor_loader._alias_to_executors_per_team: dict[str | None, dict[str, ExecutorName]] = defaultdict(
+        dict
+    )
+    executor_loader._module_to_executors_per_team: dict[str | None, dict[str, ExecutorName]] = defaultdict(
+        dict
+    )
+    executor_loader._classname_to_executors_per_team: dict[str | None, dict[str, ExecutorName]] = defaultdict(
+        dict
+    )
+    executor_loader._team_name_to_executors: dict[str | None, list[ExecutorName]] = defaultdict(list)
     executor_loader._executor_names: list[ExecutorName] = []


### PR DESCRIPTION
The executor loader caches the values it reads from config in several ways to make lookups very fast. Now with teams, we may have multiple instances of the same executor so the caches must now be per-team.

Also disallow having more than one list of executors for each team.

Add tests to cover more of these edge cases and to harden test coverage of the multi-team usecase in general.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
