### PR TITLE
Respect old logging format if given so logs don't change unexpectedly.

### DIFF
--- a/airflow-core/src/airflow/logging_config.py
+++ b/airflow-core/src/airflow/logging_config.py
@@ -89,11 +89,19 @@ def configure_logging():
 
     logging_config, logging_class_path = load_logging_config()
     try:
-        level: str = conf.get_mandatory_value("logging", "LOGGING_LEVEL").upper()
+        level: str = getattr(
+            logging_config, "LOG_LEVEL", conf.get("logging", "logging_level", fallback="INFO")
+        ).upper()
+
+        colors = getattr(
+            logging_config,
+            "COLORED_LOG",
+            conf.getboolean("logging", "colored_console_log", fallback=True),
+        )
         # Try to init logging
 
         log_fmt, callsite_params = translate_config_values(
-            log_format=conf.get("logging", "log_format"),
+            log_format=getattr(logging_config, "LOG_FORMAT", conf.get("logging", "log_format", fallback="")),
             callsite_params=conf.getlist("logging", "callsite_parameters", fallback=[]),
         )
         configure_logging(
@@ -101,6 +109,7 @@ def configure_logging():
             stdlib_config=logging_config,
             log_format=log_fmt,
             callsite_parameters=callsite_params,
+            colors=colors,
         )
     except (ValueError, KeyError) as e:
         log.error("Unable to load the config, contains a configuration error.")

--- a/shared/logging/src/airflow_shared/logging/_config.py
+++ b/shared/logging/src/airflow_shared/logging/_config.py
@@ -20,6 +20,10 @@ from __future__ import annotations
 import structlog.processors
 
 OLD_DEFAULT_LOG_FORMAT = "[%(asctime)s] {%(filename)s:%(lineno)d} %(levelname)s - %(message)s"
+OLD_DEFAULT_COLOR_LOG_FORMAT = (
+    "[%(blue)s%(asctime)s%(reset)s] {%(blue)s%(filename)s:%(reset)s%(lineno)d} "
+    "%(log_color)s%(levelname)s%(reset)s - %(log_color)s%(message)s%(reset)s"
+)
 
 
 # This doesn't load the values from config, to avoid a cross dependency between shared logging and shared
@@ -28,8 +32,9 @@ def translate_config_values(
     log_format: str, callsite_params: list[str]
 ) -> tuple[str, tuple[structlog.processors.CallsiteParameter, ...]]:
     if log_format == OLD_DEFAULT_LOG_FORMAT:
-        # It's the default, don't use it, use the new default from structlog instead
-        log_format = ""
+        # It's the default, use the coloured version by default. This will automatically not put color codes
+        # if we're not a tty, or if colors are disabled
+        log_format = OLD_DEFAULT_COLOR_LOG_FORMAT
 
     # This will raise an exception if the value isn't valid
     params_out = tuple(

--- a/shared/logging/src/airflow_shared/logging/percent_formatter.py
+++ b/shared/logging/src/airflow_shared/logging/percent_formatter.py
@@ -140,7 +140,8 @@ class PercentFormatRender(ConsoleRenderer):
         params = _LazyLogRecordDict(
             event_dict,
             method_name,
-            ConsoleRenderer.get_default_level_styles(),
+            # To maintain compat with old log levels, we don't want to color info, just everything else
+            {**ConsoleRenderer.get_default_level_styles(), "info": ""},
             self._styles,
         )
 


### PR DESCRIPTION
If someone is upgrading from any earlier version, their config file with have
`log_format` in it, even though we have now changed the default to an empty
string.

This also makes respects the colored_console_log config option

If it is specified we should respect it, even though our new default has
changed.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
