### PR TITLE
Fix XCom key handling when keys contain special characters like /

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -5403,9 +5403,7 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema:
-                type: 'null'
-                title: Response Delete Task Instance
+              schema: {}
         '401':
           content:
             application/json:
@@ -7743,9 +7741,7 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema:
-                type: 'null'
-                title: Response Reparse Dag File
+              schema: {}
         '401':
           content:
             application/json:

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
@@ -79,7 +79,7 @@ async def xcom_query(
     key: str,
     map_index: Annotated[int | None, Query()] = None,
 ) -> Select:
-    key= unquote(key)
+    key = unquote(key)
     query = XComModel.get_many(
         run_id=run_id,
         key=key,

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
@@ -35,6 +35,7 @@ from airflow.api_fastapi.execution_api.deps import JWTBearerDep
 from airflow.models.taskmap import TaskMap
 from airflow.models.xcom import XComModel
 from airflow.utils.db import get_query_count
+from urllib.parse import unquote
 
 
 async def has_xcom_access(
@@ -78,6 +79,7 @@ async def xcom_query(
     key: str,
     map_index: Annotated[int | None, Query()] = None,
 ) -> Select:
+    key= unquote(key)
     query = XComModel.get_many(
         run_id=run_id,
         key=key,
@@ -143,6 +145,7 @@ def get_xcom(
     params: Annotated[GetXcomFilterParams, Query()],
 ) -> XComResponse:
     """Get an Airflow XCom from database - not other XCom Backends."""
+    key = unquote(key)
     xcom_query = XComModel.get_many(
         run_id=run_id,
         key=key,
@@ -196,6 +199,7 @@ def get_mapped_xcom_by_index(
     offset: int,
     session: SessionDep,
 ) -> XComSequenceIndexResponse:
+    key = unquote(key)
     xcom_query = XComModel.get_many(
         run_id=run_id,
         key=key,
@@ -240,6 +244,7 @@ def get_mapped_xcom_by_slice(
     params: Annotated[GetXComSliceFilterParams, Query()],
     session: SessionDep,
 ) -> XComSequenceSliceResponse:
+    key = unquote(key)
     query = XComModel.get_many(
         run_id=run_id,
         key=key,
@@ -360,7 +365,7 @@ def set_xcom(
                 "message": "XCom key must be a non-empty string.",
             },
         )
-
+    key = unquote(key)
     if mapped_length is not None:
         task_map = TaskMap(
             dag_id=dag_id,
@@ -444,6 +449,7 @@ def delete_xcom(
     map_index: Annotated[int, Query()] = -1,
 ):
     """Delete a single XCom Value."""
+    key = unquote(key)
     query = delete(XComModel).where(
         XComModel.key == key,
         XComModel.run_id == run_id,

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import logging
 from typing import Annotated
+from urllib.parse import unquote
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, Request, Response, status
 from pydantic import BaseModel, JsonValue, StringConstraints
@@ -35,7 +36,6 @@ from airflow.api_fastapi.execution_api.deps import JWTBearerDep
 from airflow.models.taskmap import TaskMap
 from airflow.models.xcom import XComModel
 from airflow.utils.db import get_query_count
-from urllib.parse import unquote
 
 
 async def has_xcom_access(

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -24,6 +24,7 @@ import uuid
 from functools import cache
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, TypeVar
+from urllib.parse import quote
 
 import certifi
 import httpx
@@ -418,6 +419,7 @@ class XComOperations:
 
     def head(self, dag_id: str, run_id: str, task_id: str, key: str) -> XComCountResponse:
         """Get the number of mapped XCom values."""
+        key = quote(key, safe="")
         resp = self.client.head(f"xcoms/{dag_id}/{run_id}/{task_id}/{key}")
 
         # content_range: str | None
@@ -444,6 +446,7 @@ class XComOperations:
             params.update({"map_index": map_index})
         if include_prior_dates:
             params.update({"include_prior_dates": include_prior_dates})
+        key = quote(key, safe="")
         try:
             resp = self.client.get(f"xcoms/{dag_id}/{run_id}/{task_id}/{key}", params=params)
         except ServerResponseError as e:
@@ -483,6 +486,7 @@ class XComOperations:
             params = {"map_index": map_index}
         if mapped_length is not None and mapped_length >= 0:
             params["mapped_length"] = mapped_length
+        key = quote(key, safe="")
         self.client.post(f"xcoms/{dag_id}/{run_id}/{task_id}/{key}", params=params, json=value)
         # Any error from the server will anyway be propagated down to the supervisor,
         # so we choose to send a generic response to the supervisor over the server response to
@@ -501,6 +505,7 @@ class XComOperations:
         params = {}
         if map_index is not None and map_index >= 0:
             params = {"map_index": map_index}
+        key = quote(key, safe="")
         self.client.delete(f"xcoms/{dag_id}/{run_id}/{task_id}/{key}", params=params)
         # Any error from the server will anyway be propagated down to the supervisor,
         # so we choose to send a generic response to the supervisor over the server response to
@@ -515,6 +520,7 @@ class XComOperations:
         key: str,
         offset: int,
     ) -> XComSequenceIndexResponse | ErrorResponse:
+        key = quote(key, safe="")
         try:
             resp = self.client.get(f"xcoms/{dag_id}/{run_id}/{task_id}/{key}/item/{offset}")
         except ServerResponseError as e:
@@ -553,6 +559,7 @@ class XComOperations:
         step: int | None,
         include_prior_dates: bool = False,
     ) -> XComSequenceSliceResponse:
+        key = quote(key, safe="")
         params = {}
         if start is not None:
             params["start"] = start

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -336,7 +336,7 @@ class RuntimeTaskInstance(TaskInstance):
         a non-str iterable), a list of matching XComs is returned. Elements in
         the list is ordered by item ordering in ``task_id`` and ``map_index``.
         """
-        key = quote(key,safe='')
+        key = quote(key, safe="")
         if dag_id is None:
             dag_id = self.dag_id
         if run_id is None:
@@ -410,8 +410,7 @@ class RuntimeTaskInstance(TaskInstance):
         :param key: Key to store the value under.
         :param value: Value to store. Only be JSON-serializable values may be used.
         """
-        encoded_key = quote(key, safe="")
-        _xcom_push(self, encoded_key, value)
+        _xcom_push(self, key, value)
 
     def get_relevant_upstream_map_indexes(
         self, upstream: BaseOperator, ti_count: int | None, session: Any
@@ -1368,8 +1367,8 @@ def _push_xcom_if_needed(result: Any, ti: RuntimeTaskInstance, log: Logger):
                 )
 
         for k, v in result.items():
-            ti.xcom_push(k, v)
-
+            encoded_key = quote(k, safe="")
+            ti.xcom_push(encoded_key, v)
 
     _xcom_push(ti, BaseXCom.XCOM_RETURN_KEY, result, mapped_length=mapped_length)
 

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -900,10 +900,9 @@ def run(
         # First, clear the xcom data sent from server
         if ti._ti_context_from_server and (keys_to_delete := ti._ti_context_from_server.xcom_keys_to_clear):
             for x in keys_to_delete:
-                encoded_key = quote(x, safe="")
-                log.debug("Clearing XCom with key", key=encoded_key)
+                log.debug("Clearing XCom with key", key=x)
                 XCom.delete(
-                    key=encoded_key,
+                    key=x,
                     dag_id=ti.dag_id,
                     task_id=ti.task_id,
                     run_id=ti.run_id,

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -1287,7 +1287,7 @@ class TestRuntimeTaskInstance:
         # Access the connection from the context
         conn_from_context = context["conn"].test_conn
 
-        mock_supervisor_comms.send.assert_called_once_with(GetConnection(conn_id="test_conn"))
+        mock_supervisor_comms.send.assert_any_call(GetConnection(conn_id="test_conn"))
 
         assert conn_from_context == Connection(
             conn_id="test_conn",
@@ -1502,6 +1502,7 @@ class TestRuntimeTaskInstance:
                             map_index=expected_map_index,
                         ),
                     )
+
     @pytest.mark.parametrize(
         "task_ids, map_indexes, expected_value",
         [
@@ -1984,23 +1985,6 @@ class TestRuntimeTaskInstance:
             run(runtime_ti, context=runtime_ti.get_template_context(), log=mock.MagicMock())
 
             mock_delete.assert_not_called()
-
-    #TODO TESTCASE BRUNDA
-    # def test_xcom_key_with_slash_roundtrip(self,create_runtime_ti):
-    #     class DummyOperator(BaseOperator):
-    #         def execute(self, context):
-    #             return "dummy"
-
-    #     task = DummyOperator(task_id="test_task")
-    #     runtime_ti = create_runtime_ti(task=task)
-
-    #     # Push with a slash in the key
-    #     runtime_ti.xcom_push(key="key/with/slash", value="slashy")
-
-    #     # Pull back the same key
-    #     pulled_value = runtime_ti.xcom_pull(task_ids="test_task", key="key/with/slash")
-
-    #     assert pulled_value == "slashy"
 
 
 class TestXComAfterTaskExecution:

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -1287,7 +1287,7 @@ class TestRuntimeTaskInstance:
         # Access the connection from the context
         conn_from_context = context["conn"].test_conn
 
-        mock_supervisor_comms.send.assert_any_call(GetConnection(conn_id="test_conn"))
+        mock_supervisor_comms.send.assert_called_once_with(GetConnection(conn_id="test_conn"))
 
         assert conn_from_context == Connection(
             conn_id="test_conn",

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -1502,7 +1502,6 @@ class TestRuntimeTaskInstance:
                             map_index=expected_map_index,
                         ),
                     )
-
     @pytest.mark.parametrize(
         "task_ids, map_indexes, expected_value",
         [
@@ -1985,6 +1984,23 @@ class TestRuntimeTaskInstance:
             run(runtime_ti, context=runtime_ti.get_template_context(), log=mock.MagicMock())
 
             mock_delete.assert_not_called()
+
+    #TODO TESTCASE BRUNDA
+    # def test_xcom_key_with_slash_roundtrip(self,create_runtime_ti):
+    #     class DummyOperator(BaseOperator):
+    #         def execute(self, context):
+    #             return "dummy"
+
+    #     task = DummyOperator(task_id="test_task")
+    #     runtime_ti = create_runtime_ti(task=task)
+
+    #     # Push with a slash in the key
+    #     runtime_ti.xcom_push(key="key/with/slash", value="slashy")
+
+    #     # Pull back the same key
+    #     pulled_value = runtime_ti.xcom_pull(task_ids="test_task", key="key/with/slash")
+
+    #     assert pulled_value == "slashy"
 
 
 class TestXComAfterTaskExecution:

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest import mock
 from unittest.mock import patch
+from urllib.parse import quote
 
 import pandas as pd
 import pytest
@@ -1985,6 +1986,85 @@ class TestRuntimeTaskInstance:
             run(runtime_ti, context=runtime_ti.get_template_context(), log=mock.MagicMock())
 
             mock_delete.assert_not_called()
+
+    def test_xcom_push_pull_with_slash_in_key(self, create_runtime_ti, mock_supervisor_comms):
+        """
+        Ensure that XCom keys containing slashes are correctly quoted/unquoted
+        and do not break API routes (no 400/404).
+        """
+
+        class PushOperator(BaseOperator):
+            def execute(self, context):
+                context["ti"].xcom_push(key="some/key/with/slash", value="slash_value")
+
+        task = PushOperator(task_id="push_task")
+        runtime_ti = create_runtime_ti(task=task, dag_id="test_dag")
+
+        # Run the task (which should trigger xcom_push)
+        run(runtime_ti, context=runtime_ti.get_template_context(), log=mock.MagicMock())
+
+        # Verify supervisor received a SetXCom with quoted key
+        called_args = [
+            call.kwargs.get("msg") or call.args[0] for call in mock_supervisor_comms.send.call_args_list
+        ]
+        assert any(getattr(arg, "key", None) == "some/key/with/slash" for arg in called_args)
+
+        ser_value = BaseXCom.serialize_value("slash_value")
+        mock_supervisor_comms.send.reset_mock()
+        mock_supervisor_comms.send.return_value = XComSequenceSliceResult(
+            key="some/key/with/slash",
+            root=[ser_value],
+        )
+
+        pulled_value = runtime_ti.xcom_pull(key="some/key/with/slash", task_ids="push_task")
+        assert pulled_value == "slash_value"
+
+        expected_key = quote("some/key/with/slash", safe="")
+        mock_supervisor_comms.send.assert_any_call(
+            GetXComSequenceSlice(
+                key=expected_key,
+                dag_id="test_dag",
+                run_id="test_run",
+                task_id="push_task",
+                map_index=0,
+                include_prior_dates=False,
+                start=None,
+                stop=None,
+                step=None,
+                type="GetXComSequenceSlice",
+            )
+        )
+
+    def test_taskflow_dict_return_with_slash_key(self, create_runtime_ti, mock_supervisor_comms):
+        """
+        High-level: Ensure TaskFlow returning dict with slash in key doesn't 404 during XCom push.
+        """
+
+        @dag_decorator(schedule=None, start_date=timezone.datetime(2024, 12, 3))
+        def dag_with_slash_key():
+            @task_decorator
+            def dict_task():
+                return {"key with slash /": "Some Value"}
+
+            return dict_task()  # returns XComArg
+
+        dag_obj = dag_with_slash_key()
+        task_op = dag_obj.get_task("dict_task")
+        runtime_ti = create_runtime_ti(task=task_op, dag_id=dag_obj.dag_id)
+
+        # Run task instance → should trigger TaskFlow dict expansion + XCom push
+        run(runtime_ti, context=runtime_ti.get_template_context(), log=mock.MagicMock())
+
+        # Mock supervisor response to simulate retrieval
+        ser_value = BaseXCom.serialize_value("Some Value")
+        mock_supervisor_comms.send.reset_mock()
+        mock_supervisor_comms.send.return_value = XComSequenceSliceResult(
+            key="key/slash",
+            root=[ser_value],
+        )
+
+        pulled = runtime_ti.xcom_pull(key="key/slash", task_ids="dict_task")
+        assert pulled == "Some Value"
 
 
 class TestXComAfterTaskExecution:


### PR DESCRIPTION
Closes : #55410
**Summary**

This PR fixes an issue where XCom keys containing special characters (for example /) would break API calls and cause 404 Not Found errors.

The problem happened because keys were passed directly in the URL without encoding, so FastAPI treated / as a path separator.

**Changes Made**

_SDK (client.py, taskrunner.py)_

- Keys are now URL-encoded (quoted) before sending them to the API.

_APIs (core_api/routes/public/xcoms.py, execution_api/routes/xcoms.py)_

- Keys from the URL are now decoded (unquoted) before looking them up in the database.

**This PR ensures:**

- Keys are always quoted when sent (safe for URLs).

- Keys are always unquoted when received (correct DB lookup).

- Aligns XCom behavior across different access points (UI, API, execution API, and task runner).

**Testing:**
```
from airflow.decorators import dag, task

@dag(schedule=None)
def xcom_slash():

    @task
    def this_works() -> dict[str, str]:
        return {"Some Key": "Some Value"}
    @task
    def this_works_as_well() -> str:
        return "/some/path/like/key"

    @task
    def this_does_not_work() -> dict[str, str]:
        return {"key with slash /": "Some Value"}

    this_works() >> this_works_as_well() >> this_does_not_work()

dag = xcom_slash() 
``` 

<img width="1850" height="1053" alt="Screenshot from 2025-09-24 17-16-17" src="https://github.com/user-attachments/assets/55ef6afe-77a6-48e2-ad40-7343c8c4dfa4" />
