### PR TITLE
Reserialize Dags when downgrading below 3.1.0

### DIFF
--- a/airflow-core/src/airflow/cli/commands/db_command.py
+++ b/airflow-core/src/airflow/cli/commands/db_command.py
@@ -110,7 +110,7 @@ def _reserialize_dags_after_downgrade(args):
         config = db._get_alembic_config()
 
         for version, head in _REVISION_HEADS_MAP.items():
-            if head == args.revision or db._revision_greater(config, head, args.revision):
+            if head == args.to_revision or db._revision_greater(config, head, args.to_revision):
                 resolved_version = version
                 break
         if resolved_version is not None:

--- a/airflow-core/src/airflow/cli/commands/db_command.py
+++ b/airflow-core/src/airflow/cli/commands/db_command.py
@@ -108,7 +108,7 @@ def _reserialize_dags_after_downgrade(args):
         ser_version = _get_serializer_version_for_target_version(args.to_version)
     elif args.to_revision:
         config = db._get_alembic_config()
-
+        resolved_version = None
         for version, head in _REVISION_HEADS_MAP.items():
             if head == args.to_revision or db._revision_greater(config, head, args.to_revision):
                 resolved_version = version


### PR DESCRIPTION
Downgrading to Airflow ≤3.0.x could leave the metadata DB with serializer v3 Dags that older versions cannot read or reserialize. This change automatically reserializes Dags to a compatible serializer version after a successful airflow db downgrade.
On downgrade, we map the target Airflow version to a serializer version and reserialize all DAGs (skipped for --show-sql-only). The mapping is derived from a new _SER_DAG_VERSIONS_MAP, resolved from either --to-version or --to-revision.

Adds db.reserialize_all_dags_to_serializer_version supporting 3→2 down-conversion. It performs a SQL fast-path for uncompressed rows across the db types and falls back to row-wise updates for compressed rows. The function does not commit and logs warnings instead of failing the CLI.

Tests cover triggering on --to-version, skipping with --show-sql-only, and the --to-revision path.

User impact: Downgrading to 3.0.x no longer results in incompatible v3-serialized Dags; the scheduler/UI can read Dags immediately after the downgrade.
