### PR TITLE
feat: Use TaskInstance.id as OpenLineage runId

### DIFF
--- a/providers/databricks/src/airflow/providers/databricks/utils/openlineage.py
+++ b/providers/databricks/src/airflow/providers/databricks/utils/openlineage.py
@@ -77,6 +77,8 @@ def _get_ol_run_id(task_instance) -> str:
         logical_date=_get_logical_date(task_instance),
         try_number=task_instance.try_number,
         map_index=task_instance.map_index,
+        # Airflow 3.0+
+        task_instance_id=getattr(task_instance, "id", None),
     )
 
 

--- a/providers/dbt/cloud/src/airflow/providers/dbt/cloud/utils/openlineage.py
+++ b/providers/dbt/cloud/src/airflow/providers/dbt/cloud/utils/openlineage.py
@@ -147,6 +147,8 @@ def generate_openlineage_events_from_dbt_cloud_run(
         logical_date=_get_logical_date(task_instance),
         try_number=task_instance.try_number,
         map_index=task_instance.map_index,
+        # Airflow 3.0+
+        task_instance_id=getattr(task_instance, "id", None),
     )
 
     root_parent_run_id = OpenLineageAdapter.build_dag_run_id(

--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/adapter.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/adapter.py
@@ -20,6 +20,7 @@ import os
 import traceback
 from contextlib import ExitStack
 from typing import TYPE_CHECKING, Literal
+from uuid import UUID
 
 import yaml
 from openlineage.client import OpenLineageClient, set_producer
@@ -138,7 +139,10 @@ class OpenLineageAdapter(LoggingMixin):
         try_number: int,
         logical_date: datetime,
         map_index: int,
+        task_instance_id: UUID | None = None,
     ):
+        if task_instance_id:
+            return str(task_instance_id)
         return str(
             generate_static_uuid(
                 instant=logical_date,

--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
@@ -189,6 +189,8 @@ class OpenLineageListener:
                 try_number=task_instance.try_number,
                 logical_date=date,
                 map_index=task_instance.map_index,
+                # Airflow 3.0+
+                task_instance_id=getattr(task_instance, "id", None),
             )
             event_type = RunState.RUNNING.value.lower()
             operator_name = task.task_type.lower()
@@ -313,6 +315,8 @@ class OpenLineageListener:
                 try_number=task_instance.try_number,
                 logical_date=date,
                 map_index=task_instance.map_index,
+                # Airflow 3.0+
+                task_instance_id=getattr(task_instance, "id", None),
             )
             event_type = RunState.COMPLETE.value.lower()
             operator_name = task.task_type.lower()
@@ -450,6 +454,8 @@ class OpenLineageListener:
                 try_number=task_instance.try_number,
                 logical_date=date,
                 map_index=task_instance.map_index,
+                # Airflow 3.0+
+                task_instance_id=getattr(task_instance, "id", None),
             )
             event_type = RunState.FAIL.value.lower()
             operator_name = task.task_type.lower()
@@ -525,6 +531,8 @@ class OpenLineageListener:
                 try_number=ti.try_number,
                 logical_date=date,
                 map_index=ti.map_index,
+                # Airflow 3.0+
+                task_instance_id=getattr(ti, "id", None),
             )
 
             adapter_kwargs = {

--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/macros.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/macros.py
@@ -65,6 +65,8 @@ def lineage_run_id(task_instance: TaskInstance):
         try_number=task_instance.try_number,
         logical_date=_get_logical_date(task_instance),
         map_index=task_instance.map_index,
+        # Airflow 3.0+
+        task_instance_id=getattr(task_instance, "id", None),
     )
 
 

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_adapter.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_adapter.py
@@ -1226,6 +1226,18 @@ def test_build_dag_run_id_different_clear_number_give_different_results():
     assert result1 != result2
 
 
+def test_build_task_instance_for_task_instance_id():
+    result = OpenLineageAdapter.build_task_instance_run_id(
+        task_instance_id=uuid.UUID("019972a6-3eb0-7d9c-aa89-20e2cd29fad5"),
+        dag_id="whatever",
+        task_id="whatever",
+        try_number=1,
+        logical_date=datetime.datetime.now(),
+        map_index=-1,
+    )
+    assert result == "019972a6-3eb0-7d9c-aa89-20e2cd29fad5"
+
+
 def test_build_task_instance_run_id_is_valid_uuid():
     result = OpenLineageAdapter.build_task_instance_run_id(
         dag_id="dag_id",

--- a/providers/snowflake/src/airflow/providers/snowflake/utils/openlineage.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/utils/openlineage.py
@@ -149,6 +149,8 @@ def _get_ol_run_id(task_instance) -> str:
         logical_date=_get_logical_date(task_instance),
         try_number=task_instance.try_number,
         map_index=task_instance.map_index,
+        # Airflow 3.0+
+        task_instance_id=getattr(task_instance, "id", None),
     )
 
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---

OpenLineage uses UUIDv7 as `run.runId` field value. For Airflow 2.x it uses TaskInstance `logical_date` + combination of dag_id, task_id, try_number and map_index. This ensures that runId is the same for the same TaskInstance.

But since Airflow 3.x, TaskInstance already has unique ID which is UUIDv7. Let's use it as runId, if present.

**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
