### PR TITLE
Fix `example_bash_decorator` DAG

### DIFF
--- a/providers/standard/src/airflow/providers/standard/example_dags/example_bash_decorator.py
+++ b/providers/standard/src/airflow/providers/standard/example_dags/example_bash_decorator.py
@@ -92,21 +92,14 @@ def example_bash_decorator():
     # [END howto_decorator_bash_parametrize]
 
     # [START howto_decorator_bash_build_cmd]
-    def _get_files_in_cwd() -> list[str]:
-        from pathlib import Path
-
-        dir_contents = Path.cwd().glob("airflow-core/src/airflow/example_dags/*.py")
-        files = [str(elem) for elem in dir_contents if elem.is_file()]
-
-        return files
-
     @task.bash
     def get_file_stats() -> str:
+        from pathlib import Path
         from shlex import join
 
-        files = _get_files_in_cwd()
-        files = files if files else ["."]
-        cmd = join(["stat", *files])
+        # Get stats of the current DAG file itself
+        current_file = str(Path(__file__))
+        cmd = join(["stat", current_file])
 
         return cmd
 


### PR DESCRIPTION
The ``example_bash_decorator`` was broken since it relied on the Airflow source code path.

Before:

```
{"timestamp":"2025-09-23T11:44:15.971920Z","level":"info","event":"Running command: ['/usr/bin/bash', '-c', 'stat']","logger":"airflow.task.hooks.airflow.providers.standard.hooks.subprocess.SubprocessHook","filename":"subprocess.py","lineno":88}
{"timestamp":"2025-09-23T11:44:15.995649Z","level":"info","event":"Output:","logger":"airflow.task.hooks.airflow.providers.standard.hooks.subprocess.SubprocessHook","filename":"subprocess.py","lineno":99}
{"timestamp":"2025-09-23T11:44:15.999568Z","level":"info","event":"stat: missing operand","logger":"airflow.task.hooks.airflow.providers.standard.hooks.subprocess.SubprocessHook","filename":"subprocess.py","lineno":106}
{"timestamp":"2025-09-23T11:44:15.999669Z","level":"info","event":"Try 'stat --help' for more information.","logger":"airflow.task.hooks.airflow.providers.standard.hooks.subprocess.SubprocessHook","filename":"subprocess.py","lineno":106}
{"timestamp":"2025-09-23T11:44:16.000278Z","level":"info","event":"Command exited with return code 1","logger":"airflow.task.hooks.airflow.providers.standard.hooks.subprocess.SubprocessHook","filename":"subprocess.py","lineno":110}
{"timestamp":"2025-09-23T11:44:16.000884Z","level":"error","event":"Task failed with exception","logger":"task","filename":"task_runner.py","lineno":972,"error_detail":[{"exc_type":"AirflowException","exc_value":"Bash command failed. The command returned a non-zero exit code 1.","exc_notes":[],"syntax_error":null,"is_cause":false,"frames":[{"filename":"/home/airflow/.local/lib/python3.12/site-packages/airflow/sdk/execution_time/task_runner.py","lineno":920,"name":"run"},{"filename":"/home/airflow/.local/lib/python3.12/site-packages/airflow/sdk/execution_time/task_runner.py","lineno":1307,"name":"_execute_task"},{"filename":"/home/airflow/.local/lib/python3.12/site-packages/airflow/sdk/bases/operator.py","lineno":416,"name":"wrapper"},{"filename":"/home/airflow/.local/lib/python3.12/site-packages/airflow/providers/standard/decorators/bash.py","lineno":100,"name":"execute"},{"filename":"/home/airflow/.local/lib/python3.12/site-packages/airflow/sdk/bases/operator.py","lineno":416,"name":"wrapper"},{"filename":"/home/airflow/.local/lib/python3.12/site-packages/airflow/sdk/bases/decorator.py","lineno":252,"name":"execute"},{"filename":"/home/airflow/.local/lib/python3.12/site-packages/airflow/sdk/bases/operator.py","lineno":416,"name":"wrapper"},{"filename":"/home/airflow/.local/lib/python3.12/site-packages/airflow/providers/standard/operators/bash.py","lineno":232,"name":"execute"}],"is_group":false,"exceptions":[]}]}
{"timestamp":"2025-09-23T11:44:16.025800Z","level":"info","event":"Task instance in failure state","logger":"task.stdout"}
{"timestamp":"2025-09-23T11:44:16.025944Z","level":"info","event":"Task start","logger":"task.stdout"}
{"timestamp":"2025-09-23T11:44:16.026033Z","level":"info","event":"Task:<Task(_BashDecoratedOperator): get_file_stats>","logger":"task.stdout"}
{"timestamp":"2025-09-23T11:44:16.026135Z","level":"info","event":"Failure caused by Bash command failed. The command returned a non-zero exit code 1.","logger":"task.stdout"}
```

