### PR TITLE
Fix DAG deserialization failure with non-default ``weight_rule``

### DIFF
--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -1416,6 +1416,8 @@ class SerializedBaseOperator(DAGNode, BaseSerialization):
 
     @property
     def weight_rule(self) -> PriorityWeightStrategy:
+        if isinstance(self._weight_rule, PriorityWeightStrategy):
+            return self._weight_rule
         return validate_and_load_priority_weight_strategy(self._weight_rule)
 
     def __getattr__(self, name):

--- a/task-sdk/src/airflow/sdk/__init__.py
+++ b/task-sdk/src/airflow/sdk/__init__.py
@@ -63,7 +63,7 @@ __all__ = [
 __version__ = "1.2.0"
 
 if TYPE_CHECKING:
-    from airflow.sdk.api.datamodels._generated import DagRunState, TaskInstanceState, TriggerRule
+    from airflow.sdk.api.datamodels._generated import DagRunState, TaskInstanceState, TriggerRule, WeightRule
     from airflow.sdk.bases.hook import BaseHook
     from airflow.sdk.bases.notifier import BaseNotifier
     from airflow.sdk.bases.operator import BaseOperator, chain, chain_linear, cross_downstream


### PR DESCRIPTION
Resolves an issue where DAGs using non default value like `weight_rule='absolute'` would fail during deserialization with `'Unknown priority strategy'` error. The problem occurred when the scheduler attempted to deserialize tasks that had already been converted to `PriorityWeightStrategy` instances.

The `validate_and_load_priority_weight_strategy` function now properly handles cases where a `PriorityWeightStrategy` instance is passed, returning it directly instead of attempting to re-validate it.

This fix ensures that all weight rule options (`downstream`, `upstream`, `absolute`) work correctly in the complete DAG processing pipeline including serialization, storage, and deserialization.

To Reproduce the bug, run the following dag or just run the added unit test without code changes:

```py
from airflow import DAG
from airflow.sdk import task
from airflow.task.weight_rule import WeightRule

with DAG("xcom_backend_dag"):

    @task()
    def xcom_producer():
        return "my_value"

    @task(weight_rule=WeightRule.ABSOLUTE)
    def xcom_consumer(value):
        assert value == "my_value"

    xcom_consumer(xcom_producer())

```

which will then fail, when you try to trigger the dag from UI.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
