### PR TITLE
Fix .airflowignore order precedence

### DIFF
--- a/airflow-core/src/airflow/utils/file.py
+++ b/airflow-core/src/airflow/utils/file.py
@@ -102,24 +102,21 @@ class _GlobIgnoreRule(NamedTuple):
             relative_to = definition_file.parent
 
         ignore_pattern = GitWildMatchPattern(pattern)
-        return _GlobIgnoreRule(ignore_pattern, relative_to)
+        return _GlobIgnoreRule(wild_match_pattern=ignore_pattern, relative_to=relative_to)
 
     @staticmethod
     def match(path: Path, rules: list[_IgnoreRule]) -> bool:
-        """Match a list of ignore rules against the supplied path."""
+        """Match a list of ignore rules against the supplied path, accounting for exclusion rules and ordering."""
         matched = False
-        for r in rules:
-            if not isinstance(r, _GlobIgnoreRule):
-                raise ValueError(f"_GlobIgnoreRule cannot match rules of type: {type(r)}")
-            rule: _GlobIgnoreRule = r  # explicit typing to make mypy play nicely
+        for rule in rules:
+            if not isinstance(rule, _GlobIgnoreRule):
+                raise ValueError(f"_GlobIgnoreRule cannot match rules of type: {type(rule)}")
             rel_path = str(path.relative_to(rule.relative_to) if rule.relative_to else path.name)
-            matched = rule.wild_match_pattern.match_file(rel_path) is not None
-
-            if matched:
-                if not rule.wild_match_pattern.include:
-                    return False
-
-                return matched
+            if (
+                rule.wild_match_pattern.include is not None
+                and rule.wild_match_pattern.match_file(rel_path) is not None
+            ):
+                matched = rule.wild_match_pattern.include
 
         return matched
 

--- a/airflow-core/tests/unit/dags/.airflowignore_glob
+++ b/airflow-core/tests/unit/dags/.airflowignore_glob
@@ -5,12 +5,15 @@
 *_invalid_*      # skip invalid files
 
 # test ignoring files at all levels
-**/*_dont_*                # ignore all python files at all levels with "dont" in their name
-!**/*_negate_ignore.py
+**/*should_ignore_*                # ignore all python files at all levels with "should_ignore" in their name
+subdir2/subdir3/test_explicit_ignore.py  # ignore this explicit path
 subdir2/**/test_nested*.py # ignore files in subdir2/subdir3
