### PR TITLE
Fix: Adjust PanelButtons spacing and alignment

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
@@ -223,7 +223,7 @@ export const PanelButtons = ({
   );
 
   return (
-    <Box position="absolute" ref={containerRef} top={1} width="100%" zIndex={1}>
+    <Box ml="-2px" position="absolute" px={4} ref={containerRef} top={1} width="100%" zIndex={1}>
       <Flex justifyContent="space-between">
         <ButtonGroup attached size="sm" variant="outline">
           <IconButton
@@ -255,7 +255,7 @@ export const PanelButtons = ({
             <MdOutlineAccountTree />
           </IconButton>
         </ButtonGroup>
-        <Flex gap={1}>
+        <Flex alignItems="center" gap={1}>
           <ToggleGroups />
           {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
           <Popover.Root autoFocus={false} positioning={{ placement: "bottom-end" }}>

--- a/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
@@ -227,12 +227,8 @@ export const PanelButtons = ({
       <Flex justifyContent="space-between" pl={2}>
         <ButtonGroup attached size="sm" variant="outline">
           <IconButton
-            _hover={{
-              bg: "brand.500",
-              color: "white",
-            }}
             aria-label={translate("dag:panel.buttons.showGridShortcut")}
-            bg={dagView === "grid" ? "brand.500" : "var(--chakra-colors-bg-subtle)"}
+            bg={dagView === "grid" ? "brand.500" : "bg.subtle"}
             color={dagView === "grid" ? "white" : "fg.default"}
             colorPalette="brand"
             onClick={() => {
@@ -246,12 +242,8 @@ export const PanelButtons = ({
             <FiGrid />
           </IconButton>
           <IconButton
-            _hover={{
-              bg: "brand.500",
-              color: "white",
-            }}
             aria-label={translate("dag:panel.buttons.showGraphShortcut")}
-            bg={dagView === "graph" ? "brand.500" : "var(--chakra-colors-bg-subtle)"}
+            bg={dagView === "graph" ? "brand.500" : "bg.subtle"}
             color={dagView === "graph" ? "white" : "fg.default"}
             colorPalette="brand"
             onClick={() => {
@@ -270,13 +262,7 @@ export const PanelButtons = ({
           {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
           <Popover.Root autoFocus={false} positioning={{ placement: "bottom-end" }}>
             <Popover.Trigger asChild>
-              <Button
-                _hover={{ bg: "brand.500", color: "white" }}
-                bg="var(--chakra-colors-bg-subtle)"
-                color="fg.default"
-                size="sm"
-                variant="outline"
-              >
+              <Button bg="bg.subtle" color="fg.default" size="sm" variant="outline">
                 {translate("dag:panel.buttons.options")}
                 <FiChevronDown size={8} />
               </Button>

--- a/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
@@ -223,11 +223,17 @@ export const PanelButtons = ({
   );
 
   return (
-    <Box ml="-2px" position="absolute" px={4} ref={containerRef} top={1} width="100%" zIndex={1}>
-      <Flex justifyContent="space-between">
+    <Box position="absolute" px={2} ref={containerRef} top={1} width="100%" zIndex={1}>
+      <Flex justifyContent="space-between" pl={2}>
         <ButtonGroup attached size="sm" variant="outline">
           <IconButton
+            _hover={{
+              bg: "brand.500",
+              color: "white",
+            }}
             aria-label={translate("dag:panel.buttons.showGridShortcut")}
+            bg={dagView === "grid" ? "brand.500" : "var(--chakra-colors-bg-subtle)"}
+            color={dagView === "grid" ? "white" : "fg.default"}
             colorPalette="brand"
             onClick={() => {
               setDagView("grid");
@@ -236,12 +242,17 @@ export const PanelButtons = ({
               }
             }}
             title={translate("dag:panel.buttons.showGridShortcut")}
-            variant={dagView === "grid" ? "solid" : "outline"}
           >
             <FiGrid />
           </IconButton>
           <IconButton
+            _hover={{
+              bg: "brand.500",
+              color: "white",
+            }}
             aria-label={translate("dag:panel.buttons.showGraphShortcut")}
+            bg={dagView === "graph" ? "brand.500" : "var(--chakra-colors-bg-subtle)"}
+            color={dagView === "graph" ? "white" : "fg.default"}
             colorPalette="brand"
             onClick={() => {
               setDagView("graph");
@@ -250,17 +261,22 @@ export const PanelButtons = ({
               }
             }}
             title={translate("dag:panel.buttons.showGraphShortcut")}
-            variant={dagView === "graph" ? "solid" : "outline"}
           >
             <MdOutlineAccountTree />
           </IconButton>
         </ButtonGroup>
-        <Flex alignItems="center" gap={1}>
+        <Flex alignItems="center" gap={1} justifyContent="space-between" pl={2} pr={6}>
           <ToggleGroups />
           {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
           <Popover.Root autoFocus={false} positioning={{ placement: "bottom-end" }}>
             <Popover.Trigger asChild>
-              <Button size="sm" variant="outline">
+              <Button
+                _hover={{ bg: "brand.500", color: "white" }}
+                bg="var(--chakra-colors-bg-subtle)"
+                color="fg.default"
+                size="sm"
+                variant="outline"
+              >
                 {translate("dag:panel.buttons.options")}
                 <FiChevronDown size={8} />
               </Button>


### PR DESCRIPTION
## Fix mis-aligned padding for Graph View options buttons

**Issue** #56076

**Description:**  
This PR fixes the mis-aligned padding for the Graph View options buttons in the Airflow Web UI (3.1.0rc2).  

**Background:**  
The buttons on the upper-right (and slightly on the upper-left) of the Graph View were overlapping with the splitter due to inconsistent padding. 
Although this issue was previously assigned to another contributor @alisha-malik, no PR has been submitted in the past 2 weeks. I started working on it now to resolve the open UI bug.  

**What this PR does:**  
- Corrects the padding for Graph View option buttons to ensure consistent alignment on all sides.  
- Prevents the buttons from overlapping with the splitter in both left and right positions.  

**Notes:**  
- Minor UI fix; does not affect core functionality.  
- Before
<img width="1084" height="140" alt="Screenshot from 2025-10-12 18-27-14" src="https://github.com/user-attachments/assets/f0c31a00-d6c4-4e03-a20f-0256f5d54950" />

- After
<img width="978" height="140" alt="Screenshot from 2025-10-12 19-03-18" src="https://github.com/user-attachments/assets/150d7d47-06f9-4595-9bad-f4df71f389ca" />
<img width="1084" height="140" alt="Screenshot from 2025-10-12 19-03-00" src="https://github.com/user-attachments/assets/acff7035-ebc0-49c3-bdd0-ad7b641eac40" />




<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
