### PR TITLE
Correctly enable Connection "Save" button when editing 'Extra Fields'

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Connections/ConnectionForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/ConnectionForm.tsx
@@ -78,7 +78,7 @@ const ConnectionForm = ({
   const [initialExtra, setInitialExtra] = useState("");
 
   useEffect(() => {
-    const parsedInitialExtra = JSON.parse(initialConnection.extra);
+    const parsedInitialExtra = JSON.parse(initialConnection.extra) as Record<string, unknown>;
     const formattedInitialExtra = JSON.stringify(parsedInitialExtra, undefined, 2);
 
     reset((prevValues) => ({
@@ -99,19 +99,16 @@ const ConnectionForm = ({
     }));
     // Mark as dirty when extra fields are updated - compare parsed JSON objects
     try {
-      const initialParsed = JSON.parse(initialExtra);
-      const currentParsed = JSON.parse(extra);
+      const initialParsed = JSON.parse(initialExtra) as Record<string, unknown>;
+      const currentParsed = JSON.parse(extra) as Record<string, unknown>;
       const hasChanged = JSON.stringify(initialParsed) !== JSON.stringify(currentParsed);
+
       setIsExtraFieldsDirty(hasChanged);
     } catch {
       // If parsing fails, fall back to string comparison
       setIsExtraFieldsDirty(extra !== initialExtra);
     }
   }, [extra, reset, setConf, initialExtra]);
-
-  const onSubmit = (data: ConnectionBody) => {
-    mutateConnection(data);
-  };
 
   const validateAndPrettifyJson = (value: string) => {
     try {
@@ -273,11 +270,12 @@ const ConnectionForm = ({
             }
             onClick={() => {
               // Update the form's extra field with the latest conf value before submitting
-              handleSubmit((data) => {
+              void handleSubmit((data) => {
                 const updatedData = {
                   ...data,
                   extra,
                 };
+
                 mutateConnection(updatedData);
               })();
             }}


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
closes: #55496 
related: #55496 

### Issue Summary

Cannot edit the `Extra Fields` of connections in the Airflow UI. Two specific problems:

1. `Save` button is disabled when editing through `Extra Fields`
2. No response when clicking `Save` after editing through `Extra Fields JSON`

### Root Cause

The `ConnectionForm` component uses `React Hook Form` for state management, but the `FlexibleForm` component manages extra fields through a separate `Zustand` store. React Hook Form's `isDirty` state doesn't track changes made through the flexible form, causing the `Save` button to remain disabled and preventing proper form submission.

### Solution

The fix introduces proper state tracking for extra fields changes:

1. __Add dirty state tracking__: New `isExtraFieldsDirty` state tracks changes to extra fields independently
2. __Update save button logic__: Enable save button when either regular form fields OR extra fields are modified
3. __Fix form submission__: Ensure latest extra fields data is included in the submission
4. __Proper initialization__: Store and compare formatted initial JSON values to avoid false positives

### Result

`Extra Fields` and `Extra Fields JSON` are both work well after fixed
<img width="896" height="1147" alt="fix_extra_edit" src="https://github.com/user-attachments/assets/0c1c2655-beca-42fd-a460-723c957fbd8a" />


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
