### PR TITLE
Fix view for many DAG tags

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/ar/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ar/components.json
@@ -117,7 +117,7 @@
   },
   "limitedList": "+{{count}} المزيد",
   "limitedList.allItems": "جميع العناصر {{count}}:",
-  "limitedList.clickToInteract": "انقر على علامة لتصفية DAGs",
+  "limitedList.clickToInteract": "انقر على علامة لتصفية Dags",
   "limitedList.clickToOpenFull": "انقر \"+{{count}} المزيد\" لعرض القائمة الكاملة",
   "limitedList.copyPasteText": "يمكنك نسخ ولصق النص أعلاه",
   "limitedList.showingItems": "عرض {{count}} عنصرًا",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ar/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ar/components.json
@@ -5,7 +5,7 @@
     "affected_one": "مهمة واحدة ستُشغّل.",
     "affected_other": "{{count}} مهمة ستُشغل.",
     "affected_two": "مهمتان ستُشغّلان.",
-    "affected_zero": "لا توجد أي مهمة ستُشَّل.",
+    "affected_zero": "لا توجد أي مهمة ستُشغَّل.",
     "affectedNone": "لا توجد مهام تطابق المعايير المحددة.",
     "allRuns": "جميع التشغيلات",
     "backwards": "تشغيل رجعي",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ar/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ar/components.json
@@ -5,7 +5,7 @@
     "affected_one": "مهمة واحدة ستُشغّل.",
     "affected_other": "{{count}} مهمة ستُشغل.",
     "affected_two": "مهمتان ستُشغّلان.",
-    "affected_zero": "لا توجد أي مهمة ستُشغَّل.",
+    "affected_zero": "لا توجد أي مهمة ستُشَّل.",
     "affectedNone": "لا توجد مهام تطابق المعايير المحددة.",
     "allRuns": "جميع التشغيلات",
     "backwards": "تشغيل رجعي",
@@ -116,6 +116,11 @@
     "taskGroup": "مجموعة المهام"
   },
   "limitedList": "+{{count}} المزيد",
+  "limitedList.allItems": "جميع العناصر {{count}}:",
+  "limitedList.clickToInteract": "انقر على علامة لتصفية DAGs",
+  "limitedList.clickToOpenFull": "انقر \"+{{count}} المزيد\" لعرض القائمة الكاملة",
+  "limitedList.copyPasteText": "يمكنك نسخ ولصق النص أعلاه",
+  "limitedList.showingItems": "عرض {{count}} عنصرًا",
   "logs": {
     "file": "ملف",
     "location": "سطر {{line}} في {{name}}"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ca/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ca/components.json
@@ -88,6 +88,11 @@
     "taskGroup": "Grup de tasques"
   },
   "limitedList": "+{{count}} més",
+  "limitedList.allItems": "Tots els {{count}} elements:",
+  "limitedList.clickToInteract": "Fes clic en una etiqueta per filtrar els DAGs",
+  "limitedList.clickToOpenFull": "Fes clic a \"+{{count}} més\" per veure la llista completa",
+  "limitedList.copyPasteText": "Pots copiar i enganxar el text de dalt",
+  "limitedList.showingItems": "Mostrant {{count}} elements",
   "logs": {
     "file": "Fitxer",
     "location": "línia {{line}} a {{name}}"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ca/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ca/components.json
@@ -89,7 +89,7 @@
   },
   "limitedList": "+{{count}} més",
   "limitedList.allItems": "Tots els {{count}} elements:",
-  "limitedList.clickToInteract": "Fes clic en una etiqueta per filtrar els DAGs",
+  "limitedList.clickToInteract": "Fes clic en una etiqueta per filtrar els Dags",
   "limitedList.clickToOpenFull": "Fes clic a \"+{{count}} més\" per veure la llista completa",
   "limitedList.copyPasteText": "Pots copiar i enganxar el text de dalt",
   "limitedList.showingItems": "Mostrant {{count}} elements",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/de/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/de/components.json
@@ -89,7 +89,7 @@
   },
   "limitedList": "+{{count}} mehr",
   "limitedList.allItems": "Alle {{count}} Einträge:",
-  "limitedList.clickToInteract": "Klicken Sie auf ein Tag, um DAGs zu filtern",
+  "limitedList.clickToInteract": "Klicken Sie auf eine Markierung, um Dags zu filtern",
   "limitedList.clickToOpenFull": "Klicken Sie auf \"+{{count}} mehr\" für die vollständige Ansicht",
   "limitedList.copyPasteText": "Sie können den obigen Text kopieren und einfügen",
   "limitedList.showingItems": "{{count}} Einträge werden angezeigt",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/de/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/de/components.json
@@ -88,6 +88,11 @@
     "taskGroup": "Task Gruppe"
   },
   "limitedList": "+{{count}} mehr",
+  "limitedList.allItems": "Alle {{count}} Einträge:",
+  "limitedList.clickToInteract": "Klicken Sie auf ein Tag, um DAGs zu filtern",
+  "limitedList.clickToOpenFull": "Klicken Sie auf \"+{{count}} mehr\" für die vollständige Ansicht",
+  "limitedList.copyPasteText": "Sie können den obigen Text kopieren und einfügen",
+  "limitedList.showingItems": "{{count}} Einträge werden angezeigt",
   "logs": {
     "file": "Datei",
     "location": "Zeile {{line}} in {{name}}"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/components.json
@@ -87,10 +87,13 @@
   },
   "limitedList": "+{{count}} more",
   "limitedList.allItems": "All {{count}} items:",
+  "limitedList.allTags_one": "All Tags (1)",
+  "limitedList.allTags_other": "All Tags ({{count}})",
   "limitedList.clickToInteract": "Click a tag to filter Dags",
   "limitedList.clickToOpenFull": "Click \"+{{count}} more\" to open full view",
   "limitedList.copyPasteText": "You can copy and paste the text above",
-  "limitedList.showingItems": "Showing {{count}} items",
+  "limitedList.showingItems_one": "Showing 1 item",
+  "limitedList.showingItems_other": "Showing {{count}} items",
   "logs": {
     "file": "File",
     "location": "line {{line}} in {{name}}"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/components.json
@@ -87,7 +87,7 @@
   },
   "limitedList": "+{{count}} more",
   "limitedList.allItems": "All {{count}} items:",
-  "limitedList.clickToInteract": "Click a tag to filter DAGs",
+  "limitedList.clickToInteract": "Click a tag to filter Dags",
   "limitedList.clickToOpenFull": "Click \"+{{count}} more\" to open full view",
   "limitedList.copyPasteText": "You can copy and paste the text above",
   "limitedList.showingItems": "Showing {{count}} items",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/components.json
@@ -86,6 +86,11 @@
     "taskGroup": "Task Group"
   },
   "limitedList": "+{{count}} more",
+  "limitedList.allItems": "All {{count}} items:",
+  "limitedList.clickToInteract": "Click a tag to filter DAGs",
+  "limitedList.clickToOpenFull": "Click \"+{{count}} more\" to open full view",
+  "limitedList.copyPasteText": "You can copy and paste the text above",
+  "limitedList.showingItems": "Showing {{count}} items",
   "logs": {
     "file": "File",
     "location": "line {{line}} in {{name}}"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/es/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/es/components.json
@@ -96,7 +96,7 @@
   },
   "limitedList": "+{{count}} más",
   "limitedList.allItems": "Todos los {{count}} elementos:",
