### PR TITLE
Tweak the layout and display of groups in Task Logs

### DIFF
--- a/airflow-core/src/airflow/ui/package.json
+++ b/airflow-core/src/airflow/ui/package.json
@@ -53,7 +53,6 @@
     "react-hotkeys-hook": "^4.6.1",
     "react-i18next": "^15.5.1",
     "react-icons": "^5.5.0",
-    "react-innertext": "^1.1.5",
     "react-json-view": "^1.21.3",
     "react-markdown": "^9.1.0",
     "react-resizable-panels": "^2.1.7",

--- a/airflow-core/src/airflow/ui/pnpm-lock.yaml
+++ b/airflow-core/src/airflow/ui/pnpm-lock.yaml
@@ -110,9 +110,6 @@ importers:
       react-icons:
         specifier: ^5.5.0
         version: 5.5.0(react@19.1.1)
-      react-innertext:
-        specifier: ^1.1.5
-        version: 1.1.5(@types/react@18.3.19)(react@19.1.1)
       react-json-view:
         specifier: ^1.21.3
         version: 1.21.3(@types/react@18.3.19)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -3847,12 +3844,6 @@ packages:
     resolution: {integrity: sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==}
     peerDependencies:
       react: '*'
-
-  react-innertext@1.1.5:
-    resolution: {integrity: sha512-PWAqdqhxhHIv80dT9znP2KvS+hfkbRovFp4zFYHFFlOoQLRiawIic81gKb3U1wEyJZgMwgs3JoLtwryASRWP3Q==}
-    peerDependencies:
-      '@types/react': '>=0.0.0 <=99'
-      react: '>=0.0.0 <=99'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -9372,11 +9363,6 @@ snapshots:
 
   react-icons@5.5.0(react@19.1.1):
     dependencies:
-      react: 19.1.1
-
-  react-innertext@1.1.5(@types/react@18.3.19)(react@19.1.1):
-    dependencies:
-      '@types/react': 18.3.19
       react: 19.1.1
 
   react-is@16.13.1: {}

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/components.json
@@ -87,6 +87,7 @@
   },
   "limitedList": "+{{count}} more",
   "logs": {
+    "endGroup": "End of {{group}}",
     "file": "File",
     "location": "line {{line}} in {{name}}"
   },

--- a/airflow-core/src/airflow/ui/src/components/renderStructuredLog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/renderStructuredLog.tsx
@@ -178,11 +178,13 @@ export const renderStructuredLog = ({
     });
   }
 
-  elements.push(
-    <chakra.span className="event" key={2} whiteSpace="pre-wrap">
-      {addLinks(event)}
-    </chakra.span>,
-  );
+  if (!event.startsWith("::group::")) {
+    elements.push(
+      <chakra.span className="event" key={2} whiteSpace="pre-wrap">
+        {addLinks(event)}
+      </chakra.span>,
+    );
+  }
 
   if (Object.hasOwn(reStructured, "filename") && Object.hasOwn(reStructured, "lineno")) {
     // eslint-disable-next-line @typescript-eslint/restrict-template-expressions


### PR DESCRIPTION
- Show the timestamp of the log start of group log message

- Add an explicit end of group marker, that when clicked collapses the group.

  Since the "source" message is an empty group and every log has this group,
  we don't include the end of group if there is only one thing in the group

- Don't show "other properties" on the group header, only when they are
  expanded.

  This fixes the wart where the "Log message source details" was expandable,
  but contained nothing.

  It now has a shorter message to start with and expands to show more info

# 🖼️ 

**Before** (note the `filename=` and `lineno=`)
<img width="1321" height="370" alt="Screenshot 2025-09-15 at 18 50 29" src="https://github.com/user-attachments/assets/c3b0551e-6a95-446b-b084-bb307844123b" />

**After**

<img width="1316" height="374" alt="Screenshot 2025-09-15 at 18 54 01" src="https://github.com/user-attachments/assets/69e02f68-febe-40cb-9a2f-306308c75897" />


**Before (expanded)**


<img width="1309" height="651" alt="Screenshot 2025-09-15 at 18 51 25" src="https://github.com/user-attachments/assets/c30a47a7-2c72-4181-859d-1ed0b18b9436" />

**After (expanded)**

<img width="1322" height="724" alt="Screenshot 2025-09-15 at 18 43 53" src="https://github.com/user-attachments/assets/017cbb05-11a7-43ca-9cc4-7f4d9ad1f1b3" />