### PR TITLE
Update query client retry strategy

### DIFF
--- a/airflow-core/src/airflow/ui/src/queryClient.ts
+++ b/airflow-core/src/airflow/ui/src/queryClient.ts
@@ -29,15 +29,13 @@ if (OpenAPI.BASE.endsWith("/")) {
 export const client = new QueryClient({
   defaultOptions: {
     mutations: {
-      retry: 1,
-      retryDelay: 500,
+      retry: 3,
     },
     queries: {
       initialDataUpdatedAt: new Date().setMinutes(-6), // make sure initial data is already expired
       refetchOnMount: true, // Refetches stale queries, not "always"
       refetchOnWindowFocus: false,
-      retry: 1,
-      retryDelay: 500,
+      retry: 3,
       staleTime: 5 * 60 * 1000, // 5 minutes
     },
   },


### PR DESCRIPTION
Update the retry strategy for front-end request to be more failure tolerant. The current strategy was only retrying once and 500ms after the first failure.

Which means that if you are rate limited, most chances are the only retry we're doing after that will also fail and be rate limited. 

We are falling back to the default strategy here which is
`retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),`