### PR TITLE
Allow SSM operators and sensors to run in deferrable mode

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/triggers/ssm.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/triggers/ssm.py
@@ -66,8 +66,8 @@ class SsmRunCommandTrigger(AwsBaseWaiterTrigger):
 
     async def run(self) -> AsyncIterator[TriggerEvent]:
         hook = self.hook()
-        async with hook.async_conn as client:
-            response = client.list_command_invocations(CommandId=self.command_id)
+        async with await hook.get_async_conn() as client:
+            response = await client.list_command_invocations(CommandId=self.command_id)
             instance_ids = [invocation["InstanceId"] for invocation in response.get("CommandInvocations", [])]
             waiter = hook.get_waiter(self.waiter_name, deferrable=True, client=client)
 

--- a/providers/amazon/tests/system/amazon/aws/example_ssm.py
+++ b/providers/amazon/tests/system/amazon/aws/example_ssm.py
@@ -198,12 +198,15 @@ with DAG(
         document_name="AWS-RunShellScript",
         run_command_kwargs=run_command_kwargs,
         wait_for_completion=False,
+        deferrable=True
     )
     # [END howto_operator_run_command]
 
     # [START howto_sensor_run_command]
     await_run_command = SsmRunCommandCompletedSensor(
-        task_id="await_run_command", command_id=run_command.output
+        task_id="await_run_command", 
+        command_id="{{ ti.xcom_pull(task_ids='run_command') }}",
+        deferrable=True
     )
     # [END howto_sensor_run_command]
 

--- a/providers/amazon/tests/system/amazon/aws/example_ssm.py
+++ b/providers/amazon/tests/system/amazon/aws/example_ssm.py
@@ -198,15 +198,12 @@ with DAG(
         document_name="AWS-RunShellScript",
         run_command_kwargs=run_command_kwargs,
         wait_for_completion=False,
-        deferrable=True
     )
     # [END howto_operator_run_command]
 
     # [START howto_sensor_run_command]
     await_run_command = SsmRunCommandCompletedSensor(
-        task_id="await_run_command", 
-        command_id="{{ ti.xcom_pull(task_ids='run_command') }}",
-        deferrable=True
+        task_id="await_run_command", command_id="{{ ti.xcom_pull(task_ids='run_command') }}"
     )
     # [END howto_sensor_run_command]
 

--- a/providers/amazon/tests/unit/amazon/aws/triggers/test_ssm.py
+++ b/providers/amazon/tests/unit/amazon/aws/triggers/test_ssm.py
@@ -37,15 +37,17 @@ INSTANCE_ID_2 = "i-1234567890abcdef1"
 
 @pytest.fixture
 def mock_ssm_list_invocations():
-    def _setup(mock_async_conn):
+    def _setup(mock_get_async_conn):
         mock_client = mock.MagicMock()
-        mock_async_conn.__aenter__.return_value = mock_client
-        mock_client.list_command_invocations.return_value = {
-            "CommandInvocations": [
-                {"CommandId": COMMAND_ID, "InstanceId": INSTANCE_ID_1},
-                {"CommandId": COMMAND_ID, "InstanceId": INSTANCE_ID_2},
-            ]
-        }
+        mock_get_async_conn.return_value.__aenter__.return_value = mock_client
+        mock_client.list_command_invocations = mock.AsyncMock(
+            return_value={
+                "CommandInvocations": [
+                    {"CommandId": COMMAND_ID, "InstanceId": INSTANCE_ID_1},
+                    {"CommandId": COMMAND_ID, "InstanceId": INSTANCE_ID_2},
+                ]
+            }
+        )
         return mock_client
 
     return _setup
@@ -60,10 +62,10 @@ class TestSsmRunCommandTrigger:
         assert kwargs.get("command_id") == COMMAND_ID
 
     @pytest.mark.asyncio
-    @mock.patch.object(SsmHook, "async_conn")
+    @mock.patch.object(SsmHook, "get_async_conn")
     @mock.patch.object(SsmHook, "get_waiter")
-    async def test_run_success(self, mock_get_waiter, mock_async_conn, mock_ssm_list_invocations):
-        mock_client = mock_ssm_list_invocations(mock_async_conn)
+    async def test_run_success(self, mock_get_waiter, mock_get_async_conn, mock_ssm_list_invocations):
+        mock_client = mock_ssm_list_invocations(mock_get_async_conn)
         mock_get_waiter().wait = mock.AsyncMock(name="wait")
 
         trigger = SsmRunCommandTrigger(command_id=COMMAND_ID)
@@ -82,10 +84,10 @@ class TestSsmRunCommandTrigger:
         mock_client.list_command_invocations.assert_called_once_with(CommandId=COMMAND_ID)
 
     @pytest.mark.asyncio
-    @mock.patch.object(SsmHook, "async_conn")
+    @mock.patch.object(SsmHook, "get_async_conn")
     @mock.patch.object(SsmHook, "get_waiter")
-    async def test_run_fails(self, mock_get_waiter, mock_async_conn, mock_ssm_list_invocations):
-        mock_ssm_list_invocations(mock_async_conn)
+    async def test_run_fails(self, mock_get_waiter, mock_get_async_conn, mock_ssm_list_invocations):
+        mock_ssm_list_invocations(mock_get_async_conn)
         mock_get_waiter().wait.side_effect = WaiterError(
             "name", "terminal failure", {"CommandInvocations": [{"CommandId": COMMAND_ID}]}
         )


### PR DESCRIPTION
Currently the `example_ssm.py` test fails when the SSM operators are in `deferrable` mode.

First, we changed the sensor to use XCom templating instead of direct output reference because `run_command.output` isn't available at DAG parse time when using deferrable mode.

Second, we updated the SSM trigger to use the modern `get_async_conn()` method instead of the deprecated `async_conn` property and added proper async/await calls. 

These changes allow the test to work correctly with deferrable mode.