### PR TITLE
UI: switch DAG Run → Task Instances tab to FilterBar (pill UI)

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/RunTaskFilters.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/RunTaskFilters.tsx
@@ -1,0 +1,43 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF)...
+ */
+import { useMemo } from "react";
+import { FilterBar, type FilterValue } from "src/components/FilterBar";
+import { SearchParamsKeys } from "src/constants/searchParams";
+import { useFiltersHandler, type FilterableSearchParamsKeys } from "src/utils";
+
+export const RunTaskFilters = () => {
+  // Keep to keys supported by FilterBar & TaskInstances API mapping
+  const searchParamKeys = useMemo(
+    (): Array<FilterableSearchParamsKeys> => [
+      SearchParamsKeys.TASK_ID_PATTERN, // pill label "Task" (text)
+      SearchParamsKeys.START_DATE,   // date from
+      SearchParamsKeys.END_DATE,     // date to
+    ],
+    [],
+  );
+
+  const { filterConfigs, handleFiltersChange, searchParams } = useFiltersHandler(searchParamKeys);
+
+  const initialValues = useMemo(() => {
+    const values: Record<string, FilterValue> = {};
+
+    filterConfigs.forEach((cfg) => {
+      const raw = searchParams.get(cfg.key);
+
+      if (raw !== null && raw !== "") {
+        if (cfg.type === "number") {
+          const num = Number(raw);
+
+          values[cfg.key] = Number.isNaN(num) ? raw : num;
+        } else {
+          values[cfg.key] = raw;
+        }
+      }
+    });
+
+    return values;
+  }, [searchParams, filterConfigs]);
+
+  return <FilterBar configs={filterConfigs} initialValues={initialValues} onFiltersChange={handleFiltersChange} />;
+};

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/RunTaskFilters.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/RunTaskFilters.tsx
@@ -1,7 +1,23 @@
 /*!
- * Licensed to the Apache Software Foundation (ASF)...
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 import { useMemo } from "react";
+
 import { FilterBar, type FilterValue } from "src/components/FilterBar";
 import { SearchParamsKeys } from "src/constants/searchParams";
 import { useFiltersHandler, type FilterableSearchParamsKeys } from "src/utils";
@@ -11,8 +27,8 @@ export const RunTaskFilters = () => {
   const searchParamKeys = useMemo(
     (): Array<FilterableSearchParamsKeys> => [
       SearchParamsKeys.TASK_ID_PATTERN, // pill label "Task" (text)
-      SearchParamsKeys.START_DATE,   // date from
-      SearchParamsKeys.END_DATE,     // date to
+      SearchParamsKeys.START_DATE, // date from
+      SearchParamsKeys.END_DATE, // date to
     ],
     [],
   );
@@ -39,5 +55,7 @@ export const RunTaskFilters = () => {
     return values;
   }, [searchParams, filterConfigs]);
 
-  return <FilterBar configs={filterConfigs} initialValues={initialValues} onFiltersChange={handleFiltersChange} />;
+  return (
+    <FilterBar configs={filterConfigs} initialValues={initialValues} onFiltersChange={handleFiltersChange} />
+  );
 };

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
@@ -1,25 +1,9 @@
 /*!
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Licensed to the Apache Software Foundation (ASF)...
  */
 import { Flex, Link } from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
 import type { TFunction } from "i18next";
-import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link as RouterLink, useParams, useSearchParams } from "react-router-dom";
 
@@ -39,7 +23,7 @@ import { getDuration, useAutoRefresh, isStatePending } from "src/utils";
 import { getTaskInstanceLink } from "src/utils/links";
 
 import DeleteTaskInstanceButton from "./DeleteTaskInstanceButton";
-import { TaskInstancesFilter } from "./TaskInstancesFilter";
+import { RunTaskFilters } from "./RunTaskFilters";
 
 type TaskInstanceRow = { row: { original: TaskInstanceResponse } };
 
