### PR TITLE
Allow sub-pages in React UI plugins

### DIFF
--- a/airflow-core/src/airflow/ui/src/router.tsx
+++ b/airflow-core/src/airflow/ui/src/router.tsx
@@ -65,7 +65,7 @@ import { client } from "./queryClient";
 
 const pluginRoute = {
   element: <ExternalView />,
-  path: "plugin/:page",
+  path: "plugin/:page/*",
 };
 
 export const taskInstanceRoutes = [


### PR DESCRIPTION
As a follow-up on #55642 I noticed that one minor nit change was not made to main in PR https://github.com/apache/airflow/pull/56205 - the route definition allowing React UI Plugin pages to have sub-pages.

I assume this is non-breaking (at least in my naive tests) therefore it should also be applied in my view to the next minor as bugfix. But before merge would like to have a review by @pierrejeambrun not that I mis-understood.