### PR TITLE
Detect interactive terminal to set colored logging + support override env variables

### DIFF
--- a/shared/logging/tests/logging/test_structlog.py
+++ b/shared/logging/tests/logging/test_structlog.py
@@ -25,12 +25,14 @@ import os
 import sys
 import textwrap
 from datetime import datetime, timezone
+from unittest import mock
 
 import pytest
 import structlog
 from structlog.dev import BLUE, BRIGHT, CYAN, DIM, GREEN, MAGENTA, RESET_ALL as RESET
 from structlog.processors import CallsiteParameter
 
+from airflow_shared.logging import structlog as structlog_module
 from airflow_shared.logging.structlog import configure_logging
 
 # We don't want to use the caplog fixture in this test, as the main purpose of this file is to capture the
@@ -56,7 +58,10 @@ def structlog_config():
             else:
                 buff = io.StringIO()
 
-            configure_logging(**kwargs, output=buff)
+            with mock.patch("sys.stdout") as mock_stdout:
+                mock_stdout.isatty.return_value = True
+                configure_logging(**kwargs, output=buff)
+
             yield buff
             buff.seek(0)
         finally:
@@ -112,6 +117,48 @@ def test_colorful(structlog_config, get_logger, config_kwargs, extra_kwargs, ext
         f" {BRIGHT}Hello world                   {RESET}"
         f" [{RESET}{BRIGHT}{BLUE}my.logger{RESET}]{RESET}" + extra_output + "\n"
     )
+
+
+@pytest.mark.parametrize(
+    ("no_color", "force_color", "is_tty", "colors_param", "expected_colors"),
+    [
+        # NO_COLOR takes precedence over everything
+        pytest.param("1", "", True, True, False, id="no_color_set_tty_colors_true"),
+        pytest.param("1", "", True, False, False, id="no_color_set_tty_colors_false"),
+        pytest.param("1", "", False, True, False, id="no_color_set_no_tty_colors_true"),
+        pytest.param("1", "", False, False, False, id="no_color_set_no_tty_colors_false"),
+        pytest.param("1", "1", True, True, False, id="no_color_and_force_color_tty_colors_true"),
+        pytest.param("1", "1", True, False, False, id="no_color_and_force_color_tty_colors_false"),
+        pytest.param("1", "1", False, True, False, id="no_color_and_force_color_no_tty_colors_true"),
+        pytest.param("1", "1", False, False, False, id="no_color_and_force_color_no_tty_colors_false"),
+        # FORCE_COLOR takes precedence when NO_COLOR is not set
+        pytest.param("", "1", True, True, True, id="force_color_tty_colors_true"),
+        pytest.param("", "1", True, False, True, id="force_color_tty_colors_false"),
+        pytest.param("", "1", False, True, True, id="force_color_no_tty_colors_true"),
+        pytest.param("", "1", False, False, True, id="force_color_no_tty_colors_false"),
+        # When neither NO_COLOR nor FORCE_COLOR is set, check TTY and colors param
+        pytest.param("", "", True, True, True, id="tty_colors_true"),
+        pytest.param("", "", True, False, False, id="tty_colors_false"),
+        pytest.param("", "", False, True, False, id="no_tty_colors_true"),
+        pytest.param("", "", False, False, False, id="no_tty_colors_false"),
+    ],
+)
+def test_color_config(monkeypatch, no_color, force_color, is_tty, colors_param, expected_colors):
+    """Test all combinations of NO_COLOR, FORCE_COLOR, is_atty(), and colors parameter."""
+
+    monkeypatch.setenv("NO_COLOR", no_color)
+    monkeypatch.setenv("FORCE_COLOR", force_color)
+
+    with mock.patch("sys.stdout") as mock_stdout:
+        mock_stdout.isatty.return_value = is_tty
+
+        with mock.patch.object(structlog_module, "structlog_processors") as mock_processors:
+            mock_processors.return_value = ([], None, None)
+
+            structlog_module.configure_logging(colors=colors_param)
+
+            mock_processors.assert_called_once()
+            assert mock_processors.call_args.kwargs["colors"] == expected_colors
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
After #55824, colored logs were being emitted even when the terminal was not interactive, causing failures. Environment variables to force color to be turned on or off were also not being respected.

This resolves those issues and adds unit tests with all combinations of factors to determine if logs should be colored.

Resolves #56114

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
