### PR TITLE
Add more comprehensive tests on DagCards

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/DagRunInfo.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DagRunInfo.tsx
@@ -70,7 +70,7 @@ const DagRunInfo = ({ endDate, logicalDate, runAfter, startDate, state }: Props)
     >
       <Box>
         <Time datetime={runAfter} mr={2} showTooltip={false} />
-        {state === undefined ? undefined : <StateBadge data-testid="state-badge" aria-label={state} state={state} />}
+        {state === undefined ? undefined : <StateBadge aria-label={state} data-testid="state-badge" state={state} />}
       </Box>
     </Tooltip>
   );

--- a/airflow-core/src/airflow/ui/src/components/DagRunInfo.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DagRunInfo.tsx
@@ -70,7 +70,7 @@ const DagRunInfo = ({ endDate, logicalDate, runAfter, startDate, state }: Props)
     >
       <Box>
         <Time datetime={runAfter} mr={2} showTooltip={false} />
-        {state === undefined ? undefined : <StateBadge state={state} />}
+        {state === undefined ? undefined : <StateBadge data-testid="state-badge" aria-label={state} state={state} />}
       </Box>
     </Tooltip>
   );

--- a/airflow-core/src/airflow/ui/src/components/DagRunInfo.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DagRunInfo.tsx
@@ -70,7 +70,9 @@ const DagRunInfo = ({ endDate, logicalDate, runAfter, startDate, state }: Props)
     >
       <Box>
         <Time datetime={runAfter} mr={2} showTooltip={false} />
