### PR TITLE
Check if any tasks have HITL operator before fetching HITL details

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/NeedsReviewButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/NeedsReviewButton.tsx
@@ -20,7 +20,7 @@ import { Box } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 import { LuUserRoundPen } from "react-icons/lu";
 
-import { useTaskInstanceServiceGetHitlDetails } from "openapi/queries";
+import { useHitlDetails } from "src/queries/useHitlDetails";
 import { useAutoRefresh } from "src/utils/query";
 
 import { StatsCard } from "./StatsCard";
@@ -34,23 +34,23 @@ export const NeedsReviewButton = ({
   readonly runId?: string;
   readonly taskId?: string;
 }) => {
-  const refetchInterval = useAutoRefresh({ checkPendingRuns: true, dagId });
+  // check pending runs if we don't have a dagId
+  const refetchInterval = useAutoRefresh({ checkPendingRuns: dagId === undefined, dagId });
 
-  const { data: hitlStatsData, isLoading } = useTaskInstanceServiceGetHitlDetails(
+  const { data: hitlData, isLoading } = useHitlDetails(
     {
-      dagId: dagId ?? "~",
-      dagRunId: runId ?? "~",
+      dagId,
+      dagRunId: runId,
       responseReceived: false,
       state: ["deferred"],
       taskId,
     },
-    undefined,
     {
       refetchInterval,
     },
   );
 
-  const hitlTIsCount = hitlStatsData?.hitl_details.length ?? 0;
+  const hitlTIsCount = hitlData?.hitl_details.length ?? 0;
   const { i18n, t: translate } = useTranslation("hitl");
 
   const isRTL = i18n.dir() === "rtl";

--- a/airflow-core/src/airflow/ui/src/hooks/useRequiredActionTabs.ts
+++ b/airflow-core/src/airflow/ui/src/hooks/useRequiredActionTabs.ts
@@ -20,7 +20,7 @@ import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router-dom";
 
-import { useTaskInstanceServiceGetHitlDetails } from "openapi/queries";
+import { useHitlDetails } from "src/queries/useHitlDetails";
 
 export type HITLQueryParams = {
   dagId: string;
@@ -49,10 +49,9 @@ export const useRequiredActionTabs = (
   const { autoRedirect = false, refetchInterval } = options;
   const location = useLocation();
   const navigate = useNavigate();
+  const { dagId, dagRunId, taskId, taskIdPattern } = hitlParams;
 
   const redirectPath = (() => {
-    const { dagId, dagRunId, taskId, taskIdPattern } = hitlParams;
-
     if (Boolean(dagId) && Boolean(dagRunId) && Boolean(taskId)) {
       return `/dags/${dagId}/runs/${dagRunId}/tasks/${taskId}`;
     }
@@ -70,16 +69,14 @@ export const useRequiredActionTabs = (
     return location.pathname.replace("/required_actions", "");
   })();
 
-  const { data: hitlData, isLoading: isLoadingHitl } = useTaskInstanceServiceGetHitlDetails(
+  const { data: hitlData, isLoading: isLoadingHitl } = useHitlDetails(
     {
-      dagId: hitlParams.dagId,
-      dagRunId: hitlParams.dagRunId ?? "~",
-      taskId: hitlParams.taskId,
-      taskIdPattern: hitlParams.taskIdPattern,
+      dagId,
+      dagRunId,
+      taskId,
+      taskIdPattern,
     },
-    undefined,
     {
-      enabled: Boolean(hitlParams.dagId),
       refetchInterval,
     },
   );

--- a/airflow-core/src/airflow/ui/src/queries/useHitlDetails.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useHitlDetails.ts
@@ -1,0 +1,73 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useTaskInstanceServiceGetHitlDetails, useTaskServiceGetTasks } from "openapi/queries";
+
+type HITLDetailsParams = {
+  dagId?: string;
+  dagRunId?: string;
+  responseReceived?: boolean;
+  state?: Array<string>;
+  taskId?: string;
+  taskIdPattern?: string;
+};
+
+type HITLDetailsOptions = {
+  refetchInterval?: number | false;
+};
+
+export const useHitlDetails = (params: HITLDetailsParams, options: HITLDetailsOptions = {}) => {
+  const { dagId, dagRunId, responseReceived, state, taskId, taskIdPattern } = params;
+  const { refetchInterval } = options;
+
+  // If there is a dagId, let's see if any tasks have HITL operators
+  const { data: tasksData } = useTaskServiceGetTasks({ dagId: dagId ?? "~" }, undefined, {
+    enabled: Boolean(dagId),
+  });
+
+  const hasHitlOperators = Boolean(
+    tasksData?.tasks.some((task) => {
+      const operatorName = task.operator_name;
+
+      // TODO: do this in the backend
+      return (
+        operatorName === "HITLOperator" ||
+        operatorName === "ApprovalOperator" ||
+        operatorName === "HITLEntryOperator" ||
+        operatorName === "HITLBranchOperator"
+      );
+    }),
+  );
+
+  return useTaskInstanceServiceGetHitlDetails(
+    {
+      dagId: dagId ?? "~",
+      dagRunId: dagRunId ?? "~",
+      responseReceived,
+      state,
+      taskId,
+      taskIdPattern,
+    },
+    undefined,
+    {
+      // Only refetch if any tasks have HITL operators
+      // keeping enabled in case the dag used to have HITL operators in a previous version
+      refetchInterval: hasHitlOperators ? refetchInterval : false,
+    },
+  );
+};


### PR DESCRIPTION
We were fetching HITL details too often.
I still feel like this is all too complicated and brittle. So I would love to explore ways to actually know more about a Dag/Run/Task so we only display necessary tabs. Or redesign the view to not need so many tabs.


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
