### PR TITLE
feat(hitl): get rid off "Fallback to defaults" in HITL

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/hitl.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/hitl.py
@@ -116,7 +116,7 @@ def update_hitl_detail(
             f"Human-in-the-loop detail for Task Instance with id {ti_id_str} already exists.",
         )
 
-    hitl_detail_model.responded_by = HITLDetail.DEFAULT_USER
+    hitl_detail_model.responded_by = None
     hitl_detail_model.response_at = datetime.now(timezone.utc)
     hitl_detail_model.chosen_options = payload.chosen_options
     hitl_detail_model.params_input = payload.params_input

--- a/airflow-core/src/airflow/models/hitl.py
+++ b/airflow-core/src/airflow/models/hitl.py
@@ -167,8 +167,3 @@ class HITLDetail(Base):
             id=self.responded_by["id"],
             name=self.responded_by["name"],
         )
-
-    DEFAULT_USER = HITLUser(
-        id="Fallback to defaults",
-        name="Fallback to defaults",
-    )

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_hitl.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_hitl.py
@@ -93,7 +93,7 @@ def expected_sample_hitl_detail_dict(sample_ti: TaskInstance) -> dict[str, Any]:
                 "params_input": {"input_1": 2},
                 "response_at": convert_to_utc(datetime(2025, 7, 3, 0, 0, 0)),
                 "chosen_options": ["Reject"],
-                "responded_by": {"id": "Fallback to defaults", "name": "Fallback to defaults"},
+                "responded_by": None,
             },
         },
     ],
@@ -174,10 +174,7 @@ def test_update_hitl_detail(client: Client, sample_ti: TaskInstance) -> None:
         "response_at": "2025-07-03T00:00:00Z",
         "chosen_options": ["Reject"],
         "response_received": True,
-        "responded_by_user": {
-            "id": "Fallback to defaults",
-            "name": "Fallback to defaults",
-        },
+        "responded_by_user": None,
     }
 
 

--- a/providers/standard/src/airflow/providers/standard/triggers/hitl.py
+++ b/providers/standard/src/airflow/providers/standard/triggers/hitl.py
@@ -44,7 +44,7 @@ class HITLTriggerEventSuccessPayload(TypedDict, total=False):
 
     chosen_options: list[str]
     params_input: dict[str, Any]
-    responded_by_user: HITLUser
+    responded_by_user: HITLUser | None
     timedout: bool
 
 
@@ -148,10 +148,7 @@ class HITLTrigger(BaseTrigger):
                     HITLTriggerEventSuccessPayload(
                         chosen_options=self.defaults,
                         params_input=self.params,
-                        responded_by_user=HITLUser(
-                            id="Fallback to defaults",
-                            name="Fallback to defaults",
-                        ),
+                        responded_by_user=None,
                         timedout=True,
                     )
                 )

--- a/providers/standard/tests/unit/standard/triggers/test_hitl.py
+++ b/providers/standard/tests/unit/standard/triggers/test_hitl.py
@@ -125,7 +125,7 @@ class TestHITLTrigger:
             HITLTriggerEventSuccessPayload(
                 chosen_options=["1"],
                 params_input={"input": 1},
-                responded_by_user={"id": "Fallback to defaults", "name": "Fallback to defaults"},
+                responded_by_user=None,
                 timedout=True,
             )
         )


### PR DESCRIPTION
## Why
Hard-coded "Fallback to defaults" is not requried.

## What
Remove hard-coded "Fallback to defaults" and fallback to None


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
