### PR TITLE
Fix xcom access in DAG processor callbacks for notifiers

### DIFF
--- a/airflow-core/tests/unit/dag_processing/test_processor.py
+++ b/airflow-core/tests/unit/dag_processing/test_processor.py
@@ -884,10 +884,6 @@ class TestExecuteDagCallbacks:
                 XComResult(
                     key="direct_value",
                     value="test",
-                    dag_id="test_dag",
-                    run_id="test_run",
-                    task_id="test_task",
-                    map_index=None,
                 ),
             ),
         ],
@@ -909,7 +905,7 @@ class TestExecuteDagCallbacks:
             def __call__(self, context):
                 ti = context["ti"]
                 dag = context["dag"]
-                task_ids = list(dag.task_dict.keys())
+                task_ids = list(dag.task_dict)
                 xcom_operation(ti, task_ids)
 
         with DAG(dag_id="test_dag", on_success_callback=TestNotifier()) as dag:
@@ -960,8 +956,7 @@ class TestExecuteDagCallbacks:
 
         _execute_dag_callbacks(dagbag, request, structlog.get_logger())
 
-        mock_supervisor_comms.send.assert_called()
-        mock_supervisor_comms.send.assert_called_with(msg=expected_message)
+        mock_supervisor_comms.send.assert_called_once_with(msg=expected_message)
 
 
 class TestExecuteTaskCallbacks:

--- a/airflow-core/tests/unit/dag_processing/test_processor.py
+++ b/airflow-core/tests/unit/dag_processing/test_processor.py
@@ -62,6 +62,12 @@ from airflow.sdk import DAG, BaseOperator
 from airflow.sdk.api.client import Client
 from airflow.sdk.api.datamodels._generated import DagRunState
 from airflow.sdk.execution_time import comms
+from airflow.sdk.execution_time.comms import (
+    GetXCom,
+    GetXComSequenceSlice,
+    XComResult,
+    XComSequenceSliceResult,
+)
 from airflow.utils.session import create_session
 from airflow.utils.state import TaskInstanceState
 
@@ -830,6 +836,132 @@ class TestExecuteDagCallbacks:
 
         # Should log warning about no callback found
         log.warning.assert_called_once_with("Callback requested, but dag didn't have any", dag_id="test_dag")
+
+    @pytest.mark.parametrize(
+        "xcom_operation,expected_message_type,expected_message,mock_response",
+        [
+            (
+                lambda ti, task_ids: ti.xcom_pull(key="report_df", task_ids=task_ids),
+                "GetXComSequenceSlice",
+                GetXComSequenceSlice(
+                    key="report_df",
+                    dag_id="test_dag",
+                    run_id="test_run",
+                    task_id="test_task",
+                    start=None,
+                    stop=None,
+                    step=None,
+                    include_prior_dates=False,
+                ),
+                XComSequenceSliceResult(root=["test data"]),
+            ),
+            (
+                lambda ti, task_ids: ti.xcom_pull(key="single_value", task_ids=["test_task"]),
+                "GetXComSequenceSlice",
+                GetXComSequenceSlice(
+                    key="single_value",
+                    dag_id="test_dag",
+                    run_id="test_run",
+                    task_id="test_task",
+                    start=None,
+                    stop=None,
+                    step=None,
+                    include_prior_dates=False,
+                ),
+                XComSequenceSliceResult(root=["test data"]),
+            ),
+            (
+                lambda ti, task_ids: ti.xcom_pull(key="direct_value", task_ids="test_task", map_indexes=None),
+                "GetXCom",
+                GetXCom(
+                    key="direct_value",
+                    dag_id="test_dag",
+                    run_id="test_run",
+                    task_id="test_task",
+                    map_index=None,
+                    include_prior_dates=False,
+                ),
+                XComResult(
+                    key="direct_value",
+                    value="test",
+                    dag_id="test_dag",
+                    run_id="test_run",
+                    task_id="test_task",
+                    map_index=None,
+                ),
+            ),
+        ],
+    )
+    def test_notifier_xcom_operations_send_correct_messages(
+        self,
+        spy_agency,
+        mock_supervisor_comms,
+        xcom_operation,
+        expected_message_type,
+        expected_message,
+        mock_response,
+    ):
+        """Test that different XCom operations send correct message types"""
+
+        mock_supervisor_comms.send.return_value = mock_response
+
+        class TestNotifier:
+            def __call__(self, context):
+                ti = context["ti"]
+                dag = context["dag"]
+                task_ids = list(dag.task_dict.keys())
+                xcom_operation(ti, task_ids)
+
+        with DAG(dag_id="test_dag", on_success_callback=TestNotifier()) as dag:
+            BaseOperator(task_id="test_task")
+
+        def fake_collect_dags(self, *args, **kwargs):
+            self.dags[dag.dag_id] = dag
+
+        spy_agency.spy_on(DagBag.collect_dags, call_fake=fake_collect_dags, owner=DagBag)
+
+        dagbag = DagBag()
+        dagbag.collect_dags()
+
+        current_time = timezone.utcnow()
+        request = DagCallbackRequest(
+            filepath="test.py",
+            dag_id="test_dag",
+            run_id="test_run",
+            bundle_name="testing",
+            bundle_version=None,
+            context_from_server=DagRunContext(
+                dag_run=DRDataModel(
+                    dag_id="test_dag",
+                    run_id="test_run",
+                    logical_date=current_time,
+                    data_interval_start=current_time,
+                    data_interval_end=current_time,
+                    run_after=current_time,
+                    start_date=current_time,
+                    end_date=None,
+                    run_type="manual",
+                    state="success",
+                    consumed_asset_events=[],
+                ),
+                last_ti=TIDataModel(
+                    id=uuid.uuid4(),
+                    dag_id="test_dag",
+                    task_id="test_task",
+                    run_id="test_run",
+                    map_index=-1,
+                    try_number=1,
+                    dag_version_id=uuid.uuid4(),
+                ),
+            ),
+            is_failure_callback=False,
+            msg="Test success message",
+        )
+
+        _execute_dag_callbacks(dagbag, request, structlog.get_logger())
+
+        mock_supervisor_comms.send.assert_called()
+        mock_supervisor_comms.send.assert_called_with(msg=expected_message)
 
 
 class TestExecuteTaskCallbacks:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: https://github.com/apache/airflow/issues/55464

