### PR TITLE
[v3-0-test] Handle trigger calls to get_connection #55799

### DIFF
--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -153,6 +153,7 @@ dependencies = [
 "async" = [
     "eventlet>=0.37.0",
     "gevent>=24.2.1",
+    "greenback>=1.2.1",
     "greenlet>=0.4.9",
 ]
 "graphviz" = [


### PR DESCRIPTION
In 2.x sometimes get_connection (which goes to the database) might be called without wrapping in sync_to_async.

This did not fail, though it was not good behavior, since it can block the event loop.

In 3.0, since we now route db calls through an API, triggers that do this fail. The reason is, the code to hit the API wraps the get_connection call with async_to_sync, which is forbidden in the asyncio event loop.

Related: #55568

(cherry picked from commit f5b1eb437f11bb2dedc2273d83894f8c868982c3)


Works:

<img width="946" height="729" alt="image" src="https://github.com/user-attachments/assets/bf893a21-8c48-499d-bc43-4832de7f550f" />
