### PR TITLE
Verify team existence on Execution loading

### DIFF
--- a/airflow-core/src/airflow/executors/executor_loader.py
+++ b/airflow-core/src/airflow/executors/executor_loader.py
@@ -32,6 +32,7 @@ from airflow.executors.executor_constants import (
     ConnectorSource,
 )
 from airflow.executors.executor_utils import ExecutorName
+from airflow.models.team import Team
 from airflow.utils.module_loading import import_string
 
 log = logging.getLogger(__name__)
@@ -154,6 +155,30 @@ class ExecutorLoader:
             raise AirflowConfigException("Configuring multiple team based executors is not yet supported!")
 
     @classmethod
+    def _validate_teams_exist_in_database(cls, team_names: set[str]) -> None:
+        """
+        Validate that all specified team names exist in the database.
+
+        :param team_names: Set of team names to validate
+        :raises AirflowConfigException: If any team names don't exist in the database
+        """
+        if not team_names:
+            return
+
+        existing_teams = Team.get_all_team_names()
+
+        missing_teams = team_names - existing_teams
+
+        if missing_teams:
+            missing_teams_list = sorted(missing_teams)
+            missing_teams_str = ", ".join(missing_teams_list)
+
+            raise AirflowConfigException(
+                f"One or more teams specified in executor configuration do not exist in database: {missing_teams_str}. "
+                "Please create these teams first or remove them from executor configuration."
+            )
+
+    @classmethod
     def _get_team_executor_configs(cls) -> list[tuple[str | None, list[str]]]:
         """
         Return a list of executor configs to be loaded.
@@ -207,6 +232,11 @@ class ExecutorLoader:
                 "team-based executors. Please add a global executor configuration (e.g., "
                 "'CeleryExecutor;team1=LocalExecutor' instead of 'team1=CeleryExecutor;team2=LocalExecutor')."
             )
+
+        # Validate that all team names exist in the database (excluding None for global configs)
+        team_names_to_validate = {team_name for team_name in seen_teams if team_name is not None}
+        if team_names_to_validate:
+            cls._validate_teams_exist_in_database(team_names_to_validate)
 
         return configs
 

--- a/airflow-core/tests/unit/models/test_team.py
+++ b/airflow-core/tests/unit/models/test_team.py
@@ -1,0 +1,70 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+from airflow.models.team import Team
+
+
+class TestTeam:
+    """Unit tests for Team model class methods."""
+
+    def test_get_all_teams_id_to_name_mapping_with_teams(self):
+        """Test get_all_teams_id_to_name_mapping returns correct mapping when teams exist."""
+        team1_id = str(uuid.uuid4())
+        team2_id = str(uuid.uuid4())
+        team3_id = str(uuid.uuid4())
+
+        mock_query_result = [
+            (team1_id, "team_alpha"),
+            (team2_id, "team_beta"),
+            (team3_id, "team_gamma"),
+        ]
+
+        # Create a mock session
+        mock_session = MagicMock()
+        mock_session.execute.return_value.all.return_value = mock_query_result
+
+        # Call the method directly with our mock session
+        result = Team.get_all_teams_id_to_name_mapping(session=mock_session)
+
+        expected = {
+            team1_id: "team_alpha",
+            team2_id: "team_beta",
+            team3_id: "team_gamma",
+        }
+        assert result == expected
+
+        # Verify the execute method was called correctly
+        mock_session.execute.assert_called_once()
+        mock_session.execute.return_value.all.assert_called_once()
+
+    def test_get_all_team_names_with_teams(self):
+        """Test get_all_team_names returns correct set of names when teams exist."""
+        mock_mapping = {
+            "uuid-1": "team_alpha",
+            "uuid-2": "team_beta",
+            "uuid-3": "team_gamma",
+        }
+
+        with patch.object(Team, "get_all_teams_id_to_name_mapping", return_value=mock_mapping):
+            result = Team.get_all_team_names()
+
+            assert result == {"team_alpha", "team_beta", "team_gamma"}
+            assert isinstance(result, set)


### PR DESCRIPTION
If bad configuration was provided (user tried to configure an executor for a team that does not exist) then throw an exception and do not allow execution loading to complete (and Airflow Scheduler to start).

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
