### PR TITLE
Fix install_java.sh script to correctly clear /files/bin folder before reinstalling java 

### DIFF
--- a/scripts/in_container/bin/install_java.sh
+++ b/scripts/in_container/bin/install_java.sh
@@ -25,6 +25,15 @@ BIN_PATH="/files/bin/java"
 if [[ $# != "0" && ${1} == "--reinstall" ]]; then
     rm -rf "${INSTALL_DIR}"
     rm -f "${BIN_PATH}"
+    mapfile -t files_to_delete < <(find /files/bin -type l -exec bash -c '
+        for link; do
+            target=$(readlink "$link")
+            if [[ "$target" == /files/opt/java/* ]]; then
+              echo "$link"
+            fi
+        done
+    ' _ {} +)
+    rm -rf "${files_to_delete[@]}"
 fi
 
 hash -r
@@ -34,7 +43,7 @@ if command -v java; then
     exit 1
 fi
 
-DOWNLOAD_URL='https://download.java.net/openjdk/jdk8u41/ri/openjdk-8u41-b04-linux-x64-14_jan_2020.tar.gz'
+DOWNLOAD_URL="https://download.java.net/openjdk/jdk25/ri/openjdk-25+36_linux-x64_bin.tar.gz"
 
 if [[ -e ${INSTALL_DIR} ]]; then
     echo "The install directory (${INSTALL_DIR}) already exists. This may mean java is already installed."


### PR DESCRIPTION
This PR fixes install_java.sh script to use newer version of Java. 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