-  "limitedList.clickToInteract": "Haz clic en una etiqueta para filtrar DAGs",
+  "limitedList.clickToInteract": "Haz clic en una etiqueta para filtrar Dags",
   "limitedList.clickToOpenFull": "Haz clic en \"+{{count}} más\" para ver la lista completa",
   "limitedList.copyPasteText": "Puedes copiar y pegar el texto de arriba",
   "limitedList.showingItems": "Mostrando {{count}} elementos",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/es/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/es/components.json
@@ -95,6 +95,11 @@
     "taskGroup": "Grupo de Tareas"
   },
   "limitedList": "+{{count}} más",
+  "limitedList.allItems": "Todos los {{count}} elementos:",
+  "limitedList.clickToInteract": "Haz clic en una etiqueta para filtrar DAGs",
+  "limitedList.clickToOpenFull": "Haz clic en \"+{{count}} más\" para ver la lista completa",
+  "limitedList.copyPasteText": "Puedes copiar y pegar el texto de arriba",
+  "limitedList.showingItems": "Mostrando {{count}} elementos",
   "logs": {
     "file": "Archivo",
     "location": "línea {{line}} en {{name}}"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/components.json
@@ -96,7 +96,7 @@
   },
   "limitedList": "+{{count}} supplémentaires",
   "limitedList.allItems": "Tous les {{count}} éléments :",
-  "limitedList.clickToInteract": "Cliquez sur une étiquette pour filtrer les DAGs",
+  "limitedList.clickToInteract": "Cliquez sur une étiquette pour filtrer les Dags",
   "limitedList.clickToOpenFull": "Cliquez sur \"+{{count}} supplémentaires\" pour ouvrir la vue complète",
   "limitedList.copyPasteText": "Vous pouvez copier et coller le texte ci-dessus",
   "limitedList.showingItems": "Affichage de {{count}} éléments",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/components.json
@@ -95,6 +95,11 @@
     "taskGroup": "Groupe de tâches"
   },
   "limitedList": "+{{count}} supplémentaires",
+  "limitedList.allItems": "Tous les {{count}} éléments :",
+  "limitedList.clickToInteract": "Cliquez sur une étiquette pour filtrer les DAGs",
+  "limitedList.clickToOpenFull": "Cliquez sur \"+{{count}} supplémentaires\" pour ouvrir la vue complète",
+  "limitedList.copyPasteText": "Vous pouvez copier et coller le texte ci-dessus",
+  "limitedList.showingItems": "Affichage de {{count}} éléments",
   "logs": {
     "file": "Fichier",
     "location": "ligne {{line}} dans {{name}}"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/he/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/he/components.json
@@ -95,6 +95,11 @@
     "taskGroup": "קבוצת משימות"
   },
   "limitedList": "+ {{count}} נוספים",
+  "limitedList.allItems": "כל {{count}} הפריטים:",
+  "limitedList.clickToInteract": "לחץ על תגית כדי לסנן DAGs",
+  "limitedList.clickToOpenFull": "לחץ על \"+{{count}} נוספים\" כדי לפתוח את התצוגה המלאה",
+  "limitedList.copyPasteText": "ניתן להעתיק ולהדביק את הטקסט שמעל",
+  "limitedList.showingItems": "מציג {{count}} פריטים",
   "logs": {
     "file": "קובץ",
     "location": "שורה {{line}} ב{{name}}"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/he/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/he/components.json
@@ -96,7 +96,7 @@
   },
   "limitedList": "+ {{count}} נוספים",
   "limitedList.allItems": "כל {{count}} הפריטים:",
-  "limitedList.clickToInteract": "לחץ על תגית כדי לסנן DAGs",
+  "limitedList.clickToInteract": "לחץ על תגית כדי לסנן Dags",
   "limitedList.clickToOpenFull": "לחץ על \"+{{count}} נוספים\" כדי לפתוח את התצוגה המלאה",
   "limitedList.copyPasteText": "ניתן להעתיק ולהדביק את הטקסט שמעל",
   "limitedList.showingItems": "מציג {{count}} פריטים",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/hi/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/hi/components.json
@@ -89,7 +89,7 @@
   },
   "limitedList": "+{{count}} और",
   "limitedList.allItems": "सभी {{count}} आइटम:",
-  "limitedList.clickToInteract": "टैग पर क्लिक करके DAGs फ़िल्टर करें",
+  "limitedList.clickToInteract": "टैग पर क्लिक करके Dags फ़िल्टर करें",
   "limitedList.clickToOpenFull": "\"+{{count}} और\" पर क्लिक करके पूरी सूची खोलें",
   "limitedList.copyPasteText": "आप ऊपर दिए गए पाठ को कॉपी और पेस्ट कर सकते हैं",
   "limitedList.showingItems": "{{count}} आइटम दिखाए जा रहे हैं",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/hi/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/hi/components.json
@@ -88,6 +88,11 @@
     "taskGroup": "टास्क ग्रुप"
   },
   "limitedList": "+{{count}} और",
+  "limitedList.allItems": "सभी {{count}} आइटम:",
+  "limitedList.clickToInteract": "टैग पर क्लिक करके DAGs फ़िल्टर करें",
+  "limitedList.clickToOpenFull": "\"+{{count}} और\" पर क्लिक करके पूरी सूची खोलें",
+  "limitedList.copyPasteText": "आप ऊपर दिए गए पाठ को कॉपी और पेस्ट कर सकते हैं",
+  "limitedList.showingItems": "{{count}} आइटम दिखाए जा रहे हैं",
   "logs": {
     "file": "फ़ाइल",
     "location": "{{name}} में लाइन {{line}}"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/hu/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/hu/components.json
@@ -88,6 +88,11 @@
     "taskGroup": "Feladatcsoport"
   },
   "limitedList": "+{{count}} további",
+  "limitedList.allItems": "Összes {{count}} elem:",
+  "limitedList.clickToInteract": "Kattintson egy címkére a DAG-ok szűréséhez",
+  "limitedList.clickToOpenFull": "Kattintson a \"+{{count}} további\" gombra a teljes nézethez",
+  "limitedList.copyPasteText": "A fenti szöveg másolható és beilleszthető",
+  "limitedList.showingItems": "{{count}} elem megjelenítése",
   "logs": {
     "file": "Fájl",
     "location": "{{name}} fájl {{line}}. sora"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/hu/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/hu/components.json
@@ -89,7 +89,7 @@
   },
   "limitedList": "+{{count}} további",
   "limitedList.allItems": "Összes {{count}} elem:",
-  "limitedList.clickToInteract": "Kattintson egy címkére a DAG-ok szűréséhez",
+  "limitedList.clickToInteract": "Kattintson egy címkére a Dag-ok szűréséhez",
   "limitedList.clickToOpenFull": "Kattintson a \"+{{count}} további\" gombra a teljes nézethez",
   "limitedList.copyPasteText": "A fenti szöveg másolható és beilleszthető",
   "limitedList.showingItems": "{{count}} elem megjelenítése",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/it/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/it/components.json
