### PR TITLE
er: use eralchemy instead of eralchemy2

### DIFF
--- a/devel-common/pyproject.toml
+++ b/devel-common/pyproject.toml
@@ -94,7 +94,7 @@ dependencies = [
 ]
 "docs-gen" = [
     "diagrams>=0.23.4",
-    "eralchemy2>=1.3.8",
+    "eralchemy>=1.5",
 ]
 "mypy" = [
     # Mypy dependencies

--- a/generated/devel_deps.txt
+++ b/generated/devel_deps.txt
@@ -13,7 +13,7 @@ coverage
 deltalake
 diagrams
 duckdb
-eralchemy2
+eralchemy
 execnet
 gitdb
 gitpython

--- a/scripts/ci/prek/generate_airflow_diagrams.py
+++ b/scripts/ci/prek/generate_airflow_diagrams.py
@@ -55,7 +55,7 @@ def main():
                 if sys.platform == "darwin":
                     console.print(
                         "[red]Likely you have no graphviz installed[/]"
-                        "Please install eralchemy2 package to run this script. "
+                        "Please install eralchemy package to run this script. "
                         "This will require to install graphviz, "
                         "and installing graphviz might be difficult for MacOS. Please follow: "
                         "https://pygraphviz.github.io/documentation/stable/install.html#macos ."

--- a/scripts/in_container/run_prepare_er_diagram.py
+++ b/scripts/in_container/run_prepare_er_diagram.py
@@ -37,12 +37,12 @@ MIGRATIONS_DIR = AIRFLOW_ROOT_PATH / "airflow-core" / "src" / "airflow" / "migra
 if __name__ == "__main__":
     console = Console(width=400, color_system="standard")
     try:
-        from eralchemy2 import render_er
+        from eralchemy import render_er
     except ImportError:
         if sys.platform == "darwin":
             console.print(
                 "[red]Likely you have no graphviz installed[/]"
-                "Please install eralchemy2 package to run this script. "
+                "Please install eralchemy package to run this script. "
                 "This will require to install graphviz, "
                 "and installing graphviz might be difficult for MacOS. Please follow: "
                 "https://pygraphviz.github.io/documentation/stable/install.html#macos ."


### PR DESCRIPTION
a distribution of either graphviz or pygraphviz should be installed for this.

One can either use `pip install eralchemy[graphviz]` or `pipinstall eralchemy[pygraphviz]` for this as eralchemy does not distribute graphviz itself now.

eralchemy2 got merged back to eralchemy, so this should depend on the maintained version.