### PR TITLE
Hide "deferred chip" on Dashboard unless pool is set to count deferred

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/PoolBar.tsx
+++ b/airflow-core/src/airflow/ui/src/components/PoolBar.tsx
@@ -42,12 +42,10 @@ export const PoolBar = ({
         const slotValue = pool[key];
         const flexValue = slotValue / totalSlots || 0;
 
-        // Hide empty segments
         if (flexValue === 0) {
           return undefined;
         }
 
-        // NEW: If this segment represents "deferred_slots" and the current pool
         // is configured NOT to include deferred in occupied slots, hide this chip.
         // (We only have the flag on real pools; aggregated "Slots" objects don't carry it)
         const isDeferredKey = key === "deferred_slots";
@@ -84,7 +82,6 @@ export const PoolBar = ({
           </Tooltip>
         );
 
-        // Keep existing behavior: make non-"success" segments clickable to Task Instances
         return color !== "success" && "name" in pool ? (
           <Link asChild display="flex" flex={flexValue} key={key}>
             <RouterLink

--- a/airflow-core/src/airflow/ui/src/components/PoolBar.tsx
+++ b/airflow-core/src/airflow/ui/src/components/PoolBar.tsx
@@ -42,13 +42,28 @@ export const PoolBar = ({
         const slotValue = pool[key];
         const flexValue = slotValue / totalSlots || 0;
 
+        // Hide empty segments
         if (flexValue === 0) {
+          return undefined;
+        }
+
+        // NEW: If this segment represents "deferred_slots" and the current pool
+        // is configured NOT to include deferred in occupied slots, hide this chip.
+        // (We only have the flag on real pools; aggregated "Slots" objects don't carry it)
+        const isDeferredKey = key === "deferred_slots";
+
+        if (
+          isDeferredKey &&
+          "include_deferred" in pool && // type guard: only PoolResponse has this
+          !pool.include_deferred
+        ) {
           return undefined;
         }
 
         const slotType = key.replace("_slots", "");
         const poolCount = poolsWithSlotType ? poolsWithSlotType[key] : 0;
         const tooltipContent = `${translate(`pools.${slotType}`)}: ${slotValue} (${poolCount} ${translate("pools.pools", { count: poolCount })})`;
+
         const poolContent = (
           <Tooltip content={tooltipContent} key={key}>
             <Flex
@@ -69,6 +84,7 @@ export const PoolBar = ({
           </Tooltip>
         );
 
+        // Keep existing behavior: make non-"success" segments clickable to Task Instances
         return color !== "success" && "name" in pool ? (
           <Link asChild display="flex" flex={flexValue} key={key}>
             <RouterLink

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/PoolSummary/PoolSummary.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/PoolSummary/PoolSummary.tsx
@@ -38,6 +38,7 @@ export const PoolSummary = () => {
 
   const pools = data?.pools;
   const totalSlots = pools?.reduce((sum, pool) => sum + pool.slots, 0) ?? 0;
+
   const aggregatePool: Slots = {
     deferred_slots: 0,
     open_slots: 0,
@@ -57,6 +58,11 @@ export const PoolSummary = () => {
   pools?.forEach((pool) => {
     slotKeys.forEach((slotKey) => {
       const slotValue = pool[slotKey];
+
+      // NEW: only include deferred slots from pools that count deferred
+      if (slotKey === "deferred_slots" && !pool.include_deferred) {
+        return;
+      }
 
       if (slotValue > 0) {
         aggregatePool[slotKey] += slotValue;


### PR DESCRIPTION
### Description

The Pool Slots bar was misleading when pools were configured with include_deferred = false.
Deferred tasks were always shown as a purple chip, making it look like “129 of 128 slots used” even though those tasks were not consuming slots.

### This PR fixes the behaviour:

- PoolBar.tsx: skip rendering the deferred_slots chip when include_deferred is false.

- PoolSummary.tsx (Dashboard): aggregate deferred_slots only from pools with include_deferred = true.

Now, deferred tasks are only shown when they actively consume pool slots.

### How to reproduce (before fix)

- Create a pool with 128 slots.

- Run a DAG with a deferrable task (DateTimeSensorAsync).

- In Admin → Pools, toggle Include deferred tasks in occupied slots = OFF.

- UI shows ✓ 128 + purple 1 → misleading, looks like 129/128 slots.

- Same issue appears on Dashboard → Pool Summary bar.

### After fix

- With toggle OFF → only ✓ 128 is shown.

- With toggle ON → ✓ 127 + purple 1 (correct, since deferred counts toward occupied).

- Dashboard Pool Summary reflects the same rule (aggregates deferred only from pools that opted in).

### Demo Video

https://github.com/user-attachments/assets/6226fbe9-b7b9-4ffb-b6a7-28a5f87dd8e4


### Related Issue
closes: #55734 