### PR TITLE
Limit astroid to < 4 to fix broken docs builds

### DIFF
--- a/devel-common/pyproject.toml
+++ b/devel-common/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     "twine>=4.0.2",
 ]
 "docs" = [
-    "astroid>=3",
+    "astroid>=3,<4",
     "checksumdir>=1.2.0",
     "rich-click>=1.7.1",
     "click>=8.1.8",

--- a/devel-common/pyproject.toml
+++ b/devel-common/pyproject.toml
@@ -67,6 +67,7 @@ dependencies = [
     "twine>=4.0.2",
 ]
 "docs" = [
+    # Astroid 4 released 5 Oct 2025 breaks autoapi https://github.com/apache/airflow/issues/56420
     "astroid>=3,<4",
     "checksumdir>=1.2.0",
     "rich-click>=1.7.1",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

It seems like astroid 4.0.0 introduced breaking changes that are incompatible with the current version of sphinx-autoapi. The sphinx-autoapi extension uses astroid for static analysis of Python code to extract docstrings, and the API changes in astroid 4.x break this functionality.

Since I am not an expert in sphinx, and because I do not want to break current docs build / formatting, this is the best solution from me for now atleast (cc @sunank200 could you check for the docs part?)

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
