### PR TITLE
chore: safeguard external call in OL sqlparser

### DIFF
--- a/providers/openlineage/src/airflow/providers/openlineage/sqlparser.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/sqlparser.py
@@ -232,8 +232,8 @@ class SQLParser(LoggingMixin):
             else None,
         )
 
+    @staticmethod
     def get_metadata_from_parser(
-        self,
         inputs: list[DbTableMeta],
         outputs: list[DbTableMeta],
         database_info: DatabaseInfo,
@@ -315,6 +315,7 @@ class SQLParser(LoggingMixin):
         :param database_info: database specific information
         :param database: when passed it takes precedence over parsed database name
         :param sqlalchemy_engine: when passed, engine's dialect is used to compile SQL queries
+        :param use_connection: if call to db should be performed to enrich datasets (e.g., with schema)
         """
         job_facets: dict[str, JobFacet] = {"sql": sql_job.SQLJobFacet(query=self.normalize_sql(sql))}
         parse_result = self.parse(sql=self.split_sql_string(sql))
@@ -338,17 +339,28 @@ class SQLParser(LoggingMixin):
             )
 
         namespace = self.create_namespace(database_info=database_info)
+        inputs: list[Dataset] = []
+        outputs: list[Dataset] = []
         if use_connection:
-            inputs, outputs = self.parse_table_schemas(
-                hook=hook,
-                inputs=parse_result.in_tables,
-                outputs=parse_result.out_tables,
-                namespace=namespace,
-                database=database,
-                database_info=database_info,
-                sqlalchemy_engine=sqlalchemy_engine,
-            )
-        else:
+            try:
+                inputs, outputs = self.parse_table_schemas(
+                    hook=hook,
+                    inputs=parse_result.in_tables,
+                    outputs=parse_result.out_tables,
+                    namespace=namespace,
+                    database=database,
+                    database_info=database_info,
+                    sqlalchemy_engine=sqlalchemy_engine,
+                )
+            except Exception as e:
+                self.log.warning(
+                    "OpenLineage method failed to enrich datasets using db metadata. Exception: `%s`",
+                    e,
+                )
+                self.log.debug("OpenLineage failure details:", exc_info=True)
+
+        # If call to db failed or was not performed, use datasets from sql parsing alone
+        if not inputs and not outputs:
             inputs, outputs = self.get_metadata_from_parser(
                 inputs=parse_result.in_tables,
                 outputs=parse_result.out_tables,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
When doing SQL parsing, OpenLineage can call external DB to get table schemas and other details. If that call fails, we should not crash the entire OL emission but fall back to non-rich results of sql parsing. This PR achieves that.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
