### PR TITLE
Add more error handling in pod_manager consume_logs

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -521,13 +521,20 @@ class PodManager(LoggingMixin):
             # can safely resume from a few seconds later
             read_timeout = 60 * 5
             try:
+                since_seconds = None
+                if since_time:
+                    try:
+                        since_seconds = math.ceil((pendulum.now() - since_time).total_seconds())
+                    except TypeError:
+                        self.log.warning(
+                            "Error calculating since_seconds with since_time %s. Using None instead.",
+                            since_time,
+                        )
                 logs = self.read_pod_logs(
                     pod=pod,
                     container_name=container_name,
                     timestamps=True,
-                    since_seconds=(
-                        math.ceil((pendulum.now() - since_time).total_seconds()) if since_time else None
-                    ),
+                    since_seconds=since_seconds,
                     follow=follow,
                     post_termination_timeout=post_termination_timeout,
                     _request_timeout=(connection_timeout, read_timeout),


### PR DESCRIPTION
Despite a None check already existing [here](https://github.com/apache/airflow/blob/main/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py#L529)

We still regularly see the below traceback failing our system tests, particularly on the Lambda executor. This PR adds an additional try/catch for TypeError around this code to ensure we default to None in cases where the since_time is either None or some other unacceptable value.

```
Traceback (most recent call last):
  File "/opt/airflow/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py", line 704, in execute_sync
  File "/var/lang/lib/python3.12/site-packages/tenacity/__init__.py", line 338, in wrapped_f
  File "/var/lang/lib/python3.12/site-packages/tenacity/__init__.py", line 477, in __call__
  File "/var/lang/lib/python3.12/site-packages/tenacity/__init__.py", line 378, in iter
  File "/var/lang/lib/python3.12/site-packages/tenacity/__init__.py", line 400, in <lambda>
  File "/var/lang/lib/python3.12/concurrent/futures/_base.py", line 449, in result
  File "/var/lang/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
  File "/var/lang/lib/python3.12/site-packages/tenacity/__init__.py", line 480, in __call__
  File "/opt/airflow/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py", line 777, in await_pod_completion
  File "/opt/airflow/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py", line 721, in fetch_requested_container_logs
  File "/opt/airflow/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py", line 604, in fetch_container_logs
  File "/opt/airflow/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py", line 529, in consume_logs
  File "/var/lang/lib/python3.12/site-packages/pendulum/datetime.py", line 1215, in __sub__
  File "/var/lang/lib/python3.12/site-packages/pendulum/datetime.py", line 712, in diff
  File "/var/lang/lib/python3.12/site-packages/pendulum/interval.py", line 183, in __init__
TypeError: 'NoneType' object cannot be converted to 'PyString'
```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