@@ -49,6 +33,7 @@ const {
   POOL: POOL_PARAM,
   START_DATE: START_DATE_PARAM,
   STATE: STATE_PARAM,
+  TASK_ID_PATTERN: TASK_ID_PATTERN_PARAM,
 }: SearchParamsKeysType = SearchParamsKeys;
 
 const taskInstanceColumns = ({
@@ -76,7 +61,6 @@ const taskInstanceColumns = ({
     : [
         {
           accessorKey: "run_after",
-          // If we don't show the taskId column, make the dag run a link to the task instance
           cell: ({ row: { original } }: TaskInstanceRow) =>
             Boolean(taskId) ? (
               <Link asChild color="fg.info" fontWeight="bold">
@@ -201,9 +185,9 @@ export const TaskInstances = () => {
   const hasFilteredState = filteredState.length > 0;
   const hasFilteredPool = pool.length > 0;
 
-  const [taskDisplayNamePattern, setTaskDisplayNamePattern] = useState(
-    searchParams.get(NAME_PATTERN_PARAM) ?? undefined,
-  );
+  // Read the pill value (name_pattern), but accept legacy task_id_pattern too.
+  const taskNamePattern =
+    searchParams.get(NAME_PATTERN_PARAM) ?? searchParams.get(TASK_ID_PATTERN_PARAM) ?? undefined;
 
   const refetchInterval = useAutoRefresh({});
 
@@ -218,7 +202,7 @@ export const TaskInstances = () => {
       pool: hasFilteredPool ? pool : undefined,
       startDateGte: startDate ?? undefined,
       state: hasFilteredState ? filteredState : undefined,
-      taskDisplayNamePattern: groupId ?? taskDisplayNamePattern ?? undefined,
+      taskDisplayNamePattern: groupId ?? taskNamePattern ?? undefined,
       taskId: Boolean(groupId) ? undefined : taskId,
     },
     undefined,
@@ -230,10 +214,9 @@ export const TaskInstances = () => {
 
   return (
     <>
-      <TaskInstancesFilter
-        setTaskDisplayNamePattern={setTaskDisplayNamePattern}
-        taskDisplayNamePattern={taskDisplayNamePattern}
-      />
+      {/* Pill-based FilterBar for Task name + From/To */}
+      <RunTaskFilters />
+
       <DataTable
         columns={taskInstanceColumns({
           dagId,

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
@@ -1,6 +1,22 @@
 /*!
- * Licensed to the Apache Software Foundation (ASF)...
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
+
 import { Flex, Link } from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
 import type { TFunction } from "i18next";


### PR DESCRIPTION
### Why

- Standardise on the new pill-based FilterBar to reduce vertical space and match XCom/Events UX.

- Keep URL ↔ UI sync so filters are shareable/deeplinkable.

### What

- Replace the legacy filters on DAG Run → Task Instances with the reusable FilterBar.

- New component: RunTaskFilters.tsx (text + date pills).

- URL parameters handled via useFiltersHandler:

- name_pattern → passed to API as taskDisplayNamePattern

- start_date / end_date → mapped to API’s start_date_gte / end_date_lte

- No backend/API changes, no translation surface area changes.

### Scope

- Only the Task Instances tab under a DAG Run.

- Other DAG Run sub-pages will be migrated in next commits

### Testing**

- pnpm run lint + tsc --noEmit pass locally.

- Manual in Breeze:

1. Go to a DAG Run → Tasks tab.
2. Click + Filter → add Task Name; type cli_.

 Network shows:
/api/v2/dags/~/dagRuns/~/taskInstances?task_display_name_pattern=cli_…

3. Add From/To pills; network includes start_date_gte / end_date_lte.

4.Remove pills or click Reset → URL/query clears and results reset.

### Backward compatibility

- Preserves existing date query keys; adds name_pattern for task display name search.

- No UI breaking changes; the table and actions are unchanged.

Screenshots

<img width="1352" height="651" alt="Screenshot 2025-09-15 at 1 26 28 AM" src="https://github.com/user-attachments/assets/af191d1f-c2b1-4cf6-be66-140ab47fe30e" />





<img width="1352" height="651" alt="Screenshot 2025-09-15 at 1 26 36 AM" src="https://github.com/user-attachments/assets/b38b94f9-9388-414a-bf53-9984752ea65a" />


related: #55520 
