### PR TITLE
Only import OL plugin listeners/hooks if OL is enabled

### DIFF
--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/openlineage.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/openlineage.py
@@ -18,16 +18,20 @@ from __future__ import annotations
 
 from airflow.plugins_manager import AirflowPlugin
 from airflow.providers.openlineage import conf
-from airflow.providers.openlineage.plugins.listener import get_openlineage_listener
-from airflow.providers.openlineage.plugins.macros import (
-    lineage_job_name,
-    lineage_job_namespace,
-    lineage_parent_id,
-    lineage_root_job_name,
-    lineage_root_parent_id,
-    lineage_root_run_id,
-    lineage_run_id,
-)
+
+# Conditional imports - only load expensive dependencies when plugin is enabled
+if not conf.is_disabled():
+    from airflow.lineage.hook import HookLineageReader
+    from airflow.providers.openlineage.plugins.listener import get_openlineage_listener
+    from airflow.providers.openlineage.plugins.macros import (
+        lineage_job_name,
+        lineage_job_namespace,
+        lineage_parent_id,
+        lineage_root_job_name,
+        lineage_root_parent_id,
+        lineage_root_run_id,
+        lineage_run_id,
+    )
 
 
 class OpenLineageProviderPlugin(AirflowPlugin):
@@ -50,8 +54,6 @@ class OpenLineageProviderPlugin(AirflowPlugin):
             lineage_root_parent_id,
         ]
         listeners = [get_openlineage_listener()]
-        from airflow.lineage.hook import HookLineageReader
-
         hook_lineage_readers = [HookLineageReader]
     else:
         macros = []


### PR DESCRIPTION
These imports ultimately aren't cheap - it results in ~80mb of memory use, so lets skip it unless the plugin is enabled.