### PR TITLE
Add revoke_task implementation to EdgeExecutor for task queued timeout support

### DIFF
--- a/providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py
+++ b/providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py
@@ -426,7 +426,6 @@ class EdgeExecutor(BaseExecutor):
                 EdgeJobModel.try_number == ti.try_number,
             )
         )
-        session.commit()
         self.log.info("Revoked task instance %s from EdgeExecutor", ti.key)
 
     def try_adopt_task_instances(self, tis: Sequence[TaskInstance]) -> Sequence[TaskInstance]:

--- a/providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py
+++ b/providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py
@@ -399,6 +399,36 @@ class EdgeExecutor(BaseExecutor):
     def terminate(self):
         """Terminate the executor is not doing anything."""
 
+    @provide_session
+    def revoke_task(self, *, ti: TaskInstance, session: Session = NEW_SESSION):
+        """
+        Revoke a task instance from the executor.
+
+        This method removes the task from the executor's internal state and deletes
+        the corresponding EdgeJobModel record to prevent edge workers from picking it up.
+
+        :param ti: Task instance to revoke
+        :param session: Database session
+        """
+        # Remove from executor's internal state
+        self.running.discard(ti.key)
+        self.queued_tasks.pop(ti.key, None)
+        if ti.key in self.last_reported_state:
+            del self.last_reported_state[ti.key]
+
+        # Delete the job from the database to prevent edge workers from picking it up
+        session.execute(
+            delete(EdgeJobModel).where(
+                EdgeJobModel.dag_id == ti.dag_id,
+                EdgeJobModel.task_id == ti.task_id,
+                EdgeJobModel.run_id == ti.run_id,
+                EdgeJobModel.map_index == ti.map_index,
+                EdgeJobModel.try_number == ti.try_number,
+            )
+        )
+        session.commit()
+        self.log.info("Revoked task instance %s from EdgeExecutor", ti.key)
+
     def try_adopt_task_instances(self, tis: Sequence[TaskInstance]) -> Sequence[TaskInstance]:
         """
         Try to adopt running task instances that have been abandoned by a SchedulerJob dying.


### PR DESCRIPTION
EdgeExecutor was not implementing the revoke_task() method, causing it to raise NotImplementedError when the scheduler attempted to handle tasks stuck in queued state. This meant the task_queued_timeout feature was completely bypassed for EdgeExecutor.

This commit implements revoke_task() to:
  - Remove tasks from executor's internal state (running, queued_tasks, last_reported_state)
  - Delete corresponding EdgeJobModel records to prevent edge workers from picking them up
  - Enable proper task queued timeout handling by the scheduler
  
Before: 
<img width="1461" height="583" alt="image" src="https://github.com/user-attachments/assets/c09ae6f8-22f4-4c87-b47a-0744a1c17201" />

After:
<img width="1915" height="932" alt="image" src="https://github.com/user-attachments/assets/f7fa37e2-79a1-4812-bfe9-9fd2dc411ba3" />

