### PR TITLE
Add newsfragment to call out new features available now with structlog loggers

### DIFF
--- a/airflow-core/newsfragments/52651.significant.rst
+++ b/airflow-core/newsfragments/52651.significant.rst
@@ -2,7 +2,7 @@ Airflow now uses `https://www.structlog.org/en/stable/ <structlog>`_ everywhere.
 
 Most users should not notice the difference, but it is now possible to emit structured log key/value pairs from tasks.
 
-If your class subclasses LoggingMixin (which all BaseHook and BaseOperator do -- i.e. all hooks and operators) then ``self.log`` is not a ` <structlog logger>`_.
+If your class subclasses LoggingMixin (which all BaseHook and BaseOperator do -- i.e. all hooks and operators) then ``self.log`` is now a ` <structlog logger>`_.
 
 The advantage of using structured logging is that it is much easier to find specific information about log message, especially when using a central store such as OpenSearch/Elastic/Splunk etc. You don't have to make any changes, but you can now take advantage of this.
 

--- a/airflow-core/newsfragments/52651.significant.rst
+++ b/airflow-core/newsfragments/52651.significant.rst
@@ -1,0 +1,53 @@
+Airflow now uses `https://www.structlog.org/en/stable/ <structlog>`_ everywhere.
+
+Most users should not notice the difference, but it is now possible to emit structured log key/value pairs from tasks.
+
+If your class subclasses LoggingMixin (which all BaseHook and BaseOperator do -- i.e. all hooks and operators) then ``self.log`` is not a ` <structlog logger>`_.
+
+The advantage of using structured logging is that it is much easier to find specific information about log message, especially when using a central store such as OpenSearch/Elastic/Splunk etc. You don't have to make any changes, but you can now take advantage of this.
+
+.. code-block:: python
+
+    # Inside a Task/Hook etc.
+
+    # Before:
+    # self.log.info("Registering adapter %r", item.name)
+    # Now:
+    self.log.info("Registering adapter", name=item.name)
+
+This will produce a log that (in the UI) will look something like this::
+
+    [2025-09-16 10:36:13] INFO - Registering adapter  name="adapter1"
+
+
+or in JSON (i.e. the log files on disk)::
+
+    {"timestamp": "2025-09-16T10:36:13Z", "log_level": "info", "event": "Registering adapter", "name": "adapter1"}
+
+
+You can also use structlog loggers at the top level of modules etc, and stdlib both continue to work:
+
+.. code-block:: python
+
+    import logging
+    import structlog
+
+    log1 = logging.getLogger(__name__)
+    log2 = strcutlog.get_logger(__name__)
+
+    log1.info("Loading something from %s", __name__)
+    log2.info("Loading something", source=__name__)
+
+(You can't add arbitrary key/value pairs to stdlib, but the normal percent-formatter approaches still work fine.)
+
+
+* Types of change
+
+  * [ ] Dag changes
+  * [ ] Config changes
+  * [x] API changes
+  * [ ] CLI changes
+  * [ ] Behaviour changes
+  * [ ] Plugin changes
+  * [ ] Dependency changes
+  * [ ] Code interface changes


### PR DESCRIPTION
Nothing _needs_ to change, but people (both DAG authors and provider authors)
can now start to take advantage of this.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
