### PR TITLE
fix: prevent user facets from overriding OL facets

### DIFF
--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
@@ -222,8 +222,8 @@ class OpenLineageListener:
                 tags=dag.tags,
                 task=task_metadata,
                 run_facets={
-                    **get_task_parent_run_facet(parent_run_id=parent_run_id, parent_job_name=dag.dag_id),
                     **get_user_provided_run_facets(task_instance, TaskInstanceState.RUNNING),
+                    **get_task_parent_run_facet(parent_run_id=parent_run_id, parent_job_name=dag.dag_id),
                     **get_airflow_mapped_task_facet(task_instance),
                     **get_airflow_run_facet(dagrun, dag, task_instance, task, task_uuid),
                     **debug_facet,
@@ -349,8 +349,8 @@ class OpenLineageListener:
                 nominal_start_time=data_interval_start,
                 nominal_end_time=data_interval_end,
                 run_facets={
-                    **get_task_parent_run_facet(parent_run_id=parent_run_id, parent_job_name=dag.dag_id),
                     **get_user_provided_run_facets(task_instance, TaskInstanceState.SUCCESS),
+                    **get_task_parent_run_facet(parent_run_id=parent_run_id, parent_job_name=dag.dag_id),
                     **get_airflow_run_facet(dagrun, dag, task_instance, task, task_uuid),
                     **get_airflow_debug_facet(),
                 },
@@ -487,8 +487,8 @@ class OpenLineageListener:
                 job_description=doc,
                 job_description_type=doc_type,
                 run_facets={
-                    **get_task_parent_run_facet(parent_run_id=parent_run_id, parent_job_name=dag.dag_id),
                     **get_user_provided_run_facets(task_instance, TaskInstanceState.FAILED),
+                    **get_task_parent_run_facet(parent_run_id=parent_run_id, parent_job_name=dag.dag_id),
                     **get_airflow_run_facet(dagrun, dag, task_instance, task, task_uuid),
                     **get_airflow_debug_facet(),
                 },

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
@@ -314,8 +314,8 @@ class TestOpenLineageListenerAirflow2:
     )
     def test_adapter_start_task_is_called_with_proper_arguments(
         self,
-        mock_get_airflow_mapped_task_facet,
         mock_get_user_provided_run_facets,
+        mock_get_airflow_mapped_task_facet,
         mock_get_airflow_run_facet,
         mock_get_task_parent_run_facet,
         mock_disabled,
@@ -332,7 +332,7 @@ class TestOpenLineageListenerAirflow2:
 
         listener, task_instance = self._create_listener_and_task_instance()
         mock_get_airflow_mapped_task_facet.return_value = {"mapped_facet": 1}
-        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2}
+        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2, "parent": 99}
         mock_get_airflow_run_facet.return_value = {"airflow_run_facet": 3}
         mock_get_task_parent_run_facet.return_value = {"parent": 4}
         mock_debug_facet.return_value = {"debug": "packages"}
@@ -371,8 +371,8 @@ class TestOpenLineageListenerAirflow2:
     )
     def test_adapter_start_task_is_called_with_dag_owners_when_task_owner_is_default(
         self,
-        mock_get_airflow_mapped_task_facet,
         mock_get_user_provided_run_facets,
+        mock_get_airflow_mapped_task_facet,
         mock_get_airflow_run_facet,
         mock_get_task_parent_run_facet,
         mock_disabled,
@@ -381,7 +381,7 @@ class TestOpenLineageListenerAirflow2:
     ):
         listener, task_instance = self._create_listener_and_task_instance()
         mock_get_airflow_mapped_task_facet.return_value = {"mapped_facet": 1}
-        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2}
+        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2, "parent": 99}
         mock_get_airflow_run_facet.return_value = {"airflow_run_facet": 3}
         mock_get_task_parent_run_facet.return_value = {"parent": 4}
         mock_debug_facet.return_value = {"debug": "packages"}
@@ -405,8 +405,8 @@ class TestOpenLineageListenerAirflow2:
     def test_adapter_start_task_is_called_with_dag_description_when_task_doc_is_empty(
         self,
         mock_get_job_name,
-        mock_get_airflow_mapped_task_facet,
         mock_get_user_provided_run_facets,
+        mock_get_airflow_mapped_task_facet,
         mock_get_airflow_run_facet,
         mock_get_task_parent_run_facet,
         mock_disabled,
@@ -416,7 +416,7 @@ class TestOpenLineageListenerAirflow2:
         listener, task_instance = self._create_listener_and_task_instance()
         mock_get_job_name.return_value = "job_name"
         mock_get_airflow_mapped_task_facet.return_value = {"mapped_facet": 1}
-        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2}
+        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2, "parent": 99}
         mock_get_airflow_run_facet.return_value = {"airflow_run_facet": 3}
         mock_get_task_parent_run_facet.return_value = {"parent": 4}
         mock_debug_facet.return_value = {"debug": "packages"}
