### PR TITLE
Add delete button for dag runs in more options menu

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/DeleteRunButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DeleteRunButton.tsx
@@ -16,9 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useDisclosure } from "@chakra-ui/react";
+import { Box, type ButtonProps, useDisclosure } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 import { FiTrash2 } from "react-icons/fi";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import type { DAGRunResponse } from "openapi/requests/types.gen";
 import DeleteDialog from "src/components/DeleteDialog";
@@ -28,29 +29,36 @@ import { useDeleteDagRun } from "src/queries/useDeleteDagRun";
 type DeleteRunButtonProps = {
   readonly dagRun: DAGRunResponse;
   readonly withText?: boolean;
-};
+} & ButtonProps;
 
-const DeleteRunButton = ({ dagRun, withText = true }: DeleteRunButtonProps) => {
+const DeleteRunButton = ({ dagRun, width, withText = true }: DeleteRunButtonProps) => {
   const { onClose, onOpen, open } = useDisclosure();
+  const navigate = useNavigate();
+  const location = useLocation();
   const { t: translate } = useTranslation();
+
+  const isOnRunDetailPage = location.pathname.includes(`/dags/${dagRun.dag_id}/runs/${dagRun.dag_run_id}`);
 
   const { isPending, mutate: deleteDagRun } = useDeleteDagRun({
     dagId: dagRun.dag_id,
     dagRunId: dagRun.dag_run_id,
     onSuccessConfirm: () => {
       onClose();
+      if (isOnRunDetailPage) {
+        navigate(`/dags/${dagRun.dag_id}/runs`);
+      }
     },
   });
 
   return (
-    <>
+    <Box width={width}>
       <ActionButton
         actionName={translate("dags:runAndTaskActions.delete.button", { type: translate("dagRun_one") })}
         colorPalette="danger"
         icon={<FiTrash2 />}
         onClick={onOpen}
         text={translate("dags:runAndTaskActions.delete.button", { type: translate("dagRun_one") })}
-        variant="solid"
+        width={width}
         withText={withText}
       />
 
@@ -73,7 +81,7 @@ const DeleteRunButton = ({ dagRun, withText = true }: DeleteRunButtonProps) => {
           type: translate("dagRun_one"),
         })}
       />
-    </>
+    </Box>
   );
 };
 

--- a/airflow-core/src/airflow/ui/src/pages/DeleteRunButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DeleteRunButton.tsx
@@ -29,9 +29,9 @@ import { useDeleteDagRun } from "src/queries/useDeleteDagRun";
 type DeleteRunButtonProps = {
   readonly dagRun: DAGRunResponse;
   readonly withText?: boolean;
-} & ButtonProps;
+} & Omit<ButtonProps, "colorPalette" | "onClick" | "variant">;
 
