### PR TITLE
Dev: Fix another Python 3.13 compat for Prod image tests

### DIFF
--- a/docker-tests/tests/docker_tests/test_prod_image.py
+++ b/docker-tests/tests/docker_tests/test_prod_image.py
@@ -209,7 +209,8 @@ class TestPythonPackages:
                 image=default_docker_image,
             )
             if python_version.startswith("Python 3.13"):
-                import_names.remove("airflow.providers.fab")
+                if "airflow.providers.fab" in import_names:
+                    import_names.remove("airflow.providers.fab")
         run_python_in_docker(f"import {','.join(import_names)}", image=default_docker_image)
 
     def test_there_is_no_opt_airflow_airflow_folder(self, default_docker_image):


### PR DESCRIPTION
Example failure: https://github.com/apache/airflow/actions/runs/17748671388/job/50439223767

```
              if python_version.startswith("Python 3.13"):
  >               import_names.remove("airflow.providers.fab")
  E               ValueError: list.remove(x): x not in list
  tests/docker_tests/test_prod_image.py:212: ValueError
  =========================== short test summary info ============================
  FAILED tests/docker_tests/test_prod_image.py::TestPythonPackages::test_check_dependencies_imports[providers-import_names0] - ValueError: list.remove(x): x not in list
  ======================== 1 failed, 10 passed in 32.41s =========================
```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
