### PR TITLE
Fix SQLA Mapped type import errors in model classes

### DIFF
--- a/airflow-core/src/airflow/models/dag_favorite.py
+++ b/airflow-core/src/airflow/models/dag_favorite.py
@@ -17,15 +17,11 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from sqlalchemy import ForeignKey
+from sqlalchemy.orm import Mapped  # noqa: TC002
 
 from airflow.models.base import Base, StringID
 from airflow.utils.sqlalchemy import mapped_column
-
-if TYPE_CHECKING:
-    from sqlalchemy.orm import Mapped
 
 
 class DagFavorite(Base):

--- a/airflow-core/src/airflow/models/db_callback_request.py
+++ b/airflow-core/src/airflow/models/db_callback_request.py
@@ -21,14 +21,13 @@ from importlib import import_module
 from typing import TYPE_CHECKING
 
 from sqlalchemy import Integer, String
+from sqlalchemy.orm import Mapped  # noqa: TC002
 
 from airflow._shared.timezones import timezone
 from airflow.models.base import Base
 from airflow.utils.sqlalchemy import ExtendedJSON, UtcDateTime, mapped_column
 
 if TYPE_CHECKING:
-    from sqlalchemy.orm import Mapped
-
     from airflow.callbacks.callback_requests import CallbackRequest
 
 

--- a/airflow-core/src/airflow/models/errors.py
+++ b/airflow-core/src/airflow/models/errors.py
@@ -17,16 +17,12 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from sqlalchemy import Integer, String, Text
+from sqlalchemy.orm import Mapped  # noqa: TC002
 
 from airflow.dag_processing.bundles.manager import DagBundlesManager
 from airflow.models.base import Base, StringID
 from airflow.utils.sqlalchemy import UtcDateTime, mapped_column
-
-if TYPE_CHECKING:
-    from sqlalchemy.orm import Mapped
 
 
 class ParseImportError(Base):

--- a/airflow-core/src/airflow/models/pool.py
+++ b/airflow-core/src/airflow/models/pool.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, TypedDict
 
 from sqlalchemy import Boolean, ForeignKey, Integer, String, Text, func, select
+from sqlalchemy.orm import Mapped  # noqa: TC002
 from sqlalchemy_utils import UUIDType
 
 from airflow.exceptions import AirflowException, PoolNotFound
@@ -32,7 +33,6 @@ from airflow.utils.sqlalchemy import mapped_column, with_row_locks
 from airflow.utils.state import TaskInstanceState
 
 if TYPE_CHECKING:
-    from sqlalchemy.orm import Mapped
     from sqlalchemy.orm.session import Session
 
 

--- a/airflow-core/src/airflow/models/tasklog.py
+++ b/airflow-core/src/airflow/models/tasklog.py
@@ -17,16 +17,12 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from sqlalchemy import Integer, Text
+from sqlalchemy.orm import Mapped  # noqa: TC002
 
 from airflow._shared.timezones import timezone
 from airflow.models.base import Base
 from airflow.utils.sqlalchemy import UtcDateTime, mapped_column
-
-if TYPE_CHECKING:
-    from sqlalchemy.orm import Mapped
 
 
 class LogTemplate(Base):

--- a/airflow-core/src/airflow/models/taskmap.py
+++ b/airflow-core/src/airflow/models/taskmap.py
@@ -25,6 +25,7 @@ from collections.abc import Collection, Iterable, Sequence
 from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import CheckConstraint, ForeignKeyConstraint, Integer, String, func, or_, select
+from sqlalchemy.orm import Mapped  # noqa: TC002
 
 from airflow.models.base import COLLATION_ARGS, ID_LEN, TaskInstanceDependencies
 from airflow.models.dag_version import DagVersion
@@ -33,7 +34,7 @@ from airflow.utils.sqlalchemy import ExtendedJSON, mapped_column, with_row_locks
 from airflow.utils.state import State, TaskInstanceState
 
 if TYPE_CHECKING:
