### PR TITLE
Mark React Apps as Experimental for Airflow 3.1

### DIFF
--- a/airflow-core/docs/administration-and-deployment/plugins.rst
+++ b/airflow-core/docs/administration-and-deployment/plugins.rst
@@ -112,7 +112,7 @@ looks like:
         external_views = []
         # A list of dictionaries containing react apps and some metadata. See the example below.
         # Note: React apps are only supported in Airflow 3.1 and later.
-        # Note: The React app integration is experimental and interfaces might change in future versions.
+        # Note: The React app integration is experimental and interfaces might change in future versions. Particularly, dependency and state interactions between the UI and plugins may need to be refactored for more complex plugin apps.
         react_apps = []
 
         # A callback to perform actions when Airflow starts and the plugin is loaded.

--- a/airflow-core/docs/administration-and-deployment/plugins.rst
+++ b/airflow-core/docs/administration-and-deployment/plugins.rst
@@ -111,6 +111,8 @@ looks like:
         # A list of dictionaries containing external views and some metadata. See the example below.
         external_views = []
         # A list of dictionaries containing react apps and some metadata. See the example below.
+        # Note: React apps are only supported in Airflow 3.1 and later.
+        # Note: The React app integration is experimental and interfaces might change in future versions.
         react_apps = []
 
         # A callback to perform actions when Airflow starts and the plugin is loaded.
@@ -218,6 +220,7 @@ definitions in Airflow.
         "category": "browse",
     }
 
+    # Note: The React app integration is experimental and interfaces might change in future versions.
     react_app_with_metadata = {
         # Name of the React app, this will be displayed in the UI.
         "name": "Name of the React App",

--- a/airflow-core/docs/howto/custom-view-plugin.rst
+++ b/airflow-core/docs/howto/custom-view-plugin.rst
@@ -57,6 +57,7 @@ Developing React Applications with the Bootstrap Tool
 .. warning::
   React applications are new in Airflow 3.1 and should be considered experimental. The feature may be
   subject to changes in future versions without warning based on user feedback and errors reported.
+  Dependency and state interactions between the UI and plugins may need to be refactored, which will also change the bootstrapped example project provided.
 
 |experimental|
 

--- a/airflow-core/docs/howto/custom-view-plugin.rst
+++ b/airflow-core/docs/howto/custom-view-plugin.rst
@@ -54,6 +54,12 @@ available in :doc:`plugin </administration-and-deployment/plugins>`.
 Developing React Applications with the Bootstrap Tool
 =====================================================
 
+.. warning::
+  React applications are new in Airflow 3.1 and should be considered experimental. The feature may be
+  subject to changes in future versions without warning based on user feedback and errors reported.
+
+|experimental|
+
 Airflow provides a React plugin bootstrap tool to help developers quickly create, develop, and integrate external React applications into the core UI. This is the most flexible
 and recommended way to customize the Airflow UI.
 This tool generates a complete React project structure that builds as a library compatible with dynamic imports and shares React instances with the host Airflow application.


### PR DESCRIPTION
As a topic to be discussed in the Airflow 3.x DevCall on 2025-09-11 - React Apps might/should be marked as experimental as integrationd etails might change... as we probably need to learn and discover new bugs we never had before.