### PR TITLE
Fix async connection retrieval in triggerer context

### DIFF
--- a/task-sdk/pyproject.toml
+++ b/task-sdk/pyproject.toml
@@ -50,6 +50,7 @@ classifiers = [
 ]
 dependencies = [
     "apache-airflow-core<3.3.0,>=3.2.0",
+    "asgiref>=2.3.0",
     "attrs>=24.2.0, !=25.2.0",
     "fsspec>=2023.10.0",
     "httpx>=0.27.0",


### PR DESCRIPTION
Add async support for secrets backends in _async_get_connection using sync_to_async to prevent event loop blocking. This resolves the 'async_to_sync forbidden in event loop' error when triggers call get_connection() and secrets backends need to be checked.

Also fix Databricks provider to use async connection methods in async contexts instead of cached properties that cause sync calls.

Fixes triggerer failures when providers access connections during async trigger execution.

Related PRs;
- https://github.com/apache/airflow/pull/55568
- https://github.com/apache/airflow/pull/55799

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
