### PR TITLE
Fix scheduler crash with email notifications

### DIFF
--- a/airflow-core/src/airflow/callbacks/callback_requests.py
+++ b/airflow-core/src/airflow/callbacks/callback_requests.py
@@ -77,7 +77,7 @@ class TaskCallbackRequest(BaseCallbackRequest):
         }
 
 
-class EmailNotificationRequest(BaseCallbackRequest):
+class EmailRequest(BaseCallbackRequest):
     """Email notification request for task failures/retries."""
 
     ti: ti_datamodel.TaskInstance
@@ -86,7 +86,7 @@ class EmailNotificationRequest(BaseCallbackRequest):
     """Whether this is for a failure or retry email"""
     context_from_server: ti_datamodel.TIRunContext
     """Task execution context from the Server"""
-    type: Literal["EmailNotificationRequest"] = "EmailNotificationRequest"
+    type: Literal["EmailRequest"] = "EmailRequest"
 
 
 class DagRunContext(BaseModel):
@@ -108,6 +108,9 @@ class DagCallbackRequest(BaseCallbackRequest):
 
 
 CallbackRequest = Annotated[
-    DagCallbackRequest | TaskCallbackRequest | EmailNotificationRequest,
+    DagCallbackRequest | TaskCallbackRequest | EmailRequest,
     Field(discriminator="type"),
 ]
+
+# Backwards compatibility alias
+EmailNotificationRequest = EmailRequest

--- a/airflow-core/src/airflow/dag_processing/processor.py
+++ b/airflow-core/src/airflow/dag_processing/processor.py
@@ -31,7 +31,7 @@ from pydantic import BaseModel, Field, TypeAdapter
 from airflow.callbacks.callback_requests import (
     CallbackRequest,
     DagCallbackRequest,
-    EmailNotificationRequest,
+    EmailRequest,
     TaskCallbackRequest,
 )
 from airflow.configuration import conf