@@ -457,7 +457,7 @@ class TestOpenLineageListenerAirflow2:
 
         listener, task_instance = self._create_listener_and_task_instance()
         task_instance.logical_date = timezone.datetime(2020, 1, 1, 1, 1, 1)
-        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2}
+        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2, "parent": 99}
         mock_get_airflow_run_facet.return_value = {"airflow": {"task": "..."}}
         mock_get_task_parent_run_facet.return_value = {"parent": 4}
         mock_debug_facet.return_value = {"debug": "packages"}
@@ -499,8 +499,8 @@ class TestOpenLineageListenerAirflow2:
     )
     def test_adapter_fail_task_is_called_with_dag_owners_when_task_owner_is_default(
         self,
-        mock_get_airflow_mapped_task_facet,
         mock_get_user_provided_run_facets,
+        mock_get_airflow_mapped_task_facet,
         mock_get_airflow_run_facet,
         mock_get_task_parent_run_facet,
         mock_disabled,
@@ -509,7 +509,7 @@ class TestOpenLineageListenerAirflow2:
     ):
         listener, task_instance = self._create_listener_and_task_instance()
         mock_get_airflow_mapped_task_facet.return_value = {"mapped_facet": 1}
-        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2}
+        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2, "parent": 99}
         mock_get_airflow_run_facet.return_value = {"airflow_run_facet": 3}
         mock_get_task_parent_run_facet.return_value = {"parent": 4}
         mock_debug_facet.return_value = {"debug": "packages"}
@@ -534,8 +534,8 @@ class TestOpenLineageListenerAirflow2:
     )
     def test_adapter_fail_task_is_called_with_dag_description_when_task_doc_is_empty(
         self,
-        mock_get_airflow_mapped_task_facet,
         mock_get_user_provided_run_facets,
+        mock_get_airflow_mapped_task_facet,
         mock_get_airflow_run_facet,
         mock_get_task_parent_run_facet,
         mock_disabled,
@@ -544,7 +544,7 @@ class TestOpenLineageListenerAirflow2:
     ):
         listener, task_instance = self._create_listener_and_task_instance()
         mock_get_airflow_mapped_task_facet.return_value = {"mapped_facet": 1}
-        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2}
+        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2, "parent": 99}
         mock_get_airflow_run_facet.return_value = {"airflow_run_facet": 3}
         mock_get_task_parent_run_facet.return_value = {"parent": 4}
         mock_debug_facet.return_value = {"debug": "packages"}
@@ -588,7 +588,7 @@ class TestOpenLineageListenerAirflow2:
         time_machine.move_to(timezone.datetime(2023, 1, 3, 13, 1, 1))
 
         listener, task_instance = self._create_listener_and_task_instance()
-        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2}
+        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2, "parent": 99}
         mock_get_airflow_run_facet.return_value = {"airflow": {"task": "..."}}
         mock_get_task_parent_run_facet.return_value = {"parent": 4}
         mock_debug_facet.return_value = {"debug": "packages"}
@@ -630,8 +630,8 @@ class TestOpenLineageListenerAirflow2:
     )
     def test_adapter_complete_task_is_called_with_dag_owners_when_task_owner_is_default(
         self,
-        mock_get_airflow_mapped_task_facet,
         mock_get_user_provided_run_facets,
+        mock_get_airflow_mapped_task_facet,
         mock_get_airflow_run_facet,
         mock_get_task_parent_run_facet,
         mock_disabled,
@@ -640,7 +640,7 @@ class TestOpenLineageListenerAirflow2:
     ):
         listener, task_instance = self._create_listener_and_task_instance()
         mock_get_airflow_mapped_task_facet.return_value = {"mapped_facet": 1}
-        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2}
+        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2, "parent": 99}
         mock_get_airflow_run_facet.return_value = {"airflow_run_facet": 3}
         mock_get_task_parent_run_facet.return_value = {"parent": 4}
         mock_debug_facet.return_value = {"debug": "packages"}
