### PR TITLE
Fix missing reset and filter translations

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/ar/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ar/admin.json
@@ -84,7 +84,6 @@
     "tooltip": "حذف الموَّصلات المحددة"
   },
   "formActions": {
-    "reset": "إعادة تعيين",
     "save": "حفظ"
   },
   "plugins": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ar/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ar/common.json
@@ -125,16 +125,10 @@
   },
   "filter": "فلتر",
   "filters": {
-    "dagDisplayNamePlaceholder": "تصفية حسب الDag",
-    "keyPlaceholder": "تصفية حسب مفتاح XCom",
-    "logicalDateFromPlaceholder": "من التاريخ المنطقي",
-    "logicalDateToPlaceholder": "إلى التاريخ المنطقي",
-    "mapIndexPlaceholder": "تصفية حسب فهرس الخريطة",
-    "runAfterFromPlaceholder": "من تشغيل بعد",
-    "runAfterToPlaceholder": "إلى تشغيل بعد",
-    "runIdPlaceholder": "تصفية حسب معرف التشغيل",
-    "taskIdPlaceholder": "تصفية حسب معرف المهمة",
-    "triggeringUserPlaceholder": "تصفية حسب المستخدم صاحب الاطلاق"
+    "logicalDateFrom": "من التاريخ المنطقي",
+    "logicalDateTo": "إلى التاريخ المنطقي",
+    "runAfterFrom": "من تشغيل بعد",
+    "runAfterTo": "إلى تشغيل بعد"
   },
   "logicalDate": "التاريخ المنطقي",
   "logout": "تسجيل الخروج",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ar/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ar/common.json
@@ -123,6 +123,7 @@
     "any": "أي",
     "or": "أو"
   },
+  "filter": "فلتر",
   "filters": {
     "dagDisplayNamePlaceholder": "تصفية حسب الDag",
     "keyPlaceholder": "تصفية حسب مفتاح XCom",
@@ -179,6 +180,7 @@
     "running": "قيد التشغيل",
     "scheduled": "مجدول"
   },
+  "reset": "إعادة تعيين",
   "runId": "معرف التشغيل",
   "runTypes": {
     "asset_triggered": "مُشغل بواسطة الأصل",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ar/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ar/components.json
@@ -10,8 +10,6 @@
     "allRuns": "جميع التشغيلات",
     "backwards": "تشغيل رجعي",
     "dateRange": "نطاق التاريخ",
-    "dateRangeFrom": "من",
-    "dateRangeTo": "إلى",
     "errorStartDateBeforeEndDate": "يجب أن يكون تاريخ البدء قبل تاريخ الانتهاء",
     "maxRuns": "الحد الأقصى للتشغيلات النشطة",
     "missingAndErroredRuns": "تشغيلات مفقودة وخاطئة",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ca/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ca/admin.json
@@ -72,7 +72,6 @@
     "tooltip": "Eliminar connexions seleccionades"
   },
   "formActions": {
-    "reset": "Restablir",
     "save": "Desar"
   },
   "plugins": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ca/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ca/common.json
@@ -101,15 +101,10 @@
   },
   "filter": "Filtre",
   "filters": {
-    "dagDisplayNamePlaceholder": "Filtrar per Dag",
-    "keyPlaceholder": "Filtrar per clau XCom",
-    "logicalDateFromPlaceholder": "Data Lògica Des de",
-    "logicalDateToPlaceholder": "Data Lògica Fins a",
-    "mapIndexPlaceholder": "Filtrar per Índex del Mapa",
-    "runAfterFromPlaceholder": "Executar Després de",
-    "runAfterToPlaceholder": "Executar Després de",
-    "runIdPlaceholder": "Filtrar per ID d'Execució",
-    "taskIdPlaceholder": "Filtrar per ID de Tasca"
+    "logicalDateFrom": "Data Lògica Des de",
+    "logicalDateTo": "Data Lògica Fins a",
+    "runAfterFrom": "Executar Després de",
+    "runAfterTo": "Executar Després de"
   },
   "logicalDate": "Data Lògica",
   "logout": "Tancar sessió",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ca/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ca/common.json
@@ -99,6 +99,7 @@
     "any": "Qualsevol",
     "or": "O"
   },
+  "filter": "Filtre",
   "filters": {
     "dagDisplayNamePlaceholder": "Filtrar per Dag",
     "keyPlaceholder": "Filtrar per clau XCom",
@@ -150,6 +151,7 @@
     "running": "Executant-se",
     "scheduled": "Programat"
   },
+  "reset": "Restablir",
   "runId": "ID de l'execució",
   "runTypes": {
     "asset_triggered": "Executat per Asset",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ca/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ca/components.json
@@ -6,8 +6,6 @@
     "allRuns": "Totes les execucions",
     "backwards": "Executar enrere",
     "dateRange": "Interval de dates",
-    "dateRangeFrom": "Des de",
-    "dateRangeTo": "Fins",
     "errorStartDateBeforeEndDate": "La data d'inici ha de ser anterior a la data de finalització",
     "maxRuns": "Màxim d'execucions actives",
     "missingAndErroredRuns": "Execucions absents i amb errors",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/de/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/de/admin.json
@@ -72,7 +72,6 @@
     "tooltip": "Ausgewählte Verbindungen löschen"
   },
   "formActions": {
-    "reset": "Zurücksetzen",
     "save": "Speichern"
   },
   "plugins": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/de/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/de/common.json
@@ -99,6 +99,7 @@
     "any": "Jeder",
     "or": "ODER"
   },
+  "filter": "Filter",
   "filters": {
     "dagDisplayNamePlaceholder": "Nach Dag filtern",
     "keyPlaceholder": "Nach Task Kommunikation (XCom) Schlüssel filtern",
@@ -151,6 +152,7 @@
     "running": "Laufende",
     "scheduled": "Geplant"
   },
