### PR TITLE
Remove TI.run() and related code

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -422,7 +422,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
     def test_should_respond_200_task_instance_with_rendered(self, test_client, session):
         tis = self.create_task_instances(session)
         session.query()
-        rendered_fields = RTIF(tis[0], render_templates=False)
+        rendered_fields = RTIF(tis[0])
         session.add(rendered_fields)
         session.commit()
         response = test_client.get(

--- a/airflow-core/tests/unit/listeners/test_asset_listener.py
+++ b/airflow-core/tests/unit/listeners/test_asset_listener.py
@@ -40,7 +40,7 @@ def clean_listener_manager():
 
 @pytest.mark.db_test
 @provide_session
-def test_asset_listener_on_asset_changed_gets_calls(create_task_instance_of_operator, session):
+def test_asset_listener_on_asset_changed_gets_calls(dag_maker, create_task_instance_of_operator, session):
     asset_uri = "test://asset/"
     asset_name = "test_asset_uri"
     asset_group = "test-group"
@@ -57,7 +57,7 @@ def test_asset_listener_on_asset_changed_gets_calls(create_task_instance_of_oper
         session=session,
         outlets=[asset],
     )
-    ti.run()
+    dag_maker.run_ti(ti)
 
     assert len(asset_listener.changed) == 1
     assert asset_listener.changed[0].uri == asset_uri

--- a/airflow-core/tests/unit/models/test_dag.py
+++ b/airflow-core/tests/unit/models/test_dag.py
@@ -91,6 +91,7 @@ from tests_common.test_utils.db import (
 )
 from tests_common.test_utils.mapping import expand_mapped_task
 from tests_common.test_utils.mock_plugins import mock_plugin_manager
+from tests_common.test_utils.taskinstances import run_ti
 from tests_common.test_utils.timetables import cron_timetable, delta_timetable
 from unit.models import DEFAULT_DATE
 from unit.plugins.priority_weight_strategy import (
@@ -2014,9 +2015,7 @@ class TestDagModel:
         assert query.all() == []
 
         # Upstream triggered, now we need a run.
-        ti = dr.get_task_instance("op")
-        ti.refresh_from_task(op)
-        ti.run()
+        run_ti(dr.get_task_instance("op"), op)
 
         assert session.scalars(select(AssetDagRunQueue.target_dag_id)).all() == ["consumer"]
         query, _ = DagModel.dags_needing_dagruns(session)

--- a/airflow-core/tests/unit/models/test_dagrun.py
+++ b/airflow-core/tests/unit/models/test_dagrun.py
@@ -58,6 +58,7 @@ from tests_common.test_utils import db
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.mock_operators import MockOperator
+from tests_common.test_utils.taskinstances import run_ti
 from unit.models import DEFAULT_DATE as _DEFAULT_DATE
 
 pytestmark = [pytest.mark.db_test, pytest.mark.need_serialized_dag]
@@ -1649,8 +1650,7 @@ def test_mapped_literal_faulty_state_in_db(dag_maker, session):
         task_2.expand(arg2=task_1())
 
     dr = dag_maker.create_dagrun()
-    ti = dr.get_task_instance(task_id="task_1")
-    ti.run()
+    ti = dag_maker.run_ti("task_1", dr)
     decision = dr.task_instance_scheduling_decisions()
     assert len(decision.schedulable_tis) == 2
 
@@ -2103,8 +2103,8 @@ def test_mapped_expand_kwargs(dag_maker):
     assert sorted(map_index for (task_id, map_index) in tis if task_id == "task_3") == [0, 1, 2]
     assert sorted(map_index for (task_id, map_index) in tis if task_id == "task_4") == [0, 1, 2]
 
-    tis[("task_0", -1)].run()
-    tis[("task_1", -1)].run()
+    run_ti(tis[("task_0", -1)], args_0.operator)
+    run_ti(tis[("task_1", -1)], args_list.operator)
 
     # With the upstreams available, everything should get expanded now.
     decision = dr.task_instance_scheduling_decisions()

--- a/airflow-core/tests/unit/models/test_renderedtifields.py
+++ b/airflow-core/tests/unit/models/test_renderedtifields.py
@@ -43,6 +43,7 @@ from airflow.utils.task_instance_session import set_current_task_instance_sessio
 
 from tests_common.test_utils.asserts import assert_queries_count
 from tests_common.test_utils.db import clear_db_dags, clear_db_runs, clear_rendered_ti_fields
+from tests_common.test_utils.taskinstances import run_ti
 
 if TYPE_CHECKING:
     from airflow.models.taskinstance import TaskInstance
@@ -443,5 +444,4 @@ class TestRenderedTaskInstanceFields:
         ti.state = None
         session.flush()
         # rerun the old run. this will shouldn't fail
-        ti.task = task
-        ti.run()
+        run_ti(ti, task)

--- a/airflow-core/tests/unit/models/test_xcom_arg.py
+++ b/airflow-core/tests/unit/models/test_xcom_arg.py
@@ -212,13 +212,13 @@ def test_xcom_zip(dag_maker, session, fillvalue, expected_results):
     decision = dr.task_instance_scheduling_decisions(session=session)
     assert sorted(ti.task_id for ti in decision.schedulable_tis) == ["push_letters", "push_numbers"]
     for ti in decision.schedulable_tis:
-        dag_maker.run_ti(task_id=ti.task_id, map_index=ti.map_index, dag_run=dr, session=session)
+        dag_maker.run_ti(ti.task_id, map_index=ti.map_index, dag_run=dr, session=session)
     session.commit()
 
     # Run "pull".
     decision = dr.task_instance_scheduling_decisions(session=session)
     assert sorted(ti.task_id for ti in decision.schedulable_tis) == ["pull"] * len(expected_results)
     for ti in decision.schedulable_tis:
-        dag_maker.run_ti(task_id=ti.task_id, map_index=ti.map_index, dag_run=dr, session=session)
+        dag_maker.run_ti(ti.task_id, map_index=ti.map_index, dag_run=dr, session=session)
 
     assert results == expected_results

--- a/airflow-core/tests/unit/ti_deps/deps/test_not_previously_skipped_dep.py
+++ b/airflow-core/tests/unit/ti_deps/deps/test_not_previously_skipped_dep.py
@@ -28,6 +28,8 @@ from airflow.ti_deps.deps.not_previously_skipped_dep import NotPreviouslySkipped
 from airflow.utils.state import State
 from airflow.utils.types import DagRunType
 
+from tests_common.test_utils.taskinstances import run_ti
+
 pytestmark = pytest.mark.db_test
 
 
@@ -101,7 +103,7 @@ def test_parent_follow_branch(session, dag_maker):
 
     dagrun = dag_maker.create_dagrun(run_type=DagRunType.MANUAL, state=State.RUNNING)
     ti, ti2 = dagrun.task_instances
-    ti.run()
+    run_ti(ti, op1)
 
     dep = NotPreviouslySkippedDep()
     assert len(list(dep.get_dep_statuses(ti2, session, DepContext()))) == 0
@@ -129,7 +131,7 @@ def test_parent_skip_branch(session, dag_maker):
         ti.task_id: ti
         for ti in dag_maker.create_dagrun(run_type=DagRunType.MANUAL, state=State.RUNNING).task_instances
     }
-    tis["op1"].run()
+    run_ti(tis["op1"], op1)
 
     dep = NotPreviouslySkippedDep()
     assert len(list(dep.get_dep_statuses(tis["op2"], session, DepContext()))) == 1

--- a/airflow-core/tests/unit/ti_deps/deps/test_trigger_rule_dep.py
+++ b/airflow-core/tests/unit/ti_deps/deps/test_trigger_rule_dep.py
@@ -1357,35 +1357,35 @@ def test_upstream_in_mapped_group_triggers_only_relevant(dag_maker, session):
     assert sorted(tis) == [("tg1.t1", 0), ("tg1.t1", 1), ("tg1.t1", 2)]
 
     # After running the first t1, the first t2 becomes immediately available.
-    dag_maker.run_ti(task_id="tg1.t1", map_index=0, dag_run=dr)
+    dag_maker.run_ti("tg1.t1", map_index=0, dag_run=dr)
     tis = _one_scheduling_decision_iteration()
     assert sorted(tis) == [("tg1.t1", 1), ("tg1.t1", 2), ("tg1.t2", 0)]
 
     # Similarly for the subsequent t2 instances.
-    dag_maker.run_ti(task_id="tg1.t1", map_index=2, dag_run=dr)
+    dag_maker.run_ti("tg1.t1", map_index=2, dag_run=dr)
     tis = _one_scheduling_decision_iteration()
     assert sorted(tis) == [("tg1.t1", 1), ("tg1.t2", 0), ("tg1.t2", 2)]
 
     # But running t2 partially does not make t3 available.
-    dag_maker.run_ti(task_id="tg1.t1", map_index=1, dag_run=dr)
-    dag_maker.run_ti(task_id="tg1.t2", map_index=0, dag_run=dr)
-    dag_maker.run_ti(task_id="tg1.t2", map_index=2, dag_run=dr)
+    dag_maker.run_ti("tg1.t1", map_index=1, dag_run=dr)
+    dag_maker.run_ti("tg1.t2", map_index=0, dag_run=dr)
+    dag_maker.run_ti("tg1.t2", map_index=2, dag_run=dr)
     tis = _one_scheduling_decision_iteration()
     assert sorted(tis) == [("tg1.t2", 1)]
 
     # Only after all t2 instances are run does t3 become available.
-    dag_maker.run_ti(task_id="tg1.t2", map_index=1, dag_run=dr)
+    dag_maker.run_ti("tg1.t2", map_index=1, dag_run=dr)
     tis = _one_scheduling_decision_iteration()
     assert sorted(tis) == [("tg2.t3", 0), ("tg2.t3", 1), ("tg2.t3", 2)]
 
     # But running t3 partially does not make t4 available.
-    dag_maker.run_ti(task_id="tg2.t3", map_index=0, dag_run=dr)
-    dag_maker.run_ti(task_id="tg2.t3", map_index=2, dag_run=dr)
+    dag_maker.run_ti("tg2.t3", map_index=0, dag_run=dr)
+    dag_maker.run_ti("tg2.t3", map_index=2, dag_run=dr)
     tis = _one_scheduling_decision_iteration()
     assert sorted(tis) == [("tg2.t3", 1)]
 
     # Only after all t3 instances are run does t4 become available.
-    dag_maker.run_ti(task_id="tg2.t3", map_index=1, dag_run=dr)
+    dag_maker.run_ti("tg2.t3", map_index=1, dag_run=dr)
     tis = _one_scheduling_decision_iteration()
     assert sorted(tis) == [("t4", -1)]
 

--- a/devel-common/src/tests_common/test_utils/taskinstances.py
+++ b/devel-common/src/tests_common/test_utils/taskinstances.py
@@ -1,0 +1,133 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from airflow.ti_deps.dep_context import DepContext
+from airflow.ti_deps.dependencies_deps import REQUEUEABLE_DEPS, RUNNING_DEPS
+from airflow.utils.session import NEW_SESSION, provide_session
+from airflow.utils.state import State, TaskInstanceState
+
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_2_PLUS
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from airflow.models.taskinstance import TaskInstance
+    from airflow.sdk import BaseOperator, Context
+    from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
+    from airflow.sdk.types import Operator
+
+
+def _are_dependencies_met(ti: TaskInstance, dep_context: DepContext, *, session: Session) -> bool:
+    if ti.task is None:
+        raise ValueError("must supply ti.task")
+    for dep in dep_context.deps | ti.task.deps:
+        for dep_status in dep.get_dep_statuses(ti, session, dep_context):
+            if not dep_status.passed:
+                return False
+    return True
+
+
+@provide_session
+def _check_task_dependencies(ti: TaskInstance, *, session: Session = NEW_SESSION) -> bool:
+    """Minimally re-implement dependency-checking for tests."""
+    # Firstly find non-runnable and non-requeueable tis.
+    # Since mark_success is not set, we do nothing.
+    non_requeueable_dep_context = DepContext(
+        deps=RUNNING_DEPS - REQUEUEABLE_DEPS,
+        description="non-requeueable deps",
+    )
+    if not _are_dependencies_met(ti, non_requeueable_dep_context, session=session):
+        return False
+
+    # Secondly we find non-runnable but requeueable tis. We reset its state.
+    # This is because we might have hit concurrency limits,
+    # e.g. because of backfilling.
+    dep_context = DepContext(
+        deps=REQUEUEABLE_DEPS,
+        description="requeueable deps",
+    )
+    if not _are_dependencies_met(ti, dep_context, session=session):
+        return False
+
+    return True
+
+
+def run_ti(ti: TaskInstance, task: Operator) -> None:
+    if not AIRFLOW_V_3_2_PLUS:
+        ti.refresh_from_task(task)  # type: ignore[arg-type]
+        ti.run()
+        return
+
+    from airflow.sdk.definitions.dag import _run_task
+
+    if ti.state in State.finished:
+        return
+    if not _check_task_dependencies(ti):
+        return
+    if not (result := _run_task(ti=ti, task=task)):
+        return
+    ti.state = TaskInstanceState(result.state)
+    if result.error:
+        raise result.error
+
+
+def _as_runtime_task_instance(ti: TaskInstance, task: Operator) -> RuntimeTaskInstance:
+    from airflow.sdk.api.datamodels._generated import TIRunContext
+    from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
+
+    return RuntimeTaskInstance.model_construct(
+        id=ti.id,
+        task_id=ti.task_id,
+        dag_id=ti.dag_id,
+        run_id=ti.run_id,
+        try_number=ti.try_number,
+        map_index=ti.map_index,
+        dag_version_id=ti.dag_version_id,
+        task=task,
+        # This is not exactly right (ti.dag_run is an ORM object, but
+        # TIRunContext expects a data model), but let's not fuss about it...
+        _ti_context_from_server=TIRunContext.model_construct(dag_run=ti.dag_run),
+    )
+
+
+def get_template_context(ti: TaskInstance, task: Operator) -> Context:
+    if not AIRFLOW_V_3_2_PLUS:
+        ti.refresh_from_task(task)  # type: ignore[arg-type]
+        return ti.get_template_context()
+    return _as_runtime_task_instance(ti, task).get_template_context()
+
+
+def render_templates(ti: TaskInstance, task: Operator) -> BaseOperator:
+    """
+    Render templates for given ti.
+
+    :return: The fully rendered task object. If *task* is a mapped operator,
+        the returned object would be its unmapped value. If *task* is not
+        mapped, the same object is returned.
+    """
+    if not AIRFLOW_V_3_2_PLUS:
+        ti.refresh_from_task(task)  # type: ignore[arg-type]
+        ti.render_templates()
+        return ti.task  # type: ignore[return-value]
+    rti = _as_runtime_task_instance(ti, task)
+    rti.render_templates()
+    return rti.task

--- a/providers/amazon/src/airflow/providers/amazon/aws/executors/batch/batch_executor.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/executors/batch/batch_executor.py
@@ -31,25 +31,6 @@ from botocore.exceptions import ClientError, NoCredentialsError
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.executors.base_executor import BaseExecutor
-from airflow.providers.amazon.aws.executors.utils.exponential_backoff_retry import (
-    calculate_next_attempt_delay,
-    exponential_backoff_retry,
-)
-from airflow.providers.amazon.aws.hooks.batch_client import BatchClientHook
-from airflow.providers.amazon.version_compat import AIRFLOW_V_3_0_PLUS
-from airflow.stats import Stats
-
-try:
-    from airflow.sdk import timezone
-except ImportError:
-    from airflow.utils import timezone  # type: ignore[attr-defined,no-redef]
-from airflow.utils.helpers import merge_dicts
-
-if TYPE_CHECKING:
-    from sqlalchemy.orm import Session
-
-    from airflow.executors import workloads
-    from airflow.models.taskinstance import TaskInstance, TaskInstanceKey
 from airflow.providers.amazon.aws.executors.batch.boto_schema import (
     BatchDescribeJobsResponseSchema,
     BatchSubmitJobResponseSchema,
@@ -62,7 +43,26 @@ from airflow.providers.amazon.aws.executors.batch.utils import (
     BatchJobCollection,
     BatchQueuedJob,
 )
+from airflow.providers.amazon.aws.executors.utils.exponential_backoff_retry import (
+    calculate_next_attempt_delay,
+    exponential_backoff_retry,
+)
+from airflow.providers.amazon.aws.hooks.batch_client import BatchClientHook
+from airflow.providers.amazon.version_compat import AIRFLOW_V_3_0_PLUS
+from airflow.stats import Stats
+from airflow.utils.helpers import merge_dicts
 from airflow.utils.state import State
+
+try:
+    from airflow.sdk import timezone
+except ImportError:
+    from airflow.utils import timezone  # type: ignore[attr-defined,no-redef]
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from airflow.executors import workloads
+    from airflow.models.taskinstance import TaskInstance, TaskInstanceKey
 
 CommandType = Sequence[str]
 ExecutorConfigType = dict[str, Any]

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_base_aws.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_base_aws.py
@@ -24,11 +24,6 @@ from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from airflow.providers.amazon.aws.operators.base_aws import AwsBaseOperator
 from airflow.providers.amazon.version_compat import BaseHook
 
-try:
-    from airflow.sdk import timezone
-except ImportError:
-    from airflow.utils import timezone  # type: ignore[attr-defined,no-redef]
-
 TEST_CONN = "aws_test_conn"
 
 
@@ -119,10 +114,7 @@ class TestAwsBaseOperator:
     def test_execute(self, op_kwargs, dag_maker):
         with dag_maker("test_aws_base_operator", serialized=True):
             FakeS3Operator(task_id="fake-task-id", **op_kwargs)
-
-        dagrun = dag_maker.create_dagrun(logical_date=timezone.utcnow())
-        tis = {ti.task_id: ti for ti in dagrun.task_instances}
-        tis["fake-task-id"].run()
+        dag_maker.run_ti("fake-task-id")
 
     def test_no_aws_hook_class_attr(self):
         class NoAwsHookClassOperator(AwsBaseOperator): ...

--- a/providers/amazon/tests/unit/amazon/aws/sensors/test_base_aws.py
+++ b/providers/amazon/tests/unit/amazon/aws/sensors/test_base_aws.py
@@ -24,11 +24,6 @@ from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from airflow.providers.amazon.aws.sensors.base_aws import AwsBaseSensor
 from airflow.providers.amazon.version_compat import BaseHook
 
-try:
-    from airflow.sdk import timezone
-except ImportError:
-    from airflow.utils import timezone  # type: ignore[attr-defined,no-redef]
-
 TEST_CONN = "aws_test_conn"
 
 
@@ -121,10 +116,8 @@ class TestAwsBaseSensor:
     def test_execute(self, dag_maker, op_kwargs):
         with dag_maker("test_aws_base_sensor", serialized=True):
             FakeDynamoDBSensor(task_id="fake-task-id", **op_kwargs, poke_interval=1)
-
-        dagrun = dag_maker.create_dagrun(logical_date=timezone.utcnow())
-        tis = {ti.task_id: ti for ti in dagrun.task_instances}
-        tis["fake-task-id"].run()
+        ti = dag_maker.run_ti("fake-task-id")
+        assert ti.state == "success"
 
     def test_no_aws_hook_class_attr(self):
         class NoAwsHookClassSensor(AwsBaseSensor): ...

--- a/providers/apache/druid/tests/unit/apache/druid/operators/test_druid.py
+++ b/providers/apache/druid/tests/unit/apache/druid/operators/test_druid.py
@@ -27,6 +27,8 @@ from airflow.providers.apache.druid.operators.druid import DruidOperator
 from airflow.utils import timezone
 from airflow.utils.types import DagRunType
 
+from tests_common.test_utils.taskinstances import render_templates
+
 DEFAULT_DATE = timezone.datetime(2017, 1, 1)
 
 JSON_INDEX_STR = """
@@ -68,7 +70,7 @@ def test_render_template(dag_maker):
     dag_run = dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED)
     dag_maker.session.add(dag_run.task_instances[0])
     dag_maker.session.commit()
-    dag_run.task_instances[0].render_templates()
+    render_templates(dag_run.task_instances[0], operator)
     assert json.loads(operator.json_index_file) == RENDERED_INDEX
 
 
@@ -91,7 +93,7 @@ def test_render_template_from_file(tmp_path, dag_maker):
             params={"index_type": "index_hadoop", "datasource": "datasource_prd"},
         )
 
-    dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED).task_instances[0].render_templates()
+    render_templates(dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED).task_instances[0], operator)
     assert json.loads(operator.json_index_file) == RENDERED_INDEX
 
 

--- a/providers/apache/livy/tests/unit/apache/livy/operators/test_livy.py
+++ b/providers/apache/livy/tests/unit/apache/livy/operators/test_livy.py
@@ -559,7 +559,7 @@ class TestLivyOperator:
 
 
 @pytest.mark.db_test
-def test_spark_params_templating(create_task_instance_of_operator, session):
+def test_spark_params_templating(dag_maker, create_task_instance_of_operator, session):
     ti = create_task_instance_of_operator(
         LivyOperator,
         # Templated fields
@@ -585,8 +585,7 @@ def test_spark_params_templating(create_task_instance_of_operator, session):
     )
     session.add(ti)
     session.commit()
-    ti.render_templates()
-    task: LivyOperator = ti.task
+    task = dag_maker.render_templates(ti)
     assert task.spark_params == {
         "archives": "literal-archives",
         "args": "literal-args",

--- a/providers/apache/spark/tests/unit/apache/spark/decorators/test_pyspark.py
+++ b/providers/apache/spark/tests/unit/apache/spark/decorators/test_pyspark.py
@@ -21,17 +21,17 @@ from unittest import mock
 
 import pytest
 
+from airflow.models import Connection
+from airflow.utils import timezone
+
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 if AIRFLOW_V_3_0_PLUS:
     from airflow.sdk import task
 else:
     from airflow.decorators import task  # type: ignore[attr-defined,no-redef]
-from airflow.models import Connection
-from airflow.utils import timezone
 
 DEFAULT_DATE = timezone.datetime(2021, 9, 1)
-
 
 pytestmark = pytest.mark.need_serialized_dag
 
@@ -110,9 +110,7 @@ class TestPysparkDecorator:
         with dag_maker():
             f()
 
-        dr = dag_maker.create_dagrun()
-        ti = dr.get_task_instances()[0]
-        ti.run()
+        ti = dag_maker.run_ti("f")
         assert len(ti.xcom_pull()) == 100
         assert config.get("spark.master") == "spark://none"
         assert config.get("spark.executor.memory") == "2g"
@@ -137,9 +135,7 @@ class TestPysparkDecorator:
         with dag_maker():
             f()
 
-        dr = dag_maker.create_dagrun()
-        ti = dr.get_task_instances()[0]
-        ti.run()
+        ti = dag_maker.run_ti("f")
         assert ti.xcom_pull() == e
         assert config.get("spark.master") == "local[*]"
         spark_mock.builder.config.assert_called_once_with(conf=conf_mock())
@@ -161,9 +157,7 @@ class TestPysparkDecorator:
         with dag_maker():
             f()
 
-        dr = dag_maker.create_dagrun()
-        ti = dr.get_task_instances()[0]
-        ti.run()
+        ti = dag_maker.run_ti("f")
         assert ti.xcom_pull()
         assert config.get("spark.remote") == "sc://localhost"
         assert config.get("spark.master") is None
@@ -187,9 +181,7 @@ class TestPysparkDecorator:
         with dag_maker():
             f()
 
-        dr = dag_maker.create_dagrun()
-        ti = dr.get_task_instances()[0]
-        ti.run()
+        ti = dag_maker.run_ti("f")
         assert ti.xcom_pull()
         assert config.get("spark.remote") == "sc://localhost/;user_id=connect;token=1234;use_ssl=True"
         assert config.get("spark.master") is None

--- a/providers/apache/spark/tests/unit/apache/spark/operators/test_spark_jdbc.py
+++ b/providers/apache/spark/tests/unit/apache/spark/operators/test_spark_jdbc.py
@@ -132,7 +132,7 @@ class TestSparkJDBCOperator:
 
     @pytest.mark.db_test
     def test_templating_with_create_task_instance_of_operator(
-        self, create_task_instance_of_operator, session
+        self, dag_maker, create_task_instance_of_operator, session
     ):
         ti = create_task_instance_of_operator(
             SparkJDBCOperator,
@@ -158,8 +158,7 @@ class TestSparkJDBCOperator:
         )
         session.add(ti)
         session.commit()
-        ti.render_templates()
-        task: SparkJDBCOperator = ti.task
+        task = dag_maker.render_templates(ti)
         assert task.application == "application"
         assert task.conf == "conf"
         assert task.files == "files"

--- a/providers/apache/spark/tests/unit/apache/spark/operators/test_spark_sql.py
+++ b/providers/apache/spark/tests/unit/apache/spark/operators/test_spark_sql.py
@@ -67,7 +67,7 @@ class TestSparkSqlOperator:
         assert self._config["yarn_queue"] == operator._yarn_queue
 
     @pytest.mark.db_test
-    def test_templating(self, create_task_instance_of_operator, session):
+    def test_templating(self, dag_maker, create_task_instance_of_operator, session):
         ti = create_task_instance_of_operator(
             SparkSqlOperator,
             # Templated fields
@@ -78,6 +78,5 @@ class TestSparkSqlOperator:
         )
         session.add(ti)
         session.commit()
-        ti.render_templates()
-        task: SparkSqlOperator = ti.task
+        task = dag_maker.render_templates(ti)
         assert task.sql == "sql"

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/decorators/test_kubernetes_commons.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/decorators/test_kubernetes_commons.py
@@ -124,7 +124,7 @@ class TestKubernetesDecoratorsBase:
         session = self.dag_maker.session
         dag_run = self.dag_maker.create_dagrun(run_id=f"k8s_decorator_test_{DEFAULT_DATE.date()}")
         ti = dag_run.get_task_instance(task.operator.task_id, session=session)
-        return_val = task.operator.execute(context=ti.get_template_context(session=session))
+        return_val = task.operator.execute(context=self.dag_maker.get_template_context(ti))
 
         return ti, return_val
 

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_job.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_job.py
@@ -115,7 +115,7 @@ class TestKubernetesJobOperator:
 
         patch.stopall()
 
-    def test_templates(self, create_task_instance_of_operator, session):
+    def test_templates(self, dag_maker, create_task_instance_of_operator, session):
         dag_id = "TestKubernetesJobOperator"
         ti = create_task_instance_of_operator(
             KubernetesJobOperator,
@@ -147,7 +147,7 @@ class TestKubernetesJobOperator:
         session.add(ti)
         session.commit()
 
-        rendered = ti.render_templates()
+        rendered = dag_maker.render_templates(ti)
 
         assert dag_id == rendered.container_resources.limits["memory"]
         assert dag_id == rendered.container_resources.limits["cpu"]
@@ -155,14 +155,14 @@ class TestKubernetesJobOperator:
         assert dag_id == rendered.container_resources.requests["cpu"]
         assert dag_id == rendered.volume_mounts[0].name
         assert dag_id == rendered.volume_mounts[0].sub_path
-        assert dag_id == ti.task.image
-        assert dag_id == ti.task.cmds
-        assert dag_id == ti.task.namespace
-        assert dag_id == ti.task.config_file
-        assert dag_id == ti.task.labels
-        assert dag_id == ti.task.job_template_file
-        assert dag_id == ti.task.arguments
-        assert dag_id == ti.task.env_vars[0]
+        assert dag_id == rendered.image
+        assert dag_id == rendered.cmds
+        assert dag_id == rendered.namespace
+        assert dag_id == rendered.config_file
+        assert dag_id == rendered.labels
+        assert dag_id == rendered.job_template_file
+        assert dag_id == rendered.arguments
+        assert dag_id == rendered.env_vars[0]
         assert dag_id == rendered.annotations["dag-id"]
 
     def sanitize_for_serialization(self, obj):

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -184,7 +184,7 @@ class TestKubernetesPodOperator:
 
         patch.stopall()
 
-    def test_templates(self, create_task_instance_of_operator, session):
+    def test_templates(self, dag_maker, create_task_instance_of_operator, session):
         dag_id = "TestKubernetesPodOperator"
         ti = create_task_instance_of_operator(
             KubernetesPodOperator,
@@ -227,7 +227,7 @@ class TestKubernetesPodOperator:
 
         session.add(ti)
         session.commit()
-        rendered = ti.render_templates()
+        rendered = dag_maker.render_templates(ti)
 
         assert dag_id == rendered.container_resources.limits["memory"]
         assert dag_id == rendered.container_resources.limits["cpu"]
@@ -235,19 +235,19 @@ class TestKubernetesPodOperator:
         assert dag_id == rendered.container_resources.requests["cpu"]
         assert dag_id == rendered.volume_mounts[0].name
         assert dag_id == rendered.volume_mounts[0].sub_path
-        assert dag_id == ti.task.image
-        assert dag_id == ti.task.cmds
-        assert dag_id == ti.task.name
-        assert dag_id == ti.task.hostname
-        assert dag_id == ti.task.base_container_name
-        assert dag_id == ti.task.namespace
-        assert dag_id == ti.task.config_file
-        assert dag_id == ti.task.labels
-        assert dag_id == ti.task.pod_template_file
-        assert dag_id == ti.task.arguments
-        assert dag_id == ti.task.env_vars[0]
+        assert dag_id == rendered.image
+        assert dag_id == rendered.cmds
+        assert dag_id == rendered.name
+        assert dag_id == rendered.hostname
+        assert dag_id == rendered.base_container_name
+        assert dag_id == rendered.namespace
+        assert dag_id == rendered.config_file
+        assert dag_id == rendered.labels
+        assert dag_id == rendered.pod_template_file
+        assert dag_id == rendered.arguments
+        assert dag_id == rendered.env_vars[0]
         assert dag_id == rendered.annotations["dag-id"]
-        assert dag_id == ti.task.env_from[0].config_map_ref.name
+        assert dag_id == rendered.env_from[0].config_map_ref.name
         assert dag_id == rendered.volumes[0].name
         assert dag_id == rendered.volumes[0].config_map.name
 

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/test_template_rendering.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/test_template_rendering.py
@@ -24,7 +24,7 @@ import yaml
 from kubernetes.client import models as k8s
 from sqlalchemy.orm import make_transient
 
-from airflow.models.renderedtifields import RenderedTaskInstanceFields, RenderedTaskInstanceFields as RTIF
+from airflow.models.renderedtifields import RenderedTaskInstanceFields as RTIF
 from airflow.providers.cncf.kubernetes.template_rendering import get_rendered_k8s_spec, render_k8s_pod_yaml
 from airflow.utils import timezone  # type: ignore[attr-defined]
 from airflow.utils.session import create_session
@@ -170,7 +170,7 @@ def test_render_k8s_pod_yaml_with_custom_pod_template_and_pod_override(
     "only Airflow 3 is supported in providers",
 )
 @mock.patch.dict(os.environ, {"AIRFLOW_IS_K8S_EXECUTOR_POD": "True"})
-@mock.patch.object(RenderedTaskInstanceFields, "get_k8s_pod_yaml")
+@mock.patch.object(RTIF, "get_k8s_pod_yaml")
 @mock.patch("airflow.providers.cncf.kubernetes.template_rendering.render_k8s_pod_yaml")
 def test_get_rendered_k8s_spec(render_k8s_pod_yaml, rtif_get_k8s_pod_yaml, create_task_instance):
     # Create new TI for the same Task

--- a/providers/common/sql/tests/unit/common/sql/operators/test_sql.py
+++ b/providers/common/sql/tests/unit/common/sql/operators/test_sql.py
@@ -59,6 +59,7 @@ from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.db import clear_db_dag_bundles, clear_db_dags, clear_db_runs, clear_db_xcom
 from tests_common.test_utils.markers import skip_if_force_lowest_dependencies_marker
 from tests_common.test_utils.providers import get_provider_min_airflow_version
+from tests_common.test_utils.taskinstances import run_ti
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_1, AIRFLOW_V_3_0_PLUS
 
 if AIRFLOW_V_3_0_PLUS:
@@ -1226,7 +1227,7 @@ class TestSqlBranch:
         )
         if AIRFLOW_V_3_0_PLUS:
             self.scheduler_dag = sync_dag_to_db(self.dag)
-        self.get_ti(branch_op.task_id).run()
+        run_ti(self.get_ti(branch_op.task_id), branch_op)
 
     @mock.patch("airflow.providers.common.sql.operators.sql.BaseSQLOperator.get_db_hook")
     def test_branch_single_value_with_dag_run(self, mock_get_db_hook, branch_op):
@@ -1263,7 +1264,7 @@ class TestSqlBranch:
 
             assert exc_info.value.tasks == [("branch_2", -1)]
         else:
-            self.get_ti(branch_op.task_id, dr).run()
+            run_ti(self.get_ti(branch_op.task_id, dr), branch_op)
             tis = dr.get_task_instances()
 
             for ti in tis:
@@ -1312,7 +1313,7 @@ class TestSqlBranch:
 
             assert exc_info.value.tasks == [("branch_2", -1)]
         else:
-            self.get_ti(branch_op.task_id, dr).run()
+            run_ti(self.get_ti(branch_op.task_id, dr), branch_op)
             tis = dr.get_task_instances()
             for ti in tis:
                 if ti.task_id == "make_choice":
@@ -1359,7 +1360,7 @@ class TestSqlBranch:
                 branch_op.execute({})
             assert exc_info.value.tasks == [("branch_1", -1)]
         else:
-            self.get_ti(branch_op.task_id, dr).run()
+            run_ti(self.get_ti(branch_op.task_id, dr), branch_op)
             tis = dr.get_task_instances()
 
             for ti in tis:
@@ -1418,7 +1419,7 @@ class TestSqlBranch:
                 branch_op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
             assert exc_info.value.tasks == [("branch_3", -1)]
         else:
-            self.get_ti(branch_op.task_id, dr).run()
+            run_ti(self.get_ti(branch_op.task_id, dr), branch_op)
             tis = dr.get_task_instances()
             for ti in tis:
                 if ti.task_id == "make_choice":
@@ -1490,7 +1491,7 @@ class TestSqlBranch:
         for true_value in SUPPORTED_TRUE_VALUES:
             mock_get_records.return_value = [true_value]
 
-            self.get_ti(branch_op.task_id, dr).run()
+            run_ti(self.get_ti(branch_op.task_id, dr), branch_op)
 
             tis = dr.get_task_instances()
             for ti in tis:
@@ -1536,7 +1537,7 @@ class TestSqlBranch:
                 branch_op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
             assert exc_info.value.tasks == [("branch_1", -1)]
         else:
-            self.get_ti(branch_op.task_id, dr).run()
+            run_ti(self.get_ti(branch_op.task_id, dr), branch_op)
             tis = dr.get_task_instances()
             for ti in tis:
                 if ti.task_id == "make_choice":

--- a/providers/google/tests/unit/google/marketing_platform/operators/test_campaign_manager.py
+++ b/providers/google/tests/unit/google/marketing_platform/operators/test_campaign_manager.py
@@ -170,10 +170,7 @@ class TestGoogleCampaignManagerDownloadReportOperator:
         test_bucket_name,
         dag_maker,
     ):
-        http_mock.MediaIoBaseDownload.return_value.next_chunk.return_value = (
-            None,
-            True,
-        )
+        http_mock.MediaIoBaseDownload.return_value.next_chunk.return_value = (None, True)
         tempfile_mock.NamedTemporaryFile.return_value.__enter__.return_value.name = TEMP_FILE_NAME
 
         with dag_maker(dag_id="test_set_bucket_name", start_date=DEFAULT_DATE) as dag:
@@ -195,10 +192,8 @@ class TestGoogleCampaignManagerDownloadReportOperator:
                 task_id="test_task",
             )
 
-        dr = dag_maker.create_dagrun()
-
-        for ti in dr.get_task_instances():
-            ti.run()
+        for ti in dag_maker.create_dagrun().get_task_instances():
+            dag_maker.run_ti(ti)
 
         gcs_hook_mock.return_value.upload.assert_called_once_with(
             bucket_name=BUCKET_NAME,

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
@@ -130,8 +130,7 @@ class TestOpenLineageListenerAirflow2:
             state=DagRunState.RUNNING,
         )
         ti = TaskInstance(t, run_id=run_id)
-        ti.check_and_change_state_before_execution()  # make listener hook on running event
-        ti._run_raw_task()
+        ti.run()
 
         # check if task returns the same DataFrame
         pd.testing.assert_frame_equal(xcom_push_mock.call_args.kwargs["value"], render_df())

--- a/providers/standard/tests/unit/standard/decorators/test_bash.py
+++ b/providers/standard/tests/unit/standard/decorators/test_bash.py
@@ -354,10 +354,9 @@ class TestBashDecorator:
 
         assert bash_task.operator.bash_command == SET_DURING_EXECUTION
 
-        dr = self.dag_maker.create_dagrun()
-        ti = dr.task_instances[0]
+        ti = self.dag_maker.create_dagrun().task_instances[0]
         with pytest.raises(AirflowException, match=f"Can not find the cwd: {cwd_path}"):
-            ti.run()
+            self.dag_maker.run_ti(ti)
         assert ti.task.bash_command == "echo"
 
     def test_cwd_is_file(self, tmp_path):
@@ -375,10 +374,9 @@ class TestBashDecorator:
 
         assert bash_task.operator.bash_command == SET_DURING_EXECUTION
 
-        dr = self.dag_maker.create_dagrun()
-        ti = dr.task_instances[0]
+        ti = self.dag_maker.create_dagrun().task_instances[0]
         with pytest.raises(AirflowException, match=f"The cwd {cwd_file} must be a directory"):
-            ti.run()
+            self.dag_maker.run_ti(ti)
         assert ti.task.bash_command == "echo"
 
     def test_command_not_found(self):
@@ -393,12 +391,12 @@ class TestBashDecorator:
 
         assert bash_task.operator.bash_command == SET_DURING_EXECUTION
 
-        dr = self.dag_maker.create_dagrun()
-        ti = dr.task_instances[0]
+        ti = self.dag_maker.create_dagrun().task_instances[0]
         with pytest.raises(
-            AirflowException, match="Bash command failed\\. The command returned a non-zero exit code 127\\."
+            AirflowException,
+            match="Bash command failed\\. The command returned a non-zero exit code 127\\.",
         ):
-            ti.run()
+            self.dag_maker.run_ti(ti)
         assert ti.task.bash_command == "set -e; something-that-isnt-on-path"
 
     def test_multiple_outputs_true(self):
@@ -491,10 +489,9 @@ class TestBashDecorator:
 
         assert bash_task.operator.bash_command == SET_DURING_EXECUTION
 
-        dr = self.dag_maker.create_dagrun()
-        ti = dr.task_instances[0]
+        ti = self.dag_maker.create_dagrun().task_instances[0]
         with pytest.raises(AirflowException):
-            ti.run()
+            self.dag_maker.run_ti(ti)
         assert ti.task.bash_command == f"{DEFAULT_DATE.date()}; exit 1;"
 
     @pytest.mark.db_test

--- a/providers/standard/tests/unit/standard/decorators/test_python.py
+++ b/providers/standard/tests/unit/standard/decorators/test_python.py
@@ -801,7 +801,7 @@ def test_mapped_decorator_unmap_merge_op_kwargs(dag_maker, session):
     dec = run.task_instance_scheduling_decisions(session=session)
     assert [ti.task_id for ti in dec.schedulable_tis] == ["task1"]
     ti = dec.schedulable_tis[0]
-    dag_maker.run_ti(task_id=ti.task_id, dag_run=run, session=session)
+    dag_maker.run_ti(ti.task_id, dag_run=run, session=session)
 
     # Expand task2.
     dec = run.task_instance_scheduling_decisions(session=session)

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -278,7 +278,7 @@ class TaskInstanceOperations:
     def get_reschedule_start_date(self, id: uuid.UUID, try_number: int = 1) -> TaskRescheduleStartDate:
         """Get the start date of a task reschedule via the API server."""
         resp = self.client.get(f"task-reschedules/{id}/start_date", params={"try_number": try_number})
-        return TaskRescheduleStartDate.model_construct(start_date=resp.json())
+        return TaskRescheduleStartDate(start_date=resp.json())
 
     def get_count(
         self,

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -1249,7 +1249,7 @@ class TestTaskRescheduleOperations:
         result = client.task_instances.get_reschedule_start_date(id=ti_id, try_number=1)
 
         assert isinstance(result, TaskRescheduleStartDate)
-        assert result.start_date == "2024-01-01T00:00:00Z"
+        assert result.start_date == datetime(2024, 1, 1, tzinfo=timezone.utc)
 
 
 class TestHITLOperations:


### PR DESCRIPTION
This is only used in tests now. We should just rewrite all the tests to use another function (probably something inside test util)