After:

```
[2025-09-24 02:12:47] INFO - Task instance is in running state
[2025-09-24 02:12:47] INFO -  Previous state of the Task instance: TaskInstanceState.QUEUED
[2025-09-24 02:12:47] INFO - Current task name:get_file_stats
[2025-09-24 02:12:47] INFO - Dag name:example_bash_decorator
[2025-09-24 02:12:47] INFO - Tmp dir root location: /tmp
[2025-09-24 02:12:47] INFO - Running command: ['/usr/bin/bash', '-c', 'stat /opt/airflow/airflow-core/src/airflow/example_dags/standard/example_bash_decorator.py']
[2025-09-24 02:12:47] INFO - Output:
[2025-09-24 02:12:47] INFO -   File: /opt/airflow/airflow-core/src/airflow/example_dags/standard/example_bash_decorator.py
[2025-09-24 02:12:47] INFO -   Size: 3867      	Blocks: 8          IO Block: 4096   regular file
[2025-09-24 02:12:47] INFO - Device: 0,34	Inode: 2057958327228072012  Links: 1
[2025-09-24 02:12:47] INFO - Access: (0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (    0/    root)
[2025-09-24 02:12:47] INFO - Access: 2025-09-24 01:12:17.366858270 +0000
[2025-09-24 02:12:47] INFO - Modify: 2025-09-24 01:08:56.992964565 +0000
[2025-09-24 02:12:47] INFO - Change: 2025-09-24 01:08:56.992964565 +0000
[2025-09-24 02:12:47] INFO -  Birth: -
[2025-09-24 02:12:47] INFO - Command exited with return code 0
[2025-09-24 02:12:47] INFO - Pushing xcom ti=RuntimeTaskInstance(id=UUID('01997947-a73f-77ea-a2d0-a4d63f57bf03'), task_id='get_file_stats', dag_id='example_bash_decorator', run_id='manual__2025-09-24T01:12:42.913441+00:00', try_number=1, dag_version_id=UUID('01997947-6324-771c-ae0e-4a01d869e171'), map_index=-1, hostname='72ace79a9422', context_carrier={}, task=<Task(_BashDecoratedOperator): get_file_stats>, bundle_instance=LocalDagBundle(name=example_dags), max_tries=0, start_date=datetime.datetime(2025, 9, 24, 1, 12, 47, 289149, tzinfo=datetime.timezone.utc), end_date=None, state=<TaskInstanceState.RUNNING: 'running'>, is_mapped=False, rendered_map_index=None)
[2025-09-24 02:12:47] INFO - Task instance in success state
[2025-09-24 02:12:47] INFO -  Previous state of the Task instance: TaskInstanceState.RUNNING
[2025-09-24 02:12:47] INFO - Task operator:<Task(_BashDecoratedOperator): get_file_stats>
```

<img width="1723" height="710" alt="image" src="https://github.com/user-attachments/assets/c1323a27-98b8-4899-b58b-c211d93d7e50" />


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
