### PR TITLE
Improve Airflow 3 import deprecation documentation

### DIFF
--- a/airflow-core/docs/installation/upgrading_to_airflow3.rst
+++ b/airflow-core/docs/installation/upgrading_to_airflow3.rst
@@ -162,6 +162,14 @@ code import Airflow components correctly in Airflow 3. The older paths are depre
      - ``airflow.sdk.BaseNotifier``
    * - ``airflow.utils.task_group.TaskGroup``
      - ``airflow.sdk.TaskGroup``
+   * - ``airflow.datasets.Dataset``
+     - ``airflow.sdk.Asset``
+   * - ``airflow.models.connection.Connection``
+     - ``airflow.sdk.Connection``
+   * - ``airflow.models.context.Context``
+     - ``airflow.sdk.Context``
+   * - ``airflow.models.variable.Variable``
+     - ``airflow.sdk.Variable``
    * - ``airflow.io.*``
      - ``airflow.sdk.io.*``
 

--- a/airflow-core/docs/installation/upgrading_to_airflow3.rst
+++ b/airflow-core/docs/installation/upgrading_to_airflow3.rst
@@ -164,6 +164,12 @@ code import Airflow components correctly in Airflow 3. The older paths are depre
      - ``airflow.sdk.TaskGroup``
    * - ``airflow.datasets.Dataset``
      - ``airflow.sdk.Asset``
+   * - ``airflow.datasets.DatasetAlias``
+     - ``airflow.sdk.AssetAlias``
+   * - ``airflow.datasets.DatasetAll``
+     - ``airflow.sdk.AssetAll``
+   * - ``airflow.datasets.DatasetAny``
+     - ``airflow.sdk.AssetAny``
    * - ``airflow.models.connection.Connection``
      - ``airflow.sdk.Connection``
    * - ``airflow.models.context.Context``

--- a/airflow-core/docs/installation/upgrading_to_airflow3.rst
+++ b/airflow-core/docs/installation/upgrading_to_airflow3.rst
@@ -144,12 +144,22 @@ code import Airflow components correctly in Airflow 3. The older paths are depre
      - ``airflow.sdk.setup``
    * - ``airflow.decorators.teardown``
      - ``airflow.sdk.teardown``
+   * - ``airflow.models.dag.DAG``
+     - ``airflow.sdk.DAG``
    * - ``airflow.models.baseoperator.BaseOperator``
      - ``airflow.sdk.BaseOperator``
+   * - ``airflow.models.param.Param``
+     - ``airflow.sdk.Param``
+   * - ``airflow.models.param.ParamsDict``
+     - ``airflow.sdk.ParamsDict``
+   * - ``airflow.models.baseoperatorlink.BaseOperatorLink``
+     - ``airflow.sdk.BaseOperatorLink``
    * - ``airflow.sensors.base.BaseSensorOperator``
      - ``airflow.sdk.BaseSensorOperator``
    * - ``airflow.hooks.base.BaseHook``
      - ``airflow.sdk.BaseHook``
+   * - ``airflow.notifications.basenotifier.BaseNotifier``
+     - ``airflow.sdk.BaseNotifier``
    * - ``airflow.utils.task_group.TaskGroup``
      - ``airflow.sdk.TaskGroup``
    * - ``airflow.io.*``

--- a/airflow-core/docs/installation/upgrading_to_airflow3.rst
+++ b/airflow-core/docs/installation/upgrading_to_airflow3.rst
@@ -122,6 +122,44 @@ To trigger these fixes, run the following command:
 
 You can also configure these flags through configuration files. See `Configuring Ruff <https://docs.astral.sh/ruff/configuration/>`_ for details.
 
+Key Import Updates
+^^^^^^^^^^^^^^^^^^
+
+While ruff can automatically fix many import issues, here are the key import changes you'll need to make to ensure your DAGs and other
+code import Airflow components correctly in Airflow 3. The older paths are deprecated and will be removed in a future Airflow version.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 50, 50
+
+   * - **Old Import Path (Deprecated)**
+     - **New Import Path (airflow.sdk)**
+   * - ``airflow.decorators.dag``
+     - ``airflow.sdk.dag``
+   * - ``airflow.decorators.task``
+     - ``airflow.sdk.task``
+   * - ``airflow.decorators.task_group``
+     - ``airflow.sdk.task_group``
+   * - ``airflow.decorators.setup``
+     - ``airflow.sdk.setup``
+   * - ``airflow.decorators.teardown``
+     - ``airflow.sdk.teardown``
+   * - ``airflow.models.baseoperator.BaseOperator``
+     - ``airflow.sdk.BaseOperator``
+   * - ``airflow.sensors.base.BaseSensorOperator``
+     - ``airflow.sdk.BaseSensorOperator``
+   * - ``airflow.hooks.base.BaseHook``
+     - ``airflow.sdk.BaseHook``
+   * - ``airflow.utils.task_group.TaskGroup``
+     - ``airflow.sdk.TaskGroup``
+   * - ``airflow.io.*``
+     - ``airflow.sdk.io.*``
+
+**Migration Timeline**
+
+- **Airflow 3.1**: Legacy imports show deprecation warnings but continue to work
+- **Future Airflow version**: Legacy imports will be **removed**
+
 Step 4: Install the Standard Provider
 --------------------------------------
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Airflow 3.0 and 3.1 involved moving some dag authoring related classes to the task SDK (where its more appropriate for the dag authors). The older imports are deprecated and we must hint the users / dag authors to update their code to the new paths and get rid of the older paths as soon as possible.


This PR improves the documentation around the import deprecation by making the migration requirements clearer and more actionable for users.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
