### PR TITLE
Fix PoolBar flex values

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/PoolBar.tsx
+++ b/airflow-core/src/airflow/ui/src/components/PoolBar.tsx
@@ -55,7 +55,6 @@ export const PoolBar = ({
               alignItems="center"
               bg={`${color}.solid`}
               color={`${color}.contrast`}
-              flex={flexValue}
               gap={1}
               h="100%"
               justifyContent="center"


### PR DESCRIPTION
Flex values was applied two times 

closes: https://github.com/apache/airflow/issues/55595

This was introduced during the refactoring of the UI color theme (Tailwind palette), which will be release in `3.1.0`. 