### PR TITLE
Make dagrun details bundle_version clickable

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -1433,6 +1433,12 @@ components:
         dag_display_name:
           type: string
           title: Dag Display Name
+        bundle_url:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Bundle Url
+          readOnly: true
       type: object
       required:
       - dag_run_id
@@ -1455,6 +1461,7 @@ components:
       - dag_versions
       - bundle_version
       - dag_display_name
+      - bundle_url
       title: DAGRunResponse
       description: DAG Run serializer for responses.
     DAGRunStates:

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -10168,6 +10168,12 @@ components:
         dag_display_name:
           type: string
           title: Dag Display Name
+        bundle_url:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Bundle Url
+          readOnly: true
       type: object
       required:
       - dag_run_id
@@ -10190,6 +10196,7 @@ components:
       - dag_versions
       - bundle_version
       - dag_display_name
+      - bundle_url
       title: DAGRunResponse
       description: DAG Run serializer for responses.
     DAGRunsBatchBody:

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -2489,10 +2489,22 @@ export const $DAGRunResponse = {
         dag_display_name: {
             type: 'string',
             title: 'Dag Display Name'
+        },
+        bundle_url: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Bundle Url',
+            readOnly: true
         }
     },
     type: 'object',
-    required: ['dag_run_id', 'dag_id', 'logical_date', 'queued_at', 'start_date', 'end_date', 'duration', 'data_interval_start', 'data_interval_end', 'run_after', 'last_scheduling_decision', 'run_type', 'state', 'triggered_by', 'triggering_user_name', 'conf', 'note', 'dag_versions', 'bundle_version', 'dag_display_name'],
+    required: ['dag_run_id', 'dag_id', 'logical_date', 'queued_at', 'start_date', 'end_date', 'duration', 'data_interval_start', 'data_interval_end', 'run_after', 'last_scheduling_decision', 'run_type', 'state', 'triggered_by', 'triggering_user_name', 'conf', 'note', 'dag_versions', 'bundle_version', 'dag_display_name', 'bundle_url'],
     title: 'DAGRunResponse',
     description: 'DAG Run serializer for responses.'
 } as const;

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -654,6 +654,7 @@ export type DAGRunResponse = {
     dag_versions: Array<DagVersionResponse>;
     bundle_version: string | null;
     dag_display_name: string;
+    readonly bundle_url: string | null;
 };
 
 /**

--- a/airflow-core/src/airflow/ui/src/pages/Run/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/Details.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Flex, HStack, StackSeparator, Table, Text, VStack } from "@chakra-ui/react";
+import { Flex, Link, HStack, StackSeparator, Table, Text, VStack } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 
@@ -131,7 +131,15 @@ export const Details = () => {
         {dagRun.bundle_version !== null && (
           <Table.Row>
             <Table.Cell>{translate("components:versionDetails.bundleVersion")}</Table.Cell>
-            <Table.Cell>{dagRun.bundle_version}</Table.Cell>
+            <Table.Cell>
+              {dagRun.bundle_url !== null && dagRun.bundle_url !== "" ? (
+                <Link href={dagRun.bundle_url} rel="noopener noreferrer" target="_blank">
+                  {dagRun.bundle_version}
+                </Link>
+              ) : (
+                dagRun.bundle_version
+              )}
+            </Table.Cell>
           </Table.Row>
         )}
         <Table.Row>

--- a/airflow-core/tests/unit/cli/commands/test_asset_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_asset_command.py
@@ -146,6 +146,7 @@ def test_cli_assets_materialize(mock_hasattr, parser: ArgumentParser, stdout_cap
 
     assert run_list[0] | undeterministic == undeterministic | {
         "conf": {},
+        "bundle_url": None,
         "bundle_version": None,
         "dag_display_name": "asset1_producer",
         "dag_id": "asset1_producer",
@@ -184,6 +185,7 @@ def test_cli_assets_materialize_with_view_url_template(parser: ArgumentParser, s
 
     assert run_list[0] | undeterministic == undeterministic | {
         "conf": {},
+        "bundle_url": None,
         "bundle_version": None,
         "dag_display_name": "asset1_producer",
         "dag_id": "asset1_producer",

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -1350,6 +1350,7 @@ class DAGRunResponse(BaseModel):
     dag_versions: Annotated[list[DagVersionResponse], Field(title="Dag Versions")]
     bundle_version: Annotated[str | None, Field(title="Bundle Version")] = None
     dag_display_name: Annotated[str, Field(title="Dag Display Name")]
+    bundle_url: Annotated[str | None, Field(title="Bundle Url")] = None
 
 
 class DAGRunsBatchBody(BaseModel):


### PR DESCRIPTION
If we have a bundle_url, make the bundle_version we show in the dag run details table clickable.

<img width="778" height="495" alt="Screenshot 2025-09-18 at 3 35 10 PM" src="https://github.com/user-attachments/assets/0b8817ae-0f46-4ad6-9d4f-d31ae372d625" />
