### PR TITLE
Propagate AssetEvent through context when Consumer DAG triggering on AssetAlias (#50182)

### DIFF
--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -48,7 +48,13 @@ from airflow.executors.executor_loader import ExecutorLoader
 from airflow.executors.executor_utils import ExecutorName
 from airflow.jobs.job import Job, run_job
 from airflow.jobs.scheduler_job_runner import SchedulerJobRunner
-from airflow.models.asset import AssetActive, AssetDagRunQueue, AssetEvent, AssetModel
+from airflow.models.asset import (
+    AssetActive,
+    AssetAliasModel,
+    AssetDagRunQueue,
+    AssetEvent,
+    AssetModel,
+)
 from airflow.models.backfill import Backfill, _create_backfill
 from airflow.models.dag import DAG, DagModel
 from airflow.models.dag_version import DagVersion
@@ -63,7 +69,7 @@ from airflow.models.taskinstance import TaskInstance
 from airflow.providers.standard.operators.bash import BashOperator
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.sdk import task
-from airflow.sdk.definitions.asset import Asset
+from airflow.sdk.definitions.asset import Asset, AssetAlias
 from airflow.serialization.serialized_objects import LazyDeserializedDAG, SerializedDAG
 from airflow.timetables.base import DataInterval
 from airflow.traces.tracer import Trace
@@ -4108,6 +4114,82 @@ class TestSchedulerJob:
         # dag3 ADRQ record should be deleted since the dag run was triggered
         assert session.query(AssetDagRunQueue).filter_by(target_dag_id=dag3.dag_id).one_or_none() is None
 
+        assert created_run.creating_job_id == scheduler_job.id
+
+    @pytest.mark.need_serialized_dag
+    def test_create_dag_runs_asset_alias_with_asset_event_attached(self, session, dag_maker):
+        """
+        Test Dag Run trigger on AssetAlias includes the corresponding AssetEvent in `consumed_asset_events`.
+        """
+
+        # Simulate an Asset created at runtime, and it is not an active asset
+        asset1 = Asset(uri="test://asset1", name="test_asset", group="test_group")
+        # Create an AssetAlias, and the Asset will be attached to this AssetAlias
+        asset_alias = AssetAlias(name="test_asset_alias_with_asset_event", group="test_group")
+
+        # Add it to the DB so the event can be created from this Asset
+        asm = AssetModel(name=asset1.name, uri=asset1.uri, group=asset1.group)
+        session.add(asm)
+
+        asam = AssetAliasModel(name=asset_alias.name, group=asset_alias.group)
+
+        # Simulate a Producer dag attach an asset event at runtime to an AssetAlias
+        # Don't use outlets here because the needs to associate an asset alias with an asset event in the association table
+        with dag_maker(dag_id="asset-alias-producer", start_date=timezone.utcnow(), session=session):
+            BashOperator(task_id="simulate-asset-alias-outlet", bash_command="echo 1")
+        dr = dag_maker.create_dagrun(run_id="asset-alias-producer-run")
+
+        asset1_id = session.query(AssetModel.id).filter_by(uri=asset1.uri).scalar()
+
+        # Create an AssetEvent, which is associated with the Asset, and it is attached to the AssetAlias
+        event = AssetEvent(
+            asset_id=asset1_id,
+            source_task_id="simulate-asset-alias-outlet",
+            source_dag_id=dr.dag_id,
+            source_run_id=dr.run_id,
+            source_map_index=-1,
+        )
+        # Attach the Asset and the AssetEvent to the Asset Alias
+        asam.assets.append(asm)
+        asam.asset_events.append(event)
+
+        session.add_all([asam, event])
+        session.flush()
+
+        # Create the Consumer DAG and Trigger it with scheduler
+        with dag_maker(dag_id="asset-alias-consumer", schedule=[asset_alias]):
+            pass
+        consumer_dag = dag_maker.dag
+
+        session = dag_maker.session
+        session.add_all(
+            [
+                AssetDagRunQueue(asset_id=asset1_id, target_dag_id=consumer_dag.dag_id),
+            ]
+        )
+        session.flush()
+
+        scheduler_job = Job(executor=self.null_exec)
+        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+
+        with create_session() as session:
+            self.job_runner._create_dagruns_for_dags(session, session)
+
+        def dict_from_obj(obj):
+            """Get dict of column attrs from SqlAlchemy object."""
+            return {k.key: obj.__dict__.get(k) for k in obj.__mapper__.column_attrs}
+
+        created_run = session.query(DagRun).filter(DagRun.dag_id == consumer_dag.dag_id).one()
+        assert created_run.state == State.QUEUED
+        assert created_run.start_date is None
+
+        # The AssetEvent should be included in the consumed_asset_events when the consumer DAG is
+        # triggered on AssetAlias
+        assert list(map(dict_from_obj, created_run.consumed_asset_events)) == list(
+            map(dict_from_obj, [event])
+        )
+        assert created_run.data_interval_start is None
+        assert created_run.data_interval_end is None
         assert created_run.creating_job_id == scheduler_job.id
 
     @pytest.mark.need_serialized_dag


### PR DESCRIPTION
backport https://github.com/apache/airflow/pull/50182

* attach asset event that is attached to an asset alias to the triggering_asset_events in context, allow downstream consumer task to access the actual asset event when triggered by the asset alias.

* precommit fix

* add test case

* profile merge and unmerge query

* merge queries into one

* Update airflow-core/tests/unit/jobs/test_scheduler_job.py



* Update airflow-core/tests/unit/jobs/test_scheduler_job.py



---------


(cherry picked from commit 825c322a6f4c444425a373804587d6f8a21a5acf)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
