### PR TITLE
refactor: remove inactive asset check in scheduler

### DIFF
--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -70,9 +70,6 @@ from airflow import settings
 from airflow._shared.timezones import timezone
 from airflow.assets.manager import asset_manager
 from airflow.configuration import conf
-from airflow.exceptions import (
-    AirflowInactiveAssetInInletOrOutletException,
-)
 from airflow.listeners.listener import get_listener_manager
 from airflow.models.asset import AssetEvent, AssetModel
 from airflow.models.base import Base, StringID, TaskInstanceDependencies
@@ -120,7 +117,7 @@ if TYPE_CHECKING:
     from airflow.models.mappedoperator import MappedOperator
     from airflow.sdk import DAG
     from airflow.sdk.api.datamodels._generated import AssetProfile
-    from airflow.sdk.definitions.asset import AssetNameRef, AssetUniqueKey, AssetUriRef
+    from airflow.sdk.definitions.asset import AssetUniqueKey
     from airflow.sdk.types import RuntimeTaskInstanceProtocol
     from airflow.serialization.definitions.taskgroup import SerializedTaskGroup
     from airflow.serialization.serialized_objects import SerializedBaseOperator
@@ -1328,13 +1325,15 @@ class TaskInstance(Base, LoggingMixin):
             if "source_alias_name" not in event
         }
 
-        bad_asset_keys: set[AssetUniqueKey | AssetNameRef | AssetUriRef] = set()
-
         for key in asset_keys:
             try:
                 am = asset_models[key]
             except KeyError:
-                bad_asset_keys.add(key)
+                ti.log.warning(
+                    'Task has inactive assets "Asset(name=%s, uri=%s)" in inlets or outlets',
+                    key.name,
+                    key.uri,
+                )
                 continue
             ti.log.debug("register event for asset %s", am)
             asset_manager.register_asset_change(
@@ -1351,7 +1350,9 @@ class TaskInstance(Base, LoggingMixin):
                 try:
                     am = asset_models_by_name[nref.name]
                 except KeyError:
-                    bad_asset_keys.add(nref)
+                    ti.log.warning(
+                        'Task has inactive assets "Asset.ref(name=%s)" in inlets or outlets', nref.name
+                    )
                     continue
                 ti.log.debug("register event for asset name ref %s", am)
                 asset_manager.register_asset_change(
@@ -1367,7 +1368,9 @@ class TaskInstance(Base, LoggingMixin):
                 try:
                     am = asset_models_by_uri[uref.uri]
                 except KeyError:
-                    bad_asset_keys.add(uref)
+                    ti.log.warning(
+                        'Task has inactive assets "Asset.ref(uri=%s)" in inlets or outlets', uref.uri
+                    )
                     continue
                 ti.log.debug("register event for asset uri ref %s", am)
                 asset_manager.register_asset_change(
@@ -1413,9 +1416,6 @@ class TaskInstance(Base, LoggingMixin):
                         extra=dict(extra_key),
                         session=session,
                     )
-
-        if bad_asset_keys:
-            raise AirflowInactiveAssetInInletOrOutletException(bad_asset_keys)
 
     @provide_session
     def update_rtif(self, rendered_fields, session: Session = NEW_SESSION):

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -782,40 +782,6 @@ class TestTIUpdateState:
         assert event[0].asset == AssetModel(name="my-task", uri="s3://bucket/my-task", extra={})
         assert event[0].extra == expected_extra
 
-    def test_ti_update_state_to_failed_with_inactive_asset(self, client, session, create_task_instance):
-        # inactive
-        asset = AssetModel(
-            id=1,
-            name="my-task-2",
-            uri="s3://bucket/my-task",
-            group="asset",
-            extra={},
-        )
-        session.add(asset)
-
-        ti = create_task_instance(
-            task_id="test_ti_update_state_to_success_with_asset_events",
-            start_date=DEFAULT_START_DATE,
-            state=State.RUNNING,
-        )
-        session.commit()
-
-        response = client.patch(
-            f"/execution/task-instances/{ti.id}/state",
-            json={
-                "state": "success",
-                "end_date": DEFAULT_END_DATE.isoformat(),
-                "task_outlets": [{"name": "my-task-2", "uri": "s3://bucket/my-task", "type": "Asset"}],
-                "outlet_events": [],
-            },
-        )
-
-        assert response.status_code == 204
-        session.expire_all()
-
-        ti = session.get(TaskInstance, ti.id)
-        assert ti.state == State.FAILED
-
     @pytest.mark.parametrize(
         "outlet_events, expected_extra",
         [

--- a/airflow-core/tests/unit/models/test_taskinstance.py
+++ b/airflow-core/tests/unit/models/test_taskinstance.py
@@ -38,7 +38,6 @@ from airflow._shared.timezones import timezone
 from airflow.exceptions import (
     AirflowException,
     AirflowFailException,
-    AirflowInactiveAssetInInletOrOutletException,
     AirflowSkipException,
 )
 from airflow.models.asset import AssetActive, AssetAliasModel, AssetEvent, AssetModel
@@ -2687,41 +2686,6 @@ class TestTaskInstance:
         assert len(tih) == 1
         # the new try_id should be different from what's recorded in tih
         assert str(tih[0].task_instance_id) == try_id
-
-    @pytest.mark.skip(
-        reason="This test has some issues that were surfaced when dag_maker started allowing multiple serdag versions. Issue #48539 will track fixing this."
-    )
-    def test_run_with_inactive_assets(self, dag_maker, session):
-        from airflow.sdk.definitions.asset import Asset
-
-        with dag_maker(schedule=None, serialized=True, session=session):
-
-            @task(outlets=Asset("asset_first"))
-            def first_asset_task(*, outlet_events):
-                outlet_events[Asset("asset_first")].extra = {"foo": "bar"}
-
-            first_asset_task()
-
-        with dag_maker(schedule=None, serialized=True, session=session):
-
-            @task(inlets=Asset("asset_second"))
-            def asset_task_in_inlet():
-                pass
-
-            @task(outlets=Asset(name="asset_first", uri="test://asset"), inlets=Asset("asset_second"))
-            def duplicate_asset_task_in_outlet(*, outlet_events):
-                outlet_events[Asset(name="asset_first", uri="test://asset")].extra = {"foo": "bar"}
-
-            duplicate_asset_task_in_outlet() >> asset_task_in_inlet()
-
-        tis = {ti.task_id: ti for ti in dag_maker.create_dagrun().task_instances}
-
-        tis["asset_task_in_inlet"].run(session=session)
-        with pytest.raises(AirflowInactiveAssetInInletOrOutletException) as exc:
-            tis["duplicate_asset_task_in_outlet"].run(session=session)
-
-        assert "Asset(name='asset_second', uri='asset_second')" in str(exc.value)
-        assert "Asset(name='asset_first', uri='test://asset/')" in str(exc.value)
 
 
 @pytest.mark.parametrize("pool_override", [None, "test_pool2"])


### PR DESCRIPTION
## Why
The inactive asset check in the scheduler was an additional safeguard and is not supposed to happen in Airflow. It could be a leftover from when we moved the asset logic to the task SDK. As we weren't moving exceptions back then. It didn't hurt to keep an additional safeguard. We now aim to consolidate the `AirflowInactiveAssetInInletOrOutletException` into a single location. This check happens and should only happen in `task_runer.py::run`. 

## What
The two test cases have been removed as they no longer suit our implementation.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
