### PR TITLE
Override `get_authorized_connections`, `get_authorized_pools` and `get_authorized_variables` in Fab auth manager

### DIFF
--- a/providers/fab/tests/unit/fab/auth_manager/test_fab_auth_manager.py
+++ b/providers/fab/tests/unit/fab/auth_manager/test_fab_auth_manager.py
@@ -686,6 +686,12 @@ class TestFabAuthManager:
         result = auth_manager.filter_authorized_menu_items(menu_items, user=user)
         assert result == expected_result
 
+    def test_get_authorized_connections(self, auth_manager):
+        session = Mock()
+        session.execute.return_value.scalars.return_value.all.return_value = ["conn1", "conn2"]
+        result = auth_manager.get_authorized_connections(user=Mock(), method="GET", session=session)
+        assert result == {"conn1", "conn2"}
+
     @pytest.mark.parametrize(
         "method, user_permissions, expected_results",
         [
@@ -777,6 +783,18 @@ class TestFabAuthManager:
         assert results == expected_results
 
         delete_user(flask_app, "username")
+
+    def test_get_authorized_pools(self, auth_manager):
+        session = Mock()
+        session.execute.return_value.scalars.return_value.all.return_value = ["pool1", "pool2"]
+        result = auth_manager.get_authorized_pools(user=Mock(), method="GET", session=session)
+        assert result == {"pool1", "pool2"}
+
+    def test_get_authorized_variables(self, auth_manager):
+        session = Mock()
+        session.execute.return_value.scalars.return_value.all.return_value = ["var1", "var2"]
+        result = auth_manager.get_authorized_variables(user=Mock(), method="GET", session=session)
+        assert result == {"var1", "var2"}
 
     def test_security_manager_return_fab_security_manager_override(self, auth_manager_with_appbuilder):
         assert isinstance(auth_manager_with_appbuilder.security_manager, FabAirflowSecurityManagerOverride)


### PR DESCRIPTION
Fab auth manager does not allow fine-grained access with connections, pools and variables. Thus, override these methods in Fab auth manager to avoid unnecessary complexity.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