@@ -662,8 +662,8 @@ class TestOpenLineageListenerAirflow2:
     )
     def test_adapter_complete_task_is_called_with_dag_description_when_task_doc_is_empty(
         self,
-        mock_get_airflow_mapped_task_facet,
         mock_get_user_provided_run_facets,
+        mock_get_airflow_mapped_task_facet,
         mock_get_airflow_run_facet,
         mock_get_task_parent_run_facet,
         mock_disabled,
@@ -672,7 +672,7 @@ class TestOpenLineageListenerAirflow2:
     ):
         listener, task_instance = self._create_listener_and_task_instance()
         mock_get_airflow_mapped_task_facet.return_value = {"mapped_facet": 1}
-        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2}
+        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2, "parent": 99}
         mock_get_airflow_run_facet.return_value = {"airflow_run_facet": 3}
         mock_get_task_parent_run_facet.return_value = {"parent": 4}
         mock_debug_facet.return_value = {"debug": "packages"}
@@ -1198,8 +1198,8 @@ class TestOpenLineageListenerAirflow3:
     )
     def test_adapter_start_task_is_called_with_proper_arguments(
         self,
-        mock_get_airflow_mapped_task_facet,
         mock_get_user_provided_run_facets,
+        mock_get_airflow_mapped_task_facet,
         mock_get_airflow_run_facet,
         mock_get_task_parent_run_facet,
         mock_disabled,
@@ -1217,7 +1217,7 @@ class TestOpenLineageListenerAirflow3:
         listener, task_instance = self._create_listener_and_task_instance()
 
         mock_get_airflow_mapped_task_facet.return_value = {"mapped_facet": 1}
-        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2}
+        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2, "parent": 99}
         mock_get_airflow_run_facet.return_value = {"airflow_run_facet": 3}
         mock_get_task_parent_run_facet.return_value = {"parent": 4}
         mock_debug_facet.return_value = {"debug": "packages"}
@@ -1256,8 +1256,8 @@ class TestOpenLineageListenerAirflow3:
     )
     def test_adapter_start_task_is_called_with_dag_owners_when_task_owner_is_default(
         self,
-        mock_get_airflow_mapped_task_facet,
         mock_get_user_provided_run_facets,
+        mock_get_airflow_mapped_task_facet,
         mock_get_airflow_run_facet,
         mock_get_task_parent_run_facet,
         mock_disabled,
@@ -1266,7 +1266,7 @@ class TestOpenLineageListenerAirflow3:
     ):
         listener, task_instance = self._create_listener_and_task_instance()
         mock_get_airflow_mapped_task_facet.return_value = {"mapped_facet": 1}
-        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2}
+        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2, "parent": 99}
         mock_get_airflow_run_facet.return_value = {"airflow_run_facet": 3}
         mock_get_task_parent_run_facet.return_value = {"parent": 4}
         mock_debug_facet.return_value = {"debug": "packages"}
@@ -1291,8 +1291,8 @@ class TestOpenLineageListenerAirflow3:
     def test_adapter_start_task_is_called_with_dag_description_when_task_doc_is_empty(
         self,
         mock_get_job_name,
-        mock_get_airflow_mapped_task_facet,
         mock_get_user_provided_run_facets,
+        mock_get_airflow_mapped_task_facet,
         mock_get_airflow_run_facet,
         mock_get_task_parent_run_facet,
         mock_disabled,
@@ -1302,7 +1302,7 @@ class TestOpenLineageListenerAirflow3:
         listener, task_instance = self._create_listener_and_task_instance()
         mock_get_job_name.return_value = "job_name"
         mock_get_airflow_mapped_task_facet.return_value = {"mapped_facet": 1}
-        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2}
+        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2, "parent": 99}
         mock_get_airflow_run_facet.return_value = {"airflow_run_facet": 3}
         mock_get_task_parent_run_facet.return_value = {"parent": 4}
         mock_debug_facet.return_value = {"debug": "packages"}
@@ -1343,7 +1343,7 @@ class TestOpenLineageListenerAirflow3:
 
         listener, task_instance = self._create_listener_and_task_instance()
         task_instance.get_template_context()["dag_run"].logical_date = timezone.datetime(2020, 1, 1, 1, 1, 1)
-        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2}
+        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2, "parent": 99}
         mock_get_airflow_run_facet.return_value = {"airflow": {"task": "..."}}
         mock_get_task_parent_run_facet.return_value = {"parent": 4}
         mock_debug_facet.return_value = {"debug": "packages"}
