### PR TITLE
airflowctl: initialize extra for create assets event

### DIFF
--- a/airflow-ctl/src/airflowctl/api/operations.py
+++ b/airflow-ctl/src/airflowctl/api/operations.py
@@ -243,7 +243,7 @@ class AssetsOperations(BaseOperations):
     ) -> AssetEventResponse | ServerResponseError:
         """Create an asset event."""
         try:
-            # Ensure extra is an object; DB/UI choke on null
+            # Ensure extra is initialised before sent to API
             if asset_event_body.extra is None:
                 asset_event_body.extra = {}
             self.response = self.client.post(

--- a/airflow-ctl/src/airflowctl/api/operations.py
+++ b/airflow-ctl/src/airflowctl/api/operations.py
@@ -244,7 +244,7 @@ class AssetsOperations(BaseOperations):
         """Create an asset event."""
         try:
             # Ensure extra is an object; DB/UI choke on null
-            if getattr(asset_event_body, "extra", None) is None:
+            if asset_event_body.extra is None:
                 asset_event_body.extra = {}
             self.response = self.client.post(
                 "/assets/events", json=_date_safe_dict_from_pydantic(asset_event_body)

--- a/airflow-ctl/src/airflowctl/api/operations.py
+++ b/airflow-ctl/src/airflowctl/api/operations.py
@@ -247,7 +247,7 @@ class AssetsOperations(BaseOperations):
             if asset_event_body.extra is None:
                 asset_event_body.extra = {}
             self.response = self.client.post(
-                "/assets/events", json=_date_safe_dict_from_pydantic(asset_event_body)
+                "assets/events", json=_date_safe_dict_from_pydantic(asset_event_body)
             )
             return AssetEventResponse.model_validate_json(self.response.content)
         except ServerResponseError as e:

--- a/airflow-ctl/src/airflowctl/api/operations.py
+++ b/airflow-ctl/src/airflowctl/api/operations.py
@@ -243,8 +243,11 @@ class AssetsOperations(BaseOperations):
     ) -> AssetEventResponse | ServerResponseError:
         """Create an asset event."""
         try:
+            # Ensure extra is an object; DB/UI choke on null
+            if getattr(asset_event_body, "extra", None) is None:
+                asset_event_body.extra = {}
             self.response = self.client.post(
-                "assets/events", json=_date_safe_dict_from_pydantic(asset_event_body)
+                "/assets/events", json=_date_safe_dict_from_pydantic(asset_event_body)
             )
             return AssetEventResponse.model_validate_json(self.response.content)
         except ServerResponseError as e:


### PR DESCRIPTION
Align airflowctl with the FastAPI contract for **POST `/assets/events`**.

**What**
- Use absolute path `"/assets/events"` in `AssetsOperations.create_event` (was `"assets/events"`).
- Add a small client test asserting route + payload:
  - `airflow-ctl/tests/test_create_event_client.py`
- Request/response match the datamodel (`CreateAssetEventsBody` → `AssetEventResponse`).

**Why**
- Avoid routing issues from relative paths.
- Keep `airflowctl` in sync with API + models (pairs with the POST `/assets` work).

Related: #55697
Companion: #55702

**Verify**
```bash
python -m pytest -q airflow-ctl/tests -k create_event