### PR TITLE
Remove config loader from react tests

### DIFF
--- a/airflow-core/src/airflow/ui/src/utils/AppWrapper.tsx
+++ b/airflow-core/src/airflow/ui/src/utils/AppWrapper.tsx
@@ -27,7 +27,13 @@ type Props = {
 };
 
 export const AppWrapper = ({ initialEntries }: Props) => {
-  const router = createMemoryRouter(routerConfig, { basename: "/", initialEntries });
+  // Strip the config loader from tests
+  const config = routerConfig.map((route) => ({
+    ...route,
+    loader: undefined,
+  }));
+
+  const router = createMemoryRouter(config, { basename: "/", initialEntries });
 
   return (
     <BaseWrapper>


### PR DESCRIPTION
Changing our react-query defaults broke our tests because our config loader is built into the router. Instead we should strip the config loader during tests so our query defaults don't show up in tests.


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
