### PR TITLE
Fix grid small task names

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Grid.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Grid.tsx
@@ -116,7 +116,7 @@ export const Grid = ({ dagRunState, limit, runType, showGantt, triggeringUser }:
       tabIndex={0}
       width={showGantt ? "1/2" : "full"}
     >
-      <Box display="flex" flexDirection="column" flexGrow={1} justifyContent="end" minWidth={7}>
+      <Box display="flex" flexDirection="column" flexGrow={1} justifyContent="end" minWidth="100px">
         <TaskNames nodes={flatNodes} onRowClick={() => setMode("task")} />
       </Box>
       <Box position="relative">


### PR DESCRIPTION
When the gantt is not shown, and there are a lot of runs to display, the task names could be extremely collapse, to an extant that it's impossible to read anything from the grid structure.


### Before
<img width="1920" height="706" alt="Screenshot 2025-09-23 at 17 15 55" src="https://github.com/user-attachments/assets/c63fd39c-0151-4213-97e3-9af01e4efa9d" />


### After
<img width="1918" height="933" alt="Screenshot 2025-09-23 at 17 15 28" src="https://github.com/user-attachments/assets/90ed29bb-718c-45ad-8868-ab10e0cc7043" />
