### PR TITLE
Call sys.exit instead of builtin exit in task runner parse method in case of missing DAG or task.

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -633,7 +633,7 @@ def parse(what: StartupDetails, log: Logger) -> RuntimeTaskInstance:
         log.error(
             "Dag not found during start up", dag_id=what.ti.dag_id, bundle=bundle_info, path=what.dag_rel_path
         )
-        exit(1)
+        sys.exit(1)
 
     # install_loader()
 
@@ -647,7 +647,7 @@ def parse(what: StartupDetails, log: Logger) -> RuntimeTaskInstance:
             bundle=bundle_info,
             path=what.dag_rel_path,
         )
-        exit(1)
+        sys.exit(1)
 
     if not isinstance(task, (BaseOperator, MappedOperator)):
         raise TypeError(


### PR DESCRIPTION
Builtin exit method apart from raising SystemExit exception also closes stdin (supervisor socket in case of task runner), which breaks supervisor-runner communication.

Thus, we use sys.exit which is intended to be used in production (versus exit which is for interactive shell). See details in the linked issue.

closes: [#55783](https://github.com/apache/airflow/issues/55783)
related: [#55783](https://github.com/apache/airflow/issues/55783)