### PR TITLE
Fix apache licenses for Go SDK files

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -181,7 +181,7 @@ go.sum
 mocks/*
 
 # Generated protobuf files
-*.proto
+.*proto
 .*pb.go
 .*_grpc.pb.go
 

--- a/.rat-excludes
+++ b/.rat-excludes
@@ -180,5 +180,10 @@ go.mod
 go.sum
 mocks/*
 
+# Generated protobuf files
+*.proto
+.*pb.go
+.*_grpc.pb.go
+
 # Kubernetes env
 .env

--- a/go-sdk/Justfile
+++ b/go-sdk/Justfile
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # Main Justfile for Airflow Go SDK
 set shell := ["bash", "-uc", "-O", "globstar"]
 

--- a/go-sdk/example/bundle/Justfile
+++ b/go-sdk/example/bundle/Justfile
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # Justfile for example DAG bundle
 
 # Default recipe to show help


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

CI fails with:
```
Check if licenses are OK for Apache..........................................Failed
- hook id: check-apache-license-rat
- exit code: 1
  Running command:
  docker run -v /home/runner/work/airflow/airflow:/opt/airflow -t --user 1001:1001 --rm --platform linux/amd64 ghcr.io/apache/airflow-apache-rat:0.16.1-2024.03.23@sha256:83c4d2610ec4a439d1809a67fadbdc9a1df089ab130b32209351bdd4527a3f02 -d /opt/airflow --exclude-file /opt/airflow/.rat-excludes

  ERROR: Could not find Apache licences in some files:

   !????? /opt/airflow/go-sdk/Justfile
   !????? /opt/airflow/go-sdk/example/bundle/Justfile
   !????? /opt/airflow/go-sdk/internal/protov1/plugin.pb.go
   !????? /opt/airflow/go-sdk/internal/protov1/plugin.proto
   !????? /opt/airflow/go-sdk/internal/protov1/plugin_grpc.pb.go
```

I have added licenses for the Justfiles and not added to .proto or pb.go files.

If I add it to .proto, i will have to add it to pb.go as any change to proto will compile the protobuf.

Tested locally using the rat jar file.
```
(airflow) ➜  airflow git:(go-sdk-licenses) ✗ java -jar ~/Downloads/apache-rat-0.16.1/apache-rat-0.16.1.jar -d go-sdk -E ~/Documents/OSS/repos/airflow/.rat-excludes
ERROR: Ignored 59 lines in your exclusion files as comments or empty lines.

*****************************************************
Summary
-------
Generated at: 2025-09-26T00:04:11+05:30

Notes: 0
Binaries: 0
Archives: 0
Standards: 48

Apache Licensed: 48
Generated Documents: 0

JavaDocs are generated, thus a license header is optional.
Generated files do not require license headers.

0 Unknown Licenses

*****************************************************
  Files with Apache License headers will be marked AL
  Binary files (which do not require any license headers) will be marked B
  Compressed archives will be marked A
  Notices, licenses etc. will be marked N
  AL    go-sdk/.mockery.yml
  AL    go-sdk/.pre-commit-config.yaml
  AL    go-sdk/Justfile
  AL    go-sdk/README.md
  AL    go-sdk/bundle/bundlev1/doc.go
  AL    go-sdk/bundle/bundlev1/registry.go
  AL    go-sdk/bundle/bundlev1/registry_test.go
  AL    go-sdk/bundle/bundlev1/schemas.go
  AL    go-sdk/bundle/bundlev1/task.go
  AL    go-sdk/bundle/bundlev1/task_test.go
  AL    go-sdk/bundle/bundlev1/bundlev1client/doc.go
  AL    go-sdk/bundle/bundlev1/bundlev1client/grpc.go
  AL    go-sdk/bundle/bundlev1/bundlev1server/doc.go
  AL    go-sdk/bundle/bundlev1/bundlev1server/server.go
  AL    go-sdk/bundle/bundlev1/bundlev1server/impl/plugin.go
  AL    go-sdk/celery/app.go
  AL    go-sdk/celery/config.go
  AL    go-sdk/celery/cmd/main.go
  AL    go-sdk/celery/commands/root.go
  AL    go-sdk/celery/commands/run.go
  AL    go-sdk/example/bundle/Justfile
  AL    go-sdk/example/bundle/main.go
  AL    go-sdk/example/bundle/main_test.go
  AL    go-sdk/pkg/api/client.gen.go
  AL    go-sdk/pkg/api/client.go
  AL    go-sdk/pkg/api/init.go
  AL    go-sdk/pkg/api/models.go
  AL    go-sdk/pkg/api/oapi-codegen.yml
  AL    go-sdk/pkg/api/overlay.yml
  AL    go-sdk/pkg/bundles/shared/config.go
  AL    go-sdk/pkg/bundles/shared/discovery.go
  AL    go-sdk/pkg/bundles/shared/handshake.go
  AL    go-sdk/pkg/logging/attrs.go
  AL    go-sdk/pkg/logging/stdbridge.go
  AL    go-sdk/pkg/logging/tee.go
  AL    go-sdk/pkg/sdkcontext/keys.go
  AL    go-sdk/pkg/worker/init.go
  AL    go-sdk/pkg/worker/runner.go
  AL    go-sdk/pkg/worker/runner_test.go
  AL    go-sdk/pkg/worker/task.go
  AL    go-sdk/pkg/worker/task_test.go
  AL    go-sdk/sdk/client.go
  AL    go-sdk/sdk/client_test.go
  AL    go-sdk/sdk/connection.go
  AL    go-sdk/sdk/connection_test.go
  AL    go-sdk/sdk/doc.go
  AL    go-sdk/sdk/errors.go
  AL    go-sdk/sdk/sdk.go
 
*****************************************************
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