-        {state === undefined ? undefined : <StateBadge aria-label={state} data-testid="state-badge" state={state} />}
+        {state === undefined ? undefined : (
+          <StateBadge aria-label={state} data-testid="state-badge" state={state} />
+        )}
       </Box>
     </Tooltip>
   );

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.test.tsx
@@ -44,7 +44,52 @@ const mockDag = {
   last_expired: null,
   last_parse_duration: 0.23,
   last_parsed_time: "2024-08-22T13:50:10.372238+00:00",
-  latest_dag_runs: [],
+  latest_dag_runs: [
+    {
+      dag_run_id: "scheduled__2025-09-19T19:22:00+00:00",
+      dag_id: "nested_groups",
+      logical_date: "2025-09-19T19:22:00Z",
+      queued_at: "2025-09-19T19:22:00.762952Z",
+      start_date: "2025-09-19T19:22:00.782471Z",
+      end_date: "2025-09-19T19:22:00.798715Z",
+      duration: 16.244,
+      data_interval_start: "2025-09-19T19:22:00Z",
+      data_interval_end: "2025-09-19T19:22:00Z",
+      run_after: "2025-09-19T19:22:00Z",
+      last_scheduling_decision: "2025-09-19T19:22:00.796419Z",
+      run_type: "scheduled",
+      state: "success",
+      triggered_by: null,
+      triggering_user_name: null,
+      conf: {},
+      note: null,
+      dag_versions: [],
+      bundle_version: "2025-09-19T18:07:12.9148295Z",
+      dag_display_name: "nested_groups",
+    },
+    {
+      dag_run_id: "scheduled__2025-09-19T19:21:00+00:00",
+      dag_id: "nested_groups",
+      logical_date: "2025-09-19T19:21:00Z",
+      queued_at: "2025-09-19T19:21:00.695279Z",
+      start_date: "2025-09-19T19:21:00.714807Z",
+      end_date: "2025-09-19T19:21:00.731218Z",
+      duration: 16.411,
+      data_interval_start: "2025-09-19T19:21:00Z",
+      data_interval_end: "2025-09-19T19:21:00Z",
+      run_after: "2025-09-19T19:21:00Z",
+      last_scheduling_decision: "2025-09-19T19:21:00.728105Z",
+      run_type: "scheduled",
+      state: "success",
+      triggered_by: null,
+      triggering_user_name: null,
+      conf: {},
+      note: null,
+      dag_versions: [],
+      bundle_version: "2025-09-19T18:07:12.9148295Z",
+      dag_display_name: "nested_groups",
+    },
+  ],
   max_active_runs: 16,
   max_active_tasks: 16,
   max_consecutive_failed_dag_runs: 0,
@@ -56,8 +101,8 @@ const mockDag = {
   pending_actions: [],
   relative_fileloc: "nested_task_groups.py",
   tags: [],
-  timetable_description: "",
-  timetable_summary: "",
+  timetable_description: "Every minute",
+  timetable_summary: "* * * * *",
 } satisfies DAGWithLatestDagRunsResponse;
 
 beforeAll(async () => {
@@ -102,6 +147,7 @@ describe("DagCard", () => {
     } satisfies DAGWithLatestDagRunsResponse;
 
     render(<DagCard dag={expandedMockDag} />, { wrapper: Wrapper });
+    expect(screen.getByTestId("dag-id")).toBeInTheDocument();
     expect(screen.getByTestId("dag-tag")).toBeInTheDocument();
     expect(screen.queryByText("tag3")).toBeInTheDocument();
     expect(screen.queryByText("tag4")).toBeInTheDocument();
@@ -123,7 +169,58 @@ describe("DagCard", () => {
     } satisfies DAGWithLatestDagRunsResponse;
 
     render(<DagCard dag={expandedMockDag} />, { wrapper: Wrapper });
+    expect(screen.getByTestId("dag-id")).toBeInTheDocument();
     expect(screen.getByTestId("dag-tag")).toBeInTheDocument();
     expect(screen.getByText("+2 more")).toBeInTheDocument();
+  });
+
+  it("DagCard should render schedule section", () => {
+    render(<DagCard dag={mockDag} />, { wrapper: Wrapper });
+    const scheduleElement = screen.getByTestId("schedule");
+    expect(scheduleElement).toBeInTheDocument();
+    // Should display the timetable summary from mockDag
+    expect(scheduleElement).toHaveTextContent("* * * * *");
+  });
+
+  it("DagCard should render latest run section with actual run data", () => {
+    render(<DagCard dag={mockDag} />, { wrapper: Wrapper });
+    const latestRunElement = screen.getByTestId("latest-run");
+    expect(latestRunElement).toBeInTheDocument();
+    // Should contain the formatted latest run timestamp (formatted for local timezone)
+    expect(latestRunElement).toHaveTextContent("2025-09-19 14:22:00");
+  });
+
+  it("DagCard should render next run section with timestamp", () => {
+    render(<DagCard dag={mockDag} />, { wrapper: Wrapper });
+    const nextRunElement = screen.getByTestId("next-run");
+    expect(nextRunElement).toBeInTheDocument();
+    // Should display the formatted next run timestamp (converted to local timezone)
+    expect(nextRunElement).toHaveTextContent("2024-08-22 19:00:00");
+  });
+
+  it("DagCard should render StateBadge as success", () => {
+    render(<DagCard dag={mockDag} />, { wrapper: Wrapper });
+    const stateBadge = screen.getByTestId("state-badge");
+    expect(stateBadge).toBeInTheDocument();
+    // Should have the success state from mockDag.latest_dag_runs[0].state
+    expect(stateBadge).toHaveAttribute("aria-label", "success");
+  });
+
+  it("DagCard should render StateBadge as failed", () => {
+    const mockDagWithFailedRun = {
+      ...mockDag,
+      latest_dag_runs: [
+        {
+          ...mockDag.latest_dag_runs[0]!,
+          state: "failed" as const,
+        },
+      ],
+    } satisfies DAGWithLatestDagRunsResponse;
+
+    render(<DagCard dag={mockDagWithFailedRun} />, { wrapper: Wrapper });
+    const stateBadge = screen.getByTestId("state-badge");
+    expect(stateBadge).toBeInTheDocument();
+    // Should have the failed state
+    expect(stateBadge).toHaveAttribute("aria-label", "failed");
   });
 });

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.test.tsx
@@ -46,48 +46,48 @@ const mockDag = {
   last_parsed_time: "2024-08-22T13:50:10.372238+00:00",
   latest_dag_runs: [
     {
-      dag_run_id: "scheduled__2025-09-19T19:22:00+00:00",
+      bundle_version: "2025-09-19T18:07:12.9148295Z",
+      conf: {},
+      dag_display_name: "nested_groups",
       dag_id: "nested_groups",
-      logical_date: "2025-09-19T19:22:00Z",
-      queued_at: "2025-09-19T19:22:00.762952Z",
-      start_date: "2025-09-19T19:22:00.782471Z",
-      end_date: "2025-09-19T19:22:00.798715Z",
-      duration: 16.244,
-      data_interval_start: "2025-09-19T19:22:00Z",
+      dag_run_id: "scheduled__2025-09-19T19:22:00+00:00",
+      dag_versions: [],
       data_interval_end: "2025-09-19T19:22:00Z",
-      run_after: "2025-09-19T19:22:00Z",
+      data_interval_start: "2025-09-19T19:22:00Z",
+      duration: 16.244,
+      end_date: "2025-09-19T19:22:00.798715Z",
       last_scheduling_decision: "2025-09-19T19:22:00.796419Z",
+      logical_date: "2025-09-19T19:22:00Z",
+      note: null,
+      queued_at: "2025-09-19T19:22:00.762952Z",
+      run_after: "2025-09-19T19:22:00Z",
       run_type: "scheduled",
+      start_date: "2025-09-19T19:22:00.782471Z",
       state: "success",
       triggered_by: null,
       triggering_user_name: null,
-      conf: {},
-      note: null,
-      dag_versions: [],
-      bundle_version: "2025-09-19T18:07:12.9148295Z",
-      dag_display_name: "nested_groups",
     },
     {
-      dag_run_id: "scheduled__2025-09-19T19:21:00+00:00",
+      bundle_version: "2025-09-19T18:07:12.9148295Z",
+      conf: {},
+      dag_display_name: "nested_groups",
       dag_id: "nested_groups",
-      logical_date: "2025-09-19T19:21:00Z",
-      queued_at: "2025-09-19T19:21:00.695279Z",
-      start_date: "2025-09-19T19:21:00.714807Z",
-      end_date: "2025-09-19T19:21:00.731218Z",
-      duration: 16.411,
-      data_interval_start: "2025-09-19T19:21:00Z",
+      dag_run_id: "scheduled__2025-09-19T19:21:00+00:00",
+      dag_versions: [],
       data_interval_end: "2025-09-19T19:21:00Z",
-      run_after: "2025-09-19T19:21:00Z",
+      data_interval_start: "2025-09-19T19:21:00Z",
+      duration: 16.411,
+      end_date: "2025-09-19T19:21:00.731218Z",
       last_scheduling_decision: "2025-09-19T19:21:00.728105Z",
+      logical_date: "2025-09-19T19:21:00Z",
+      note: null,
+      queued_at: "2025-09-19T19:21:00.695279Z",
+      run_after: "2025-09-19T19:21:00Z",
       run_type: "scheduled",
+      start_date: "2025-09-19T19:21:00.714807Z",
       state: "success",
       triggered_by: null,
       triggering_user_name: null,
-      conf: {},
-      note: null,
-      dag_versions: [],
-      bundle_version: "2025-09-19T18:07:12.9148295Z",
-      dag_display_name: "nested_groups",
     },
   ],
   max_active_runs: 16,
@@ -177,6 +177,7 @@ describe("DagCard", () => {
   it("DagCard should render schedule section", () => {
     render(<DagCard dag={mockDag} />, { wrapper: Wrapper });
     const scheduleElement = screen.getByTestId("schedule");
+
     expect(scheduleElement).toBeInTheDocument();
     // Should display the timetable summary from mockDag
     expect(scheduleElement).toHaveTextContent("* * * * *");
@@ -185,6 +186,7 @@ describe("DagCard", () => {
   it("DagCard should render latest run section with actual run data", () => {
     render(<DagCard dag={mockDag} />, { wrapper: Wrapper });
     const latestRunElement = screen.getByTestId("latest-run");
+
     expect(latestRunElement).toBeInTheDocument();
     // Should contain the formatted latest run timestamp (formatted for local timezone)
     expect(latestRunElement).toHaveTextContent("2025-09-19 14:22:00");
@@ -193,6 +195,7 @@ describe("DagCard", () => {
   it("DagCard should render next run section with timestamp", () => {
     render(<DagCard dag={mockDag} />, { wrapper: Wrapper });
     const nextRunElement = screen.getByTestId("next-run");
+
     expect(nextRunElement).toBeInTheDocument();
     // Should display the formatted next run timestamp (converted to local timezone)
     expect(nextRunElement).toHaveTextContent("2024-08-22 19:00:00");
@@ -201,6 +204,7 @@ describe("DagCard", () => {
   it("DagCard should render StateBadge as success", () => {
     render(<DagCard dag={mockDag} />, { wrapper: Wrapper });
     const stateBadge = screen.getByTestId("state-badge");
+
     expect(stateBadge).toBeInTheDocument();
     // Should have the success state from mockDag.latest_dag_runs[0].state
     expect(stateBadge).toHaveAttribute("aria-label", "success");
@@ -219,6 +223,7 @@ describe("DagCard", () => {
 
     render(<DagCard dag={mockDagWithFailedRun} />, { wrapper: Wrapper });
     const stateBadge = screen.getByTestId("state-badge");
+
     expect(stateBadge).toBeInTheDocument();
     // Should have the failed state
     expect(stateBadge).toHaveAttribute("aria-label", "failed");

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.test.tsx
@@ -18,6 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import "@testing-library/jest-dom/vitest";
 import { render, screen } from "@testing-library/react";
 import i18n from "i18next";
 import type { DagTagResponse, DAGWithLatestDagRunsResponse } from "openapi-gen/requests/types.gen";
@@ -211,11 +212,17 @@ describe("DagCard", () => {
   });
 
   it("DagCard should render StateBadge as failed", () => {
+    const [firstDagRun] = mockDag.latest_dag_runs;
+
+    if (!firstDagRun) {
+      throw new Error("Mock data should have at least one dag run");
+    }
+
     const mockDagWithFailedRun = {
       ...mockDag,
       latest_dag_runs: [
         {
-          ...mockDag.latest_dag_runs[0]!,
+          ...firstDagRun,
           state: "failed" as const,
         },
       ],

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -51,7 +51,7 @@ export const DagCard = ({ dag }: Props) => {
         <HStack>
           <Tooltip content={dag.description} disabled={!Boolean(dag.description)}>
             <Link asChild color="fg.info" fontWeight="bold">
-              <RouterLink to={`/dags/${dag.dag_id}`} data-testid="dag-id">{dag.dag_display_name}</RouterLink>
+              <RouterLink data-testid="dag-id" to={`/dags/${dag.dag_id}`}>{dag.dag_display_name}</RouterLink>
             </Link>
           </Tooltip>
           <DagTags tags={dag.tags} />
@@ -75,7 +75,7 @@ export const DagCard = ({ dag }: Props) => {
         </HStack>
       </Flex>
       <SimpleGrid columns={4} gap={1} height={20} px={3} py={1}>
-        <Stat label={translate("dagDetails.schedule")} data-testid="schedule">
+        <Stat data-testid="schedule" label={translate("dagDetails.schedule")}>
           <Schedule
             assetExpression={dag.asset_expression}
             dagId={dag.dag_id}
@@ -84,7 +84,7 @@ export const DagCard = ({ dag }: Props) => {
             timetableSummary={dag.timetable_summary}
           />
         </Stat>
-        <Stat label={translate("dagDetails.latestRun")} data-testid="latest-run">
+        <Stat data-testid="latest-run" label={translate("dagDetails.latestRun")}>
           {latestRun ? (
             <Link asChild color="fg.info">
               <RouterLink to={`/dags/${latestRun.dag_id}/runs/${latestRun.dag_run_id}`}>
@@ -100,7 +100,7 @@ export const DagCard = ({ dag }: Props) => {
             </Link>
           ) : undefined}
         </Stat>
-        <Stat label={translate("dagDetails.nextRun")} data-testid="next-run">
+        <Stat data-testid="next-run" label={translate("dagDetails.nextRun")}>
           {Boolean(dag.next_dagrun_run_after) ? (
             <DagRunInfo
               logicalDate={dag.next_dagrun_logical_date}

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -51,7 +51,9 @@ export const DagCard = ({ dag }: Props) => {
         <HStack>
           <Tooltip content={dag.description} disabled={!Boolean(dag.description)}>
             <Link asChild color="fg.info" fontWeight="bold">
-              <RouterLink data-testid="dag-id" to={`/dags/${dag.dag_id}`}>{dag.dag_display_name}</RouterLink>
+              <RouterLink data-testid="dag-id" to={`/dags/${dag.dag_id}`}>
+                {dag.dag_display_name}
+              </RouterLink>
             </Link>
           </Tooltip>
           <DagTags tags={dag.tags} />

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -51,7 +51,7 @@ export const DagCard = ({ dag }: Props) => {
         <HStack>
           <Tooltip content={dag.description} disabled={!Boolean(dag.description)}>
             <Link asChild color="fg.info" fontWeight="bold">
-              <RouterLink to={`/dags/${dag.dag_id}`}>{dag.dag_display_name}</RouterLink>
+              <RouterLink to={`/dags/${dag.dag_id}`} data-testid="dag-id">{dag.dag_display_name}</RouterLink>
             </Link>
           </Tooltip>
           <DagTags tags={dag.tags} />
@@ -75,7 +75,7 @@ export const DagCard = ({ dag }: Props) => {
         </HStack>
       </Flex>
       <SimpleGrid columns={4} gap={1} height={20} px={3} py={1}>
-        <Stat label={translate("dagDetails.schedule")}>
+        <Stat label={translate("dagDetails.schedule")} data-testid="schedule">
           <Schedule
             assetExpression={dag.asset_expression}
             dagId={dag.dag_id}
@@ -84,7 +84,7 @@ export const DagCard = ({ dag }: Props) => {
             timetableSummary={dag.timetable_summary}
           />
         </Stat>
-        <Stat label={translate("dagDetails.latestRun")}>
+        <Stat label={translate("dagDetails.latestRun")} data-testid="latest-run">
           {latestRun ? (
             <Link asChild color="fg.info">
               <RouterLink to={`/dags/${latestRun.dag_id}/runs/${latestRun.dag_run_id}`}>
@@ -100,7 +100,7 @@ export const DagCard = ({ dag }: Props) => {
             </Link>
           ) : undefined}
         </Stat>
-        <Stat label={translate("dagDetails.nextRun")}>
+        <Stat label={translate("dagDetails.nextRun")} data-testid="next-run">
           {Boolean(dag.next_dagrun_run_after) ? (
             <DagRunInfo
               logicalDate={dag.next_dagrun_logical_date}


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->

`data-testid`'s are added and used for tests to ensure the DagCards render as expected. `aria-label`'s are also added to visual indicators to indicate state.

Times are rendered in local timezone so the components are wrapped in the tests to force GMT.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
