### PR TITLE
Add fail_on_file_not_exist to SFTPToGCSOperator

### DIFF
--- a/providers/google/tests/unit/google/cloud/transfers/test_sftp_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_sftp_to_gcs.py
@@ -377,3 +377,33 @@ class TestSFTPToGCSOperator:
         assert result.inputs[0].name == expected_source
         assert result.outputs[0].namespace == f"gs://{TEST_BUCKET}"
         assert result.outputs[0].name == expected_destination
+
+    @pytest.mark.parametrize("fail_on_file_not_exist", [True, False])
+    @mock.patch("airflow.providers.google.cloud.transfers.sftp_to_gcs.SFTPHook")
+    def test_sftp_to_gcs_fail_on_file_not_exist(
+        self, fail_on_file_not_exist):
+        if fail_on_file_not_exist:
+            with pytest.raises(FileNotFoundError):
+                SFTPToGCSOperator(
+                    task_id=TASK_ID,
+                    source_path=SOURCE_OBJECT_NO_WILDCARD,
+                    destination_bucket=TEST_BUCKET,
+                    destination_path=DESTINATION_PATH_FILE,
+                    move_object=False,
+                    gcp_conn_id=GCP_CONN_ID,
+                    sftp_conn_id=SFTP_CONN_ID,
+                    impersonation_chain=IMPERSONATION_CHAIN,
+                    fail_on_file_not_exist=fail_on_file_not_exist,
+                ).execute(None)
+        else:
+            SFTPToGCSOperator(
+                task_id=TASK_ID,
+                source_path=SOURCE_OBJECT_NO_WILDCARD,
+                destination_bucket=TEST_BUCKET,
+                destination_path=DESTINATION_PATH_FILE,
+                move_object=False,
+                gcp_conn_id=GCP_CONN_ID,
+                sftp_conn_id=SFTP_CONN_ID,
+                impersonation_chain=IMPERSONATION_CHAIN,
+                fail_on_file_not_exist=fail_on_file_not_exist,
+            ).execute(None)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->

Fixes: https://github.com/apache/airflow/issues/40576
Similar to https://github.com/apache/airflow/pull/44320, this is adding `fail_on_file_not_exist` param to `SFTPToGCSOperator` so that user can configure the parameter and operator will not fail in case of sftp file not exist.

TODO: Add local test result
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
