### PR TITLE
nit: Bump required OL client to 1.38 for Openlineage provider

### DIFF
--- a/providers/dbt/cloud/tests/unit/dbt/cloud/utils/test_openlineage.py
+++ b/providers/dbt/cloud/tests/unit/dbt/cloud/utils/test_openlineage.py
@@ -157,6 +157,7 @@ class TestGenerateOpenLineageEventsFromDbtCloudRun:
             "data": {
                 "connection": {
                     "type": "snowflake",
+                    "name": "conn_name",
                     "details": {
                         "account": "gp21411.us-east-1",
                         "database": "SANDBOX",

--- a/providers/openlineage/pyproject.toml
+++ b/providers/openlineage/pyproject.toml
@@ -61,8 +61,8 @@ dependencies = [
     "apache-airflow-providers-common-sql>=1.20.0",
     "apache-airflow-providers-common-compat>=1.4.0",
     "attrs>=22.2",
-    "openlineage-integration-common>=1.36.0",
-    "openlineage-python>=1.36.0",
+    "openlineage-integration-common>=1.38.0",
+    "openlineage-python>=1.38.0",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Just a regular bump of OL client dependency.

Also fixing an OL related dbt cloud test, our mock of API response was not full, it does contain a name ([api doc](https://docs.getdbt.com/dbt-cloud/api-v3#/operations/Retrieve%20Project)).


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
