### PR TITLE
Display responder username for better audit.

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/HITLTaskInstances/HITLResponseForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/HITLTaskInstances/HITLResponseForm.tsx
@@ -51,7 +51,6 @@ const isHighlightOption = (option: string, hitlDetail: HITLDetail, preloadedHITL
 };
 
 export const HITLResponseForm = ({ hitlDetail }: HITLResponseFormProps) => {
-  const DEFAULT_USERNAME = "Fallback to defaults";
   const { t: translate } = useTranslation("hitl");
   const [errors, setErrors] = useState<boolean>(false);
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
@@ -100,9 +99,9 @@ export const HITLResponseForm = ({ hitlDetail }: HITLResponseFormProps) => {
         <Text color="fg.muted" fontSize="sm">
           {translate("response.received")}
           <Time datetime={hitlDetail.responded_at} format={DEFAULT_DATETIME_FORMAT} />
-          {hitlDetail.responded_user_name === DEFAULT_USERNAME
-            ? undefined
-            : ` ${translate("common:table.from").toLowerCase()} ${hitlDetail.responded_user_name}`}
+          {hitlDetail.responded_by_user
+            ? ` ${translate("common:table.from").toLowerCase()} ${hitlDetail.responded_by_user.name}`
+            : undefined}
         </Text>
       ) : undefined}
       <Accordion.Root

--- a/airflow-core/src/airflow/ui/src/pages/HITLTaskInstances/HITLResponseForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/HITLTaskInstances/HITLResponseForm.tsx
@@ -51,6 +51,7 @@ const isHighlightOption = (option: string, hitlDetail: HITLDetail, preloadedHITL
 };
 
 export const HITLResponseForm = ({ hitlDetail }: HITLResponseFormProps) => {
+  const DEFAULT_USERNAME = "Fallback to defaults";
   const { t: translate } = useTranslation("hitl");
   const [errors, setErrors] = useState<boolean>(false);
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
@@ -99,6 +100,9 @@ export const HITLResponseForm = ({ hitlDetail }: HITLResponseFormProps) => {
         <Text color="fg.muted" fontSize="sm">
           {translate("response.received")}
           <Time datetime={hitlDetail.responded_at} format={DEFAULT_DATETIME_FORMAT} />
+          {hitlDetail.responded_user_name === DEFAULT_USERNAME
+            ? undefined
+            : ` ${translate("common:table.from").toLowerCase()} ${hitlDetail.responded_user_name}`}
         </Text>
       ) : undefined}
       <Accordion.Root


### PR DESCRIPTION
When responder username is not the default value then display it with response received timestamp for better audit.

closes #55033

<img width="1115" height="848" alt="image" src="https://github.com/user-attachments/assets/8b66dfdc-973c-435e-a665-8c18efe90ef6" />
