### PR TITLE
Update Airflow SDK Param text input to use textarea with text wrapping

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldString.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldString.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Input } from "@chakra-ui/react";
+import { Textarea } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 
 import { paramPlaceholder, useParamStore } from "src/queries/useParamStore";
@@ -40,10 +40,9 @@ export const FieldString = ({ name, namespace = "default", onUpdate }: FlexibleF
 
   return (
     <>
-      <Input
+      <Textarea
         disabled={disabled}
         id={`element_${name}`}
-        list={param.schema.examples ? `list_${name}` : undefined}
         maxLength={param.schema.maxLength ?? undefined}
         minLength={param.schema.minLength ?? undefined}
         name={`element_${name}`}


### PR DESCRIPTION
Long input textstrings need to wrap so that it is easy to view the contents
Changed FieldString component from Input to Textarea to enable text
wrapping for better user experience when entering longer string values.
Removed datalist support as it's incompatible with textarea elements.

Before:
<img width="1093" height="718" alt="image" src="https://github.com/user-attachments/assets/8d57fa38-0fb9-4769-8703-668b2c22c6b6" />


After: 
<img width="1108" height="736" alt="image" src="https://github.com/user-attachments/assets/0117afa5-daeb-45a6-a322-1671215c214e" />


