### PR TITLE
Fix reset button text in pools dialog

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Pools/PoolForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Pools/PoolForm.tsx
@@ -41,7 +41,7 @@ type PoolFormProps = {
 };
 
 const PoolForm = ({ error, initialPool, isPending, manageMutate, setError }: PoolFormProps) => {
-  const { t: translate } = useTranslation("admin");
+  const { t: translate } = useTranslation(["admin", "common"]);
   const {
     control,
     formState: { isDirty, isValid },
@@ -122,7 +122,7 @@ const PoolForm = ({ error, initialPool, isPending, manageMutate, setError }: Poo
         <HStack w="full">
           {isDirty ? (
             <Button onClick={handleReset} variant="outline">
-              {translate("formActions.reset")}
+              {translate("common:reset")}
             </Button>
           ) : undefined}
           <Spacer />


### PR DESCRIPTION
Replace 'formActions.reset' with proper 'common:reset' translation key

bug: 
<img width="1135" height="597" alt="image" src="https://github.com/user-attachments/assets/f1a4b499-166c-4e01-adca-bc8473e60005" />

Fix:
<img width="1107" height="591" alt="image" src="https://github.com/user-attachments/assets/9e46f073-8a1a-4b81-8a6a-c6112b833f64" />
