### PR TITLE
Only send hostname to celery worker if passed in cli

### DIFF
--- a/providers/celery/src/airflow/providers/celery/cli/celery_command.py
+++ b/providers/celery/src/airflow/providers/celery/cli/celery_command.py
@@ -239,11 +239,11 @@ def worker(args):
         args.queues,
         "--concurrency",
         args.concurrency,
-        "--hostname",
-        args.celery_hostname,
         "--loglevel",
         celery_log_level,
     ]
+    if args.celery_hostname:
+        options.extend(["--hostname", args.celery_hostname])
     if autoscale:
         options.extend(["--autoscale", autoscale])
     if args.without_mingle:

--- a/providers/celery/tests/unit/celery/cli/test_celery_command.py
+++ b/providers/celery/tests/unit/celery/cli/test_celery_command.py
@@ -131,6 +131,7 @@ class TestWorkerStart:
     @classmethod
     def setup_class(cls):
         with conf_vars({("core", "executor"): "CeleryExecutor"}):
+            importlib.reload(executor_loader)
             importlib.reload(cli_parser)
             cls.parser = cli_parser.get_parser()
 
@@ -172,10 +173,10 @@ class TestWorkerStart:
                 queues,
                 "--concurrency",
                 int(concurrency),
-                "--hostname",
-                celery_hostname,
                 "--loglevel",
                 conf.get("logging", "CELERY_LOGGING_LEVEL"),
+                "--hostname",
+                celery_hostname,
                 "--autoscale",
                 autoscale,
                 "--without-mingle",


### PR DESCRIPTION
We were setting the hostname in the celery worker, even if the user did not specify one. This meant we were passing on None. Historically, that has still resulted in the default value being used instead of None, but that has changed in click 8.3.0 (which celery uses in its cli). Either way, no need for us to pass it!