### PR TITLE
Respect DOCKER_IMAGE environ var in e2e tests

### DIFF
--- a/airflow-e2e-tests/tests/airflow_e2e_tests/conftest.py
+++ b/airflow-e2e-tests/tests/airflow_e2e_tests/conftest.py
@@ -73,6 +73,8 @@ def spin_up_airflow_environment(tmp_path_factory):
     # as it is already available and loaded using prepare_breeze_and_image step in workflow
     pull = False if DOCKER_IMAGE.startswith("ghcr.io/apache/airflow/main/") else True
 
+    console.print(f"[blue]Spinning up airflow environment using {DOCKER_IMAGE}")
+
     compose_instance = DockerCompose(tmp_dir, compose_file_name=["docker-compose.yaml"], pull=pull)
 
     compose_instance.start()
@@ -84,8 +86,6 @@ def spin_up_airflow_environment(tmp_path_factory):
 
 
 def pytest_sessionstart(session):
-    console.print("[blue]Spinning airflow environment...")
-
     tmp_path_factory = session.config._tmp_path_factory
     spin_up_airflow_environment(tmp_path_factory)
 

--- a/dev/breeze/src/airflow_breeze/utils/run_tests.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_tests.py
@@ -103,11 +103,13 @@ def run_docker_compose_tests(
     skip_docker_compose_deletion: bool,
     include_success_outputs: bool,
     test_type: str = "docker-compose",
+    skip_image_check: bool = False,
 ) -> tuple[int, str]:
-    command_result = run_command(["docker", "inspect", image_name], check=False, stdout=DEVNULL)
-    if command_result.returncode != 0:
-        get_console().print(f"[error]Error when inspecting PROD image: {command_result.returncode}[/]")
-        return command_result.returncode, f"Testing {test_type} python with {image_name}"
+    if not skip_image_check:
+        command_result = run_command(["docker", "inspect", image_name], check=False, stdout=DEVNULL)
+        if command_result.returncode != 0:
+            get_console().print(f"[error]Error when inspecting PROD image: {command_result.returncode}[/]")
+            return command_result.returncode, f"Testing {test_type} python with {image_name}"
     pytest_args = ("--color=yes",)
 
     if test_type == "task-sdk-integration":


### PR DESCRIPTION
Image is not considering when giving input. defaulting to ghcr image.
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
