### PR TITLE
Reduce default API server workers to 1

### DIFF
--- a/airflow-core/newsfragments/55707.significant.rst
+++ b/airflow-core/newsfragments/55707.significant.rst
@@ -1,0 +1,23 @@
+Reduce default API server workers to 1
+
+The default number of API server workers (``[api] workers``) has been reduced from 4 to 1.
+
+With FastAPI, sync code runs in external thread pools, making multiple workers within a single
+process less necessary. Additionally, with uvicorn's spawn behavior instead of fork, there is
+no shared copy-on-write memory between workers, so horizontal scaling with multiple API server
+instances is now the recommended approach for better resource utilization and fault isolation.
+
+A good starting point for the number of workers is to set it to the number of CPU cores available.
+If you do have multiple CPU cores available for the API server, consider deploying multiple API
+server instances instead of increasing the number of workers.
+
+* Types of change
+
+  * [ ] Dag changes
+  * [x] Config changes
+  * [ ] API changes
+  * [ ] CLI changes
+  * [ ] Behaviour changes
+  * [ ] Plugin changes
+  * [ ] Dependency changes
+  * [ ] Code interface changes

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1389,11 +1389,12 @@ api:
       default: "8080"
     workers:
       description: |
-        Number of workers to run on the API server
+        Number of workers to run on the API server. If you need to scale the API server,
+        consider deploying multiple API servers instead of increasing the number of workers.
       version_added: ~
       type: integer
       example: ~
-      default: "4"
+      default: "1"
     worker_timeout:
       description: |
         Number of seconds the API server waits before timing out on a worker

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1389,8 +1389,9 @@ api:
       default: "8080"
     workers:
       description: |
-        Number of workers to run on the API server. If you need to scale the API server,
-        consider deploying multiple API servers instead of increasing the number of workers.
+        Number of workers to run on the API server. Should be roughly equal to the number of
+        cpu cores available. If you need to scale the API server, consider deploying multiple API
+        servers instead of increasing the number of workers.
       version_added: ~
       type: integer
       example: ~


### PR DESCRIPTION
Change the default number of API server workers from 4 to 1 and add guidance to deploy multiple API servers for scaling instead of increasing workers per server.

With FastAPI, sync code runs in an external thread pool, making multiple workers within a single api server less necessary than it was in our flask days. And with uvicorns new spawn behavior instead of fork, it means no shared copy-on-write memory between workers, so it's better to scale horizontally now.

Closes #52270