### PR TITLE
attempt to update 3.0.1 release notes for serialization interface change

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -319,6 +319,22 @@ You can also use ``structlog`` loggers at the top level of modules etc, and ``st
 
 (You can't add arbitrary key/value pairs to ``stdlib``, but the normal ``percent-formatter`` approaches still work fine.)
 
+Serialization Interface Changes
+"""""""""""""""""""""""""""""""
+
+The deserializer interface in ``airflow.serialization.serializers`` has changed for improved security.
+
+**Before Airflow 3.1.0:**
+
+``def deserialize(classname: str, version: int, data: Any)``
+
+**Starting with Airflow 3.1.0:**
+
+``def deserialize(cls: type, version: int, data: Any)``
+
+The class loading is now handled in ``serde.py``, and the deserializer receives the loaded class directly rather than a ``classname`` string.
+This update avoids the use of ``import_string`` in the deserializer, making deserialization more secure.
+
 New Features
 ^^^^^^^^^^^^
 

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -324,11 +324,11 @@ Serialization Interface Changes
 
 The deserializer interface in ``airflow.serialization.serializers`` has changed for improved security.
 
-**Before Airflow 3.1.0:**
+**Before 3.1.0:**
 
 ``def deserialize(classname: str, version: int, data: Any)``
 
-**Starting with Airflow 3.1.0:**
+**Starting with 3.1.0:**
 
 ``def deserialize(cls: type, version: int, data: Any)``
 

--- a/reproducible_build.yaml
+++ b/reproducible_build.yaml
@@ -1,2 +1,2 @@
-release-notes-hash: 07082f3225cc822b8f456a377336d689
-source-date-epoch: 1759336130
+release-notes-hash: 41adbc9f67104d5f0b2cdfad3419ee8e
+source-date-epoch: 1759370088

--- a/reproducible_build.yaml
+++ b/reproducible_build.yaml
@@ -1,2 +1,2 @@
-release-notes-hash: 41adbc9f67104d5f0b2cdfad3419ee8e
-source-date-epoch: 1759370088
+release-notes-hash: decf692f4614345c187317f600697668
+source-date-epoch: 1759372174


### PR DESCRIPTION
Related to: #56215 

Attempt to update the release note to include the update to `deserialize` interface in the registered deserializer in `airflow.serialization.serializers` namespace as a significant change.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
