### PR TITLE
AIP-67 - Multi Team: Pass args/kwargs to super in Celery executors

### DIFF
--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
@@ -290,8 +290,8 @@ class CeleryExecutor(BaseExecutor):
         # TODO: TaskSDK: move this type change into BaseExecutor
         queued_tasks: dict[TaskInstanceKey, workloads.All]  # type: ignore[assignment]
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         # Celery doesn't support bulk sending the tasks (which can become a bottleneck on bigger clusters)
         # so we use a multiprocessing pool to speed this up.

--- a/providers/celery/tests/unit/celery/executors/test_celery_executor.py
+++ b/providers/celery/tests/unit/celery/executors/test_celery_executor.py
@@ -126,6 +126,17 @@ class TestCeleryExecutor:
     def test_cli_commands_vended(self):
         assert CeleryExecutor.get_cli_commands()
 
+    def test_celery_executor_init_with_args_kwargs(self):
+        """Test that CeleryExecutor properly passes args and kwargs to BaseExecutor."""
+        parallelism = 50
+        team_name = "test_team"
+
+        executor = celery_executor.CeleryExecutor(parallelism, team_name=team_name)
+
+        assert executor.parallelism == parallelism
+        assert executor.team_name == team_name
+        assert executor.conf.team_name == team_name
+
     @pytest.mark.backend("mysql", "postgres")
     def test_exception_propagation(self, caplog):
         caplog.set_level(

--- a/providers/celery/tests/unit/celery/executors/test_celery_executor.py
+++ b/providers/celery/tests/unit/celery/executors/test_celery_executor.py
@@ -131,11 +131,18 @@ class TestCeleryExecutor:
         parallelism = 50
         team_name = "test_team"
 
-        executor = celery_executor.CeleryExecutor(parallelism, team_name=team_name)
+        if AIRFLOW_V_3_1_PLUS:
+            # team_name was added in Airflow 3.1
+            executor = celery_executor.CeleryExecutor(parallelism=parallelism, team_name=team_name)
+        else:
+            executor = celery_executor.CeleryExecutor(parallelism)
 
         assert executor.parallelism == parallelism
-        assert executor.team_name == team_name
-        assert executor.conf.team_name == team_name
+
+        if AIRFLOW_V_3_1_PLUS:
+            # team_name was added in Airflow 3.1
+            assert executor.team_name == team_name
+            assert executor.conf.team_name == team_name
 
     @pytest.mark.backend("mysql", "postgres")
     def test_exception_propagation(self, caplog):


### PR DESCRIPTION
This allows the team_name to be passed to the super class. This is low hanging fruit to allow the Celery executor to be used for multi team testing. More changes will be needed to allow the Celery executor to use team-based config, but that will be done at a future time.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
