### PR TITLE
Add Kerberos dependency to hive provider

### DIFF
--- a/providers/apache/hive/pyproject.toml
+++ b/providers/apache/hive/pyproject.toml
@@ -64,7 +64,8 @@ dependencies = [
     'pandas>=2.2.3; python_version >="3.13"',
     "pyhive[hive_pure_sasl]>=0.7.0",
     "thrift>=0.11.0",
-    "jmespath>=0.7.0"]
+    "jmespath>=0.7.0",
+]
 
 # The optional dependencies should be modified in place in the generated file
 # Any change in the dependencies is preserved when the file is regenerated

--- a/providers/apache/hive/pyproject.toml
+++ b/providers/apache/hive/pyproject.toml
@@ -65,6 +65,7 @@ dependencies = [
     "pyhive[hive_pure_sasl]>=0.7.0",
     "thrift>=0.11.0",
     "jmespath>=0.7.0",
+    "pykerberos>=1.1.13",
 ]
 
 # The optional dependencies should be modified in place in the generated file

--- a/providers/apache/hive/pyproject.toml
+++ b/providers/apache/hive/pyproject.toml
@@ -64,8 +64,7 @@ dependencies = [
     'pandas>=2.2.3; python_version >="3.13"',
     "pyhive[hive_pure_sasl]>=0.7.0",
     "thrift>=0.11.0",
-    "jmespath>=0.7.0",
-]
+    "jmespath>=0.7.0"]
 
 # The optional dependencies should be modified in place in the generated file
 # Any change in the dependencies is preserved when the file is regenerated

--- a/providers/apache/hive/pyproject.toml
+++ b/providers/apache/hive/pyproject.toml
@@ -88,8 +88,10 @@ dependencies = [
 "vertica" = [
     "apache-airflow-providers-vertica"
 ]
-"kerberos" = [
-    "Kerberos>=1.3.0"
+"GSSAPI" = [
+    # Windows: use winkerberos, others: use kerberos
+    'winkerberos>=0.7.0; sys_platform == "win32"',
+    'kerberos>=1.3.0; sys_platform != "win32"'
 ]
 "common.compat" = [
     "apache-airflow-providers-common-compat"

--- a/providers/apache/hive/pyproject.toml
+++ b/providers/apache/hive/pyproject.toml
@@ -65,7 +65,6 @@ dependencies = [
     "pyhive[hive_pure_sasl]>=0.7.0",
     "thrift>=0.11.0",
     "jmespath>=0.7.0",
-    "Kerberos>=1.3.0",
 ]
 
 # The optional dependencies should be modified in place in the generated file
@@ -88,6 +87,9 @@ dependencies = [
 ]
 "vertica" = [
     "apache-airflow-providers-vertica"
+]
+"kerberos" = [
+    "Kerberos>=1.3.0"
 ]
 "common.compat" = [
     "apache-airflow-providers-common-compat"

--- a/providers/apache/hive/pyproject.toml
+++ b/providers/apache/hive/pyproject.toml
@@ -65,7 +65,7 @@ dependencies = [
     "pyhive[hive_pure_sasl]>=0.7.0",
     "thrift>=0.11.0",
     "jmespath>=0.7.0",
-    "pykerberos>=1.1.13",
+    "Kerberos>=1.3.0",
 ]
 
 # The optional dependencies should be modified in place in the generated file


### PR DESCRIPTION
Add Kerberos (GSSAPI) dependency to Hive provider
When using Python 3.12, the apache-airflow-providers-apache-hive provider relies on pure-sasl for SASL authentication.
If a user attempts to connect to Hive using Kerberos (GSSAPI) without having the required Kerberos libraries installed, they encounter the following error:
Could not start SASL: None of the mechanisms listed meet all required properties

After investigating and debugging, it was determined that this error occurs because pure-sasl requires the kerberos (or winkerberos on Windows) package to support GSSAPI, and it is not installed by default.
This PR updates the Hive provider’s dependencies to include pure-sasl[GSSAPI], ensuring that the necessary Kerberos support is installed automatically. This resolves the SASL startup error and allows users to connect to Hive using Kerberos without additional manual steps