### PR TITLE
Fix: Correctly parse JSON for --dag_run_conf in airflow dags backfill CLI

### DIFF
--- a/airflow-core/src/airflow/cli/commands/backfill_command.py
+++ b/airflow-core/src/airflow/cli/commands/backfill_command.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import signal
 
@@ -80,13 +81,22 @@ def create_backfill(args) -> None:
     except AirflowConfigException as e:
         log.warning("Failed to get user name from os: %s, not setting the triggering user", e)
         user = None
+
+    # Parse dag_run_conf if provided
+    dag_run_conf = None
+    if args.dag_run_conf:
+        try:
+            dag_run_conf = json.loads(args.dag_run_conf)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid JSON in --dag-run-conf: {e}")
+
     _create_backfill(
         dag_id=args.dag_id,
         from_date=args.from_date,
         to_date=args.to_date,
         max_active_runs=args.max_active_runs,
         reverse=args.run_backwards,
-        dag_run_conf=args.dag_run_conf,
+        dag_run_conf=dag_run_conf,
         triggering_user_name=user,
         reprocess_behavior=reprocess_behavior,
         run_on_latest_version=args.run_on_latest_version,

--- a/airflow-core/tests/unit/cli/commands/test_backfill_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_backfill_command.py
@@ -162,3 +162,78 @@ class TestCliBackfill:
             reprocess_behavior="none",
             session=mock.ANY,
         )
+
+    @mock.patch("airflow.cli.commands.backfill_command._create_backfill")
+    def test_backfill_with_dag_run_conf(self, mock_create):
+        """Test that dag_run_conf is properly parsed from JSON string."""
+        args = [
+            "backfill",
+            "create",
+            "--dag-id",
+            "example_bash_operator",
+            "--from-date",
+            DEFAULT_DATE.isoformat(),
+            "--to-date",
+            DEFAULT_DATE.isoformat(),
+            "--dag-run-conf",
+            '{"example_key": "example_value"}',
+        ]
+        airflow.cli.commands.backfill_command.create_backfill(self.parser.parse_args(args))
+
+        mock_create.assert_called_once_with(
+            dag_id="example_bash_operator",
+            from_date=DEFAULT_DATE,
+            to_date=DEFAULT_DATE,
+            max_active_runs=None,
+            reverse=False,
+            dag_run_conf={"example_key": "example_value"},
+            reprocess_behavior=None,
+            triggering_user_name="root",
+            run_on_latest_version=False,
+        )
+
+    def test_backfill_with_invalid_dag_run_conf(self):
+        """Test that invalid JSON in dag_run_conf raises ValueError."""
+        args = [
+            "backfill",
+            "create",
+            "--dag-id",
+            "example_bash_operator",
+            "--from-date",
+            DEFAULT_DATE.isoformat(),
+            "--to-date",
+            DEFAULT_DATE.isoformat(),
+            "--dag-run-conf",
+            '{"invalid": json}',  # Invalid JSON
+        ]
+        with pytest.raises(ValueError, match="Invalid JSON in --dag-run-conf"):
+            airflow.cli.commands.backfill_command.create_backfill(self.parser.parse_args(args))
+
+    @mock.patch("airflow.cli.commands.backfill_command._create_backfill")
+    def test_backfill_with_empty_dag_run_conf(self, mock_create):
+        """Test that empty dag_run_conf is properly parsed."""
+        args = [
+            "backfill",
+            "create",
+            "--dag-id",
+            "example_bash_operator",
+            "--from-date",
+            DEFAULT_DATE.isoformat(),
+            "--to-date",
+            DEFAULT_DATE.isoformat(),
+            "--dag-run-conf",
+            "{}",
+        ]
+        airflow.cli.commands.backfill_command.create_backfill(self.parser.parse_args(args))
+
+        mock_create.assert_called_once_with(
+            dag_id="example_bash_operator",
+            from_date=DEFAULT_DATE,
+            to_date=DEFAULT_DATE,
+            max_active_runs=None,
+            reverse=False,
+            dag_run_conf={},
+            reprocess_behavior=None,
+            triggering_user_name="root",
+            run_on_latest_version=False,
+        )


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
### Description
The configuration passed to the `airflow dags backfill` command using the --dag_run_conf argument was not being correctly parsed as a JSON string.

> Problem: Cause the `ValueError: not enough values to unpack (expected 2, got 1)`
<img width="873" height="679" alt="Screenshot 2025-10-04 at 9 31 45 AM" src="https://github.com/user-attachments/assets/aa23664f-d004-45aa-b900-71e0dfc29947" />


### Changes
- Parse `dag_run_conf` from JSON string to dict when provided
- Add proper error handling for invalid JSON

Close: #56230

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