+  "reset": "Zurücksetzen",
   "runId": "Lauf Id",
   "runTypes": {
     "asset_triggered": "Durch Datenset (Asset) ausgelöst",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/de/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/de/common.json
@@ -101,16 +101,10 @@
   },
   "filter": "Filter",
   "filters": {
-    "dagDisplayNamePlaceholder": "Nach Dag filtern",
-    "keyPlaceholder": "Nach Task Kommunikation (XCom) Schlüssel filtern",
-    "logicalDateFromPlaceholder": "Logisches Datum Von",
-    "logicalDateToPlaceholder": "Logisches Datum Bis",
-    "mapIndexPlaceholder": "Nach Planungs-Index filtern",
-    "runAfterFromPlaceholder": "Gelaufen-nach von filtern",
-    "runAfterToPlaceholder": "Gelaufen-nach bis filtern",
-    "runIdPlaceholder": "Nach Lauf ID filtern",
-    "taskIdPlaceholder": "Nach Task ID filtern",
-    "triggeringUserPlaceholder": "Nach auslösendem Benutzer filtern"
+    "logicalDateFrom": "Logisches Datum Von",
+    "logicalDateTo": "Logisches Datum Bis",
+    "runAfterFrom": "Gelaufen-nach von filtern",
+    "runAfterTo": "Gelaufen-nach bis filtern"
   },
   "logicalDate": "Logisches Datum",
   "logout": "Abmelden",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/de/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/de/components.json
@@ -6,8 +6,6 @@
     "allRuns": "Alle Läufe",
     "backwards": "Verarbeitung in Rückwärtiger Reihenfolge",
     "dateRange": "Datumsbereich",
-    "dateRangeFrom": "Von",
-    "dateRangeTo": "Bis",
     "errorStartDateBeforeEndDate": "Das Startdatum muss vor dem Enddatum liegen.",
     "maxRuns": "Anzahl aktiver paralleler Läufe",
     "missingAndErroredRuns": "Fehlende und fehlgeschlagene Läufe",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/admin.json
@@ -72,7 +72,6 @@
     "tooltip": "Delete selected connections"
   },
   "formActions": {
-    "reset": "Reset",
     "save": "Save"
   },
   "plugins": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
@@ -140,6 +140,7 @@
     "running": "Running",
     "scheduled": "Scheduled"
   },
+  "reset": "Reset",
   "runId": "Run ID",
   "runTypes": {
     "asset_triggered": "Asset Triggered",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
@@ -100,6 +100,12 @@
     "or": "OR"
   },
   "filter": "Filter",
+  "filters": {
+    "logicalDateFrom": "Logical Date From",
+    "logicalDateTo": "Logical Date To",
+    "runAfterFrom": "Run After From",
+    "runAfterTo": "Run After To"
+  },
   "logicalDate": "Logical Date",
   "logout": "Logout",
   "logoutConfirmation": "You are about to logout from the application.",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/components.json
@@ -6,8 +6,6 @@
     "allRuns": "All Runs",
     "backwards": "Run Backwards",
     "dateRange": "Date Range",
-    "dateRangeFrom": "From",
-    "dateRangeTo": "To",
     "errorStartDateBeforeEndDate": "Start Date must be before the End Date",
     "maxRuns": "Max Active Runs",
     "missingAndErroredRuns": "Missing and Errored Runs",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/es/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/es/admin.json
@@ -75,7 +75,6 @@
     "tooltip": "Eliminar conexiones seleccionadas"
   },
   "formActions": {
-    "reset": "Restablecer",
     "save": "Guardar"
   },
   "plugins": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/es/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/es/common.json
@@ -104,6 +104,7 @@
     "any": "Cualquiera",
     "or": "O"
   },
+  "filter": "Filtro",
   "filters": {
     "dagDisplayNamePlaceholder": "Filtrar por Dag",
     "keyPlaceholder": "Filtrar por Clave de XCom",
@@ -156,6 +157,7 @@
     "running": "En Ejecución",
     "scheduled": "Programado"
   },
+  "reset": "Restablecer",
   "runId": "ID de la corrida",
   "runTypes": {
     "asset_triggered": "Asset Activado",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/es/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/es/common.json
@@ -106,15 +106,10 @@
   },
   "filter": "Filtro",
   "filters": {
-    "dagDisplayNamePlaceholder": "Filtrar por Dag",
-    "keyPlaceholder": "Filtrar por Clave de XCom",
-    "logicalDateFromPlaceholder": "Fecha Lógica Desde",
-    "logicalDateToPlaceholder": "Fecha Lógica Hasta",
-    "mapIndexPlaceholder": "Filtrar por Índice de Mapa",
-    "runAfterFromPlaceholder": "Ejecutar Después Desde",
-    "runAfterToPlaceholder": "Ejecutar Después Hasta",
-    "runIdPlaceholder": "Filtrar por ID de Ejecución",
-    "taskIdPlaceholder": "Filtrar por ID de Tarea"
+    "logicalDateFrom": "Fecha Lógica Desde",
+    "logicalDateTo": "Fecha Lógica Hasta",
+    "runAfterFrom": "Ejecutar Después Desde",
+    "runAfterTo": "Ejecutar Después Hasta"
   },
   "logicalDate": "Fecha Lógica",
   "logout": "Cerrar Sesión",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/es/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/es/components.json
@@ -7,8 +7,6 @@
     "allRuns": "Todas las Ejecuciones",
     "backwards": "Ejecutar Hacia Atrás",
     "dateRange": "Rango de Fechas",
-    "dateRangeFrom": "Desde",
-    "dateRangeTo": "Hasta",
     "errorStartDateBeforeEndDate": "La Fecha Inicial debe ser antes de la Fecha Final",
     "maxRuns": "Máximo de Ejecuciones Activas",
     "missingAndErroredRuns": "Ejecutaciones Faltantes y con Errores",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/admin.json
@@ -75,7 +75,6 @@
     "tooltip": "Supprimer les connexions sélectionnées"
   },
   "formActions": {
-    "reset": "Réinitialiser",
     "save": "Sauvegarder"
   },
   "plugins": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/common.json
@@ -105,7 +105,18 @@
     "any": "N'importe lequel",
     "or": "Ou"
   },
