### PR TITLE
Use FilterBar for Asset Event filters

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/Assets/AssetEventsFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Assets/AssetEventsFilter.tsx
@@ -16,96 +16,37 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { VStack, HStack, Box, Text, Button } from "@chakra-ui/react";
-import { useCallback, useMemo, useState } from "react";
-import { useTranslation } from "react-i18next";
-import { LuX } from "react-icons/lu";
-import { useSearchParams } from "react-router-dom";
+import { useMemo } from "react";
 
-import { DateTimeInput } from "src/components/DateTimeInput";
-import { SearchBar } from "src/components/SearchBar";
+import { FilterBar } from "src/components/FilterBar";
 import { SearchParamsKeys } from "src/constants/searchParams";
+import { useFiltersHandler, type FilterableSearchParamsKeys } from "src/utils/useFiltersHandler";
 
-const { DAG_ID, END_DATE, START_DATE, TASK_ID } = SearchParamsKeys;
-const filterKeys = [START_DATE, END_DATE, DAG_ID, TASK_ID];
+const FILTER_KEYS: Array<FilterableSearchParamsKeys> = [
+  SearchParamsKeys.START_DATE,
+  SearchParamsKeys.END_DATE,
+  SearchParamsKeys.DAG_ID,
+  SearchParamsKeys.TASK_ID,
+];
 
 export const AssetEventsFilter = () => {
-  const { t: translate } = useTranslation("common");
-  const [searchParams, setSearchParams] = useSearchParams();
-  const startDate = searchParams.get(START_DATE) ?? "";
-  const endDate = searchParams.get(END_DATE) ?? "";
-  const dagId = searchParams.get(DAG_ID) ?? "";
-  const taskId = searchParams.get(TASK_ID) ?? "";
-  const [resetKey, setResetKey] = useState(0);
-  const handleFilterChange = useCallback(
-    (paramKey: string) => (value: string) => {
-      if (value === "") {
-        searchParams.delete(paramKey);
-      } else {
-        searchParams.set(paramKey, value);
+  const { filterConfigs, handleFiltersChange, searchParams } = useFiltersHandler(FILTER_KEYS);
+
+  const initialValues = useMemo(() => {
+    const values: Record<string, string> = {};
+
+    FILTER_KEYS.forEach((key) => {
+      const value = searchParams.get(key);
+
+      if (value !== null && value.trim() !== "") {
+        values[key] = value;
       }
-      setSearchParams(searchParams);
-    },
-    [searchParams, setSearchParams],
-  );
-  const filterCount = useMemo(
-    () => filterKeys.reduce((acc, key) => (searchParams.get(key) === null ? acc : acc + 1), 0),
-    [searchParams],
-  );
-  const handleResetFilters = useCallback(() => {
-    filterKeys.forEach((key) => searchParams.delete(key));
-    setSearchParams(searchParams);
-    setResetKey((prev) => prev + 1);
-  }, [searchParams, setSearchParams]);
+    });
+
+    return values;
+  }, [searchParams]);
 
   return (
-    <VStack align="start" gap={4} paddingY="4px">
-      <HStack flexWrap="wrap" gap={4}>
-        <Box w="200px">
-          <Text fontSize="xs">{translate("common:table.from")}</Text>
-          <DateTimeInput
-            onChange={(event) => handleFilterChange(START_DATE)(event.target.value)}
-            value={startDate}
-          />
-        </Box>
-        <Box w="200px">
-          <Text fontSize="xs">{translate("common:table.to")}</Text>
-          <DateTimeInput
-            onChange={(event) => handleFilterChange(END_DATE)(event.target.value)}
-            value={endDate}
-          />
-        </Box>
-        <Box w="200px">
-          <Text fontSize="xs">{translate("common:filters.dagDisplayNamePlaceholder")}</Text>
-          <SearchBar
-            defaultValue={dagId}
-            hideAdvanced
-            hotkeyDisabled={true}
-            key={`dag-id-${resetKey}`}
-            onChange={handleFilterChange(DAG_ID)}
-            placeHolder={translate("common:filters.dagDisplayNamePlaceholder")}
-          />
-        </Box>
-        <Box w="200px">
-          <Text fontSize="xs">{translate("common:filters.taskIdPlaceholder")}</Text>
-          <SearchBar
-            defaultValue={taskId}
-            hideAdvanced
-            hotkeyDisabled={true}
-            key={`task-id-${resetKey}`}
-            onChange={handleFilterChange(TASK_ID)}
-            placeHolder={translate("common:filters.taskIdPlaceholder")}
-          />
-        </Box>
-        <Box alignSelf="end">
-          {filterCount > 0 && (
-            <Button onClick={handleResetFilters} size="md" variant="outline">
-              <LuX />
-              {translate("common:table.filterReset", { count: filterCount })}
-            </Button>
-          )}
-        </Box>
-      </HStack>
-    </VStack>
+    <FilterBar configs={filterConfigs} initialValues={initialValues} onFiltersChange={handleFiltersChange} />
   );
 };

--- a/airflow-core/src/airflow/ui/src/constants/filterConfigs.tsx
+++ b/airflow-core/src/airflow/ui/src/constants/filterConfigs.tsx
@@ -59,6 +59,11 @@ export const useFilterConfigs = () => {
       label: translate("common:dagId"),
       type: FilterTypes.TEXT,
     },
+    [SearchParamsKeys.END_DATE]: {
+      icon: <MdDateRange />,
+      label: translate("common:table.to"),
+      type: FilterTypes.DATE,
+    },
     [SearchParamsKeys.EVENT_TYPE]: {
       label: translate("browse:auditLog.filters.eventType"),
       type: FilterTypes.TEXT,
@@ -105,6 +110,11 @@ export const useFilterConfigs = () => {
       icon: <FiBarChart />,
       label: translate("common:runId"),
       type: FilterTypes.TEXT,
+    },
+    [SearchParamsKeys.START_DATE]: {
+      icon: <MdDateRange />,
+      label: translate("common:table.from"),
+      type: FilterTypes.DATE,
     },
     [SearchParamsKeys.TASK_ID]: {
       hotkeyDisabled: true,

--- a/airflow-core/src/airflow/ui/src/utils/useFiltersHandler.ts
+++ b/airflow-core/src/airflow/ui/src/utils/useFiltersHandler.ts
@@ -29,6 +29,7 @@ export type FilterableSearchParamsKeys =
   | SearchParamsKeys.BEFORE
   | SearchParamsKeys.DAG_DISPLAY_NAME_PATTERN
   | SearchParamsKeys.DAG_ID
+  | SearchParamsKeys.END_DATE
   | SearchParamsKeys.EVENT_TYPE
   | SearchParamsKeys.KEY_PATTERN
   | SearchParamsKeys.LOGICAL_DATE_GTE
@@ -38,6 +39,7 @@ export type FilterableSearchParamsKeys =
   | SearchParamsKeys.RUN_AFTER_LTE
   | SearchParamsKeys.RUN_ID
   | SearchParamsKeys.RUN_ID_PATTERN
+  | SearchParamsKeys.START_DATE
   | SearchParamsKeys.TASK_ID
   | SearchParamsKeys.TASK_ID_PATTERN
   | SearchParamsKeys.TRY_NUMBER


### PR DESCRIPTION
Update Asset Event filters to use our new filter bar component. This also fix some issues with translation keys.

<img width="708" height="691" alt="Screenshot 2025-09-11 at 11 19 26 AM" src="https://github.com/user-attachments/assets/c72894c8-6c0e-454d-b490-71ccc33c7100" />



---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
