### PR TITLE
Disable Gantt view by default

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -74,7 +74,7 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
     undefined,
   );
 
-  const [showGantt, setShowGantt] = useLocalStorage<boolean>(`show_gantt-${dagId}`, true);
+  const [showGantt, setShowGantt] = useLocalStorage<boolean>(`show_gantt-${dagId}`, false);
   const { fitView, getZoom } = useReactFlow();
   const { data: warningData } = useDagWarningServiceListDagWarnings({ dagId });
   const { onClose, onOpen, open } = useDisclosure();


### PR DESCRIPTION
Gantt view is great to get insight on runtimes for a given dag run. However, user may not want to see gantt chart for every dag run they click on by default. It also moves around the grid view which can be annoying when you are trying to quickly look at some results. 

This feature is best when its default state is OFF and can be turned on as needed.

<img width="852" height="642" alt="image" src="https://github.com/user-attachments/assets/594eeaad-3f77-4952-86a4-a86994b79ec6" />
