### PR TITLE
Fix `breeze run` command to respect `--backend` flag

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/developer_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/developer_commands.py
@@ -1153,6 +1153,8 @@ def run(
             shell_params=shell_params,
             project_name=unique_project_name,
             command=full_command,
+            # Always preserve the backend specified by user (or resolved from default)
+            preserve_backend=True,
         )
 
     # Clean up ownership

--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -730,13 +730,14 @@ def execute_command_in_shell(
     command: str | None = None,
     output: Output | None = None,
     signal_error: bool = True,
+    preserve_backend: bool = False,
 ) -> RunCommandResult:
     """Executes command in shell.
 
     When you want to execute a script/bash command inside the CI container and want to use `enter_shell`
     for this purpose, the helper methods sets the following parameters of shell_params:
 
-    * backend - to force sqlite backend
+    * backend - to force sqlite backend (unless preserve_backend=True)
     * clean_sql_db=True - to clean the sqlite DB
     * forward_ports=False - to avoid forwarding ports from the container to the host - again that will
       allow to avoid clashes with other commands and opened breeze shell
@@ -751,16 +752,23 @@ def execute_command_in_shell(
     :param project_name: Name of the project to use. This avoids name clashes with default 'breeze"
         project name used - this way you will be able to run the command in parallel to regular
         "breeze" shell opened in parallel
-    :param command:
+    :param command: command to execute in the shell
+    :param output: output configuration
+    :param signal_error: whether to signal error
+    :param preserve_backend: if True, preserve the backend specified in shell_params instead of forcing sqlite
     """
-    shell_params.backend = "sqlite"
+    if not preserve_backend:
+        shell_params.backend = "sqlite"
     shell_params.forward_ports = False
     shell_params.project_name = project_name
     shell_params.quiet = True
     shell_params.skip_environment_initialization = True
     shell_params.skip_image_upgrade_check = True
     if get_verbose():
-        get_console().print("[warning]Sqlite DB is cleaned[/]")
+        if not preserve_backend:
+            get_console().print("[warning]Sqlite DB is cleaned[/]")
+        else:
+            get_console().print(f"[info]Using backend: {shell_params.backend}[/]")
         get_console().print("[warning]Disabled port forwarding[/]")
         get_console().print(f"[warning]Project name set to: {project_name}[/]")
         get_console().print("[warning]Forced quiet mode[/]")


### PR DESCRIPTION
The breeze run command was ignoring the `--backend` flag and always using `SQLite` for command execution. This change adds a `preserve_backend` parameter to `execute_command_in_shell()` to allow respecting the user's backend choice while maintaining the default SQLite behavior for safety.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
