### PR TITLE
Fix SQLA Mapped datetime imports in models

### DIFF
--- a/airflow-core/src/airflow/models/backfill.py
+++ b/airflow-core/src/airflow/models/backfill.py
@@ -24,6 +24,7 @@ Internal classes for management of dag backfills.
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING
 
@@ -51,8 +52,6 @@ from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 if TYPE_CHECKING:
-    from datetime import datetime
-
     from airflow.serialization.serialized_objects import SerializedDAG
     from airflow.timetables.base import DagRunInfo
 

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -22,6 +22,7 @@ import os
 import re
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator, Sequence
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar, cast, overload
 
 import structlog
@@ -85,7 +86,6 @@ from airflow.utils.thread_safe_dict import ThreadSafeDict
 from airflow.utils.types import NOTSET, DagRunTriggeredByType, DagRunType
 
 if TYPE_CHECKING:
-    from datetime import datetime
     from typing import Literal, TypeAlias
 
     from opentelemetry.sdk.trace import Span


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Along similar vein as https://github.com/apache/airflow/pull/56253

Latest issue: 
```
  NameError: Could not de-stringify annotation 'datetime | None'
  
  The above exception was the direct cause of the following exception:
  
  Traceback (most recent call last):
    File "/usr/python/bin/airflow", line 4, in <module>
      from airflow.__main__ import main
    File "/opt/airflow/airflow-core/src/airflow/__main__.py", line 37, in <module>
      from airflow.cli import cli_parser
    File "/opt/airflow/airflow-core/src/airflow/cli/cli_parser.py", line 40, in <module>
      from airflow.cli.cli_config import (
      ...<5 lines>...
      )
    File "/opt/airflow/airflow-core/src/airflow/cli/cli_config.py", line 36, in <module>
      from airflow.utils.cli import ColorMode
    File "/opt/airflow/airflow-core/src/airflow/utils/cli.py", line 39, in <module>
      from airflow.dag_processing.dagbag import DagBag
    File "/opt/airflow/airflow-core/src/airflow/dag_processing/dagbag.py", line 52, in <module>
      from airflow.serialization.serialized_objects import LazyDeserializedDAG
    File "/opt/airflow/airflow-core/src/airflow/serialization/serialized_objects.py", line 69, in <module>
      from airflow.models.dag import DagModel
    File "/opt/airflow/airflow-core/src/airflow/models/dag.py", line 55, in <module>
      from airflow.models.dagrun import DagRun
    File "/opt/airflow/airflow-core/src/airflow/models/dagrun.py", line 64, in <module>
      from airflow.models.backfill import Backfill
    File "/opt/airflow/airflow-core/src/airflow/models/backfill.py", line 114, in <module>
      class Backfill(Base):
      ...<39 lines>...
              return f"Backfill({self.dag_id=}, {self.from_date=}, {self.to_date=})"
    File "/usr/python/lib/python3.13/site-packages/sqlalchemy/orm/decl_api.py", line 198, in __init__
      _as_declarative(reg, cls, dict_)
      ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
    File "/usr/python/lib/python3.13/site-packages/sqlalchemy/orm/decl_base.py", line 245, in _as_declarative
      return _MapperConfig.setup_mapping(registry, cls, dict_, None, {})
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/python/lib/python3.13/site-packages/sqlalchemy/orm/decl_base.py", line 326, in setup_mapping
      return _ClassScanMapperConfig(
          registry, cls_, dict_, table, mapper_kw
      )
    File "/usr/python/lib/python3.13/site-packages/sqlalchemy/orm/decl_base.py", line 573, in __init__
      self._extract_mappable_attributes()
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
    File "/usr/python/lib/python3.13/site-packages/sqlalchemy/orm/decl_base.py", line 1579, in _extract_mappable_attributes
      raise orm_exc.MappedAnnotationError(
      ...<4 lines>...
      ) from ne
  sqlalchemy.orm.exc.MappedAnnotationError: Could not resolve all types within mapped annotation: "Mapped[datetime | None]".  Ensure all types are written correctly and are imported within the module in use.
  
  Error: check_environment returned 1. Exiting.
  
```


Example: https://github.com/apache/airflow/actions/runs/18135253335/job/51613587395

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
