### PR TITLE
Bump mypy to 1.18.1

### DIFF
--- a/devel-common/pyproject.toml
+++ b/devel-common/pyproject.toml
@@ -99,7 +99,7 @@ dependencies = [
 "mypy" = [
     # Mypy dependencies
     # TODO: upgrade to newer versions of MyPy continuously as they are released
-    "mypy==1.17.1",
+    "mypy==1.18.1",
     "types-Deprecated>=1.2.9.20240311",
     "types-Markdown>=3.6.0.20240316",
     "types-PyMySQL>=1.1.0.20240425",

--- a/providers/common/compat/src/airflow/providers/common/compat/lineage/entities.py
+++ b/providers/common/compat/src/airflow/providers/common/compat/lineage/entities.py
@@ -28,7 +28,7 @@ import attr
 class File:
     """File entity. Refers to a file."""
 
-    template_fields: ClassVar = ("url",)
+    template_fields: ClassVar[tuple[str, ...]] = ("url",)
 
     url: str = attr.ib()
     type_hint: str | None = None

--- a/providers/google/tests/unit/google/cloud/sensors/test_dataproc_metastore.py
+++ b/providers/google/tests/unit/google/cloud/sensors/test_dataproc_metastore.py
@@ -41,8 +41,8 @@ MANIFEST_SUCCESS = {
 }
 MANIFEST_FAIL = {"status": {"code": 1, "message": "Bad things happened", "details": []}, "filenames": []}
 RESULT_FILE_CONTENT: dict[str, Any] = {"rows": [], "metadata": {}}
-ROW_1 = []
-ROW_2 = []
+ROW_1: list[Any] = []
+ROW_2: list[Any] = []
 TEST_SERVICE_ID = "test-service"
 TEST_REGION = "test-region"
 TEST_TABLE = "test_table"

--- a/providers/papermill/src/airflow/providers/papermill/operators/papermill.py
+++ b/providers/papermill/src/airflow/providers/papermill/operators/papermill.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from collections.abc import Collection, Sequence
+from collections.abc import Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING, ClassVar
 
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 class NoteBook(File):
     """Jupyter notebook."""
 
-    template_fields: ClassVar[Collection[str]] = {"parameters", *File.template_fields}
+    template_fields: ClassVar[tuple[str, ...]] = ("parameters", *File.template_fields)
 
     type_hint: str | None = "jupyter_notebook"
     parameters: dict | None = {}


### PR DESCRIPTION
There are numerous changes https://mypy.readthedocs.io/en/stable/changelog.html#mypy-1-18

 lets see how it behaves :)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
