### PR TITLE
Fix error when retrieving logs of ti not run because of upstream failures

### DIFF
--- a/airflow-core/src/airflow/utils/log/file_task_handler.py
+++ b/airflow-core/src/airflow/utils/log/file_task_handler.py
@@ -741,7 +741,10 @@ class FileTaskHandler(logging.Handler):
         if try_number is None:
             try_number = task_instance.try_number
 
-        if try_number == 0 and task_instance.state == TaskInstanceState.SKIPPED:
+        if try_number == 0 and task_instance.state in (
+            TaskInstanceState.SKIPPED,
+            TaskInstanceState.UPSTREAM_FAILED,
+        ):
             logs = [StructuredLogMessage(event="Task was skipped, no logs available.")]
             return chain(logs), {"end_of_log": True}
 

--- a/airflow-core/tests/unit/utils/test_log_handlers.py
+++ b/airflow-core/tests/unit/utils/test_log_handlers.py
@@ -79,7 +79,7 @@ from tests_common.test_utils.file_task_handler import (
 )
 from tests_common.test_utils.markers import skip_if_force_lowest_dependencies_marker
 
-pytestmark = [pytest.mark.db_test, pytest.mark.xfail()]
+pytestmark = [pytest.mark.db_test]
 
 DEFAULT_DATE = pendulum.datetime(2016, 1, 1)
 TASK_LOGGER = "airflow.task"
@@ -172,8 +172,8 @@ class TestFileTaskLogHandler:
         ti.try_number = 0
         ti.state = State.SKIPPED
 
-        logger = ti.log
-        ti.log.disabled = False
+        logger = logging.getLogger(TASK_LOGGER)
+        logger.disabled = False
 
         file_handler = next(
             (handler for handler in logger.handlers if handler.name == FILE_TASK_HANDLER), None
@@ -295,8 +295,8 @@ class TestFileTaskLogHandler:
                 ti.executor = executor_name
             ti.try_number = 1
             ti.state = TaskInstanceState.RUNNING
-            logger = ti.log
-            ti.log.disabled = False
+            logger = logging.getLogger(TASK_LOGGER)
+            logger.disabled = False
 
             file_handler = next(
                 (handler for handler in logger.handlers if handler.name == FILE_TASK_HANDLER), None
@@ -344,8 +344,8 @@ class TestFileTaskLogHandler:
         ti.try_number = 2
         ti.state = State.RUNNING
 
-        logger = ti.log
-        ti.log.disabled = False
+        logger = logging.getLogger(TASK_LOGGER)
+        logger.disabled = False
 
         file_handler = next(
             (handler for handler in logger.handlers if handler.name == FILE_TASK_HANDLER), None
@@ -396,8 +396,8 @@ class TestFileTaskLogHandler:
         ti.try_number = 1
         ti.state = State.RUNNING
 
-        logger = ti.log
-        ti.log.disabled = False
+        logger = logging.getLogger(TASK_LOGGER)
+        logger.disabled = False
 
         file_handler = next(
             (handler for handler in logger.handlers if handler.name == FILE_TASK_HANDLER), None
@@ -413,7 +413,7 @@ class TestFileTaskLogHandler:
         assert log_filename.endswith("1.log"), log_filename
 
         # mock to generate 2000 lines of log, the total size is larger than max_bytes_size
-        for i in range(1, 2000):
+        for i in range(1, 3000):
             logger.info("this is a Test. %s", i)
 
         # this is the rotate log file

--- a/airflow-core/tests/unit/utils/test_log_handlers.py
+++ b/airflow-core/tests/unit/utils/test_log_handlers.py
@@ -156,7 +156,8 @@ class TestFileTaskLogHandler:
         # Remove the generated tmp log file.
         os.remove(log_filename)
 
-    def test_file_task_handler_when_ti_is_skipped(self, dag_maker):
+    @pytest.mark.parametrize("ti_state", [TaskInstanceState.SKIPPED, TaskInstanceState.UPSTREAM_FAILED])
+    def test_file_task_handler_when_ti_is_not_run(self, dag_maker, ti_state):
         def task_callable(ti):
             ti.log.info("test")
 
@@ -170,7 +171,7 @@ class TestFileTaskLogHandler:
         ti = TaskInstance(task=task, run_id=dagrun.run_id, dag_version_id=dag_version.id)
 
         ti.try_number = 0
-        ti.state = State.SKIPPED
+        ti.state = ti_state
 
         logger = logging.getLogger(TASK_LOGGER)
         logger.disabled = False


### PR DESCRIPTION
Return placeholder message when requested the logs of tasks skipped because of upstream failures as we were doing previously for skipped tis.

Before updating the test for the fix, enable the tests in `TestFileTaskLogHandler` and fix them. 

closes: #55514 

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
