### PR TITLE
Make task stdout/stderr output filterable in the Sources list in the UI

### DIFF
--- a/airflow-core/newsfragments/55508.feature.rst
+++ b/airflow-core/newsfragments/55508.feature.rst
@@ -1,0 +1,1 @@
+Output on stdout/stderr from within tasks is now filterable in the Sources list in the UI log view

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -272,24 +272,21 @@ class TestWatchedSubprocess:
         assert captured_logs == unordered(
             [
                 {
-                    "chan": "stdout",
+                    "logger": "task.stdout",
                     "event": "I'm a short message",
                     "level": "info",
-                    "logger": "task",
                     "timestamp": "2024-11-07T12:34:56.078901Z",
                 },
                 {
-                    "chan": "stderr",
+                    "logger": "task.stderr",
                     "event": "stderr message",
                     "level": "error",
-                    "logger": "task",
                     "timestamp": "2024-11-07T12:34:56.078901Z",
                 },
                 {
-                    "chan": "stdout",
+                    "logger": "task.stdout",
                     "event": "Message split across two writes",
                     "level": "info",
-                    "logger": "task",
                     "timestamp": "2024-11-07T12:34:56.078901Z",
                 },
                 {
@@ -578,10 +575,9 @@ class TestWatchedSubprocess:
 
         # We should have a log from the task!
         assert {
-            "chan": "stdout",
+            "logger": "task.stdout",
             "event": "Hello World hello!",
             "level": "info",
-            "logger": "task",
             "timestamp": "2024-11-07T12:34:56.078901Z",
         } in captured_logs
 
@@ -1144,36 +1140,34 @@ class TestWatchedSubprocessKill:
         assert proc.wait() == exit_after or -signal.SIGKILL
         exit_after = exit_after or signal.SIGKILL
 
-        logs = [{"event": m["event"], "chan": m.get("chan"), "logger": m["logger"]} for m in captured_logs]
+        logs = [{"event": m["event"], "logger": m["logger"]} for m in captured_logs]
         expected_logs = [
-            {"chan": "stdout", "event": "Ready", "logger": "task"},
+            {"logger": "task.stdout", "event": "Ready"},
         ]
         # Work out what logs we expect to see
         if signal_to_send == signal.SIGINT:
-            expected_logs.append({"chan": "stderr", "event": "Signal 2 received", "logger": "task"})
+            expected_logs.append({"logger": "task.stderr", "event": "Signal 2 received"})
         if signal_to_send == signal.SIGTERM or (
             signal_to_send == signal.SIGINT and exit_after != signal.SIGINT
         ):
             if signal_to_send == signal.SIGINT:
                 expected_logs.append(
                     {
-                        "chan": None,
                         "event": "Process did not terminate in time; escalating",
                         "logger": "supervisor",
                     }
                 )
-            expected_logs.append({"chan": "stderr", "event": "Signal 15 received", "logger": "task"})
+            expected_logs.append({"logger": "task.stderr", "event": "Signal 15 received"})
         if exit_after == signal.SIGKILL:
             if signal_to_send in {signal.SIGINT, signal.SIGTERM}:
                 expected_logs.append(
                     {
-                        "chan": None,
                         "event": "Process did not terminate in time; escalating",
                         "logger": "supervisor",
                     }
                 )
 
-        expected_logs.extend(({"chan": None, "event": "Process exited", "logger": "supervisor"},))
+        expected_logs.extend(({"event": "Process exited", "logger": "supervisor"},))
         assert logs == expected_logs
 
     def test_service_subprocess(self, watched_subprocess, mock_process, mocker):


### PR DESCRIPTION
Previously output on stdout or stderr was showing up with `chan="stdout"` etc,
which as a leakly implementation detail (no where else do we refer to
channels, and it was just an internal detail that we treat these std streams
somwhat like a "channel")

This changes it so that we record the information in the same "logger" key
that the structured logs store the logger name in, meaning we can filter by
them in the UI.

<img width="933" height="188" alt="Screenshot 2025-09-11 at 14 47 26" src="https://github.com/user-attachments/assets/54d32634-e39a-449b-9d39-69ad06e48533" />


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
