### PR TITLE
Add async support for Amazon SNS Notifier

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/notifications/sns.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/notifications/sns.py
@@ -83,5 +83,14 @@ class SnsNotifier(BaseNotifier):
             message_attributes=self.message_attributes,
         )
 
+    async def async_notify(self, context):
+        """Publish the notification message to Amazon SNS (async)."""
+        await self.hook.apublish_to_target(
+            target_arn=self.target_arn,
+            message=self.message,
+            subject=self.subject,
+            message_attributes=self.message_attributes,
+        )
+
 
 send_sns_notification = SnsNotifier

--- a/providers/amazon/src/airflow/providers/amazon/aws/notifications/sns.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/notifications/sns.py
@@ -21,6 +21,7 @@ from collections.abc import Sequence
 from functools import cached_property
 
 from airflow.providers.amazon.aws.hooks.sns import SnsHook
+from airflow.providers.amazon.version_compat import AIRFLOW_V_3_1_PLUS
 from airflow.providers.common.compat.notifier import BaseNotifier
 
 
@@ -60,8 +61,13 @@ class SnsNotifier(BaseNotifier):
         subject: str | None = None,
         message_attributes: dict | None = None,
         region_name: str | None = None,
+        **kwargs,
     ):
-        super().__init__()
+        if AIRFLOW_V_3_1_PLUS:
+            #  Support for passing context was added in 3.1.0
+            super().__init__(**kwargs)
+        else:
+            super().__init__()
         self.aws_conn_id = aws_conn_id
         self.region_name = region_name
         self.target_arn = target_arn

--- a/providers/amazon/tests/unit/amazon/aws/notifications/test_sns.py
+++ b/providers/amazon/tests/unit/amazon/aws/notifications/test_sns.py
@@ -23,30 +23,44 @@ import pytest
 from airflow.providers.amazon.aws.notifications.sns import SnsNotifier, send_sns_notification
 from airflow.utils.types import NOTSET
 
-PARAM_DEFAULT_VALUE = pytest.param(NOTSET, id="default-value")
+PUBLISH_KWARGS = {
+    "target_arn": "arn:aws:sns:us-west-2:123456789098:TopicName",
+    "message": "foo-bar",
+    "subject": "spam-egg",
+    "message_attributes": {},
+}
 
 
 class TestSnsNotifier:
     def test_class_and_notifier_are_same(self):
         assert send_sns_notification is SnsNotifier
 
-    @pytest.mark.parametrize("aws_conn_id", ["aws_test_conn_id", None, PARAM_DEFAULT_VALUE])
-    @pytest.mark.parametrize("region_name", ["eu-west-2", None, PARAM_DEFAULT_VALUE])
+    @pytest.mark.parametrize(
+        "aws_conn_id",
+        [
+            pytest.param("aws_test_conn_id", id="custom-conn"),
+            pytest.param(None, id="none-conn"),
+            pytest.param(NOTSET, id="default-value"),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "region_name",
+        [
+            pytest.param("eu-west-2", id="custom-region"),
+            pytest.param(None, id="no-region"),
+            pytest.param(NOTSET, id="default-value"),
+        ],
+    )
     def test_parameters_propagate_to_hook(self, aws_conn_id, region_name):
         """Test notifier attributes propagate to SnsHook."""
-        publish_kwargs = {
-            "target_arn": "arn:aws:sns:us-west-2:123456789098:TopicName",
-            "message": "foo-bar",
-            "subject": "spam-egg",
-            "message_attributes": {},
-        }
+
         notifier_kwargs = {}
         if aws_conn_id is not NOTSET:
             notifier_kwargs["aws_conn_id"] = aws_conn_id
         if region_name is not NOTSET:
             notifier_kwargs["region_name"] = region_name
 
-        notifier = SnsNotifier(**notifier_kwargs, **publish_kwargs)
+        notifier = SnsNotifier(**notifier_kwargs, **PUBLISH_KWARGS)
         with mock.patch("airflow.providers.amazon.aws.notifications.sns.SnsHook") as mock_hook:
             hook = notifier.hook
             assert hook is notifier.hook, "Hook property not cached"
@@ -57,7 +71,17 @@ class TestSnsNotifier:
 
             # Basic check for notifier
             notifier.notify({})
-            mock_hook.return_value.publish_to_target.assert_called_once_with(**publish_kwargs)
+            mock_hook.return_value.publish_to_target.assert_called_once_with(**PUBLISH_KWARGS)
+
+    @pytest.mark.asyncio
+    async def test_async_notify(self):
+        notifier = SnsNotifier(**PUBLISH_KWARGS)
+        with mock.patch("airflow.providers.amazon.aws.notifications.sns.SnsHook") as mock_hook:
+            mock_hook.return_value.apublish_to_target = mock.AsyncMock()
+
+            await notifier.async_notify({})
+
+            mock_hook.return_value.apublish_to_target.assert_called_once_with(**PUBLISH_KWARGS)
 
     def test_sns_notifier_templated(self, create_dag_without_db):
         notifier = SnsNotifier(


### PR DESCRIPTION
Adds async support to the existing SNS Notifier so it can be used as an AsyncCallback for DeadlineAlerts, among other things


dags used for manual testing:

```python
from datetime import datetime, timedelta

from airflow.providers.amazon.aws.hooks.sns import SnsHook
from airflow.providers.amazon.aws.notifications.sns import SnsNotifier
from airflow.sdk import task, DAG
from airflow.sdk.definitions.deadline import DeadlineAlert, DeadlineReference, AsyncCallback

PAST_DATE = datetime(1980, 8, 10, 2)
MSG_PREFIX = "SNS Testing Rnd 1:"

DEFAULTS = {"target_arn": << REDACTED >>, "message": "testing via Airflow"}


def _sns_callback(context):
    SnsHook().publish_to_target(**DEFAULTS, subject=f"{MSG_PREFIX} Hook as Callback -- {context['dag_run'].dag_id}")


@task
def send_sns_message(subject):
    SnsHook().publish_to_target(**DEFAULTS, subject=subject)


@task.bash(task_id='sleep_task')
def sleep_n_secs(seconds):
    return f'sleep {seconds}'


with DAG(
    "sns_hook_via_taskflow",
    tags=["sns"]
):
    send_sns_message(subject=f"{MSG_PREFIX} Taskflow -- {{{{ dag_run.dag_id }}}} ")

with DAG(
    "sns_callback_on_success",
    on_success_callback=_sns_callback,
    tags=["sns"],
):
    sleep_n_secs(1)

with DAG(
    "sns_notifier_as_callback",
    on_success_callback=SnsNotifier(**DEFAULTS, subject=f"{MSG_PREFIX} Sync Notifier as callback -- {{{{ dag_run.dag_id }}}} "),
    tags=["sns"],
):
    sleep_n_secs(1)


with DAG(
    "sns_notifier_as_deadline",
    deadline=DeadlineAlert(
        reference=DeadlineReference.FIXED_DATETIME(PAST_DATE),
        interval=timedelta(0),
        callback=AsyncCallback(
            SnsNotifier,
            kwargs={**DEFAULTS, "subject": f"{MSG_PREFIX} Async Notifier as Deadline -- {{{{ dag_run.dag_id }}}} "}
        ),
    ),
    tags=["sns"],
):
    sleep_n_secs(1)
```

and proof of delivery with working templating

<img width="553" height="356" alt="image" src="https://github.com/user-attachments/assets/565276ac-6ad9-44a3-bba7-74e158035522" />


CC:  @ramitkataria @seanghaeli 


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