@@ -103,7 +103,7 @@
   },
   "limitedList": "+{{count}} altro",
   "limitedList.allItems": "Tutti i {{count}} elementi:",
-  "limitedList.clickToInteract": "Fai clic su un'etichetta per filtrare i DAG",
+  "limitedList.clickToInteract": "Fai clic su un'etichetta per filtrare i Dag",
   "limitedList.clickToOpenFull": "Fai clic su \"+{{count}} altro\" per visualizzare tutto",
   "limitedList.copyPasteText": "Puoi copiare e incollare il testo sopra",
   "limitedList.showingItems": "Visualizzazione di {{count}} elementi",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/it/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/it/components.json
@@ -102,6 +102,11 @@
     "taskGroup": "Task Group"
   },
   "limitedList": "+{{count}} altro",
+  "limitedList.allItems": "Tutti i {{count}} elementi:",
+  "limitedList.clickToInteract": "Fai clic su un'etichetta per filtrare i DAG",
+  "limitedList.clickToOpenFull": "Fai clic su \"+{{count}} altro\" per visualizzare tutto",
+  "limitedList.copyPasteText": "Puoi copiare e incollare il testo sopra",
+  "limitedList.showingItems": "Visualizzazione di {{count}} elementi",
   "logs": {
     "file": "File",
     "location": "linea {{line}} in {{name}}"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/components.json
@@ -87,7 +87,7 @@
   },
   "limitedList": "+{{count}}개 더 보기",
   "limitedList.allItems": "모든 {{count}}개 항목:",
-  "limitedList.clickToInteract": "태그를 클릭하여 DAG를 필터링하세요",
+  "limitedList.clickToInteract": "태그를 클릭하여 Dag를 필터링하세요",
   "limitedList.clickToOpenFull": "\"+{{count}}개 더 보기\"를 클릭하여 전체 보기 열기",
   "limitedList.copyPasteText": "위의 텍스트를 복사하여 붙여넣을 수 있습니다",
   "limitedList.showingItems": "{{count}}개 항목 표시 중",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/components.json
@@ -86,6 +86,11 @@
     "taskGroup": "작업 그룹"
   },
   "limitedList": "+{{count}}개 더 보기",
+  "limitedList.allItems": "모든 {{count}}개 항목:",
+  "limitedList.clickToInteract": "태그를 클릭하여 DAG를 필터링하세요",
+  "limitedList.clickToOpenFull": "\"+{{count}}개 더 보기\"를 클릭하여 전체 보기 열기",
+  "limitedList.copyPasteText": "위의 텍스트를 복사하여 붙여넣을 수 있습니다",
+  "limitedList.showingItems": "{{count}}개 항목 표시 중",
   "logs": {
     "file": "파일",
     "location": "{{name}}의 {{line}}번째 줄"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/nl/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/nl/components.json
@@ -1,7 +1,7 @@
 {
   "backfill": {
     "affected_one": "1 run zal getriggerd worden.",
-    "affected_other": "{{count}} Runs zullen getriggered worden.",
+    "affected_other": "{{count}} Runs zullen getriggerd worden.",
     "affectedNone": "Geen Runs komen overeen met de geselecteerde criteria.",
     "allRuns": "Alle Runs",
     "backwards": "Run achterstevoren",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/nl/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/nl/components.json
@@ -1,6 +1,6 @@
 {
   "backfill": {
-    "affected_one": "1 run zal getriggered worden.",
+    "affected_one": "1 run zal getriggerd worden.",
     "affected_other": "{{count}} Runs zullen getriggered worden.",
     "affectedNone": "Geen Runs komen overeen met de geselecteerde criteria.",
     "allRuns": "Alle Runs",
@@ -88,6 +88,11 @@
     "taskGroup": "Task Group"
   },
   "limitedList": "+{{count}} meer",
+  "limitedList.allItems": "Alle {{count}} items:",
+  "limitedList.clickToInteract": "Klik op een label om DAGs te filteren",
+  "limitedList.clickToOpenFull": "Klik op \"+{{count}} meer\" om de volledige lijst te openen",
+  "limitedList.copyPasteText": "Je kunt de bovenstaande tekst kopiëren en plakken",
+  "limitedList.showingItems": "{{count}} items weergegeven",
   "logs": {
     "file": "Bestand",
     "location": "regel {{line}} in {{name}}"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/nl/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/nl/components.json
@@ -89,7 +89,7 @@
   },
   "limitedList": "+{{count}} meer",
   "limitedList.allItems": "Alle {{count}} items:",
-  "limitedList.clickToInteract": "Klik op een label om DAGs te filteren",
+  "limitedList.clickToInteract": "Klik op een label om Dags te filteren",
   "limitedList.clickToOpenFull": "Klik op \"+{{count}} meer\" om de volledige lijst te openen",
   "limitedList.copyPasteText": "Je kunt de bovenstaande tekst kopiëren en plakken",
   "limitedList.showingItems": "{{count}} items weergegeven",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/components.json
@@ -102,6 +102,11 @@
     "taskGroup": "Grupa zadań"
   },
   "limitedList": "+{{count}} więcej",
+  "limitedList.allItems": "Wszystkie {{count}} elementy:",
+  "limitedList.clickToInteract": "Kliknij etykietę, aby przefiltrować DAGi",
+  "limitedList.clickToOpenFull": "Kliknij \"+{{count}} więcej\", aby zobaczyć pełną listę",
+  "limitedList.copyPasteText": "Możesz skopiować i wkleić powyższy tekst",
+  "limitedList.showingItems": "Wyświetlanie {{count}} elementów",
   "logs": {
     "file": "Plik",
     "location": "linia {{line}} w {{name}}"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/components.json
@@ -1,4 +1,8 @@
 {
+  "allTags_few": "Wszystkie tagi ({{count}})",
+  "allTags_many": "Wszystkie tagi ({{count}})",
+  "allTags_one": "Wszystkie tagi ({{count}})",
+  "allTags_other": "Wszystkie tagi ({{count}})",
   "backfill": {
     "affected_few": "{{count}} wykonania zostaną uruchomione.",
     "affected_many": "{{count}} wykonań zostanie uruchomionych.",
@@ -112,6 +116,10 @@
     "location": "linia {{line}} w {{name}}"
   },
   "reparseDag": "Ponowne przetworznie Daga",
+  "showingItems_few": "Wyświetlanie {{count}} elementy",
+  "showingItems_many": "Wyświetlanie {{count}} elementów",
+  "showingItems_one": "Wyświetlanie {{count}} elementu",
+  "showingItems_other": "Wyświetlanie {{count}} elementów",
   "sortedAscending": "posortowane rosnąco",
   "sortedDescending": "posortowane malejąco",
   "sortedUnsorted": "nieposortowane",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/components.json
@@ -103,7 +103,7 @@
   },
   "limitedList": "+{{count}} więcej",
   "limitedList.allItems": "Wszystkie {{count}} elementy:",
-  "limitedList.clickToInteract": "Kliknij etykietę, aby przefiltrować DAGi",
+  "limitedList.clickToInteract": "Kliknij etykietę, aby przefiltrować Dagi",
   "limitedList.clickToOpenFull": "Kliknij \"+{{count}} więcej\", aby zobaczyć pełną listę",
   "limitedList.copyPasteText": "Możesz skopiować i wkleić powyższy tekst",
   "limitedList.showingItems": "Wyświetlanie {{count}} elementów",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt/components.json
@@ -103,7 +103,7 @@
   },
   "limitedList": "+{{count}} mais",
   "limitedList.allItems": "Todos os {{count}} itens:",
-  "limitedList.clickToInteract": "Clique em uma etiqueta para filtrar os DAGs",
+  "limitedList.clickToInteract": "Clique em uma etiqueta para filtrar os Dags",
   "limitedList.clickToOpenFull": "Clique em \"+{{count}} mais\" para ver a lista completa",
   "limitedList.copyPasteText": "Você pode copiar e colar o texto acima",
   "limitedList.showingItems": "Exibindo {{count}} itens",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt/components.json
@@ -102,6 +102,11 @@
     "taskGroup": "Grupo de Tarefas"
   },
   "limitedList": "+{{count}} mais",
+  "limitedList.allItems": "Todos os {{count}} itens:",
+  "limitedList.clickToInteract": "Clique em uma etiqueta para filtrar os DAGs",
+  "limitedList.clickToOpenFull": "Clique em \"+{{count}} mais\" para ver a lista completa",
+  "limitedList.copyPasteText": "Você pode copiar e colar o texto acima",
+  "limitedList.showingItems": "Exibindo {{count}} itens",
   "logs": {
     "file": "Arquivo",
     "location": "linha {{line}} em {{name}}"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/tr/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/tr/components.json
@@ -88,6 +88,11 @@
     "taskGroup": "Görev Grubu"
   },
   "limitedList": "+{{count}} daha",
+  "limitedList.allItems": "Tüm {{count}} öğe:",
+  "limitedList.clickToInteract": "Bir etikete tıklayarak DAG'ları filtreleyin",
+  "limitedList.clickToOpenFull": "\"+{{count}} daha\" tıklayarak tam görünümü açın",
+  "limitedList.copyPasteText": "Yukarıdaki metni kopyalayıp yapıştırabilirsiniz",
+  "limitedList.showingItems": "{{count}} öğe gösteriliyor",
   "logs": {
     "file": "Dosya",
     "location": "{{name}} içinde satır {{line}}"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/tr/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/tr/components.json
@@ -88,7 +88,7 @@
     "taskGroup": "Görev Grubu"
   },
   "limitedList": "+{{count}} daha",
-  "limitedList.allItems": "Tüm {{count}} öğe:",
+  "limitedList.allItems": "Tüm {{count}} öğeler:",
   "limitedList.clickToInteract": "Bir etikete tıklayarak Dag'leri filtreleyin",
   "limitedList.clickToOpenFull": "\"+{{count}} daha\" tıklayarak tam görünümü açın",
   "limitedList.copyPasteText": "Yukarıdaki metni kopyalayıp yapıştırabilirsiniz",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/tr/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/tr/components.json
@@ -89,7 +89,7 @@
   },
   "limitedList": "+{{count}} daha",
   "limitedList.allItems": "Tüm {{count}} öğe:",
-  "limitedList.clickToInteract": "Bir etikete tıklayarak DAG'ları filtreleyin",
+  "limitedList.clickToInteract": "Bir etikete tıklayarak Dag'leri filtreleyin",
   "limitedList.clickToOpenFull": "\"+{{count}} daha\" tıklayarak tam görünümü açın",
   "limitedList.copyPasteText": "Yukarıdaki metni kopyalayıp yapıştırabilirsiniz",
   "limitedList.showingItems": "{{count}} öğe gösteriliyor",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/components.json
@@ -86,6 +86,11 @@
     "taskGroup": "任务分组"
   },
   "limitedList": "+ 其他 {{count}} 项",
