### PR TITLE
Use Task Display Name in Grid if existing

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/grid.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/grid.py
@@ -196,18 +196,18 @@ def get_dag_structure(
         return ids
 
     existing_ids = _collect_ids(merged_nodes)
-    historical_task_ids = session.scalars(
-        select(TaskInstance.task_id)
+    historical_tasks = session.execute(
+        select(TaskInstance.task_id, TaskInstance.task_display_name)
         .join(TaskInstance.dag_run)
         .where(TaskInstance.dag_id == dag_id, DagRun.id.in_(run_ids))
         .distinct()
     )
-    for task_id in historical_task_ids:
+    for task_id, task_display_name in historical_tasks:
         if task_id not in existing_ids:
             merged_nodes.append(
                 {
                     "id": task_id,
-                    "label": task_id,
+                    "label": task_display_name,
                     "is_mapped": None,
                     "children": None,
                 }

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/ui/task_group.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/ui/task_group.py
@@ -91,9 +91,11 @@ def task_group_to_dict_grid(task_item_or_group, parent_group_is_mapped=False):
             setup_teardown_type = "setup"
         elif task.is_teardown is True:
             setup_teardown_type = "teardown"
+        # we explicitly want the short task ID here, not the full doted notation if in a group
+        task_display_name = task.task_display_name if task.task_display_name != task.task_id else task.label
         return {
             "id": task.task_id,
-            "label": task.task_display_name,
+            "label": task_display_name,
             "is_mapped": mapped,
             "children": None,
             "setup_teardown_type": setup_teardown_type,

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/ui/task_group.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/ui/task_group.py
@@ -25,6 +25,7 @@ from operator import methodcaller
 
 from airflow.configuration import conf
 from airflow.models.mappedoperator import MappedOperator, is_mapped
+from airflow.sdk import TaskGroup
 from airflow.serialization.serialized_objects import SerializedBaseOperator
 
 
@@ -92,13 +93,13 @@ def task_group_to_dict_grid(task_item_or_group, parent_group_is_mapped=False):
             setup_teardown_type = "teardown"
         return {
             "id": task.task_id,
-            "label": task.label,
+            "label": task.task_display_name,
             "is_mapped": mapped,
             "children": None,
             "setup_teardown_type": setup_teardown_type,
         }
 
-    task_group = task_item_or_group
+    task_group: TaskGroup = task_item_or_group
     task_group_sort = get_task_group_children_getter()
     mapped = is_mapped(task_group)
     children = [
@@ -108,7 +109,7 @@ def task_group_to_dict_grid(task_item_or_group, parent_group_is_mapped=False):
 
     return {
         "id": task_group.group_id,
-        "label": task_group.label,
+        "label": task_group.group_display_name or task_group.label,
         "is_mapped": mapped or None,
         "children": children or None,
     }

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
@@ -125,7 +125,6 @@ export const Header = ({
         isRefreshing={isRefreshing}
         state={taskInstance.state}
         stats={stats}
-        subTitle={<Time datetime={taskInstance.start_date} />}
         title={`${taskInstance.task_display_name}${taskInstance.map_index > -1 ? ` [${taskInstance.rendered_map_index ?? taskInstance.map_index}]` : ""}`}
       />
     </Box>

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_grid.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_grid.py
@@ -132,7 +132,9 @@ def setup(dag_maker, session=None):
         with TaskGroup(group_id=TASK_GROUP_ID):
             MockOperator.partial(task_id=MAPPED_TASK_ID).expand(arg1=["a", "b", "c", "d"])
             with TaskGroup(group_id=INNER_TASK_GROUP, group_display_name="My Inner Task Group"):
-                MockOperator.partial(task_id=INNER_TASK_GROUP_SUB_TASK, task_display_name="Inner Task Group Sub Task Label").expand(arg1=["a", "b"])
+                MockOperator.partial(
+                    task_id=INNER_TASK_GROUP_SUB_TASK, task_display_name="Inner Task Group Sub Task Label"
+                ).expand(arg1=["a", "b"])
 
         # Mapped but never expanded. API should not crash, but count this as one no-status ti.
         MockOperator.partial(task_id=MAPPED_TASK_ID_2).expand(arg1=task.output)

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_grid.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_grid.py
@@ -84,7 +84,7 @@ GRID_NODES = [
         "is_mapped": True,
         "label": "mapped_task_group",
     },
-    {"id": "task", "label": "task"},
+    {"id": "task", "label": "A Beautiful Task Name 🚀"},
     {
         "children": [
             {
@@ -92,11 +92,11 @@ GRID_NODES = [
                     {
                         "id": "task_group.inner_task_group.inner_task_group_sub_task",
                         "is_mapped": True,
-                        "label": "inner_task_group_sub_task",
+                        "label": "Inner Task Group Sub Task Label",
                     }
                 ],
                 "id": "task_group.inner_task_group",
-                "label": "inner_task_group",
+                "label": "My Inner Task Group",
             },
             {"id": "task_group.mapped_task", "is_mapped": True, "label": "mapped_task"},
         ],
@@ -121,7 +121,7 @@ def setup(dag_maker, session=None):
 
     # DAG 1
     with dag_maker(dag_id=DAG_ID, serialized=True, session=session) as dag:
-        task = EmptyOperator(task_id=TASK_ID)
+        task = EmptyOperator(task_id=TASK_ID, task_display_name="A Beautiful Task Name 🚀")
 
         @task_group
         def mapped_task_group(arg1):
@@ -131,8 +131,8 @@ def setup(dag_maker, session=None):
 
         with TaskGroup(group_id=TASK_GROUP_ID):
             MockOperator.partial(task_id=MAPPED_TASK_ID).expand(arg1=["a", "b", "c", "d"])
-            with TaskGroup(group_id=INNER_TASK_GROUP):
-                MockOperator.partial(task_id=INNER_TASK_GROUP_SUB_TASK).expand(arg1=["a", "b"])
+            with TaskGroup(group_id=INNER_TASK_GROUP, group_display_name="My Inner Task Group"):
+                MockOperator.partial(task_id=INNER_TASK_GROUP_SUB_TASK, task_display_name="Inner Task Group Sub Task Label").expand(arg1=["a", "b"])
 
         # Mapped but never expanded. API should not crash, but count this as one no-status ti.
         MockOperator.partial(task_id=MAPPED_TASK_ID_2).expand(arg1=task.output)
@@ -480,7 +480,7 @@ class TestGetGridDataEndpoint:
                 "is_mapped": True,
                 "label": "mapped_task_group",
             },
-            {"id": "task", "label": "task"},
+            {"id": "task", "label": "A Beautiful Task Name 🚀"},
             {
                 "children": [
                     {
@@ -488,11 +488,11 @@ class TestGetGridDataEndpoint:
                             {
                                 "id": "task_group.inner_task_group.inner_task_group_sub_task",
                                 "is_mapped": True,
-                                "label": "inner_task_group_sub_task",
+                                "label": "Inner Task Group Sub Task Label",
                             }
                         ],
                         "id": "task_group.inner_task_group",
-                        "label": "inner_task_group",
+                        "label": "My Inner Task Group",
                     },
                     {"id": "task_group.mapped_task", "is_mapped": True, "label": "mapped_task"},
                 ],


### PR DESCRIPTION
While I was prepping PR #56392 I noticed that the Task Display Name is not used (anymore?) in the Grid view. Might be a victim of refactoring... this PR adds the Task Display name back again such that "beautiful" task names as introduced in Airflow 2.10 are back again in Grid view.

Before:
<img width="1215" height="587" alt="image" src="https://github.com/user-attachments/assets/dc92a4ca-e860-44cc-a839-938ab22995b4" />

After:
<img width="1215" height="584" alt="image" src="https://github.com/user-attachments/assets/c35026ea-6b27-424d-a792-7ce7cfd65644" />
