### PR TITLE
fixed the bug report template dropdown option list

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-airflow_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1-airflow_bug_report.yml
@@ -28,12 +28,12 @@ body:
         - "3.1.0"
         - "2.11.0"
         - "main (development)"
-        - "Other Airflow 2 version (please specify below)"
+        - "Other Airflow 2/3 version (please specify below)"
     validations:
       required: true
   - type: input
     attributes:
-      label: If "Other Airflow 2 version" selected, which one?
+      label: If "Other Airflow 2/3 version" selected, which one?
       # yamllint disable rule:line-length
       description: >
         On what 2.X version of Airflow are you currently experiencing the issue? Remember, you are encouraged to


### PR DESCRIPTION
# Issue Details
The github issue template only specifies Other Airflow 2 versions, since we have now Airflow 3 release as well, it should be updated to `Other Airflow 2/3 versions` in the dropdown option.