### PR TITLE
Fix trigger job log tests

### DIFF
--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -277,17 +277,20 @@ def test_trigger_log(mock_monotonic, trigger, watcher_count, trigger_count, sess
     """
     Checks that the triggerer will log watcher and trigger in separate lines.
     """
-    create_trigger_in_db(session, trigger)
+    _, _, trigger_orm, _ = create_trigger_in_db(session, trigger)
 
-    trigger_runner_supervisor = TriggerRunnerSupervisor.start(job=Job(id=12345), capacity=10)
+    trigger_runner_supervisor = TriggerRunnerSupervisor.start(job=Job(id=123456), capacity=10)
     trigger_runner_supervisor.load_triggers()
 
-    for _ in range(10):
+    for _ in range(30):
         trigger_runner_supervisor._service_subprocess(0.1)
 
     stdout = capsys.readouterr().out
     assert f"{trigger_count} triggers currently running" in stdout
     assert f"{watcher_count} watchers currently running" in stdout
+
+    session.delete(trigger_orm)
+    session.commit()
 
     trigger_runner_supervisor.kill(force=False)
 

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -66,7 +66,9 @@ from tests_common.test_utils.db import (
     clear_db_connections,
     clear_db_dag_bundles,
     clear_db_dags,
+    clear_db_jobs,
     clear_db_runs,
+    clear_db_triggers,
     clear_db_variables,
     clear_db_xcom,
 )
@@ -86,6 +88,8 @@ def clean_database():
     clear_db_dag_bundles()
     clear_db_xcom()
     clear_db_variables()
+    clear_db_triggers()
+    clear_db_jobs()
     yield  # Test runs here
     clear_db_connections()
     clear_db_runs()
@@ -93,6 +97,8 @@ def clean_database():
     clear_db_dag_bundles()
     clear_db_xcom()
     clear_db_variables()
+    clear_db_triggers()
+    clear_db_jobs()
 
 
 def create_trigger_in_db(session, trigger, operator=None):
@@ -280,7 +286,7 @@ def test_trigger_log(mock_monotonic, trigger, watcher_count, trigger_count, sess
     """
     Checks that the triggerer will log watcher and trigger in separate lines.
     """
-    _, _, trigger_orm, _ = create_trigger_in_db(session, trigger)
+    create_trigger_in_db(session, trigger)
 
     trigger_runner_supervisor = TriggerRunnerSupervisor.start(job=Job(id=123456), capacity=10)
     trigger_runner_supervisor.load_triggers()
@@ -291,9 +297,6 @@ def test_trigger_log(mock_monotonic, trigger, watcher_count, trigger_count, sess
     stdout = capsys.readouterr().out
     assert f"{trigger_count} triggers currently running" in stdout
     assert f"{watcher_count} watchers currently running" in stdout
-
-    session.delete(trigger_orm)
-    session.commit()
 
     trigger_runner_supervisor.kill(force=False)
 

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -270,7 +270,10 @@ def test_trigger_lifecycle(spy_agency: SpyAgency, session, testing_dag_bundle):
 
 @pytest.mark.parametrize(
     "trigger, watcher_count, trigger_count",
-    [(TimeDeltaTrigger(datetime.timedelta(days=7)), 0, 1), (FileDeleteTrigger("/tmp/foo.txt"), 1, 0)],
+    [
+        (TimeDeltaTrigger(datetime.timedelta(days=7)), 0, 1),
+        (FileDeleteTrigger("/tmp/foo.txt", poke_interval=1), 1, 0),
+    ],
 )
 @patch("time.monotonic", side_effect=itertools.count(start=1, step=60))
 def test_trigger_log(mock_monotonic, trigger, watcher_count, trigger_count, session, capsys):


### PR DESCRIPTION
Seems triggers are blocking, https://github.com/apache/airflow/actions/runs/17663772440/job/50205537877#step:8:3237

Reduce poke interval and lets delete the triggers created after the assertion. this is just an attempt to fix.
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
