### PR TITLE
Fix Task header in full screen logs

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.tsx
@@ -148,7 +148,7 @@ export const Logs = () => {
       <Dialog.Root onOpenChange={onOpenChange} open={fullscreen} scrollBehavior="inside" size="full">
         <Dialog.Content backdrop>
           <Dialog.Header>
-            <VStack gap={2}>
+            <VStack alignItems="flex-start" gap={2}>
               <Heading size="xl">{taskId}</Heading>
               <TaskLogHeader
                 expanded={expanded}


### PR DESCRIPTION
Task Id was misaligned.

closes: https://github.com/apache/airflow/issues/55785

### Before
<img width="1918" height="934" alt="Screenshot 2025-09-17 at 17 10 48" src="https://github.com/user-attachments/assets/491da959-a390-486c-9f8e-eefe60516e3c" />



### After 
<img width="1910" height="928" alt="Screenshot 2025-09-17 at 17 10 30" src="https://github.com/user-attachments/assets/7af5a15f-79c3-47a8-ac0c-5ceb7c1824cd" />
