### PR TITLE
Expose config option to set different loggers at different levels.

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -788,11 +788,34 @@ logging:
       description: |
         Logging level.
 
+        Individual loggers can be set at a different level with the :ref:`config:logging__namespace_levels`
+        option.
+
         Supported values: ``CRITICAL``, ``ERROR``, ``WARNING``, ``INFO``, ``DEBUG``.
       version_added: 2.0.0
       type: string
       example: ~
       default: "INFO"
+    namespace_levels:
+      description: |
+        Set the log level for individual named loggers.
+
+        A very common convention in Python is to use the module name as the name of the logger from which log
+        messages originate. This config option gives us the ability to set log levels for those loggers
+        easily.
+
+        The format of this variable is a series of ``<logger>=<level>`` pairs, separated by whitespace or
+        commas.
+
+        Each level is one of the possible values to ``logging_level``.
+
+        The logger names are viewable in task logs (as the "source" attribute), or in server components by
+        including ``%(name)s`` in your format string, or in the between ``[]`` after the message in the
+        default format.
+      version_added: 3.1.0
+      type: string
+      example: "sqlalchemy=INFO sqlalchemy.engine=DEBUG, botocor"
+      default: ~
     celery_logging_level:
       description: |
         Logging level for celery. If not set, it uses the value of logging_level

--- a/airflow-core/src/airflow/logging_config.py
+++ b/airflow-core/src/airflow/logging_config.py
@@ -98,6 +98,7 @@ def configure_logging():
         )
         configure_logging(
             log_level=level,
+            namespace_log_levels=conf.get("logging", "namespace_levels", fallback=None),
             stdlib_config=logging_config,
             log_format=log_fmt,
             callsite_parameters=callsite_params,

--- a/shared/logging/tests/logging/test_structlog.py
+++ b/shared/logging/tests/logging/test_structlog.py
@@ -306,7 +306,7 @@ def test_logger_filtering(structlog_config, levels):
         colors=False,
         log_format="[%(name)s] %(message)s",
         log_level="DEBUG",
-        log_levels=levels,
+        namespace_log_levels=levels,
     ) as sio:
         structlog.get_logger("my").info("Hello", key1="value1")
         structlog.get_logger("my.logger").info("Hello", key1="value2")

--- a/task-sdk/src/airflow/sdk/log.py
+++ b/task-sdk/src/airflow/sdk/log.py
@@ -91,6 +91,8 @@ def configure_logging(
     if colored_console_log is None:
         colored_console_log = conf.getboolean("logging", "colored_console_log", fallback=True)
 
+    namespace_log_levels = conf.get("logging", "namespace_levels", fallback=None)
+
     from airflow.sdk._shared.logging import configure_logging, translate_config_values
 
     log_fmt, callsite_params = translate_config_values(
@@ -110,6 +112,7 @@ def configure_logging(
     configure_logging(
         json_output=json_output,
         log_level=log_level,
+        namespace_log_levels=namespace_log_levels,
         log_format=log_fmt,
         output=output,
         cache_logger_on_first_use=cache_logger_on_first_use,
@@ -278,9 +281,9 @@ def _showwarning(
         if _warnings_showwarning is not None:
             _warnings_showwarning(message, category, filename, lineno, file, line)
     else:
-        from airflow.sdk._shared.logging.structlog import logger_without_processor_of_type
+        from airflow.sdk._shared.logging.structlog import reconfigure_logger
 
-        log = logger_without_processor_of_type(
+        log = reconfigure_logger(
             structlog.get_logger("py.warnings").bind(), structlog.processors.CallsiteParameterAdder
         )
 


### PR DESCRIPTION
This is commonly very useful when debugging when you want to set _something_
at debug but not everything, espeically not sqlalchemy logs (as they are so
noisy as to overwhelm everything)

This gives users an easy way to do that. For example, they could set 

```bash
AIRFLOW__LOGGING__NAMESPACE_LEVELS='botocore=error sqlalchemy=debug sqlalchemy.engine=error'
```

which would log anything from botocore at error, all of sqlalchemy at debug, _except_ for sqlalchemy.engine which is at error.

The main functionality to do this was added not long ago when we ported
Airflow over to structlog. This exposes that capability via a config option.

As part of this I needed to make a change to how logs are handled from task
processes -- they were being mistakenly level flitered _again_, meaning that
if the task decided it wanted to log anything at debug, but the main process
was at info, it would get dropped and not make it to the log file. This now
changes it so that anything send by the subprocess makes it to the log file.

Example of what you can do:

```python
@task
def my_function(my_var: str, secret: str) -> None:
    for name in ("a", "a.b.c", "d", "d.e.f"):
        log = structlog.get_logger(name)
        log.debug("Testing structlog")
        log.info("Testing structlog")
        log.warning("Testing structlog")
        log.error("Testing structlog")
```

And then set this option `AIRFLOW__LOGGING__NAMESPACE_LEVELS='a.b=error a=debug d=info'`

<img width="759" height="113" alt="Screenshot 2025-09-18 at 18 36 50" src="https://github.com/user-attachments/assets/116aaaa9-c9f8-4689-ae63-ab0f3e7bae9a" />


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
