### PR TITLE
Add async support for Amazon SQS Notifier

### DIFF
--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_sqs.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_sqs.py
@@ -71,4 +71,3 @@ class TestAsyncSqsHook:
         response = await hook.asend_message(queue_url=QUEUE_URL, message_body=MESSAGE_BODY)
 
         assert MESSAGE_ID_KEY in response
-        assert response[MESSAGE_ID_KEY] == MESSAGE_BODY

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_sqs.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_sqs.py
@@ -17,9 +17,17 @@
 # under the License.
 from __future__ import annotations
 
+from unittest import mock
+
+import pytest
 from moto import mock_aws
 
 from airflow.providers.amazon.aws.hooks.sqs import SqsHook
+
+QUEUE_URL = "https://sqs.region.amazonaws.com/123456789/test-queue"
+MESSAGE_BODY = "test message"
+
+MESSAGE_ID_KEY = "MessageId"
 
 
 class TestSqsHook:
@@ -27,3 +35,40 @@ class TestSqsHook:
     def test_get_conn(self):
         hook = SqsHook(aws_conn_id="aws_default")
         assert hook.get_conn() is not None
+
+
+@pytest.mark.asyncio
+class TestAsyncSqsHook:
+    """The mock_aws decorator uses `moto` which does not currently support async SQS so we mock it manually."""
+
+    @pytest.fixture
+    def hook(self):
+        return SqsHook(aws_conn_id="aws_default")
+
+    @pytest.fixture
+    def mock_async_client(self):
+        mock_client = mock.AsyncMock()
+        mock_client.send_message.return_value = {MESSAGE_ID_KEY: "test-message-id"}
+        return mock_client
+
+    @pytest.fixture
+    def mock_get_async_conn(self, mock_async_client):
+        with mock.patch.object(SqsHook, "get_async_conn") as mocked_conn:
+            mocked_conn.return_value = mock_async_client
+            mocked_conn.return_value.__aenter__.return_value = mock_async_client
+            yield mocked_conn
+
+    async def test_get_async_conn(self, hook, mock_get_async_conn, mock_async_client):
+        # Test context manager access
+        async with await hook.get_async_conn() as async_conn:
+            assert async_conn is mock_async_client
+
+        # Test direct access
+        async_conn = await hook.get_async_conn()
+        assert async_conn is mock_async_client
+
+    async def test_asend_message(self, hook, mock_get_async_conn, mock_async_client):
+        response = await hook.asend_message(queue_url=QUEUE_URL, message_body=MESSAGE_BODY)
+
+        assert MESSAGE_ID_KEY in response
+        assert response[MESSAGE_ID_KEY] == MESSAGE_BODY

--- a/providers/amazon/tests/unit/amazon/aws/notifications/test_sqs.py
+++ b/providers/amazon/tests/unit/amazon/aws/notifications/test_sqs.py
@@ -25,6 +25,14 @@ from airflow.utils.types import NOTSET
 
 PARAM_DEFAULT_VALUE = pytest.param(NOTSET, id="default-value")
 
+SEND_MSG_KWARGS = {
+    "queue_url": "https://sqs.eu-west-1.amazonaws.com/123456789098/MyQueue",
+    "message_body": "foo-bar",
+    "delay_seconds": 42,
+    "message_attributes": {},
+    "message_group_id": "foo-bar",
+}
+
 
 class TestSqsNotifier:
     def test_class_and_notifier_are_same(self):
@@ -34,20 +42,14 @@ class TestSqsNotifier:
     @pytest.mark.parametrize("region_name", ["eu-west-2", None, PARAM_DEFAULT_VALUE])
     def test_parameters_propagate_to_hook(self, aws_conn_id, region_name):
         """Test notifier attributes propagate to SqsHook."""
-        send_message_kwargs = {
-            "queue_url": "https://sqs.eu-west-1.amazonaws.com/123456789098/MyQueue",
-            "message_body": "foo-bar",
-            "delay_seconds": 42,
-            "message_attributes": {},
-            "message_group_id": "foo-bar",
-        }
+
         notifier_kwargs = {}
         if aws_conn_id is not NOTSET:
             notifier_kwargs["aws_conn_id"] = aws_conn_id
         if region_name is not NOTSET:
             notifier_kwargs["region_name"] = region_name
 
