### PR TITLE
Fix Python 3.12+ fork warning in async Task SDK connection tests

### DIFF
--- a/task-sdk/tests/conftest.py
+++ b/task-sdk/tests/conftest.py
@@ -175,6 +175,48 @@ def _disable_ol_plugin():
     airflow.plugins_manager.plugins = None
 
 
+@pytest.fixture(autouse=True)
+def _cleanup_async_resources(request):
+    """
+    Clean up async resources that can cause Python 3.12 fork warnings.
+
+    Problem: asgiref.sync.sync_to_async (used in _async_get_connection) creates
+    ThreadPoolExecutors that persist between tests. When supervisor.py calls
+    os.fork() in subsequent tests, Python 3.12+ warns about forking a
+    multi-threaded process.
+
+    Solution: Clean up asgiref's ThreadPoolExecutors after async tests to ensure
+    subsequent tests start with a clean thread environment.
+    """
+    yield
+
+    # Only clean up after async tests to avoid unnecessary overhead
+    if "asyncio" in request.keywords:
+        # Clean up asgiref ThreadPoolExecutors that persist between tests
+        # These are created by sync_to_async() calls in async connection retrieval
+        try:
+            from asgiref.sync import SyncToAsync
+
+            # SyncToAsync maintains a class-level executor for performance
+            # We need to shut it down to prevent multi-threading warnings on fork()
+            if hasattr(SyncToAsync, "single_thread_executor") and SyncToAsync.single_thread_executor:
+                if not SyncToAsync.single_thread_executor._shutdown:
+                    SyncToAsync.single_thread_executor.shutdown(wait=True)
+                SyncToAsync.single_thread_executor = None
+
+            # SyncToAsync also maintains a WeakKeyDictionary of context-specific executors
+            # Clean these up too to ensure complete thread cleanup
+            if hasattr(SyncToAsync, "context_to_thread_executor"):
+                for executor in list(SyncToAsync.context_to_thread_executor.values()):
+                    if hasattr(executor, "shutdown") and not getattr(executor, "_shutdown", True):
+                        executor.shutdown(wait=True)
+                SyncToAsync.context_to_thread_executor.clear()
+
+        except (ImportError, AttributeError):
+            # If asgiref structure changes, fail gracefully
+            pass
+
+
 class MakeTIContextCallable(Protocol):
     def __call__(
         self,


### PR DESCRIPTION
We encountered an intermittent test failure on Python 3.12 only in the Task SDK: https://github.com/apache/airflow/actions/runs/17957802850/job/51079451184#step:9:696 and marked that test as `XFAIL`: https://github.com/apache/airflow/commit/6d2aac69c8e0a727c3489306bd0b164a6332795d

```
DeprecationWarning: This process (pid=78) is multi-threaded, use of fork() may lead to deadlocks in the child.
```

**Failed Test:** `

```
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestWatchedSubprocess::test_reading_from_pipes
```

Example failure: https://github.com/apache/airflow/actions/runs/17957802850/job/51079451184#step:9:696

## Root Cause Analysis

### The Threading Issue
Python 3.12 introduced a `DeprecationWarning` when `os.fork()` is called in a multi-threaded process. 

### Code Path Investigation
Through systematic analysis, we discovered:

1. **Source**: `asgiref.sync.sync_to_async` creates persistent `ThreadPoolExecutor` threads
2. **Location**: `task-sdk/src/airflow/sdk/execution_time/context.py:217`
   ```python
   conn = await sync_to_async(secrets_backend.get_connection)(conn_id)
   ```
3. **Flow**:
   ```
   test_async_get_connection_from_api
     └── _async_get_connection()
         └── ensure_secrets_backend_loaded()
             └── sync_to_async(secrets_backend.get_connection)  # Creates ThreadPoolExecutor
                 └── ThreadPoolExecutor thread persists
                     └── Next test: test_reading_from_pipes
                         └── os.fork() triggers Python 3.12 warning
   ```


**Testing Instructions for Reviewers:**

```bash
# Test the specific problematic sequence
breeze run pytest task-sdk/tests/task_sdk/execution_time/test_context_cache.py::TestAsyncConnectionCache::test_async_get_connection_from_api task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestWatchedSubprocess::test_reading_from_pipes -v

# Test broader async test suite  
breeze run pytest task-sdk/tests/task_sdk/execution_time/ -k asyncio
```

Example run:

```
root@7bbad33290d7:/opt/airflow# pytest  task-sdk/tests/task_sdk/execution_time/test_context_cache.py::TestAsyncConnectionCache::test_async_get_connection_from_api   task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestWatchedSubprocess::test_reading_from_pipes
================================================================================================ test session starts =================================================================================================
platform linux -- Python 3.12.11, pytest-8.4.2, pluggy-1.6.0 -- /usr/local/bin/python3
cachedir: .pytest_cache
rootdir: /opt/airflow/task-sdk
configfile: pyproject.toml
plugins: kgb-7.2, asyncio-1.2.0, cov-7.0.0, custom-exit-code-0.3.0, icdiff-0.9, instafail-0.5.0, mock-3.15.1, rerunfailures-16.0.1, timeouts-1.2.1, unordered-0.7.0, requests-mock-1.12.1, xdist-3.8.0, time-machine-2.19.0, anyio-4.11.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
setup timeout: 0.0s, execution timeout: 0.0s, teardown timeout: 0.0s
collected 2 items

task-sdk/tests/task_sdk/execution_time/test_context_cache.py::TestAsyncConnectionCache::test_async_get_connection_from_api PASSED                                                                              [ 50%]
task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestWatchedSubprocess::test_reading_from_pipes FAILED                                                                                               [100%]

====================================================================================================== FAILURES ======================================================================================================
___________________________________________________________________________________ TestWatchedSubprocess.test_reading_from_pipes ____________________________________________________________________________________
task-sdk/tests/task_sdk/execution_time/test_supervisor.py:274: in test_reading_from_pipes
    assert captured_logs == unordered(
E   assert [{'category': 'DeprecationWarning', 'event': 'This process (pid=3505) is multi-threaded, use of fork() may lead to dea...lsite', 'filename': '/opt/airflow/task-sdk/tests/task_sdk/execution_time/test_supervisor.py', 'level': 'warning', ...}] == [{'logger': 'task.stdout', 'event': "I'm a short message", 'level': 'info', 'timestamp': '2024-11-07T12:34:56.078901Z'... 249, 'logger': 'py.warnings', 'timestamp': datetime.datetime(2024, 11, 7, 12, 34, 56, 78901, tzinfo=Timezone('UTC'))}]
E     Extra items in the left sequence:
E     {'category': 'DeprecationWarning', 'event': 'This process (pid=3505) is multi-threaded, use of fork() may lead to dead...the child.', 'filename': '/opt/airflow/task-sdk/src/airflow/sdk/execution_time/supervisor.py', 'level': 'warning', ...}
```

I do not want to admit how much time I & @jedcunningham spent on debugging this frustratingly :) 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
