### PR TITLE
Fix task instance display in task group grid view

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/services/ui/grid.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/ui/grid.py
@@ -98,28 +98,26 @@ def _find_aggregates(
             "type": "mapped_task",
             "parent_id": parent_id,
             **_get_aggs_for_node(mapped_details),
+            "details": mapped_details,
         }
 
         return
     if isinstance(node, SerializedTaskGroup):
-        children = []
+        children_details = []
         for child in get_task_group_children_getter()(node):
             for child_node in _find_aggregates(node=child, parent_node=node, ti_details=ti_details):
                 if child_node["parent_id"] == node_id:
-                    children.append(
-                        {
-                            "state": child_node["state"],
-                            "start_date": child_node["min_start_date"],
-                            "end_date": child_node["max_end_date"],
-                        }
-                    )
+                    # Collect detailed task instance data from all children
+                    if child_node.get("details"):
+                        children_details.extend(child_node["details"])
                 yield child_node
         if node_id:
             yield {
                 "task_id": node_id,
                 "type": "group",
                 "parent_id": parent_id,
-                **_get_aggs_for_node(children),
+                **_get_aggs_for_node(children_details),
+                "details": children_details,
             }
         return
     if isinstance(node, SerializedBaseOperator):
@@ -128,5 +126,6 @@ def _find_aggregates(
             "type": "task",
             "parent_id": parent_id,
             **_get_aggs_for_node(details),
+            "details": details,
         }
         return

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_grid.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_grid.py
@@ -614,7 +614,7 @@ class TestGetGridDataEndpoint:
                     "min_start_date": None,
                 },
                 {
-                    "child_states": {"success": 2},
+                    "child_states": {"success": 4},
                     "max_end_date": "2025-03-02T00:00:12Z",
                     "min_start_date": "2025-03-02T00:00:04Z",
                     "state": "success",
@@ -687,7 +687,7 @@ class TestGetGridDataEndpoint:
                 "state": None,
             },
             {
-                "child_states": {"running": 1},
+                "child_states": {"success": 1, "running": 1, "None": 1},
                 "max_end_date": "2024-12-30T01:02:03Z",
                 "min_start_date": "2024-12-30T01:00:00Z",
                 "state": "running",
@@ -708,14 +708,14 @@ class TestGetGridDataEndpoint:
                 "min_start_date": None,
             },
             {
-                "child_states": {"None": 2},
+                "child_states": {"None": 6},
                 "task_id": "task_group",
                 "max_end_date": None,
                 "min_start_date": None,
                 "state": None,
             },
             {
-                "child_states": {"None": 1},
+                "child_states": {"None": 2},
                 "task_id": "task_group.inner_task_group",
                 "max_end_date": None,
                 "min_start_date": None,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #55319 

## Problem Summary
When checking the status of a task group in the grid view: 
1. The header only shows the # of abstract tasks in mapped task group (e..g, `3 tasks` instead of `40 tasks`).
2. The task instances list has no results. (**This will be addressed in a separate MR**)

## Proposed Solution
### For Issue 1
- When child nodes have `child_states` (mapped tasks), now we expand and count each state of individual task instances rather than treating them as one abstract task

~~### For Issue 2~~
~~- First we check whether the task name pattern is a task group ID~~
~~- Next we resolve this pattern to all task ids within the group~~
~~- So whenever we encounter a task group, we query task instances by filtering on the task ids extracted from last step other than using the original name pattern.~~

## After the Fix

https://github.com/user-attachments/assets/2618d1f0-a4a2-45ea-87ae-f2bacc84cd2e

### Running result on 2025-10-29
<img width="2094" height="753" alt="image" src="https://github.com/user-attachments/assets/a9386d36-a3de-4ac3-a19b-39931c5b9796" />



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