-  "filter": "Filtrer",
+  "filter": "Filtre",
+  "filters": {
+    "dagDisplayNamePlaceholder": "Filtrer par Dag",
+    "keyPlaceholder": "Filtrer par clé XCom",
+    "logicalDateFromPlaceholder": "Date logique de début",
+    "logicalDateToPlaceholder": "Date logique de fin",
+    "mapIndexPlaceholder": "Filtrer par Map Index",
+    "runAfterFromPlaceholder": "Exécuté après - de",
+    "runAfterToPlaceholder": "Exécuté après - à",
+    "runIdPlaceholder": "Filtrer par ID d'exécution",
+    "taskIdPlaceholder": "Filtrer par ID de tâche"
+  },
   "logicalDate": "Date logique",
   "logout": "Déconnexion",
   "logoutConfirmation": "Vous êtes sur le point de vous déconnecter de l'application.",
@@ -147,6 +158,7 @@
     "running": "En cours",
     "scheduled": "Planifié"
   },
+  "reset": "Réinitialiser",
   "runId": "ID d'exécution",
   "runTypes": {
     "asset_triggered": "Déclenché par Asset",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/common.json
@@ -107,15 +107,10 @@
   },
   "filter": "Filtre",
   "filters": {
-    "dagDisplayNamePlaceholder": "Filtrer par Dag",
-    "keyPlaceholder": "Filtrer par clé XCom",
-    "logicalDateFromPlaceholder": "Date logique de début",
-    "logicalDateToPlaceholder": "Date logique de fin",
-    "mapIndexPlaceholder": "Filtrer par Map Index",
-    "runAfterFromPlaceholder": "Exécuté après - de",
-    "runAfterToPlaceholder": "Exécuté après - à",
-    "runIdPlaceholder": "Filtrer par ID d'exécution",
-    "taskIdPlaceholder": "Filtrer par ID de tâche"
+    "logicalDateFrom": "Date logique de début",
+    "logicalDateTo": "Date logique de fin",
+    "runAfterFrom": "Exécuté après - de",
+    "runAfterTo": "Exécuté après - à"
   },
   "logicalDate": "Date logique",
   "logout": "Déconnexion",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/components.json
@@ -7,8 +7,6 @@
     "allRuns": "Toutes les exécutions",
     "backwards": "Exécuter à rebours",
     "dateRange": "Plage de dates",
-    "dateRangeFrom": "De",
-    "dateRangeTo": "À",
     "errorStartDateBeforeEndDate": "La date de début doit être antérieure à la date de fin",
     "maxRuns": "Nombre maximum d'exécutions actives",
     "missingAndErroredRuns": "Exécutions manquantes et en erreur",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/he/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/he/admin.json
@@ -75,7 +75,6 @@
     "tooltip": "מחק חיבורים נבחרים"
   },
   "formActions": {
-    "reset": "אתחל",
     "save": "שמור"
   },
   "plugins": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/he/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/he/common.json
@@ -105,6 +105,7 @@
     "any": "כלשהו",
     "or": "או"
   },
+  "filter": "מסנן",
   "filters": {
     "dagDisplayNamePlaceholder": "סנן לפי Dag",
     "keyPlaceholder": "סנן לפי מפתח XCom",
@@ -158,6 +159,7 @@
     "running": "בביצוע",
     "scheduled": "מתוזמן"
   },
+  "reset": "אתחל",
   "runId": "מזהה ריצה",
   "runTypes": {
     "asset_triggered": "הופעל על-ידי נכס",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/he/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/he/common.json
@@ -107,16 +107,10 @@
   },
   "filter": "מסנן",
   "filters": {
-    "dagDisplayNamePlaceholder": "סנן לפי Dag",
-    "keyPlaceholder": "סנן לפי מפתח XCom",
-    "logicalDateFromPlaceholder": "תאריך לוגי מ-",
-    "logicalDateToPlaceholder": "תאריך לוגי עד",
-    "mapIndexPlaceholder": "סנן לפי אינדקס מיפוי",
-    "runAfterFromPlaceholder": "ריצה לאחר (מתאריך)",
-    "runAfterToPlaceholder": "ריצה לאחר (עד תאריך)",
-    "runIdPlaceholder": "סנן לפי מזהה ריצה",
-    "taskIdPlaceholder": "סנן לפי מזהה משימה",
-    "triggeringUserPlaceholder": "סנן לפי משתמש מפעיל"
+    "logicalDateFrom": "תאריך לוגי מ-",
+    "logicalDateTo": "תאריך לוגי עד",
+    "runAfterFrom": "ריצה לאחר (מתאריך)",
+    "runAfterTo": "ריצה לאחר (עד תאריך)"
   },
   "logicalDate": "תאריך לוגי",
   "logout": "התנתק",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/he/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/he/components.json
@@ -7,8 +7,6 @@
     "allRuns": "כל ההרצות",
     "backwards": "הרץ לאחור",
     "dateRange": "טווח תאריכים",
-    "dateRangeFrom": "מתאריך",
-    "dateRangeTo": "עד תאריך",
     "errorStartDateBeforeEndDate": "תאריך ההתחלה חייב להיות לפני תאריך הסיום",
     "maxRuns": "מספר ריצות מקבילות מירבי",
     "missingAndErroredRuns": "הרצות חסרות ושגויות",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/hi/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/hi/admin.json
@@ -72,7 +72,6 @@
     "tooltip": "चयनित कनेक्शन्स हटाएं"
   },
   "formActions": {
-    "reset": "रीसेट करें",
     "save": "सेव करें"
   },
   "plugins": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/hi/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/hi/common.json
@@ -92,6 +92,7 @@
     "any": "कोई भी",
     "or": "या"
   },
+  "filter": "फ़िल्टर",
   "filters": {
     "dagDisplayNamePlaceholder": "डैग द्वारा फ़िल्टर करें",
     "keyPlaceholder": "XCom कुंजी द्वारा फ़िल्टर करें",
@@ -143,6 +144,7 @@
     "running": "चल रहा",
     "scheduled": "निर्धारित"
   },
