### PR TITLE
Enable PT011 rule to prvoider tests

### DIFF
--- a/providers/common/compat/tests/unit/common/compat/openlineage/test_check.py
+++ b/providers/common/compat/tests/unit/common/compat/openlineage/test_check.py
@@ -27,6 +27,8 @@ import pytest
 from airflow.exceptions import AirflowOptionalProviderFeatureException
 from airflow.providers.common.compat.openlineage.check import require_openlineage_version
 
+REQUIRE_OPENLINEAGE_VERSION = r"`require_openlineage_version` decorator must be used with at least one argument.*@require_openlineage_version\(provider_min_version=\"1\.0\.0\"\)"
+
 
 def _mock_version(package):
     if package == "apache-airflow-providers-openlineage":
@@ -52,29 +54,16 @@ def test_decorator_without_arguments():
 
 
 def test_decorator_without_arguments_with_parentheses():
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match=REQUIRE_OPENLINEAGE_VERSION):
 
         @require_openlineage_version()
         def dummy():
             return "result"
 
-    expected_error = (
-        "`require_openlineage_version` decorator must be used with at least one argument: "
-        "'provider_min_version' or 'client_min_version', "
-        'e.g., @require_openlineage_version(provider_min_version="1.0.0")'
-    )
-    assert str(excinfo.value) == expected_error
-
 
 def test_no_arguments_provided():
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match=REQUIRE_OPENLINEAGE_VERSION):
         require_openlineage_version()
-    expected_error = (
-        "`require_openlineage_version` decorator must be used with at least one argument: "
-        "'provider_min_version' or 'client_min_version', "
-        'e.g., @require_openlineage_version(provider_min_version="1.0.0")'
-    )
-    assert str(excinfo.value) == expected_error
 
 
 @pytest.mark.parametrize("provider_min_version", ("1.0.0", "0.9", "0", "0.9.9", "1.0.0.dev0", "1.0.0rc1"))

--- a/providers/common/io/tests/unit/common/io/assets/test_file.py
+++ b/providers/common/io/tests/unit/common/io/assets/test_file.py
@@ -44,7 +44,7 @@ def test_sanitize_uri_valid(uri, expected):
 
 @pytest.mark.parametrize("uri", ("file://",))
 def test_sanitize_uri_invalid(uri):
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="URI format file:// must contain a non-empty path."):
         sanitize_uri(urlsplit(uri))
 
 

--- a/providers/common/messaging/tests/unit/common/messaging/triggers/test_msg_queue.py
+++ b/providers/common/messaging/tests/unit/common/messaging/triggers/test_msg_queue.py
@@ -135,7 +135,7 @@ class TestMessageQueueTrigger:
         with mock.patch(MESSAGE_QUEUE_PROVIDERS_PATH, [provider1, provider2]):
             trigger = MessageQueueTrigger(queue=UNSUPPORTED_QUEUE)
 
-            with pytest.raises(ValueError):
+            with pytest.raises(ValueError, match=UNSUPPORTED_QUEUE):
                 _ = trigger.trigger
 
     def test_trigger_kwargs_passed_correctly(self):

--- a/providers/common/sql/tests/unit/common/sql/hooks/test_dbapi.py
+++ b/providers/common/sql/tests/unit/common/sql/hooks/test_dbapi.py
@@ -577,9 +577,8 @@ class TestDbApiHook:
         assert result == [obj, obj]
 
     def test_run_no_queries(self):
-        with pytest.raises(ValueError) as err:
+        with pytest.raises(ValueError, match="List of SQL statements is empty"):
             self.db_hook.run(sql=[])
-        assert err.value.args[0] == "List of SQL statements is empty"
 
     def test_run_and_log_db_messages(self):
         statement = "SQL"

--- a/providers/common/sql/tests/unit/common/sql/hooks/test_sql.py
+++ b/providers/common/sql/tests/unit/common/sql/hooks/test_sql.py
@@ -239,9 +239,8 @@ class TestDbApiHook:
     )
     def test_no_query(self, empty_statement):
         dbapi_hook = mock_db_hook(DbApiHook)
-        with pytest.raises(ValueError) as err:
+        with pytest.raises(ValueError, match="List of SQL statements is empty"):
             dbapi_hook.run(sql=empty_statement)
-        assert err.value.args[0] == "List of SQL statements is empty"
 
     @pytest.mark.db_test
     def test_placeholder_config_from_extra(self):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
issue: Enable Even More PyDocStyle Checks #40567
@ferruzzi
This PR is for enable PT011 rule:
PT011: all instances of pytest.raises should include a match term to make sure they are catching the right error.
https://docs.astral.sh/ruff/rules/pytest-raises-too-broad/
There are 102 files changes is need.
So, I separate to many PR, which contains about 5 file changes for easy review.
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