@@ -1383,8 +1383,8 @@ class TestOpenLineageListenerAirflow3:
     )
     def test_adapter_fail_task_is_called_with_dag_owners_when_task_owner_is_default(
         self,
-        mock_get_airflow_mapped_task_facet,
         mock_get_user_provided_run_facets,
+        mock_get_airflow_mapped_task_facet,
         mock_get_airflow_run_facet,
         mock_get_task_parent_run_facet,
         mock_disabled,
@@ -1393,7 +1393,7 @@ class TestOpenLineageListenerAirflow3:
     ):
         listener, task_instance = self._create_listener_and_task_instance()
         mock_get_airflow_mapped_task_facet.return_value = {"mapped_facet": 1}
-        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2}
+        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2, "parent": 99}
         mock_get_airflow_run_facet.return_value = {"airflow_run_facet": 3}
         mock_get_task_parent_run_facet.return_value = {"parent": 4}
         mock_debug_facet.return_value = {"debug": "packages"}
@@ -1418,8 +1418,8 @@ class TestOpenLineageListenerAirflow3:
     )
     def test_adapter_fail_task_is_called_with_dag_description_when_task_doc_is_empty(
         self,
-        mock_get_airflow_mapped_task_facet,
         mock_get_user_provided_run_facets,
+        mock_get_airflow_mapped_task_facet,
         mock_get_airflow_run_facet,
         mock_get_task_parent_run_facet,
         mock_disabled,
@@ -1428,7 +1428,7 @@ class TestOpenLineageListenerAirflow3:
     ):
         listener, task_instance = self._create_listener_and_task_instance()
         mock_get_airflow_mapped_task_facet.return_value = {"mapped_facet": 1}
-        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2}
+        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2, "parent": 99}
         mock_get_airflow_run_facet.return_value = {"airflow_run_facet": 3}
         mock_get_task_parent_run_facet.return_value = {"parent": 4}
         mock_debug_facet.return_value = {"debug": "packages"}
@@ -1526,7 +1526,7 @@ class TestOpenLineageListenerAirflow3:
         time_machine.move_to(timezone.datetime(2023, 1, 3, 13, 1, 1), tick=False)
 
         listener, task_instance = self._create_listener_and_task_instance()
-        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2}
+        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2, "parent": 99}
         mock_get_airflow_run_facet.return_value = {"airflow": {"task": "..."}}
         mock_get_task_parent_run_facet.return_value = {"parent": 4}
         mock_debug_facet.return_value = {"debug": "packages"}
@@ -1566,8 +1566,8 @@ class TestOpenLineageListenerAirflow3:
     )
     def test_adapter_complete_task_is_called_with_dag_owners_when_task_owner_is_default(
         self,
-        mock_get_airflow_mapped_task_facet,
         mock_get_user_provided_run_facets,
+        mock_get_airflow_mapped_task_facet,
         mock_get_airflow_run_facet,
         mock_get_task_parent_run_facet,
         mock_disabled,
@@ -1576,7 +1576,7 @@ class TestOpenLineageListenerAirflow3:
     ):
         listener, task_instance = self._create_listener_and_task_instance()
         mock_get_airflow_mapped_task_facet.return_value = {"mapped_facet": 1}
-        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2}
+        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2, "parent": 99}
         mock_get_airflow_run_facet.return_value = {"airflow_run_facet": 3}
         mock_get_task_parent_run_facet.return_value = {"parent": 4}
         mock_debug_facet.return_value = {"debug": "packages"}
@@ -1600,8 +1600,8 @@ class TestOpenLineageListenerAirflow3:
     )
     def test_adapter_complete_task_is_called_with_dag_description_when_task_doc_is_empty(
         self,
-        mock_get_airflow_mapped_task_facet,
         mock_get_user_provided_run_facets,
+        mock_get_airflow_mapped_task_facet,
         mock_get_airflow_run_facet,
         mock_get_task_parent_run_facet,
         mock_disabled,
@@ -1610,7 +1610,7 @@ class TestOpenLineageListenerAirflow3:
     ):
         listener, task_instance = self._create_listener_and_task_instance()
         mock_get_airflow_mapped_task_facet.return_value = {"mapped_facet": 1}
-        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2}
+        mock_get_user_provided_run_facets.return_value = {"custom_user_facet": 2, "parent": 99}
         mock_get_airflow_run_facet.return_value = {"airflow_run_facet": 3}
         mock_get_task_parent_run_facet.return_value = {"parent": 4}
         mock_debug_facet.return_value = {"debug": "packages"}


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Users can provide their custom facets under any key. We should prevent them from overriding crucial facets that OL integration supplies, like parent run facet that was the only one possible to override by accident now.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
