### PR TITLE
Fix Dataflow Java system test and link inside the operator

### DIFF
--- a/providers/apache/beam/src/airflow/providers/apache/beam/operators/beam.py
+++ b/providers/apache/beam/src/airflow/providers/apache/beam/operators/beam.py
@@ -458,7 +458,12 @@ class BeamRunPythonPipelineOperator(BeamBasePipelineOperator):
         )
 
         location = self.dataflow_config.location or DEFAULT_DATAFLOW_LOCATION
-        DataflowJobLink.persist(context=context, region=location)
+        DataflowJobLink.persist(
+            context=context,
+            region=self.dataflow_config.location,
+            job_id=self.dataflow_job_id,
+            project_id=self.dataflow_config.project_id,
+        )
 
         if self.deferrable:
             trigger_args = {
@@ -648,7 +653,12 @@ class BeamRunJavaPipelineOperator(BeamBasePipelineOperator):
                 is_dataflow_job_id_exist_callback=self.is_dataflow_job_id_exist_callback,
             )
             if self.dataflow_job_name and self.dataflow_config.location:
-                DataflowJobLink.persist(context=context)
+                DataflowJobLink.persist(
+                    context=context,
+                    region=self.dataflow_config.location,
+                    job_id=self.dataflow_job_id,
+                    project_id=self.dataflow_config.project_id,
+                )
                 if self.deferrable:
                     trigger_args = {
                         "job_id": self.dataflow_job_id,

--- a/providers/apache/beam/tests/unit/apache/beam/operators/test_beam.py
+++ b/providers/apache/beam/tests/unit/apache/beam/operators/test_beam.py
@@ -247,7 +247,12 @@ class TestBeamRunPythonPipelineOperator:
         }
         gcs_provide_file.assert_any_call(object_url=PY_FILE)
         gcs_provide_file.assert_any_call(object_url=REQURIEMENTS_FILE)
-        persist_link_mock.assert_called_once_with(context={}, region="us-central1")
+        persist_link_mock.assert_called_once_with(
+            context={},
+            region="us-central1",
+            job_id=None,
+            project_id=dataflow_hook_mock.return_value.project_id,
+        )
         beam_hook_mock.return_value.start_python_pipeline.assert_called_once_with(
             variables=expected_options,
             py_file=gcs_provide_file.return_value.__enter__.return_value.name,
@@ -468,7 +473,12 @@ class TestBeamRunJavaPipelineOperator:
             "output": "gs://test/output",
             "impersonateServiceAccount": TEST_IMPERSONATION_ACCOUNT,
         }
