### PR TITLE
pyproject docstring tweaks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -622,12 +622,12 @@ extend-select = [
 ]
 ignore = [
     "D100", # Unwanted; Docstring at the top of every file.
-    "D102", # TODO: Missing docstring in public method
-    "D103", # TODO: Missing docstring in public function
+    "D102", # Unwanted; Missing docstring in public method
+    "D103", # Unwanted; Missing docstring in public function
     "D104", # Unwanted; Docstring at the top of every `__init__.py` file.
     "D105", # Unwanted; See https://lists.apache.org/thread/8jbg1dd2lr2cfydtqbjxsd6pb6q2wkc3
     "D107", # Unwanted; Docstring in every constructor is unnecessary if the class has a docstring.
-    "D203",
+    "D203", # Conflicts with D211.  Both can not be enabled.
     "D212", # Conflicts with D213.  Both can not be enabled.
     "E731", # Do not assign a lambda expression, use a def
     "TC003", # Do not move imports from stdlib to TYPE_CHECKING block


### PR DESCRIPTION
Just a quick update on a couple of the comments.

- `102` and `103` are being left as they are per discussion back in July ([here](https://lists.apache.org/thread/lcvocwxnrrzq9ofrg4b4hj0yvpzbnygf)) and I thought this comment was already updated.  
- `203` I just added context on why we're not going to enable it, it conflicts with an existing rule.  `203` requires a black line before a class docstring, `D211` states no blank line; both can not be true and `211` is already implemented.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
