### PR TITLE
[UI] Allow copying text in Log view(remove user-select: none)

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/renderStructuredLog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/renderStructuredLog.tsx
@@ -233,15 +233,13 @@ export const renderStructuredLog = ({
           marginInlineEnd: "10px",
           paddingInlineEnd: "5px",
           textAlign: "end",
-          userSelect: "none",
-          WebkitUserSelect: "none",
           width: "3em",
         }}
         to={`${logLink}#${index}`}
       >
         {index}
       </RouterLink>
-      <chakra.span overflow="auto" whiteSpace="pre-wrap" width="100%">
+      <chakra.span overflow="auto" whiteSpace="pre-wrap" width="100%" userSelect="text">
         {elements}
       </chakra.span>
     </chakra.div>


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Related #56248 

What changed? 
- Removed the CSS properties that disabled text selection (userSelect: none, WebkitUserSelect: none).

- Updated the <chakra.span> to explicitly allow text selection by using userSelect="text".


---
How to test 
1. Run Airflow webserver.

2. Trigger a DAG run that produces some logs.

3. Open any task’s log view.

4. Try selecting/copying log lines with your mouse or keyboard.
	

<img width="877" height="148" alt="image" src="https://github.com/user-attachments/assets/03c7afc3-3cca-4dd1-9831-ab860cb3fbc3" />