+  "reset": "रीसेट करें",
   "runId": "रन ID",
   "runTypes": {
     "asset_triggered": "एसेट द्वारा ट्रिगर",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/hi/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/hi/common.json
@@ -94,15 +94,10 @@
   },
   "filter": "फ़िल्टर",
   "filters": {
-    "dagDisplayNamePlaceholder": "डैग द्वारा फ़िल्टर करें",
-    "keyPlaceholder": "XCom कुंजी द्वारा फ़िल्टर करें",
-    "logicalDateFromPlaceholder": "तार्किक तिथि से",
-    "logicalDateToPlaceholder": "तार्किक तिथि तक",
-    "mapIndexPlaceholder": "मैप इंडेक्स द्वारा फ़िल्टर करें",
-    "runAfterFromPlaceholder": "रन आफ़्टर से",
-    "runAfterToPlaceholder": "रन आफ़्टर तक",
-    "runIdPlaceholder": "रन ID द्वारा फ़िल्टर करें",
-    "taskIdPlaceholder": "टास्क ID द्वारा फ़िल्टर करें"
+    "logicalDateFrom": "तार्किक तिथि से",
+    "logicalDateTo": "तार्किक तिथि तक",
+    "runAfterFrom": "रन आफ़्टर से",
+    "runAfterTo": "रन आफ़्टर तक"
   },
   "logicalDate": "तार्किक तिथि",
   "logout": "लॉग आउट",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/hi/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/hi/components.json
@@ -6,8 +6,6 @@
     "allRuns": "सभी रन्स",
     "backwards": "पीछे की ओर चलाएं",
     "dateRange": "तिथि रेंज",
-    "dateRangeFrom": "से",
-    "dateRangeTo": "तक",
     "errorStartDateBeforeEndDate": "प्रारंभ तिथि समाप्ति तिथि से पहले होनी चाहिए",
     "maxRuns": "अधिकतम सक्रिय रन्स",
     "missingAndErroredRuns": "गुम और त्रुटि वाले रन्स",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/hu/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/hu/admin.json
@@ -72,7 +72,6 @@
     "tooltip": "Kijelölt kapcsolatok törlése"
   },
   "formActions": {
-    "reset": "Alaphelyzetbe állítás",
     "save": "Mentés"
   },
   "plugins": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/hu/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/hu/common.json
@@ -94,15 +94,10 @@
   },
   "filter": "Szűrő",
   "filters": {
-    "dagDisplayNamePlaceholder": "Szűrés Dag szerint",
-    "keyPlaceholder": "Szűrés XCom kulcs szerint",
-    "logicalDateFromPlaceholder": "Logikai dátum -tól",
-    "logicalDateToPlaceholder": "Logikai dátum -ig",
-    "mapIndexPlaceholder": "Szűrés Map Index szerint",
-    "runAfterFromPlaceholder": "Futás ekkortól",
-    "runAfterToPlaceholder": "Futás eddig",
-    "runIdPlaceholder": "Szűrés futás azonosító szerint",
-    "taskIdPlaceholder": "Szűrés feladat azonosító szerint"
+    "logicalDateFrom": "Logikai dátum -tól",
+    "logicalDateTo": "Logikai dátum -ig",
+    "runAfterFrom": "Futás ekkortól",
+    "runAfterTo": "Futás eddig"
   },
   "logicalDate": "Logikai dátum",
   "logout": "Kijelentkezés",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/hu/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/hu/common.json
@@ -92,6 +92,7 @@
     "any": "Bármely",
     "or": "VAGY"
   },
+  "filter": "Szűrő",
   "filters": {
     "dagDisplayNamePlaceholder": "Szűrés Dag szerint",
     "keyPlaceholder": "Szűrés XCom kulcs szerint",
@@ -143,6 +144,7 @@
     "running": "Fut",
     "scheduled": "Ütemezett"
   },
+  "reset": "Alaphelyzetbe állítás",
   "runId": "Futás azonosító",
   "runTypes": {
     "asset_triggered": "Adatkészlet által indított",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/hu/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/hu/components.json
@@ -6,8 +6,6 @@
     "allRuns": "Összes futás",
     "backwards": "Futtatás visszafelé",
     "dateRange": "Dátumtartomány",
-    "dateRangeFrom": "Kezdő dátum",
-    "dateRangeTo": "Befejező dátum",
     "errorStartDateBeforeEndDate": "A kezdő dátumnak a befejező dátum előtt kell lennie.",
     "maxRuns": "Maximális aktív futások",
     "missingAndErroredRuns": "Hiányzó és hibás futások",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/it/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/it/admin.json
@@ -78,7 +78,6 @@
     "tooltip": "Elimina le connessioni selezionate"
   },
   "formActions": {
-    "reset": "Resetta",
     "save": "Salva"
   },
   "plugins": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/it/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/it/common.json
@@ -111,17 +111,12 @@
     "any": "Qualunque",
     "or": "O"
   },
+  "filter": "Filtro",
   "filters": {
-    "dagDisplayNamePlaceholder": "Filtra per DAG",
-    "keyPlaceholder": "Filtra per chiave XCom",
-    "logicalDateFromPlaceholder": "Data Logica Da",
-    "logicalDateToPlaceholder": "Data Logica A",
-    "mapIndexPlaceholder": "Filtra per Map Index",
-    "runAfterFromPlaceholder": "Esegui Dopo Da",
-    "runAfterToPlaceholder": "Esegui Dopo A",
-    "runIdPlaceholder": "Filtra per ID Run",
-    "taskIdPlaceholder": "Filtra per ID Task",
-    "triggeringUserPlaceholder": "Filtra per utente scatenante"
+    "logicalDateFrom": "Data Logica Da",
+    "logicalDateTo": "Data Logica A",
+    "runAfterFrom": "Esegui Dopo Da",
+    "runAfterTo": "Esegui Dopo A"
   },
   "logicalDate": "Data Logica",
   "logout": "Esci",
@@ -165,6 +160,7 @@
     "running": "In Esecuzione",
     "scheduled": "Programmato"
   },
+  "reset": "Resetta",
   "runId": "ID del Run",
   "runTypes": {
     "asset_triggered": "Asset Triggered",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/it/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/it/components.json
@@ -8,8 +8,6 @@
     "allRuns": "Tutti i Run",
     "backwards": "Run all'indietro",
     "dateRange": "Intervallo di Date",
-    "dateRangeFrom": "Da",
-    "dateRangeTo": "A",
     "errorStartDateBeforeEndDate": "La Data di Inizio deve essere precedente alla Data di Fine",
     "maxRuns": "Numero massimo di Runs attive",
     "missingAndErroredRuns": "Run Mancanti ed Errati",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/admin.json
@@ -72,7 +72,6 @@
     "tooltip": "선택된 커넥션들 삭제"
   },
   "formActions": {
-    "reset": "초기화",
     "save": "저장"
   },
   "plugins": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/common.json
