### PR TITLE
Enable PT011 rule to prvoider tests

### DIFF
--- a/providers/edge3/tests/unit/edge3/executors/test_edge_executor.py
+++ b/providers/edge3/tests/unit/edge3/executors/test_edge_executor.py
@@ -66,7 +66,7 @@ class TestEdgeExecutor:
     def test__process_tasks_bad_command(self):
         executor, key = self.get_test_executor()
         task_tuple = (key, ["hello", "world"], None, None)
-        with pytest.raises(ValueError, match="Command should start with "):
+        with pytest.raises(ValueError, match=r"The command must start with \['airflow', 'tasks', 'run'\]."):
             executor._process_tasks([task_tuple])
 
     @pytest.mark.skipif(AIRFLOW_V_3_0_PLUS, reason="_process_tasks is not used in Airflow 3.0+")

--- a/providers/edge3/tests/unit/edge3/executors/test_edge_executor.py
+++ b/providers/edge3/tests/unit/edge3/executors/test_edge_executor.py
@@ -66,7 +66,7 @@ class TestEdgeExecutor:
     def test__process_tasks_bad_command(self):
         executor, key = self.get_test_executor()
         task_tuple = (key, ["hello", "world"], None, None)
-        with pytest.raises(ValueError, match="Command should start with 'airflow'"):
+        with pytest.raises(ValueError, match="Command should start with "):
             executor._process_tasks([task_tuple])
 
     @pytest.mark.skipif(AIRFLOW_V_3_0_PLUS, reason="_process_tasks is not used in Airflow 3.0+")

--- a/providers/edge3/tests/unit/edge3/executors/test_edge_executor.py
+++ b/providers/edge3/tests/unit/edge3/executors/test_edge_executor.py
@@ -66,7 +66,7 @@ class TestEdgeExecutor:
     def test__process_tasks_bad_command(self):
         executor, key = self.get_test_executor()
         task_tuple = (key, ["hello", "world"], None, None)
-        with pytest.raises(ValueError, match=r"The command must start with \['airflow', 'tasks', 'run'\]."):
+        with pytest.raises(ValueError, match="The command must start with "):
             executor._process_tasks([task_tuple])
 
     @pytest.mark.skipif(AIRFLOW_V_3_0_PLUS, reason="_process_tasks is not used in Airflow 3.0+")

--- a/providers/edge3/tests/unit/edge3/executors/test_edge_executor.py
+++ b/providers/edge3/tests/unit/edge3/executors/test_edge_executor.py
@@ -28,7 +28,11 @@ from airflow.models.taskinstancekey import TaskInstanceKey
 from airflow.providers.edge3.executors.edge_executor import EdgeExecutor
 from airflow.providers.edge3.models.edge_job import EdgeJobModel
 from airflow.providers.edge3.models.edge_worker import EdgeWorkerModel, EdgeWorkerState
-from airflow.utils import timezone
+
+try:
+    from airflow.sdk import timezone
+except ImportError:
+    from airflow.utils import timezone  # type: ignore[attr-defined,no-redef]
 from airflow.utils.session import create_session
 from airflow.utils.state import TaskInstanceState
 
@@ -62,7 +66,7 @@ class TestEdgeExecutor:
     def test__process_tasks_bad_command(self):
         executor, key = self.get_test_executor()
         task_tuple = (key, ["hello", "world"], None, None)
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Command should start with 'airflow'"):
             executor._process_tasks([task_tuple])
 
     @pytest.mark.skipif(AIRFLOW_V_3_0_PLUS, reason="_process_tasks is not used in Airflow 3.0+")

--- a/providers/elasticsearch/tests/unit/elasticsearch/log/test_es_task_handler.py
+++ b/providers/elasticsearch/tests/unit/elasticsearch/log/test_es_task_handler.py
@@ -162,7 +162,7 @@ class TestElasticsearchTaskHandler:
         Test the format_url method of the ElasticsearchTaskHandler class.
         """
         if expected == "ValueError":
-            with pytest.raises(ValueError):
+            with pytest.raises(ValueError, match="'https://' is not a valid URL."):
                 assert ElasticsearchTaskHandler.format_url(host) == expected
         else:
             assert ElasticsearchTaskHandler.format_url(host) == expected

--- a/providers/exasol/tests/unit/exasol/hooks/test_exasol.py
+++ b/providers/exasol/tests/unit/exasol/hooks/test_exasol.py
@@ -99,7 +99,7 @@ class TestExasolHookSqlalchemy:
         if not expect_error:
             assert hook.sqlalchemy_scheme == expected_result
         else:
-            with pytest.raises(ValueError):
+            with pytest.raises(ValueError, match="sqlalchemy_scheme in connection extra should be one of"):
                 _ = hook.sqlalchemy_scheme
 
     @pytest.mark.parametrize(
@@ -213,9 +213,8 @@ class TestExasolHook:
         self.conn.commit.assert_not_called()
 
     def test_run_no_queries(self):
-        with pytest.raises(ValueError) as err:
+        with pytest.raises(ValueError, match="List of SQL statements is empty"):
             self.db_hook.run(sql=[])
-        assert err.value.args[0] == "List of SQL statements is empty"
 
     def test_no_result_set(self):
         """Queries like DROP and SELECT are of type rowCount (not resultSet),

--- a/providers/exasol/tests/unit/exasol/hooks/test_sql.py
+++ b/providers/exasol/tests/unit/exasol/hooks/test_sql.py
@@ -285,6 +285,5 @@ def test_query(
 def test_no_query(empty_statement):
     dbapi_hook = ExasolHookForTests()
     dbapi_hook.get_conn.return_value.cursor.rowcount = lambda: 0
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError, match="List of SQL statements is empty"):
         dbapi_hook.run(sql=empty_statement)
-    assert err.value.args[0] == "List of SQL statements is empty"

--- a/providers/ftp/tests/unit/ftp/operators/test_ftp.py
+++ b/providers/ftp/tests/unit/ftp/operators/test_ftp.py
@@ -168,7 +168,7 @@ class TestFTPFileTransmitOperator:
             task_1.execute(None)
 
     def test_unequal_local_remote_file_paths(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="1 paths in local_filepath != 2 paths in remote_filepath"):
             FTPFileTransmitOperator(
                 task_id="test_ftp_unequal_paths",
                 ftp_conn_id=DEFAULT_CONN_ID,
@@ -176,7 +176,7 @@ class TestFTPFileTransmitOperator:
                 remote_filepath=["/tmp/test1", "/tmp/test2"],
             ).execute(None)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="2 paths in local_filepath != 1 paths in remote_filepath"):
             FTPFileTransmitOperator(
                 task_id="test_ftp_unequal_paths",
                 ftp_conn_id=DEFAULT_CONN_ID,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
issue: Enable Even More PyDocStyle Checks #40567
@ferruzzi
This PR is for enable PT011 rule:
PT011: all instances of pytest.raises should include a match term to make sure they are catching the right error.
https://docs.astral.sh/ruff/rules/pytest-raises-too-broad/
There are 102 files changes is need.
So, I separate to many PR, which contains about 5 file changes for easy review.
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
