### PR TITLE
Fix redirection to 'next' url raises an unsafe error

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/security.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/security.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, cast
-from urllib.parse import ParseResult, quote, unquote, urljoin, urlparse
+from urllib.parse import ParseResult, unquote, urljoin, urlparse
 
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPBearer, OAuth2PasswordBearer
@@ -618,16 +618,12 @@ def is_safe_url(target_url: str, request: Request | None = None) -> bool:
     if base_url := conf.get("api", "base_url", fallback=None):
         parsed_bases += ((base_url, urlparse(base_url)),)
 
-    # Check if the target URL is encoded, and unquote it when it is the same as the known base URL
-    if any(quote(base, safe="") == target_url for base, _ in parsed_bases if base is not None):
-        target_url = unquote(target_url)
-
     if not parsed_bases:
         # Can't enforce any security check.
         return True
 
     for base_url, parsed_base in parsed_bases:
-        parsed_target = urlparse(urljoin(base_url, target_url))  # Resolves relative URLs
+        parsed_target = urlparse(urljoin(base_url, unquote(target_url)))  # Resolves relative URLs
 
         target_path = Path(parsed_target.path).resolve()
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/security.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/security.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, cast
-from urllib.parse import ParseResult, urljoin, urlparse
+from urllib.parse import ParseResult, quote, unquote, urljoin, urlparse
 
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPBearer, OAuth2PasswordBearer
@@ -617,6 +617,10 @@ def is_safe_url(target_url: str, request: Request | None = None) -> bool:
         parsed_bases += ((url, urlparse(url)),)
     if base_url := conf.get("api", "base_url", fallback=None):
         parsed_bases += ((base_url, urlparse(base_url)),)
+
+    # Check if the target URL is encoded, and unquote it when it is the same as the known base URL
+    if any(quote(base, safe="") == target_url for base, _ in parsed_bases if base is not None):
+        target_url = unquote(target_url)
 
     if not parsed_bases:
         # Can't enforce any security check.

--- a/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
@@ -166,6 +166,21 @@ class TestFastApiSecurity:
         request.base_url = "https://requesting_server_base_url.com/prefix2"
         assert is_safe_url(url, request=request) == expected_is_safe
 
+    @pytest.mark.parametrize(
+        "url, expected_is_safe",
+        [
+            ("https://server_base_url.com/prefix", False),
+            ("https://requesting_server_base_url.com/prefix2", True),
+            ("prefix/some_other", False),
+            ("https%3A%2F%2Fserver_base_url.com%2Fprefix", False),
+            ("https%3A%2F%2Frequesting_server_base_url.com%2Fprefix2", True),
+        ],
+    )
+    def test_is_safe_url_with_base_url_unset(self, url, expected_is_safe):
+        request = Mock()
+        request.base_url = "https://requesting_server_base_url.com/prefix2"
+        assert is_safe_url(url, request=request) == expected_is_safe
+
     @pytest.mark.db_test
     @pytest.mark.parametrize(
         "team_name",

--- a/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
@@ -158,6 +158,8 @@ class TestFastApiSecurity:
             ("https%3A%2F%2Frequesting_server_base_url.com%2Fprefix2", True),
             ("https%3A%2F%2Fserver_base_url.com%2Fprefix", True),
             ("https%3A%2F%2Fsome_netlock.com%2Fprefix%2Fsome_page%3Fwith_param%3D3", False),
+            ("https%3A%2F%2Frequesting_server_base_url.com%2Fprefix2%2Fsub_path", True),
+            ("%2F..%2F..%2F..%2F..%2Fsome_page%3Fwith_param%3D3", False),
         ],
     )
     @conf_vars({("api", "base_url"): "https://server_base_url.com/prefix"})
@@ -174,6 +176,8 @@ class TestFastApiSecurity:
             ("prefix/some_other", False),
             ("https%3A%2F%2Fserver_base_url.com%2Fprefix", False),
             ("https%3A%2F%2Frequesting_server_base_url.com%2Fprefix2", True),
+            ("https%3A%2F%2Frequesting_server_base_url.com%2Fprefix2%2Fsub_path", True),
+            ("%2F..%2F..%2F..%2F..%2Fsome_page%3Fwith_param%3D3", False),
         ],
     )
     def test_is_safe_url_with_base_url_unset(self, url, expected_is_safe):

--- a/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
@@ -154,6 +154,10 @@ class TestFastApiSecurity:
             ("/some_other_page/", False),
             # traversal, escaping the `prefix` folder
             ("/../../../../some_page?with_param=3", False),
+            # encoded url
+            ("https%3A%2F%2Frequesting_server_base_url.com%2Fprefix2", True),
+            ("https%3A%2F%2Fserver_base_url.com%2Fprefix", True),
+            ("https%3A%2F%2Fsome_netlock.com%2Fprefix%2Fsome_page%3Fwith_param%3D3", False),
         ],
     )
     @conf_vars({("api", "base_url"): "https://server_base_url.com/prefix"})


### PR DESCRIPTION
Close: #55473 

### why
The `is_safe_url` method will return `False` when the `target_url` is encoded and it is the same as either `base_url` or `request.base_url`. Therefore, we will unquote it before joining with base.

https://github.com/apache/airflow/issues/55143#issuecomment-3275754077
#55473

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
