### PR TITLE
fix: show appropriate time units in grid view

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/ar/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ar/common.json
@@ -189,7 +189,6 @@
     },
     "tooltip": "اضغط {{hotkey}} للتمرير إلى {{direction}}"
   },
-  "seconds": "ثواني",
   "security": {
     "actions": "إجراءات",
     "permissions": "صلاحيات",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ca/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ca/common.json
@@ -161,7 +161,6 @@
     },
     "tooltip": "Prem {{hotkey}} per desplaçar-te cap a {{direction}}"
   },
-  "seconds": "{{count}}s",
   "security": {
     "actions": "Accions",
     "permissions": "Permisos",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/de/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/de/common.json
@@ -161,7 +161,6 @@
     },
     "tooltip": "Tastenkombination {{hotkey}} zum scrollen nach {{direction}}"
   },
-  "seconds": "{{count}}s",
   "security": {
     "actions": "Aktionen",
     "permissions": "Berechtigungen",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
@@ -163,7 +163,6 @@
     },
     "tooltip": "Press {{hotkey}} to scroll to {{direction}}"
   },
-  "seconds": "{{count}}s",
   "security": {
     "actions": "Actions",
     "permissions": "Permissions",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/es/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/es/common.json
@@ -168,7 +168,6 @@
     },
     "tooltip": "Presiona {{hotkey}} para desplazarte a {{direction}}"
   },
-  "seconds": "{{count}}s",
   "security": {
     "actions": "Acciones",
     "permissions": "Permisos",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/common.json
@@ -168,7 +168,6 @@
     },
     "tooltip": "Appuyez sur {{hotkey}} pour faire défiler vers le {{direction}}"
   },
-  "seconds": "{{count}}s",
   "security": {
     "actions": "Actions",
     "permissions": "Permissions",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/he/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/he/common.json
@@ -168,7 +168,6 @@
     },
     "tooltip": "לחץ {{hotkey}} לגלילה ל{{direction}}"
   },
-  "seconds": "{{count}} שניות",
   "security": {
     "actions": "פעולות",
     "permissions": "הרשאות",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/hi/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/hi/common.json
@@ -154,7 +154,6 @@
     },
     "tooltip": "{{direction}} तक स्क्रॉल करने के लिए {{hotkey}} दबाएं"
   },
-  "seconds": "{{count}}सेकंड",
   "security": {
     "actions": "क्रियाएं",
     "permissions": "अनुमतियां",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/hu/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/hu/common.json
@@ -154,7 +154,6 @@
     },
     "tooltip": "Nyomd meg a(z) {{hotkey}} gombot a görgetéshez ide: {{direction}}"
   },
-  "seconds": "{{count}} mp",
   "security": {
     "actions": "Műveletek",
     "permissions": "Jogosultságok",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/it/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/it/common.json
@@ -175,7 +175,6 @@
     },
     "tooltip": "Premi {{hotkey}} per scorrere a {{direction}}"
   },
-  "seconds": "{{count}}s",
   "security": {
     "actions": "Azioni",
     "permissions": "Permessi",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/common.json
@@ -161,7 +161,6 @@
     },
     "tooltip": "{{hotkey}}를 눌러 {{direction}}로 스크롤"
   },
-  "seconds": "{{count}}초",
   "security": {
     "actions": "작업",
     "permissions": "권한",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/nl/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/nl/common.json
@@ -161,7 +161,6 @@
     },
     "tooltip": "Druk op {{hotkey}} om te scrollen naar {{direction}}"
   },
-  "seconds": "{{count}}s",
   "security": {
     "actions": "Acties",
     "permissions": "Permissies",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/common.json
@@ -177,7 +177,6 @@
     },
     "tooltip": "Naciśnij {{hotkey}}, aby przewinąć do {{direction}}"
   },
-  "seconds": "{{count}}s",
   "security": {
     "actions": "Akcje",
     "permissions": "Uprawnienia",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt/common.json
@@ -175,7 +175,6 @@
     },
     "tooltip": "Pressione {{hotkey}} para rolar para {{direction}}"
   },
-  "seconds": "{{count}}s",
   "security": {
     "actions": "Ações",
     "permissions": "Permissões",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/tr/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/tr/common.json
@@ -161,7 +161,6 @@
     },
     "tooltip": "{{direction}} kaydırmak için {{hotkey}} tuşuna basın"
   },
-  "seconds": "{{count}}sn",
   "security": {
     "actions": "Eylemler",
     "permissions": "İzinler",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/common.json
@@ -161,7 +161,6 @@
     },
     "tooltip": "按 {{hotkey}} 滚动到{{direction}}"
   },
-  "seconds": "{{count}} 秒",
   "security": {
     "actions": "操作",
     "permissions": "权限",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/common.json
@@ -161,7 +161,6 @@
     },
     "tooltip": "按 {{hotkey}} 捲動到{{direction}}"
   },
-  "seconds": "{{count}} 秒",
   "security": {
     "actions": "操作",
     "permissions": "權限",

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/DurationTick.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/DurationTick.tsx
@@ -17,18 +17,15 @@
  * under the License.
  */
 import { Text, type TextProps } from "@chakra-ui/react";
-import { useTranslation } from "react-i18next";
+
+import { renderDuration } from "src/utils";
 
 type Props = {
   readonly duration: number;
 } & TextProps;
 
-export const DurationTick = ({ duration, ...rest }: Props) => {
-  const { t: translate } = useTranslation();
-
-  return (
-    <Text color="border.emphasized" fontSize="xs" position="absolute" right={1} whiteSpace="nowrap" {...rest}>
-      {translate("seconds", { count: Math.floor(duration) })}
-    </Text>
-  );
-};
+export const DurationTick = ({ duration, ...rest }: Props) => (
+  <Text color="border.emphasized" fontSize="xs" position="absolute" right={1} whiteSpace="nowrap" {...rest}>
+    {renderDuration(duration)}
+  </Text>
+);


### PR DESCRIPTION
## Related
part of #56250

## Why 
> The grid dag timing seems to always be in terms of seconds

## Screenshots
<img width="436" height="322" alt="duration_before" src="https://github.com/user-attachments/assets/58e0263e-932f-4137-b4b1-73158d7738b2" />

<img width="436" height="322" alt="duration_after" src="https://github.com/user-attachments/assets/359e2e0a-653f-467f-ae64-dc0e0dbcca3f" />

## Notes

We would need to remove all of the translation keys for "seconds"

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
