### PR TITLE
Reduce log level for connection not found from ERROR to WARNING

### DIFF
--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -356,7 +356,7 @@ class ConnectionOperations:
             resp = self.client.get(f"connections/{conn_id}")
         except ServerResponseError as e:
             if e.response.status_code == HTTPStatus.NOT_FOUND:
-                log.error(
+                log.warning(
                     "Connection not found",
                     conn_id=conn_id,
                     detail=e.detail,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->

### Problem 
When KubernetesPodOperator uses the default connection ID `kubernetes_default`, the hook is designed to fallback to 
cluster-derived credentials. 
https://github.com/apache/airflow/blob/b7ea2a6fa5418862b93fcb11c75c02bef0f85c95/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py#L172-L184

But the current behavior where the Kubernetes API client logs 404 responses as ERROR is causing unnecessary noise.

<img width="1519" height="361" alt="Screenshot 2025-10-10 at 9 45 04 AM" src="https://github.com/user-attachments/assets/cc98e3fb-bfa0-4554-927f-3a346690e3fa" />


### Fix
When default connection ID `kubernetes_default` is set, the 404 is an expected behavior, not an actual error. Also, HTTP 404 represents a resource state. ERROR severity might be too high.
So i think it would be better to reduce log level for connection not found from `ERROR` to `WARNING.` 

Fix: #56360


<img width="1511" height="358" alt="Screenshot 2025-10-10 at 8 35 35 PM" src="https://github.com/user-attachments/assets/0482f3cb-d498-4fdf-b8fd-66c61eeaa26f" />

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
