### PR TITLE
Better error handling for running ti heartbeats after task is cleared

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -605,12 +605,12 @@ def ti_heartbeat(
             "Retrieved current task state", state=previous_state, current_hostname=hostname, current_pid=pid
         )
     except NoResultFound:
-        log.error("Task Instance not found")
+        log.error("Task Instance not found in Task Instance, might have moved to the Task Instance History table")
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
+            status_code=status.HTTP_410_GONE,
             detail={
                 "reason": "not_found",
-                "message": "Task Instance not found",
+                "message": "Task Instance not found, might have moved to the Task Instance History table",
             },
         )
 

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -577,7 +577,7 @@ def ti_skip_downstream(
     "/{task_instance_id}/heartbeat",
     status_code=status.HTTP_204_NO_CONTENT,
     responses={
-        status.HTTP_404_NOT_FOUND: {"description": "Task Instance not found"},
+        status.HTTP_410_GONE: {"description": "Task Instance not found, might have moved to the Task Instance History table"},
         status.HTTP_409_CONFLICT: {
             "description": "The TI attempting to heartbeat should be terminated for the given reason"
         },
@@ -605,7 +605,7 @@ def ti_heartbeat(
             "Retrieved current task state", state=previous_state, current_hostname=hostname, current_pid=pid
         )
     except NoResultFound:
-        log.error("Task Instance not found in Task Instance, might have moved to the Task Instance History table")
+        log.error("Task Instance not found in Task Instance table, might have moved to the Task Instance History table")
         raise HTTPException(
             status_code=status.HTTP_410_GONE,
             detail={

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -610,7 +610,7 @@ def ti_heartbeat(
             status_code=status.HTTP_410_GONE,
             detail={
                 "reason": "not_found",
-                "message": "Task Instance not found, might have moved to the Task Instance History table",
+        status.HTTP_410_GONE: {"description": "Task Instance no longer exists, it may have moved to the Task Instance History table"},
             },
         )
 

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -605,7 +605,7 @@ def ti_heartbeat(
             "Retrieved current task state", state=previous_state, current_hostname=hostname, current_pid=pid
         )
     except NoResultFound:
-        log.error("Task Instance not found in Task Instance table, might have moved to the Task Instance History table")
+        status.HTTP_410_GONE: {"description": "Task Instance no longer exists, it may have moved to the Task Instance History table"},
         raise HTTPException(
             status_code=status.HTTP_410_GONE,
             detail={

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -577,7 +577,7 @@ def ti_skip_downstream(
     "/{task_instance_id}/heartbeat",
     status_code=status.HTTP_204_NO_CONTENT,
     responses={
-        status.HTTP_410_GONE: {"description": "Task Instance not found, might have moved to the Task Instance History table"},
+        status.HTTP_410_GONE: {"description": "Task Instance no longer exists, it may have moved to the Task Instance History table"},
         status.HTTP_409_CONFLICT: {
             "description": "The TI attempting to heartbeat should be terminated for the given reason"
         },

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -1264,7 +1264,7 @@ class TestTIHealthEndpoint:
             assert response.json()["detail"] == expected_detail
 
     def test_ti_heartbeat_non_existent_task(self, client, session, create_task_instance):
-        """Test that a 404 error is returned when the Task Instance does not exist."""
+        """Test that a 410 error is returned when the Task Instance does not exist."""
         task_instance_id = "0182e924-0f1e-77e6-ab50-e977118bc139"
 
         # Pre-condition: the Task Instance does not exist
@@ -1275,10 +1275,10 @@ class TestTIHealthEndpoint:
             json={"hostname": "random-hostname", "pid": 1547},
         )
 
-        assert response.status_code == 404
+        assert response.status_code == 410
         assert response.json()["detail"] == {
             "reason": "not_found",
-            "message": "Task Instance not found",
+            "message": "Task Instance not found, might have moved to the Task Instance History table",
         }
 
     @pytest.mark.parametrize(

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -1099,7 +1099,7 @@ class ActivitySubprocess(WatchedSubprocess):
             # Reset the counter on success
             self.failed_heartbeats = 0
         except ServerResponseError as e:
-            if e.response.status_code in {HTTPStatus.NOT_FOUND, HTTPStatus.CONFLICT}:
+            if e.response.status_code in {HTTPStatus.GONE, HTTPStatus.CONFLICT}:
                 log.error(
                     "Server indicated the task shouldn't be running anymore",
                     detail=e.detail,


### PR DESCRIPTION
Return `410 - GONE` instead of `404 - NOT_FOUND` when the running task instance heartbeats after task is cleared. 

When a running task is cleared, the previous task instance is moved from the Task Instance table to the Task Instance History table. As a result, if the task instance hearbeats, the api server returns a 404. A more appropriate error is 410. 

closes: [#53140](https://github.com/apache/airflow/issues/53140)

#### Airflow task logs:
<img width="1160" height="438" alt="image" src="https://github.com/user-attachments/assets/3c0ca02a-704d-4e01-a6eb-79cd58281471" />


#### Scheduler and API server logs:
```
api-server | [2025-10-06T21:28:42.135650Z] {task_instances.py:608} ERROR - Task Instance not found in Task Instance table, might have moved to the Task Instance History table ti_id=0199bb6c-f0be-7686-a26e-30f70d893ae1
api-server | INFO:     127.0.0.1:53520 - "PUT /execution/task-instances/0199bb6c-f0be-7686-a26e-30f70d893ae1/heartbeat HTTP/1.1" 410 Gone
scheduler  | [2025-10-06T21:28:42.137967Z] {supervisor.py:1103} ERROR - Server indicated the task shouldn't be running anymore detail={'detail': {'reason': 'not_found', 'message': 'Task Instance not found, might have moved to the Task Instance History table'}} status_code=410 ti_id=UUID('0199bb6c-f0be-7686-a26e-30f70d893ae1')
scheduler  | [2025-10-06T21:28:42.144732Z] {supervisor.py:713} INFO - Process exited pid=96561 exit_code=0 signal_sent=SIGTERM
scheduler  | [2025-10-06T21:28:42.144989Z] {supervisor.py:1899} INFO - Task finished exit_code=0 duration=15.431881000055 final_state=SERVER_TERMINATED
```






<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
