### PR TITLE
AIP-67 - Multi-team: Verify dag/task executors are present in team

### DIFF
--- a/airflow-core/src/airflow/dag_processing/dagbag.py
+++ b/airflow-core/src/airflow/dag_processing/dagbag.py
@@ -141,22 +141,20 @@ def _validate_executor_fields(dag: DAG) -> None:
     log = logging.getLogger(__name__)
     dag_team_name = None
 
-    # Get team name from bundle configuration if available
-    if hasattr(dag, "bundle_name") and dag.bundle_name:
-        try:
+    # Check if multi team is available by reading the multi_team configuration (which is boolean)
+    if conf.getboolean("core", "multi_team"):
+        # Get team name from bundle configuration if available
+        if hasattr(dag, "bundle_name") and dag.bundle_name:
             from airflow.dag_processing.bundles.manager import DagBundlesManager
 
             bundle_manager = DagBundlesManager()
             bundle_config = bundle_manager._bundle_config[dag.bundle_name]
-            # TODO[multi-team] Raise exceptions below instead of logging once we have a multi-team feature flag configuration
+
             dag_team_name = bundle_config.team_name
-            log.debug(
-                "Found team '%s' for DAG '%s' via bundle '%s'", dag_team_name, dag.dag_id, dag.bundle_name
-            )
-        except Exception as e:
-            log.debug(
-                "Could not determine team from bundle configuration for DAG '%s': %s", dag.dag_id, str(e)
-            )
+            if dag_team_name:
+                log.debug(
+                    "Found team '%s' for DAG '%s' via bundle '%s'", dag_team_name, dag.dag_id, dag.bundle_name
+                )
 
     for task in dag.tasks:
         if not task.executor:

--- a/airflow-core/tests/unit/dag_processing/test_dagbag.py
+++ b/airflow-core/tests/unit/dag_processing/test_dagbag.py
@@ -62,6 +62,102 @@ PY313 = sys.version_info >= (3, 13)
 INVALID_DAG_WITH_DEPTH_FILE_CONTENTS = "def something():\n    return airflow_DAG\nsomething()"
 
 