@@ -101,15 +101,10 @@
   },
   "filter": "필터",
   "filters": {
-    "dagDisplayNamePlaceholder": "Dag로 필터링",
-    "keyPlaceholder": "XCom 키로 필터링",
-    "logicalDateFromPlaceholder": "논리적 날짜 (시작)",
-    "logicalDateToPlaceholder": "논리적 날짜 (종료)",
-    "mapIndexPlaceholder": "맵 인덱스로 필터링",
-    "runAfterFromPlaceholder": "실행 이후 (시작)",
-    "runAfterToPlaceholder": "실행 이후 (종료)",
-    "runIdPlaceholder": "실행 ID로 필터링",
-    "taskIdPlaceholder": "작업 ID로 필터링"
+    "logicalDateFrom": "논리적 날짜 (시작)",
+    "logicalDateTo": "논리적 날짜 (종료)",
+    "runAfterFrom": "실행 이후 (시작)",
+    "runAfterTo": "실행 이후 (종료)"
   },
   "logicalDate": "논리적 날짜",
   "logout": "로그아웃",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/common.json
@@ -99,6 +99,7 @@
     "any": "모든",
     "or": "또는"
   },
+  "filter": "필터",
   "filters": {
     "dagDisplayNamePlaceholder": "Dag로 필터링",
     "keyPlaceholder": "XCom 키로 필터링",
@@ -150,6 +151,7 @@
     "running": "실행 중",
     "scheduled": "예약됨"
   },
+  "reset": "초기화",
   "runId": "실행 ID",
   "runTypes": {
     "asset_triggered": "에셋 트리거",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/components.json
@@ -6,8 +6,6 @@
     "allRuns": "모든 실행",
     "backwards": "거꾸로 실행",
     "dateRange": "날짜 범위",
-    "dateRangeFrom": "시작",
-    "dateRangeTo": "종료",
     "errorStartDateBeforeEndDate": "시작일은 종료일보다 빨라야 합니다.",
     "maxRuns": "최대 활성 실행 수",
     "missingAndErroredRuns": "누락되었거나 오류가 발생한 실행",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/nl/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/nl/admin.json
@@ -72,7 +72,6 @@
     "tooltip": "Verwijder geselecteerde connecties"
   },
   "formActions": {
-    "reset": "Reset",
     "save": "Opsalaan"
   },
   "plugins": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/nl/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/nl/common.json
@@ -98,6 +98,7 @@
     "any": "Elk",
     "or": "Of"
   },
+  "filter": "Filter",
   "filters": {
     "dagDisplayNamePlaceholder": "Filter op Dag",
     "keyPlaceholder": "Filter op XCom sleutel",
@@ -149,6 +150,7 @@
     "running": "Lopend",
     "scheduled": "Gepland"
   },
+  "reset": "Reset",
   "runId": "Run ID",
   "runTypes": {
     "asset_triggered": "Asset Triggered",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/nl/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/nl/common.json
@@ -100,15 +100,10 @@
   },
   "filter": "Filter",
   "filters": {
-    "dagDisplayNamePlaceholder": "Filter op Dag",
-    "keyPlaceholder": "Filter op XCom sleutel",
-    "logicalDateFromPlaceholder": "Van logische datum",
-    "logicalDateToPlaceholder": "Tot logische datum",
-    "mapIndexPlaceholder": "Filter op Map Index",
-    "runAfterFromPlaceholder": "Van Run na",
-    "runAfterToPlaceholder": "Tot Run na",
-    "runIdPlaceholder": "Filter op Run ID",
-    "taskIdPlaceholder": "Filter op Task ID"
+    "logicalDateFrom": "Van logische datum",
+    "logicalDateTo": "Tot logische datum",
+    "runAfterFrom": "Van Run na",
+    "runAfterTo": "Tot Run na"
   },
   "logicalDate": "Logische datum",
   "logout": "Uitloggen",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/nl/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/nl/components.json
@@ -6,8 +6,6 @@
     "allRuns": "Alle Runs",
     "backwards": "Run achterstevoren",
     "dateRange": "Datumbereik",
-    "dateRangeFrom": "Van",
-    "dateRangeTo": "Tot",
     "errorStartDateBeforeEndDate": "Startdatum moet voor de einddatum",
     "maxRuns": "Maximaal aantal actieve Runs",
     "missingAndErroredRuns": "Missende en mislukte Runs",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/admin.json
@@ -78,7 +78,6 @@
     "tooltip": "Usuń wybrane połączenia"
   },
   "formActions": {
-    "reset": "Resetuj",
     "save": "Zapisz"
   },
   "plugins": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/common.json
@@ -111,6 +111,7 @@
     "any": "Dowolne",
     "or": "LUB"
   },
+  "filter": "Filtr",
   "filters": {
     "dagDisplayNamePlaceholder": "Filtruj według Daga",
     "keyPlaceholder": "Filtruj według klucza XCom",
@@ -165,6 +166,7 @@
     "running": "W trakcie",
     "scheduled": "Zaplanowane"
   },
+  "reset": "Resetuj",
   "runId": "Identyfikator wykonania",
   "runTypes": {
     "asset_triggered": "Uruchomiony przez zasób",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/common.json
@@ -113,16 +113,10 @@
   },
   "filter": "Filtr",
   "filters": {
-    "dagDisplayNamePlaceholder": "Filtruj według Daga",
-    "keyPlaceholder": "Filtruj według klucza XCom",
-    "logicalDateFromPlaceholder": "Data logiczna od",
-    "logicalDateToPlaceholder": "Data logiczna do",
-    "mapIndexPlaceholder": "Filtruj według indeksu mapowania",
-    "runAfterFromPlaceholder": "Uruchom po (od)",
-    "runAfterToPlaceholder": "Uruchom po (do)",
-    "runIdPlaceholder": "Filtruj według identyfikatora uruchomienia",
-    "taskIdPlaceholder": "Filtruj według identyfikatora zadania",
-    "triggeringUserPlaceholder": "Filtruj według uruchamiającego użytkownika"
+    "logicalDateFrom": "Data logiczna od",
+    "logicalDateTo": "Data logiczna do",
+    "runAfterFrom": "Uruchom po (od)",
+    "runAfterTo": "Uruchom po (do)"
   },
   "logicalDate": "Data logiczna",
   "logout": "Wyloguj",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/components.json
