### PR TITLE
Adding a backcompat warning layer for airflow.settings.MASK_SECRETS_IN_LOGS

### DIFF
--- a/airflow-core/src/airflow/settings.py
+++ b/airflow-core/src/airflow/settings.py
@@ -633,6 +633,21 @@ def prepare_syspath_for_config_and_plugins():
         sys.path.append(PLUGINS_FOLDER)
 
 
+def __getattr__(name: str):
+    """Handle deprecated module attributes."""
+    if name == "MASK_SECRETS_IN_LOGS":
+        import warnings
+
+        warnings.warn(
+            "settings.MASK_SECRETS_IN_LOGS has been removed. "
+            "Use SecretsMasker.enable_log_masking(), disable_log_masking(), or is_log_masking_enabled() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
+
 def import_local_settings():
     """Import airflow_local_settings.py files to allow overriding any configs in settings.py file."""
     try:

--- a/airflow-core/src/airflow/settings.py
+++ b/airflow-core/src/airflow/settings.py
@@ -639,12 +639,12 @@ def __getattr__(name: str):
         import warnings
 
         warnings.warn(
-            "settings.MASK_SECRETS_IN_LOGS has been removed. "
+            "settings.MASK_SECRETS_IN_LOGS has been removed. This shim returns default value of False. "
             "Use SecretsMasker.enable_log_masking(), disable_log_masking(), or is_log_masking_enabled() instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return
+        return False
     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
 
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Rare, but there is a chance that folks would use `airflow.settings.MASK_SECRETS_IN_LOGS` for some reason in their deployments.

This constant has been slayed and moved over to inside the SecretsMasker class now. Although it is not too important, but adding an informational warning for this would probably help.

Earlier:
```
Python 3.10.18 (main, Sep  8 2025, 22:04:00) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>>
>>>
>>>
>>> from airflow.settings
KeyboardInterrupt
>>> import airflow.settings
>>> settings.MASK_SECRETS_IN_LOGS
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'settings' is not defined
>>> airflow.settings.MASK_SECRET_IN_LOGS
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'airflow.settings' has no attribute 'MASK_SECRET_IN_LOGS'
>>> airflow.settings.MASK_SECRETS_IN_LOGS
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'airflow.settings' has no attribute 'MASK_SECRETS_IN_LOGS'
>>> exit()
```

Now:
```
root@f6f4a87fe6c4:/opt/airflow# python
Python 3.10.18 (main, Sep  8 2025, 22:04:00) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import airflow.settings
>>> airflow.settings.MASK_SECRETS_IN_LOGS
<stdin>:1 DeprecationWarning: settings.MASK_SECRETS_IN_LOGS has been removed. Use SecretsMasker.enable_log_masking(), disable_log_masking(), or is_log_masking_enabled() instead.
>>> import airflow.settings
KeyboardInterrupt
>>>
KeyboardInterrupt
>>> exit()
root@f6f4a87fe6c4:/opt/airflow# python
Python 3.10.18 (main, Sep  8 2025, 22:04:00) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import airflow.settings
>>> airflow.settings.MASK_SECRETS_IN_LOGS
<stdin>:1 DeprecationWarning: settings.MASK_SECRETS_IN_LOGS has been removed. This shim returns default value of False. Use SecretsMasker.enable_log_masking(), disable_log_masking(), or is_log_masking_enabled() instead.
False
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
