### PR TITLE
Temporary fix to Bitnami psql chart licensing issues

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2853,9 +2853,13 @@ cleanup:
   successfulJobsHistoryLimit: ~
 
 # Configuration for postgresql subchart
-# Not recommended for production
+# Uses bitnamilegacy images to avoid Bitnami licensing restrictions
+# Not recommended for production - use external database instead
 postgresql:
   enabled: true
+  image:
+    repository: bitnamilegacy/postgresql
+    tag: "13.2.0"
   auth:
     enablePostgresUser: true
     postgresPassword: postgres

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2858,8 +2858,8 @@ cleanup:
 postgresql:
   enabled: true
   image:
-    repository: bitnamilegacy/postgresql
-    tag: "13.2.0"
+    repository: postgres
+    tag: "13"
   auth:
     enablePostgresUser: true
     postgresPassword: postgres


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

The Airflow Helm chart deployment fails with `ImagePullBackOff` errors when trying to pull `docker.io/bitnami/postgresql:16.1.0-debian-11-r15`. This is due to Bitnami's recent licensing changes that moved newer postgres images behind a paywall, requiring VMware Tanzu subscriptions for access.



* Bitnami (now VMware) has restricted access to newer PostgreSQL images in their main repository
* The current chart version (13.2.24) tries to pull restricted images that require authentication
* This affects all KinD-based testing and development workflows
* Bitnami is running a "brownout" period where they're gradually restricting access to newer images -- Sept 17 - Sept 19 is when postgres got impacted. Check details here: https://github.com/bitnami/charts/issues/35164


### Solution

The solution to this issue is two fold:

#### Short Term

Switch to bitnamilegacy/postgresql images which are freely available and contain the same postgres functionality without licensing restrictions. (this is also suggested in the linked issue)

To do that i've added:
```
  image:
    repository: bitnamilegacy/postgresql
    tag: "13.2.0"
```

This uses the closest complaint image to `docker.io/bitnami/postgresql:16.1.0-debian-11-r15` and overrides the image in the postgres charts that we keep in the repository as subcharts.

#### Testing:
[x] kind cluster deployment succeeds
[x] postgres pod starts successfully -- with the right image that has been overriden
[x] Airflow components can connect to database
[x] No functionality regression

Deployment successful:

<img width="1702" height="910" alt="image (45)" src="https://github.com/user-attachments/assets/2c7b85b5-4f8f-4a0c-8154-6120c867aee2" />

Tests passing locally:

```
Kubeconfig file in:
/Users/amoghdesai/Documents/OSS/repos/airflow/.build/.k8s-clusters/airflow-python-3.10-v1.30.10/.kubeconfig


KinD Cluster API server URL: http://localhost:12271
Connecting to localhost:46651. Num try: 1
Established connection to api server at http://localhost:46651/api/v2/monitor/health and it is healthy.
Airflow API server URL: http://localhost:46651 (admin/admin)


Deleting cluster for Python 3.10, Kubernetes v1.30.10

Deleting KinD cluster airflow-python-3.10-v1.30.10!
Deleting cluster "airflow-python-3.10-v1.30.10" ...
Deleted nodes: ["airflow-python-3.10-v1.30.10-control-plane" "airflow-python-3.10-v1.30.10-worker"]
KinD cluster airflow-python-3.10-v1.30.10 deleted!


Successfully run tests for Python 3.10, Kubernetes v1.30.10
```


#### Long Term

* Remove postgres dependency entirely from the helm chart (lazy consensus has been achieved: https://lists.apache.org/thread/3o4wj76pmd2m13jho7sxcbfkbgpv88h9)
* Make sqlite the default database in values.yaml for development/testing
* Update CI/CD pipelines to use sqlite
* Eliminate bitnami dependency
* Users can extend our helm charts and provide their own DBs on top of it.




<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
