### PR TITLE
Remove removed rule UP038

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -654,7 +654,6 @@ ignore = [
     "COM819",
     "E501", # Formatted code may exceed the line length, leading to line-too-long (E501) errors.
     "ASYNC110", # TODO: Use `anyio.Event` instead of awaiting `anyio.sleep` in a `while` loop
-    "UP038",
     "SIM105", # Use contextlib.suppress({exception}) instead of try-except-pass
 ]
 unfixable = [


### PR DESCRIPTION
fixes `uv run ruff check` warning

```
warning: The following rules have been removed and ignoring them has no effect:           
    - UP038   
```