### PR TITLE
Add if_not_exists to index creation in migrations

### DIFF
--- a/providers/fab/src/airflow/providers/fab/migrations/versions/0001_1_4_0_create_ab_tables_if_missing.py
+++ b/providers/fab/src/airflow/providers/fab/migrations/versions/0001_1_4_0_create_ab_tables_if_missing.py
@@ -139,8 +139,8 @@ def upgrade() -> None:
         if_not_exists=True,
     )
     with op.batch_alter_table("ab_group_role", schema=None) as batch_op:
-        batch_op.create_index("idx_group_id", ["group_id"], unique=False)
-        batch_op.create_index("idx_group_role_id", ["role_id"], unique=False)
+        batch_op.create_index("idx_group_id", ["group_id"], unique=False, if_not_exists=True)
+        batch_op.create_index("idx_group_role_id", ["role_id"], unique=False, if_not_exists=True)
 
     op.create_table(
         "ab_permission_view",
@@ -175,8 +175,8 @@ def upgrade() -> None:
         if_not_exists=True,
     )
     with op.batch_alter_table("ab_user_group", schema=None) as batch_op:
-        batch_op.create_index("idx_user_group_id", ["group_id"], unique=False)
-        batch_op.create_index("idx_user_id", ["user_id"], unique=False)
+        batch_op.create_index("idx_user_group_id", ["group_id"], unique=False, if_not_exists=True)
+        batch_op.create_index("idx_user_id", ["user_id"], unique=False, if_not_exists=True)
 
     op.create_table(
         "ab_user_role",


### PR DESCRIPTION
closes:  #56327 . This is an extension of #56100

Adds if_not_exists=True during index creation ensuring completion of the migration script

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
