### PR TITLE
Update EOL AWS Redshift cluster node types

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/redshift_cluster.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/redshift_cluster.py
@@ -57,10 +57,9 @@ class RedshiftHook(AwsBaseHook):
             - :external+boto3:py:meth:`Redshift.Client.create_cluster`
 
         :param cluster_identifier: A unique identifier for the cluster.
-        :param node_type: The node type to be provisioned for the cluster.
-            Valid Values: ``ds2.xlarge``, ``ds2.8xlarge``, ``dc1.large``,
-            ``dc1.8xlarge``, ``dc2.large``, ``dc2.8xlarge``, ``ra3.xlplus``,
-            ``ra3.4xlarge``, and ``ra3.16xlarge``.
+        :param node_type: The node type to be provisioned for the cluster. Refer
+            https://docs.aws.amazon.com/redshift/latest/mgmt/working-with-clusters.html#rs-node-type-info
+            for the list of available node types.
         :param master_username: The username associated with the admin user account
             for the cluster that is being created.
         :param master_user_password: password associated with the admin user account

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/redshift_cluster.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/redshift_cluster.py
@@ -49,10 +49,9 @@ class RedshiftCreateClusterOperator(AwsBaseOperator[RedshiftHook]):
         :ref:`howto/operator:RedshiftCreateClusterOperator`
 
     :param cluster_identifier:  A unique identifier for the cluster.
-    :param node_type: The node type to be provisioned for the cluster.
-            Valid Values: ``ds2.xlarge``, ``ds2.8xlarge``, ``dc1.large``,
-            ``dc1.8xlarge``, ``dc2.large``, ``dc2.8xlarge``, ``ra3.xlplus``,
-            ``ra3.4xlarge``, and ``ra3.16xlarge``.
+    :param node_type: The node type to be provisioned for the cluster. Refer
+            https://docs.aws.amazon.com/redshift/latest/mgmt/working-with-clusters.html#rs-node-type-info
+            for the list of available node types.
     :param master_username: The username associated with the admin user account for
         the cluster that is being created.
     :param master_user_password: The password associated with the admin user account for

--- a/providers/amazon/tests/system/amazon/aws/example_s3_to_sql.py
+++ b/providers/amazon/tests/system/amazon/aws/example_s3_to_sql.py
@@ -117,7 +117,7 @@ with DAG(
         vpc_security_group_ids=[security_group_id],
         cluster_subnet_group_name=cluster_subnet_group_name,
         cluster_type="single-node",
-        node_type="dc2.large",
+        node_type="ra3.large",
         master_username=DB_LOGIN,
         master_user_password=DB_PASS,
     )

--- a/providers/amazon/tests/system/amazon/aws/example_sql_to_s3.py
+++ b/providers/amazon/tests/system/amazon/aws/example_sql_to_s3.py
@@ -124,7 +124,7 @@ with DAG(
         vpc_security_group_ids=[security_group_id],
         cluster_subnet_group_name=cluster_subnet_group_name,
         cluster_type="single-node",
-        node_type="dc2.large",
+        node_type="ra3.large",
         master_username=DB_LOGIN,
         master_user_password=DB_PASS,
     )

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_redshift_cluster.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_redshift_cluster.py
@@ -47,13 +47,13 @@ class TestRedshiftCreateClusterOperator:
         redshift_operator = RedshiftCreateClusterOperator(
             task_id="task_test",
             cluster_identifier="test_cluster",
-            node_type="dc2.large",
+            node_type="ra3.large",
             master_username="adminuser",
             master_user_password="Test123$",
         )
         assert redshift_operator.task_id == "task_test"
         assert redshift_operator.cluster_identifier == "test_cluster"
-        assert redshift_operator.node_type == "dc2.large"
+        assert redshift_operator.node_type == "ra3.large"
         assert redshift_operator.master_username == "adminuser"
         assert redshift_operator.master_user_password == "Test123$"
 
@@ -62,7 +62,7 @@ class TestRedshiftCreateClusterOperator:
         redshift_operator = RedshiftCreateClusterOperator(
             task_id="task_test",
             cluster_identifier="test-cluster",
-            node_type="dc2.large",
+            node_type="ra3.large",
             master_username="adminuser",
             master_user_password="Test123$",
             cluster_type="single-node",
@@ -80,7 +80,7 @@ class TestRedshiftCreateClusterOperator:
         }
         mock_conn.create_cluster.assert_called_once_with(
             ClusterIdentifier="test-cluster",
-            NodeType="dc2.large",
+            NodeType="ra3.large",
             MasterUsername="adminuser",
             MasterUserPassword="Test123$",
             **params,
@@ -96,7 +96,7 @@ class TestRedshiftCreateClusterOperator:
         redshift_operator = RedshiftCreateClusterOperator(
             task_id="task_test",
             cluster_identifier="test-cluster",
-            node_type="dc2.large",
+            node_type="ra3.large",
             number_of_nodes=3,
             master_username="adminuser",
             master_user_password="Test123$",
@@ -115,7 +115,7 @@ class TestRedshiftCreateClusterOperator:
         }
         mock_conn.create_cluster.assert_called_once_with(
             ClusterIdentifier="test-cluster",
-            NodeType="dc2.large",
+            NodeType="ra3.large",
             MasterUsername="adminuser",
             MasterUserPassword="Test123$",
             **params,
@@ -129,7 +129,7 @@ class TestRedshiftCreateClusterOperator:
         redshift_operator = RedshiftCreateClusterOperator(
             task_id="task_test",
             cluster_identifier="test-cluster",
-            node_type="dc2.large",
+            node_type="ra3.large",
             master_username="adminuser",
             master_user_password="Test123$",
             cluster_type="single-node",
@@ -143,7 +143,7 @@ class TestRedshiftCreateClusterOperator:
         operator = RedshiftCreateClusterOperator(
             task_id="task_test",
             cluster_identifier="test-cluster",
-            node_type="dc2.large",
+            node_type="ra3.large",
             master_username="adminuser",
             master_user_password="Test123$",
             cluster_type="single-node",


### PR DESCRIPTION
The dc2.large node type and other node types in the dc and ds family seem to not be supported anymore: https://repost.aws/questions/QULBkUFiF4S3yFxOECb00zkQ/terraform-redshift-cluster-can-t-create-node-type-with-dc2-large

This replaces their usage in system tests and unit tests as well as updates docstrings for Redshift's create cluster hook and operator to refer to the offical docs for the list of supported node types.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