@@ -8,8 +8,6 @@
     "allRuns": "Wszystkie wykonania",
     "backwards": "Uruchom wstecz",
     "dateRange": "Zakres dat",
-    "dateRangeFrom": "Od",
-    "dateRangeTo": "Do",
     "errorStartDateBeforeEndDate": "Data początkowa musi być wcześniejsza niż data końcowa",
     "maxRuns": "Maksymalna liczba aktywnych wykonań",
     "missingAndErroredRuns": "Brakujące i błędne wykonania",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt/admin.json
@@ -78,7 +78,6 @@
     "tooltip": "Excluir conexões selecionadas"
   },
   "formActions": {
-    "reset": "Redefinir",
     "save": "Salvar"
   },
   "plugins": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt/common.json
@@ -111,17 +111,12 @@
     "any": "Qualquer",
     "or": "OU"
   },
+  "filter": "Filtro",
   "filters": {
-    "dagDisplayNamePlaceholder": "Filtrar por DAG",
-    "keyPlaceholder": "Filtrar por chave XCom",
-    "logicalDateFromPlaceholder": "Data Lógica De",
-    "logicalDateToPlaceholder": "Data Lógica Para",
-    "mapIndexPlaceholder": "Filtrar por Índice do Mapa",
-    "runAfterFromPlaceholder": "Executar Depois De",
-    "runAfterToPlaceholder": "Executar Depois Para",
-    "runIdPlaceholder": "Filtrar por ID da Execução",
-    "taskIdPlaceholder": "Filtrar por ID da Tarefa",
-    "triggeringUserPlaceholder": "Filtrar por Usuário que Disparou"
+    "logicalDateFrom": "Data Lógica De",
+    "logicalDateTo": "Data Lógica Para",
+    "runAfterFrom": "Executar Depois De",
+    "runAfterTo": "Executar Depois Para"
   },
   "logicalDate": "Data Lógica",
   "logout": "Sair",
@@ -165,6 +160,7 @@
     "running": "Executando",
     "scheduled": "Agendado"
   },
+  "reset": "Resetar",
   "runId": "ID da Execução",
   "runTypes": {
     "asset_triggered": "Asset Acionado",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt/components.json
@@ -8,8 +8,6 @@
     "allRuns": "Todas as Execuções",
     "backwards": "Executar para trás",
     "dateRange": "Intervalo de Data",
-    "dateRangeFrom": "De",
-    "dateRangeTo": "Para",
     "errorStartDateBeforeEndDate": "A Data Inicial deve ser antes da Data Final",
     "maxRuns": "Máximo de Execuções Ativas",
     "missingAndErroredRuns": "Execuções Faltando e com Erro",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/tr/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/tr/admin.json
@@ -72,7 +72,6 @@
     "tooltip": "Seçilen bağlantıları sil"
   },
   "formActions": {
-    "reset": "Sıfırla",
     "save": "Kaydet"
   },
   "plugins": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/tr/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/tr/common.json
@@ -99,6 +99,7 @@
     "any": "Herhangi",
     "or": "VEYA"
   },
+  "filter": "Filtre",
   "filters": {
     "dagDisplayNamePlaceholder": "Dag adına göre filtrele",
     "keyPlaceholder": "XCom anahtarına göre filtrele",
@@ -151,6 +152,7 @@
     "running": "Çalışıyor",
     "scheduled": "Planlanmış"
   },
+  "reset": "Sıfırla",
   "runId": "Çalıştırma Kimliği",
   "runTypes": {
     "asset_triggered": "Varlık Tetiklemeli",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/tr/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/tr/common.json
@@ -101,16 +101,10 @@
   },
   "filter": "Filtre",
   "filters": {
-    "dagDisplayNamePlaceholder": "Dag adına göre filtrele",
-    "keyPlaceholder": "XCom anahtarına göre filtrele",
-    "logicalDateFromPlaceholder": "Mantıksal tarih başlangıcı",
-    "logicalDateToPlaceholder": "Mantıksal tarih bitişi",
-    "mapIndexPlaceholder": "Harita indeksine göre filtrele",
-    "runAfterFromPlaceholder": "Şu tarihten sonra çalıştır (başlangıç)",
-    "runAfterToPlaceholder": "Şu tarihten sonra çalıştır (bitiş)",
-    "runIdPlaceholder": "Çalıştırma kimliğine göre filtrele",
-    "taskIdPlaceholder": "Görev kimliğine göre filtrele",
-    "triggeringUserPlaceholder": "Tetikleyen kullanıcıya göre filtrele"
+    "logicalDateFrom": "Mantıksal tarih başlangıcı",
+    "logicalDateTo": "Mantıksal tarih bitişi",
+    "runAfterFrom": "Şu tarihten sonra çalıştır (başlangıç)",
+    "runAfterTo": "Şu tarihten sonra çalıştır (bitiş)"
   },
   "logicalDate": "Mantıksal Tarih",
   "logout": "Çıkış",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/tr/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/tr/components.json
@@ -6,8 +6,6 @@
     "allRuns": "Bütün Dag Çalıştırmaları",
     "backwards": "Geriye Dönük Çalıştır",
     "dateRange": "Tarih Aralığı",
-    "dateRangeFrom": "Başlangıç",
-    "dateRangeTo": "Bitiş",
     "errorStartDateBeforeEndDate": "Başlangıç Tarihi, Bitiş Tarihinden önce olmalıdır",
     "maxRuns": "Maksimum Aktif Çalıştırma",
     "missingAndErroredRuns": "Eksik ve Hata Almış Dag Çalıştırmaları",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/admin.json
@@ -72,7 +72,6 @@
     "tooltip": "删除所选连接"
   },
   "formActions": {
-    "reset": "重置",
     "save": "保存"
   },
   "plugins": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/common.json
@@ -133,6 +133,7 @@
     "running": "执行中",
     "scheduled": "已调度"
   },
