### PR TITLE
Validate plugins in /plugins API and skip invalid ones with warnings

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/plugins.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/plugins.py
@@ -55,9 +55,9 @@ def get_plugins(
             valid_plugins.append(plugin)
         except ValidationError as e:
             logger.warning(
-                "Skipping invalid plugin %s due to error: %s",
-                plugin_dict.get("name", "<unknown>"),
-                e,
+                "Skipping invalid plugin due to error",
+                plugin_name=plugin_dict.get("name", "<unknown>"),
+                error=str(e),
             )
             continue
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/plugins.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/plugins.py
@@ -17,7 +17,6 @@
 
 from __future__ import annotations
 
-import logging
 
 from fastapi import Depends
 from pydantic import ValidationError

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/plugins.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/plugins.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 
+import structlog
 from fastapi import Depends
 from pydantic import ValidationError
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/plugins.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/plugins.py
@@ -33,7 +33,7 @@ from airflow.api_fastapi.core_api.datamodels.plugins import (
 )
 from airflow.api_fastapi.core_api.security import requires_access_view
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 plugins_router = AirflowRouter(tags=["Plugin"], prefix="/plugins")
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/plugins.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/plugins.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import logging
 
 from fastapi import Depends
+from pydantic import ValidationError
 
 from airflow import plugins_manager
 from airflow.api_fastapi.auth.managers.models.resource_details import AccessView
@@ -52,7 +53,7 @@ def get_plugins(
             # Validate each plugin individually
             plugin = PluginResponse.model_validate(plugin_dict)
             valid_plugins.append(plugin)
-        except Exception as e:
+        except ValidationError as e:
             logger.warning(
                 "Skipping invalid plugin %s due to error: %s",
                 plugin_dict.get("name", "<unknown>"),

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/plugins.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/plugins.py
@@ -17,7 +17,6 @@
 
 from __future__ import annotations
 
-
 import structlog
 from fastapi import Depends
 from pydantic import ValidationError
@@ -48,7 +47,7 @@ def get_plugins(
 ) -> PluginCollectionResponse:
     plugins_info = sorted(plugins_manager.get_plugin_info(), key=lambda x: x["name"])
     valid_plugins: list[PluginResponse] = []
-    for plugin_dict in plugins_info[offset.value :][: limit.value]:
+    for plugin_dict in plugins_info:
         try:
             # Validate each plugin individually
             plugin = PluginResponse.model_validate(plugin_dict)
@@ -61,9 +60,13 @@ def get_plugins(
             )
             continue
 
+    offset_value = offset.value or 0
+    limit_value = limit.value if limit.value is not None else len(valid_plugins)
+
+    paginated_plugins = valid_plugins[offset_value : offset_value + limit_value]
     return PluginCollectionResponse(
-        plugins=valid_plugins,
-        total_entries=len(plugins_info),
+        plugins=paginated_plugins,
+        total_entries=len(valid_plugins),
     )
 
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_plugins.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_plugins.py
@@ -134,10 +134,7 @@ class TestGetPlugins:
         assert "test_plugin_invalid" not in plugin_names
 
         # Verify warning was logged
-        assert any(
-            "Skipping invalid plugin test_plugin_invalid due to error:" in rec.message
-            for rec in caplog.records
-        )
+        assert any("Skipping invalid plugin due to error" in rec.message for rec in caplog.records)
 
 
 @skip_if_force_lowest_dependencies_marker

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_plugins.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_plugins.py
@@ -33,7 +33,7 @@ class TestGetPlugins:
             # Filters
             (
                 {},
-                14,
+                13,
                 [
                     "MetadataCollectionPlugin",
                     "OpenLineageProviderPlugin",
@@ -52,10 +52,10 @@ class TestGetPlugins:
             ),
             (
                 {"limit": 3, "offset": 2},
-                14,
+                13,
                 ["databricks_workflow", "decreasing_priority_weight_strategy_plugin", "edge_executor"],
             ),
-            ({"limit": 1}, 14, ["MetadataCollectionPlugin"]),
+            ({"limit": 1}, 13, ["MetadataCollectionPlugin"]),
         ],
     )
     def test_should_respond_200(
@@ -135,6 +135,18 @@ class TestGetPlugins:
 
         # Verify warning was logged
         assert any("Skipping invalid plugin due to error" in rec.message for rec in caplog.records)
+
+        response = test_client.get("/plugins", params={"limit": 5, "offset": 9})
+        assert response.status_code == 200
+
+        body = response.json()
+        plugins_page = body["plugins"]
+
+        # Even though limit=5, only 4 valid plugins should come back
+        assert len(plugins_page) == 4
+        assert "test_plugin_invalid" not in [p["name"] for p in plugins_page]
+
+        assert body["total_entries"] == 13
 
 
 @skip_if_force_lowest_dependencies_marker

--- a/airflow-core/tests/unit/plugins/test_plugin.py
+++ b/airflow-core/tests/unit/plugins/test_plugin.py
@@ -183,3 +183,18 @@ class AirflowTestOnLoadPlugin(AirflowPlugin):
 
     def on_load(self, *args, **kwargs):
         self.name = "postload"
+
+
+# Example external view with invalid destination
+external_view_with_invalid_destination = {
+    "name": "Invalid External View",
+    "href": "https://example.com/invalid",
+    "url_route": "invalid_external_view",
+    "destination": "Assets",  # <-- invalid destination
+    "icon": "book",
+}
+
+
+class AirflowTestPluginInvalid(AirflowPlugin):
+    name = "test_plugin_invalid"
+    external_views = [external_view_with_invalid_destination]

--- a/airflow-core/tests/unit/plugins/test_plugins_manager.py
+++ b/airflow-core/tests/unit/plugins/test_plugins_manager.py
@@ -94,7 +94,7 @@ class TestPluginsManager:
         with mock.patch("airflow.plugins_manager.plugins", []):
             plugins_manager.load_plugins_from_plugin_directory()
 
-            assert len(plugins_manager.plugins) == 9
+            assert len(plugins_manager.plugins) == 10
             for plugin in plugins_manager.plugins:
                 if "AirflowTestOnLoadPlugin" in str(plugin):
                     assert plugin.name == "postload"


### PR DESCRIPTION
This PR fixes an issue where an invalid plugin definition (e.g., an unsupported destination in external_views) caused the entire /plugins API endpoint to fail with a 500.

Closes : https://github.com/apache/airflow/issues/55571

With this change:

Added validation when constructing PluginResponse objects.

Only valid plugins are returned in the /api/v2/plugins API response.

Invalid plugins are skipped gracefully.

A warning is logged in the terminal with the plugin name and the error details.

This ensures the UI remains functional even if some plugins are misconfigured.


Impact:
- Prevents the entire /plugins API from failing due to a single invalid plugin.
- Users will continue to see all valid plugins in the UI, while still being informed about invalid ones through logs.
  
Attached screenshot for reference 
<img width="1438" height="1102" alt="Screenshot from 2025-09-15 17-49-50" src="https://github.com/user-attachments/assets/63fab837-b78f-4e8f-90ca-8be91d320c7e" />
  


