### PR TITLE
Use welcome on dashboard instead of airflow

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/Dashboard.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/Dashboard.tsx
@@ -71,7 +71,9 @@ export const Dashboard = () => {
           </Accordion.Root>
         ) : undefined}
         <Heading order={2} size="2xl">
-          {typeof instanceName === "string" && instanceName !== "" ? instanceName : translate("welcome")}
+          {typeof instanceName === "string" && instanceName !== "" && instanceName !== "Airflow"
+            ? instanceName
+            : translate("welcome")}
         </Heading>
         <Box order={3}>
           <Stats />


### PR DESCRIPTION
The backend actually falls back on passing `Airflow` as the instance name. I think the dashboard works better by actually using Welcome as the fallback instead.


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
