### PR TITLE
[v2-11-test] Prevent scheduler to crash due to RecursionError when making a SQL query

### DIFF
--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -940,7 +940,16 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     )
                     executor.send_callback(request)
                 else:
-                    ti.handle_failure(error=msg, session=session)
+                    try:
+                        ti.handle_failure(error=msg, session=session)
+                    except RecursionError as error:
+                        self.log.error(
+                            "Impossible to handle failure for a task instance %s due to %s.",
+                            ti,
+                            error,
+                        )
+                        session.rollback()
+                        continue
 
         return len(event_buffer)
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

In this PR I have added a `try-except` block for preventing the scheduler from crashing due to `RecursionError` when making a SQL query. This error happens when a session tries to commit a transaction with `non-json-serializble` parameters(task-instance, dag-runs, context, etc.) [here](https://github.com/apache/airflow/blob/v2-11-test/airflow/models/taskinstance.py#L1260).

The DAG which can reproduce this error:
```python
from airflow.models.dag import DAG
from datetime import datetime
from airflow.operators.empty import EmptyOperator
from airflow.operators.python import PythonOperator

with DAG(
    dag_id="circular_conf_error",
    start_date=datetime(2021, 1, 1),
    schedule=None,
    catchup=False,
    max_active_runs=1,
    default_args={"retries": 0},
    description="Example of a DAG which can cause Airflow Scheduler crash.",
) as dag:

    start = EmptyOperator(task_id="start")

    def _create_circular_conf(**context):
        context["dag_run"].conf["steps"] = context["dag_run"].conf

    def _downstream_task(**context):
        print("Help!")

    create_circular_conf = PythonOperator(
        task_id="create_circular_conf", python_callable=_create_circular_conf
    )

    downstream_task = PythonOperator(
        task_id="downstream_task", python_callable=_downstream_task
    )

    end = EmptyOperator(task_id="end")

    # Define task dependencies
    start >> create_circular_conf >> downstream_task >> end

    # If you run the create_circular_conf task without a real downstream task
    # (note that the "end" task is an EmptyOperator which doesn't actually get run)
    # then the scheduler doesn't run into infinite sigterm loop.
    # start >> create_circular_conf >> end

```

This problem doesn't exist for AF3. Because for AF3 the code [raise](https://github.com/apache/airflow/blob/main/task-sdk/src/airflow/sdk/definitions/param.py#L68C1-L72C1) exception and failed immediately in place where discover the `non-json-serializable` data. In the AF2 the code [shows](https://github.com/apache/airflow/blob/v2-11-test/airflow/models/param.py#L74C1-L82C1) the warning that using `non-json-serializable` parameters will be deprecated in AF3. It does not prevent airflow from crashing later with more dramatic consequences.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