-        notifier = SqsNotifier(**notifier_kwargs, **send_message_kwargs)
+        notifier = SqsNotifier(**notifier_kwargs, **SEND_MSG_KWARGS)
         with mock.patch("airflow.providers.amazon.aws.notifications.sqs.SqsHook") as mock_hook:
             hook = notifier.hook
             assert hook is notifier.hook, "Hook property not cached"
@@ -58,7 +60,7 @@ class TestSqsNotifier:
 
             # Basic check for notifier
             notifier.notify({})
-            mock_hook.return_value.send_message.assert_called_once_with(**send_message_kwargs)
+            mock_hook.return_value.send_message.assert_called_once_with(**SEND_MSG_KWARGS)
 
     def test_sqs_notifier_templated(self, create_dag_without_db):
         notifier = SqsNotifier(
@@ -90,3 +92,13 @@ class TestSqsNotifier:
                 message_attributes={"bar": "test_sqs_notifier_templated"},
                 delay_seconds=0,
             )
+
+    @pytest.mark.asyncio
+    async def test_async_notify(self):
+        notifier = SqsNotifier(**SEND_MSG_KWARGS)
+        with mock.patch("airflow.providers.amazon.aws.notifications.sqs.SqsHook") as mock_hook:
+            mock_hook.return_value.asend_message = mock.AsyncMock()
+
+            await notifier.async_notify({})
+
+            mock_hook.return_value.asend_message.assert_called_once_with(**SEND_MSG_KWARGS)


### PR DESCRIPTION
Adds async support to the existing SQS Notifier so it can be used as an AsyncCallback for DeadlineAlerts, among other things

dags used for manual testing:

```python

from datetime import datetime, timedelta

from airflow.providers.amazon.aws.hooks.sqs import SqsHook
from airflow.providers.amazon.aws.notifications.sqs import SqsNotifier
from airflow.sdk import task, DAG
from airflow.sdk.definitions.deadline import DeadlineAlert, DeadlineReference, AsyncCallback

PAST_DATE = datetime(1980, 8, 10, 2)
MSG_PREFIX = "SQS Testing Rnd 0:"

DEFAULTS = {"queue_url": "https://sqs.us-east-1.amazonaws.com/324969868898/async-notifier-testing"}


def _sqs_callback(context):
    SqsHook().send_message(**DEFAULTS, message_body=f"{MSG_PREFIX} Hook as Callback -- {context['dag_run'].dag_id}")


@task
def send_sqs_message(message):
    SqsHook().send_message(**DEFAULTS, message_body=message)


@task.bash(task_id='sleep_task')
def sleep_n_secs(seconds):
    return f'sleep {seconds}'


with DAG(
    "sqs_hook_via_taskflow",
    tags=["sqs"]
):
    send_sqs_message(message=f"{MSG_PREFIX} Taskflow -- {{{{ dag_run.dag_id }}}} ")

with DAG(
    "sqs_callback_on_success",
    on_success_callback=_sqs_callback,
    tags=["sqs"],
):
    sleep_n_secs(1)

with DAG(
    "sqs_notifier_as_callback",
    on_success_callback=SqsNotifier(**DEFAULTS, message_body=f"{MSG_PREFIX} Sync Notifier as callback -- {{{{ dag_run.dag_id }}}} "),
    tags=["sqs"],
):
    sleep_n_secs(1)


with DAG(
    "sqs_notifier_as_deadline",
    deadline=DeadlineAlert(
        reference=DeadlineReference.FIXED_DATETIME(PAST_DATE),
        interval=timedelta(0),
        callback=AsyncCallback(
            SqsNotifier,
            kwargs={**DEFAULTS, "message_body": f"{MSG_PREFIX} Async Notifier as Deadline -- {{{{ dag_run.dag_id }}}} "}
        ),
    ),
    tags=["sqs"],
):
    sleep_n_secs(1)

```

and proof of delivery with intact templating:

<img width="1087" height="255" alt="image" src="https://github.com/user-attachments/assets/e0c3a5f4-808e-403e-90bb-ba0032e46458" />


cc @ramitkataria @seanghaeli 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
