### PR TITLE
Fix circular import error when Kubernetes executors are dynamically loaded with Sentry

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/job.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/job.py
@@ -42,7 +42,12 @@ from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperato
 from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator, merge_objects
 from airflow.providers.cncf.kubernetes.triggers.job import KubernetesJobTrigger
 from airflow.providers.cncf.kubernetes.utils.pod_manager import EMPTY_XCOM_RESULT, PodNotFoundException
-from airflow.providers.cncf.kubernetes.version_compat import BaseOperator
+from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_1_PLUS
+
+if AIRFLOW_V_3_1_PLUS:
+    from airflow.sdk import BaseOperator
+else:
+    from airflow.models import BaseOperator
 from airflow.utils import yaml
 from airflow.utils.context import Context
 

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/kueue.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/kueue.py
@@ -27,7 +27,12 @@ from kubernetes.utils import FailToCreateError
 from airflow.exceptions import AirflowException
 from airflow.providers.cncf.kubernetes.hooks.kubernetes import KubernetesHook
 from airflow.providers.cncf.kubernetes.operators.job import KubernetesJobOperator
-from airflow.providers.cncf.kubernetes.version_compat import BaseOperator
+from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_1_PLUS
+
+if AIRFLOW_V_3_1_PLUS:
+    from airflow.sdk import BaseOperator
+else:
+    from airflow.models import BaseOperator
 
 
 class KubernetesInstallKueueOperator(BaseOperator):

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -80,7 +80,12 @@ from airflow.providers.cncf.kubernetes.utils.pod_manager import (
     container_is_succeeded,
     get_container_termination_message,
 )
-from airflow.providers.cncf.kubernetes.version_compat import XCOM_RETURN_KEY, BaseOperator
+from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_1_PLUS, XCOM_RETURN_KEY
+
+if AIRFLOW_V_3_1_PLUS:
+    from airflow.sdk import BaseOperator
+else:
+    from airflow.models import BaseOperator
 from airflow.settings import pod_mutation_hook
 from airflow.utils import yaml
 from airflow.utils.helpers import prune_dict, validate_key

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/resource.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/resource.py
@@ -32,7 +32,12 @@ from airflow.providers.cncf.kubernetes.hooks.kubernetes import KubernetesHook
 from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import should_retry_creation
 from airflow.providers.cncf.kubernetes.utils.delete_from import delete_from_yaml
 from airflow.providers.cncf.kubernetes.utils.k8s_resource_iterator import k8s_resource_iterator
-from airflow.providers.cncf.kubernetes.version_compat import BaseOperator
+from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_1_PLUS
+
+if AIRFLOW_V_3_1_PLUS:
+    from airflow.sdk import BaseOperator
+else:
+    from airflow.models import BaseOperator
 
 if TYPE_CHECKING:
     from kubernetes.client import ApiClient, CustomObjectsApi

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/sensors/spark_kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/sensors/spark_kubernetes.py
@@ -25,7 +25,12 @@ from kubernetes import client
 
 from airflow.exceptions import AirflowException
 from airflow.providers.cncf.kubernetes.hooks.kubernetes import KubernetesHook
-from airflow.providers.cncf.kubernetes.version_compat import BaseSensorOperator
+from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_0_PLUS
+
+if AIRFLOW_V_3_0_PLUS:
+    from airflow.sdk import BaseSensorOperator
+else:
+    from airflow.sensors.base import BaseSensorOperator  # type: ignore[no-redef]
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/version_compat.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/version_compat.py
@@ -37,16 +37,14 @@ AIRFLOW_V_3_1_PLUS = get_base_airflow_version_tuple() >= (3, 1, 0)
 
 if AIRFLOW_V_3_1_PLUS:
     from airflow.models.xcom import XCOM_RETURN_KEY
-    from airflow.sdk import BaseHook, BaseOperator
+    from airflow.sdk import BaseHook
     from airflow.sdk.definitions.context import context_merge
 else:
     from airflow.hooks.base import BaseHook  # type: ignore[attr-defined,no-redef]
-    from airflow.models import BaseOperator
     from airflow.utils.context import context_merge  # type: ignore[attr-defined, no-redef]
     from airflow.utils.xcom import XCOM_RETURN_KEY  # type: ignore[no-redef]
 
 if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import BaseSensorOperator
     from airflow.sdk.bases.decorator import DecoratedOperator, TaskDecorator, task_decorator_factory
 else:
     from airflow.decorators.base import (  # type: ignore[no-redef]
@@ -54,14 +52,14 @@ else:
         TaskDecorator,
         task_decorator_factory,
     )
