### PR TITLE
UI: Skip dual confirm on DAG Run note

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/EditableMarkdownArea.tsx
+++ b/airflow-core/src/airflow/ui/src/components/EditableMarkdownArea.tsx
@@ -18,6 +18,7 @@
  */
 import { Box, VStack, Editable, Text } from "@chakra-ui/react";
 import type { ChangeEvent } from "react";
+import { useEffect, useState } from "react";
 
 import ReactMarkdown from "./ReactMarkdown";
 
@@ -31,36 +32,51 @@ const EditableMarkdownArea = ({
   readonly onBlur?: () => void;
   readonly placeholder?: string | null;
   readonly setMdContent: (value: string) => void;
-}) => (
-  <Box mt={4} px={4} width="100%">
-    <Editable.Root
-      onBlur={onBlur}
-      onChange={(event: ChangeEvent<HTMLInputElement>) => setMdContent(event.target.value)}
-      value={mdContent ?? ""}
-    >
-      <Editable.Preview
-        _hover={{ backgroundColor: "transparent" }}
-        alignItems="flex-start"
-        as={VStack}
-        gap="0"
-        overflowY="auto"
-        width="100%"
-      >
-        {Boolean(mdContent) ? (
-          <ReactMarkdown>{mdContent}</ReactMarkdown>
-        ) : (
-          <Text color="fg.subtle">{placeholder}</Text>
-        )}
-      </Editable.Preview>
-      <Editable.Textarea
-        data-testid="markdown-input"
-        height="200px"
-        overflowY="auto"
-        placeholder={placeholder ?? ""}
-        resize="none"
-      />
-    </Editable.Root>
-  </Box>
-);
+}) => {
+  const [currentValue, setCurrentValue] = useState(mdContent ?? "");
+
+  // Keep local state in sync with external prop
+  useEffect(() => {
+    setCurrentValue(mdContent ?? "");
+  }, [mdContent]);
+
+  // Update both local and external state
+  const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    const { value } = event.target;
+
+    setCurrentValue(value);
+    setMdContent(value);
+  };
+
+  return (
+    <Box mt={4} px={4} width="100%">
+      <Editable.Root onBlur={onBlur} value={currentValue}>
+        <Editable.Preview
+          _hover={{ backgroundColor: "transparent" }}
+          alignItems="flex-start"
+          as={VStack}
+          gap="0"
+          height="200px"
+          overflowY="auto"
+          width="100%"
+        >
+          {Boolean(currentValue) ? (
+            <ReactMarkdown>{currentValue}</ReactMarkdown>
+          ) : (
+            <Text color="fg.subtle">{placeholder}</Text>
+          )}
+        </Editable.Preview>
+        <Editable.Textarea
+          data-testid="markdown-input"
+          height="200px"
+          onChange={handleChange}
+          overflowY="auto"
+          placeholder={placeholder ?? ""}
+          resize="none"
+        />
+      </Editable.Root>
+    </Box>
+  );
+};
 
 export default EditableMarkdownArea;


### PR DESCRIPTION
### Problem
When editing a DAG Run note, users were sometimes prompted with **two confirmation dialogs** when navigating away — one real and one spurious.  
This happened because the Markdown editor was uncontrolled, and the dirty-form detector assumed there were unsaved changes even when the content was already saved.

### Fix
- Converted the note editor into a **controlled component**.
- Added local state (`currentValue`) that syncs with `mdContent` via `useEffect`.
- Updates now flow cleanly through `setMdContent` from the textarea `onChange`.
- Prevents the false-positive dirty state that caused duplicate confirmations.

### Result
- Users only get a confirmation prompt when there are **actual unsaved changes**.
- DAG Run note editing behaves consistently with no redundant dialogs.

### Testing
- Verified that typing into the note updates both preview and parent state.
- Navigating away after saving does not trigger any extra confirmation.
- Placeholder renders correctly when the note is empty.

### Demo Video

https://github.com/user-attachments/assets/6bf49685-4661-42db-9e3e-4c966e83cde7




---

Closes: #55847 
