### PR TITLE
Add no/force color env variables handling to airflow standalone

### DIFF
--- a/airflow-core/src/airflow/cli/commands/standalone_command.py
+++ b/airflow-core/src/airflow/cli/commands/standalone_command.py
@@ -41,6 +41,9 @@ from airflow.utils.providers_configuration_loader import providers_configuration
 if TYPE_CHECKING:
     from airflow.jobs.base_job_runner import BaseJobRunner
 
+FORCE_COLOR = bool(os.environ.get("FORCE_COLOR", ""))
+NO_COLOR = bool(os.environ.get("NO_COLOR", ""))
+
 
 class StandaloneCommand:
     """
@@ -149,7 +152,9 @@ class StandaloneCommand:
             "triggerer": "cyan",
             "standalone": "white",
         }
-        colorised_name = colored(f"{name:10}", color.get(name, "white"))
+        colorised_name = colored(
+            f"{name:10}", color.get(name, "white"), no_color=NO_COLOR, force_color=FORCE_COLOR
+        )
         for line in output.splitlines():
             print(f"{colorised_name} | {line.strip()}")
 


### PR DESCRIPTION
Airflow standalone based color/no-color detection on terminal capability auto-detection, but when run in CI or when redirecting output to a file that would always be "no color". This PR adds capability of overwriting automatic detection with standard env variables used elsewhere (NO_COLOR/FORCE_COLOR).

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