+!subdir2/**/*_negate_ignore.py  # do not ignore files ending with '_negate_ignore.py'
 
 # test matching and ignoring of path separators
 subdir1/*         # ignore all of subdir1
+!subdir1/test_explicit_dont_ignore.py  # do not ignore this explicit path
+!subdir1/*_negate_ignore.py  # Do not ignore this one file in subdir1
 subdir2*test*    # this should not match anything in the subdir2 directory
 subdir2?test*    # this should not match anything in the subdir2 directory
 

--- a/airflow-core/tests/unit/dags/subdir1/test_explicit_dont_ignore.py
+++ b/airflow-core/tests/unit/dags/subdir1/test_explicit_dont_ignore.py
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from airflow.models.dag import DAG
+from airflow.providers.standard.operators.bash import BashOperator
+
+DEFAULT_DATE = datetime(2019, 12, 1)
+
+dag = DAG(dag_id="test_dag_explicit_dont_ignore", start_date=DEFAULT_DATE, schedule=None)
+task = BashOperator(task_id="task1", bash_command='echo "test dag explicitly dont ignore"', dag=dag)

--- a/airflow-core/tests/unit/dags/subdir2/subdir3/should_ignore_this.py
+++ b/airflow-core/tests/unit/dags/subdir2/subdir3/should_ignore_this.py
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow-core/tests/unit/dags/subdir2/subdir3/test_explicit_ignore.py
+++ b/airflow-core/tests/unit/dags/subdir2/subdir3/test_explicit_ignore.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow-core/tests/unit/utils/test_file.py
+++ b/airflow-core/tests/unit/utils/test_file.py
@@ -154,9 +154,6 @@ class TestListPyFilesPath:
         assert actual_included_filenames == should_not_ignore, (
             f"actual_included_filenames: {pformat(actual_included_filenames)}\nexpected_included_filenames: {pformat(should_not_ignore)}"
         )
-        # assert len([filepath for filepath in actual_files if os.path.basename(filepath) in should_not_ignore]) == len(
-        #     should_not_ignore
-        # )
 
     def test_find_path_from_directory_respects_symlinks_regexp_ignore(self, test_dir):
         ignore_list_file = ".airflowignore"

--- a/airflow-core/tests/unit/utils/test_file.py
+++ b/airflow-core/tests/unit/utils/test_file.py
@@ -136,7 +136,6 @@ class TestListPyFilesPath:
             "test_nested_dag.py",
             ".airflowignore",
         }
-        #  "test_dont_ignore.py",
         should_not_ignore = {
             "test_on_kill.py",
             "test_negate_ignore.py",

--- a/airflow-core/tests/unit/utils/test_file.py
+++ b/airflow-core/tests/unit/utils/test_file.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import os
 import zipfile
 from pathlib import Path
+from pprint import pformat
 from unittest import mock
 
 import pytest
@@ -125,23 +126,37 @@ class TestListPyFilesPath:
         assert all(os.path.basename(file) not in should_ignore for file in files)
 
     def test_find_path_from_directory_glob_ignore(self):
-        should_ignore = [
+        should_ignore = {
+            "should_ignore_this.py",
+            "test_explicit_ignore.py",
             "test_invalid_cron.py",
             "test_invalid_param.py",
             "test_ignore_this.py",
             "test_prev_dagrun_dep.py",
             "test_nested_dag.py",
-            "test_dont_ignore.py",
             ".airflowignore",
-        ]
-        should_not_ignore = ["test_on_kill.py", "test_negate_ignore.py", "test_nested_negate_ignore.py"]
-        files = list(find_path_from_directory(TEST_DAGS_FOLDER, ".airflowignore_glob", "glob"))
+        }
+        #  "test_dont_ignore.py",
+        should_not_ignore = {
+            "test_on_kill.py",
+            "test_negate_ignore.py",
+            "test_dont_ignore_this.py",
+            "test_nested_negate_ignore.py",
+            "test_explicit_dont_ignore.py",
+        }
+        actual_files = list(find_path_from_directory(TEST_DAGS_FOLDER, ".airflowignore_glob", "glob"))
 
-        assert files
-        assert all(os.path.basename(file) not in should_ignore for file in files)
-        assert sum(1 for file in files if os.path.basename(file) in should_not_ignore) == len(
-            should_not_ignore
+        assert actual_files
+        assert all(os.path.basename(file) not in should_ignore for file in actual_files)
+        actual_included_filenames = set(
+            [os.path.basename(f) for f in actual_files if os.path.basename(f) in should_not_ignore]
         )
+        assert actual_included_filenames == should_not_ignore, (
+            f"actual_included_filenames: {pformat(actual_included_filenames)}\nexpected_included_filenames: {pformat(should_not_ignore)}"
+        )
+        # assert len([filepath for filepath in actual_files if os.path.basename(filepath) in should_not_ignore]) == len(
+        #     should_not_ignore
+        # )
 
     def test_find_path_from_directory_respects_symlinks_regexp_ignore(self, test_dir):
         ignore_list_file = ".airflowignore"
@@ -223,6 +238,8 @@ class TestListPyFilesPath:
         # No_dags is empty, _invalid_ is ignored by .airflowignore
         ignored_files = {
             "no_dags.py",
+            "should_ignore_this.py",
+            "test_explicit_ignore.py",
             "test_invalid_cron.py",
             "test_invalid_dup_task.py",
             "test_ignore_this.py",
@@ -243,7 +260,9 @@ class TestListPyFilesPath:
                     if file_name not in ignored_files:
                         expected_files.add(f"{root}/{file_name}")
         detected_files = set(list_py_file_paths(TEST_DAG_FOLDER))
-        assert detected_files == expected_files
+        assert detected_files == expected_files, (
+            f"Detected files mismatched expected files:\ndetected_files: {pformat(detected_files)}\nexpected_files: {pformat(expected_files)}"
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---

Closes: #56299

## What?
* Fixes a bug where the order of precedence is opposite of what is expected for gitignore-like glob patterns for `.airflowignore` rules.
* Add more unit test cases for include/exclude behavior (`/**/*` patterns, individual explicit path includes / excludes).
* Cleans up the unit tests:
    * Ensures the test ignore/include files names match their expected behavior
    * Add human-readable diff output for test failures

## Testing
* Ran `uv run pytest airflow-core/tests/unit/utils --skip-db-tests -n auto` without failure
* Ran `prek` without failure
