### PR TITLE
Bump version of providers

### DIFF
--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -140,11 +140,11 @@ dependencies = [
     "uuid6>=2024.7.10",
     "apache-airflow-task-sdk<1.3.0,>=1.1.0",
     # pre-installed providers
-    "apache-airflow-providers-common-compat>=1.6.0",
-    "apache-airflow-providers-common-io>=1.5.3",
-    "apache-airflow-providers-common-sql>=1.26.0",
-    "apache-airflow-providers-smtp>=2.0.2",
-    "apache-airflow-providers-standard>=0.4.0",
+    "apache-airflow-providers-common-compat>=1.7.4",
+    "apache-airflow-providers-common-io>=1.6.3",
+    "apache-airflow-providers-common-sql>=1.28.1",
+    "apache-airflow-providers-smtp>=2.3.1",
+    "apache-airflow-providers-standard>=1.9.0",
     # Start of shared logging dependencies
     "msgspec>=0.19.0",
     "pygtrie>=2.5.0",


### PR DESCRIPTION
Some Airflow 3.1 compatibility issues were addressed in recent provider releases. Lets bump min version to help users avoid hitting problems that are solved by updating providers.