### PR TITLE
Fix log text selection contrast in light mode

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
@@ -114,11 +114,6 @@ export const TaskLogContent = ({ error, isLoading, logError, parsedLogs, wrap }:
       <ErrorAlert error={error ?? logError} />
       <ProgressBar size="xs" visibility={isLoading ? "visible" : "hidden"} />
       <Code
-        css={{
-          "& *::selection": {
-            bg: "gray.emphasized",
-          },
-        }}
         data-testid="virtualized-list"
         flexGrow={1}
         h="auto"

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
@@ -116,7 +116,7 @@ export const TaskLogContent = ({ error, isLoading, logError, parsedLogs, wrap }:
       <Code
         css={{
           "& *::selection": {
-            bg: "brand.subtle",
+            bg: "gray.emphasized",
           },
         }}
         data-testid="virtualized-list"


### PR DESCRIPTION
Remove CSS prop to improve readability when highlighting text in the log viewer.
This aligns with the DAG code viewer styling and provides better
contrast across both light and dark themes.
  
Before: (yes the lines are highlighted but you cant see it!!)

<img width="1918" height="871" alt="image" src="https://github.com/user-attachments/assets/6f44fe9c-abfb-4266-a65a-0488f9c5b6a5" />

After: 
<img width="1917" height="1032" alt="image" src="https://github.com/user-attachments/assets/04605c95-6fab-4ad6-8e7e-e2c7ec1cdef4" />

<img width="1917" height="925" alt="image" src="https://github.com/user-attachments/assets/6368e8ff-d61a-45ef-95da-ca9eb945151a" />
