### PR TITLE
docs(ruff-AIR-rules-usage): remove --preview as it's stablized after ruff==0.13.0

### DIFF
--- a/airflow-core/docs/best-practices.rst
+++ b/airflow-core/docs/best-practices.rst
@@ -316,7 +316,7 @@ Installing and Using ruff
 
    .. code-block:: bash
 
-      ruff check dags/ --select AIR3 --preview
+      ruff check dags/ --select AIR3
 
    This command will analyze your Dags located in the ``dags/`` directory and report any issues related to the specified rules.
 

--- a/airflow-core/docs/installation/upgrading_to_airflow3.rst
+++ b/airflow-core/docs/installation/upgrading_to_airflow3.rst
@@ -89,24 +89,24 @@ Step 3: Dag authors - Check your Airflow Dags for compatibility
 To minimize friction for users upgrading from prior versions of Airflow, we have created a Dag upgrade check utility using `Ruff <https://docs.astral.sh/ruff/>`_ combined with `AIR <https://docs.astral.sh/ruff/rules/#airflow-air>`_ rules.
 The rules AIR301 and AIR302 indicate breaking changes in Airflow 3, while AIR311 and AIR312 highlight changes that are not currently breaking but are strongly recommended for updates.
 
-The latest available ``ruff`` version will have the most up-to-date rules, but be sure to use at least version ``0.11.13``. The below example demonstrates how to check
+The latest available ``ruff`` version will have the most up-to-date rules, but be sure to use at least version ``0.13.0``. The below example demonstrates how to check
 for Dag incompatibilities that will need to be fixed before they will work as expected on Airflow 3.
 
 .. code-block:: bash
 
-    ruff check dags/ --select AIR301 --preview
+    ruff check dags/ --select AIR301
 
 To preview the recommended fixes, run the following command:
 
 .. code-block:: bash
 
-    ruff check dags/ --select AIR301 --show-fixes --preview
+    ruff check dags/ --select AIR301 --show-fixes
 
 Some changes can be automatically fixed. To do so, run the following command:
 
 .. code-block:: bash
 
-    ruff check dags/ --select AIR301 --fix --preview
+    ruff check dags/ --select AIR301 --fix
 
 
 Some of the fixes are marked as unsafe. Unsafe fixes usually do not break Dag code. They're marked as unsafe as they may change some runtime behavior. For more information, see `Fix Safety <https://docs.astral.sh/ruff/linter/#fix-safety>`_.
@@ -114,12 +114,7 @@ To trigger these fixes, run the following command:
 
 .. code-block:: bash
 
-    ruff check dags/ --select AIR301 --fix --unsafe-fixes --preview
-
-.. note::
-  Ruff has strict policy about when a rule becomes stable. Till it does you must use --preview flag.
-  The progress of Airflow Ruff rule become stable can be tracked in https://github.com/astral-sh/ruff/issues/17749
-  That said, from Airflow side the rules are perfectly fine to be used.
+    ruff check dags/ --select AIR301 --fix --unsafe-fixes
 
 .. note::
 


### PR DESCRIPTION
## Why
ruff==0.13.0 has been released. AIR301, 302, 311, 312, 002 have been stabilized.

## What
Update the doc accordingly

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
