### PR TITLE
Fix XCom object storage backend path validation

### DIFF
--- a/providers/common/io/src/airflow/providers/common/io/xcom/backend.py
+++ b/providers/common/io/src/airflow/providers/common/io/xcom/backend.py
@@ -20,7 +20,6 @@ import contextlib
 import json
 import uuid
 from functools import cache
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar
 from urllib.parse import urlsplit
 
@@ -102,7 +101,7 @@ class XComObjectStorageBackend(BaseXCom):
             raise TypeError(f"Not a valid url: {data}") from None
 
         if url.scheme:
-            if not Path.is_relative_to(ObjectStoragePath(data), p):
+            if not ObjectStoragePath(data).is_relative_to(p):
                 raise ValueError(f"Invalid key: {data}")
             return p / data.replace(str(p), "", 1).lstrip("/")
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


`universal_pathlib` releases a 0.3.0 version and that added `pathlib_abc==0.5.1` in it,  which introduced stricter type checking on Path objects.


The original code was calling `is_relative_to()` incorrectly on `Path` objects leading to error:

```
  Using airflow version from current sources

  providers/common/io/src/airflow/providers/common/io/xcom/backend.py:105: error: Argument 1 to "is_relative_to" of "PurePath" has incompatible type "ObjectStoragePath"; expected "PurePath"  [arg-type]
                  if not Path.is_relative_to(ObjectStoragePath(data), p):
                                             ^~~~~~~~~~~~~~~~~~~~~~~
  providers/common/io/src/airflow/providers/common/io/xcom/backend.py:105: error: Argument 2 to "is_relative_to" of "PurePath" has incompatible type "ObjectStoragePath"; expected "str | PathLike[str]" 
  [arg-type]
                  if not Path.is_relative_to(ObjectStoragePath(data), p):
                                                                      ^
  Found 2 errors in 1 file (checked 3984 source files)

```

I have changed to call it as an instance method on the ObjectStoragePath object itself.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
