### PR TITLE
UI: Align padding and border radius in Assets View

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/Assets/AssetEvents.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Assets/AssetEvents.tsx
@@ -69,7 +69,7 @@ export const AssetEvents = ({
   });
 
   return (
-    <Box borderBottomWidth={0} borderRadius={5} borderWidth={1} p={4} py={2} {...rest}>
+    <Box borderBottomWidth={0} borderRadius={8} borderWidth={1} p={4} py={2} {...rest}>
       <Flex alignItems="center" justify="space-between">
         <HStack>
           <StateBadge colorPalette="brand" fontSize="md" variant="solid">

--- a/airflow-core/src/airflow/ui/src/components/HeaderCard.tsx
+++ b/airflow-core/src/airflow/ui/src/components/HeaderCard.tsx
@@ -38,7 +38,7 @@ export const HeaderCard = ({ actions, icon, isRefreshing, state, stats, subTitle
   const { t: translate } = useTranslation();
 
   return (
-    <Box borderColor="border.emphasized" borderRadius={8} borderWidth={1} ml={2} p={2}>
+    <Box borderColor="border.emphasized" borderRadius={8} borderWidth={1} p={2}>
       <Flex alignItems="center" flexWrap="wrap" justifyContent="space-between" mb={2}>
         <Flex alignItems="center" flexWrap="wrap" gap={2}>
           <Heading size="xl">{icon}</Heading>


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
## Why
Currently, the header and Asset Events components have inconsistent padding and different border radii. 

## What
This PR updates them to be consistent for a cleaner UI.

Before
<img width="411" height="272" alt="image" src="https://github.com/user-attachments/assets/f8346d19-d7e2-49d9-ac36-5ec8ab072c26" />

After
<img width="411" height="280" alt="image" src="https://github.com/user-attachments/assets/8dfb7855-9ed9-4731-8491-b610ef5d1d03" />




<!-- Please keep an empty line above the dashes. -->
---

