### PR TITLE
Allow arguments and parameters when powershell is used in PsrpOperator

### DIFF
--- a/providers/microsoft/psrp/src/airflow/providers/microsoft/psrp/operators/psrp.py
+++ b/providers/microsoft/psrp/src/airflow/providers/microsoft/psrp/operators/psrp.py
@@ -110,10 +110,10 @@ class PsrpOperator(BaseOperator):
         args = {command, powershell, cmdlet}
         if not exactly_one(*args):
             raise ValueError("Must provide exactly one of 'command', 'powershell', or 'cmdlet'")
-        if arguments and not cmdlet:
-            raise ValueError("Arguments only allowed with 'cmdlet'")
-        if parameters and not cmdlet:
-            raise ValueError("Parameters only allowed with 'cmdlet'")
+        if arguments and not (powershell or cmdlet):
+            raise ValueError("Arguments only allowed with 'powershell' or 'cmdlet'")
+        if parameters and not (powershell or cmdlet):
+            raise ValueError("Parameters only allowed with 'powershell' or 'cmdlet'")
         if cmdlet:
             kwargs.setdefault("task_id", cmdlet)
         super().__init__(**kwargs)


### PR DESCRIPTION
Fixes https://github.com/apache/airflow/issues/55974.

According to the docstrings for these kwargs, powershell should accept arguments and parameters.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: [#55974](https://github.com/apache/airflow/issues/55974)
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
