### PR TITLE
Fix issue where LocalExecutor could start tasks before the state was commited

### DIFF
--- a/airflow-core/src/airflow/executors/local_executor.py
+++ b/airflow-core/src/airflow/executors/local_executor.py
@@ -36,7 +36,6 @@ from typing import TYPE_CHECKING
 
 from airflow.executors import workloads
 from airflow.executors.base_executor import PARALLELISM, BaseExecutor
-from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import TaskInstanceState
 
 # add logger to parameter of setproctitle to support logging
@@ -48,8 +47,6 @@ else:
     setproctitle = lambda title, logger: real_setproctitle(title)
 
 if TYPE_CHECKING:
-    from sqlalchemy.orm import Session
-
     TaskInstanceStateType = tuple[workloads.TaskInstance, TaskInstanceState, Exception | None]
 
 
@@ -253,9 +250,10 @@ class LocalExecutor(BaseExecutor):
     def terminate(self):
         """Terminate the executor is not doing anything."""
 
-    @provide_session
-    def queue_workload(self, workload: workloads.All, session: Session = NEW_SESSION):
-        self.activity_queue.put(workload)
+    def _process_workloads(self, workloads):
+        for workload in workloads:
+            self.activity_queue.put(workload)
+            del self.queued_tasks[workload.ti.key]
         with self._unread_messages:
-            self._unread_messages.value += 1
+            self._unread_messages.value += len(workloads)
         self._check_workers()

--- a/airflow-core/tests/unit/executors/test_local_executor.py
+++ b/airflow-core/tests/unit/executors/test_local_executor.py
@@ -28,6 +28,7 @@ from uuid6 import uuid7
 from airflow._shared.timezones import timezone
 from airflow.executors import workloads
 from airflow.executors.local_executor import LocalExecutor, _execute_work
+from airflow.settings import Session
 from airflow.utils.state import State
 
 from tests_common.test_utils.config import conf_vars
@@ -97,7 +98,8 @@ class TestLocalExecutor:
                         dag_rel_path="some/path",
                         log_path=None,
                         bundle_info=dict(name="hi", version="hi"),
-                    )
+                    ),
+                    session=mock.MagicMock(spec=Session),
                 )
 
             executor.queue_workload(
@@ -107,8 +109,12 @@ class TestLocalExecutor:
                     dag_rel_path="some/path",
                     log_path=None,
                     bundle_info=dict(name="hi", version="hi"),
-                )
+                ),
+                session=mock.MagicMock(spec=Session),
             )
+
+            # Process queued workloads to trigger worker spawning
+            executor._process_workloads(list(executor.queued_tasks.values()))
 
             executor.end()
 


### PR DESCRIPTION
With some recent changes LocalExec was now able to start a task _too quickly_,
and due to it's custom implementation of `queue_workload` it was directly
sending the message to the MP queue the task in queue_workload, which means if
there is an idle worker process already it will pick it up "instantly" --
crucially before the database transaction in with TI.state is changed from
scheduled to queued, is committed!

The fix here is to correctly follow the BaseExecutor interface, and not start
send the workloads for processing until heartbeat is called (which happens in
the scheduler right after the transaction is committed.)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