## Problem

When custom notifiers extending BaseNotifier attempted to access XCom
via `ti.xcom_pull()` in success/failure callbacks, they failed with
ValidationError because the DAG processor didn't support XCom message
types in the supervisor.


This fix adds support for xcom operations in the DAG processor by:
- Adding XCom request types (GetXCom, GetXComSequenceSlice, etc.) to `ToManager`
- Adding XCom response types (XComResult, XComSequenceSliceResult, etc.) to `ToDagProcessor`  
- Implementing XCom request handlers in `DagFileProcessorProcess._handle_request()`


## Testing

DAG used:
```
from airflow.sdk import DAG
from airflow.providers.standard.operators.python import PythonOperator
from datetime import datetime

from airflow.sdk.bases.notifier import BaseNotifier
from airflow.sdk.definitions.context import Context


class XComNotifier(BaseNotifier):
    def notify(self, context: Context) -> None:
        ti = context['ti']
        d = context['dag']
        task_ids = list(d.task_dict.keys())

        print("trying pulling task ids:", task_ids)

        report_df = ti.xcom_pull(key='report_df', task_ids=task_ids)

        print(f"XCom data: {report_df}")


def push_data(**context):
    # Push some XCom data
    context['ti'].xcom_push(key='report_df', value='test data')
    return 'success'


with DAG(
    dag_id='xcom_notifier_repro',
    start_date=datetime(2024, 1, 1),
    schedule=None,
    on_success_callback=XComNotifier(),
    catchup=False,
) as dag:
    task1 = PythonOperator(
        task_id='push_xcom_data',
        python_callable=push_data,
    )
    task1

```


Earlier:

