### PR TITLE
Add optional pending dag runs check to auto refresh

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/NeedsReviewButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/NeedsReviewButton.tsx
@@ -27,16 +27,15 @@ import { StatsCard } from "./StatsCard";
 
 export const NeedsReviewButton = ({
   dagId,
-  refreshInterval,
   runId,
   taskId,
 }: {
   readonly dagId?: string;
-  readonly refreshInterval?: number | false;
   readonly runId?: string;
   readonly taskId?: string;
 }) => {
-  const hookAutoRefresh = useAutoRefresh({ dagId });
+  const refetchInterval = useAutoRefresh({ checkPendingRuns: true, dagId });
+
   const { data: hitlStatsData, isLoading } = useTaskInstanceServiceGetHitlDetails(
     {
       dagId: dagId ?? "~",
@@ -47,7 +46,7 @@ export const NeedsReviewButton = ({
     },
     undefined,
     {
-      refetchInterval: refreshInterval ?? hookAutoRefresh,
+      refetchInterval,
     },
   );
 

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Grid.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Grid.tsx
@@ -29,6 +29,7 @@ import { useOpenGroups } from "src/context/openGroups";
 import { useNavigation } from "src/hooks/navigation";
 import { useGridRuns } from "src/queries/useGridRuns.ts";
 import { useGridStructure } from "src/queries/useGridStructure.ts";
+import { isStatePending } from "src/utils";
 
 import { Bar } from "./Bar";
 import { DurationAxis } from "./DurationAxis";
@@ -68,7 +69,13 @@ export const Grid = ({ dagRunState, limit, runType, showGantt, triggeringUser }:
     }
   }, [runId, gridRuns, selectedIsVisible, setSelectedIsVisible]);
 
-  const { data: dagStructure } = useGridStructure({ dagRunState, limit, runType, triggeringUser });
+  const { data: dagStructure } = useGridStructure({
+    dagRunState,
+    hasActiveRun: gridRuns?.some((dr) => isStatePending(dr.state)),
+    limit,
+    runType,
+    triggeringUser,
+  });
 
   // calculate dag run bar heights relative to max
   const max = Math.max.apply(

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Grid.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Grid.tsx
@@ -29,7 +29,6 @@ import { useOpenGroups } from "src/context/openGroups";
 import { useNavigation } from "src/hooks/navigation";
 import { useGridRuns } from "src/queries/useGridRuns.ts";
 import { useGridStructure } from "src/queries/useGridStructure.ts";
-import { isStatePending } from "src/utils";
 
 import { Bar } from "./Bar";
 import { DurationAxis } from "./DurationAxis";
@@ -52,7 +51,6 @@ export const Grid = ({ dagRunState, limit, runType, showGantt, triggeringUser }:
   const gridRef = useRef<HTMLDivElement>(null);
 
   const [selectedIsVisible, setSelectedIsVisible] = useState<boolean | undefined>();
-  const [hasActiveRun, setHasActiveRun] = useState<boolean | undefined>();
   const { openGroupIds, toggleGroupId } = useOpenGroups();
   const { dagId = "", runId = "" } = useParams();
 
@@ -70,25 +68,9 @@ export const Grid = ({ dagRunState, limit, runType, showGantt, triggeringUser }:
     }
   }, [runId, gridRuns, selectedIsVisible, setSelectedIsVisible]);
 
-  useEffect(() => {
-    if (gridRuns) {
-      const run = gridRuns.some((dr: GridRunsResponse) => isStatePending(dr.state));
+  const { data: dagStructure } = useGridStructure({ dagRunState, limit, runType, triggeringUser });
 
-      if (!run) {
-        setHasActiveRun(false);
-      }
-    }
-  }, [gridRuns, setHasActiveRun]);
-
-  const { data: dagStructure } = useGridStructure({
-    dagRunState,
-    hasActiveRun,
-    limit,
-    runType,
-    triggeringUser,
-  });
   // calculate dag run bar heights relative to max
-
   const max = Math.max.apply(
     undefined,
     gridRuns === undefined

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Dag.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Dag.tsx
@@ -92,7 +92,7 @@ export const Dag = () => {
   );
 
   const { tabs: processedTabs } = useRequiredActionTabs({ dagId }, tabs, {
-    refetchInterval: isStatePending(latestRun?.state) ? refetchInterval : false,
+    refetchInterval,
   });
 
   const displayTabs = processedTabs.filter((tab) => {

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Overview/Overview.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Overview/Overview.tsx
@@ -35,7 +35,6 @@ import TimeRangeSelector from "src/components/TimeRangeSelector";
 import { TrendCountButton } from "src/components/TrendCountButton";
 import { SearchParamsKeys } from "src/constants/searchParams";
 import { useGridRuns } from "src/queries/useGridRuns.ts";
-import { isStatePending, useAutoRefresh } from "src/utils";
 
 const FailedLogs = lazy(() => import("./FailedLogs"));
 
@@ -76,14 +75,9 @@ export const Overview = () => {
     timestampLte: endDate,
   });
 
-  const refetchInterval = useAutoRefresh({});
-
   return (
     <Box m={4} spaceY={4}>
-      <NeedsReviewButton
-        dagId={dagId}
-        refreshInterval={gridRuns?.some((dr) => isStatePending(dr.state)) ? refetchInterval : false}
-      />
+      <NeedsReviewButton dagId={dagId} />
       <Box my={2}>
         <TimeRangeSelector
           defaultValue={defaultHour}

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -43,7 +43,7 @@ export const DagCard = ({ dag }: Props) => {
   const { t: translate } = useTranslation(["common", "dag"]);
   const [latestRun] = dag.latest_dag_runs;
 
-  const refetchInterval = useAutoRefresh({ isPaused: dag.is_paused });
+  const refetchInterval = useAutoRefresh({});
 
   return (
     <Box borderColor="border.emphasized" borderRadius={8} borderWidth={1} overflow="hidden">
@@ -95,7 +95,9 @@ export const DagCard = ({ dag }: Props) => {
                   startDate={latestRun.start_date}
                   state={latestRun.state}
                 />
-                {isStatePending(latestRun.state) && Boolean(refetchInterval) ? <Spinner /> : undefined}
+                {isStatePending(latestRun.state) && !dag.is_paused && Boolean(refetchInterval) ? (
+                  <Spinner />
+                ) : undefined}
               </RouterLink>
             </Link>
           ) : undefined}

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/Health/Health.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/Health/Health.tsx
@@ -27,7 +27,7 @@ import { useAutoRefresh } from "src/utils";
 import { HealthBadge } from "./HealthBadge";
 
 export const Health = () => {
-  const refetchInterval = useAutoRefresh({});
+  const refetchInterval = useAutoRefresh({ checkPendingRuns: true });
 
   const { data, error, isLoading } = useMonitorServiceGetHealth(undefined, {
     refetchInterval,

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/HistoricalMetrics.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/HistoricalMetrics.tsx
@@ -41,7 +41,7 @@ export const HistoricalMetrics = () => {
   const [endDate, setEndDate] = useState(now.toISOString());
   const [assetSortBy, setAssetSortBy] = useState("-timestamp");
 
-  const refetchInterval = useAutoRefresh({});
+  const refetchInterval = useAutoRefresh({ checkPendingRuns: true });
 
   const { data, error, isLoading } = useDashboardServiceHistoricalMetrics(
     {

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/PoolSummary/PoolSummary.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/PoolSummary/PoolSummary.tsx
@@ -29,7 +29,7 @@ import { type Slots, slotKeys } from "src/utils/slots";
 
 export const PoolSummary = () => {
   const { t: translate } = useTranslation("dashboard");
-  const refetchInterval = useAutoRefresh({});
+  const refetchInterval = useAutoRefresh({ checkPendingRuns: true });
   const { data, isLoading } = usePoolServiceGetPools(undefined, undefined, {
     refetchInterval,
   });

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/Stats.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/Stats.tsx
@@ -29,7 +29,7 @@ import { DAGImportErrors } from "./DAGImportErrors";
 import { PluginImportErrors } from "./PluginImportErrors";
 
 export const Stats = () => {
-  const refetchInterval = useAutoRefresh({});
+  const refetchInterval = useAutoRefresh({ checkPendingRuns: true });
   const { data: statsData, isLoading: isStatsLoading } = useDashboardServiceDagStats(undefined, {
     refetchInterval,
   });

--- a/airflow-core/src/airflow/ui/src/pages/Task/Overview/Overview.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Task/Overview/Overview.tsx
@@ -54,7 +54,7 @@ export const Overview = () => {
       taskId: Boolean(groupId) ? undefined : taskId,
     });
 
-  const { data: taskInstances, isLoading: isLoadingTaskInstances } = useTaskInstanceServiceGetTaskInstances(
+  const { data: tiData, isLoading: isLoadingTaskInstances } = useTaskInstanceServiceGetTaskInstances(
     {
       dagId,
       dagRunId: "~",
@@ -72,12 +72,7 @@ export const Overview = () => {
 
   return (
     <Box m={4} spaceY={4}>
-      <NeedsReviewButton
-        refreshInterval={
-          taskInstances?.task_instances.some((ti) => isStatePending(ti.state)) ? refetchInterval : false
-        }
-        taskId={taskId}
-      />
+      <NeedsReviewButton taskId={taskId} />
       <Box my={2}>
         <TimeRangeSelector
           defaultValue={defaultHour}
@@ -111,7 +106,7 @@ export const Overview = () => {
           {isLoadingTaskInstances ? (
             <Skeleton height="200px" w="full" />
           ) : (
-            <DurationChart entries={taskInstances?.task_instances.slice().reverse()} kind="Task Instance" />
+            <DurationChart entries={tiData?.task_instances.slice().reverse()} kind="Task Instance" />
           )}
         </Box>
       </SimpleGrid>

--- a/airflow-core/src/airflow/ui/src/queries/useGridRuns.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useGridRuns.ts
@@ -35,7 +35,7 @@ export const useGridRuns = ({
 }) => {
   const { dagId = "" } = useParams();
 
-  const defaultRefetchInterval = useAutoRefresh({ dagId });
+  const refetchInterval = useAutoRefresh({ dagId });
 
   const { data: GridRuns, ...rest } = useGridServiceGetGridRuns(
     {
@@ -50,7 +50,7 @@ export const useGridRuns = ({
     {
       placeholderData: (prev) => prev,
       refetchInterval: (query) =>
-        query.state.data?.some((run) => isStatePending(run.state)) && defaultRefetchInterval,
+        query.state.data?.some((run) => isStatePending(run.state)) && refetchInterval,
     },
   );
 

--- a/airflow-core/src/airflow/ui/src/queries/useGridStructure.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useGridStructure.ts
@@ -24,11 +24,13 @@ import { useAutoRefresh } from "src/utils";
 
 export const useGridStructure = ({
   dagRunState,
+  hasActiveRun,
   limit,
   runType,
   triggeringUser,
 }: {
   dagRunState?: DagRunState | undefined;
+  hasActiveRun?: boolean;
   limit?: number;
   runType?: DagRunType | undefined;
   triggeringUser?: string | undefined;
@@ -48,8 +50,7 @@ export const useGridStructure = ({
     },
     undefined,
     {
-      placeholderData: (prev) => prev,
-      refetchInterval,
+      refetchInterval: hasActiveRun ? refetchInterval : false,
     },
   );
 

--- a/airflow-core/src/airflow/ui/src/queries/useGridStructure.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useGridStructure.ts
@@ -24,13 +24,11 @@ import { useAutoRefresh } from "src/utils";
 
 export const useGridStructure = ({
   dagRunState,
-  hasActiveRun = undefined,
   limit,
   runType,
   triggeringUser,
 }: {
   dagRunState?: DagRunState | undefined;
-  hasActiveRun?: boolean;
   limit?: number;
   runType?: DagRunType | undefined;
   triggeringUser?: string | undefined;
@@ -51,7 +49,7 @@ export const useGridStructure = ({
     undefined,
     {
       placeholderData: (prev) => prev,
-      refetchInterval: hasActiveRun ? refetchInterval : false,
+      refetchInterval,
     },
   );
 

--- a/airflow-core/src/airflow/ui/src/utils/query.ts
+++ b/airflow-core/src/airflow/ui/src/utils/query.ts
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useDagServiceGetDagDetails } from "openapi/queries";
+import { useDagRunServiceGetDagRuns, useDagServiceGetDagDetails } from "openapi/queries";
 import type { TaskInstanceState } from "openapi/requests/types.gen";
 import { useConfig } from "src/queries/useConfig";
 
@@ -30,7 +30,14 @@ export const isStatePending = (state?: TaskInstanceState | null) =>
   state === "restarting" ||
   !Boolean(state);
 
-export const useAutoRefresh = ({ dagId, isPaused }: { dagId?: string; isPaused?: boolean }) => {
+// checkPendingRuns=false assumes that the component is already handling pending, setting to true will have useAutoRefresh handle it
+export const useAutoRefresh = ({
+  checkPendingRuns,
+  dagId,
+}: {
+  checkPendingRuns?: boolean;
+  dagId?: string;
+}) => {
   const autoRefreshInterval = useConfig("auto_refresh_interval") as number | undefined;
   const { data: dag } = useDagServiceGetDagDetails(
     {
@@ -40,9 +47,27 @@ export const useAutoRefresh = ({ dagId, isPaused }: { dagId?: string; isPaused?:
     { enabled: dagId !== undefined },
   );
 
-  const paused = isPaused ?? dag?.is_paused;
+  const { data: dagRunData } = useDagRunServiceGetDagRuns(
+    {
+      dagId: dagId ?? "~",
+      state: ["running", "queued"],
+    },
+    undefined,
+    // Scale back refetching to 10x longer if there are no pending runs (eg: every 3 secs for active runs, otherwise 30 secs)
+    {
+      enabled: checkPendingRuns,
+      refetchInterval: (query) =>
+        autoRefreshInterval !== undefined &&
+        ((query.state.data?.dag_runs ?? []).length > 0
+          ? autoRefreshInterval * 1000
+          : autoRefreshInterval * 10 * 1000),
+    },
+  );
 
-  const canRefresh = autoRefreshInterval !== undefined && !paused;
+  const pendingRuns = checkPendingRuns ? (dagRunData?.dag_runs ?? []).length > 1 : true;
+  const paused = Boolean(dagId) ? dag?.is_paused : false;
+
+  const canRefresh = autoRefreshInterval !== undefined && !paused && pendingRuns;
 
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
   return (canRefresh ? autoRefreshInterval * 1000 : false) as number | false;


### PR DESCRIPTION
We use auto refresh in too many places without knowing if we actually should be refetching anything.

This PR adds a `checkPendingRuns` option to query for dag runs with the state of queued or running. If any runs are returned we will refetch at the normal refetch interval, otherwise the query will scale back to 10x the refetch interval (every 3s becomes every 30s). If you also pass a dagId we will only refetch dag runs for that specific dag.

Also removed the extraneous isPaused check.


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
