### PR TITLE
Add a `@task.stub` to allow tasks in other languages to be defined in dags

### DIFF
--- a/providers/standard/provider.yaml
+++ b/providers/standard/provider.yaml
@@ -141,3 +141,5 @@ task-decorators:
     name: sensor
   - class-name: airflow.providers.standard.decorators.short_circuit.short_circuit_task
     name: short_circuit
+  - class-name: airflow.providers.standard.decorators.stub.stub
+    name: stub

--- a/providers/standard/src/airflow/providers/standard/decorators/stub.py
+++ b/providers/standard/src/airflow/providers/standard/decorators/stub.py
@@ -89,7 +89,8 @@ def stub(
     """
     Define a stub task in the DAG.
 
-    Stub tasks must be defined
+    Stub tasks exist in the Dag graph only, but the execution must happen in an external
+    environment via the Task Execution Interface. 
 
     """
     return task_decorator_factory(

--- a/providers/standard/src/airflow/providers/standard/decorators/stub.py
+++ b/providers/standard/src/airflow/providers/standard/decorators/stub.py
@@ -1,0 +1,101 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from airflow.sdk.bases.decorator import DecoratedOperator, TaskDecorator, task_decorator_factory
+else:
+    try:
+        from airflow.sdk.bases.decorator import DecoratedOperator, TaskDecorator, task_decorator_factory
+    except ModuleNotFoundError:
+        from airflow.decorators.base import (
+            DecoratedOperator,
+            TaskDecorator,
+            task_decorator_factory,
+        )
+
+if TYPE_CHECKING:
+    from airflow.sdk.definitions.context import Context
+
+
+class _StubOperator(DecoratedOperator):
+    custom_operator_name: str = "@task.stub"
+
+    def __init__(
+        self,
+        *,
+        python_callable: Callable,
+        task_id: str,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            python_callable=python_callable,
+            task_id=task_id,
+            **kwargs,
+        )
+        # Validate python callable
+        module = ast.parse(self.get_python_source())
+
+        if len(module.body) != 1:
+            raise RuntimeError("Expected a single statement")
+        fn = module.body[0]
+        if not isinstance(fn, ast.FunctionDef):
+            raise RuntimeError("Expected a single sync function")
+        for stmt in fn.body:
+            if isinstance(stmt, ast.Pass):
+                continue
+            if isinstance(stmt, ast.Expr):
+                if isinstance(stmt.value, ast.Constant) and isinstance(stmt.value.value, (str, type(...))):
+                    continue
+
+            raise ValueError(
+                f"Functions passed to @task.stub must be an empty function (`pass`, or `...` only) (got {stmt})"
+            )
+
+        ...
+
+    def execute(self, context: Context) -> Any:
+        raise RuntimeError(
+            "@task.stub should not be executed directly -- we expected this to go to a remote worker. "
+            "Check your pool and worker configs"
+        )
+
+
+def stub(
+    python_callable: Callable | None = None,
+    queue: str | None = None,
+    executor: str | None = None,
+    **kwargs,
+) -> TaskDecorator:
+    """
+    Define a stub task in the DAG.
+
+    Stub tasks must be defined
+
+    """
+    return task_decorator_factory(
+        decorated_operator_class=_StubOperator,
+        python_callable=python_callable,
+        queue=queue,
+        executor=executor,
+        **kwargs,
+    )

--- a/providers/standard/src/airflow/providers/standard/decorators/stub.py
+++ b/providers/standard/src/airflow/providers/standard/decorators/stub.py
@@ -90,7 +90,7 @@ def stub(
     Define a stub task in the DAG.
 
     Stub tasks exist in the Dag graph only, but the execution must happen in an external
-    environment via the Task Execution Interface. 
+    environment via the Task Execution Interface.
 
     """
     return task_decorator_factory(

--- a/providers/standard/src/airflow/providers/standard/get_provider_info.py
+++ b/providers/standard/src/airflow/providers/standard/get_provider_info.py
@@ -144,5 +144,6 @@ def get_provider_info():
                 "class-name": "airflow.providers.standard.decorators.short_circuit.short_circuit_task",
                 "name": "short_circuit",
             },
+            {"class-name": "airflow.providers.standard.decorators.stub.stub", "name": "stub"},
         ],
     }

--- a/providers/standard/tests/unit/standard/decorators/test_stub.py
+++ b/providers/standard/tests/unit/standard/decorators/test_stub.py
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import contextlib
+
+import pytest
+
+from airflow.providers.standard.decorators.stub import stub
+
+
+def fn_ellipsis(): ...
+
+
+def fn_pass(): ...
+
+
+def fn_doc():
+    """Some string"""
+
+
+def fn_doc_pass():
+    """Some string"""
+    pass
+
+
+def fn_code():
+    return None
+
+
+@pytest.mark.parametrize(
+    ("fn", "error"),
+    [
+        pytest.param(fn_ellipsis, contextlib.nullcontext(), id="ellipsis"),
+        pytest.param(fn_pass, contextlib.nullcontext(), id="pass"),
+        pytest.param(fn_doc, contextlib.nullcontext(), id="doc"),
+        pytest.param(fn_doc_pass, contextlib.nullcontext(), id="doc-and-pass"),
+        pytest.param(fn_code, pytest.raises(ValueError, match="must be an empty function"), id="not-empty"),
+    ],
+)
+def test_stub_signature(fn, error):
+    with error:
+        stub(fn)()


### PR DESCRIPTION
As of today, even with Edge Executor and TaskSDK, Dags must be defined in
Python. However if we want tasks to run in other languages we need "something"
we can put in the python dag that is an operator. This is that.

It's implementation is quite simple -- it checks the function is empty
(because if it's not someone might mistakenly think it would run the
function), and then _if_ it ever runs, it raises an exception.

Docs for this will be included in the Go example itself, so it is purposefully not included here.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
