### PR TITLE
Create an explicit control for createUserJob

### DIFF
--- a/chart/templates/jobs/create-user-job.yaml
+++ b/chart/templates/jobs/create-user-job.yaml
@@ -20,7 +20,7 @@
 ################################
 ## Airflow Create User Job
 #################################
-{{- if .Values.webserver.defaultUser.enabled }}
+{{- if and .Values.webserver.defaultUser.enabled .Values.createUserJob.enabled }}
 {{- $nodeSelector := or .Values.createUserJob.nodeSelector .Values.nodeSelector }}
 {{- $affinity := or .Values.createUserJob.affinity .Values.affinity }}
 {{- $tolerations := or .Values.createUserJob.tolerations .Values.tolerations }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -4282,6 +4282,11 @@
             "x-docsSection": "Jobs",
             "additionalProperties": false,
             "properties": {
+                "enabled": {
+                    "description": "Whether the create user job should be created.",
+                    "type": "boolean",
+                    "default": true
+                },
                 "command": {
                     "description": "Command to use when running create user job (templated).",
                     "type": [

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1212,6 +1212,8 @@ scheduler:
 
 # Airflow create user job settings
 createUserJob:
+  # Whether the create user job should be created
+  enabled: true
   # Limit the lifetime of the job object after it finished execution.
   ttlSecondsAfterFinished: 300
   # Command to use when running the create user job (templated).

--- a/helm-tests/tests/helm_tests/airflow_aux/test_create_user_job.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_create_user_job.py
@@ -469,6 +469,56 @@ class TestCreateUserJob:
         )
         assert restart_policy == jmespath.search("spec.template.spec.restartPolicy", docs[0])
 
+    def test_should_not_create_job_when_createuserjob_disabled(self):
+        """Test that job is not created when createUserJob.enabled is false."""
+        docs = render_chart(
+            values={"createUserJob": {"enabled": False}},
+            show_only=["templates/jobs/create-user-job.yaml"],
+        )
+        assert len(docs) == 0
+
+    def test_should_not_create_job_when_webserver_defaultuser_disabled(self):
+        """Test that job is not created when webserver.defaultUser.enabled is false."""
+        docs = render_chart(
+            values={"webserver": {"defaultUser": {"enabled": False}}},
+            show_only=["templates/jobs/create-user-job.yaml"],
+        )
+        assert len(docs) == 0
+
+    def test_should_not_create_job_when_both_disabled(self):
+        """Test that job is not created when both flags are disabled."""
+        docs = render_chart(
+            values={
+                "createUserJob": {"enabled": False},
+                "webserver": {"defaultUser": {"enabled": False}},
+            },
+            show_only=["templates/jobs/create-user-job.yaml"],
+        )
+        assert len(docs) == 0
+
+    def test_should_not_create_job_when_createuserjob_disabled_but_defaultuser_enabled(self):
+        """Test that job is not created when createUserJob.enabled is false even if defaultUser.enabled is true."""
+        docs = render_chart(
+            values={
+                "createUserJob": {"enabled": False},
+                "webserver": {"defaultUser": {"enabled": True}},
+            },
+            show_only=["templates/jobs/create-user-job.yaml"],
+        )
+        assert len(docs) == 0
+
+    def test_should_create_job_when_both_enabled(self):
+        """Test that job is created when both createUserJob.enabled and defaultUser.enabled are true."""
+        docs = render_chart(
+            values={
+                "createUserJob": {"enabled": True},
+                "webserver": {"defaultUser": {"enabled": True}},
+            },
+            show_only=["templates/jobs/create-user-job.yaml"],
+        )
+        assert len(docs) == 1
+        assert docs[0]["kind"] == "Job"
+
 
 class TestCreateUserJobServiceAccount:
     """Tests create user job service account."""


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #51304 

As describe in the issue, the createUserJob fails on the new standalone installation on helm. 
This is because the createUserJob only checks in the setting for `defaultUser.enabled` in webserver. This value check while being perfectly fine for older versions of airflow, created a bit of confusion for newer versions where you just put `webserver.enable: false` and expect nothing to be coupled with other deployments. 
Particularly, deployment trying to use simple_auth get an "unwanted" createUserJob which always fails.

To make the creation of `createUserJob` explicit, I have included another value which explicitly sets `enabled: true | false`.
This should make things clear and init control (a bit) independent.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
