### PR TITLE
 Make the "Toggle Source" log display only hide source fields, not all fields

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/renderStructuredLog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/renderStructuredLog.tsx
@@ -92,6 +92,8 @@ const addLinks = (line: string) => {
   return elements;
 };
 
+const sourceFields = ["logger", "chan"];
+
 export const renderStructuredLog = ({
   index,
   logLevelFilters,
@@ -182,16 +184,21 @@ export const renderStructuredLog = ({
     </chakra.span>,
   );
 
-  if (showSource) {
-    for (const key in reStructured) {
-      if (Object.hasOwn(reStructured, key)) {
-        elements.push(
-          ": ",
-          <chakra.span color={key === "logger" ? "fg.info" : undefined} key={`prop_${key}`}>
-            {key === "logger" ? "source" : key}={JSON.stringify(reStructured[key])}
-          </chakra.span>,
-        );
+  for (const key in reStructured) {
+    if (Object.hasOwn(reStructured, key)) {
+      if (!showSource && sourceFields.includes(key)) {
+        continue; // eslint-disable-line no-continue
       }
+      const val = reStructured[key] as boolean | number | object | string | null;
+
+      elements.push(
+        " ",
+        <chakra.span color="fg.info" key={`prop_${key}`}>
+          {key === "logger" ? "source" : key}
+        </chakra.span>,
+        // Let strings, ints, etc through as is, but JSON stringify anything more complex
+        `=${val instanceof Object ? JSON.stringify(val) : val}`,
+      );
     }
   }
 

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.test.tsx
@@ -64,7 +64,7 @@ describe("Task log grouping", () => {
     );
 
     const summarySource = screen.getByTestId(
-      'summary-Log message source details: sources=["/home/airflow/logs/dag_id=tutorial_dag/run_id=manual__2025-02-28T05:18:54.249762+00:00/task_id=load/attempt=1.log"]',
+      'summary-Log message source details sources=["/home/airflow/logs/dag_id=tutorial_dag/run_id=manual__2025-02-28T05:18:54.249762+00:00/task_id=load/attempt=1.log"]',
     );
 
     expect(summarySource).toBeVisible();


### PR DESCRIPTION
With the move to structured logging wholesale in #52651, we are going to start
seeing a lot more structured log key/values other than just `logger` and
`chan` -- so "Toggle Source" now just hides those specific fields.

It also changes the format/display to cope better with more than one KV being shown
in the logs.

**Before, with Source**
<img width="1423" height="228" alt="Screenshot 2025-09-10 at 18 41 38" src="https://github.com/user-attachments/assets/dabc12cc-8161-4876-8165-8e6af0a8e082" />

**Before, without Source**

<img width="1422" height="230" alt="Screenshot 2025-09-10 at 18 41 44" src="https://github.com/user-attachments/assets/5bccecd5-26bf-4c26-82fd-5eb722ad00c2" />

**After, with Source**
<img width="1429" height="235" alt="Screenshot 2025-09-10 at 18 41 03" src="https://github.com/user-attachments/assets/b7135407-481a-442f-8cad-302256f95286" />

**After, without Source**
<img width="1432" height="236" alt="Screenshot 2025-09-10 at 18 41 10" src="https://github.com/user-attachments/assets/73b4dc88-8d1d-4330-98db-7311ea55d4cb" />

Note the `filename=` and `lineno=` in a few places -- those are other key/value pairs from log lines like this (that I am working on as part of another change:

```json
{
    "timestamp":"2025-09-10T15:44:46.734893",
    "level":"info",
    "event":"Done. Returned value was: None",
    "logger":"airflow.task.operators.airflow.providers.standard.operators.python.PythonOperator", 
    "filename":"python.py",
    "lineno":218
}
```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
