### PR TITLE
Don't import/load executor if it's not necessary

### DIFF
--- a/airflow-core/src/airflow/cli/commands/scheduler_command.py
+++ b/airflow-core/src/airflow/cli/commands/scheduler_command.py
@@ -62,9 +62,9 @@ def _serve_logs(skip_serve_logs: bool = False):
     from airflow.utils.serve_logs import serve_logs
 
     sub_proc = None
-    executor_class, _ = ExecutorLoader.import_default_executor_cls()
-    if executor_class.serve_logs:
-        if skip_serve_logs is False:
+    if skip_serve_logs is False:
+        executor_class, _ = ExecutorLoader.import_default_executor_cls()
+        if executor_class.serve_logs:
             sub_proc = Process(target=serve_logs)
             sub_proc.start()
     try:

--- a/airflow-core/tests/unit/cli/commands/test_scheduler_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_scheduler_command.py
@@ -70,8 +70,7 @@ class TestSchedulerCommand:
         with conf_vars({("core", "executor"): executor}):
             reload(executor_loader)
             scheduler_command.scheduler(args)
-            with pytest.raises(AssertionError):
-                mock_process.assert_has_calls([mock.call(target=serve_logs)])
+            assert mock_process.call_count == 0
 
     @mock.patch("airflow.utils.db.check_and_run_migrations")
     @mock.patch("airflow.utils.db.synchronize_log_template")


### PR DESCRIPTION
If we are skipping log serving there is no need to import/load the executor to check if it supports log serving.

Discovered this small optimization when working on a related bit of code.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
