### PR TITLE
Fix Grid cache invalidation for multi-run task operations

### DIFF
--- a/airflow-core/src/airflow/ui/src/queries/useClearTaskInstances.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useClearTaskInstances.ts
@@ -83,7 +83,7 @@ export const useClearTaskInstances = ({
     const { include_future: includeFuture, include_past: includePast } = variables.requestBody;
     const affectsMultipleRuns = includeFuture === true || includePast === true;
 
-    const invalidateKeys = [
+    const queryKeys = [
       ...taskInstanceKeys,
       UseDagRunServiceGetDagRunKeyFn({ dagId, dagRunId }),
       [useDagRunServiceGetDagRunsKey],
@@ -93,7 +93,7 @@ export const useClearTaskInstances = ({
       UseGridServiceGetGridTiSummariesKeyFn({ dagId, runId: affectsMultipleRuns ? undefined : dagRunId }),
     ];
 
-    await Promise.all(invalidateKeys.map((key) => queryClient.invalidateQueries({ queryKey: key })));
+    await Promise.all(queryKeys.map((key) => queryClient.invalidateQueries({ queryKey: key })));
 
     onSuccessConfirm();
   };

--- a/airflow-core/src/airflow/ui/src/queries/useClearTaskInstances.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useClearTaskInstances.ts
@@ -90,7 +90,9 @@ export const useClearTaskInstances = ({
       [useClearTaskInstancesDryRunKey, dagId],
       [usePatchTaskInstanceDryRunKey, dagId, dagRunId],
       UseGridServiceGetGridRunsKeyFn({ dagId }, [{ dagId }]),
-      UseGridServiceGetGridTiSummariesKeyFn({ dagId, runId: affectsMultipleRuns ? undefined : dagRunId }),
+      affectsMultipleRuns
+        ? [useGridServiceGetGridTiSummariesKey, { dagId }]
+        : UseGridServiceGetGridTiSummariesKeyFn({ dagId, runId: dagRunId }),
     ];
 
     await Promise.all(queryKeys.map((key) => queryClient.invalidateQueries({ queryKey: key })));

--- a/airflow-core/src/airflow/ui/src/queries/useClearTaskInstances.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useClearTaskInstances.ts
@@ -90,9 +90,7 @@ export const useClearTaskInstances = ({
       [useClearTaskInstancesDryRunKey, dagId],
       [usePatchTaskInstanceDryRunKey, dagId, dagRunId],
       UseGridServiceGetGridRunsKeyFn({ dagId }, [{ dagId }]),
-      affectsMultipleRuns
-        ? [useGridServiceGetGridTiSummariesKey, { dagId }]
-        : UseGridServiceGetGridTiSummariesKeyFn({ dagId, runId: dagRunId }),
+      UseGridServiceGetGridTiSummariesKeyFn({ dagId, runId: affectsMultipleRuns ? undefined : dagRunId }),
     ];
 
     await Promise.all(invalidateKeys.map((key) => queryClient.invalidateQueries({ queryKey: key })));

--- a/airflow-core/src/airflow/ui/src/queries/usePatchTaskInstance.ts
+++ b/airflow-core/src/airflow/ui/src/queries/usePatchTaskInstance.ts
@@ -72,7 +72,7 @@ export const usePatchTaskInstance = ({
     const { include_future: includeFuture, include_past: includePast } = variables.requestBody;
     const affectsMultipleRuns = includeFuture === true || includePast === true;
 
-    const invalidateKeys = [
+    const queryKeys = [
       UseTaskInstanceServiceGetTaskInstanceKeyFn({ dagId, dagRunId, taskId }),
       UseTaskInstanceServiceGetMappedTaskInstanceKeyFn({ dagId, dagRunId, mapIndex, taskId }),
       [useTaskInstanceServiceGetTaskInstancesKey],
@@ -84,7 +84,7 @@ export const usePatchTaskInstance = ({
         : UseGridServiceGetGridTiSummariesKeyFn({ dagId, runId: dagRunId }),
     ];
 
-    await Promise.all(invalidateKeys.map((key) => queryClient.invalidateQueries({ queryKey: key })));
+    await Promise.all(queryKeys.map((key) => queryClient.invalidateQueries({ queryKey: key })));
 
     if (onSuccess) {
       onSuccess();


### PR DESCRIPTION
### Problem
Grid UI was not updating after clearing or patching task instances when
using the `include_future` or `include_past` options.(#55267 )

### Solution
- Fixed cache invalidation logic to properly refresh all affected DAG runs,
  not just the current run.
- Considered precise invalidation based on past/future options, but this
  required overly complex predicate logic.
- Opted for a simpler approach: invalidate all DAG Grid data whenever
  multiple runs are affected.

### Related Issues
Fixes #55267
