### PR TITLE
Improve copy button usability on code blocks

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/RenderedTemplates.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/RenderedTemplates.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, HStack, Table } from "@chakra-ui/react";
+import { Box, Table } from "@chakra-ui/react";
 import { useParams } from "react-router-dom";
 import { PrismLight as SyntaxHighlighter } from "react-syntax-highlighter";
 import bash from "react-syntax-highlighter/dist/esm/languages/prism/bash";
@@ -61,24 +61,37 @@ export const RenderedTemplates = () => {
                 <Table.Row key={key}>
                   <Table.Cell>{key}</Table.Cell>
                   <Table.Cell>
-                    <HStack alignItems="flex-start">
-                      <Box flex="1">
-                        <Box as="pre" borderRadius="md" fontSize="sm" m={0} overflowX="auto" p={2}>
-                          <SyntaxHighlighter
-                            language={language}
-                            PreTag="div" // Prevents double <pre> nesting
-                            showLineNumbers
-                            style={style}
-                            wrapLongLines
-                          >
-                            {renderedValue}
-                          </SyntaxHighlighter>
-                        </Box>
+                    <Box
+                      css={{
+                        "&:hover .copy-button": {
+                          opacity: 1,
+                        },
+                      }}
+                    >
+                      <Box as="pre" borderRadius="md" fontSize="sm" m={0} overflowX="auto" p={2}>
+                        <SyntaxHighlighter
+                          language={language}
+                          PreTag="div" // Prevents double <pre> nesting
+                          showLineNumbers
+                          style={style}
+                          wrapLongLines
+                        >
+                          {renderedValue}
+                        </SyntaxHighlighter>
                       </Box>
-                      <ClipboardRoot value={renderedValue}>
+                      <ClipboardRoot
+                        className="copy-button"
+                        float="right"
+                        marginTop="-3.5rem"
+                        opacity={0}
+                        position="sticky"
+                        right={4}
+                        transition="opacity 0.2s ease-in-out"
+                        value={renderedValue}
+                      >
                         <ClipboardIconButton />
                       </ClipboardRoot>
-                    </HStack>
+                    </Box>
                   </Table.Cell>
                 </Table.Row>
               );


### PR DESCRIPTION
## Related issue

part of #56250

## Why
Previously, for long lines of code, the copy button was pushed off-screen, forcing users to scroll horizontally to access it.

## What
Now, if you hover on the code block, the button is always visible on the right edge of the container, regardless of horizontal scroll position.

## Screenshots


https://github.com/user-attachments/assets/7d212c0b-c9c8-4c72-9622-f3fb3318d43b


https://github.com/user-attachments/assets/e7b86093-979f-4cc1-9f48-40db1f44b686






<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
