### PR TITLE
Azure IAM/Entra ID support for PostgresHook

### DIFF
--- a/providers/postgres/docs/configurations-ref.rst
+++ b/providers/postgres/docs/configurations-ref.rst
@@ -1,0 +1,19 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+.. include:: /../../../../devel-common/src/sphinx_exts/includes/providers-configurations-ref.rst
+.. include:: /../../../../devel-common/src/sphinx_exts/includes/sections-and-options.rst

--- a/providers/postgres/docs/connections/postgres.rst
+++ b/providers/postgres/docs/connections/postgres.rst
@@ -96,7 +96,9 @@ Extra (optional)
     * ``iam`` - If set to ``True`` than use AWS IAM database authentication for
       `Amazon RDS <https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html>`__,
       `Amazon Aurora <https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.IAMDBAuth.html>`__
-      or `Amazon Redshift <https://docs.aws.amazon.com/redshift/latest/mgmt/generating-user-credentials.html>`__.
+      `Amazon Redshift <https://docs.aws.amazon.com/redshift/latest/mgmt/generating-user-credentials.html>`__
+      or use Microsoft Entra Authentication for
+      `Azure Postgres Flexible Server <https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/security-entra-concepts>`__.
     * ``aws_conn_id`` - AWS Connection ID which use for authentication via AWS IAM,
       if not specified then **aws_default** is used.
     * ``redshift`` - Used when AWS IAM database authentication enabled.
@@ -104,6 +106,9 @@ Extra (optional)
     * ``cluster-identifier`` - The unique identifier of the Amazon Redshift Cluster that contains the database
       for which you are requesting credentials. This parameter is case sensitive.
       If not specified than hostname from **Connection Host** is used.
+    * ``azure_conn_id`` - Azure Connection ID to be used for authentication via Azure Entra ID. Azure Oauth token
+      is retrieved from the azure connection which is used as password for PostgreSQL connection.
+
 
     Example "extras" field (Amazon RDS PostgreSQL or Amazon Aurora PostgreSQL):
 

--- a/providers/postgres/docs/connections/postgres.rst
+++ b/providers/postgres/docs/connections/postgres.rst
@@ -109,7 +109,6 @@ Extra (optional)
     * ``azure_conn_id`` - Azure Connection ID to be used for authentication via Azure Entra ID. Azure Oauth token
       is retrieved from the azure connection which is used as password for PostgreSQL connection.
 
-
     Example "extras" field (Amazon RDS PostgreSQL or Amazon Aurora PostgreSQL):
 
     .. code-block:: json

--- a/providers/postgres/docs/connections/postgres.rst
+++ b/providers/postgres/docs/connections/postgres.rst
@@ -130,6 +130,15 @@ Extra (optional)
           "cluster-identifier": "awesome-redshift-identifier"
        }
 
+    Example "extras" field (to use Azure Entra Authentication for Postgres Flexible Server):
+
+    .. code-block:: json
+
+       {
+          "iam": true,
+          "azure_conn_id": "azure_default_conn"
+       }
+
     When specifying the connection as URI (in :envvar:`AIRFLOW_CONN_{CONN_ID}` variable) you should specify it
     following the standard syntax of DB connections, where extras are passed as parameters
     of the URI (note that all components of the URI should be URL-encoded).

--- a/providers/postgres/docs/index.rst
+++ b/providers/postgres/docs/index.rst
@@ -41,6 +41,7 @@
     :maxdepth: 1
     :caption: References
 
+    Configuration <configurations-ref>
     Python API <_api/airflow/providers/postgres/index>
     Dialects <dialects>
 

--- a/providers/postgres/provider.yaml
+++ b/providers/postgres/provider.yaml
@@ -109,3 +109,16 @@ asset-uris:
 dataset-uris:
   - schemes: [postgres, postgresql]
     handler: airflow.providers.postgres.assets.postgres.sanitize_uri
+
+config:
+  postgres:
+    description: |
+      Configuration for Postgres hooks and operators.
+    options:
+      azure_oauth_scope:
+        description: |
+          The scope to use while retrieving Oauth token for Postgres Flexible Server from Azure Entra authentication.
+        version_added: 6.3.1
+        type: string
+        example: ~
+        default: "https://ossrdbms-aad.database.windows.net/.default"

--- a/providers/postgres/tests/unit/postgres/hooks/test_postgres.py
+++ b/providers/postgres/tests/unit/postgres/hooks/test_postgres.py
@@ -458,7 +458,7 @@ class TestPostgresHookConn:
 
         # Check AzureBaseHook initialization and get_token call args
         mock_connection_class.get.assert_called_once_with(mock_azure_conn_id)
-        mock_azure_base_hook.get_token.assert_called_once_with(PostgresHook.azure_oauth_scope)
+        mock_azure_base_hook.get_token.assert_called_once_with(PostgresHook.default_azure_oauth_scope)
 
         # Check expected psycopg2 connection call args
         mock_connect.assert_called_once_with(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Add functionality to authenticate postgres with Azure Entra ID authentication similar to existing functionality with AWS IAM.

Example "extras" field:
```json
{
  "iam": true,
  "azure_conn_id": "azure_default_conn"
}
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
