### PR TITLE
Add configurable confirm parameter to S3ToSFTPOperator

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/s3_to_sftp.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/s3_to_sftp.py
@@ -51,6 +51,9 @@ class S3ToSFTPOperator(BaseOperator):
         where the file is downloaded.
     :param s3_key: The targeted s3 key. This is the specified file path for
         downloading the file from S3.
+    :param confirm: specify if the SFTP operation should be confirmed, defaults to True.
+        When True, a stat will be performed on the remote file after upload to verify
+        the file size matches and confirm successful transfer.
     """
 
     template_fields: Sequence[str] = ("s3_key", "sftp_path", "s3_bucket")
@@ -63,6 +66,7 @@ class S3ToSFTPOperator(BaseOperator):
         sftp_path: str,
         sftp_conn_id: str = "ssh_default",
         aws_conn_id: str | None = "aws_default",
+        confirm: bool = True,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -71,6 +75,7 @@ class S3ToSFTPOperator(BaseOperator):
         self.s3_bucket = s3_bucket
         self.s3_key = s3_key
         self.aws_conn_id = aws_conn_id
+        self.confirm = confirm
 
     @staticmethod
     def get_s3_key(s3_key: str) -> str:
@@ -88,4 +93,4 @@ class S3ToSFTPOperator(BaseOperator):
 
         with NamedTemporaryFile("w") as f:
             s3_client.download_file(self.s3_bucket, self.s3_key, f.name)
-            sftp_client.put(f.name, self.sftp_path)
+            sftp_client.put(f.name, self.sftp_path, confirm=self.confirm)

--- a/providers/amazon/tests/unit/amazon/aws/transfers/test_s3_to_sftp.py
+++ b/providers/amazon/tests/unit/amazon/aws/transfers/test_s3_to_sftp.py
@@ -17,8 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
-
 import boto3
 import pytest
 from moto import mock_aws
@@ -142,25 +140,34 @@ class TestS3ToSFTPOperator:
         remove_file_task.execute(None)
 
     @mock_aws
-    @patch("airflow.providers.ssh.hooks.ssh.SSHHook.get_conn")
-    def test_s3_to_sftp_operation_confirm_true_default(self, mock_ssh_conn):
-        """Test that S3ToSFTPOperator calls sftp_client.put with confirm=True by default"""
-        # Mock setup
-        mock_sftp_client = MagicMock()
-        mock_ssh_connection = MagicMock()
-        mock_ssh_connection.open_sftp.return_value = mock_sftp_client
-        mock_ssh_conn.return_value = mock_ssh_connection
-
-        # S3 setup
+    @conf_vars({("core", "enable_xcom_pickling"): "True"})
+    def test_s3_to_sftp_operation_confirm_true_default(self):
+        """Test that S3ToSFTPOperator works with confirm=True by default (real SSH connection)"""
         s3_hook = S3Hook(aws_conn_id=None)
+        # Setting
+        test_remote_file_content = (
+            "This is remote file content for confirm=True test \n which is also multiline "
+            "another line here \n this is last line. EOF"
+        )
+
+        # Test for creation of s3 bucket
         conn = boto3.client("s3")
         conn.create_bucket(Bucket=self.s3_bucket)
+        assert s3_hook.check_for_bucket(self.s3_bucket)
 
         with open(LOCAL_FILE_PATH, "w") as file:
-            file.write("test content for confirm=True test")
+            file.write(test_remote_file_content)
         s3_hook.load_file(LOCAL_FILE_PATH, self.s3_key, bucket_name=BUCKET)
 
-        # Test with default confirm=True
+        # Check if object was created in s3
+        objects_in_dest_bucket = conn.list_objects(Bucket=self.s3_bucket, Prefix=self.s3_key)
+        # there should be object found, and there should only be one object found
+        assert len(objects_in_dest_bucket["Contents"]) == 1
+
+        # the object found should be consistent with dest_key specified earlier
+        assert objects_in_dest_bucket["Contents"][0]["Key"] == self.s3_key
+
+        # get remote file to local - Test with default confirm=True
         run_task = S3ToSFTPOperator(
             s3_bucket=BUCKET,
             s3_key=S3_KEY,
@@ -169,39 +176,56 @@ class TestS3ToSFTPOperator:
             task_id=TASK_ID + "_confirm_true",
             dag=self.dag,
         )
+        assert run_task is not None
 
         run_task.execute(None)
 
-        # Verify confirm=True was used
-        mock_sftp_client.put.assert_called_once()
-        call_args = mock_sftp_client.put.call_args
-        assert "confirm" in call_args.kwargs
-        assert call_args.kwargs["confirm"] is True
+        # Check that the file is created remotely with correct content
+        check_file_task = SSHOperator(
+            task_id="test_check_file_confirm_true",
+            ssh_hook=self.hook,
+            command=f"cat {self.sftp_path}",
+            do_xcom_push=True,
+            dag=self.dag,
+        )
+        assert check_file_task is not None
+        result = check_file_task.execute(None)
+        assert result.strip() == test_remote_file_content.encode("utf-8")
 
-        # Cleanup
+        # Clean up after finishing with test
         conn.delete_object(Bucket=self.s3_bucket, Key=self.s3_key)
         conn.delete_bucket(Bucket=self.s3_bucket)
+        assert not s3_hook.check_for_bucket(self.s3_bucket)
 
     @mock_aws
-    @patch("airflow.providers.ssh.hooks.ssh.SSHHook.get_conn")
-    def test_s3_to_sftp_operation_confirm_false(self, mock_ssh_conn):
-        """Test that S3ToSFTPOperator calls sftp_client.put with confirm=False when specified"""
-        # Mock setup
-        mock_sftp_client = MagicMock()
-        mock_ssh_connection = MagicMock()
-        mock_ssh_connection.open_sftp.return_value = mock_sftp_client
-        mock_ssh_conn.return_value = mock_ssh_connection
-
-        # S3 setup
+    @conf_vars({("core", "enable_xcom_pickling"): "True"})
+    def test_s3_to_sftp_operation_confirm_false(self):
+        """Test that S3ToSFTPOperator works with confirm=False when specified (real SSH connection)"""
         s3_hook = S3Hook(aws_conn_id=None)
+        # Setting
+        test_remote_file_content = (
+            "This is remote file content for confirm=False test \n which is also multiline "
+            "another line here \n this is last line. EOF"
+        )
+
+        # Test for creation of s3 bucket
         conn = boto3.client("s3")
         conn.create_bucket(Bucket=self.s3_bucket)
+        assert s3_hook.check_for_bucket(self.s3_bucket)
 
         with open(LOCAL_FILE_PATH, "w") as file:
-            file.write("test content for confirm=False test")
+            file.write(test_remote_file_content)
         s3_hook.load_file(LOCAL_FILE_PATH, self.s3_key, bucket_name=BUCKET)
 
-        # Test with explicit confirm=False
+        # Check if object was created in s3
+        objects_in_dest_bucket = conn.list_objects(Bucket=self.s3_bucket, Prefix=self.s3_key)
+        # there should be object found, and there should only be one object found
+        assert len(objects_in_dest_bucket["Contents"]) == 1
+
+        # the object found should be consistent with dest_key specified earlier
+        assert objects_in_dest_bucket["Contents"][0]["Key"] == self.s3_key
+
+        # get remote file to local - Test with explicit confirm=False
         run_task = S3ToSFTPOperator(
             s3_bucket=BUCKET,
             s3_key=S3_KEY,
@@ -211,18 +235,26 @@ class TestS3ToSFTPOperator:
             confirm=False,  # Explicitly set to False
             dag=self.dag,
         )
+        assert run_task is not None
 
         run_task.execute(None)
 
-        # Verify confirm=False was used
-        mock_sftp_client.put.assert_called_once()
-        call_args = mock_sftp_client.put.call_args
-        assert "confirm" in call_args.kwargs
-        assert call_args.kwargs["confirm"] is False
+        # Check that the file is created remotely with correct content
+        check_file_task = SSHOperator(
+            task_id="test_check_file_confirm_false",
+            ssh_hook=self.hook,
+            command=f"cat {self.sftp_path}",
+            do_xcom_push=True,
+            dag=self.dag,
+        )
+        assert check_file_task is not None
+        result = check_file_task.execute(None)
+        assert result.strip() == test_remote_file_content.encode("utf-8")
 
-        # Cleanup
+        # Clean up after finishing with test
         conn.delete_object(Bucket=self.s3_bucket, Key=self.s3_key)
         conn.delete_bucket(Bucket=self.s3_bucket)
+        assert not s3_hook.check_for_bucket(self.s3_bucket)
 
     def teardown_method(self):
         self.delete_remote_resource()


### PR DESCRIPTION
## Add configurable confirm parameter to S3ToSFTPOperator

### Summary
This enhancement adds a `confirm` parameter to the S3ToSFTPOperator to make SFTP file transfer confirmation behavior explicit and configurable, providing consistency with SFTPOperator.

### Changes
- Add `confirm: bool = True` parameter to S3ToSFTPOperator constructor.
- Pass confirm parameter explicitly to [Paramiko's `put()`](https://docs.paramiko.org/en/stable/api/sftp.html#paramiko.sftp_client.SFTPClient.put) method.
- Update docstring with parameter documentation.
- Add comprehensive unit tests for both `confirm=True` and `confirm=False` scenarios.

### Motivation
- One of the production jobs encountered an issue while dropping the file to the SFTP server using S3TOSFTPOperator. The server is configured to automatically move files to another designated directory when they are dropped at the root path.
- Since S3ToSFTPOperator works with [Paramiko’s default setting confirm=True](https://docs.paramiko.org/en/stable/api/sftp.html#paramiko.sftp_client.SFTPClient.put), it calls stat() to confirm a successful file transfer, which causes the pipeline to fail.
<img width="1552" height="516" alt="Screenshot 2025-09-05 at 9 45 01 AM" src="https://github.com/user-attachments/assets/039da4b0-19a3-46a7-8f35-264c26d7d750" />

- This change allows users to:
   - Explicitly control confirmation behavior
   - Choose `confirm=False` for performance-critical scenarios  
   - Have consistent API design with SFTPOperator.

### Testing
- Added unit tests verifying both confirmation scenarios.
- All existing tests continue to pass.
- Code passes static analysis checks.

### Backward Compatibility
This change is fully backward compatible. Existing code will continue to work exactly as before since the default value `confirm=True` matches Paramiko's existing default behavior.