### PR TITLE
Enable PT001 rule to prvoider tests

### DIFF
--- a/providers/sftp/tests/unit/sftp/hooks/test_sftp.py
+++ b/providers/sftp/tests/unit/sftp/hooks/test_sftp.py
@@ -814,10 +814,8 @@ class TestSFTPHookAsync:
         )
 
         hook = SFTPHookAsync()
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="Host key check was skipped, but `host_key` value was given"):
             await hook._get_conn()
-
-        assert str(exc.value) == "Host key check was skipped, but `host_key` value was given"
 
     @patch("paramiko.SSHClient.connect")
     @patch("asyncssh.import_private_key")

--- a/providers/sftp/tests/unit/sftp/operators/test_sftp.py
+++ b/providers/sftp/tests/unit/sftp/operators/test_sftp.py
@@ -389,7 +389,7 @@ class TestSFTPOperator:
         assert task_3.sftp_hook.remote_host == "remotehost"
 
     def test_unequal_local_remote_file_paths(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="1 paths in local_filepath != 2 paths in remote_filepath"):
             SFTPOperator(
                 task_id="test_sftp_unequal_paths",
                 local_filepath="/tmp/test",

--- a/providers/slack/tests/unit/slack/transfers/test_sql_to_slack.py
+++ b/providers/slack/tests/unit/slack/transfers/test_sql_to_slack.py
@@ -148,7 +148,7 @@ class TestSqlToSlackApiFileOperator:
         op = SqlToSlackApiFileOperator(
             task_id="test_send_file", slack_filename=filename, **self.default_op_kwargs
         )
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Unsupported file format"):
             op.execute(mock.MagicMock())
 
     @mock.patch("airflow.providers.slack.transfers.sql_to_slack.SlackHook")

--- a/providers/snowflake/tests/unit/snowflake/hooks/test_snowflake.py
+++ b/providers/snowflake/tests/unit/snowflake/hooks/test_snowflake.py
@@ -879,9 +879,8 @@ class TestPytestSnowflakeHook:
         hook = SnowflakeHook()
 
         for empty_statement in ([], "", "\n"):
-            with pytest.raises(ValueError) as err:
+            with pytest.raises(ValueError, match="List of SQL statements is empty"):
                 hook.run(sql=empty_statement)
-            assert err.value.args[0] == "List of SQL statements is empty"
 
     def test_get_openlineage_default_schema_with_no_schema_set(self):
         connection_kwargs = {

--- a/providers/snowflake/tests/unit/snowflake/hooks/test_sql.py
+++ b/providers/snowflake/tests/unit/snowflake/hooks/test_sql.py
@@ -244,6 +244,5 @@ def test_query(
 def test_no_query(empty_statement):
     dbapi_hook = SnowflakeHookForTests()
     dbapi_hook.get_conn.return_value.cursor.rowcount = 0
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError, match="List of SQL statements is empty"):
         dbapi_hook.run(sql=empty_statement)
-    assert err.value.args[0] == "List of SQL statements is empty"

--- a/providers/ssh/tests/unit/ssh/hooks/test_ssh.py
+++ b/providers/ssh/tests/unit/ssh/hooks/test_ssh.py
@@ -598,7 +598,7 @@ class TestSSHHook:
             assert ssh_client.return_value.get_host_keys.return_value.add.called is False
 
     def test_ssh_connection_with_host_key_where_no_host_key_check_is_true(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Must check host key when provided"):
             SSHHook(ssh_conn_id=self.CONN_SSH_WITH_HOST_KEY_AND_NO_HOST_KEY_CHECK_TRUE)
 
     @mock.patch("airflow.providers.ssh.hooks.ssh.paramiko.SSHClient")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->

issue: Enable Even More PyDocStyle Checks https://github.com/apache/airflow/issues/40567
@ferruzzi
This PR is for enable PT011 rule:
PT011: all instances of pytest.raises should include a match term to make sure they are catching the right error.
https://docs.astral.sh/ruff/rules/pytest-raises-too-broad/
There are 102 files changes is need.
So, I separate to many PR, which contains about 5 file changes for easy review.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
