### PR TITLE
Enforce at least one global executor is configured

### DIFF
--- a/airflow-core/src/airflow/executors/executor_loader.py
+++ b/airflow-core/src/airflow/executors/executor_loader.py
@@ -199,6 +199,15 @@ class ExecutorLoader:
             # Split by comma to get the individual executor names and strip spaces off of them
             configs.append((team_name, [name.strip() for name in executor_names.split(",")]))
 
+            # Validate that at least one global executor exists
+            has_global_executor = any(team_name is None for team_name, _ in configs)
+            if not has_global_executor:
+                raise AirflowConfigException(
+                    "At least one global executor must be configured. The current configuration only contains "
+                    "team-based executors. Please add a global executor configuration (e.g., "
+                    "'CeleryExecutor;team1=LocalExecutor' instead of 'team1=CeleryExecutor;team2=LocalExecutor')."
+                )
+
         return configs
 
     @classmethod

--- a/airflow-core/src/airflow/executors/executor_loader.py
+++ b/airflow-core/src/airflow/executors/executor_loader.py
@@ -199,14 +199,14 @@ class ExecutorLoader:
             # Split by comma to get the individual executor names and strip spaces off of them
             configs.append((team_name, [name.strip() for name in executor_names.split(",")]))
 
-            # Validate that at least one global executor exists
-            has_global_executor = any(team_name is None for team_name, _ in configs)
-            if not has_global_executor:
-                raise AirflowConfigException(
-                    "At least one global executor must be configured. The current configuration only contains "
-                    "team-based executors. Please add a global executor configuration (e.g., "
-                    "'CeleryExecutor;team1=LocalExecutor' instead of 'team1=CeleryExecutor;team2=LocalExecutor')."
-                )
+        # Validate that at least one global executor exists
+        has_global_executor = any(team_name is None for team_name, _ in configs)
+        if not has_global_executor:
+            raise AirflowConfigException(
+                "At least one global executor must be configured. Current configuration only contains "
+                "team-based executors. Please add a global executor configuration (e.g., "
+                "'CeleryExecutor;team1=LocalExecutor' instead of 'team1=CeleryExecutor;team2=LocalExecutor')."
+            )
 
         return configs
 

--- a/airflow-core/tests/unit/executors/test_executor_loader.py
+++ b/airflow-core/tests/unit/executors/test_executor_loader.py
@@ -475,10 +475,8 @@ class TestExecutorLoader:
     @pytest.mark.parametrize(
         "executor_config",
         [
-            "team1=CeleryExecutor;team1=LocalExecutor",
-            "team1=CeleryExecutor;team2=LocalExecutor;team1=KubernetesExecutor",
             "CeleryExecutor;team1=LocalExecutor;team1=KubernetesExecutor",
-            "team_a=CeleryExecutor;team_b=LocalExecutor;team_a=KubernetesExecutor",
+            "CeleryExecutor;team_a=LocalExecutor;team_b=KubernetesExecutor;team_a=CeleryExecutor",
         ],
     )
     def test_duplicate_team_names_should_fail(self, executor_config):
@@ -563,8 +561,9 @@ class TestExecutorLoader:
         """Test that configurations with only team-based executors fail validation."""
         with (
             mock.patch.object(executor_loader.ExecutorLoader, "block_use_of_multi_team"),
-            mock.patch.object(executor_loader.ExecutorLoader, "_validate_teams_exist_in_database"),
             conf_vars({("core", "executor"): executor_config}),
         ):
-            with pytest.raises(AirflowConfigException):
+            with pytest.raises(
+                AirflowConfigException, match=r"At least one global executor must be configured"
+            ):
                 executor_loader.ExecutorLoader._get_team_executor_configs()


### PR DESCRIPTION
There are various processes in Airflow that are not yet team-ified and that rely on executors (serving logs, callback handling) so for now, enforce that at least one global executor is present to be used for such things. This can be revisited and relaxed at a future time.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