-    from airflow.sensors.base import BaseSensorOperator  # type: ignore[no-redef]
+
+# BaseOperator and BaseSensorOperator removed from version_compat to avoid circular imports
+# Import them directly in files that need them instead
 
 __all__ = [
     "AIRFLOW_V_3_0_PLUS",
     "AIRFLOW_V_3_1_PLUS",
     "BaseHook",
-    "BaseOperator",
-    "BaseSensorOperator",
     "DecoratedOperator",
     "TaskDecorator",
     "task_decorator_factory",


### PR DESCRIPTION
Resolves circular import that occurs when `KubernetesExecutor` is dynamically loaded during Airflow startup. The issue manifests as 'cannot import name from partially initialized module' errors during scheduler/triggerer initialization.

Root cause: The import chain `executor` → `version_compat` → `BaseOperator` → `taskinstance` → `sentry` → `executor` creates a circular dependency when sentry is enabled, as sentry initialization attempts to load the executor while it's already being imported.

Changes:
- Remove `BaseOperator` and `BaseSensorOperator` from `version_compat.py` module-level imports
- Add conditional imports directly in operator/sensor files that need these classes
- Maintain compatibility across Airflow 2.x and 3.x versions

This prevents the circular import by breaking the chain at version_compat, ensuring sentry initialization doesn't trigger recursive executor loading.

Fixes https://github.com/apache/airflow/issues/55810

---

To Reproduce:

```shell
❯ docker run --rm apache/airflow:2.11.0 bash -c 'pip install sentry-sdk apache-airflow-providers-cncf-kubernetes==10.6.1
export AIRFLOW__CORE__EXECUTOR="KubernetesExecutor"
export AIRFLOW__SENTRY__SENTRY_ON="True"
export AIRFLOW__SENTRY__SENTRY_DSN="https://fake@fake.ingest.sentry.io/fake"
export AIRFLOW__DATABASE__SQL_ALCHEMY_CONN="postgresql://fake:fake@fake:5432/Sentry enabled (sentry_on=True)"

python3 -c "import airflow.providers.cncf.kubernetes.executors.kubernetes_executor"
'
```

Error log:

```
Collecting sentry-sdk
  ...

/home/airflow/.local/lib/python3.12/site-packages/airflow/metrics/base_stats_logger.py:22 RemovedInAirflow3Warning: Timer and timing metrics publish in seconds were deprecated. It is enabled by default from Airflow 3 onwards. Enable timer_unit_consistency to publish all the timer and timing metrics in milliseconds.
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/utils/module_loading.py", line 42, in import_string
    return getattr(module, class_name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: partially initialized module 'airflow.providers.cncf.kubernetes.executors.kubernetes_executor' has no attribute 'KubernetesExecutor' (most likely due to a circular import)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py", line 43, in <module>
    from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/providers/cncf/kubernetes/pod_generator.py", line 49, in <module>
    from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_0_PLUS
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/providers/cncf/kubernetes/version_compat.py", line 41, in <module>
    from airflow.models import BaseOperator  # type: ignore[no-redef]
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/models/__init__.py", line 79, in __getattr__
    val = import_string(f"{path}.{name}")
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/utils/module_loading.py", line 39, in import_string
    module = import_module(module_path)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/models/baseoperator.py", line 83, in <module>
    from airflow.models.mappedoperator import OperatorPartial, validate_mapping_kwargs
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/models/mappedoperator.py", line 54, in <module>
    from airflow.triggers.base import StartTriggerArgs
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/triggers/base.py", line 27, in <module>
    from airflow.models.taskinstance import SimpleTaskInstance
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/models/taskinstance.py", line 106, in <module>
    from airflow.sentry import Sentry
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/sentry.py", line 196, in <module>
    Sentry = ConfiguredSentry()
             ^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/sentry.py", line 88, in __init__
    executor_class, _ = ExecutorLoader.import_default_executor_cls(validate=False)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/executors/executor_loader.py", line 314, in import_default_executor_cls
    executor, source = cls.import_executor_cls(executor_name, validate=validate)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/executors/executor_loader.py", line 302, in import_executor_cls
    return _import_and_validate(executor_name.module_path), executor_name.connector_source
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/executors/executor_loader.py", line 286, in _import_and_validate
    executor = import_string(path)
               ^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/utils/module_loading.py", line 44, in import_string
    raise ImportError(f'Module "{module_path}" does not define a "{class_name}" attribute/class')
ImportError: Module "airflow.providers.cncf.kubernetes.executors.kubernetes_executor" does not define a "KubernetesExecutor" attribute/class
```

