### PR TITLE
Fix deprecation warnings for airflow v2 imports

### DIFF
--- a/airflow-core/src/airflow/utils/deprecation_tools.py
+++ b/airflow-core/src/airflow/utils/deprecation_tools.py
@@ -23,6 +23,17 @@ import warnings
 from types import ModuleType
 
 
+class DeprecatedImportWarning(FutureWarning):
+    """
+    Warning class for deprecated imports in Airflow.
+
+    This warning is raised when users import deprecated classes or functions
+    from Airflow modules that have been moved to better locations.
+    """
+
+    ...
+
+
 def getattr_with_deprecation(
     imports: dict[str, str],
     module: str,
@@ -59,7 +70,7 @@ def getattr_with_deprecation(
     message = f"The `{module}.{name}` attribute is deprecated. Please use `{warning_class_name!r}`."
     if extra_message:
         message += f" {extra_message}."
-    warnings.warn(message, DeprecationWarning, stacklevel=2)
+    warnings.warn(message, DeprecatedImportWarning, stacklevel=2)
 
     # Import and return the target attribute
     new_module, new_class_name = target_class_full_name.rsplit(".", 1)

--- a/airflow-core/tests/unit/utils/test_deprecation_tools.py
+++ b/airflow-core/tests/unit/utils/test_deprecation_tools.py
@@ -27,7 +27,11 @@ from unittest import mock
 
 import pytest
 
-from airflow.utils.deprecation_tools import add_deprecated_classes, getattr_with_deprecation
+from airflow.utils.deprecation_tools import (
+    DeprecatedImportWarning,
+    add_deprecated_classes,
+    getattr_with_deprecation,
+)
 
 
 @contextmanager
@@ -73,7 +77,7 @@ class TestGetAttrWithDeprecation:
 
                 assert result == mock_new_class
                 assert len(w) == 1
-                assert issubclass(w[0].category, DeprecationWarning)
+                assert issubclass(w[0].category, DeprecatedImportWarning)
                 assert "old.module.OldClass" in str(w[0].message)
                 assert "new.module.NewClass" in str(w[0].message)
 
@@ -99,7 +103,7 @@ class TestGetAttrWithDeprecation:
 
                 assert result == mock_attribute
                 assert len(w) == 1
-                assert issubclass(w[0].category, DeprecationWarning)
+                assert issubclass(w[0].category, DeprecatedImportWarning)
                 assert "old.module.SomeAttribute" in str(w[0].message)
                 assert "new.module.SomeAttribute" in str(w[0].message)
 
@@ -126,7 +130,7 @@ class TestGetAttrWithDeprecation:
 
                 assert result == mock_attribute
                 assert len(w) == 1
-                assert issubclass(w[0].category, DeprecationWarning)
+                assert issubclass(w[0].category, DeprecatedImportWarning)
                 assert "old.module.SomeAttribute" in str(w[0].message)
                 assert "override.module.OverrideClass" in str(w[0].message)
 
@@ -152,7 +156,7 @@ class TestGetAttrWithDeprecation:
 
                 assert result == mock_specific_class
                 assert len(w) == 1
-                assert issubclass(w[0].category, DeprecationWarning)
+                assert issubclass(w[0].category, DeprecatedImportWarning)
                 assert "old.module.SpecificClass" in str(w[0].message)
                 assert "specific.module.SpecificClass" in str(w[0].message)
 
@@ -383,7 +387,7 @@ class TestAddDeprecatedClasses:
 
                     assert result == mock_attribute
                     assert len(w) == 1
-                    assert issubclass(w[0].category, DeprecationWarning)
+                    assert issubclass(w[0].category, DeprecatedImportWarning)
                     assert f"{full_module_name}.{attr_name}" in str(w[0].message)
                     assert expected_target_msg in str(w[0].message)
 
@@ -437,7 +441,7 @@ class TestAddDeprecatedClasses:
 
                     assert result == mock_current_attr
                     assert len(w) == 1
-                    assert issubclass(w[0].category, DeprecationWarning)
+                    assert issubclass(w[0].category, DeprecatedImportWarning)
                     assert f"{full_module_name}.current_attr" in str(w[0].message)
 
                 # Test virtual module access
@@ -448,7 +452,7 @@ class TestAddDeprecatedClasses:
 
                     assert result == mock_virtual_attr
                     assert len(w) == 1
-                    assert issubclass(w[0].category, DeprecationWarning)
+                    assert issubclass(w[0].category, DeprecatedImportWarning)
                     assert f"{full_virtual_module_name}.VirtualClass" in str(w[0].message)
 
     def test_add_deprecated_classes_current_module_not_in_sys_modules(self):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: https://github.com/apache/airflow/issues/55875

## Problem

Deprecation warnings for AIP-72 (task-sdk) related module moves were not appearing in DAG processor logs or task execution logs, even though we were importing deprecated classes like `DayOfWeekSensor` from `airflow.sensors.weekday`.

## Root Cause

The issue was with Python's warning filter system added by us in configuration.py. We configure warning filters to show DeprecationWarning only for modules matching the pattern "airflow":

```
warnings.filterwarnings(action="default", category=DeprecationWarning, module="airflow")
```

Here: https://github.com/apache/airflow/blob/main/airflow-core/src/airflow/configuration.py#L61-L63


However, the location of the import was rising from the dag file itself, which didn't really match the regex for warning filters, causing the warnings to go past even though the Python Shell raised it:
```
Python 3.10.18 (main, Sep  8 2025, 22:04:00) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from airflow import DAG
>>> from airflow.sensors.weekday import DayOfWeekSensor
<stdin>:1 DeprecationWarning: The `airflow.sensors.weekday.DayOfWeekSensor` attribute is deprecated. Please use `'airflow.providers.standard.sensors.weekday.DayOfWeekSensor'`.
```


### Solution

- Created a custom `DeprecatedImportWarning` which we can use henceforth, it inherits from `FutureWarning` instead of `DeprecationWarning`
- `FutureWarning` is more visible and less confusing
- Didnt want to edit the filters because it would show all the warnings in task execution then


### Testing

DAG used:
```
from socket import timeout
from airflow.sdk import DAG
from pendulum import today
# from airflow.providers.standard.sensors.weekday import DayOfWeekSensor
from airflow.sensors.weekday import DayOfWeekSensor


with DAG(
    "example_week_sensor",
    schedule=None,
    start_date=today('UTC').add(days=-2),
    tags=[ "sensor"],
) as dag:
    working_day_check = DayOfWeekSensor(
        task_id="working_day_check",
        # added weekend days so that no matter what any day of the week this sensor will work.
        week_day={"Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"},
        use_task_logical_date=True,
        poke_interval=20.0,
        timeout=120.0,
        dag=dag,
    )
    working_day_check
```

DAG processor logs:
<img width="2557" height="577" alt="image" src="https://github.com/user-attachments/assets/a4a925da-1b80-45b4-9998-0a946163669c" />



Task Execution Logs:

<img width="2557" height="577" alt="image" src="https://github.com/user-attachments/assets/d8c91162-dfe2-46a2-a57d-90ce57f17a97" />







<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
