### PR TITLE
Simplify serve_logs IPv4/v6 binding

### DIFF
--- a/airflow-core/src/airflow/utils/serve_logs/core.py
+++ b/airflow-core/src/airflow/utils/serve_logs/core.py
@@ -42,19 +42,15 @@ def serve_logs(port=None):
 
     port = port or conf.getint("logging", "WORKER_LOG_SERVER_PORT")
 
-    # If dual stack is available and IPV6_V6ONLY is not enabled on the socket
-    # then when IPV6 is bound to it will also bind to IPV4 automatically
-    if getattr(socket, "has_dualstack_ipv6", lambda: False)():
-        host = "::"  # ASGI uses `::` syntax for IPv6 binding instead of the `[::]` notation used in WSGI, while preserving the `[::]` format in logs
+    if socket.has_dualstack_ipv6():
         serve_log_uri = f"http://[::]:{port}"
     else:
-        host = "0.0.0.0"
-        serve_log_uri = f"http://{host}:{port}"
+        serve_log_uri = f"http://0.0.0.0:{port}"
 
     logger.info("Starting log server on %s", serve_log_uri)
 
     # Use uvicorn directly for ASGI applications
-    uvicorn.run("airflow.utils.serve_logs.log_server:get_app", host=host, port=port, log_level="info")
+    uvicorn.run("airflow.utils.serve_logs.log_server:get_app", host="", port=port, log_level="info")
     # Log serving is I/O bound and has low concurrency, so single process is sufficient
 
 


### PR DESCRIPTION
We were trying to be "smart" about what interface we listened on, but that
isn't really needed, and passing an empty host achieves the same effect:

```
$ netstat -antlp  | grep 8793
tcp        0      0 0.0.0.0:8793            0.0.0.0:*               LISTEN      85699/airflow serve
tcp6       0      0 :::8793                 :::*                    LISTEN      85699/airflow serve
```

The existing approach was working fine for most people (including myself) it
was working fine and listening on ipv6 and v4 wildcard interfaces as expected,
but some Docker/container set ups this was not the case, and despite Dualstack
saying True, listening on `::` ended up _only_ listening on IPv6, but the
entry in `/etc/hosts` in the container only had an entry for the IPv4 address
of the pod, which we weren't listening on, so log requests would fail.

Which is all a round about way of saying "doing less works better" 😀

(We also don't need the getattr+lambda anymore, as that was to support Python
<= 3.7!)

Fixes #55470