+  "reset": "重置",
   "runId": "执行 ID",
   "runTypes": {
     "asset_triggered": "资源触发",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/common.json
@@ -93,12 +93,6 @@
     "or": "或"
   },
   "filter": "筛选",
-  "filters": {
-    "logicalDateFrom": "从逻辑日期",
-    "logicalDateTo": "到逻辑日期",
-    "runAfterFrom": "从运行之后",
-    "runAfterTo": "到运行之前"
-  },
   "logicalDate": "逻辑日期",
   "logout": "退出登录",
   "logoutConfirmation": "确定要退出登录吗？",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/common.json
@@ -93,6 +93,12 @@
     "or": "或"
   },
   "filter": "筛选",
+  "filters": {
+    "logicalDateFrom": "逻辑日期从",
+    "logicalDateTo": "逻辑日期到",
+    "runAfterFrom": "运行之后从",
+    "runAfterTo": "运行之后到"
+  },
   "logicalDate": "逻辑日期",
   "logout": "退出登录",
   "logoutConfirmation": "确定要退出登录吗？",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/common.json
@@ -97,7 +97,7 @@
     "logicalDateFrom": "从逻辑日期",
     "logicalDateTo": "到逻辑日期",
     "runAfterFrom": "从运行之后",
-    "runAfterTo": "到运行之后"
+    "runAfterTo": "到运行之前"
   },
   "logicalDate": "逻辑日期",
   "logout": "退出登录",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/common.json
@@ -94,10 +94,10 @@
   },
   "filter": "筛选",
   "filters": {
-    "logicalDateFrom": "逻辑日期从",
-    "logicalDateTo": "逻辑日期到",
-    "runAfterFrom": "运行之后从",
-    "runAfterTo": "运行之后到"
+    "logicalDateFrom": "从逻辑日期",
+    "logicalDateTo": "到逻辑日期",
+    "runAfterFrom": "从运行之后",
+    "runAfterTo": "到运行之后"
   },
   "logicalDate": "逻辑日期",
   "logout": "退出登录",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/components.json
@@ -6,8 +6,6 @@
     "allRuns": "所有执行",
     "backwards": "反向执行",
     "dateRange": "日期范围",
-    "dateRangeFrom": "从",
-    "dateRangeTo": "到",
     "errorStartDateBeforeEndDate": "开始日期必须早于结束日期。",
     "maxRuns": "活跃执行数上限",
     "missingAndErroredRuns": "遗漏和错误的执行",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/admin.json
@@ -72,7 +72,6 @@
     "tooltip": "刪除所選連線"
   },
   "formActions": {
-    "reset": "重置",
     "save": "儲存"
   },
   "plugins": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/common.json
@@ -100,6 +100,12 @@
     "or": "或"
   },
   "filter": "篩選",
+  "filters": {
+    "logicalDateFrom": "邏輯日期從",
+    "logicalDateTo": "邏輯日期到",
+    "runAfterFrom": "運行之後從",
+    "runAfterTo": "運行之後到"
+  },
   "logicalDate": "邏輯日期",
   "logout": "登出",
   "logoutConfirmation": "確定要登出嗎？",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/common.json
@@ -103,8 +103,8 @@
   "filters": {
     "logicalDateFrom": "從邏輯日期",
     "logicalDateTo": "到邏輯日期",
-    "runAfterFrom": "從最早可執行時間之後",
-    "runAfterTo": "到最早可執行時間之前"
+    "runAfterFrom": "從最早可執行時間",
+    "runAfterTo": "到最早可執行時間"
   },
   "logicalDate": "邏輯日期",
   "logout": "登出",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/common.json
@@ -103,8 +103,8 @@
   "filters": {
     "logicalDateFrom": "從邏輯日期",
     "logicalDateTo": "到邏輯日期",
-    "runAfterFrom": "從運行之後",
-    "runAfterTo": "到運行之後"
+    "runAfterFrom": "從最早可執行時間之後",
+    "runAfterTo": "到最早可執行時間之前"
   },
   "logicalDate": "邏輯日期",
   "logout": "登出",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/common.json
@@ -101,10 +101,10 @@
   },
   "filter": "篩選",
   "filters": {
-    "logicalDateFrom": "邏輯日期從",
-    "logicalDateTo": "邏輯日期到",
-    "runAfterFrom": "運行之後從",
-    "runAfterTo": "運行之後到"
+    "logicalDateFrom": "從邏輯日期",
+    "logicalDateTo": "到邏輯日期",
+    "runAfterFrom": "從運行之後",
+    "runAfterTo": "到運行之後"
   },
   "logicalDate": "邏輯日期",
   "logout": "登出",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/common.json
@@ -140,6 +140,7 @@
     "running": "執行中",
     "scheduled": "已排程"
   },
