### PR TITLE
Prefer BigQueryInsertJobOperator's project_id over hook's project_id for openlineage

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/openlineage/mixins.py
+++ b/providers/google/src/airflow/providers/google/cloud/openlineage/mixins.py
@@ -97,7 +97,9 @@ class _BigQueryInsertJobOperatorOpenLineageMixin:
         run_facets: dict[str, RunFacet] = {
             "externalQuery": ExternalQueryRunFacet(externalQueryId=self.job_id, source="bigquery")
         }
-        self._client = self.hook.get_client(project_id=self.hook.project_id, location=self.location)
+        self._client = self.hook.get_client(
+            project_id=self.project_id or self.hook.project_id, location=self.location
+        )
         try:
             job_properties = self._client.get_job(job_id=self.job_id)._properties
 

--- a/providers/google/tests/unit/google/cloud/openlineage/test_mixins.py
+++ b/providers/google/tests/unit/google/cloud/openlineage/test_mixins.py
@@ -20,7 +20,7 @@ import copy
 import json
 import logging
 import os
-from unittest.mock import MagicMock, patch, ANY
+from unittest.mock import MagicMock, patch
 
 import pytest
 from google.cloud.bigquery.table import Table

--- a/providers/google/tests/unit/google/cloud/openlineage/test_mixins.py
+++ b/providers/google/tests/unit/google/cloud/openlineage/test_mixins.py
@@ -1020,6 +1020,7 @@ class TestBigQueryOpenLineageMixin:
         connection.
         """
         from airflow.providers.google.cloud.operators.cloud_base import GoogleCloudBaseOperator
+
         class TestOperator(GoogleCloudBaseOperator, _BigQueryInsertJobOperatorOpenLineageMixin):
             def __init__(self, project_id: str = None, **kwargs):
                 self.project_id = project_id

--- a/providers/google/tests/unit/google/cloud/openlineage/test_mixins.py
+++ b/providers/google/tests/unit/google/cloud/openlineage/test_mixins.py
@@ -1022,14 +1022,14 @@ class TestBigQueryOpenLineageMixin:
         from airflow.providers.google.cloud.operators.cloud_base import GoogleCloudBaseOperator
 
         class TestOperator(GoogleCloudBaseOperator, _BigQueryInsertJobOperatorOpenLineageMixin):
-            def __init__(self, project_id: str = None, **kwargs):
+            def __init__(self, project_id: str = None, **_):
                 self.project_id = project_id
                 self.job_id = "foobar"
                 self.location = "foobar"
                 self.sql = "foobar"
 
         # First test task where project_id is set explicitly
-        test = TestOperator(task_id="foo", job_id="bar", project_id="project_a")
+        test = TestOperator(project_id="project_a")
         test.hook = MagicMock()
         test.hook.project_id = "project_b"
         test._client = MagicMock()
@@ -1039,7 +1039,7 @@ class TestBigQueryOpenLineageMixin:
         assert kwargs["project_id"] == "project_a"
 
         # Then test task where project_id is inherited from the hook
-        test = TestOperator(task_id="foo", job_id="bar")
+        test = TestOperator()
         test.hook = MagicMock()
         test.hook.project_id = "project_b"
         test._client = MagicMock()

--- a/providers/google/tests/unit/google/cloud/openlineage/test_mixins.py
+++ b/providers/google/tests/unit/google/cloud/openlineage/test_mixins.py
@@ -1022,7 +1022,7 @@ class TestBigQueryOpenLineageMixin:
         from airflow.providers.google.cloud.operators.cloud_base import GoogleCloudBaseOperator
 
         class TestOperator(GoogleCloudBaseOperator, _BigQueryInsertJobOperatorOpenLineageMixin):
-            def __init__(self, project_id: str = None, **_):
+            def __init__(self, project_id: str | None = None, **_):
                 self.project_id = project_id
                 self.job_id = "foobar"
                 self.location = "foobar"


### PR DESCRIPTION
This PR changes the `_BigQueryInsertJobOperatorOpenLineageMixin` to prefer the operator's (`BigQueryInsertJobOperator`) project_id (if set) over the project_id set in the connection.

Currently, the mixin defaults to only using the project_id configured in the connection. While the BigQueryInsertJobOperator uses the project_id set via an argument, the mixin does not, leading to warnings in the logs because openlineage information could not be fetched from the correct project.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