+  "limitedList.allItems": "所有 {{count}} 项：",
+  "limitedList.clickToInteract": "点击标签以筛选 DAGs",
+  "limitedList.clickToOpenFull": "点击 \"+{{count}} 更多\" 打开完整视图",
+  "limitedList.copyPasteText": "你可以复制并粘贴上方文本",
+  "limitedList.showingItems": "显示 {{count}} 项",
   "logs": {
     "file": "文件",
     "location": "第 {{line}} 行，位于 {{name}}"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/components.json
@@ -90,7 +90,7 @@
   "limitedList.clickToInteract": "點擊標籤以篩選 Dags",
   "limitedList.clickToOpenFull": "點擊 \"+{{count}} 更多\" 以開啟完整檢視",
   "limitedList.copyPasteText": "你可以複製並貼上上方文字",
-  "limitedList.showingItems": "顯示 {{count}} 項目",
+  "limitedList.showingItems": "顯示 {{count}} 個項目",
   "logs": {
     "file": "檔案",
     "location": "第 {{line}} 行，位於 {{name}}"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/components.json
@@ -87,7 +87,7 @@
   },
   "limitedList": "+ 其他 {{count}} 項",
   "limitedList.allItems": "所有 {{count}} 項目：",
-  "limitedList.clickToInteract": "點擊標籤以篩選 DAGs",
+  "limitedList.clickToInteract": "點擊標籤以篩選 Dags",
   "limitedList.clickToOpenFull": "點擊 \"+{{count}} 更多\" 以開啟完整檢視",
   "limitedList.copyPasteText": "你可以複製並貼上上方文字",
   "limitedList.showingItems": "顯示 {{count}} 項目",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/components.json
@@ -86,7 +86,7 @@
     "taskGroup": "任務群組"
   },
   "limitedList": "+ 其他 {{count}} 項",
-  "limitedList.allItems": "所有 {{count}} 項目：",
+  "limitedList.allItems": "所有 {{count}} 個項目：",
   "limitedList.clickToInteract": "點擊標籤以篩選 Dags",
   "limitedList.clickToOpenFull": "點擊 \"+{{count}} 更多\" 以開啟完整檢視",
   "limitedList.copyPasteText": "你可以複製並貼上上方文字",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/components.json
@@ -86,6 +86,11 @@
     "taskGroup": "任務群組"
   },
   "limitedList": "+ 其他 {{count}} 項",
