### PR TITLE
Remove configuration embedded note from providers

### DIFF
--- a/devel-common/src/sphinx_exts/includes/providers-configurations-ref.rst
+++ b/devel-common/src/sphinx_exts/includes/providers-configurations-ref.rst
@@ -24,10 +24,4 @@ Configuration Reference
   ``{{ package_name }}`` provider that can be set in the ``airflow.cfg`` file or using environment variables.
 
   .. note::
-    The configuration embedded in providers started to be used as of Airflow 2.7.0. Previously the
-    configuration was described and configured in the Airflow core package - so if you are using Airflow
-    below 2.7.0, look at Airflow documentation for the list of available configuration options
-    that were available in Airflow core.
-
-  .. note::
      For more information see :doc:`apache-airflow:howto/set-config`.


### PR DESCRIPTION
This change removed the configuration embedded block from the Configuration menu tab in providers:
<img width="1549" height="928" alt="Screenshot 2025-09-29 at 15 28 24" src="https://github.com/user-attachments/assets/10abf7ab-c68a-41d9-96f4-0c65175c57ee" />


the minimum version of Airflow for providers is 2.10 - There is no longer need to note about something that is relevant for 2.7+