### PR TITLE
Reduce default columns of Dag Run and Task Instance lists

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/DagRuns.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagRuns.tsx
@@ -180,7 +180,13 @@ export const DagRuns = () => {
   const { dagId } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const { setTableURLState, tableURLState } = useTableURLState();
+  const { setTableURLState, tableURLState } = useTableURLState({
+    columnVisibility: {
+      conf: false,
+      dag_version: false,
+      end_date: false,
+    },
+  });
   const { pagination, sorting } = tableURLState;
   const [sort] = sorting;
   const orderBy = sort ? [`${sort.desc ? "-" : ""}${sort.id}`] : ["-run_after"];

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
@@ -216,8 +216,11 @@ export const TaskInstances = () => {
   const [searchParams] = useSearchParams();
   const { setTableURLState, tableURLState } = useTableURLState({
     columnVisibility: {
+      dag_version: false,
+      end_date: false,
       executor: false,
       hostname: false,
+      pool: false,
       queue: false,
     },
   });


### PR DESCRIPTION
Following the PR #55922 I have the feeling and consider that too many columns are displayed in the Dag Run and Task Instances lists per default. This clutters the screen and makes it hard to use the lists in normale and less than FHD screens.

This PR disables some columns per default and allows also to check lists when the screen is smaller than FHD, columns can be enabled on demand.

FYI @dheerajturaga 

**Before**:

(1) Dag Runs:
<img width="1910" height="677" alt="image" src="https://github.com/user-attachments/assets/c7c2f721-be26-4f0e-9b57-a5cc1381377d" />

(2) Task Instances:
<img width="1910" height="1486" alt="image" src="https://github.com/user-attachments/assets/5762c202-be54-4007-82d0-4f5294ebdc52" />

**After**:

(1) Dag Runs:
<img width="1910" height="677" alt="image" src="https://github.com/user-attachments/assets/b150412a-4363-45ef-9e39-97fd83ca22cb" />

(2) Task Instances:
<img width="1910" height="1406" alt="image" src="https://github.com/user-attachments/assets/5be067c3-6e53-46f3-811f-ce1d7cf880f7" />