+  "reset": "重置",
   "runId": "執行 ID",
   "runTypes": {
     "asset_triggered": "資源觸發",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/components.json
@@ -6,8 +6,6 @@
     "allRuns": "所有執行",
     "backwards": "反向執行",
     "dateRange": "日期範圍",
-    "dateRangeFrom": "從",
-    "dateRangeTo": "到",
     "errorStartDateBeforeEndDate": "開始日期必須早於結束日期。",
     "maxRuns": "活躍執行數上限",
     "missingAndErroredRuns": "遺漏和錯誤的執行",

--- a/airflow-core/src/airflow/ui/src/components/DagActions/RunBackfillForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DagActions/RunBackfillForm.tsx
@@ -48,7 +48,7 @@ const today = new Date().toISOString().slice(0, 16);
 type BackfillFormProps = DagRunTriggerParams & Omit<BackfillPostBody, "dag_run_conf">;
 
 const RunBackfillForm = ({ dag, onClose }: RunBackfillFormProps) => {
-  const { t: translate } = useTranslation("components");
+  const { t: translate } = useTranslation(["components", "common"]);
   const [errors, setErrors] = useState<{ conf?: string; date?: unknown }>({});
   const [unpause, setUnpause] = useState(true);
   const [formError, setFormError] = useState(false);
@@ -154,7 +154,7 @@ const RunBackfillForm = ({ dag, onClose }: RunBackfillFormProps) => {
               name="from_date"
               render={({ field }) => (
                 <Field.Root invalid={Boolean(errors.date) || dataIntervalInvalid} required>
-                  <Field.Label>{translate("backfill.dateRangeFrom")}</Field.Label>
+                  <Field.Label>{translate("common:table.from")}</Field.Label>
                   <DateTimeInput {...field} max={today} onBlur={resetDateError} size="sm" />
                   <Field.ErrorText>{translate("backfill.errorStartDateBeforeEndDate")}</Field.ErrorText>
                 </Field.Root>
@@ -165,7 +165,7 @@ const RunBackfillForm = ({ dag, onClose }: RunBackfillFormProps) => {
               name="to_date"
               render={({ field }) => (
                 <Field.Root invalid={Boolean(errors.date) || dataIntervalInvalid} required>
-                  <Field.Label>{translate("backfill.dateRangeTo")}</Field.Label>
+                  <Field.Label>{translate("common:table.to")}</Field.Label>
                   <DateTimeInput {...field} max={today} onBlur={resetDateError} size="sm" />
                 </Field.Root>
               )}

--- a/airflow-core/src/airflow/ui/src/components/FilterBar/FilterBar.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FilterBar/FilterBar.tsx
@@ -164,7 +164,7 @@ export const FilterBar = ({
       {filters.length > 0 && (
         <Button borderRadius="full" colorPalette="gray" onClick={resetFilters} size="sm" variant="outline">
           <MdClear />
-          {translate("admin:formActions.reset")}
+          {translate("common:reset")}
         </Button>
       )}
     </HStack>

--- a/airflow-core/src/airflow/ui/src/constants/filterConfigs.tsx
+++ b/airflow-core/src/airflow/ui/src/constants/filterConfigs.tsx
@@ -50,12 +50,12 @@ export const useFilterConfigs = () => {
     },
     [SearchParamsKeys.LOGICAL_DATE_GTE]: {
       icon: <MdDateRange />,
-      label: translate("common:filters.logicalDateFromLabel", "Logical date from"), // TODO: delete the fallback after the translation freeze
+      label: translate("common:filters.logicalDateFrom"),
       type: FilterTypes.DATE,
     },
     [SearchParamsKeys.LOGICAL_DATE_LTE]: {
       icon: <MdDateRange />,
-      label: translate("common:filters.logicalDateToLabel", "Logical date to"), // TODO: delete the fallback after the translation freeze
+      label: translate("common:filters.logicalDateTo"),
       type: FilterTypes.DATE,
     },
     [SearchParamsKeys.MAP_INDEX]: {
@@ -66,12 +66,12 @@ export const useFilterConfigs = () => {
     },
     [SearchParamsKeys.RUN_AFTER_GTE]: {
       icon: <MdDateRange />,
-      label: translate("common:filters.runAfterFromLabel", "Run after from"), // TODO: delete the fallback after the translation freeze
+      label: translate("common:filters.runAfterFrom"),
       type: FilterTypes.DATE,
     },
     [SearchParamsKeys.RUN_AFTER_LTE]: {
       icon: <MdDateRange />,
-      label: translate("common:filters.runAfterToLabel", "Run after to"), // TODO: delete the fallback after the translation freeze
+      label: translate("common:filters.runAfterTo"),
       type: FilterTypes.DATE,
     },
     [SearchParamsKeys.RUN_ID_PATTERN]: {

--- a/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
@@ -377,7 +377,7 @@ export const PanelButtons = ({
                             hideAdvanced
                             hotkeyDisabled
                             onChange={handleTriggeringUserChange}
-                            placeHolder={translate("common:filters.triggeringUserPlaceholder")}
+                            placeHolder={translate("common:dagRun.triggeringUser")}
                           />
                         </VStack>
                         {shouldShowToggleButtons ? (

--- a/airflow-core/src/airflow/ui/src/pages/Events/EventsFilters.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Events/EventsFilters.tsx
@@ -47,7 +47,7 @@ type EventsFiltersProps = {
 };
 
 export const EventsFilters = ({ urlDagId, urlRunId, urlTaskId }: EventsFiltersProps) => {
-  const { t: translate } = useTranslation(["browse", "common", "components"]);
+  const { t: translate } = useTranslation(["browse", "common"]);
   const [searchParams, setSearchParams] = useSearchParams();
   const { setTableURLState, tableURLState } = useTableURLState();
 
@@ -131,7 +131,7 @@ export const EventsFilters = ({ urlDagId, urlRunId, urlTaskId }: EventsFiltersPr
         {/* Timestamp Range Filters */}
         <VStack alignItems="flex-start" gap={1}>
           <Text fontSize="xs" fontWeight="medium">
-            {translate("components:backfill.dateRangeFrom")}
+            {translate("common:table.from")}
           </Text>
           <DateTimeInput
             onChange={handleDateTimeChange(AFTER_PARAM)}
@@ -142,7 +142,7 @@ export const EventsFilters = ({ urlDagId, urlRunId, urlTaskId }: EventsFiltersPr
         </VStack>
         <VStack alignItems="flex-start" gap={1}>
           <Text fontSize="xs" fontWeight="medium">
-            {translate("components:backfill.dateRangeTo")}
+            {translate("common:table.to")}
           </Text>
           <DateTimeInput
             onChange={handleDateTimeChange(BEFORE_PARAM)}

--- a/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/VariableForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/VariableForm.tsx
@@ -49,7 +49,7 @@ type VariableFormProps = {
 };
 
 const VariableForm = ({ error, initialVariable, isPending, manageMutate, setError }: VariableFormProps) => {
-  const { t: translate } = useTranslation("admin");
+  const { t: translate } = useTranslation(["admin", "common"]);
   const {
     control,
     formState: { isDirty, isValid },
@@ -133,7 +133,7 @@ const VariableForm = ({ error, initialVariable, isPending, manageMutate, setErro
         <HStack w="full">
           {isDirty ? (
             <Button onClick={handleReset} variant="outline">
-              {translate("formActions.reset")}
+              {translate("common:reset")}
             </Button>
           ) : undefined}
           <Spacer />


### PR DESCRIPTION
Following up from https://github.com/apache/airflow/pull/54895 to fix some translations. 

Move "Reset" into common
and since we already had the word for "Filter" in each language, I moved that to fill in the missing "filter" key in common


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
