### PR TITLE
Add uvicorn_logging_level config option to control API server access logs (#55405)

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -842,6 +842,15 @@ logging:
       type: string
       example: ~
       default: "WARNING"
+    uvicorn_logging_level:
+      description: |
+        Logging level for uvicorn (API server and serve-logs).
+
+        Supported values: ``CRITICAL``, ``ERROR``, ``WARNING``, ``INFO``, ``DEBUG``.
+      version_added: 3.2.0
+      type: string
+      example: ~
+      default: "INFO"
     logging_config_class:
       description: |
         Logging class

--- a/airflow-core/src/airflow/configuration.py
+++ b/airflow-core/src/airflow/configuration.py
@@ -296,6 +296,9 @@ class AirflowConfigParser(_SharedAirflowConfigParser):
         ("logging", "fab_logging_level"): _available_logging_levels,
         # celery_logging_level can be empty, which uses logging_level as fallback
         ("logging", "celery_logging_level"): [*_available_logging_levels, ""],
+        # uvicorn and gunicorn logging levels for web servers
+        ("logging", "uvicorn_logging_level"): _available_logging_levels,
+        ("logging", "gunicorn_logging_level"): _available_logging_levels,
         ("webserver", "analytical_tool"): ["google_analytics", "metarouter", "segment", "matomo", ""],
         ("api", "grid_view_sorting_order"): ["topological", "hierarchical_alphabetical"],
     }

--- a/airflow-core/src/airflow/utils/serve_logs/core.py
+++ b/airflow-core/src/airflow/utils/serve_logs/core.py
@@ -51,7 +51,7 @@ def serve_logs(port=None):
 
     # Get uvicorn logging configuration from Airflow settings
     uvicorn_log_level = conf.get("logging", "uvicorn_logging_level", fallback="info").lower()
-    
+
     # Use uvicorn directly for ASGI applications
     uvicorn.run("airflow.utils.serve_logs.log_server:get_app", host="", port=port, log_level=uvicorn_log_level)
     # Log serving is I/O bound and has low concurrency, so single process is sufficient

--- a/airflow-core/src/airflow/utils/serve_logs/core.py
+++ b/airflow-core/src/airflow/utils/serve_logs/core.py
@@ -53,7 +53,9 @@ def serve_logs(port=None):
     uvicorn_log_level = conf.get("logging", "uvicorn_logging_level", fallback="info").lower()
 
     # Use uvicorn directly for ASGI applications
-    uvicorn.run("airflow.utils.serve_logs.log_server:get_app", host="", port=port, log_level=uvicorn_log_level)
+    uvicorn.run(
+        "airflow.utils.serve_logs.log_server:get_app", host="", port=port, log_level=uvicorn_log_level
+    )
     # Log serving is I/O bound and has low concurrency, so single process is sufficient
 
 

--- a/airflow-core/src/airflow/utils/serve_logs/core.py
+++ b/airflow-core/src/airflow/utils/serve_logs/core.py
@@ -49,8 +49,11 @@ def serve_logs(port=None):
 
     logger.info("Starting log server on %s", serve_log_uri)
 
+    # Get uvicorn logging configuration from Airflow settings
+    uvicorn_log_level = conf.get("logging", "uvicorn_logging_level", fallback="info").lower()
+    
     # Use uvicorn directly for ASGI applications
-    uvicorn.run("airflow.utils.serve_logs.log_server:get_app", host="", port=port, log_level="info")
+    uvicorn.run("airflow.utils.serve_logs.log_server:get_app", host="", port=port, log_level=uvicorn_log_level)
     # Log serving is I/O bound and has low concurrency, so single process is sufficient
 
 

--- a/airflow-core/tests/unit/cli/commands/test_api_server_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_api_server_command.py
@@ -194,6 +194,7 @@ class TestCliApiServer(_CommonCLIUvicornTestClass):
                     "timeout_graceful_shutdown": args.worker_timeout,
                     "timeout_worker_healthcheck": args.worker_timeout,
                     "access_log": True,
+                    "log_level": "info",
                     "proxy_headers": args.proxy_headers,
                     **expected_additional_kwargs,
                 },
@@ -246,6 +247,7 @@ class TestCliApiServer(_CommonCLIUvicornTestClass):
             ssl_keyfile=None,
             ssl_certfile=None,
             access_log=True,
+            log_level="info",
             proxy_headers=False,
         )
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Add configuration options to control uvicorn and gunicorn logging levels independently from Airflow's main logging configuration.

This allows users to suppress noisy uvicorn access logs in production environments while maintaining appropriate Airflow logging levels.

**Changes:**
- Add `uvicorn_logging_level` and `gunicorn_logging_level` configuration options
- Control uvicorn access logs in API server based on logging level
- Apply uvicorn logging configuration to triggerer log server
- Support for both production and development modes

**Testing:**
- Tested in Apache Airflow Dev Container environment with PostgreSQL backend
- Verified that `uvicorn_logging_level=error` suppresses INFO access logs
- Verified that `uvicorn_logging_level=info` maintains existing behavior  
- Confirmed API functionality remains unchanged
- Tested environment variable and config file settings

**Dev Container Test Results:**

**Environment:** Apache Airflow Dev Container (PostgreSQL backend, Python 3.10)

**1. Before (default behavior)**
![before-info logs visible](https://github.com/user-attachments/assets/6f0f094b-c694-4616-9f95-9884ee9b52ef)  
```bash
# terminal 1
$ airflow api-server --port 8080 --host 0.0.0.0

# terminal 2
for i in {1..3}; do
  curl -s http://localhost:8080/api/v2/version
  echo "✅ API call $i completed"
  sleep 1
done

# terminal 1
INFO:     127.0.0.1:45678 - "GET /api/v2/version HTTP/1.1" 200 OK
INFO:     127.0.0.1:45679 - "GET /api/v2/version HTTP/1.1" 200 OK  
INFO:     127.0.0.1:45680 - "GET /api/v2/version HTTP/1.1" 200 OK
```  

**2. Switch Log Configuration**  

![configuration options](https://github.com/user-attachments/assets/b5341228-8128-4a33-bae1-d31ed26067a7)
```bash
# terminal 1
$ export AIRFLOW__LOGGING__UVICORN_LOGGING_LEVEL=ERROR
$ airflow config get-value logging uvicorn_logging_level  
ERROR
```

**3. After - INFO logs suppressed** 
![after-info logs suppressed](https://github.com/user-attachments/assets/63d03a4f-a8a3-4f46-8210-b1fa96eadaf7)

```bash
# terminal 1
$ airflow config get-value logging uvicorn_logging_level
ERROR
$ airflow api-server --port 8080 --host 0.0.0.0

# terminal 2
for i in {1..3}; do
  curl -s http://localhost:8080/api/v2/version
  echo "✅ API call $i completed"
  sleep 1
done

# terminal 1
no access logs displayed - successfully suppressed
```
**Backward Compatibility:**
- Fully backward compatible (default: `info` maintains existing behavior)
- No breaking changes
- Optional feature that users can enable as needed

closes: #55405

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
