### PR TITLE
Fix custom timetable generate_run_id not called for manual triggers

### DIFF
--- a/airflow-core/src/airflow/api/common/trigger_dag.py
+++ b/airflow-core/src/airflow/api/common/trigger_dag.py
@@ -92,10 +92,10 @@ def _trigger_dag(
     else:
         data_interval = None
 
-    run_id = run_id or DagRun.generate_run_id(
+    run_id = run_id or dag.timetable.generate_run_id(
         run_type=DagRunType.MANUAL,
-        logical_date=coerced_logical_date,
         run_after=timezone.coerce_datetime(run_after),
+        data_interval=data_interval,
     )
 
     # This intentionally does not use 'session' in the current scope because it

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
@@ -26,7 +26,6 @@ from pydantic import AliasPath, AwareDatetime, Field, NonNegativeInt, model_vali
 from airflow._shared.timezones import timezone
 from airflow.api_fastapi.core_api.base import BaseModel, StrictBaseModel
 from airflow.api_fastapi.core_api.datamodels.dag_versions import DagVersionResponse
-from airflow.models import DagRun
 from airflow.timetables.base import DataInterval
 from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
@@ -129,10 +128,10 @@ class TriggerDAGRunPostBody(StrictBaseModel):
                 )
                 run_after = data_interval.end
 
-        run_id = self.dag_run_id or DagRun.generate_run_id(
-            run_type=DagRunType.SCHEDULED,
-            logical_date=coerced_logical_date,
-            run_after=run_after,
+        run_id = self.dag_run_id or dag.timetable.generate_run_id(
+            run_type=DagRunType.MANUAL,
+            run_after=timezone.coerce_datetime(run_after),
+            data_interval=data_interval,
         )
         return {
             "run_id": run_id,
@@ -142,14 +141,6 @@ class TriggerDAGRunPostBody(StrictBaseModel):
             "conf": self.conf,
             "note": self.note,
         }
-
-    @model_validator(mode="after")
-    def validate_dag_run_id(self):
-        if not self.dag_run_id:
-            self.dag_run_id = DagRun.generate_run_id(
-                run_type=DagRunType.MANUAL, logical_date=self.logical_date, run_after=self.run_after
-            )
-        return self
 
 
 class DAGRunsBatchBody(StrictBaseModel):

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -50,6 +50,7 @@ from tests_common.test_utils.format_datetime import from_datetime_to_zulu, from_
 
 if TYPE_CHECKING:
     from airflow.models.dag_version import DagVersion
+    from airflow.timetables.base import DataInterval
 
 pytestmark = pytest.mark.db_test
 
@@ -1832,7 +1833,6 @@ class TestTriggerDagRun:
         """Test that custom timetable's generate_run_id is used for manual triggers (issue #55908)."""
         from pendulum import DateTime
 
-        from airflow.timetables.base import DataInterval
         from airflow.timetables.interval import CronDataIntervalTimetable
 
         class CustomTimetable(CronDataIntervalTimetable):


### PR DESCRIPTION
In Airflow 3.x, commit 035060d7f3 (PR #46616) changed the trigger_dag module to use DagRun.generate_run_id() instead of
dag.timetable.generate_run_id() for manual DAG runs. This bypassed custom timetable logic, causing a regression from Airflow 2.x behavior.

This commit restores the use of dag.timetable.generate_run_id() for manual triggers, allowing custom timetables to control run_id generation for both scheduled and manually triggered runs.

Changes:
- airflow/api/common/trigger_dag.py: Changed to call dag.timetable.generate_run_id() with run_after and data_interval parameters instead of DagRun.generate_run_id()
- tests/api_fastapi/core_api/routes/public/test_dag_run.py: Added test to verify custom timetable generate_run_id is called for manual triggers with both logical_date provided and null

This pattern matches how manual triggers are handled in other parts of the codebase (e.g., assets.py, scheduler_job_runner.py).

Fixes: #55908

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
