### PR TITLE
Cleanup disk space in image cache push jobs

### DIFF
--- a/.github/workflows/push-image-cache.yml
+++ b/.github/workflows/push-image-cache.yml
@@ -116,6 +116,8 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           persist-credentials: false
+      - name: "Free up disk space"
+        run: ./scripts/tools/free_up_disk_space.sh
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
       - name: Login to ghcr.io
@@ -183,6 +185,8 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           persist-credentials: false
+      - name: "Free up disk space"
+        run: ./scripts/tools/free_up_disk_space.sh
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
       - name: "Cleanup dist and context file"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

In some recent jobs, we saw some issues such related to disk space: https://github.com/apache/airflow/actions/runs/18071055239/job/51422086979


```
  #59 loading layer 2f7fcd295b18 61.07MB / 61.07MB 40.3s done
  #59 ERROR: write /usr/python/lib/python3.10/site-packages/scipy/linalg/cython_lapack.cpython-310-x86_64-linux-gnu.so: no space left on device
  
  #56 exporting to docker image format
  #56 sending tarball 74.3s done
  #56 ERROR: rpc error: code = Unknown desc = write /usr/python/lib/python3.10/site-packages/scipy/linalg/cython_lapack.cpython-310-x86_64-linux-gnu.so: no space left on device
  ------
   > exporting to docker image format:
  ------
  ------
   > importing to docker:
  ------
  ERROR: failed to build: failed to solve: rpc error: code = Unknown desc = write /usr/python/lib/python3.10/site-packages/scipy/linalg/cython_lapack.cpython-310-x86_64-linux-gnu.so: no space left on device
Your image build failed. It could be caused by conflicting dependencies.
```

As a potential improvement, we could reuse of disk cleanup job in these CI workflows too, right after checkout to clean some clutter up.

I do not see side effects because the cleanup step:
* Removes large unused toolchains (.NET, GraalVM, Android SDK, etc.)
* Cleans package caches (APT, pip, npm)

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
