### PR TITLE
Add kubernetes_audience parameter support for Vault secret backend 

### DIFF
--- a/providers/hashicorp/docs/connections/vault.rst
+++ b/providers/hashicorp/docs/connections/vault.rst
@@ -67,6 +67,9 @@ Extra
     ``kubernetes_jwt_path``: Path for kubernetes jwt token (for ``kubernetes`` auth_type, default:
     ``/var/run/secrets/kubernetes.io/serviceaccount/token``).
 
+    ``kubernetes_audience``: Optional audience claim to verify in the JWT token (for ``kubernetes`` auth_type).
+    Required for Vault 1.21+ to suppress deprecation warnings.
+
     ``token_path``: path to file containing authentication token to include in requests sent to Vault
     (for ``token`` and ``github`` auth_type).
 

--- a/providers/hashicorp/docs/secrets-backends/hashicorp-vault.rst
+++ b/providers/hashicorp/docs/secrets-backends/hashicorp-vault.rst
@@ -230,6 +230,17 @@ For more details, please refer to the AWS Assume Role Authentication documentati
     backend = airflow.providers.hashicorp.secrets.vault.VaultBackend
     backend_kwargs = {"connections_path": "airflow-connections", "variables_path": null, "mount_point": "airflow", "url": "http://127.0.0.1:8200", "auth_type": "aws_iam", "assume_role_kwargs": {"RoleArn":"arn:aws:iam::123456789000:role/hashicorp-aws-iam-role", "RoleSessionName": "Airflow"}}
 
+Vault authentication with Kubernetes
+""""""""""""""""""""""""""""""""""""
+
+For Vault 1.21+ you should specify the ``kubernetes_audience`` parameter to suppress deprecation warnings.
+
+.. code-block:: ini
+
+    [secrets]
+    backend = airflow.providers.hashicorp.secrets.vault.VaultBackend
+    backend_kwargs = {"connections_path": "airflow-connections", "variables_path": "airflow-variables", "mount_point": "airflow", "url": "http://127.0.0.1:8200", "auth_type": "kubernetes", "kubernetes_role": "airflow-role", "kubernetes_audience": "vault"}
+
 Using multiple mount points
 """""""""""""""""""""""""""
 

--- a/providers/hashicorp/src/airflow/providers/hashicorp/secrets/vault.py
+++ b/providers/hashicorp/src/airflow/providers/hashicorp/secrets/vault.py
@@ -78,6 +78,8 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
     :param kubernetes_role: Role for Authentication (for ``kubernetes`` auth_type).
     :param kubernetes_jwt_path: Path for kubernetes jwt token (for ``kubernetes`` auth_type, default:
         ``/var/run/secrets/kubernetes.io/serviceaccount/token``).
+    :param kubernetes_audience: Optional audience claim to verify in the JWT token (for ``kubernetes`` auth_type).
+        Required for Vault 1.21+ to suppress deprecation warnings.
     :param gcp_key_path: Path to Google Cloud Service Account key file (JSON) (for ``gcp`` auth_type).
            Mutually exclusive with gcp_keyfile_dict.
     :param gcp_keyfile_dict: Dictionary of keyfile parameters. (for ``gcp`` auth_type).
@@ -112,6 +114,7 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
         region: str | None = None,
         kubernetes_role: str | None = None,
         kubernetes_jwt_path: str = "/var/run/secrets/kubernetes.io/serviceaccount/token",
+        kubernetes_audience: str | None = None,
         gcp_key_path: str | None = None,
         gcp_keyfile_dict: dict | None = None,
         gcp_scopes: str | None = None,
@@ -145,6 +148,7 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
             region=region,
             kubernetes_role=kubernetes_role,
             kubernetes_jwt_path=kubernetes_jwt_path,
+            kubernetes_audience=kubernetes_audience,
             gcp_key_path=gcp_key_path,
             gcp_keyfile_dict=gcp_keyfile_dict,
             gcp_scopes=gcp_scopes,

--- a/providers/hashicorp/tests/unit/hashicorp/_internal_client/test_vault_client.py
+++ b/providers/hashicorp/tests/unit/hashicorp/_internal_client/test_vault_client.py
@@ -588,55 +588,6 @@ class TestVaultClient:
             )
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
-    @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.Kubernetes")
-    def test_kubernetes_with_audience(self, mock_kubernetes, mock_hvac):
-        mock_client = mock.MagicMock()
-        mock_hvac.Client.return_value = mock_client
-        vault_client = _VaultClient(
-            auth_type="kubernetes",
-            kubernetes_role="kube_role",
-            kubernetes_jwt_path="path",
-            kubernetes_audience="test-audience",
-            url="http://localhost:8180",
-            session=None,
-        )
-        with patch("builtins.open", mock_open(read_data="data")) as mock_file:
-            client = vault_client.client
-        mock_file.assert_called_with("path")
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
-        mock_kubernetes.assert_called_with(mock_client.adapter)
-        mock_kubernetes.return_value.login.assert_called_with(
-            role="kube_role", jwt="data", audience="test-audience"
-        )
-        client.is_authenticated.assert_called_with()
-        assert vault_client.kv_engine_version == 2
-
-    @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
-    @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.Kubernetes")
-    def test_kubernetes_with_audience_and_mount_point(self, mock_kubernetes, mock_hvac):
-        mock_client = mock.MagicMock()
-        mock_hvac.Client.return_value = mock_client
-        vault_client = _VaultClient(
-            auth_type="kubernetes",
-            kubernetes_role="kube_role",
-            kubernetes_jwt_path="path",
-            kubernetes_audience="test-audience",
-            auth_mount_point="other",
-            url="http://localhost:8180",
-            session=None,
-        )
-        with patch("builtins.open", mock_open(read_data="data")) as mock_file:
-            client = vault_client.client
-        mock_file.assert_called_with("path")
-        mock_hvac.Client.assert_called_with(url="http://localhost:8180", session=None)
-        mock_kubernetes.assert_called_with(mock_client.adapter)
-        mock_kubernetes.return_value.login.assert_called_with(
-            role="kube_role", jwt="data", audience="test-audience", mount_point="other"
-        )
-        client.is_authenticated.assert_called_with()
-        assert vault_client.kv_engine_version == 2
-
-    @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
     def test_ldap(self, mock_hvac):
         mock_client = mock.MagicMock()
         mock_hvac.Client.return_value = mock_client


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
### **Description**
Starting from Vault 1.21+, when using Kubernetes authentication without an audience parameter configured in the role, users see deprecation warnings:
```
A role without an audience was used to authenticate into Vault. 
Vault v1.21+ will require roles to have an audience.
```

### **Change Made**
- Add optional `kubernetes_audience` parameter to `_VaultClient` class
- Add optional `kubernetes_audience` parameter to `VaultBackend` class  
- Modify `_auth_kubernetes` method to conditionally pass audience to hvac library


### **Dependencies**
This feature requires hvac library version that supports audience parameter in Kubernetes authentication. 
https://github.com/hvac/hvac/pull/1224

**Closes**: #55460

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
