### PR TITLE
[v3-1-test] Fix FAB provider name in auth manager section of release notes (#56301)

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -1210,7 +1210,7 @@ simplify onboarding:
 
 - ``catchup_by_default`` is now set to ``False`` by default. DAGs will not automatically backfill unless explicitly configured to do so.
 - ``create_cron_data_intervals`` is now set to ``False`` by default. As a result, cron expressions will be interpreted using the ``CronTriggerTimetable`` instead of the legacy ``CronDataIntervalTimetable``.
-- ``SimpleAuthManager`` is now the default ``auth_manager``. To continue using Flask AppBuilder-based authentication, install the ``apache-airflow-providers-flask-appbuilder`` provider and explicitly set ``auth_manager = airflow.providers.fab.auth_manager.FabAuthManager``.
+- ``SimpleAuthManager`` is now the default ``auth_manager``. To continue using Flask AppBuilder-based authentication, install the ``apache-airflow-providers-fab`` provider and explicitly set ``auth_manager = airflow.providers.fab.auth_manager.FabAuthManager``.
 
 These changes represent the most significant evolution of the Airflow platform since the release of 2.0 — setting the
 stage for more scalable, event-driven, and language-agnostic orchestration in the years ahead.

--- a/reproducible_build.yaml
+++ b/reproducible_build.yaml
@@ -1,2 +1,2 @@
-release-notes-hash: d60e2f01871dcc6f72f882d9a2411ec0
-source-date-epoch: 1758658051
+release-notes-hash: 12eeecae70eec5ee9772db72a9b06f89
+source-date-epoch: 1759358538


### PR DESCRIPTION
(cherry picked from commit c0deb211096c260e4e8f6cd9c1e7433892932a0f)
