### PR TITLE
fix: Astroid 4 breaks docs building

### DIFF
--- a/devel-common/pyproject.toml
+++ b/devel-common/pyproject.toml
@@ -70,6 +70,7 @@ dependencies = [
     "twine>=4.0.2",
 ]
 "docs" = [
+    "astroid>=3",
     "checksumdir>=1.2.0",
     "rich-click>=1.7.1",
     "click>=8.1.8",

--- a/devel-common/pyproject.toml
+++ b/devel-common/pyproject.toml
@@ -78,7 +78,7 @@ dependencies = [
     "docutils>=0.21",
     "sphinx-airflow-theme@https://github.com/apache/airflow-site/releases/download/0.2.3/sphinx_airflow_theme-0.2.3-py3-none-any.whl",
     "sphinx-argparse>=0.4.0",
-    "sphinx-autoapi>=3",
+    "sphinx-autoapi>=3.5.0",
     "sphinx-autobuild>=2024.10.2",
     "sphinx-copybutton>=0.5.2",
     "sphinx-design>=0.5.0",

--- a/devel-common/pyproject.toml
+++ b/devel-common/pyproject.toml
@@ -70,15 +70,13 @@ dependencies = [
     "twine>=4.0.2",
 ]
 "docs" = [
-    # Astroid 4 released 5 Oct 2025 breaks autoapi https://github.com/apache/airflow/issues/56420
-    "astroid>=3,<4",
     "checksumdir>=1.2.0",
     "rich-click>=1.7.1",
     "click>=8.1.8",
     "docutils>=0.21",
     "sphinx-airflow-theme@https://github.com/apache/airflow-site/releases/download/0.2.3/sphinx_airflow_theme-0.2.3-py3-none-any.whl",
     "sphinx-argparse>=0.4.0",
-    "sphinx-autoapi>=3.5.0",
+    "sphinx-autoapi>=3.6.1",
     "sphinx-autobuild>=2024.10.2",
     "sphinx-copybutton>=0.5.2",
     "sphinx-design>=0.5.0",

--- a/devel-common/src/docs/utils/conf_constants.py
+++ b/devel-common/src/docs/utils/conf_constants.py
@@ -326,24 +326,23 @@ def get_google_intersphinx_mapping() -> dict[str, tuple[str, tuple[str]]]:
 
 
 BASIC_AUTOAPI_IGNORE_PATTERNS = [
-    "*/airflow/_vendor/*",
-    "*/airflow/executors/*",
-    "*/_internal*",
-    "*/node_modules/*",
-    "*/migrations/*",
-    "*/contrib/*",
-    "*/example_taskflow_api_docker_virtualenv.py",
-    "*/example_dag_decorator.py",
-    "*/conftest.py",
-    "*/tests/__init__.py",
-    "*/tests/system/__init__.py",
-    "*/tests/system/*/tests/*",
-    "*/tests/system/example_empty.py",
-    "*/check_translations_completeness.py",
-    # Files that are not useful for API reference and can trip AutoAPI under astroid>=4
-    "*/airflow/providers/*/__init__.py",
-    "*/airflow/providers/*/get_provider_info.py",
-    "*/airflow/providers/*/version_compat.py",
+    "**/airflow/_vendor/**",
+    "**/airflow/executors/**",
+    "**/_internal*",
+    "**/node_modules/**",
+    "**/migrations/**",
+    "**/contrib/**",
+    "**/example_taskflow_api_docker_virtualenv.py",
+    "**/example_dag_decorator.py",
+    "**/conftest.py",
+    "**/tests/**",
+    "**/*test*.py",
+    "**/test_*.py",
+    "**/*_test.py",
+    "**/check_translations_completeness.py",
+    # Do not ignore __init__.py - Astroid 4 needs it for package discovery
+    "**/airflow/providers/*/get_provider_info.py",
+    "**/airflow/providers/*/version_compat.py",
 ]
 
 IGNORE_PATTERNS_RECOGNITION = re.compile(r"\[AutoAPI\] .* Ignoring \s (?P<path>/[\w/.]*)", re.VERBOSE)

--- a/devel-common/src/docs/utils/conf_constants.py
+++ b/devel-common/src/docs/utils/conf_constants.py
@@ -339,6 +339,11 @@ BASIC_AUTOAPI_IGNORE_PATTERNS = [
     "*/tests/system/__init__.py",
     "*/tests/system/*/tests/*",
     "*/tests/system/example_empty.py",
+    "*/check_translations_completeness.py",
+    # Files that are not useful for API reference and can trip AutoAPI under astroid>=4
+    "*/airflow/providers/*/__init__.py",
+    "*/airflow/providers/*/get_provider_info.py",
+    "*/airflow/providers/*/version_compat.py",
 ]
 
 IGNORE_PATTERNS_RECOGNITION = re.compile(r"\[AutoAPI\] .* Ignoring \s (?P<path>/[\w/.]*)", re.VERBOSE)
@@ -361,6 +366,9 @@ AUTOAPI_OPTIONS = [
     "show-inheritance",
     "show-module-summary",
     "special-members",
+    # Ensure objects imported into modules are documented as members.
+    # This helps AutoAPI correctly resolve symbols when using Astroid 4.
+    "imported-members",
 ]
 
 SUPPRESS_WARNINGS = [

--- a/providers/airbyte/docs/index.rst
+++ b/providers/airbyte/docs/index.rst
@@ -48,6 +48,8 @@
     :maxdepth: 1
     :caption: System tests
 
+    System Tests <_api/tests/system/airbyte/index>
+
 .. note::
    System tests live in the source tree under ``providers/airbyte/tests/system``.
    They are not part of the API reference. When AutoAPI generates system test

--- a/providers/airbyte/docs/index.rst
+++ b/providers/airbyte/docs/index.rst
@@ -41,14 +41,18 @@
     :maxdepth: 1
     :caption: References
 
-    Python API <_api/airflow/providers/airbyte/index>
+    Python API <_api/modules>
 
 .. toctree::
     :hidden:
     :maxdepth: 1
     :caption: System tests
 
-    System Tests <_api/tests/system/airbyte/index>
+.. note::
+   System tests live in the source tree under ``providers/airbyte/tests/system``.
+   They are not part of the API reference. When AutoAPI generates system test
+   pages (``_api/tests/system/...``) in environments that support it, they will
+   appear automatically in the left navigation.
 
 .. toctree::
     :hidden:

--- a/providers/airbyte/docs/index.rst
+++ b/providers/airbyte/docs/index.rst
@@ -41,7 +41,7 @@
     :maxdepth: 1
     :caption: References
 
-    Python API <_api/modules>
+    Python API <_api/airflow/providers/airbyte/index>
 
 .. toctree::
     :hidden:
@@ -49,12 +49,6 @@
     :caption: System tests
 
     System Tests <_api/tests/system/airbyte/index>
-
-.. note::
-   System tests live in the source tree under ``providers/airbyte/tests/system``.
-   They are not part of the API reference. When AutoAPI generates system test
-   pages (``_api/tests/system/...``) in environments that support it, they will
-   appear automatically in the left navigation.
 
 .. toctree::
     :hidden:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
related: #56420 

This PR switch to apidoc+autodoc only for provider docs when Astroid ≥ 4 and everything else still uses AutoAPI.  On Sphinx startup, we run sphinx-apidoc to generate _api, sidestepping Astroid 4 vs AutoAPI ignore quirks.  This PR changed the ignore list (exclude get_provider_info.py, version_compat.py, etc.) that aren’t useful for API and can break parsing. Also This updated Airbyte docs: Python API now links to _api/modules; System tests is a note instead of a hard toctree, avoiding dead links.  W#ithout using version pinning or downgrades, once AutoAPI supports Astroid 4, we can just remove the conditional and revert easily.

### test
`uv run --group docs build-docs --docs-only`

<img width="666" height="205" alt="image" src="https://github.com/user-attachments/assets/4c35b81c-cb1a-4d74-b8a9-92ec094ab922" />


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
