### PR TITLE
UI : DAG list sort “Last run” by run_after

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -253,13 +253,13 @@ paths:
             type: string
           description: 'Attributes to order by, multi criteria sort is supported.
             Prefix with `-` for descending order. Supported attributes: `dag_id, dag_display_name,
-            next_dagrun, state, start_date`'
+            next_dagrun, state, start_date, last_run_run_after`'
           default:
-          - dag_id
+          - last_run_run_after
           title: Order By
         description: 'Attributes to order by, multi criteria sort is supported. Prefix
           with `-` for descending order. Supported attributes: `dag_id, dag_display_name,
-          next_dagrun, state, start_date`'
+          next_dagrun, state, start_date, last_run_run_after`'
       - name: is_favorite
         in: query
         required: false

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/dags.py
@@ -104,7 +104,12 @@ def get_dags(
             SortParam(
                 ["dag_id", "dag_display_name", "next_dagrun", "state", "start_date"],
                 DagModel,
-                {"last_run_state": DagRun.state, "last_run_start_date": DagRun.start_date},
+                {
+                    "last_run_state": DagRun.state,
+                    "start_date": func.coalesce(DagRun.run_after, DagRun.start_date),
+                    "last_run_start_date": func.coalesce(DagRun.run_after, DagRun.start_date),
+                    "last_run_after": DagRun.run_after,
+                },
             ).dynamic_depends()
         ),
     ],

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/dags.py
@@ -102,18 +102,15 @@ def get_dags(
         SortParam,
         Depends(
             SortParam(
-                # expose the available orderable keys
                 ["dag_id", "dag_display_name", "next_dagrun", "state", "start_date", "last_run_run_after"],
                 DagModel,
                 {
                     "last_run_state": DagRun.state,
-                    # keep start_date semantics intact
                     "start_date": DagRun.start_date,
-                    "last_run_start_date": DagRun.start_date,   # alias, same behavior
-                    # new explicit key that sorts by run_after
+                    "last_run_start_date": DagRun.start_date,
                     "last_run_run_after": DagRun.run_after,
                 },
-            ).dynamic_depends(default="last_run_run_after")  # default to run_after for the UI list
+            ).dynamic_depends(default="last_run_run_after")
         ),
     ],
     is_favorite: QueryFavoriteFilter,

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/dags.py
@@ -102,15 +102,18 @@ def get_dags(
         SortParam,
         Depends(
             SortParam(
-                ["dag_id", "dag_display_name", "next_dagrun", "state", "start_date"],
+                # expose the available orderable keys
+                ["dag_id", "dag_display_name", "next_dagrun", "state", "start_date", "last_run_run_after"],
                 DagModel,
                 {
                     "last_run_state": DagRun.state,
-                    "start_date": func.coalesce(DagRun.run_after, DagRun.start_date),
-                    "last_run_start_date": func.coalesce(DagRun.run_after, DagRun.start_date),
-                    "last_run_after": DagRun.run_after,
+                    # keep start_date semantics intact
+                    "start_date": DagRun.start_date,
+                    "last_run_start_date": DagRun.start_date,   # alias, same behavior
+                    # new explicit key that sorts by run_after
+                    "last_run_run_after": DagRun.run_after,
                 },
-            ).dynamic_depends()
+            ).dynamic_depends(default="last_run_run_after")  # default to run_after for the UI list
         ),
     ],
     is_favorite: QueryFavoriteFilter,

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/ensureQueryData.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/ensureQueryData.ts
@@ -579,7 +579,7 @@ export const ensureUseDagServiceGetDagTagsData = (queryClient: QueryClient, { li
 * @param data.lastDagRunState
 * @param data.bundleName
 * @param data.bundleVersion
-* @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `dag_id, dag_display_name, next_dagrun, state, start_date`
+* @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `dag_id, dag_display_name, next_dagrun, state, start_date, last_run_run_after`
 * @param data.isFavorite
 * @param data.hasAssetSchedule Filter Dags with asset-based scheduling
 * @param data.assetDependency Filter Dags by asset dependency (name or URI)

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -579,7 +579,7 @@ export const prefetchUseDagServiceGetDagTags = (queryClient: QueryClient, { limi
 * @param data.lastDagRunState
 * @param data.bundleName
 * @param data.bundleVersion
-* @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `dag_id, dag_display_name, next_dagrun, state, start_date`
+* @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `dag_id, dag_display_name, next_dagrun, state, start_date, last_run_run_after`
 * @param data.isFavorite
 * @param data.hasAssetSchedule Filter Dags with asset-based scheduling
 * @param data.assetDependency Filter Dags by asset dependency (name or URI)

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/queries.ts
@@ -579,7 +579,7 @@ export const useDagServiceGetDagTags = <TData = Common.DagServiceGetDagTagsDefau
 * @param data.lastDagRunState
 * @param data.bundleName
 * @param data.bundleVersion
-* @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `dag_id, dag_display_name, next_dagrun, state, start_date`
+* @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `dag_id, dag_display_name, next_dagrun, state, start_date, last_run_run_after`
 * @param data.isFavorite
 * @param data.hasAssetSchedule Filter Dags with asset-based scheduling
 * @param data.assetDependency Filter Dags by asset dependency (name or URI)

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/suspense.ts
@@ -579,7 +579,7 @@ export const useDagServiceGetDagTagsSuspense = <TData = Common.DagServiceGetDagT
 * @param data.lastDagRunState
 * @param data.bundleName
 * @param data.bundleVersion
-* @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `dag_id, dag_display_name, next_dagrun, state, start_date`
+* @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `dag_id, dag_display_name, next_dagrun, state, start_date, last_run_run_after`
 * @param data.isFavorite
 * @param data.hasAssetSchedule Filter Dags with asset-based scheduling
 * @param data.assetDependency Filter Dags by asset dependency (name or URI)

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -1713,7 +1713,7 @@ export class DagService {
      * @param data.lastDagRunState
      * @param data.bundleName
      * @param data.bundleVersion
-     * @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `dag_id, dag_display_name, next_dagrun, state, start_date`
+     * @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `dag_id, dag_display_name, next_dagrun, state, start_date, last_run_run_after`
      * @param data.isFavorite
      * @param data.hasAssetSchedule Filter Dags with asset-based scheduling
      * @param data.assetDependency Filter Dags by asset dependency (name or URI)

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -2575,7 +2575,7 @@ export type GetDagsUiData = {
     limit?: number;
     offset?: number;
     /**
-     * Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `dag_id, dag_display_name, next_dagrun, state, start_date`
+     * Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `dag_id, dag_display_name, next_dagrun, state, start_date, last_run_run_after`
      */
     orderBy?: Array<(string)>;
     owners?: Array<(string)>;


### PR DESCRIPTION
### Problem

- On the DAGs list, sorting by Last run currently uses last_run_start_date. Newly triggered runs that are Queued don’t have a start_date, so the row ordering is unstable: the DAG can sit low in the list (or off page 1) while queued, then jump to the top when the run transitions Queued → Running and start_date becomes non-NULL. This matches the issue report.

### Root cause

- Sorting depends on start_date, which is only populated after a worker picks up the run. Queued runs lack start_date, but they do have run_after (the time they became eligible to run).

### What this PR changes

- For the UI DAGs list endpoint, map the Last run sort key to:

- MAX(COALESCE(DagRun.run_after, DagRun.start_date))


so queued runs participate in ordering immediately and the list remains stable through state transitions.

- Keep the existing order_by contract used by the UI:

order_by=start_date (and last_run_start_date, if sent) now resolve to the coalesced expression.

No UI changes required.

Preserve existing secondary ordering (e.g., by dag_id) where applicable, so pagination remains deterministic.

### User-visible effect

- Descending (Latest → Earliest): the most recently triggered DAG (even if Queued) appears at/near the top immediately and does not jump when it starts running.

- Ascending (Earliest → Latest): newly triggered DAGs move to the bottom immediately and stay during Queued → Running.

With many DAGs (pagination), a DAG no longer disappears from page 1 simply because it is Queued.

closes: #56073 