### PR TITLE
Fix UI keeps poking pools API when no permission

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/PoolSummary/PoolSummary.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/PoolSummary/PoolSummary.tsx
@@ -21,8 +21,9 @@ import { useTranslation } from "react-i18next";
 import { BiTargetLock } from "react-icons/bi";
 import { Link as RouterLink } from "react-router-dom";
 
-import { useAuthLinksServiceGetAuthMenus } from "openapi/queries";
+import { type PoolServiceGetPoolsDefaultResponse, useAuthLinksServiceGetAuthMenus } from "openapi/queries";
 import { usePoolServiceGetPools } from "openapi/queries/queries";
+import type { ApiError } from "openapi/requests";
 import { PoolBar } from "src/components/PoolBar";
 import { useAutoRefresh } from "src/utils";
 import { type Slots, slotKeys } from "src/utils/slots";
@@ -30,11 +31,25 @@ import { type Slots, slotKeys } from "src/utils/slots";
 export const PoolSummary = () => {
   const { t: translate } = useTranslation("dashboard");
   const refetchInterval = useAutoRefresh({ checkPendingRuns: true });
-  const { data, isLoading } = usePoolServiceGetPools(undefined, undefined, {
-    refetchInterval,
-  });
+
   const { data: authLinks } = useAuthLinksServiceGetAuthMenus();
   const hasPoolsAccess = authLinks?.authorized_menu_items.includes("Pools");
+
+  const { data, error, isLoading } = usePoolServiceGetPools<PoolServiceGetPoolsDefaultResponse, ApiError>(
+    undefined,
+    undefined,
+    {
+      refetchInterval: (query) => {
+        const apiError = query.state.error;
+
+        return apiError?.status === 403 ? false : refetchInterval;
+      },
+    },
+  );
+
+  if (error?.status === 403) {
+    return undefined;
+  }
 
   const pools = data?.pools;
   const totalSlots = pools?.reduce((sum, pool) => sum + pool.slots, 0) ?? 0;


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
Closes: #54969 

## Problem Summary
The pools widget on the HomePage is hammering the API when users don't have the `can read on Pools` permission.

## Proposed Solution
- Call the pool API first 
- If the error.status `403` is captured, then we stop all further request retries and disable auto-refresh for this component
- Show `403 Forbidden` 

## Results
### Before the fix
<img width="1895" height="837" alt="Pasted image 20250927212904" src="https://github.com/user-attachments/assets/d3dee582-f3a6-454c-84b2-c6746c922c90" />

### After the fix
<img width="1899" height="790" alt="Pasted image 20250927224615" src="https://github.com/user-attachments/assets/117ed4b0-9d12-4498-9762-b4aae505919f" />



## Questions
Dear Committers and Reviewers, 

Just thinking loudly, given the granularity of these permissions, this problem could potentially affect other UI components? I haven't tested others, but happy to investigate further if you think that would make sense?

Looking forward to your comments and review feedbacks
Thanks!

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
