### PR TITLE
Fix HITL getting requested too often on overview Dag and Task tab

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/NeedsReviewButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/NeedsReviewButton.tsx
@@ -27,14 +27,16 @@ import { StatsCard } from "./StatsCard";
 
 export const NeedsReviewButton = ({
   dagId,
+  refreshInterval,
   runId,
   taskId,
 }: {
   readonly dagId?: string;
+  readonly refreshInterval?: number | false;
   readonly runId?: string;
   readonly taskId?: string;
 }) => {
-  const refetchInterval = useAutoRefresh({ dagId });
+  const hookAutoRefresh = useAutoRefresh({ dagId });
   const { data: hitlStatsData, isLoading } = useHumanInTheLoopServiceGetHitlDetails(
     {
       dagId,
@@ -45,7 +47,7 @@ export const NeedsReviewButton = ({
     },
     undefined,
     {
-      refetchInterval,
+      refetchInterval: refreshInterval ?? hookAutoRefresh,
     },
   );
 

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Overview/Overview.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Overview/Overview.tsx
@@ -35,6 +35,7 @@ import TimeRangeSelector from "src/components/TimeRangeSelector";
 import { TrendCountButton } from "src/components/TrendCountButton";
 import { SearchParamsKeys } from "src/constants/searchParams";
 import { useGridRuns } from "src/queries/useGridRuns.ts";
+import { isStatePending, useAutoRefresh } from "src/utils";
 
 const FailedLogs = lazy(() => import("./FailedLogs"));
 
@@ -75,9 +76,14 @@ export const Overview = () => {
     timestampLte: endDate,
   });
 
+  const refetchInterval = useAutoRefresh({});
+
   return (
     <Box m={4} spaceY={4}>
-      <NeedsReviewButton dagId={dagId} />
+      <NeedsReviewButton
+        dagId={dagId}
+        refreshInterval={gridRuns?.some((dr) => isStatePending(dr.state)) ? refetchInterval : false}
+      />
       <Box my={2}>
         <TimeRangeSelector
           defaultValue={defaultHour}

--- a/airflow-core/src/airflow/ui/src/pages/Task/Overview/Overview.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Task/Overview/Overview.tsx
@@ -72,7 +72,12 @@ export const Overview = () => {
 
   return (
     <Box m={4} spaceY={4}>
-      <NeedsReviewButton taskId={taskId} />
+      <NeedsReviewButton
+        refreshInterval={
+          taskInstances?.task_instances.some((ti) => isStatePending(ti.state)) ? refetchInterval : false
+        }
+        taskId={taskId}
+      />
       <Box my={2}>
         <TimeRangeSelector
           defaultValue={defaultHour}


### PR DESCRIPTION
We shouldn't be refetching HITL for settled Dag and Run overview.