### PR TITLE
Add CLI command to remove all queues from Celery worker

### DIFF
--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
@@ -268,6 +268,12 @@ CELERY_COMMANDS = (
             ARG_FULL_CELERY_HOSTNAME,
         ),
     ),
+    ActionCommand(
+        name="remove-all-queues",
+        help="Unsubscribe Celery worker from all its active queues",
+        func=lazy_load_command(f"{CELERY_CLI_COMMAND_PATH}.remove_all_queues"),
+        args=(ARG_FULL_CELERY_HOSTNAME,),
+    ),
 )
 
 


### PR DESCRIPTION
Implement  command that unsubscribes a Celery worker from all its active queues. This complements the existing command by providing a bulk operation for queue management. Idea is to quickly move a worker out from service without actually shutting it down. Intent is to create a similar effect as Edge Executor's `Maintenance Mode`

<img width="1210" height="178" alt="image" src="https://github.com/user-attachments/assets/0d4b7a24-2070-4c9a-b46b-e325d8b85067" />


cc: @jscheffl 