-    from sqlalchemy.orm import Mapped, Session
+    from sqlalchemy.orm import Session
 
     from airflow.models.mappedoperator import MappedOperator
     from airflow.models.taskinstance import TaskInstance


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

SQLAlchemy requires the Mapped type to be available at runtime when processing
class annotations, but several model files imported it only in TYPE_CHECKING
blocks. This caused NameError exceptions during database initialization. CI broken with error:

```
  /opt/airflow/airflow-core/src/airflow/dag_processing/dagbag.py:40 DeprecationWarning: airflow.exceptions.AirflowDagCycleException is deprecated. Use airflow.sdk.exceptions.AirflowDagCycleException instead.
  Traceback (most recent call last):
    File "/usr/python/lib/python3.13/site-packages/sqlalchemy/util/typing.py", line 306, in eval_name_only
      return base_globals[name]
             ~~~~~~~~~~~~^^^^^^
  KeyError: 'Mapped'
  
  The above exception was the direct cause of the following exception:
  
  Traceback (most recent call last):
    File "/usr/python/lib/python3.13/site-packages/sqlalchemy/orm/util.py", line 2221, in _cleanup_mapped_str_annotation
      obj = eval_name_only(mm.group(1), originating_module)
    File "/usr/python/lib/python3.13/site-packages/sqlalchemy/util/typing.py", line 314, in eval_name_only
      raise NameError(
          f"Could not locate name {name} in module {module_name}"
      ) from ke
  NameError: Could not locate name Mapped in module airflow.models.taskmap
  
  The above exception was the direct cause of the following exception:
  
  Traceback (most recent call last):
    File "/usr/python/lib/python3.13/site-packages/sqlalchemy/orm/util.py", line 2323, in _extract_mapped_subtype
      annotated = de_stringify_annotation(
          cls,
      ...<2 lines>...
          str_cleanup_fn=_cleanup_mapped_str_annotation,
      )
    File "/usr/python/lib/python3.13/site-packages/sqlalchemy/util/typing.py", line 156, in de_stringify_annotation
      annotation = str_cleanup_fn(annotation, originating_module)
    File "/usr/python/lib/python3.13/site-packages/sqlalchemy/orm/util.py", line 2223, in _cleanup_mapped_str_annotation
      raise _CleanupError(
      ...<4 lines>...
      ) from ne
  sqlalchemy.orm.util._CleanupError: For annotation "Mapped[str]", could not resolve container type "Mapped".  Please ensure this type is imported at the module level outside of TYPE_CHECKING blocks
  
  The above exception was the direct cause of the following exception:
  
  Traceback (most recent call last):
    File "/usr/python/bin/airflow", line 4, in <module>
      from airflow.__main__ import main
    File "/opt/airflow/airflow-core/src/airflow/__main__.py", line 37, in <module>
      from airflow.cli import cli_parser
    File "/opt/airflow/airflow-core/src/airflow/cli/cli_parser.py", line 40, in <module>
      from airflow.cli.cli_config import (
      ...<5 lines>...
      )
    File "/opt/airflow/airflow-core/src/airflow/cli/cli_config.py", line 36, in <module>
      from airflow.utils.cli import ColorMode
    File "/opt/airflow/airflow-core/src/airflow/utils/cli.py", line 39, in <module>
      from airflow.dag_processing.dagbag import DagBag
    File "/opt/airflow/airflow-core/src/airflow/dag_processing/dagbag.py", line 52, in <module>
      from airflow.serialization.serialized_objects import LazyDeserializedDAG
    File "/opt/airflow/airflow-core/src/airflow/serialization/serialized_objects.py", line 69, in <module>
      from airflow.models.dag import DagModel
    File "/opt/airflow/airflow-core/src/airflow/models/dag.py", line 55, in <module>
      from airflow.models.dagrun import DagRun
    File "/opt/airflow/airflow-core/src/airflow/models/dagrun.py", line 63, in <module>
      from airflow.models import Deadline, Log
    File "<frozen importlib._bootstrap>", line 1412, in _handle_fromlist
    File "/opt/airflow/airflow-core/src/airflow/models/__init__.py", line 85, in __getattr__
      val = import_string(f"{path}.{name}")
    File "/opt/airflow/airflow-core/src/airflow/utils/module_loading.py", line 41, in import_string
      module = import_module(module_path)
    File "/usr/python/lib/python3.13/importlib/__init__.py", line 88, in import_module
      return _bootstrap._gcd_import(name[level:], package, level)
             ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/opt/airflow/airflow-core/src/airflow/models/deadline.py", line 35, in <module>
      from airflow.models import Trigger
    File "<frozen importlib._bootstrap>", line 1412, in _handle_fromlist
    File "/opt/airflow/airflow-core/src/airflow/models/__init__.py", line 85, in __getattr__
      val = import_string(f"{path}.{name}")
    File "/opt/airflow/airflow-core/src/airflow/utils/module_loading.py", line 41, in import_string
      module = import_module(module_path)
    File "/usr/python/lib/python3.13/importlib/__init__.py", line 88, in import_module
      return _bootstrap._gcd_import(name[level:], package, level)
             ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/opt/airflow/airflow-core/src/airflow/models/trigger.py", line 36, in <module>
      from airflow.models.taskinstance import TaskInstance
    File "/opt/airflow/airflow-core/src/airflow/models/taskinstance.py", line 81, in <module>
      from airflow.models.taskmap import TaskMap
    File "/opt/airflow/airflow-core/src/airflow/models/taskmap.py", line 55, in <module>
      class TaskMap(TaskInstanceDependencies):
      ...<216 lines>...
              return all_expanded_tis, total_expanded_ti_count - 1
    File "/usr/python/lib/python3.13/site-packages/sqlalchemy/orm/decl_api.py", line 198, in __init__
      _as_declarative(reg, cls, dict_)
      ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
    File "/usr/python/lib/python3.13/site-packages/sqlalchemy/orm/decl_base.py", line 245, in _as_declarative
      return _MapperConfig.setup_mapping(registry, cls, dict_, None, {})
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/python/lib/python3.13/site-packages/sqlalchemy/orm/decl_base.py", line 326, in setup_mapping
      return _ClassScanMapperConfig(
          registry, cls_, dict_, table, mapper_kw
      )
    File "/usr/python/lib/python3.13/site-packages/sqlalchemy/orm/decl_base.py", line 562, in __init__
      self._scan_attributes()
      ~~~~~~~~~~~~~~~~~~~~~^^
    File "/usr/python/lib/python3.13/site-packages/sqlalchemy/orm/decl_base.py", line 1022, in _scan_attributes
      collected_annotation = self._collect_annotation(
          name, annotation, base, None, obj
      )
    File "/usr/python/lib/python3.13/site-packages/sqlalchemy/orm/decl_base.py", line 1302, in _collect_annotation
      extracted = _extract_mapped_subtype(
          raw_annotation,
      ...<6 lines>...
          expect_mapped=expect_mapped and not is_dataclass,
      )
    File "/usr/python/lib/python3.13/site-packages/sqlalchemy/orm/util.py", line 2330, in _extract_mapped_subtype
      raise orm_exc.MappedAnnotationError(
      ...<3 lines>...
      ) from ce
  sqlalchemy.orm.exc.MappedAnnotationError: Could not interpret annotation Mapped[str].  Check that it uses names that are correctly imported at the module level. See chained stack trace for more hints.
  
  Error: check_environment returned 1. Exiting.
  
```

Example: https://github.com/apache/airflow/actions/runs/18125410465/job/51580394658

Seems to be caused by: #55954

The reason is that: 





<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
