### PR TITLE
Add shutdown-all-workers command to Edge CLI

### DIFF
--- a/providers/edge3/docs/deployment.rst
+++ b/providers/edge3/docs/deployment.rst
@@ -189,6 +189,7 @@ instance. The commands are:
 - ``airflow edge remote-edge-worker-update-maintenance-comment``: Updates the maintenance comment for a remote edge worker
 - ``airflow edge remote-edge-worker-exit-maintenance``: Request a remote edge worker to exit maintenance mode
 - ``airflow edge shutdown-remote-edge-worker``: Shuts down a remote edge worker gracefully
+- ``airflow edge shutdown-all-workers``: Request graceful shutdown of all registered edge workers
 - ``airflow edge remove-remote-edge-worker``: Remove a worker instance from the cluster
 - ``airflow edge add-worker-queues``: Add queues to an edge worker
 - ``airflow edge remove-worker-queues``: Remove queues from an edge worker


### PR DESCRIPTION
Implement new Edge CLI command to gracefully shutdown all registered edge workers with confirmation prompt. Command follows similar pattern to celery shutdown-all-workers, requiring user confirmation with y/n prompt unless bypassed with --yes flag.

<img width="1737" height="335" alt="image" src="https://github.com/user-attachments/assets/06a8970b-4697-474c-8c5d-4f39b17d2a07" />

cc: @jscheffl 

