### PR TITLE
Add conversion to timedelta type for self.timeout value for CloudComposerDAGRunSensor

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/sensors/cloud_composer.py
+++ b/providers/google/src/airflow/providers/google/cloud/sensors/cloud_composer.py
@@ -222,7 +222,7 @@ class CloudComposerDAGRunSensor(BaseSensorOperator):
         if self.deferrable:
             start_date, end_date = self._get_logical_dates(context)
             self.defer(
-                timeout=self.timeout,
+                timeout=timedelta(seconds=self.timeout) if self.timeout else None,
                 trigger=CloudComposerDAGRunTrigger(
                     project_id=self.project_id,
                     region=self.region,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

In this PR I have added a conversion to `timedelta` type for `self.timeout` value in the deferrable mode for `CloudComposerDAGRunSensor`.
It is needed for backward compatibility with Airflow2, because for Airflow2 `self.defer` method supports only `timedelta` [type](https://github.com/apache/airflow/blob/2.11.0/airflow/models/baseoperator.py#L1789) unlike Airflow3 which additionally  [supports](https://github.com/apache/airflow/blob/main/task-sdk/src/airflow/sdk/bases/operator.py#L1598) `float` and `int` type. 

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
