### PR TITLE
fix get latest serialized_dag model query to prevent "Out of sort memory" error

### DIFF
--- a/airflow-core/src/airflow/models/serialized_dag.py
+++ b/airflow-core/src/airflow/models/serialized_dag.py
@@ -461,6 +461,7 @@ class SerializedDagModel(Base):
 
     @classmethod
     def latest_item_select_object(cls, dag_id):
+        # prevent "Out of sort memory" caused by large values in cls.data column
         latest_item_id = select(cls.id).where(cls.dag_id == dag_id).order_by(cls.created_at.desc()).limit(1)
         return select(cls).where(cls.id == latest_item_id)
 

--- a/airflow-core/src/airflow/models/serialized_dag.py
+++ b/airflow-core/src/airflow/models/serialized_dag.py
@@ -461,9 +461,16 @@ class SerializedDagModel(Base):
 
     @classmethod
     def latest_item_select_object(cls, dag_id):
-        # prevent "Out of sort memory" caused by large values in cls.data column
-        latest_item_id = select(cls.id).where(cls.dag_id == dag_id).order_by(cls.created_at.desc()).limit(1)
-        return select(cls).where(cls.id == latest_item_id)
+        from airflow.settings import engine
+
+        if engine.dialect.name == "mysql":
+            # Prevent "Out of sort memory" caused by large values in cls.data column for MySQL.
+            # Details in https://github.com/apache/airflow/pull/55589
+            latest_item_id = (
+                select(cls.id).where(cls.dag_id == dag_id).order_by(cls.created_at.desc()).limit(1)
+            )
+            return select(cls).where(cls.id == latest_item_id)
+        return select(cls).where(cls.dag_id == dag_id).order_by(cls.created_at.desc()).limit(1)
 
     @classmethod
     @provide_session

--- a/airflow-core/src/airflow/models/serialized_dag.py
+++ b/airflow-core/src/airflow/models/serialized_dag.py
@@ -461,7 +461,8 @@ class SerializedDagModel(Base):
 
     @classmethod
     def latest_item_select_object(cls, dag_id):
-        return select(cls).where(cls.dag_id == dag_id).order_by(cls.created_at.desc()).limit(1)
+        latest_item_id = select(cls.id).where(cls.dag_id == dag_id).order_by(cls.created_at.desc()).limit(1)
+        return select(cls).where(cls.id == latest_item_id)
 
     @classmethod
     @provide_session


### PR DESCRIPTION
## Description

Hello,

While testing Airflow 3.0.6 on Kubernetes, I observed that the dag-processor keeps restarting.
Upon checking the pod logs, I found the following error:
```
sqlalchemy.exc.OperationalError: (MySQLdb.OperationalError) (1038, 'Out of sort memory, consider increasing server sort buffer size')
[SQL: SELECT serialized_dag.data, serialized_dag.data_compressed, serialized_dag.id, serialized_dag.dag_id, serialized_dag.created_at, serialized_dag.last_updated, serialized_dag.dag_hash, serialized_dag.dag_version_id
FROM serialized_dag
WHERE serialized_dag.dag_id = %s ORDER BY serialized_dag.created_at DESC
 LIMIT %s]
[parameters: ('my_dag', 1)]
(Background on this error at: https://sqlalche.me/e/14/e3q8)
```
After investigating the root cause, I found that some rows in serialized_dag contained data values exceeding 1MB
<img width="360" height="57" alt="image" src="https://github.com/user-attachments/assets/5748f845-8484-44bf-9ec0-a49949fffc51" />

Since MySQL’s default sort_buffer_size is 256KB, any row where serialized_dag.data exceeds this size cannot fit into the buffer. As a result, the query fails with the “Out of sort memory” error and it makes pod restart.

There are three ways to solve this problem.
- User adjusts sort buffer size (increase)
- Add index to created_at
- Modify Queries

No. 1 requires the user to change arbitrarily, and it is difficult to figure out what side effects No. 2 will have on the system. Therefore, we propose to change the existing query in the following way.
```
SELECT serialized_dag.data, serialized_dag.data_compressed, serialized_dag.id, serialized_dag.dag_id, serialized_dag.created_at, serialized_dag.last_updated, serialized_dag.dag_hash, serialized_dag.dag_version_id
FROM serialized_dag
WHERE serialized_dag.id = (
    SELECT serialized_dag.id
    FROM serialized_dag
    WHERE serialized_dag.dag_id = 'my_dag' 
    ORDER BY serialized_dag.created_at DESC
    LIMIT 1
) 
```

The corresponding pr is the pr that contains the change point.
Since the modified query produces the same result as the original one, no additional test cases or changes to existing tests are required.


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
