### PR TITLE
Fix grid scrollbar overlapping on firefox

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -133,7 +133,7 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
               minSize={showGantt && dagView === "grid" && Boolean(runId) ? 35 : 6}
               order={1}
             >
-              <Box height="100%" marginInlineEnd={2} overflowY="auto" position="relative">
+              <Box height="100%" marginInlineEnd={2} overflowY="auto" paddingRight={4} position="relative">
                 <PanelButtons
                   dagRunStateFilter={dagRunStateFilter}
                   dagView={dagView}

--- a/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
@@ -255,7 +255,7 @@ export const PanelButtons = ({
             <MdOutlineAccountTree />
           </IconButton>
         </ButtonGroup>
-        <Flex gap={1} mr={3}>
+        <Flex gap={1}>
           <ToggleGroups />
           {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
           <Popover.Root autoFocus={false} positioning={{ placement: "bottom-end" }}>


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/55030

The reported issue seems specific to 'Firefox' on non MacOS. (maybe ubuntu/linux only).

We had the exact same issue on AF 2 https://github.com/apache/airflow/pull/25554/files. I applied the same fix. There is now just a little bit more padding right to allow for the firefox scrollbar to fit there.

<img width="1312" height="934" alt="Screenshot 2025-09-22 at 18 44 37" src="https://github.com/user-attachments/assets/8bcb803c-f007-4c39-85ab-4c7ef6e9f7da" />
