### PR TITLE
feat: Add triggered_by and triggering_user_name to Task SDK DagRun model

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
@@ -41,7 +41,7 @@ from airflow.utils.state import (
     TaskInstanceState as TIState,
     TerminalTIState,
 )
-from airflow.utils.types import DagRunType
+from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 AwareDatetimeAdapter = TypeAdapter(AwareDatetime)
 
@@ -300,6 +300,8 @@ class DagRun(StrictBaseModel):
     state: DagRunState
     conf: Annotated[dict[str, Any], Field(default_factory=dict)]
     consumed_asset_events: list[AssetEventDagRunReference]
+    triggered_by: DagRunTriggeredByType | None = None
+    triggering_user_name: str | None = None
 
 
 class TIRunContext(BaseModel):

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -143,6 +143,21 @@ class DagRunStateResponse(BaseModel):
     state: DagRunState
 
 
+class DagRunTriggeredByType(str, Enum):
+    """
+    Class with DagRun triggered by types.
+    """
+
+    ASSET = "asset"
+    BACKFILL = "backfill"
+    CLI = "cli"
+    OPERATOR = "operator"
+    REST_API = "rest_api"
+    TEST = "test"
+    TIMETABLE = "timetable"
+    UI = "ui"
+
+
 class DagRunType(str, Enum):
     """
     Class with DagRun types.
@@ -540,6 +555,8 @@ class DagRun(BaseModel):
     state: DagRunState
     conf: Annotated[dict[str, Any] | None, Field(title="Conf")] = None
     consumed_asset_events: Annotated[list[AssetEventDagRunReference], Field(title="Consumed Asset Events")]
+    triggered_by: Annotated[DagRunTriggeredByType | None, Field(title="Triggered By")] = None
+    triggering_user_name: Annotated[str | None, Field(title="Triggering User Name")] = None
 
 
 class HITLDetailRequest(BaseModel):
@@ -583,9 +600,9 @@ class TIRunContext(BaseModel):
     max_tries: Annotated[int, Field(title="Max Tries")]
     variables: Annotated[list[VariableResponse] | None, Field(title="Variables")] = None
     connections: Annotated[list[ConnectionResponse] | None, Field(title="Connections")] = None
-    upstream_map_indexes: Annotated[
-        dict[str, int | list[int] | None] | None, Field(title="Upstream Map Indexes")
-    ] = None
+    upstream_map_indexes: Annotated[dict[str, int | list[int] | None] | None, Field(title="Upstream Map Indexes")] = (
+        None
+    )
     next_method: Annotated[str | None, Field(title="Next Method")] = None
     next_kwargs: Annotated[dict[str, Any] | str | None, Field(title="Next Kwargs")] = None
     xcom_keys_to_clear: Annotated[list[str] | None, Field(title="Xcom Keys To Clear")] = None


### PR DESCRIPTION
- Add DagRunTriggeredByType and triggering_user_name fields to Execution API DagRun model
- Regenerate Task SDK models with new fields for user tracking
- Enable DAG tasks to access triggering user information via context['dag_run']

This allows DAG tasks to access information about who triggered the DAG run and how it was triggered, enabling better audit trails and user-specific logic.

related PR: 
- https://github.com/apache/airflow/pull/53510
- https://github.com/apache/airflow/pull/51738


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
