### PR TITLE
Add autorefresh to Required Actions button

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/NeedsReviewButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/NeedsReviewButton.tsx
@@ -40,6 +40,7 @@ export const NeedsReviewButton = ({
       dagId,
       dagRunId: runId,
       responseReceived: false,
+      state: ["deferred"],
       taskId,
     },
     undefined,

--- a/airflow-core/src/airflow/ui/src/components/NeedsReviewButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/NeedsReviewButton.tsx
@@ -21,6 +21,7 @@ import { useTranslation } from "react-i18next";
 import { LuUserRoundPen } from "react-icons/lu";
 
 import { useHumanInTheLoopServiceGetHitlDetails } from "openapi/queries";
+import { useAutoRefresh } from "src/utils/query";
 
 import { StatsCard } from "./StatsCard";
 
@@ -33,12 +34,19 @@ export const NeedsReviewButton = ({
   readonly runId?: string;
   readonly taskId?: string;
 }) => {
-  const { data: hitlStatsData, isLoading } = useHumanInTheLoopServiceGetHitlDetails({
-    dagId,
-    dagRunId: runId,
-    responseReceived: false,
-    taskId,
-  });
+  const refetchInterval = useAutoRefresh({ dagId });
+  const { data: hitlStatsData, isLoading } = useHumanInTheLoopServiceGetHitlDetails(
+    {
+      dagId,
+      dagRunId: runId,
+      responseReceived: false,
+      taskId,
+    },
+    undefined,
+    {
+      refetchInterval,
+    },
+  );
 
   const hitlTIsCount = hitlStatsData?.hitl_details.length ?? 0;
   const { t: translate } = useTranslation("hitl");


### PR DESCRIPTION
Add autorefresh to the Required Actions stat that is used on the Dashboard and Overview pages.


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