+@pytest.fixture
+def mock_dag_bundle_manager():
+    """Fixture to create a mock DAG bundle manager with team configuration."""
+    from airflow.dag_processing.bundles.base import BaseDagBundle
+    from airflow.dag_processing.bundles.manager import _InternalBundleConfig
+
+    class MockDagBundle(BaseDagBundle):
+        @property
+        def path(self):
+            return None
+
+        def get_current_version(self):
+            return "1.0.0"
+
+        def refresh(self):
+            pass
+
+    @contextlib.contextmanager
+    def _create_bundle_manager(bundle_name="test_bundle", team_name="test_team"):
+        mock_bundle_config = _InternalBundleConfig(bundle_class=MockDagBundle, kwargs={}, team_name=team_name)
+
+        bundle_config = {bundle_name: mock_bundle_config}
+
+        with patch("airflow.dag_processing.bundles.manager.DagBundlesManager") as mock_manager_class:
+            mock_manager = mock_manager_class.return_value
+            mock_manager._bundle_config = bundle_config
+            yield mock_manager
+
+    return _create_bundle_manager
+
+
+@patch.object(ExecutorLoader, "lookup_executor_name_by_str")
+def test_validate_executor_field_with_team_restriction(mock_executor_lookup, mock_dag_bundle_manager):
+    """Test executor validation with team-based restrictions using bundle configuration."""
+    with mock_dag_bundle_manager():
+        mock_executor_lookup.side_effect = UnknownExecutorException("Executor not available for team")
+
+        with DAG("test-dag", schedule=None) as dag:
+            # Simulate DAG having bundle_name set during parsing
+            dag.bundle_name = "test_bundle"
+            BaseOperator(task_id="t1", executor="team.restricted.executor")
+
+        with pytest.raises(
+            UnknownExecutorException,
+            match=re.escape(
+                "Task 't1' specifies executor 'team.restricted.executor', which is not available "
+                "for team 'test_team' (the team associated with DAG 'test-dag'). "
+                "Make sure 'team.restricted.executor' is configured for team 'test_team' in your "
+                "[core] executors configuration, or update the task's executor to use one of the "
+                "configured executors for team 'test_team'."
+            ),
+        ):
+            _validate_executor_fields(dag)
+
+        # Verify the executor lookup was called with the team name from config
+        mock_executor_lookup.assert_called_with("team.restricted.executor", team_name="test_team")
+
+
+@patch.object(ExecutorLoader, "lookup_executor_name_by_str")
+def test_validate_executor_field_no_team_associated(mock_executor_lookup):
+    """Test executor validation when no team is associated with DAG (no bundle_name)."""
+    mock_executor_lookup.side_effect = UnknownExecutorException("Unknown executor")
+
+    with DAG("test-dag", schedule=None) as dag:
+        # No bundle_name attribute, so no team will be found, see final assertion below
+        BaseOperator(task_id="t1", executor="unknown.executor")
+
+    with pytest.raises(
+        UnknownExecutorException,
+        match=re.escape(
+            "Task 't1' specifies executor 'unknown.executor', which is not available. "
+            "Make sure it is listed in your [core] executors configuration, or update the task's "
+            "executor to use one of the configured executors."
+        ),
+    ):
+        _validate_executor_fields(dag)
+
+    mock_executor_lookup.assert_called_with("unknown.executor", team_name=None)
+
+
+@patch.object(ExecutorLoader, "lookup_executor_name_by_str")
+def test_validate_executor_field_valid_team_executor(mock_executor_lookup, mock_dag_bundle_manager):
+    """Test executor validation when executor is valid for the DAG's team (happy path)."""
+    with mock_dag_bundle_manager():
+        mock_executor_lookup.return_value = None
+
+        with DAG("test-dag", schedule=None) as dag:
+            dag.bundle_name = "test_bundle"
+            BaseOperator(task_id="t1", executor="team.valid.executor")
+
+        _validate_executor_fields(dag)
+
+        # Verify the executor lookup was called with the team name which is fetched from bundle config
+        mock_executor_lookup.assert_called_with("team.valid.executor", team_name="test_team")
+
+
 def db_clean_up():
     db.clear_db_dags()
     db.clear_db_runs()

--- a/airflow-core/tests/unit/dag_processing/test_dagbag.py
+++ b/airflow-core/tests/unit/dag_processing/test_dagbag.py
@@ -114,7 +114,8 @@ def test_validate_executor_field_with_team_restriction(mock_executor_lookup, moc
                 "configured executors for team 'test_team'."
             ),
         ):
-            _validate_executor_fields(dag)
+            with conf_vars({("core", "multi_team"): "True"}):
+                _validate_executor_fields(dag)
 
         # Verify the executor lookup was called with the team name from config
         mock_executor_lookup.assert_called_with("team.restricted.executor", team_name="test_team")
@@ -137,7 +138,8 @@ def test_validate_executor_field_no_team_associated(mock_executor_lookup):
             "executor to use one of the configured executors."
         ),
     ):
-        _validate_executor_fields(dag)
+        with conf_vars({("core", "multi_team"): "True"}):
+            _validate_executor_fields(dag)
 
     mock_executor_lookup.assert_called_with("unknown.executor", team_name=None)
 
@@ -152,7 +154,8 @@ def test_validate_executor_field_valid_team_executor(mock_executor_lookup, mock_
             dag.bundle_name = "test_bundle"
             BaseOperator(task_id="t1", executor="team.valid.executor")
 
-        _validate_executor_fields(dag)
+        with conf_vars({("core", "multi_team"): "True"}):
+            _validate_executor_fields(dag)
 
         # Verify the executor lookup was called with the team name which is fetched from bundle config
         mock_executor_lookup.assert_called_with("team.valid.executor", team_name="test_team")


### PR DESCRIPTION
If a dag or task is configured to use a specific executor (leveraging Multiple Executor Configuration) and the dag belongs to a team, then validate that the executor is present in that team before adding the dag to the dag bag.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
