### PR TITLE
Fix openlineage dag state event emit on timed out dag

### DIFF
--- a/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
@@ -755,11 +755,10 @@ def get_airflow_state_run_facet(
     def get_task_duration(ti):
         if ti.duration is not None:
             return ti.duration
-        elif ti.end_date is not None and ti.start_date is not None:
+        if ti.end_date is not None and ti.start_date is not None:
             return (ti.end_date - ti.start_date).total_seconds()
-        else:
-            # Fallback to 0.0 for tasks with missing timestamps (e.g., skipped/terminated tasks)
-            return 0.0
+        # Fallback to 0.0 for tasks with missing timestamps (e.g., skipped/terminated tasks)
+        return 0.0
 
     return {
         "airflowState": AirflowStateRunFacet(

--- a/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
@@ -751,16 +751,21 @@ def get_airflow_state_run_facet(
     dag_id: str, run_id: str, task_ids: list[str], dag_run_state: DagRunState
 ) -> dict[str, AirflowStateRunFacet]:
     tis = DagRun.fetch_task_instances(dag_id=dag_id, run_id=run_id, task_ids=task_ids)
+
+    def get_task_duration(ti):
+        if ti.duration is not None:
+            return ti.duration
+        elif ti.end_date is not None and ti.start_date is not None:
+            return (ti.end_date - ti.start_date).total_seconds()
+        else:
+            # Fallback to 0.0 for tasks with missing timestamps (e.g., skipped/terminated tasks)
+            return 0.0
+
     return {
         "airflowState": AirflowStateRunFacet(
             dagRunState=dag_run_state,
             tasksState={ti.task_id: ti.state for ti in tis},
-            tasksDuration={
-                ti.task_id: ti.duration
-                if ti.duration is not None
-                else (ti.end_date - ti.start_date).total_seconds()
-                for ti in tis
-            },
+            tasksDuration={ti.task_id: get_task_duration(ti) for ti in tis},
         )
     }
 


### PR DESCRIPTION
For dag that is timed out, with only skipped tasks, following error is thrown
```
Failed to emit OpenLineage DAG failed event: 
 Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/airflow/providers/openlineage/plugins/adapter.py", line 505, in dag_failed
    **get_airflow_state_run_facet(dag_id, run_id, task_ids, dag_run_state),
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/airflow/providers/openlineage/utils/utils.py", line 746, in get_airflow_state_run_facet
    else (ti.end_date - ti.start_date).total_seconds()
          ~~~~~~~~~~~~^~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for -: 'NoneType' and 'NoneType'
```

This PR fixes said issue