### PR TITLE
feature: Allow batch filtering for dags using Keycloak provider

### DIFF
--- a/providers/keycloak/docs/auth-manager/manage/permissions.rst
+++ b/providers/keycloak/docs/auth-manager/manage/permissions.rst
@@ -31,8 +31,8 @@ They can create the permissions and needed resources easily.
 
 There are two options to create the permissions:
 
-* Create all permissions (Scopes, Resources, Permissions) in one go using one CLI command
-* Create all permissions (Scopes, Resources, Permissions) step-by-step using the CLI commands
+* Create all permissions (Scopes, Resources, Permissions and Policies) in one go using one CLI command
+* Create all permissions (Scopes, Resources, Permissions and Policies) step-by-step using the CLI commands
 
 CLI commands take the following parameters:
 
@@ -52,7 +52,7 @@ One-go creation of permissions
 
 There is a single command do all the magic for you.
 
-This command will create scopes, resources and permissions in one-go.
+This command will create scopes, resources, permissions and policies in one-go.
 
 .. code-block:: bash
 
@@ -87,6 +87,22 @@ This will create
 * admin permissions
 * user permissions
 * operations permissions
+
+Run ``files/scripts/register_keycloak_base.sh`` to create the base client roles
+(``admin``, ``viewer``, ``user``, ``op``), their associated ``Allow-*`` policies, and the
+default resource permissions referenced above. After that, execute
+``files/scripts/register_keycloak_policy.sh`` to upload the DAG visibility policy JAR and
+wire ``DagVisibilityPolicy`` to the ``DagVisibilityPermission`` entry. Airflow now simply
+passes the requested DAG ids to Keycloak, so all filtering logic should live in the JavaScript
+policy located at ``airflow/providers/keycloak/auth_manager/policies/dag_visibility.js``.
+Adjust ``isDagAllowedForUser`` in that file to implement your organisation specific rules.
+
+If your Keycloak instance is running in Docker (the default when starting Breeze with the
+``keycloak`` integration), you can also run
+``files/scripts/create_keycloak_permissions.sh`` to (re)create the standard ``Admin``,
+``ReadOnly``, ``User``, ``Op`` and ``DagVisibilityPermission`` entries without using the
+Airflow CLI. The script talks to the container via ``kcadm`` and only needs Docker and ``jq``
+installed on the host.
 
 More resources about permissions can be found in the official documentation of Keycloak:
 

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/policies/__init__.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/policies/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/policies/dag_visibility.js
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/policies/dag_visibility.js
@@ -1,0 +1,94 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Keycloak JavaScript policy for batch DAG authorization decisions.
+ *
+ * Airflow sends all candidate DAG ids in the UMA ticket context attribute
+ * ``dag_ids`` (comma separated). This policy inspects each id and adds
+ * allowed DAG ids back to the permission as individual scopes so that the
+ * Airflow auth manager can map the results efficiently.
+ *
+ * Customize ``isDagAllowedForUser`` to match your organisation's access model.
+ */
+var context = $evaluation.getContext();
+var attributes = context.getAttributes();
+
+(function () {
+    var dagIdsAttr = attributes.getValue("dag_ids");
+    if (!dagIdsAttr || dagIdsAttr.isEmpty()) {
+        $evaluation.grant();
+        return;
+    }
+
+    var dagIds = dagIdsAttr.get(0).split(/\s*,\s*/);
+
+    var permission = $evaluation.getPermission();
+    var granted = false;
+
+    var isDagAllowedForUser = function (dagId) {
+        /**
+         * Customize this check to implement organisation specific policies.
+         * You can access Keycloak attributes via:
+         *
+         *   var identity = context.getIdentity();
+         *   identity.getAttributes().getValue("attribute_name");
+         *
+         * or use UMA context attributes such as team_name. By default we allow every DAG.
+         */
+        return true;
+    };
+
+    for (var i = 0; i < dagIds.length; i++) {
+        var dagId = dagIds[i];
+        if (!dagId) {
+            continue;
+        }
+
+        if (isDagAllowedForUser(dagId)) {
+            permission.addScope(dagId);
+            granted = true;
+        }
+    }
+
+    if (granted) {
+        $evaluation.grant();
+    } else {
+        $evaluation.deny();
+    }
+})();

--- a/providers/keycloak/src/airflow/providers/keycloak/cli/definition.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/cli/definition.py
@@ -92,8 +92,24 @@ KEYCLOAK_AUTH_MANAGER_COMMANDS = (
         args=(ARG_USERNAME, ARG_PASSWORD, ARG_USER_REALM, ARG_CLIENT_ID, ARG_DRY_RUN),
     ),
     ActionCommand(
+        name="create-policies",
+        help="Create policies in Keycloak",
+        func=lazy_load_command(
+            "airflow.providers.keycloak.auth_manager.cli.commands.create_policies_command"
+        ),
+        args=(ARG_USERNAME, ARG_PASSWORD, ARG_USER_REALM, ARG_CLIENT_ID),
+    ),
+    ActionCommand(
+        name="create-policies",
+        help="Create policies in Keycloak",
+        func=lazy_load_command(
+            "airflow.providers.keycloak.auth_manager.cli.commands.create_policies_command"
+        ),
+        args=(ARG_USERNAME, ARG_PASSWORD, ARG_USER_REALM, ARG_CLIENT_ID),
+    ),
+    ActionCommand(
         name="create-all",
-        help="Create all entities (scopes, resources and permissions) in Keycloak",
+        help="Create all entities (scopes, resources, permissions and policies) in Keycloak",
         func=lazy_load_command("airflow.providers.keycloak.auth_manager.cli.commands.create_all_command"),
         args=(ARG_USERNAME, ARG_PASSWORD, ARG_USER_REALM, ARG_CLIENT_ID, ARG_DRY_RUN),
     ),

--- a/scripts/ci/docker-compose/integration-keycloak.yml
+++ b/scripts/ci/docker-compose/integration-keycloak.yml
@@ -17,7 +17,7 @@
 ---
 services:
   keycloak:
-    image: quay.io/keycloak/keycloak:23.0.6
+    image: quay.io/keycloak/keycloak:26.2.5
     labels:
       breeze.description: "Integration for manual testing of multi-team Airflow."
     entrypoint: /opt/keycloak/keycloak-entrypoint.sh
@@ -30,6 +30,7 @@ services:
 
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_FEATURES: scripts
 
       KC_DB: postgres
       KC_DB_URL: jdbc:postgresql://postgres/keycloak
@@ -43,6 +44,8 @@ services:
         condition: service_healthy
     volumes:
       - ./keycloak/keycloak-entrypoint.sh:/opt/keycloak/keycloak-entrypoint.sh
+      - keycloak-policy-provider:/opt/keycloak/providers
+      - ../../../providers/keycloak/src/airflow/providers/keycloak/auth_manager/policies:/opt/keycloak/script-src:ro
 
   postgres:
     volumes:
@@ -61,3 +64,6 @@ services:
   airflow:
     depends_on:
       - keycloak
+
+volumes:
+  keycloak-policy-provider:


### PR DESCRIPTION
Due to the growing number of dags we have, the default filtering flow to list the dags was leading to performance issue as hinted in the documentation of function filter_authorized_connections.

- This pull request adds a provider specific implementation to Keycloak, allowing to authenticate using batch functions.
- Updated the documentation to setup a Keycloak environment to match new breeze subcommand

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