+  "limitedList.allItems": "所有 {{count}} 項目：",
+  "limitedList.clickToInteract": "點擊標籤以篩選 DAGs",
+  "limitedList.clickToOpenFull": "點擊 \"+{{count}} 更多\" 以開啟完整檢視",
+  "limitedList.copyPasteText": "你可以複製並貼上上方文字",
+  "limitedList.showingItems": "顯示 {{count}} 項目",
   "logs": {
     "file": "檔案",
     "location": "第 {{line}} 行，位於 {{name}}"

--- a/airflow-core/src/airflow/ui/src/components/LimitedItemsList.tsx
+++ b/airflow-core/src/airflow/ui/src/components/LimitedItemsList.tsx
@@ -53,8 +53,7 @@ export const LimitedItemsList = ({
       </Text>
       <Stack gap={1}>
         {items.map((item, index) => (
-          // eslint-disable-next-line react/no-array-index-key
-          <Box fontSize="sm" key={index}>
+          <Box fontSize="sm" key={typeof item === "string" ? item : index}>
             {item}
           </Box>
         ))}
@@ -70,9 +69,8 @@ export const LimitedItemsList = ({
       </Text>
       <Stack gap={1}>
         {items.map((item, index) => (
-          // eslint-disable-next-line react/no-array-index-key
-          <Text fontSize="sm" key={index}>
-            {typeof item === "string" ? item : "item"}
+          <Text fontSize="sm" key={typeof item === "string" ? item : index}>
+            {item}
           </Text>
         ))}
       </Stack>
@@ -151,9 +149,9 @@ export const LimitedItemsList = ({
                 </Text>
 
                 <Box
-                  bg="gray.50"
+                  bg="bg.subtle"
                   border="1px solid"
-                  borderColor="gray.200"
+                  borderColor="border.subtle"
                   borderRadius="md"
                   maxH="400px"
                   overflowY="auto"
@@ -162,16 +160,14 @@ export const LimitedItemsList = ({
                   {interactive ? (
                     <HStack flexWrap="wrap" gap={2}>
                       {items.map((item, index) => (
-                        // eslint-disable-next-line react/no-array-index-key
-                        <Box key={index}>{item}</Box>
+                        <Box key={typeof item === "string" ? item : index}>{item}</Box>
                       ))}
                     </HStack>
                   ) : (
                     <Stack gap={2}>
                       {items.map((item, index) => (
-                        // eslint-disable-next-line react/no-array-index-key
-                        <Text fontSize="sm" key={index} userSelect="text">
-                          {typeof item === "string" ? item : "item"}
+                        <Text fontSize="sm" key={typeof item === "string" ? item : index} userSelect="text">
+                          {item}
                         </Text>
                       ))}
                     </Stack>

--- a/airflow-core/src/airflow/ui/src/components/LimitedItemsList.tsx
+++ b/airflow-core/src/airflow/ui/src/components/LimitedItemsList.tsx
@@ -113,7 +113,7 @@ export const LimitedItemsList = ({
                     )}
                   </Box>
 
-                  <Text color="gray.500" fontSize="xs" mt={3}>
+                  <Text fontSize="xs" mt={3}>
                     {interactive
                       ? translate("limitedList.clickToInteract")
                       : translate("limitedList.copyPasteText")}

--- a/airflow-core/src/airflow/ui/src/components/LimitedItemsList.tsx
+++ b/airflow-core/src/airflow/ui/src/components/LimitedItemsList.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Text, HStack, useDisclosure, Heading, Stack } from "@chakra-ui/react";
+import { Box, Text, HStack, useDisclosure, Heading, Stack, StackSeparator } from "@chakra-ui/react";
 import React, { type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -47,39 +47,9 @@ export const LimitedItemsList = ({
   const displayItems = shouldTruncate ? items.slice(0, maxItems) : items;
   const remainingItems = shouldTruncate ? items.slice(maxItems) : [];
   const remainingItemsList = interactive ? (
-    <Box maxH="200px" overflowY="auto" p={2}>
-      <Text fontSize="sm" fontWeight="bold" mb={2}>
-        {translate("limitedList.allItems", { count: items.length })}
-      </Text>
-      <Stack gap={1}>
-        {items.map((item, index) => (
-          <Box fontSize="sm" key={typeof item === "string" ? item : index}>
-            {item}
-          </Box>
-        ))}
-      </Stack>
-      <Text color="gray.500" fontSize="xs" mt={2}>
-        {translate("limitedList.clickToOpenFull", { count: remainingItems.length })}
-      </Text>
-    </Box>
+    <HStack separator={<StackSeparator />}>{remainingItems}</HStack>
   ) : (
-    <Box maxH="200px" overflowY="auto" p={2}>
-      <Text fontSize="sm" fontWeight="bold" mb={2}>
-        {translate("limitedList.allItems", { count: items.length })}
-      </Text>
-      <Stack gap={1}>
-        {items.map((item, index) => (
-          <Text fontSize="sm" key={typeof item === "string" ? item : index}>
-            {item}
-          </Text>
-        ))}
-      </Stack>
-      {showModal ? (
-        <Text color="gray.500" fontSize="xs" mt={2}>
-          {translate("limitedList.clickToOpenFull", { count: remainingItems.length })}
-        </Text>
-      ) : undefined}
-    </Box>
+    `More items: ${remainingItems.map((item) => (typeof item === "string" ? item : "item")).join(", ")}`
   );
 
   if (!items.length) {
@@ -105,22 +75,20 @@ export const LimitedItemsList = ({
             remainingItems.length === 1 ? (
               <Text as="span">{remainingItems[0]}</Text>
             ) : showModal ? (
-              <Tooltip content={remainingItemsList} interactive={interactive}>
-                <Button
-                  _hover={{ color: "blue.600", textDecoration: "underline" }}
-                  color="blue.500"
-                  cursor="pointer"
-                  fontSize="sm"
-                  minH="auto"
-                  onClick={onOpen}
-                  px={1}
-                  py={0}
-                  size="xs"
-                  variant="ghost"
-                >
-                  {translate("limitedList", { count: remainingItems.length })}
-                </Button>
-              </Tooltip>
+              <Button
+                _hover={{ color: "blue.600", textDecoration: "underline" }}
+                color="blue.500"
+                cursor="pointer"
+                fontSize="sm"
+                minH="auto"
+                onClick={onOpen}
+                px={1}
+                py={0}
+                size="xs"
+                variant="ghost"
+              >
+                {translate("limitedList", { count: remainingItems.length })}
+              </Button>
             ) : (
               <Tooltip content={remainingItemsList} interactive={interactive}>
                 <Text as="span" cursor="help">

--- a/airflow-core/src/airflow/ui/src/components/LimitedItemsList.tsx
+++ b/airflow-core/src/airflow/ui/src/components/LimitedItemsList.tsx
@@ -16,18 +16,20 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Text, HStack, StackSeparator } from "@chakra-ui/react";
+import { Box, Text, HStack, useDisclosure, Heading, Stack } from "@chakra-ui/react";
 import React, { type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
-import { Tooltip } from "./ui";
+import { Tooltip, Dialog, Button } from "./ui";
 
 type ListProps = {
   readonly icon?: ReactNode;
   readonly interactive?: boolean;
   readonly items: Array<ReactNode | string>;
   readonly maxItems?: number;
+  readonly modalTitle?: string;
   readonly separator?: string;
+  readonly showModal?: boolean;
 };
 
 export const LimitedItemsList = ({
@@ -35,16 +37,51 @@ export const LimitedItemsList = ({
   interactive = false,
   items,
   maxItems,
+  modalTitle = "All Items",
   separator = ", ",
+  showModal = false,
 }: ListProps) => {
   const { t: translate } = useTranslation("components");
+  const { onClose, onOpen, open } = useDisclosure();
   const shouldTruncate = maxItems !== undefined && items.length > maxItems;
   const displayItems = shouldTruncate ? items.slice(0, maxItems) : items;
   const remainingItems = shouldTruncate ? items.slice(maxItems) : [];
   const remainingItemsList = interactive ? (
-    <HStack separator={<StackSeparator />}>{remainingItems}</HStack>
+    <Box maxH="200px" overflowY="auto" p={2}>
+      <Text fontSize="sm" fontWeight="bold" mb={2}>
+        {translate("limitedList.allItems", { count: items.length })}
+      </Text>
+      <Stack gap={1}>
+        {items.map((item, index) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <Box fontSize="sm" key={index}>
+            {item}
+          </Box>
+        ))}
+      </Stack>
+      <Text color="gray.500" fontSize="xs" mt={2}>
+        {translate("limitedList.clickToOpenFull", { count: remainingItems.length })}
+      </Text>
+    </Box>
   ) : (
-    `More items: ${remainingItems.map((item) => (typeof item === "string" ? item : "item")).join(", ")}`
+    <Box maxH="200px" overflowY="auto" p={2}>
+      <Text fontSize="sm" fontWeight="bold" mb={2}>
+        {translate("limitedList.allItems", { count: items.length })}
+      </Text>
+      <Stack gap={1}>
+        {items.map((item, index) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <Text fontSize="sm" key={index}>
+            {typeof item === "string" ? item : "item"}
+          </Text>
+        ))}
+      </Stack>
+      {showModal ? (
+        <Text color="gray.500" fontSize="xs" mt={2}>
+          {translate("limitedList.clickToOpenFull", { count: remainingItems.length })}
+        </Text>
+      ) : undefined}
+    </Box>
   );
 
   if (!items.length) {
@@ -52,31 +89,105 @@ export const LimitedItemsList = ({
   }
 
   return (
-    <HStack align="center" gap={1}>
-      {icon}
-      <Box fontSize="sm">
-        {displayItems.map((item, index) => (
-          // eslint-disable-next-line react/no-array-index-key
-          <React.Fragment key={index}>
-            <Text as="span">{item}</Text>
-            {index < displayItems.length - 1 ||
-            (shouldTruncate && remainingItems.length >= 1 && index === displayItems.length - 1) ? (
-              <Text as="span">{separator}</Text>
-            ) : undefined}
-          </React.Fragment>
-        ))}
-        {shouldTruncate ? (
-          remainingItems.length === 1 ? (
-            <Text as="span">{remainingItems[0]}</Text>
-          ) : (
-            <Tooltip content={remainingItemsList} interactive={interactive}>
-              <Text as="span" cursor="help">
-                {translate("limitedList", { count: remainingItems.length })}
-              </Text>
-            </Tooltip>
-          )
-        ) : undefined}
-      </Box>
-    </HStack>
+    <>
+      <HStack align="center" gap={1}>
+        {icon}
+        <Box fontSize="sm">
+          {displayItems.map((item, index) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <React.Fragment key={index}>
+              <Text as="span">{item}</Text>
+              {index < displayItems.length - 1 ||
+              (shouldTruncate && remainingItems.length >= 1 && index === displayItems.length - 1) ? (
+                <Text as="span">{separator}</Text>
+              ) : undefined}
+            </React.Fragment>
+          ))}
+          {shouldTruncate ? (
+            remainingItems.length === 1 ? (
+              <Text as="span">{remainingItems[0]}</Text>
+            ) : showModal ? (
+              <Tooltip content={remainingItemsList} interactive={interactive}>
+                <Button
+                  _hover={{ color: "blue.600", textDecoration: "underline" }}
+                  color="blue.500"
+                  cursor="pointer"
+                  fontSize="sm"
+                  minH="auto"
+                  onClick={onOpen}
+                  px={1}
+                  py={0}
+                  size="xs"
+                  variant="ghost"
+                >
+                  {translate("limitedList", { count: remainingItems.length })}
+                </Button>
+              </Tooltip>
+            ) : (
+              <Tooltip content={remainingItemsList} interactive={interactive}>
+                <Text as="span" cursor="help">
+                  {translate("limitedList", { count: remainingItems.length })}
+                </Text>
+              </Tooltip>
+            )
+          ) : undefined}
+        </Box>
+      </HStack>
+
+      {/* Modal for showing all items */}
+      {showModal ? (
+        <Dialog.Root onOpenChange={onClose} open={open} size="xl">
+          <Dialog.Content backdrop>
+            <Dialog.Header>
+              <Heading size="lg">{modalTitle}</Heading>
+            </Dialog.Header>
+
+            <Dialog.CloseTrigger />
+
+            <Dialog.Body>
+              <Box>
+                <Text color="gray.600" fontSize="sm" mb={3}>
+                  {translate("limitedList.showingItems", { count: items.length })}
+                </Text>
+
+                <Box
+                  bg="gray.50"
+                  border="1px solid"
+                  borderColor="gray.200"
+                  borderRadius="md"
+                  maxH="400px"
+                  overflowY="auto"
+                  p={3}
+                >
+                  {interactive ? (
+                    <HStack flexWrap="wrap" gap={2}>
+                      {items.map((item, index) => (
+                        // eslint-disable-next-line react/no-array-index-key
+                        <Box key={index}>{item}</Box>
+                      ))}
+                    </HStack>
+                  ) : (
+                    <Stack gap={2}>
+                      {items.map((item, index) => (
+                        // eslint-disable-next-line react/no-array-index-key
+                        <Text fontSize="sm" key={index} userSelect="text">
+                          {typeof item === "string" ? item : "item"}
+                        </Text>
+                      ))}
+                    </Stack>
+                  )}
+                </Box>
+
+                <Text color="gray.500" fontSize="xs" mt={3}>
+                  {interactive
+                    ? translate("limitedList.clickToInteract")
+                    : translate("limitedList.copyPasteText")}
+                </Text>
+              </Box>
+            </Dialog.Body>
+          </Dialog.Content>
+        </Dialog.Root>
+      ) : undefined}
+    </>
   );
 };

--- a/airflow-core/src/airflow/ui/src/components/LimitedItemsList.tsx
+++ b/airflow-core/src/airflow/ui/src/components/LimitedItemsList.tsx
@@ -68,7 +68,7 @@ export const LimitedItemsList = ({
               <Popover.Trigger asChild>
                 <Button
                   _hover={{ color: "blue.600", textDecoration: "underline" }}
-                  color="blue.500"
+                  colorPalette="brand"
                   cursor="pointer"
                   fontSize="sm"
                   minH="auto"

--- a/airflow-core/src/airflow/ui/src/components/LimitedItemsList.tsx
+++ b/airflow-core/src/airflow/ui/src/components/LimitedItemsList.tsx
@@ -67,7 +67,6 @@ export const LimitedItemsList = ({
             <Popover.Root lazyMount unmountOnExit>
               <Popover.Trigger asChild>
                 <Button
-                  _hover={{ color: "blue.600", textDecoration: "underline" }}
                   colorPalette="brand"
                   cursor="pointer"
                   fontSize="sm"

--- a/airflow-core/src/airflow/ui/src/components/LimitedItemsList.tsx
+++ b/airflow-core/src/airflow/ui/src/components/LimitedItemsList.tsx
@@ -16,20 +16,18 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Text, HStack, useDisclosure, Heading, Stack, StackSeparator } from "@chakra-ui/react";
+import { Box, Text, HStack, Stack } from "@chakra-ui/react";
 import React, { type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
-import { Tooltip, Dialog, Button } from "./ui";
+import { Popover, Button } from "./ui";
 
 type ListProps = {
   readonly icon?: ReactNode;
   readonly interactive?: boolean;
   readonly items: Array<ReactNode | string>;
   readonly maxItems?: number;
-  readonly modalTitle?: string;
   readonly separator?: string;
-  readonly showModal?: boolean;
 };
 
 export const LimitedItemsList = ({
@@ -37,121 +35,95 @@ export const LimitedItemsList = ({
   interactive = false,
   items,
   maxItems,
-  modalTitle = "All Items",
   separator = ", ",
-  showModal = false,
 }: ListProps) => {
   const { t: translate } = useTranslation("components");
-  const { onClose, onOpen, open } = useDisclosure();
   const shouldTruncate = maxItems !== undefined && items.length > maxItems;
   const displayItems = shouldTruncate ? items.slice(0, maxItems) : items;
   const remainingItems = shouldTruncate ? items.slice(maxItems) : [];
-  const remainingItemsList = interactive ? (
-    <HStack separator={<StackSeparator />}>{remainingItems}</HStack>
-  ) : (
-    `More items: ${remainingItems.map((item) => (typeof item === "string" ? item : "item")).join(", ")}`
-  );
 
   if (!items.length) {
     return undefined;
   }
 
   return (
-    <>
-      <HStack align="center" gap={1}>
-        {icon}
-        <Box fontSize="sm">
-          {displayItems.map((item, index) => (
-            // eslint-disable-next-line react/no-array-index-key
-            <React.Fragment key={index}>
-              <Text as="span">{item}</Text>
-              {index < displayItems.length - 1 ||
-              (shouldTruncate && remainingItems.length >= 1 && index === displayItems.length - 1) ? (
-                <Text as="span">{separator}</Text>
-              ) : undefined}
-            </React.Fragment>
-          ))}
-          {shouldTruncate ? (
-            remainingItems.length === 1 ? (
-              <Text as="span">{remainingItems[0]}</Text>
-            ) : showModal ? (
-              <Button
-                _hover={{ color: "blue.600", textDecoration: "underline" }}
-                color="blue.500"
-                cursor="pointer"
-                fontSize="sm"
-                minH="auto"
-                onClick={onOpen}
-                px={1}
-                py={0}
-                size="xs"
-                variant="ghost"
-              >
-                {translate("limitedList", { count: remainingItems.length })}
-              </Button>
-            ) : (
-              <Tooltip content={remainingItemsList} interactive={interactive}>
-                <Text as="span" cursor="help">
-                  {translate("limitedList", { count: remainingItems.length })}
-                </Text>
-              </Tooltip>
-            )
-          ) : undefined}
-        </Box>
-      </HStack>
-
-      {/* Modal for showing all items */}
-      {showModal ? (
-        <Dialog.Root onOpenChange={onClose} open={open} size="xl">
-          <Dialog.Content backdrop>
-            <Dialog.Header>
-              <Heading size="lg">{modalTitle}</Heading>
-            </Dialog.Header>
-
-            <Dialog.CloseTrigger />
-
-            <Dialog.Body>
-              <Box>
-                <Text color="gray.600" fontSize="sm" mb={3}>
-                  {translate("limitedList.showingItems", { count: items.length })}
-                </Text>
-
-                <Box
-                  bg="bg.subtle"
-                  border="1px solid"
-                  borderColor="border.subtle"
-                  borderRadius="md"
-                  maxH="400px"
-                  overflowY="auto"
-                  p={3}
+    <HStack align="center" gap={1}>
+      {icon}
+      <Box fontSize="sm">
+        {displayItems.map((item, index) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <React.Fragment key={index}>
+            <Text as="span">{item}</Text>
+            {index < displayItems.length - 1 ||
+            (shouldTruncate && remainingItems.length >= 1 && index === displayItems.length - 1) ? (
+              <Text as="span">{separator}</Text>
+            ) : undefined}
+          </React.Fragment>
+        ))}
+        {shouldTruncate ? (
+          remainingItems.length === 1 ? (
+            <Text as="span">{remainingItems[0]}</Text>
+          ) : (
+            <Popover.Root lazyMount unmountOnExit>
+              <Popover.Trigger asChild>
+                <Button
+                  _hover={{ color: "blue.600", textDecoration: "underline" }}
+                  color="blue.500"
+                  cursor="pointer"
+                  fontSize="sm"
+                  minH="auto"
+                  px={1}
+                  py={0}
+                  size="xs"
+                  variant="ghost"
                 >
-                  {interactive ? (
-                    <HStack flexWrap="wrap" gap={2}>
-                      {items.map((item, index) => (
-                        <Box key={typeof item === "string" ? item : index}>{item}</Box>
-                      ))}
-                    </HStack>
-                  ) : (
-                    <Stack gap={2}>
-                      {items.map((item, index) => (
-                        <Text fontSize="sm" key={typeof item === "string" ? item : index} userSelect="text">
-                          {item}
-                        </Text>
-                      ))}
-                    </Stack>
-                  )}
-                </Box>
+                  {translate("limitedList", { count: remainingItems.length })}
+                </Button>
+              </Popover.Trigger>
+              <Popover.Content maxW="400px" width="fit-content">
+                <Popover.Arrow />
+                <Popover.Body>
+                  <Text fontSize="sm" fontWeight="medium" mb={3}>
+                    {translate("limitedList.allItems", { count: items.length })}
+                  </Text>
 
-                <Text color="gray.500" fontSize="xs" mt={3}>
-                  {interactive
-                    ? translate("limitedList.clickToInteract")
-                    : translate("limitedList.copyPasteText")}
-                </Text>
-              </Box>
-            </Dialog.Body>
-          </Dialog.Content>
-        </Dialog.Root>
-      ) : undefined}
-    </>
+                  <Box maxH="300px" overflowY="auto">
+                    {interactive ? (
+                      <HStack flexWrap="wrap" gap={2}>
+                        {items.map((item, index) => (
+                          <Box
+                            bg="bg.subtle"
+                            borderRadius="sm"
+                            key={typeof item === "string" ? item : index}
+                            px={2}
+                            py={1}
+                          >
+                            {item}
+                          </Box>
+                        ))}
+                      </HStack>
+                    ) : (
+                      <Stack gap={1}>
+                        {items.map((item, index) => (
+                          <Text fontSize="sm" key={typeof item === "string" ? item : index} userSelect="text">
+                            {item}
+                          </Text>
+                        ))}
+                      </Stack>
+                    )}
+                  </Box>
+
+                  <Text color="gray.500" fontSize="xs" mt={3}>
+                    {interactive
+                      ? translate("limitedList.clickToInteract")
+                      : translate("limitedList.copyPasteText")}
+                  </Text>
+                </Popover.Body>
+              </Popover.Content>
+            </Popover.Root>
+          )
+        ) : undefined}
+      </Box>
+    </HStack>
   );
 };

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagTags.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagTags.tsx
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { useTranslation } from "react-i18next";
 import { FiTag } from "react-icons/fi";
 import { Link as RouterLink } from "react-router-dom";
 
@@ -30,17 +31,21 @@ type Props = {
   readonly tags: Array<DagTagResponse>;
 };
 
-export const DagTags = ({ hideIcon = false, tags }: Props) => (
-  <LimitedItemsList
-    icon={hideIcon ? undefined : <FiTag data-testid="dag-tag" />}
-    interactive
-    items={tags.map(({ name }) => (
-      <RouterLink key={name} to={`/dags?${SearchParamsKeys.TAGS}=${name}`}>
-        {name}
-      </RouterLink>
-    ))}
-    maxItems={MAX_TAGS}
-    modalTitle={`All Tags (${tags.length})`}
-    showModal={true}
-  />
-);
+export const DagTags = ({ hideIcon = false, tags }: Props) => {
+  const { t: translate } = useTranslation("components");
+
+  return (
+    <LimitedItemsList
+      icon={hideIcon ? undefined : <FiTag data-testid="dag-tag" />}
+      interactive
+      items={tags.map(({ name }) => (
+        <RouterLink key={name} to={`/dags?${SearchParamsKeys.TAGS}=${name}`}>
+          {name}
+        </RouterLink>
+      ))}
+      maxItems={MAX_TAGS}
+      modalTitle={translate("limitedList.allTags", { count: tags.length })}
+      showModal={true}
+    />
+  );
+};

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagTags.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagTags.tsx
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useTranslation } from "react-i18next";
 import { FiTag } from "react-icons/fi";
 import { Link as RouterLink } from "react-router-dom";
 
@@ -31,21 +30,15 @@ type Props = {
   readonly tags: Array<DagTagResponse>;
 };
 
-export const DagTags = ({ hideIcon = false, tags }: Props) => {
-  const { t: translate } = useTranslation("components");
-
-  return (
-    <LimitedItemsList
-      icon={hideIcon ? undefined : <FiTag data-testid="dag-tag" />}
-      interactive
-      items={tags.map(({ name }) => (
-        <RouterLink key={name} to={`/dags?${SearchParamsKeys.TAGS}=${name}`}>
-          {name}
-        </RouterLink>
-      ))}
-      maxItems={MAX_TAGS}
-      modalTitle={translate("limitedList.allTags", { count: tags.length })}
-      showModal={true}
-    />
-  );
-};
+export const DagTags = ({ hideIcon = false, tags }: Props) => (
+  <LimitedItemsList
+    icon={hideIcon ? undefined : <FiTag data-testid="dag-tag" />}
+    interactive
+    items={tags.map(({ name }) => (
+      <RouterLink key={name} to={`/dags?${SearchParamsKeys.TAGS}=${name}`}>
+        {name}
+      </RouterLink>
+    ))}
+    maxItems={MAX_TAGS}
+  />
+);

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagTags.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagTags.tsx
@@ -40,5 +40,7 @@ export const DagTags = ({ hideIcon = false, tags }: Props) => (
       </RouterLink>
     ))}
     maxItems={MAX_TAGS}
+    modalTitle={`All Tags (${tags.length})`}
+    showModal={true}
   />
 );

--- a/dev/i18n/check_translations_completeness.py
+++ b/dev/i18n/check_translations_completeness.py
@@ -463,11 +463,13 @@ def cli(language: str | None = None, add_missing: bool = False):
     found_difference = print_file_set_differences(locale_files, console, language)
     summary, missing_counts = compare_keys(locale_files, console)
     console.print("\n[bold underline]Summary of differences by language:[/bold underline]", style="cyan")
-    if add_missing:
+    if add_missing and language != "en":
         # Loop through all languages except 'en' and add missing translations
-        for lf in locale_files:
-            if lf.locale == "en":
-                continue
+        if language:
+            language_files = [lf for lf in locale_files if lf.locale == language]
+        else:
+            language_files = [lf for lf in locale_files if lf.locale != "en"]
+        for lf in language_files:
             filtered_summary = {}
             for filename, diff in summary.items():
                 filtered_summary[filename] = LocaleSummary(

--- a/dev/i18n/check_translations_completeness.py
+++ b/dev/i18n/check_translations_completeness.py
@@ -454,20 +454,29 @@ def print_translation_progress(console, locale_files, missing_counts, summary):
     "--add-missing",
     is_flag=True,
     default=False,
-    help="Add missing translations for the selected language, prefixed with 'TODO: translate:'.",
+    help="Add missing translations for all languages except English, prefixed with 'TODO: translate:'.",
 )
 def cli(language: str | None = None, add_missing: bool = False):
-    if add_missing:
-        if not language:
-            raise ValueError("--language is required when passing --add_missing")
-        locale_path = LOCALES_DIR / language
-        locale_path.mkdir(exist_ok=True)
     locale_files = get_locale_files()
     console = Console(force_terminal=True, color_system="auto")
     print_locale_file_table(locale_files, console, language)
     found_difference = print_file_set_differences(locale_files, console, language)
     summary, missing_counts = compare_keys(locale_files, console)
     console.print("\n[bold underline]Summary of differences by language:[/bold underline]", style="cyan")
+    if add_missing:
+        # Loop through all languages except 'en' and add missing translations
+        for lf in locale_files:
+            if lf.locale == "en":
+                continue
+            filtered_summary = {}
+            for filename, diff in summary.items():
+                filtered_summary[filename] = LocaleSummary(
+                    missing_keys={lf.locale: diff.missing_keys.get(lf.locale, [])},
+                    extra_keys={lf.locale: diff.extra_keys.get(lf.locale, [])},
+                )
+            add_missing_translations(lf.locale, filtered_summary, console)
+        # After adding, re-run the summary for all languages
+        summary, missing_counts = compare_keys(get_locale_files(), console)
     if language:
         locales = [lf.locale for lf in locale_files]
         if language not in locales:
@@ -487,8 +496,6 @@ def cli(language: str | None = None, add_missing: bool = False):
                 [lf for lf in locale_files if lf.locale == language], filtered_summary, console
             )
             found_difference = found_difference or lang_diff
-            if add_missing:
-                add_missing_translations(language, filtered_summary, console)
     else:
         lang_diff = print_language_summary(locale_files, summary, console)
         found_difference = found_difference or lang_diff


### PR DESCRIPTION
## Summary
Add modal dialog to display all DAG tags when the tag list is truncated (more than 3 tags), allowing users to view and interact with all tags regardless of quantity.

## Problem
The DAG tags display was limited to showing only the first 3 tags with a "+X more" tooltip that displayed additional tags in a cramped, non-interactive format. Users with DAGs containing many tags (20+ tags) had no way to properly view or click on the hidden tags

## Solution
Added modal functionality to LimitedItemsList component

 ## Testing
Tested with a DAG containing 25+ tags:
  - Modal opens correctly showing all tags
  - Tag filtering works properly

## Related Issues
Fixes #55511