### PR TITLE
Fix Gantt misalignment

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -152,7 +152,7 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
                 {dagView === "graph" ? (
                   <Graph />
                 ) : (
-                  <HStack gap={0}>
+                  <HStack alignItems="flex-end" gap={0}>
                     <Grid
                       dagRunState={dagRunStateFilter}
                       limit={limit}

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/Gantt.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/Gantt.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines */
-
 /*!
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -291,14 +289,7 @@ export const Gantt = ({ dagRunState, limit, runType, triggeringUser }: Props) =>
   };
 
   return (
-    <Box
-      height={`${fixedHeight}px`}
-      minW="250px"
-      ml={-2}
-      mt={36}
-      onMouseLeave={handleChartMouseLeave}
-      w="100%"
-    >
+    <Box height={`${fixedHeight}px`} minW="250px" ml={-2} onMouseLeave={handleChartMouseLeave} w="100%">
       <Bar
         data={chartData}
         options={chartOptions}

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Grid.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Grid.tsx
@@ -57,7 +57,6 @@ export const Grid = ({ dagRunState, limit, runType, showGantt, triggeringUser }:
   const { dagId = "", runId = "" } = useParams();
 
   const { data: gridRuns, isLoading } = useGridRuns({ dagRunState, limit, runType, triggeringUser });
-  const selectedRun = gridRuns?.find((run) => run.run_id === runId);
 
   // Check if the selected dag run is inside of the grid response, if not, we'll update the grid filters
   // Eventually we should redo the api endpoint to make this work better
@@ -117,12 +116,7 @@ export const Grid = ({ dagRunState, limit, runType, showGantt, triggeringUser }:
       tabIndex={0}
       width={showGantt ? "1/2" : "full"}
     >
-      <Box
-        flexGrow={1}
-        minWidth={7}
-        position="relative"
-        top={Boolean(runId) && !Boolean(selectedRun) ? "50px" : "100px"}
-      >
+      <Box display="flex" flexDirection="column" flexGrow={1} justifyContent="end" minWidth={7}>
         <TaskNames nodes={flatNodes} onRowClick={() => setMode("task")} />
       </Box>
       <Box position="relative">


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/55983

Changes the alignment approach for 'grid' and 'gantt' to make them more robust. It is hard to know where the grid and gantt 'task names' start, considering above elements, and align them.

What we do now is simply 'bottom' align the grid and the gantt so the last tasks 'align' and from there up, everything should be in line, always.

<img width="1369" height="907" alt="Screenshot 2025-09-23 at 16 
59 24" src="https://github.com/user-attachments/assets/edcd7b63-234e-460c-9214-b68e5c54db7b" />
<img width="1375" height="644" alt="Screenshot 2025-09-23 at 16 59 31" src="https://github.com/user-attachments/assets/3075a23a-0f73-4c35-837e-0be94015d241" />
<img width="1359" height="600" alt="Screenshot 2025-09-23 at 17 00 15" src="https://github.com/user-attachments/assets/9098871a-b731-405f-bf0c-2bb311348483" />
<img width="1365" height="847" alt="Screenshot 2025-09-23 at 17 00 58" src="https://github.com/user-attachments/assets/6aefa60d-dd9c-4046-b941-0e031dc44c25" />