-        persist_link_mock.assert_called_once_with(context={})
+        persist_link_mock.assert_called_once_with(
+            context={},
+            region="us-central1",
+            job_id=None,
+            project_id=dataflow_hook_mock.return_value.project_id,
+        )
         beam_hook_mock.return_value.start_java_pipeline.assert_called_once_with(
             variables=expected_options,
             jar=gcs_provide_file.return_value.__enter__.return_value.name,

--- a/providers/apache/beam/tests/unit/apache/beam/triggers/test_beam.py
+++ b/providers/apache/beam/tests/unit/apache/beam/triggers/test_beam.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import asyncio
 from unittest import mock
 
 import pytest
@@ -134,17 +135,41 @@ class TestBeamPythonPipelineTrigger:
         assert TriggerEvent({"status": "error", "message": "Test exception"}) == actual
 
     @pytest.mark.asyncio
-    async def test_beam_trigger_gcs_provide_file_should_execute_successfully(self, python_trigger):
+    async def test_beam_trigger_gcs_provide_file_should_execute_successfully(
+        self, python_trigger, monkeypatch
+    ):
         """
-        Test that BeamPythonPipelineTrigger downloads GCS provide file correct.
+        Test that BeamPythonPipelineTrigger downloads GCS provide file correctly with GCSAsyncHook.
         """
+        TEST_GCS_PY_FILE = "gs://bucket/path/file.py"
         python_trigger.py_file = TEST_GCS_PY_FILE
-        with mock.patch("airflow.providers.google.cloud.hooks.gcs.GCSHook") as mock_gcs_hook:
-            mock_gcs_hook.return_value.provide_file.return_value = "mocked_temp_file"
-            generator = python_trigger.run()
-            await generator.asend(None)
-            mock_gcs_hook.assert_called_once_with(gcp_conn_id=python_trigger.gcp_conn_id)
-            mock_gcs_hook.return_value.provide_file.assert_called_once_with(object_url=TEST_GCS_PY_FILE)
+
+        with mock.patch("airflow.providers.google.cloud.hooks.gcs.GCSAsyncHook") as MockAsyncHook:
+            async_hook_instance = MockAsyncHook.return_value
+
+            class DummyCM:
+                def __enter__(self):
+                    return "mocked_temp_file"
+
+                def __exit__(self, exc_type, exc, tb):
+                    return False
+
+            sync_hook = mock.Mock(name="SyncGCSHook")
+            sync_hook.provide_file.return_value = DummyCM()
+
+            async_hook_instance.get_sync_hook = mock.AsyncMock(return_value=sync_hook)
+
+            fake_loop = mock.Mock()
+            fake_loop.run_in_executor = mock.AsyncMock(return_value="mocked_temp_file")
+            monkeypatch.setattr(asyncio, "get_running_loop", lambda: fake_loop)
+
+            gen = python_trigger.run()
+            await gen.asend(None)
+
+            MockAsyncHook.assert_called_once_with(gcp_conn_id=python_trigger.gcp_conn_id)
+            async_hook_instance.get_sync_hook.assert_awaited_once()
+            sync_hook.provide_file.assert_called_once_with(object_url=TEST_GCS_PY_FILE)
+            fake_loop.run_in_executor.assert_awaited_once()
 
 
 class TestBeamJavaPipelineTrigger:
@@ -211,15 +236,35 @@ class TestBeamJavaPipelineTrigger:
         assert TriggerEvent({"status": "error", "message": "Test exception"}) == actual
 
     @pytest.mark.asyncio
-    async def test_beam_trigger_gcs_provide_file_should_execute_successfully(self, java_trigger):
+    async def test_beam_trigger_gcs_provide_file_should_execute_successfully(self, java_trigger, monkeypatch):
         """
-        Test that BeamJavaPipelineTrigger downloads GCS provide file correct.
+        Test that BeamJavaPipelineTrigger downloads GCS provide file correctly with GCSAsyncHook.
         """
         java_trigger.jar = TEST_GCS_JAR_FILE
 
-        with mock.patch("airflow.providers.google.cloud.hooks.gcs.GCSHook") as mock_gcs_hook:
-            mock_gcs_hook.return_value.provide_file.return_value = "mocked_temp_file"
-            generator = java_trigger.run()
-            await generator.asend(None)
-            mock_gcs_hook.assert_called_once_with(gcp_conn_id=java_trigger.gcp_conn_id)
-            mock_gcs_hook.return_value.provide_file.assert_called_once_with(object_url=TEST_GCS_JAR_FILE)
+        with mock.patch("airflow.providers.google.cloud.hooks.gcs.GCSAsyncHook") as MockAsyncHook:
+            async_hook_instance = MockAsyncHook.return_value
+
+            class DummyCM:
+                def __enter__(self):
+                    return "mocked_temp_file"
+
+                def __exit__(self, exc_type, exc, tb):
+                    return False
+
+            sync_hook = mock.Mock(name="SyncGCSHook")
+            sync_hook.provide_file.return_value = DummyCM()
+
+            async_hook_instance.get_sync_hook = mock.AsyncMock(return_value=sync_hook)
+
+            fake_loop = mock.Mock()
+            fake_loop.run_in_executor = mock.AsyncMock(return_value="mocked_temp_file")
+            monkeypatch.setattr(asyncio, "get_running_loop", lambda: fake_loop)
+
+            gen = java_trigger.run()
+            await gen.asend(None)
+
+            MockAsyncHook.assert_called_once_with(gcp_conn_id=java_trigger.gcp_conn_id)
+            async_hook_instance.get_sync_hook.assert_awaited_once()
+            sync_hook.provide_file.assert_called_once_with(object_url=TEST_GCS_JAR_FILE)
+            fake_loop.run_in_executor.assert_awaited_once()

--- a/providers/google/tests/system/google/cloud/dataflow/example_dataflow_native_java.py
+++ b/providers/google/tests/system/google/cloud/dataflow/example_dataflow_native_java.py
@@ -87,7 +87,7 @@ with DAG(
     # [START howto_operator_start_java_job_local_jar]
     start_java_job_direct = BeamRunJavaPipelineOperator(
         task_id="start_java_job_direct",
-        jar=LOCAL_JAR,
+        jar=GCS_JAR,
         pipeline_options={
             "output": GCS_OUTPUT,
         },
@@ -102,7 +102,7 @@ with DAG(
 
     start_java_job_direct_deferrable = BeamRunJavaPipelineOperator(
         task_id="start_java_job_direct_deferrable",
-        jar=GCS_JAR,
+        jar=LOCAL_JAR,
         pipeline_options={
             "output": GCS_OUTPUT,
         },


### PR DESCRIPTION
This PR:

 - fixes link in Dataflow Java operators
 - fixes system test
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
