### PR TITLE
Make Dag Run ID visible in Dag Header Card

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/DagBreadcrumb.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DagBreadcrumb.tsx
@@ -28,7 +28,6 @@ import {
 } from "openapi/queries";
 import { BreadcrumbStats } from "src/components/BreadcrumbStats";
 import { StateBadge } from "src/components/StateBadge";
-import Time from "src/components/Time";
 import { TogglePause } from "src/components/TogglePause";
 import { isStatePending, useAutoRefresh } from "src/utils";
 
@@ -82,7 +81,7 @@ export const DagBreadcrumb = () => {
   // Add dag run breadcrumb
   if (runId !== undefined) {
     links.push({
-      label: dagRun === undefined ? runId : <Time datetime={dagRun.run_after} />,
+      label: dagRun === undefined ? runId : dagRun.dag_run_id,
       labelExtra: dagRun === undefined ? undefined : <StateBadge fontSize="xs" state={dagRun.state} />,
       title: translate("dagRun_one"),
       value: `/dags/${dagId}/runs/${runId}`,

--- a/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
@@ -164,7 +164,7 @@ export const Header = ({
             ),
           },
         ]}
-        title={<Time datetime={dagRun.run_after} />}
+        title={dagRun.dag_run_id}
       />
     </Box>
   );


### PR DESCRIPTION
I noticed that in the Dag header card there is at no place the "Run ID" being visible anymore. You need to click on the "Details" tab to see it. If you use (like us) the Run ID as an identifier to know which run a run is (and not a logical date which anyway is optional) then it is hard to see (except looking at URL) which Dag run you are looking at.

After short discussion in https://apache-airflow.slack.com/archives/C0809U4S1Q9/p1758748483974429 I understood that this was not intended/concept but is likely nobody complained about until now.

This PR replaces the "run after" date with the "run ID".

Before:
<img width="1350" height="395" alt="image" src="https://github.com/user-attachments/assets/9fbb7756-5c6c-4694-ae71-2bbebdd799f3" />

After:
<img width="1350" height="393" alt="image" src="https://github.com/user-attachments/assets/43e19b78-a871-4ff4-b6ff-4cc64466d31c" />