@@ -243,7 +243,7 @@ def _execute_callbacks(
             _execute_task_callbacks(dagbag, request, log)
         elif isinstance(request, DagCallbackRequest):
             _execute_dag_callbacks(dagbag, request, log)
-        elif isinstance(request, EmailNotificationRequest):
+        elif isinstance(request, EmailRequest):
             _execute_email_callbacks(dagbag, request, log)
 
 
@@ -354,9 +354,7 @@ def _execute_task_callbacks(dagbag: DagBag, request: TaskCallbackRequest, log: F
             log.exception("Error in callback at index %d: %s", idx, callback_repr)
 
 
-def _execute_email_callbacks(
-    dagbag: DagBag, request: EmailNotificationRequest, log: FilteringBoundLogger
-) -> None:
+def _execute_email_callbacks(dagbag: DagBag, request: EmailRequest, log: FilteringBoundLogger) -> None:
     """Execute email notification for task failure/retry."""
     dag = dagbag.dags[request.ti.dag_id]
     task = dag.get_task(request.ti.task_id)

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -43,7 +43,7 @@ from airflow.api_fastapi.execution_api.datamodels.taskinstance import DagRun as 
 from airflow.callbacks.callback_requests import (
     DagCallbackRequest,
     DagRunContext,
-    EmailNotificationRequest,
+    EmailRequest,
     TaskCallbackRequest,
 )
 from airflow.configuration import conf
@@ -959,7 +959,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                         "Sending email request for task %s to DAG Processor",
                         ti,
                     )
-                    email_request = EmailNotificationRequest(
+                    email_request = EmailRequest(
                         filepath=ti.dag_model.relative_fileloc,
                         bundle_name=ti.dag_version.bundle_name,
                         bundle_version=ti.dag_version.bundle_version,

--- a/airflow-core/tests/unit/callbacks/test_callback_requests.py
+++ b/airflow-core/tests/unit/callbacks/test_callback_requests.py
@@ -32,7 +32,7 @@ from airflow.callbacks.callback_requests import (
     CallbackRequest,
     DagCallbackRequest,
     DagRunContext,
-    EmailNotificationRequest,
+    EmailRequest,
     TaskCallbackRequest,
 )
 from airflow.models.dag import DAG
@@ -314,9 +314,9 @@ class TestDagCallbackRequestWithContext:
         assert result.context_from_server.last_ti.task_id == "test_task"
 
 
-class TestEmailNotificationRequest:
+class TestEmailRequest:
     def test_email_notification_request_serialization(self):
-        """Test EmailNotificationRequest can be serialized and used in CallbackRequest union."""
+        """Test EmailRequest can be serialized and used in CallbackRequest union."""
         ti_data = TIDataModel(
             id=str(uuid.uuid4()),
             task_id="test_task",
@@ -331,8 +331,8 @@ class TestEmailNotificationRequest:
 
         current_time = timezone.utcnow()
 
-        # Create EmailNotificationRequest
-        email_request = EmailNotificationRequest(
+        # Create EmailRequest
+        email_request = EmailRequest(
             filepath="/path/to/dag.py",
             bundle_name="test_bundle",
             bundle_version="1.0.0",
@@ -359,17 +359,17 @@ class TestEmailNotificationRequest:
 
         # Test serialization
         json_str = email_request.to_json()
-        assert "EmailNotificationRequest" in json_str
+        assert "EmailRequest" in json_str
         assert "failure" in json_str
 
         # Test deserialization
-        result = EmailNotificationRequest.from_json(json_str)
+        result = EmailRequest.from_json(json_str)
         assert result == email_request
         assert result.email_type == "failure"
         assert result.ti.task_id == "test_task"
 
     def test_callback_request_union_with_email_notification(self):
-        """Test EmailNotificationRequest works in CallbackRequest union type."""
+        """Test EmailRequest works in CallbackRequest union type."""
         ti_data = TIDataModel(
             id=str(uuid.uuid4()),
             task_id="test_task",
@@ -402,7 +402,7 @@ class TestEmailNotificationRequest:
         )
 
         email_data = {
-            "type": "EmailNotificationRequest",
+            "type": "EmailRequest",
             "filepath": "/path/to/dag.py",
             "bundle_name": "test_bundle",
             "bundle_version": "1.0.0",
@@ -416,7 +416,7 @@ class TestEmailNotificationRequest:
         adapter = TypeAdapter(CallbackRequest)
         callback_request = adapter.validate_python(email_data)
 
-        # Verify it's correctly identified as EmailNotificationRequest
-        assert isinstance(callback_request, EmailNotificationRequest)
+        # Verify it's correctly identified as EmailRequest
+        assert isinstance(callback_request, EmailRequest)
         assert callback_request.email_type == "retry"
         assert callback_request.ti.task_id == "test_task"

--- a/airflow-core/tests/unit/dag_processing/test_processor.py
+++ b/airflow-core/tests/unit/dag_processing/test_processor.py
@@ -45,7 +45,7 @@ from airflow.callbacks.callback_requests import (
     CallbackRequest,
     DagCallbackRequest,
     DagRunContext,
-    EmailNotificationRequest,
+    EmailRequest,
     TaskCallbackRequest,
 )
 from airflow.dag_processing.dagbag import DagBag
@@ -1303,7 +1303,7 @@ class TestExecuteEmailCallbacks:
         )
 
         current_time = timezone.utcnow()
-        request = EmailNotificationRequest(
+        request = EmailRequest(
             filepath="/path/to/dag.py",
             bundle_name="test_bundle",
             bundle_version="1.0.0",
@@ -1363,7 +1363,7 @@ class TestExecuteEmailCallbacks:
 
         current_time = timezone.utcnow()
 
-        request = EmailNotificationRequest(
+        request = EmailRequest(
             filepath="/path/to/dag.py",
             bundle_name="test_bundle",
             bundle_version="1.0.0",
@@ -1422,7 +1422,7 @@ class TestExecuteEmailCallbacks:
         )
 
         current_time = timezone.utcnow()
-        request = EmailNotificationRequest(
+        request = EmailRequest(
             filepath="/path/to/dag.py",
             bundle_name="test_bundle",
             bundle_version="1.0.0",
@@ -1480,7 +1480,7 @@ class TestExecuteEmailCallbacks:
         current_time = timezone.utcnow()
 
         # Create request for failure (but email_on_failure is False)
-        request = EmailNotificationRequest(
+        request = EmailRequest(
             filepath="/path/to/dag.py",
             bundle_name="test_bundle",
             bundle_version="1.0.0",


### PR DESCRIPTION
The ``EmailNotificationRequest`` class name (25 characters) exceeded the database constraint for ``DbCallbackRequest.callback_type column`` (20 characters), causing scheduler crashes when email notifications were triggered for task failures or retries.

This fix renames the class to ``EmailRequest`` (12 characters) to fit within the constraint. A backwards compatibility alias ensures existing DB entries with `'EmailNotificationRequest'` can still be deserialized via getattr lookup.

The 20-character limit is arbitrary and does not affect performance. In a follow-up PR for 3.2, we should increase this to 50+ characters to accommodate descriptive class names without requiring abbreviations.

Fixes #56426

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