```
2025-09-10 10:31:54 [error    ] Unable to decode message       [supervisor] body={'key': 'report_df', 'dag_id': 'Oracle-DB-Check', 'run_id': 'manual__2025-09-10T15:31:49.020767+00:00', 'task_id': 'check_dw_prod', 'start': None, 'stop': None, 'step': None, 'include_prior_dates': False, 'type': 'GetXComSequenceSlice'}
2025-09-10T15:31:54.097275837Z ╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
2025-09-10T15:31:54.097279587Z │ /home/airflow/.local/lib/python3.12/site-packages/airflow/sdk/execution_time/supervisor.py:601   │
2025-09-10T15:31:54.097281128Z │ in handle_requests                                                                               │
2025-09-10T15:31:54.097282170Z │                                                                                                  │
2025-09-10T15:31:54.097283337Z │    598 │   │   │   request = yield                                                               │
2025-09-10T15:31:54.097284587Z │    599 │   │   │                                                                                 │
2025-09-10T15:31:54.097285587Z │    600 │   │   │   try:                                                                          │
2025-09-10T15:31:54.097286670Z │ ❱  601 │   │   │   │   msg = self.decoder.validate_python(request.body)                          │
2025-09-10T15:31:54.097287837Z │    602 │   │   │   except Exception:                                                             │
2025-09-10T15:31:54.097289003Z │    603 │   │   │   │   log.exception("Unable to decode message", body=request.body)              │
2025-09-10T15:31:54.097290795Z │    604 │   │   │   │   continue                                                                  │
2025-09-10T15:31:54.097291837Z │                                                                                                  │
2025-09-10T15:31:54.097292795Z │ ╭─────────────────────────────────────────── locals ───────────────────────────────────────────╮ │
2025-09-10T15:31:54.097299003Z │ │     log = <BoundLoggerLazyProxy(logger=None, wrapper_class=None, processors=None,            │ │
2025-09-10T15:31:54.097301128Z │ │           context_class=None, initial_values={'logger_name': 'supervisor'},                  │ │
2025-09-10T15:31:54.097302795Z │ │           logger_factory_args=())>                                                           │ │
2025-09-10T15:31:54.097304087Z │ │     msg = MaskSecret(                                                                        │ │
2025-09-10T15:31:54.097305378Z │ │           │   value='<secret_value_hidden>',                                  │ │
2025-09-10T15:31:54.097306670Z │ │           │   name='dispatch_api_key',                                                       │ │
2025-09-10T15:31:54.097309837Z │ │           │   type='MaskSecret'                                                              │ │
2025-09-10T15:31:54.097311295Z │ │           )                                                                                  │ │
2025-09-10T15:31:54.097312337Z │ │ request = _RequestFrame(                                                                     │ │
2025-09-10T15:31:54.097313503Z │ │           │   id=1,                                                                          │ │
2025-09-10T15:31:54.097314628Z │ │           │   body={                                                                         │ │
2025-09-10T15:31:54.097315795Z │ │           │   │   'key': 'report_df',                                                        │ │
2025-09-10T15:31:54.097321962Z │ │           │   │   'dag_id': 'Oracle-DB-Check',                                               │ │
2025-09-10T15:31:54.097323253Z │ │           │   │   'run_id': 'manual__2025-09-10T15:31:49.020767+00:00',                      │ │
2025-09-10T15:31:54.097324503Z │ │           │   │   'task_id': 'check_dw_prod',                                                │ │
2025-09-10T15:31:54.097325795Z │ │           │   │   'start': None,                                                             │ │
2025-09-10T15:31:54.097327087Z │ │           │   │   'stop': None,                                                              │ │
2025-09-10T15:31:54.097328337Z │ │           │   │   'step': None,                                                              │ │
2025-09-10T15:31:54.097329462Z │ │           │   │   'include_prior_dates': False,                                              │ │
2025-09-10T15:31:54.097331628Z │ │           │   │   'type': 'GetXComSequenceSlice'                                             │ │
2025-09-10T15:31:54.097332753Z │ │           │   }                                                                              │ │
2025-09-10T15:31:54.097333837Z │ │           )                                                                                  │ │
2025-09-10T15:31:54.097334878Z │ │    self = <DagFileProcessorProcess id=UUID('01993441-38d2-7bcc-8bbd-53306533f95a') pid=177>  │ │
2025-09-10T15:31:54.097336670Z │ ╰──────────────────────────────────────────────────────────────────────────────────────────────╯ │
2025-09-10T15:31:54.097339170Z │                                                                                                  │
2025-09-10T15:31:54.097340253Z │ /home/airflow/.local/lib/python3.12/site-packages/pydantic/type_adapter.py:421 in                │
2025-09-10T15:31:54.097341462Z │ validate_python                                                                                  │
2025-09-10T15:31:54.097342545Z │                                                                                                  │
2025-09-10T15:31:54.097343545Z │   418 │   │   │   │   code='validate-by-alias-and-name-false',                                   │
2025-09-10T15:31:54.097344837Z │   419 │   │   │   )                                                                              │
2025-09-10T15:31:54.097346045Z │   420 │   │                                                                                      │
2025-09-10T15:31:54.097347128Z │ ❱ 421 │   │   return self.validator.validate_python(                                             │
2025-09-10T15:31:54.097348378Z │   422 │   │   │   object,                                                                        │
2025-09-10T15:31:54.097349420Z │   423 │   │   │   strict=strict,                                                                 │
2025-09-10T15:31:54.097350378Z │   424 │   │   │   from_attributes=from_attributes,                                               │
2025-09-10T15:31:54.097351420Z │                                                                                                  │
2025-09-10T15:31:54.097352462Z │ ╭─────────────────────────────────────────── locals ───────────────────────────────────────────╮ │
2025-09-10T15:31:54.097353920Z │ │                   by_alias = None                                                            │ │
2025-09-10T15:31:54.097355087Z │ │                    by_name = None                                                            │ │
2025-09-10T15:31:54.097357045Z │ │                    context = None                                                            │ │
2025-09-10T15:31:54.097358212Z │ │ experimental_allow_partial = False                                                           │ │
2025-09-10T15:31:54.097359295Z │ │            from_attributes = None                                                            │ │
2025-09-10T15:31:54.097360420Z │ │                     object = {                                                               │ │
2025-09-10T15:31:54.097361670Z │ │                              │   'key': 'report_df',                                         │ │
2025-09-10T15:31:54.097363545Z │ │                              │   'dag_id': 'Oracle-DB-Check',                                │ │
2025-09-10T15:31:54.097364837Z │ │                              │   'run_id': 'manual__2025-09-10T15:31:49.020767+00:00',       │ │
2025-09-10T15:31:54.097365962Z │ │                              │   'task_id': 'check_dw_prod',                                 │ │
2025-09-10T15:31:54.097367212Z │ │                              │   'start': None,                                              │ │
2025-09-10T15:31:54.097368295Z │ │                              │   'stop': None,                                               │ │
2025-09-10T15:31:54.097369545Z │ │                              │   'step': None,                                               │ │
2025-09-10T15:31:54.097370587Z │ │                              │   'include_prior_dates': False,                               │ │
2025-09-10T15:31:54.097371753Z │ │                              │   'type': 'GetXComSequenceSlice'                              │ │
2025-09-10T15:31:54.097373795Z │ │                              }                                                               │ │
2025-09-10T15:31:54.097374837Z │ │                       self = TypeAdapter(Annotated[Union[DagFileParsingResult,               │ │
2025-09-10T15:31:54.097376003Z │ │                              GetConnection, GetVariable, PutVariable, DeleteVariable,        │ │
2025-09-10T15:31:54.097377253Z │ │                              GetPrevSuccessfulDagRun, GetPreviousDagRun, MaskSecret],        │ │
2025-09-10T15:31:54.097378295Z │ │                              FieldInfo(annotation=NoneType, required=True,                   │ │
2025-09-10T15:31:54.097379712Z │ │                              discriminator='type')])                                         │ │
2025-09-10T15:31:54.097380920Z │ │                     strict = None                                                            │ │
2025-09-10T15:31:54.097382128Z │ ╰──────────────────────────────────────────────────────────────────────────────────────────────╯ │
2025-09-10T15:31:54.097383295Z ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
2025-09-10T15:31:54.097384420Z ValidationError: 1 validation error for 
2025-09-10T15:31:54.097385337Z tagged-union[DagFileParsingResult,GetConnection,GetVariable,PutVariable,DeleteVariable,GetPrevSucces
2025-09-10T15:31:54.097386462Z sfulDagRun,GetPreviousDagRun,MaskSecret]
2025-09-10T15:31:54.097387295Z   Input tag 'GetXComSequenceSlice' found using 'type' does not match any of the expected tags: 
2025-09-10T15:31:54.097388378Z 'DagFileParsingResult', 'GetConnection', 'GetVariable', 'PutVariable', 'DeleteVariable', 
2025-09-10T15:31:54.097389545Z 'GetPrevSuccessfulDagRun', 'GetPreviousDagRun', 'MaskSecret' [type=union_tag_invalid, 
2025-09-10T15:31:54.097391545Z input_value={'key': 'report_df', 'dag... 'GetXComSequenceSlice'}, input_type=dict]
2025-09-10T15:31:54.097392878Z     For further information visit https://errors.pydantic.dev/2.11/v/union_tag_invalid
```


Now:

<img width="1172" height="150" alt="image" src="https://github.com/user-attachments/assets/c5546199-403b-46cb-9978-3ea0adc3d607" />




<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
