### PR TITLE
Apply correct release date in changelog for providers

### DIFF
--- a/dev/breeze/src/airflow_breeze/templates/CHANGELOG_TEMPLATE.rst.jinja2
+++ b/dev/breeze/src/airflow_breeze/templates/CHANGELOG_TEMPLATE.rst.jinja2
@@ -21,9 +21,6 @@
 {{ version_header }}
 
 
-Release Date: ``|PypiReleaseDate|``
-
-
 {%- if min_airflow_version_bump %}
 
 .. note::


### PR DESCRIPTION
Why:

Part of this https://github.com/apache/airflow/pull/54525 we moved release date template to changelog. this has some issue, as we are replacing the `PyPIReleaseDate` template field at docs build time, and the change log has this same template field for older versions, due to this we are seeing the current release date for the previous changelog entires see below for example databricks, release date is same.

<img width="669" height="611" alt="image" src="https://github.com/user-attachments/assets/ad51557b-4713-420f-a6b9-933f38c1686f" />

I have update logic to place directly the html format as we are handling this html files. I am not sure whats the other bestway to get this and place. feel free to suggest any other.

Below screenshot after this update. as you can see it replicated for all the release versions in the change log entry below.

<img width="583" height="845" alt="image" src="https://github.com/user-attachments/assets/d637f4dd-d29b-4672-8978-65a59f8f4a8b" />



<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