-const DeleteRunButton = ({ dagRun, width, withText = true }: DeleteRunButtonProps) => {
+const DeleteRunButton = ({ dagRun, withText = true, ...rest }: DeleteRunButtonProps) => {
   const { onClose, onOpen, open } = useDisclosure();
   const navigate = useNavigate();
   const location = useLocation();
@@ -58,8 +58,8 @@ const DeleteRunButton = ({ dagRun, width, withText = true }: DeleteRunButtonProp
         icon={<FiTrash2 />}
         onClick={onOpen}
         text={translate("dags:runAndTaskActions.delete.button", { type: translate("dagRun_one") })}
-        width={width}
         withText={withText}
+        {...rest}
       />
 
       <DeleteDialog

--- a/airflow-core/src/airflow/ui/src/pages/DeleteRunButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DeleteRunButton.tsx
@@ -28,10 +28,11 @@ import { useDeleteDagRun } from "src/queries/useDeleteDagRun";
 
 type DeleteRunButtonProps = {
   readonly dagRun: DAGRunResponse;
+  readonly variant?: string;
   readonly withText?: boolean;
 } & Omit<ButtonProps, "colorPalette" | "onClick" | "variant">;
 
-const DeleteRunButton = ({ dagRun, withText = true, ...rest }: DeleteRunButtonProps) => {
+const DeleteRunButton = ({ dagRun, variant, withText = true, ...rest }: DeleteRunButtonProps) => {
   const { onClose, onOpen, open } = useDisclosure();
   const navigate = useNavigate();
   const location = useLocation();
@@ -58,6 +59,7 @@ const DeleteRunButton = ({ dagRun, withText = true, ...rest }: DeleteRunButtonPr
         icon={<FiTrash2 />}
         onClick={onOpen}
         text={translate("dags:runAndTaskActions.delete.button", { type: translate("dagRun_one") })}
+        variant={variant}
         withText={withText}
         {...rest}
       />

--- a/airflow-core/src/airflow/ui/src/pages/DeleteRunButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DeleteRunButton.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, type ButtonProps, useDisclosure } from "@chakra-ui/react";
+import { type ButtonProps, useDisclosure } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 import { FiTrash2 } from "react-icons/fi";
 import { useLocation, useNavigate } from "react-router-dom";
@@ -51,7 +51,7 @@ const DeleteRunButton = ({ dagRun, width, withText = true }: DeleteRunButtonProp
   });
 
   return (
-    <Box width={width}>
+    <>
       <ActionButton
         actionName={translate("dags:runAndTaskActions.delete.button", { type: translate("dagRun_one") })}
         colorPalette="danger"
@@ -81,7 +81,7 @@ const DeleteRunButton = ({ dagRun, width, withText = true }: DeleteRunButtonProp
           type: translate("dagRun_one"),
         })}
       />
-    </Box>
+    </>
   );
 };
 

--- a/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
@@ -102,7 +102,9 @@ export const Header = ({
                 <Menu.Positioner>
                   <Menu.Content>
                     <Menu.Item closeOnSelect={false} value="delete">
-                      <DeleteRunButton dagRun={dagRun} width="100%" withText={true} />
+                      <Box width="100%">
+                        <DeleteRunButton dagRun={dagRun} width="100%" withText={true} />
+                      </Box>
                     </Menu.Item>
                   </Menu.Content>
                 </Menu.Positioner>

--- a/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
@@ -16,10 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { HStack, Text, Box, Link } from "@chakra-ui/react";
+import { HStack, Text, Box, Link, Button, Menu, Portal } from "@chakra-ui/react";
 import { useCallback, useState, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { FiBarChart } from "react-icons/fi";
+import { LuMenu } from "react-icons/lu";
 import { Link as RouterLink } from "react-router-dom";
 
 import type { DAGRunResponse } from "openapi/requests/types.gen";
@@ -32,6 +33,7 @@ import { MarkRunAsButton } from "src/components/MarkAs";
 import { RunTypeIcon } from "src/components/RunTypeIcon";
 import Time from "src/components/Time";
 import { SearchParamsKeys } from "src/constants/searchParams";
+import DeleteRunButton from "src/pages/DeleteRunButton";
 import { usePatchDagRun } from "src/queries/usePatchDagRun";
 import { getDuration, useContainerWidth } from "src/utils";
 
@@ -90,6 +92,22 @@ export const Header = ({
             />
             <ClearRunButton dagRun={dagRun} isHotkeyEnabled withText={containerWidth > 700} />
             <MarkRunAsButton dagRun={dagRun} isHotkeyEnabled withText={containerWidth > 700} />
+            <Menu.Root>
+              <Menu.Trigger asChild>
+                <Button aria-label={translate("dag:header.buttons.advanced")} variant="outline">
+                  <LuMenu />
+                </Button>
+              </Menu.Trigger>
+              <Portal>
+                <Menu.Positioner>
+                  <Menu.Content>
+                    <Menu.Item closeOnSelect={false} value="delete">
+                      <DeleteRunButton dagRun={dagRun} width="100%" withText={true} />
+                    </Menu.Item>
+                  </Menu.Content>
+                </Menu.Positioner>
+              </Portal>
+            </Menu.Root>
           </>
         }
         icon={<FiBarChart />}


### PR DESCRIPTION
- Add 'more options' hamburger menu button next to 'Mark Dag Run as' dropdown in dag run header
- Move delete functionality into the more options menu following the same pattern as dag header
- Update DeleteRunButton styling to match delete dag button theme (remove solid variant, add Box wrapper)
- Add conditional navigation: only navigate to /dags/<dag_id>/runs when deleting from specific run detail page

<img width="1910" height="747" alt="image" src="https://github.com/user-attachments/assets/92434524-fdd0-4c01-a251-0fcde8af8ace" />

<img width="1917" height="737" alt="image" src="https://github.com/user-attachments/assets/6704aa62-ebda-4072-8841-0d92c51df65a" />
