### PR TITLE
Move rtl logic to react

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/BaseLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/BaseLayout.tsx
@@ -35,9 +35,12 @@ export const BaseLayout = ({ children }: PropsWithChildren) => {
 
   useEffect(() => {
     const html = document.documentElement;
-    const updateHtml = (lng: string) => {
-      html.setAttribute("dir", i18n.dir(lng));
-      html.setAttribute("lang", lng);
+
+    const updateHtml = (language: string) => {
+      if (language) {
+        html.setAttribute("dir", i18n.dir(language));
+        html.setAttribute("lang", language);
+      }
     };
 
     i18n.on("languageChanged", updateHtml);

--- a/airflow-core/src/airflow/ui/src/layouts/BaseLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/BaseLayout.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { Box, LocaleProvider } from "@chakra-ui/react";
-import type { PropsWithChildren } from "react";
+import { useEffect, type PropsWithChildren } from "react";
 import { useTranslation } from "react-i18next";
 import { Outlet } from "react-router-dom";
 
@@ -32,6 +32,20 @@ export const BaseLayout = ({ children }: PropsWithChildren) => {
   if (typeof instanceName === "string") {
     document.title = instanceName;
   }
+
+  useEffect(() => {
+    const html = document.documentElement;
+    const updateHtml = (lng: string) => {
+      html.setAttribute("dir", i18n.dir(lng));
+      html.setAttribute("lang", lng);
+    };
+
+    i18n.on("languageChanged", updateHtml);
+
+    return () => {
+      i18n.off("languageChanged", updateHtml);
+    };
+  }, [i18n]);
 
   return (
     <LocaleProvider locale={i18n.language}>

--- a/airflow-core/src/airflow/ui/src/main.tsx
+++ b/airflow-core/src/airflow/ui/src/main.tsx
@@ -68,19 +68,10 @@ axios.interceptors.response.use(
 
 axios.interceptors.request.use(tokenHandler);
 
-const html = document.documentElement;
-const updateHtml = (lng: string) => {
-  html.setAttribute("dir", i18n.dir(lng));
-  html.setAttribute("lang", lng);
-};
-
-updateHtml(i18n.language);
-i18n.on("languageChanged", updateHtml);
-
 createRoot(document.querySelector("#root") as HTMLDivElement).render(
   <StrictMode>
     <I18nextProvider i18n={i18n}>
-      <ChakraProvider i18nIsDynamicList={true} value={system}>
+      <ChakraProvider value={system}>
         <ColorModeProvider>
           <QueryClientProvider client={client}>
             <TimezoneProvider>


### PR DESCRIPTION
`i18n()` is a promise. Our original check wasn't waiting on our translations to load before setting the html direction and language, which if an empty string was passed then it would erroneously default to RTL.

Instead, let's handle it inside of a useEffect that actually waits on changes.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
