### PR TITLE
Bug: Removing resources properly for DatabricksWorkflowGroup

### DIFF
--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks_workflow.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks_workflow.py
@@ -366,20 +366,21 @@ class DatabricksWorkflowTaskGroup(TaskGroup):
             spark_submit_params=self.spark_submit_params,
         )
 
-        for task in tasks:
-            if not (
-                hasattr(task, "_convert_to_databricks_workflow_task")
-                and callable(task._convert_to_databricks_workflow_task)
-            ):
-                raise AirflowException(
-                    f"Task {task.task_id} does not support conversion to databricks workflow task."
-                )
+        try:
+            for task in tasks:
+                if not (
+                    hasattr(task, "_convert_to_databricks_workflow_task")
+                    and callable(task._convert_to_databricks_workflow_task)
+                ):
+                    raise AirflowException(
+                        f"Task {task.task_id} does not support conversion to databricks workflow task."
+                    )
 
-            task.workflow_run_metadata = create_databricks_workflow_task.output
-            create_databricks_workflow_task.relevant_upstreams.append(task.task_id)
-            create_databricks_workflow_task.add_task(task.task_id, task)
+                task.workflow_run_metadata = create_databricks_workflow_task.output
+                create_databricks_workflow_task.relevant_upstreams.append(task.task_id)
+                create_databricks_workflow_task.add_task(task.task_id, task)
 
-        for root_task in roots:
-            root_task.set_upstream(create_databricks_workflow_task)
-
-        super().__exit__(_type, _value, _tb)
+            for root_task in roots:
+                root_task.set_upstream(create_databricks_workflow_task)
+        finally:
+            super().__exit__(_type, _value, _tb)

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
@@ -228,7 +228,7 @@ def test_task_group_exit_creates_operator(mock_databricks_workflow_operator):
 def test_task_group_exception_super_exit():
     """Test that DatabricksWorkflowTaskGroup execute super().__exit__ even with an exception."""
 
-    with patch('airflow.utils.task_group.TaskGroup.__exit__') as mock_super_exit:
+    with patch('airflow.providers.common.compat.sdk.TaskGroup.__exit__') as mock_super_exit:
         with pytest.raises(AirflowException):
             with DAG(dag_id="example_databricks_workflow_dag", schedule=None,
                      start_date=DEFAULT_DATE):

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
@@ -225,6 +225,22 @@ def test_task_group_exit_creates_operator(mock_databricks_workflow_operator):
     )
 
 
+def test_task_group_exception_super_exit():
+    """Test that DatabricksWorkflowTaskGroup execute super().__exit__ even with an exception."""
+
+    with patch('airflow.utils.task_group.TaskGroup.__exit__') as mock_super_exit:
+        with pytest.raises(AirflowException):
+            with DAG(dag_id="example_databricks_workflow_dag", schedule=None,
+                     start_date=DEFAULT_DATE):
+                with DatabricksWorkflowTaskGroup(
+                    group_id="test_databricks_workflow", databricks_conn_id="databricks_conn"
+                ):
+                    EmptyOperator(task_id="task1")
+
+    # Assert that super().__exit__ was called even with an exception
+    mock_super_exit.assert_called_once()
+
+
 def test_task_group_root_tasks_set_upstream_to_operator(mock_databricks_workflow_operator):
     """Test that tasks added to a DatabricksWorkflowTaskGroup are set upstream to the operator."""
     with DAG(dag_id="example_databricks_workflow_dag", schedule=None, start_date=DEFAULT_DATE):

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
@@ -237,7 +237,6 @@ def test_task_group_exception_super_exit():
                 ):
                     EmptyOperator(task_id="task1")
 
-    # Assert that super().__exit__ was called even with an exception
     mock_super_exit.assert_called_once()
 
 

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
@@ -17,9 +17,13 @@
 
 from __future__ import annotations
 
+from functools import wraps
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+from airflow.sdk import TaskGroup
+from airflow.sdk.definitions._internal.contextmanager import TaskGroupContext
 
 # Do not run the tests when FAB / Flask is not installed
 pytest.importorskip("flask_session")
@@ -228,16 +232,17 @@ def test_task_group_exit_creates_operator(mock_databricks_workflow_operator):
 def test_task_group_exception_super_exit():
     """Test that DatabricksWorkflowTaskGroup execute super().__exit__ even with an exception."""
 
-    with patch('airflow.providers.common.compat.sdk.TaskGroup.__exit__') as mock_super_exit:
+    with patch("airflow.providers.common.compat.sdk.TaskGroup.__exit__") as mock_super_exit:
         with pytest.raises(AirflowException):
-            with DAG(dag_id="example_databricks_workflow_dag", schedule=None,
-                     start_date=DEFAULT_DATE):
+            with DAG(dag_id="example_databricks_workflow_dag_err", schedule=None, start_date=DEFAULT_DATE):
                 with DatabricksWorkflowTaskGroup(
-                    group_id="test_databricks_workflow", databricks_conn_id="databricks_conn"
+                    group_id="test_databricks_workflow_err", databricks_conn_id="databricks_conn"
                 ):
-                    EmptyOperator(task_id="task1")
+                    # Trigger the exception that prevents normal exit
+                    raise AirflowException("Force fail")
 
     mock_super_exit.assert_called_once()
+    TaskGroupContext._context.clear()
 
 
 def test_task_group_root_tasks_set_upstream_to_operator(mock_databricks_workflow_operator):


### PR DESCRIPTION
Move the superclass's exit to the finally block. This will prevent a situation in which, if something inside the method raises an exception, the superclass's __exit__ method will not be called. 

Fix [42164](https://github.com/apache/airflow/issues/42164)