### PR TITLE
[v3-1-test] Fix failed image build in v3-1-test

### DIFF
--- a/providers/common/compat/provider.yaml
+++ b/providers/common/compat/provider.yaml
@@ -28,6 +28,7 @@ source-date-epoch: 1753690102
 # In such case adding >= NEW_VERSION and bumping to NEW_VERSION in a provider have
 # to be done in the same PR
 versions:
+  - 1.7.4
   - 1.7.3
   - 1.7.2
   - 1.7.1

--- a/providers/common/compat/pyproject.toml
+++ b/providers/common/compat/pyproject.toml
@@ -25,7 +25,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "apache-airflow-providers-common-compat"
-version = "1.7.3"
+version = "1.7.4"
 description = "Provider package apache-airflow-providers-common-compat for Apache Airflow"
 readme = "README.rst"
 authors = [
@@ -106,8 +106,8 @@ apache-airflow-providers-common-sql = {workspace = true}
 apache-airflow-providers-standard = {workspace = true}
 
 [project.urls]
-"Documentation" = "https://airflow.apache.org/docs/apache-airflow-providers-common-compat/1.7.3"
-"Changelog" = "https://airflow.apache.org/docs/apache-airflow-providers-common-compat/1.7.3/changelog.html"
+"Documentation" = "https://airflow.apache.org/docs/apache-airflow-providers-common-compat/1.7.4"
+"Changelog" = "https://airflow.apache.org/docs/apache-airflow-providers-common-compat/1.7.4/changelog.html"
 "Bug Tracker" = "https://github.com/apache/airflow/issues"
 "Source Code" = "https://github.com/apache/airflow"
 "Slack Chat" = "https://s.apache.org/airflow-slack"

--- a/providers/common/compat/src/airflow/providers/common/compat/__init__.py
+++ b/providers/common/compat/src/airflow/providers/common/compat/__init__.py
@@ -29,7 +29,7 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "1.7.3"
+__version__ = "1.7.4"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.10.0"

--- a/providers/common/io/provider.yaml
+++ b/providers/common/io/provider.yaml
@@ -28,6 +28,7 @@ source-date-epoch: 1753690124
 # In such case adding >= NEW_VERSION and bumping to NEW_VERSION in a provider have
 # to be done in the same PR
 versions:
+  - 1.6.3
   - 1.6.2
   - 1.6.1
   - 1.6.0

--- a/providers/common/io/pyproject.toml
+++ b/providers/common/io/pyproject.toml
@@ -25,7 +25,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "apache-airflow-providers-common-io"
-version = "1.6.2"
+version = "1.6.3"
 description = "Provider package apache-airflow-providers-common-io for Apache Airflow"
 readme = "README.rst"
 authors = [
@@ -106,8 +106,8 @@ apache-airflow-providers-common-sql = {workspace = true}
 apache-airflow-providers-standard = {workspace = true}
 
 [project.urls]
-"Documentation" = "https://airflow.apache.org/docs/apache-airflow-providers-common-io/1.6.2"
-"Changelog" = "https://airflow.apache.org/docs/apache-airflow-providers-common-io/1.6.2/changelog.html"
+"Documentation" = "https://airflow.apache.org/docs/apache-airflow-providers-common-io/1.6.3"
+"Changelog" = "https://airflow.apache.org/docs/apache-airflow-providers-common-io/1.6.3/changelog.html"
 "Bug Tracker" = "https://github.com/apache/airflow/issues"
 "Source Code" = "https://github.com/apache/airflow"
 "Slack Chat" = "https://s.apache.org/airflow-slack"

--- a/providers/common/io/src/airflow/providers/common/io/__init__.py
+++ b/providers/common/io/src/airflow/providers/common/io/__init__.py
@@ -29,7 +29,7 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "1.6.2"
+__version__ = "1.6.3"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.10.0"

--- a/providers/common/sql/provider.yaml
+++ b/providers/common/sql/provider.yaml
@@ -28,6 +28,7 @@ source-date-epoch: 1756876759
 # In such case adding >= NEW_VERSION and bumping to NEW_VERSION in a provider have
 # to be done in the same PR
 versions:
+  - 1.28.1
   - 1.28.0
   - 1.27.5
   - 1.27.4

--- a/providers/common/sql/pyproject.toml
+++ b/providers/common/sql/pyproject.toml
@@ -25,7 +25,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "apache-airflow-providers-common-sql"
-version = "1.28.0"
+version = "1.28.1"
 description = "Provider package apache-airflow-providers-common-sql for Apache Airflow"
 readme = "README.rst"
 authors = [
@@ -121,8 +121,8 @@ apache-airflow-providers-common-sql = {workspace = true}
 apache-airflow-providers-standard = {workspace = true}
 
 [project.urls]
-"Documentation" = "https://airflow.apache.org/docs/apache-airflow-providers-common-sql/1.28.0"
-"Changelog" = "https://airflow.apache.org/docs/apache-airflow-providers-common-sql/1.28.0/changelog.html"
+"Documentation" = "https://airflow.apache.org/docs/apache-airflow-providers-common-sql/1.28.1"
+"Changelog" = "https://airflow.apache.org/docs/apache-airflow-providers-common-sql/1.28.1/changelog.html"
 "Bug Tracker" = "https://github.com/apache/airflow/issues"
 "Source Code" = "https://github.com/apache/airflow"
 "Slack Chat" = "https://s.apache.org/airflow-slack"

--- a/providers/common/sql/src/airflow/providers/common/sql/__init__.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/__init__.py
@@ -29,7 +29,7 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "1.28.0"
+__version__ = "1.28.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.10.0"

--- a/providers/smtp/provider.yaml
+++ b/providers/smtp/provider.yaml
@@ -29,6 +29,7 @@ source-date-epoch: 1756877538
 # In such case adding >= NEW_VERSION and bumping to NEW_VERSION in a provider have
 # to be done in the same PR
 versions:
+  - 2.3.1
   - 2.2.1
   - 2.2.0
   - 2.1.2

--- a/providers/smtp/pyproject.toml
+++ b/providers/smtp/pyproject.toml
@@ -25,7 +25,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "apache-airflow-providers-smtp"
-version = "2.2.1"
+version = "2.3.1"
 description = "Provider package apache-airflow-providers-smtp for Apache Airflow"
 readme = "README.rst"
 authors = [
@@ -96,8 +96,8 @@ apache-airflow-providers-common-sql = {workspace = true}
 apache-airflow-providers-standard = {workspace = true}
 
 [project.urls]
-"Documentation" = "https://airflow.apache.org/docs/apache-airflow-providers-smtp/2.2.1"
-"Changelog" = "https://airflow.apache.org/docs/apache-airflow-providers-smtp/2.2.1/changelog.html"
+"Documentation" = "https://airflow.apache.org/docs/apache-airflow-providers-smtp/2.3.1"
+"Changelog" = "https://airflow.apache.org/docs/apache-airflow-providers-smtp/2.3.1/changelog.html"
 "Bug Tracker" = "https://github.com/apache/airflow/issues"
 "Source Code" = "https://github.com/apache/airflow"
 "Slack Chat" = "https://s.apache.org/airflow-slack"

--- a/providers/smtp/src/airflow/providers/smtp/__init__.py
+++ b/providers/smtp/src/airflow/providers/smtp/__init__.py
@@ -29,7 +29,7 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "2.2.1"
+__version__ = "2.3.1"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.10.0"

--- a/providers/standard/provider.yaml
+++ b/providers/standard/provider.yaml
@@ -27,6 +27,7 @@ source-date-epoch: 1756877597
 # In such case adding >= NEW_VERSION and bumping to NEW_VERSION in a provider have
 # to be done in the same PR
 versions:
+  - 1.9.0
   - 1.7.0
   - 1.6.0
   - 1.5.0

--- a/providers/standard/pyproject.toml
+++ b/providers/standard/pyproject.toml
@@ -25,7 +25,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "apache-airflow-providers-standard"
-version = "1.7.0"
+version = "1.9.0"
 description = "Provider package apache-airflow-providers-standard for Apache Airflow"
 readme = "README.rst"
 authors = [
@@ -95,8 +95,8 @@ apache-airflow-providers-common-sql = {workspace = true}
 apache-airflow-providers-standard = {workspace = true}
 
 [project.urls]
-"Documentation" = "https://airflow.apache.org/docs/apache-airflow-providers-standard/1.7.0"
-"Changelog" = "https://airflow.apache.org/docs/apache-airflow-providers-standard/1.7.0/changelog.html"
+"Documentation" = "https://airflow.apache.org/docs/apache-airflow-providers-standard/1.9.0"
+"Changelog" = "https://airflow.apache.org/docs/apache-airflow-providers-standard/1.9.0/changelog.html"
 "Bug Tracker" = "https://github.com/apache/airflow/issues"
 "Source Code" = "https://github.com/apache/airflow"
 "Slack Chat" = "https://s.apache.org/airflow-slack"

--- a/providers/standard/src/airflow/providers/standard/__init__.py
+++ b/providers/standard/src/airflow/providers/standard/__init__.py
@@ -29,7 +29,7 @@ from airflow import __version__ as airflow_version
 
 __all__ = ["__version__"]
 
-__version__ = "1.7.0"
+__version__ = "1.9.0"
 
 if packaging.version.parse(packaging.version.parse(airflow_version).base_version) < packaging.version.parse(
     "2.10.0"


### PR DESCRIPTION
The #56208 has broken v3-1-test because it added requirements for providers, where (at least curerntly) uv workspace in v3-1-test uses provider's depedencies from local "providers" folder. We are planning to remove providers from v3-1-test branch but this is not yet done and bumping providers only in "airflow" requireements without bumping them in pyproject.toml caused conflicts when installing airflow from local sources in CI image.

bumping the versions in pyproject.toml should solve the problem until different mechanism is implemented in v3-* branches.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
