### PR TITLE
Add missing `.level` property on our structlog shim.

### DIFF
--- a/shared/logging/src/airflow_shared/logging/structlog.py
+++ b/shared/logging/src/airflow_shared/logging/structlog.py
@@ -70,11 +70,9 @@ def _make_airflow_structlogger(min_level):
     def handlers(self):
         return [logging.NullHandler()]
 
-    def isEnabledFor(self: Any, level):
-        return self.is_enabled_for(level)
-
-    def getEffectiveLevel(self: Any):
-        return self.get_effective_level()
+    @property
+    def level(self):
+        return min_level
 
     @property
     def name(self):
@@ -109,8 +107,9 @@ def _make_airflow_structlogger(min_level):
         f"AirflowBoundLoggerFilteringAt{LEVEL_TO_NAME.get(min_level, 'Notset').capitalize()}",
         (base,),
         {
-            "isEnabledFor": isEnabledFor,
-            "getEffectiveLevel": getEffectiveLevel,
+            "isEnabledFor": base.is_enabled_for,
+            "getEffectiveLevel": base.get_effective_level,
+            "level": level,
             "name": name,
             "handlers": handlers,
         }


### PR DESCRIPTION
This wasn't caught in unit tests, but it was reported that something within
Slack's python library itself is trying to access this property.

https://github.com/slackapi/python-slack-sdk/blob/ed1893d/slack_sdk/socket_mode/client.py#L98
for example

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
