### PR TITLE
Use name passed to `@asset` decorator when fetching the asset.

### DIFF
--- a/task-sdk/src/airflow/sdk/definitions/asset/decorators.py
+++ b/task-sdk/src/airflow/sdk/definitions/asset/decorators.py
@@ -57,12 +57,6 @@ class _AssetMainOperator(PythonOperator):
     @classmethod
     def from_definition(cls, definition: AssetDefinition | MultiAssetDefinition) -> Self:
         _validate_asset_function_arguments(definition._function)
-
-        if isinstance(definition, AssetDefinition):
-            definition_name = definition.name
-        else:
-            definition_name = definition._function.__name__
-
         return cls(
             task_id=definition._function.__name__,
             inlets=[
@@ -72,7 +66,7 @@ class _AssetMainOperator(PythonOperator):
             ],
             outlets=[v for _, v in definition.iter_assets()],
             python_callable=definition._function,
-            definition_name=definition_name,
+            definition_name=definition.name,
         )
 
     def _iter_kwargs(self, context: Mapping[str, Any]) -> Iterator[tuple[str, Any]]:
@@ -143,6 +137,7 @@ class MultiAssetDefinition(BaseAsset):
     :meta private:
     """
 
+    name: str
     _function: Callable
     _source: asset.multi
 
@@ -237,7 +232,7 @@ class asset(_DAGFactory):
                 raise ValueError("nested function not supported")
             if not self.outlets:
                 raise ValueError("no outlets provided")
-            return MultiAssetDefinition(function=f, source=self)
+            return MultiAssetDefinition(function=f, source=self, name=f.__name__)
 
     def __call__(self, f: Callable) -> AssetDefinition:
         if f.__name__ != f.__qualname__:

--- a/task-sdk/src/airflow/sdk/definitions/asset/decorators.py
+++ b/task-sdk/src/airflow/sdk/definitions/asset/decorators.py
@@ -57,6 +57,12 @@ class _AssetMainOperator(PythonOperator):
     @classmethod
     def from_definition(cls, definition: AssetDefinition | MultiAssetDefinition) -> Self:
         _validate_asset_function_arguments(definition._function)
+
+        if isinstance(definition, AssetDefinition):
+            definition_name = definition.name
+        else:
+            definition_name = definition._function.__name__
+
         return cls(
             task_id=definition._function.__name__,
             inlets=[
@@ -66,7 +72,7 @@ class _AssetMainOperator(PythonOperator):
             ],
             outlets=[v for _, v in definition.iter_assets()],
             python_callable=definition._function,
-            definition_name=definition._function.__name__,
+            definition_name=definition_name,
         )
 
     def _iter_kwargs(self, context: Mapping[str, Any]) -> Iterator[tuple[str, Any]]:

--- a/task-sdk/tests/task_sdk/definitions/test_asset_decorators.py
+++ b/task-sdk/tests/task_sdk/definitions/test_asset_decorators.py
@@ -437,3 +437,26 @@ class Test_AssetMainOperator:
         assert mock_supervisor_comms.mock_calls == [
             mock.call.send(GetAssetByName(name="inlet_asset_1")),
         ]
+
+    def test_from_definition_custom_name(self, mock_supervisor_comms, func_fixer):
+        @func_fixer
+        def example_asset_func(self):
+            pass
+
+        definition = asset(schedule=None, name="custom_name")(example_asset_func)
+        op = _AssetMainOperator.from_definition(definition)
+        assert op.task_id == "example_asset_func"
+        assert op.python_callable == example_asset_func
+        assert op._definition_name == "custom_name"
+
+        mock_supervisor_comms.send.side_effect = [
+            AssetResult(name="custom_name", uri="s3://bucket/object1", group="Asset")
+        ]
+
+        assert op.determine_kwargs(context={}) == {
+            "self": Asset(name="custom_name", uri="s3://bucket/object1", group="Asset")
+        }
+
+        assert mock_supervisor_comms.mock_calls == [
+            mock.call.send(GetAssetByName(name="custom_name", uri="s3://bucket/object1", group="Asset"))
+        ]


### PR DESCRIPTION
When name is used in `@asset` decorator then fetching asset should use the value instead of always using the function name which leads to asset not being found.

closes #56401