### PR TITLE
Default checkPendingRuns to false

### DIFF
--- a/airflow-core/src/airflow/ui/src/utils/query.ts
+++ b/airflow-core/src/airflow/ui/src/utils/query.ts
@@ -32,7 +32,7 @@ export const isStatePending = (state?: TaskInstanceState | null) =>
 
 // checkPendingRuns=false assumes that the component is already handling pending, setting to true will have useAutoRefresh handle it
 export const useAutoRefresh = ({
-  checkPendingRuns,
+  checkPendingRuns = false,
   dagId,
 }: {
   checkPendingRuns?: boolean;


### PR DESCRIPTION
In my auto refresh updates, I missed that `enabled: undefined` will default to true which is not what we want in this case. Now we explicitly default to false.


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
