### PR TITLE
Identify duplicate kubernetes section airflow configuration and mark them as deprecated #36389 Add deprecation warnings for Kubernetes configuration options

### DIFF
--- a/airflow-core/newsfragments/36389.significant.rst
+++ b/airflow-core/newsfragments/36389.significant.rst
@@ -1,0 +1,11 @@
+Deprecate duplicate Kubernetes configuration options in favor of pod_template_file
+
+The following configuration options in the ``[kubernetes_executor]`` section are now deprecated and will be removed in a future version:
+
+* ``worker_container_repository`` - Use ``pod_template_file`` to specify the container image instead
+* ``worker_container_tag`` - Use ``pod_template_file`` to specify the container image instead  
+* ``namespace`` - Use ``pod_template_file`` to specify the namespace instead
+
+These options have been redundant since Airflow 2.0 when ``pod_template_file`` became the preferred method for configuring Kubernetes pods. Users should migrate to using ``pod_template_file`` for all pod configuration needs.
+
+Deprecation warnings will now be issued when these options are used with non-default values.

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/get_provider_info.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/get_provider_info.py
@@ -135,6 +135,8 @@ def get_provider_info():
                         "type": "string",
                         "example": None,
                         "default": "",
+                        "deprecated": True,
+                        "deprecation_reason": "Use 'pod_template_file' to specify the container image instead.",
                     },
                     "worker_container_tag": {
                         "description": "The tag of the Kubernetes Image for the Worker to Run\n",
@@ -142,6 +144,8 @@ def get_provider_info():
                         "type": "string",
                         "example": None,
                         "default": "",
+                        "deprecated": True,
+                        "deprecation_reason": "Use 'pod_template_file' to specify the container image instead.",
                     },
                     "namespace": {
                         "description": "The Kubernetes namespace where airflow workers should be created. Defaults to ``default``\n",
@@ -149,6 +153,8 @@ def get_provider_info():
                         "type": "string",
                         "example": None,
                         "default": "default",
+                        "deprecated": True,
+                        "deprecation_reason": "Use 'pod_template_file' to specify the namespace instead.",
                     },
                     "delete_worker_pods": {
                         "description": "If True, all worker pods will be deleted upon termination\n",

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/test_kube_config.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/test_kube_config.py
@@ -1,0 +1,242 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import warnings
+from unittest import mock
+
+import pytest
+
+from airflow.providers.cncf.kubernetes.kube_config import KubeConfig
+
+
+class TestKubeConfig:
+    """Test KubeConfig class."""
+
+    @mock.patch("airflow.providers.cncf.kubernetes.kube_config.conf")
+    def test_deprecated_worker_container_repository_warning(self, mock_conf):
+        """Test that deprecation warning is issued for worker_container_repository."""
+        # Set up mock configuration with deprecated field
+        mock_conf.get.side_effect = lambda section, key, fallback=None: {
+            ("kubernetes_executor", "worker_container_repository"): "my-repo",
+            ("kubernetes_executor", "worker_container_tag"): "",
+            ("kubernetes_executor", "namespace"): "default",
+            ("kubernetes_executor", "pod_template_file"): None,
+            ("kubernetes_executor", "worker_pod_pending_fatal_container_state_reasons"): "",
+            ("kubernetes_executor", "multi_namespace_mode_namespace_list"): None,
+            ("kubernetes_executor", "kube_client_request_args"): {},
+            ("kubernetes_executor", "delete_option_kwargs"): {},
+            ("core", "dags_folder"): "/tmp/dags",
+        }.get((section, key), fallback)
+
+        mock_conf.getboolean.side_effect = lambda section, key, fallback=None: {
+            ("kubernetes_executor", "delete_worker_pods"): True,
+            ("kubernetes_executor", "delete_worker_pods_on_failure"): False,
+            ("kubernetes_executor", "multi_namespace_mode"): False,
+        }.get((section, key), fallback)
+
+        mock_conf.getint.side_effect = lambda section, key, fallback=None: {
+            ("kubernetes_executor", "worker_pods_creation_batch_size"): 1,
+            ("core", "parallelism"): 32,
+        }.get((section, key), fallback)
+
+        mock_conf.getjson.side_effect = lambda section, key, fallback=None: {
+            ("kubernetes_executor", "kube_client_request_args"): {},
+            ("kubernetes_executor", "delete_option_kwargs"): {},
+        }.get((section, key), fallback)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            KubeConfig()
+
+            # Check that deprecation warning was issued
+            deprecation_warnings = [warning for warning in w if issubclass(warning.category, DeprecationWarning)]
+            assert len(deprecation_warnings) == 1
+            assert "worker_container_repository" in str(deprecation_warnings[0].message)
+            assert "deprecated" in str(deprecation_warnings[0].message)
+            assert "pod_template_file" in str(deprecation_warnings[0].message)
+
+    @mock.patch("airflow.providers.cncf.kubernetes.kube_config.conf")
+    def test_deprecated_worker_container_tag_warning(self, mock_conf):
+        """Test that deprecation warning is issued for worker_container_tag."""
+        # Set up mock configuration with deprecated field
+        mock_conf.get.side_effect = lambda section, key, fallback=None: {
+            ("kubernetes_executor", "worker_container_repository"): "",
+            ("kubernetes_executor", "worker_container_tag"): "my-tag",
+            ("kubernetes_executor", "namespace"): "default",
+            ("kubernetes_executor", "pod_template_file"): None,
+            ("kubernetes_executor", "worker_pod_pending_fatal_container_state_reasons"): "",
+            ("kubernetes_executor", "multi_namespace_mode_namespace_list"): None,
+            ("kubernetes_executor", "kube_client_request_args"): {},
+            ("kubernetes_executor", "delete_option_kwargs"): {},
+            ("core", "dags_folder"): "/tmp/dags",
+        }.get((section, key), fallback)
+
+        mock_conf.getboolean.side_effect = lambda section, key, fallback=None: {
+            ("kubernetes_executor", "delete_worker_pods"): True,
+            ("kubernetes_executor", "delete_worker_pods_on_failure"): False,
+            ("kubernetes_executor", "multi_namespace_mode"): False,
+        }.get((section, key), fallback)
+
+        mock_conf.getint.side_effect = lambda section, key, fallback=None: {
+            ("kubernetes_executor", "worker_pods_creation_batch_size"): 1,
+            ("core", "parallelism"): 32,
+        }.get((section, key), fallback)
+
+        mock_conf.getjson.side_effect = lambda section, key, fallback=None: {
+            ("kubernetes_executor", "kube_client_request_args"): {},
+            ("kubernetes_executor", "delete_option_kwargs"): {},
+        }.get((section, key), fallback)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            KubeConfig()
+
+            # Check that deprecation warning was issued
+            deprecation_warnings = [warning for warning in w if issubclass(warning.category, DeprecationWarning)]
+            assert len(deprecation_warnings) == 1
+            assert "worker_container_tag" in str(deprecation_warnings[0].message)
+            assert "deprecated" in str(deprecation_warnings[0].message)
+            assert "pod_template_file" in str(deprecation_warnings[0].message)
+
+    @mock.patch("airflow.providers.cncf.kubernetes.kube_config.conf")
+    def test_deprecated_namespace_warning(self, mock_conf):
+        """Test that deprecation warning is issued for non-default namespace."""
+        # Set up mock configuration with deprecated field
+        mock_conf.get.side_effect = lambda section, key, fallback=None: {
+            ("kubernetes_executor", "worker_container_repository"): "",
+            ("kubernetes_executor", "worker_container_tag"): "",
+            ("kubernetes_executor", "namespace"): "my-namespace",
+            ("kubernetes_executor", "pod_template_file"): None,
+            ("kubernetes_executor", "worker_pod_pending_fatal_container_state_reasons"): "",
+            ("kubernetes_executor", "multi_namespace_mode_namespace_list"): None,
+            ("kubernetes_executor", "kube_client_request_args"): {},
+            ("kubernetes_executor", "delete_option_kwargs"): {},
+            ("core", "dags_folder"): "/tmp/dags",
+        }.get((section, key), fallback)
+
+        mock_conf.getboolean.side_effect = lambda section, key, fallback=None: {
+            ("kubernetes_executor", "delete_worker_pods"): True,
+            ("kubernetes_executor", "delete_worker_pods_on_failure"): False,
+            ("kubernetes_executor", "multi_namespace_mode"): False,
+        }.get((section, key), fallback)
+
+        mock_conf.getint.side_effect = lambda section, key, fallback=None: {
+            ("kubernetes_executor", "worker_pods_creation_batch_size"): 1,
+            ("core", "parallelism"): 32,
+        }.get((section, key), fallback)
+
+        mock_conf.getjson.side_effect = lambda section, key, fallback=None: {
+            ("kubernetes_executor", "kube_client_request_args"): {},
+            ("kubernetes_executor", "delete_option_kwargs"): {},
+        }.get((section, key), fallback)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            KubeConfig()
+
+            # Check that deprecation warning was issued
+            deprecation_warnings = [warning for warning in w if issubclass(warning.category, DeprecationWarning)]
+            assert len(deprecation_warnings) == 1
+            assert "namespace" in str(deprecation_warnings[0].message)
+            assert "deprecated" in str(deprecation_warnings[0].message)
+            assert "pod_template_file" in str(deprecation_warnings[0].message)
+
+    @mock.patch("airflow.providers.cncf.kubernetes.kube_config.conf")
+    def test_no_warning_for_default_namespace(self, mock_conf):
+        """Test that no deprecation warning is issued for default namespace."""
+        # Set up mock configuration with default namespace
+        mock_conf.get.side_effect = lambda section, key, fallback=None: {
+            ("kubernetes_executor", "worker_container_repository"): "",
+            ("kubernetes_executor", "worker_container_tag"): "",
+            ("kubernetes_executor", "namespace"): "default",
+            ("kubernetes_executor", "pod_template_file"): None,
+            ("kubernetes_executor", "worker_pod_pending_fatal_container_state_reasons"): "",
+            ("kubernetes_executor", "multi_namespace_mode_namespace_list"): None,
+            ("kubernetes_executor", "kube_client_request_args"): {},
+            ("kubernetes_executor", "delete_option_kwargs"): {},
+            ("core", "dags_folder"): "/tmp/dags",
+        }.get((section, key), fallback)
+
+        mock_conf.getboolean.side_effect = lambda section, key, fallback=None: {
+            ("kubernetes_executor", "delete_worker_pods"): True,
+            ("kubernetes_executor", "delete_worker_pods_on_failure"): False,
+            ("kubernetes_executor", "multi_namespace_mode"): False,
+        }.get((section, key), fallback)
+
+        mock_conf.getint.side_effect = lambda section, key, fallback=None: {
+            ("kubernetes_executor", "worker_pods_creation_batch_size"): 1,
+            ("core", "parallelism"): 32,
+        }.get((section, key), fallback)
+
+        mock_conf.getjson.side_effect = lambda section, key, fallback=None: {
+            ("kubernetes_executor", "kube_client_request_args"): {},
+            ("kubernetes_executor", "delete_option_kwargs"): {},
+        }.get((section, key), fallback)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            KubeConfig()
+
+            # Check that no deprecation warning was issued for default namespace
+            deprecation_warnings = [warning for warning in w if issubclass(warning.category, DeprecationWarning)]
+            assert len(deprecation_warnings) == 0
+
+    @mock.patch("airflow.providers.cncf.kubernetes.kube_config.conf")
+    def test_multiple_deprecated_fields_warnings(self, mock_conf):
+        """Test that multiple deprecation warnings are issued when multiple deprecated fields are used."""
+        # Set up mock configuration with multiple deprecated fields
+        mock_conf.get.side_effect = lambda section, key, fallback=None: {
+            ("kubernetes_executor", "worker_container_repository"): "my-repo",
+            ("kubernetes_executor", "worker_container_tag"): "my-tag",
+            ("kubernetes_executor", "namespace"): "my-namespace",
+            ("kubernetes_executor", "pod_template_file"): None,
+            ("kubernetes_executor", "worker_pod_pending_fatal_container_state_reasons"): "",
+            ("kubernetes_executor", "multi_namespace_mode_namespace_list"): None,
+            ("kubernetes_executor", "kube_client_request_args"): {},
+            ("kubernetes_executor", "delete_option_kwargs"): {},
+            ("core", "dags_folder"): "/tmp/dags",
+        }.get((section, key), fallback)
+
+        mock_conf.getboolean.side_effect = lambda section, key, fallback=None: {
+            ("kubernetes_executor", "delete_worker_pods"): True,
+            ("kubernetes_executor", "delete_worker_pods_on_failure"): False,
+            ("kubernetes_executor", "multi_namespace_mode"): False,
+        }.get((section, key), fallback)
+
+        mock_conf.getint.side_effect = lambda section, key, fallback=None: {
+            ("kubernetes_executor", "worker_pods_creation_batch_size"): 1,
+            ("core", "parallelism"): 32,
+        }.get((section, key), fallback)
+
+        mock_conf.getjson.side_effect = lambda section, key, fallback=None: {
+            ("kubernetes_executor", "kube_client_request_args"): {},
+            ("kubernetes_executor", "delete_option_kwargs"): {},
+        }.get((section, key), fallback)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            KubeConfig()
+
+            # Check that all three deprecation warnings were issued
+            deprecation_warnings = [warning for warning in w if issubclass(warning.category, DeprecationWarning)]
+            assert len(deprecation_warnings) == 3
+
+            warning_messages = [str(warning.message) for warning in deprecation_warnings]
+            assert any("worker_container_repository" in msg for msg in warning_messages)
+            assert any("worker_container_tag" in msg for msg in warning_messages)
+            assert any("namespace" in msg for msg in warning_messages)

--- a/test_deprecation_warnings.py
+++ b/test_deprecation_warnings.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+Test script to verify that deprecation warnings are properly issued
+for deprecated Kubernetes configuration options.
+"""
+
+import warnings
+import tempfile
+import os
+from unittest.mock import patch
+
+# Add the airflow-core src to the path
+import sys
+sys.path.insert(0, '/Users/johannes.jungbluth/airflow/airflow-core/src')
+sys.path.insert(0, '/Users/johannes.jungbluth/airflow/providers/cncf/kubernetes/src')
+
+def test_deprecation_warnings():
+    """Test that deprecation warnings are issued for deprecated configuration options."""
+    
+    # Create a temporary config file with deprecated options
+    config_content = """
+[kubernetes_executor]
+worker_container_repository = my-repo
+worker_container_tag = my-tag
+namespace = my-namespace
+pod_template_file = 
+"""
+    
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.cfg', delete=False) as f:
+        f.write(config_content)
+        config_file = f.name
+    
+    try:
+        # Mock the configuration to use our test config
+        with patch('airflow.configuration.conf') as mock_conf:
+            # Set up mock configuration responses
+            mock_conf.get.side_effect = lambda section, key, fallback=None: {
+                ('kubernetes_executor', 'worker_container_repository'): 'my-repo',
+                ('kubernetes_executor', 'worker_container_tag'): 'my-tag', 
+                ('kubernetes_executor', 'namespace'): 'my-namespace',
+                ('kubernetes_executor', 'pod_template_file'): None,
+                ('kubernetes_executor', 'delete_worker_pods'): True,
+                ('kubernetes_executor', 'delete_worker_pods_on_failure'): False,
+                ('kubernetes_executor', 'worker_pod_pending_fatal_container_state_reasons'): '',
+                ('kubernetes_executor', 'worker_pods_creation_batch_size'): 1,
+                ('kubernetes_executor', 'multi_namespace_mode'): False,
+                ('kubernetes_executor', 'multi_namespace_mode_namespace_list'): None,
+                ('kubernetes_executor', 'kube_client_request_args'): {},
+                ('kubernetes_executor', 'delete_option_kwargs'): {},
+                ('core', 'dags_folder'): '/tmp/dags',
+                ('core', 'parallelism'): 32,
+            }.get((section, key), fallback)
+            
+            mock_conf.getboolean.side_effect = lambda section, key, fallback=None: {
+                ('kubernetes_executor', 'delete_worker_pods'): True,
+                ('kubernetes_executor', 'delete_worker_pods_on_failure'): False,
+                ('kubernetes_executor', 'multi_namespace_mode'): False,
+            }.get((section, key), fallback)
+            
+            mock_conf.getint.side_effect = lambda section, key, fallback=None: {
+                ('kubernetes_executor', 'worker_pods_creation_batch_size'): 1,
+                ('core', 'parallelism'): 32,
+            }.get((section, key), fallback)
+            
+            mock_conf.getjson.side_effect = lambda section, key, fallback=None: {
+                ('kubernetes_executor', 'kube_client_request_args'): {},
+                ('kubernetes_executor', 'delete_option_kwargs'): {},
+            }.get((section, key), fallback)
+            
+            # Capture warnings
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                
+                # Import and instantiate KubeConfig to trigger the warnings
+                from airflow.providers.cncf.kubernetes.kube_config import KubeConfig
+                config = KubeConfig()
+                
+                # Check that we got the expected deprecation warnings
+                deprecation_warnings = [warning for warning in w if issubclass(warning.category, DeprecationWarning)]
+                
+                print(f"Found {len(deprecation_warnings)} deprecation warnings:")
+                for warning in deprecation_warnings:
+                    print(f"  - {warning.message}")
+                
+                # Verify we have warnings for all three deprecated fields
+                expected_warnings = [
+                    "worker_container_repository",
+                    "worker_container_tag", 
+                    "namespace"
+                ]
+                
+                found_warnings = []
+                for warning in deprecation_warnings:
+                    message = str(warning.message)
+                    for expected in expected_warnings:
+                        if expected in message:
+                            found_warnings.append(expected)
+                            break
+                
+                print(f"\nExpected warnings: {expected_warnings}")
+                print(f"Found warnings for: {found_warnings}")
+                
+                if set(found_warnings) == set(expected_warnings):
+                    print("\n✅ SUCCESS: All expected deprecation warnings were issued!")
+                    return True
+                else:
+                    missing = set(expected_warnings) - set(found_warnings)
+                    print(f"\n❌ FAILURE: Missing warnings for: {missing}")
+                    return False
+                    
+    finally:
+        # Clean up temp file
+        os.unlink(config_file)
+
+if __name__ == "__main__":
+    success = test_deprecation_warnings()
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
This commit introduces a test script to verify that deprecation warnings are issued for deprecated Kubernetes configuration options. The following options are now marked as deprecated in the `[kubernetes_executor]` section: `worker_container_repository`, `worker_container_tag`, and `namespace`. Users are advised to use `pod_template_file` instead.

Additionally, the `KubeConfig` class has been updated to issue warnings when these deprecated options are used, and corresponding unit tests have been added to ensure the warnings are correctly triggered.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
