### PR TITLE
Add support for multiple Celery worker groups with queue-specific configurations in Helm chart

### DIFF
--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -25,12 +25,12 @@
 {{- $hpa := and .Values.workers.hpa.enabled (not .Values.workers.keda.enabled) }}
 {{- if or (contains "CeleryExecutor" .Values.executor) (contains "CeleryKubernetesExecutor" .Values.executor) }}
 
-{{- /* Build worker groups list: use celeryQueueGroups if defined, otherwise create default worker */ -}}
+{{- /* Build worker groups list: use queueGroups if defined, otherwise create default worker */ -}}
 {{- $workerGroups := list }}
-{{- if .Values.workers.celery.celeryQueueGroups }}
-  {{- $workerGroups = .Values.workers.celery.celeryQueueGroups }}
+{{- if .Values.workers.celery.queueGroups }}
+  {{- $workerGroups = .Values.workers.celery.queueGroups }}
 {{- else }}
-  {{- $defaultWorker := dict
+  {{- $baseWorker := dict
     "name" ""
     "queues" ""
     "replicas" .Values.workers.replicas
@@ -41,18 +41,18 @@
     "podAnnotations" .Values.workers.podAnnotations
     "priorityClassName" .Values.workers.priorityClassName
     "env" .Values.workers.env }}
-  {{- $workerGroups = list $defaultWorker }}
+  {{- $workerGroups = list $baseWorker }}
 {{- end }}
 
-{{- /* Loop through all worker groups (either celeryQueueGroups or default) */ -}}
+{{- /* Loop through all worker groups (either queueGroups or default) */ -}}
 {{- range $groupIndex, $workerGroup := $workerGroups }}
 {{- if $groupIndex }}
 ---
 {{- end }}
 
 {{- /* Set variables based on whether this is default worker or custom group */ -}}
-{{- $isDefaultWorker := eq $workerGroup.name "" }}
-{{- $workerName := ternary "worker" (printf "worker-%s" $workerGroup.name) $isDefaultWorker }}
+{{- $isBaseWorker := eq $workerGroup.name "" }}
+{{- $workerName := ternary "worker" (printf "worker-%s" $workerGroup.name) $isBaseWorker }}
 {{- $groupQueues := $workerGroup.queues }}
 {{- $groupReplicas := $workerGroup.replicas | default 1 }}
 {{- $groupNodeSelector := $workerGroup.nodeSelector | default dict }}
@@ -88,7 +88,7 @@ metadata:
   labels:
     tier: airflow
     component: worker
-    {{- if not $isDefaultWorker }}
+    {{- if not $isBaseWorker }}
     worker-group: {{ $workerGroup.name }}
     {{- end }}
     release: {{ $.Release.Name }}
@@ -104,7 +104,7 @@ spec:
   {{- if $persistence }}
   serviceName: {{ include "airflow.fullname" $ }}-{{ $workerName }}
   {{- end }}
-  {{- if not $isDefaultWorker }}
+  {{- if not $isBaseWorker }}
   replicas: {{ $groupReplicas }}
   {{- else if and (not $keda) (not $hpa) }}
   replicas: {{ $.Values.workers.replicas }}
@@ -119,7 +119,7 @@ spec:
     matchLabels:
       tier: airflow
       component: worker
-      {{- if not $isDefaultWorker }}
+      {{- if not $isBaseWorker }}
       worker-group: {{ $workerGroup.name }}
       {{- end }}
       release: {{ $.Release.Name }}
@@ -141,7 +141,7 @@ spec:
         {{- if or ($.Values.labels) ($.Values.workers.labels) ($groupLabels) }}
           {{- mustMerge $groupLabels $.Values.workers.labels $.Values.labels | toYaml | nindent 8 }}
         {{- end }}
-        {{- if not $isDefaultWorker }}
+        {{- if not $isBaseWorker }}
         worker-group: {{ $workerGroup.name }}
         {{- end }}
       annotations:
@@ -179,7 +179,7 @@ spec:
               labelSelector:
                 matchLabels:
                   component: worker
-                  {{- if not $isDefaultWorker }}
+                  {{- if not $isBaseWorker }}
                   worker-group: {{ $workerGroup.name }}
                   {{- end }}
               topologyKey: kubernetes.io/hostname
@@ -303,9 +303,9 @@ spec:
           {{- if $.Values.workers.command }}
           command: {{ tpl (toYaml $.Values.workers.command) $ | nindent 12 }}
           {{- end }}
-          {{- if and $isDefaultWorker $.Values.workers.args }}
+          {{- if and $isBaseWorker $.Values.workers.args }}
           args: {{ tpl (toYaml $.Values.workers.args) $ | nindent 12 }}
-          {{- else if not $isDefaultWorker }}
+          {{- else if not $isBaseWorker }}
           args:
             - "bash"
             - "-c"

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -104,10 +104,10 @@ spec:
   {{- if $persistence }}
   serviceName: {{ include "airflow.fullname" $ }}-{{ $workerName }}
   {{- end }}
-  {{- if and $isDefaultWorker (not $keda) (not $hpa) }}
+  {{- if not $isDefaultWorker }}
   replicas: {{ $groupReplicas }}
-  {{- else }}
-  replicas: {{ $groupReplicas }}
+  {{- else if and (not $keda) (not $hpa) }}
+  replicas: {{ $.Values.workers.replicas }}
   {{- end }}
   {{- if $revisionHistoryLimit }}
   revisionHistoryLimit: {{ $revisionHistoryLimit }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -24,93 +24,146 @@
 {{- $keda := .Values.workers.keda.enabled }}
 {{- $hpa := and .Values.workers.hpa.enabled (not .Values.workers.keda.enabled) }}
 {{- if or (contains "CeleryExecutor" .Values.executor) (contains "CeleryKubernetesExecutor" .Values.executor) }}
-{{- $nodeSelector := or .Values.workers.nodeSelector .Values.nodeSelector }}
-{{- $affinity := or .Values.workers.affinity .Values.affinity }}
-{{- $tolerations := or .Values.workers.tolerations .Values.tolerations }}
-{{- $topologySpreadConstraints := or .Values.workers.topologySpreadConstraints .Values.topologySpreadConstraints }}
-{{- $revisionHistoryLimit := or .Values.workers.revisionHistoryLimit .Values.revisionHistoryLimit }}
-{{- $securityContext := include "airflowPodSecurityContext" (list . .Values.workers) }}
-{{- $containerSecurityContext := include "containerSecurityContext" (list . .Values.workers) }}
-{{- $containerSecurityContextPersistence := include "containerSecurityContext" (list . .Values.workers.persistence) }}
-{{- $containerSecurityContextWaitForMigrations := include "containerSecurityContext" (list . .Values.workers.waitForMigrations) }}
-{{- $containerSecurityContextLogGroomerSidecar := include "containerSecurityContext" (list . .Values.workers.logGroomerSidecar) }}
-{{- $containerSecurityContextKerberosSidecar := include "containerSecurityContext" (list . .Values.workers.kerberosSidecar) }}
-{{- $containerLifecycleHooks := or .Values.workers.containerLifecycleHooks .Values.containerLifecycleHooks }}
-{{- $containerLifecycleHooksLogGroomerSidecar := or .Values.workers.logGroomerSidecar.containerLifecycleHooks .Values.containerLifecycleHooks }}
-{{- $containerLifecycleHooksKerberosSidecar := or .Values.workers.kerberosSidecar.containerLifecycleHooks .Values.containerLifecycleHooks }}
-{{- $safeToEvict := dict "cluster-autoscaler.kubernetes.io/safe-to-evict" (.Values.workers.safeToEvict | toString) }}
-{{- $podAnnotations := mergeOverwrite (deepCopy .Values.airflowPodAnnotations) $safeToEvict .Values.workers.podAnnotations }}
-{{- $schedulerName := or .Values.workers.schedulerName .Values.schedulerName }}
+
+{{- /* Build worker groups list: use celeryQueueGroups if defined, otherwise create default worker */ -}}
+{{- $workerGroups := list }}
+{{- if .Values.workers.celeryQueueGroups }}
+  {{- $workerGroups = .Values.workers.celeryQueueGroups }}
+{{- else }}
+  {{- $defaultWorker := dict
+    "name" ""
+    "queues" ""
+    "replicas" .Values.workers.replicas
+    "nodeSelector" (or .Values.workers.nodeSelector .Values.nodeSelector)
+    "tolerations" (or .Values.workers.tolerations .Values.tolerations)
+    "resources" .Values.workers.resources
+    "labels" .Values.workers.labels
+    "podAnnotations" .Values.workers.podAnnotations
+    "priorityClassName" .Values.workers.priorityClassName
+    "env" .Values.workers.env }}
+  {{- $workerGroups = list $defaultWorker }}
+{{- end }}
+
+{{- /* Loop through all worker groups (either celeryQueueGroups or default) */ -}}
+{{- range $groupIndex, $workerGroup := $workerGroups }}
+{{- if $groupIndex }}
+---
+{{- end }}
+
+{{- /* Set variables based on whether this is default worker or custom group */ -}}
+{{- $isDefaultWorker := eq $workerGroup.name "" }}
+{{- $workerName := ternary "worker" (printf "worker-%s" $workerGroup.name) $isDefaultWorker }}
+{{- $groupQueues := $workerGroup.queues }}
+{{- $groupReplicas := $workerGroup.replicas | default 1 }}
+{{- $groupNodeSelector := $workerGroup.nodeSelector | default dict }}
+{{- $groupTolerations := $workerGroup.tolerations | default list }}
+{{- $groupResources := $workerGroup.resources | default dict }}
+{{- $groupLabels := $workerGroup.labels | default dict }}
+{{- $groupPodAnnotations := $workerGroup.podAnnotations | default dict }}
+{{- $groupPriorityClassName := $workerGroup.priorityClassName | default "" }}
+{{- $groupEnv := $workerGroup.env | default list }}
+
+{{- /* Standard variables (same for all workers) */ -}}
+{{- $nodeSelector := or $groupNodeSelector $.Values.nodeSelector }}
+{{- $affinity := or $.Values.workers.affinity $.Values.affinity }}
+{{- $tolerations := or $groupTolerations $.Values.tolerations }}
+{{- $topologySpreadConstraints := or $.Values.workers.topologySpreadConstraints $.Values.topologySpreadConstraints }}
+{{- $revisionHistoryLimit := or $.Values.workers.revisionHistoryLimit $.Values.revisionHistoryLimit }}
+{{- $securityContext := include "airflowPodSecurityContext" (list $ $.Values.workers) }}
+{{- $containerSecurityContext := include "containerSecurityContext" (list $ $.Values.workers) }}
+{{- $containerSecurityContextPersistence := include "containerSecurityContext" (list $ $.Values.workers.persistence) }}
+{{- $containerSecurityContextWaitForMigrations := include "containerSecurityContext" (list $ $.Values.workers.waitForMigrations) }}
+{{- $containerSecurityContextLogGroomerSidecar := include "containerSecurityContext" (list $ $.Values.workers.logGroomerSidecar) }}
+{{- $containerSecurityContextKerberosSidecar := include "containerSecurityContext" (list $ $.Values.workers.kerberosSidecar) }}
+{{- $containerLifecycleHooks := or $.Values.workers.containerLifecycleHooks $.Values.containerLifecycleHooks }}
+{{- $containerLifecycleHooksLogGroomerSidecar := or $.Values.workers.logGroomerSidecar.containerLifecycleHooks $.Values.containerLifecycleHooks }}
+{{- $containerLifecycleHooksKerberosSidecar := or $.Values.workers.kerberosSidecar.containerLifecycleHooks $.Values.containerLifecycleHooks }}
+{{- $safeToEvict := dict "cluster-autoscaler.kubernetes.io/safe-to-evict" ($.Values.workers.safeToEvict | toString) }}
+{{- $mergedPodAnnotations := mergeOverwrite (deepCopy $.Values.airflowPodAnnotations) $safeToEvict $groupPodAnnotations }}
+{{- $schedulerName := or $.Values.workers.schedulerName $.Values.schedulerName }}
 apiVersion: apps/v1
 kind: {{ if $persistence }}StatefulSet{{ else }}Deployment{{ end }}
 metadata:
-  name: {{ include "airflow.fullname" . }}-worker
+  name: {{ include "airflow.fullname" $ }}-{{ $workerName }}
   labels:
     tier: airflow
     component: worker
-    release: {{ .Release.Name }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    heritage: {{ .Release.Service }}
-    {{- with .Values.labels }}
+    {{- if not $isDefaultWorker }}
+    worker-group: {{ $workerGroup.name }}
+    {{- end }}
+    release: {{ $.Release.Name }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    heritage: {{ $.Release.Service }}
+    {{- with $.Values.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- if .Values.workers.annotations }}
-  annotations: {{- toYaml .Values.workers.annotations | nindent 4 }}
+  {{- if $.Values.workers.annotations }}
+  annotations: {{- toYaml $.Values.workers.annotations | nindent 4 }}
   {{- end }}
 spec:
   {{- if $persistence }}
-  serviceName: {{ include "airflow.fullname" . }}-worker
+  serviceName: {{ include "airflow.fullname" $ }}-{{ $workerName }}
   {{- end }}
-  {{- if and (not $keda) (not $hpa) }}
-  replicas: {{ .Values.workers.replicas }}
+  {{- if and $isDefaultWorker (not $keda) (not $hpa) }}
+  replicas: {{ $groupReplicas }}
+  {{- else }}
+  replicas: {{ $groupReplicas }}
   {{- end }}
   {{- if $revisionHistoryLimit }}
   revisionHistoryLimit: {{ $revisionHistoryLimit }}
   {{- end }}
-  {{- if and $persistence .Values.workers.persistence.persistentVolumeClaimRetentionPolicy }}
-  persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.workers.persistence.persistentVolumeClaimRetentionPolicy  | nindent 4 }}
+  {{- if and $persistence $.Values.workers.persistence.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy: {{- toYaml $.Values.workers.persistence.persistentVolumeClaimRetentionPolicy  | nindent 4 }}
   {{- end }}
   selector:
     matchLabels:
       tier: airflow
       component: worker
-      release: {{ .Release.Name }}
-  {{- if and $persistence .Values.workers.podManagementPolicy }}
-  podManagementPolicy: {{ .Values.workers.podManagementPolicy }}
+      {{- if not $isDefaultWorker }}
+      worker-group: {{ $workerGroup.name }}
+      {{- end }}
+      release: {{ $.Release.Name }}
+  {{- if and $persistence $.Values.workers.podManagementPolicy }}
+  podManagementPolicy: {{ $.Values.workers.podManagementPolicy }}
   {{- end }}
-  {{- if and $persistence .Values.workers.updateStrategy }}
-  updateStrategy: {{- toYaml .Values.workers.updateStrategy | nindent 4 }}
+  {{- if and $persistence $.Values.workers.updateStrategy }}
+  updateStrategy: {{- toYaml $.Values.workers.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- if and (not $persistence) (.Values.workers.strategy) }}
-  strategy: {{- toYaml .Values.workers.strategy | nindent 4 }}
+  {{- if and (not $persistence) ($.Values.workers.strategy) }}
+  strategy: {{- toYaml $.Values.workers.strategy | nindent 4 }}
   {{- end }}
   template:
     metadata:
       labels:
         tier: airflow
         component: worker
-        release: {{ .Release.Name }}
-        {{- if or (.Values.labels) (.Values.workers.labels) }}
-          {{- mustMerge .Values.workers.labels .Values.labels | toYaml | nindent 8 }}
+        release: {{ $.Release.Name }}
+        {{- if or ($.Values.labels) ($.Values.workers.labels) ($groupLabels) }}
+          {{- mustMerge $groupLabels $.Values.workers.labels $.Values.labels | toYaml | nindent 8 }}
+        {{- end }}
+        {{- if not $isDefaultWorker }}
+        worker-group: {{ $workerGroup.name }}
         {{- end }}
       annotations:
-        checksum/metadata-secret: {{ include (print $.Template.BasePath "/secrets/metadata-connection-secret.yaml") . | sha256sum }}
-        checksum/result-backend-secret: {{ include (print $.Template.BasePath "/secrets/result-backend-connection-secret.yaml") . | sha256sum }}
-        checksum/pgbouncer-config-secret: {{ include (print $.Template.BasePath "/secrets/pgbouncer-config-secret.yaml") . | sha256sum }}
-        checksum/webserver-secret-key: {{ include (print $.Template.BasePath "/secrets/webserver-secret-key-secret.yaml") . | sha256sum }}
-        checksum/kerberos-keytab: {{ include (print $.Template.BasePath "/secrets/kerberos-keytab-secret.yaml") . | sha256sum }}
-        checksum/airflow-config: {{ include (print $.Template.BasePath "/configmaps/configmap.yaml") . | sha256sum }}
-        checksum/extra-configmaps: {{ include (print $.Template.BasePath "/configmaps/extra-configmaps.yaml") . | sha256sum }}
-        checksum/extra-secrets: {{ include (print $.Template.BasePath "/secrets/extra-secrets.yaml") . | sha256sum }}
-        {{- if $podAnnotations }}
-          {{- toYaml $podAnnotations | nindent 8 }}
+        checksum/metadata-secret: {{ include (print $.Template.BasePath "/secrets/metadata-connection-secret.yaml") $ | sha256sum }}
+        checksum/result-backend-secret: {{ include (print $.Template.BasePath "/secrets/result-backend-connection-secret.yaml") $ | sha256sum }}
+        checksum/pgbouncer-config-secret: {{ include (print $.Template.BasePath "/secrets/pgbouncer-config-secret.yaml") $ | sha256sum }}
+        checksum/webserver-secret-key: {{ include (print $.Template.BasePath "/secrets/webserver-secret-key-secret.yaml") $ | sha256sum }}
+        checksum/kerberos-keytab: {{ include (print $.Template.BasePath "/secrets/kerberos-keytab-secret.yaml") $ | sha256sum }}
+        checksum/airflow-config: {{ include (print $.Template.BasePath "/configmaps/configmap.yaml") $ | sha256sum }}
+        checksum/extra-configmaps: {{ include (print $.Template.BasePath "/configmaps/extra-configmaps.yaml") $ | sha256sum }}
+        checksum/extra-secrets: {{ include (print $.Template.BasePath "/secrets/extra-secrets.yaml") $ | sha256sum }}
+        {{- if $mergedPodAnnotations }}
+          {{- toYaml $mergedPodAnnotations | nindent 8 }}
         {{- end }}
     spec:
-      {{- if .Values.workers.runtimeClassName }}
-      runtimeClassName: {{ .Values.workers.runtimeClassName }}
+      {{- if $.Values.workers.runtimeClassName }}
+      runtimeClassName: {{ $.Values.workers.runtimeClassName }}
       {{- end }}
-      {{- if .Values.workers.priorityClassName }}
-      priorityClassName: {{ .Values.workers.priorityClassName }}
+      {{- if $groupPriorityClassName }}
+      priorityClassName: {{ $groupPriorityClassName }}
+      {{- else if $.Values.workers.priorityClassName }}
+      priorityClassName: {{ $.Values.workers.priorityClassName }}
       {{- end }}
       {{- if $schedulerName }}
       schedulerName: {{ $schedulerName }}
@@ -126,355 +179,368 @@ spec:
               labelSelector:
                 matchLabels:
                   component: worker
+                  {{- if not $isDefaultWorker }}
+                  worker-group: {{ $workerGroup.name }}
+                  {{- end }}
               topologyKey: kubernetes.io/hostname
             weight: 100
         {{- end }}
       tolerations: {{- toYaml $tolerations | nindent 8 }}
       topologySpreadConstraints: {{- toYaml $topologySpreadConstraints | nindent 8 }}
-      {{- if .Values.workers.hostAliases }}
-      hostAliases: {{- toYaml .Values.workers.hostAliases | nindent 8 }}
+      {{- if $.Values.workers.hostAliases }}
+      hostAliases: {{- toYaml $.Values.workers.hostAliases | nindent 8 }}
       {{- end }}
-      terminationGracePeriodSeconds: {{ .Values.workers.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ $.Values.workers.terminationGracePeriodSeconds }}
       restartPolicy: Always
-      {{- if .Values.workers.useWorkerDedicatedServiceAccounts }}
-      serviceAccountName: {{ include "worker.celery.serviceAccountName" . }}
+      {{- if $.Values.workers.useWorkerDedicatedServiceAccounts }}
+      serviceAccountName: {{ include "worker.celery.serviceAccountName" $ }}
       {{- else }}
-      serviceAccountName: {{ include "worker.serviceAccountName" . }}
+      serviceAccountName: {{ include "worker.serviceAccountName" $ }}
       {{- end }}
       securityContext: {{ $securityContext | nindent 8 }}
-      imagePullSecrets: {{ include "image_pull_secrets" . | nindent 8 }}
+      imagePullSecrets: {{ include "image_pull_secrets" $ | nindent 8 }}
       initContainers:
-        {{- if and $persistence .Values.workers.persistence.fixPermissions }}
+        {{- if and $persistence $.Values.workers.persistence.fixPermissions }}
         - name: volume-permissions
-          resources: {{- toYaml .Values.workers.resources | nindent 12 }}
-          image: {{ template "airflow_image" . }}
-          imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
+          resources: {{- toYaml $.Values.workers.resources | nindent 12 }}
+          image: {{ template "airflow_image" $ }}
+          imagePullPolicy: {{ $.Values.images.airflow.pullPolicy }}
           command:
             - chown
             - -R
-            - "{{ include "airflowPodSecurityContextsIds" (list . .Values.workers) }}"
-            - {{ template "airflow_logs" . }}
+            - "{{ include "airflowPodSecurityContextsIds" (list $ $.Values.workers) }}"
+            - {{ template "airflow_logs" $ }}
           securityContext: {{ $containerSecurityContextPersistence | nindent 12 }}
           volumeMounts:
             - name: logs
-              mountPath: {{ template "airflow_logs" . }}
-              {{- if .Values.logs.persistence.subPath }}
-              subPath: {{ .Values.logs.persistence.subPath }}
+              mountPath: {{ template "airflow_logs" $ }}
+              {{- if $.Values.logs.persistence.subPath }}
+              subPath: {{ $.Values.logs.persistence.subPath }}
               {{- end }}
         {{- end }}
-        {{- if and (semverCompare ">=2.8.0" .Values.airflowVersion) .Values.workers.kerberosInitContainer.enabled }}
+        {{- if and (semverCompare ">=2.8.0" $.Values.airflowVersion) $.Values.workers.kerberosInitContainer.enabled }}
         - name: kerberos-init
-          image: {{ template "airflow_image" . }}
-          imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
+          image: {{ template "airflow_image" $ }}
+          imagePullPolicy: {{ $.Values.images.airflow.pullPolicy }}
           args: ["kerberos", "-o"]
-          resources: {{- toYaml .Values.workers.kerberosInitContainer.resources | nindent 12 }}
+          resources: {{- toYaml $.Values.workers.kerberosInitContainer.resources | nindent 12 }}
           volumeMounts:
             - name: logs
-              mountPath: {{ template "airflow_logs" . }}
-              {{- if .Values.logs.persistence.subPath }}
-              subPath: {{ .Values.logs.persistence.subPath }}
+              mountPath: {{ template "airflow_logs" $ }}
+              {{- if $.Values.logs.persistence.subPath }}
+              subPath: {{ $.Values.logs.persistence.subPath }}
               {{- end }}
-            {{- include "airflow_config_mount" . | nindent 12 }}
+            {{- include "airflow_config_mount" $ | nindent 12 }}
             - name: config
-              mountPath: {{ .Values.kerberos.configPath | quote }}
+              mountPath: {{ $.Values.kerberos.configPath | quote }}
               subPath: krb5.conf
               readOnly: true
             - name: kerberos-keytab
               subPath: "kerberos.keytab"
-              mountPath: {{ .Values.kerberos.keytabPath | quote }}
+              mountPath: {{ $.Values.kerberos.keytabPath | quote }}
               readOnly: true
             - name: kerberos-ccache
-              mountPath: {{ .Values.kerberos.ccacheMountPath | quote }}
+              mountPath: {{ $.Values.kerberos.ccacheMountPath | quote }}
               readOnly: false
-            {{- if .Values.volumeMounts }}
-              {{- toYaml .Values.volumeMounts | nindent 12 }}
+            {{- if $.Values.volumeMounts }}
+              {{- toYaml $.Values.volumeMounts | nindent 12 }}
             {{- end }}
-            {{- if .Values.workers.extraVolumeMounts }}
-              {{- tpl (toYaml .Values.workers.extraVolumeMounts) . | nindent 12 }}
+            {{- if $.Values.workers.extraVolumeMounts }}
+              {{- tpl (toYaml $.Values.workers.extraVolumeMounts) $ | nindent 12 }}
             {{- end }}
-            {{- if or .Values.webserver.webserverConfig .Values.webserver.webserverConfigConfigMapName }}
-              {{- include "airflow_webserver_config_mount" . | nindent 12 }}
+            {{- if or $.Values.webserver.webserverConfig $.Values.webserver.webserverConfigConfigMapName }}
+              {{- include "airflow_webserver_config_mount" $ | nindent 12 }}
             {{- end }}
-          envFrom: {{- include "custom_airflow_environment_from" . | default "\n  []" | indent 10 }}
+          envFrom: {{- include "custom_airflow_environment_from" $ | default "\n  []" | indent 10 }}
           env:
             - name: KRB5_CONFIG
-              value:  {{ .Values.kerberos.configPath | quote }}
+              value:  {{ $.Values.kerberos.configPath | quote }}
             - name: KRB5CCNAME
-              value:  {{ include "kerberos_ccache_path" . | quote }}
-            {{- include "custom_airflow_environment" . | indent 10 }}
-            {{- include "standard_airflow_environment" . | indent 10 }}
+              value:  {{ include "kerberos_ccache_path" $ | quote }}
+            {{- include "custom_airflow_environment" $ | indent 10 }}
+            {{- include "standard_airflow_environment" $ | indent 10 }}
         {{- end }}
-        {{- if .Values.workers.waitForMigrations.enabled }}
+        {{- if $.Values.workers.waitForMigrations.enabled }}
         - name: wait-for-airflow-migrations
-          resources: {{- toYaml .Values.workers.resources | nindent 12 }}
-          image: {{ template "airflow_image_for_migrations" . }}
-          imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
+          resources: {{- toYaml $.Values.workers.resources | nindent 12 }}
+          image: {{ template "airflow_image_for_migrations" $ }}
+          imagePullPolicy: {{ $.Values.images.airflow.pullPolicy }}
           securityContext: {{ $containerSecurityContextWaitForMigrations | nindent 12 }}
           volumeMounts:
-            {{- include "airflow_config_mount" . | nindent 12 }}
-            {{- if .Values.volumeMounts }}
-              {{- toYaml .Values.volumeMounts | nindent 12 }}
+            {{- include "airflow_config_mount" $ | nindent 12 }}
+            {{- if $.Values.volumeMounts }}
+              {{- toYaml $.Values.volumeMounts | nindent 12 }}
             {{- end }}
-            {{- if .Values.workers.extraVolumeMounts }}
-              {{- tpl (toYaml .Values.workers.extraVolumeMounts) . | nindent 12 }}
+            {{- if $.Values.workers.extraVolumeMounts }}
+              {{- tpl (toYaml $.Values.workers.extraVolumeMounts) $ | nindent 12 }}
             {{- end }}
-            {{- if or .Values.webserver.webserverConfig .Values.webserver.webserverConfigConfigMapName }}
-              {{- include "airflow_webserver_config_mount" . | nindent 12 }}
+            {{- if or $.Values.webserver.webserverConfig $.Values.webserver.webserverConfigConfigMapName }}
+              {{- include "airflow_webserver_config_mount" $ | nindent 12 }}
             {{- end }}
-          args: {{- include "wait-for-migrations-command" . | indent 10 }}
-          envFrom: {{- include "custom_airflow_environment_from" . | default "\n  []" | indent 10 }}
+          args: {{- include "wait-for-migrations-command" $ | indent 10 }}
+          envFrom: {{- include "custom_airflow_environment_from" $ | default "\n  []" | indent 10 }}
           env:
-            {{- include "custom_airflow_environment" . | indent 10 }}
-            {{- include "standard_airflow_environment" . | indent 10 }}
-            {{- if .Values.workers.waitForMigrations.env }}
-              {{- tpl (toYaml .Values.workers.waitForMigrations.env) $ | nindent 12 }}
+            {{- include "custom_airflow_environment" $ | indent 10 }}
+            {{- include "standard_airflow_environment" $ | indent 10 }}
+            {{- if $.Values.workers.waitForMigrations.env }}
+              {{- tpl (toYaml $.Values.workers.waitForMigrations.env) $ | nindent 12 }}
             {{- end }}
         {{- end }}
-        {{- if and (.Values.dags.gitSync.enabled) (not .Values.dags.persistence.enabled) }}
-          {{- include "git_sync_container" (dict "Values" .Values "is_init" "true" "Template" .Template) | nindent 8 }}
+        {{- if and ($.Values.dags.gitSync.enabled) (not $.Values.dags.persistence.enabled) }}
+          {{- include "git_sync_container" (dict "Values" $.Values "is_init" "true" "Template" $.Template) | nindent 8 }}
         {{- end }}
-        {{- if .Values.workers.extraInitContainers }}
-          {{- tpl (toYaml .Values.workers.extraInitContainers) . | nindent 8 }}
+        {{- if $.Values.workers.extraInitContainers }}
+          {{- tpl (toYaml $.Values.workers.extraInitContainers) $ | nindent 8 }}
         {{- end }}
       containers:
         - name: worker
-          image: {{ template "airflow_image" . }}
-          imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
+          image: {{ template "airflow_image" $ }}
+          imagePullPolicy: {{ $.Values.images.airflow.pullPolicy }}
           securityContext: {{ $containerSecurityContext | nindent 12 }}
           {{- if $containerLifecycleHooks  }}
-          lifecycle: {{- tpl (toYaml $containerLifecycleHooks) . | nindent 12 }}
+          lifecycle: {{- tpl (toYaml $containerLifecycleHooks) $ | nindent 12 }}
           {{- end }}
-          {{- if .Values.workers.command }}
-          command: {{ tpl (toYaml .Values.workers.command) . | nindent 12 }}
+          {{- if $.Values.workers.command }}
+          command: {{ tpl (toYaml $.Values.workers.command) $ | nindent 12 }}
           {{- end }}
-          {{- if .Values.workers.args }}
-          args: {{ tpl (toYaml .Values.workers.args) . | nindent 12 }}
+          {{- if and $isDefaultWorker $.Values.workers.args }}
+          args: {{ tpl (toYaml $.Values.workers.args) $ | nindent 12 }}
+          {{- else if not $isDefaultWorker }}
+          args:
+            - "bash"
+            - "-c"
+            - 'exec airflow celery worker --queues {{ $groupQueues }}'
           {{- end }}
-          resources: {{- toYaml .Values.workers.resources | nindent 12 }}
-          {{- if .Values.workers.livenessProbe.enabled }}
+          resources: {{- toYaml $groupResources | nindent 12 }}
+          {{- if $.Values.workers.livenessProbe.enabled }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.workers.livenessProbe.initialDelaySeconds }}
-            timeoutSeconds: {{ .Values.workers.livenessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.workers.livenessProbe.failureThreshold }}
-            periodSeconds: {{ .Values.workers.livenessProbe.periodSeconds }}
+            initialDelaySeconds: {{ $.Values.workers.livenessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ $.Values.workers.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ $.Values.workers.livenessProbe.failureThreshold }}
+            periodSeconds: {{ $.Values.workers.livenessProbe.periodSeconds }}
             exec:
               command:
-                {{- if .Values.workers.livenessProbe.command }}
-                  {{- toYaml .Values.workers.livenessProbe.command  | nindent 16 }}
+                {{- if $.Values.workers.livenessProbe.command }}
+                  {{- toYaml $.Values.workers.livenessProbe.command  | nindent 16 }}
                 {{- else }}
                 - sh
                 - -c
-                - CONNECTION_CHECK_MAX_COUNT=0 exec /entrypoint python -m celery --app {{ include "celery_executor_namespace" . }} inspect ping -d celery@$(hostname)
+                - CONNECTION_CHECK_MAX_COUNT=0 exec /entrypoint python -m celery --app {{ include "celery_executor_namespace" $ }} inspect ping -d celery@$(hostname)
                 {{- end }}
           {{- end }}
           ports:
-            {{- if .Values.workers.extraPorts }}
-              {{- toYaml .Values.workers.extraPorts | nindent 12 }}
+            {{- if $.Values.workers.extraPorts }}
+              {{- toYaml $.Values.workers.extraPorts | nindent 12 }}
             {{- end }}
             - name: worker-logs
-              containerPort: {{ .Values.ports.workerLogs }}
+              containerPort: {{ $.Values.ports.workerLogs }}
           volumeMounts:
-            {{- if .Values.volumeMounts }}
-              {{- toYaml .Values.volumeMounts | nindent 12 }}
+            {{- if $.Values.volumeMounts }}
+              {{- toYaml $.Values.volumeMounts | nindent 12 }}
             {{- end }}
-            {{- if .Values.workers.extraVolumeMounts }}
-              {{- tpl (toYaml .Values.workers.extraVolumeMounts) . | nindent 12 }}
+            {{- if $.Values.workers.extraVolumeMounts }}
+              {{- tpl (toYaml $.Values.workers.extraVolumeMounts) $ | nindent 12 }}
             {{- end }}
             - name: logs
-              mountPath: {{ template "airflow_logs" . }}
-              {{- if .Values.logs.persistence.subPath }}
-              subPath: {{ .Values.logs.persistence.subPath }}
+              mountPath: {{ template "airflow_logs" $ }}
+              {{- if $.Values.logs.persistence.subPath }}
+              subPath: {{ $.Values.logs.persistence.subPath }}
               {{- end }}
-            {{- include "airflow_config_mount" . | nindent 12 }}
-            {{- if .Values.kerberos.enabled }}
+            {{- include "airflow_config_mount" $ | nindent 12 }}
+            {{- if $.Values.kerberos.enabled }}
             - name: kerberos-keytab
               subPath: "kerberos.keytab"
-              mountPath: {{ .Values.kerberos.keytabPath | quote }}
+              mountPath: {{ $.Values.kerberos.keytabPath | quote }}
               readOnly: true
             - name: config
-              mountPath: {{ .Values.kerberos.configPath | quote }}
+              mountPath: {{ $.Values.kerberos.configPath | quote }}
               subPath: krb5.conf
               readOnly: true
             - name: kerberos-ccache
-              mountPath: {{ .Values.kerberos.ccacheMountPath | quote }}
+              mountPath: {{ $.Values.kerberos.ccacheMountPath | quote }}
               readOnly: true
             {{- end }}
-            {{- if or .Values.dags.persistence.enabled .Values.dags.gitSync.enabled }}
-              {{- include "airflow_dags_mount" . | nindent 12 }}
+            {{- if or $.Values.dags.persistence.enabled $.Values.dags.gitSync.enabled }}
+              {{- include "airflow_dags_mount" $ | nindent 12 }}
             {{- end }}
-            {{- if or .Values.webserver.webserverConfig .Values.webserver.webserverConfigConfigMapName }}
-              {{- include "airflow_webserver_config_mount" . | nindent 12 }}
+            {{- if or $.Values.webserver.webserverConfig $.Values.webserver.webserverConfigConfigMapName }}
+              {{- include "airflow_webserver_config_mount" $ | nindent 12 }}
             {{- end }}
-          envFrom: {{- include "custom_airflow_environment_from" . | default "\n  []" | indent 10 }}
+          envFrom: {{- include "custom_airflow_environment_from" $ | default "\n  []" | indent 10 }}
           env:
             # Only signal the main process, not the process group, to make Warm Shutdown work properly
             - name: DUMB_INIT_SETSID
               value: "0"
-            {{- include "custom_airflow_environment" . | indent 10 }}
-            {{- include "standard_airflow_environment" . | indent 10 }}
-            {{- include "container_extra_envs" (list . .Values.workers.env) | indent 10 }}
-            {{- if .Values.workers.kerberosSidecar.enabled }}
-            - name: KRB5_CONFIG
-              value:  {{ .Values.kerberos.configPath | quote }}
-            - name: KRB5CCNAME
-              value:  {{ include "kerberos_ccache_path" . | quote }}
+            {{- include "custom_airflow_environment" $ | indent 10 }}
+            {{- include "standard_airflow_environment" $ | indent 10 }}
+            {{- if $groupEnv }}
+              {{- tpl (toYaml $groupEnv) $ | nindent 12 }}
+            {{- else }}
+            {{- include "container_extra_envs" (list $ $.Values.workers.env) | indent 10 }}
             {{- end }}
-        {{- if and (.Values.dags.gitSync.enabled) (not .Values.dags.persistence.enabled) }}
-          {{- include "git_sync_container" . | nindent 8 }}
+            {{- if $.Values.workers.kerberosSidecar.enabled }}
+            - name: KRB5_CONFIG
+              value:  {{ $.Values.kerberos.configPath | quote }}
+            - name: KRB5CCNAME
+              value:  {{ include "kerberos_ccache_path" $ | quote }}
+            {{- end }}
+        {{- if and ($.Values.dags.gitSync.enabled) (not $.Values.dags.persistence.enabled) }}
+          {{- include "git_sync_container" $ | nindent 8 }}
         {{- end }}
-        {{- if and $persistence .Values.workers.logGroomerSidecar.enabled }}
+        {{- if and $persistence $.Values.workers.logGroomerSidecar.enabled }}
         - name: worker-log-groomer
-          image: {{ template "airflow_image" . }}
-          imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
+          image: {{ template "airflow_image" $ }}
+          imagePullPolicy: {{ $.Values.images.airflow.pullPolicy }}
           securityContext: {{ $containerSecurityContextLogGroomerSidecar | nindent 12 }}
           {{- if $containerLifecycleHooksLogGroomerSidecar }}
-          lifecycle: {{- tpl (toYaml $containerLifecycleHooksLogGroomerSidecar) . | nindent 12 }}
+          lifecycle: {{- tpl (toYaml $containerLifecycleHooksLogGroomerSidecar) $ | nindent 12 }}
           {{- end }}
-          {{- if .Values.workers.logGroomerSidecar.command }}
-          command: {{ tpl (toYaml .Values.workers.logGroomerSidecar.command) . | nindent 12 }}
+          {{- if $.Values.workers.logGroomerSidecar.command }}
+          command: {{ tpl (toYaml $.Values.workers.logGroomerSidecar.command) $ | nindent 12 }}
           {{- end }}
-          {{- if .Values.workers.logGroomerSidecar.args }}
-          args: {{ tpl (toYaml .Values.workers.logGroomerSidecar.args) . | nindent 12 }}
+          {{- if $.Values.workers.logGroomerSidecar.args }}
+          args: {{ tpl (toYaml $.Values.workers.logGroomerSidecar.args) $ | nindent 12 }}
           {{- end }}
           env:
-          {{- if .Values.workers.logGroomerSidecar.retentionDays }}
+          {{- if $.Values.workers.logGroomerSidecar.retentionDays }}
             - name: AIRFLOW__LOG_RETENTION_DAYS
-              value: "{{ .Values.workers.logGroomerSidecar.retentionDays }}"
+              value: "{{ $.Values.workers.logGroomerSidecar.retentionDays }}"
           {{- end }}
-          {{- if .Values.workers.logGroomerSidecar.frequencyMinutes }}
+          {{- if $.Values.workers.logGroomerSidecar.frequencyMinutes }}
             - name: AIRFLOW__LOG_CLEANUP_FREQUENCY_MINUTES
-              value: "{{ .Values.workers.logGroomerSidecar.frequencyMinutes }}"
+              value: "{{ $.Values.workers.logGroomerSidecar.frequencyMinutes }}"
           {{- end }}
             - name: AIRFLOW_HOME
-              value: "{{ .Values.airflowHome }}"
-          {{- if .Values.workers.logGroomerSidecar.env }}
-              {{- tpl (toYaml .Values.workers.logGroomerSidecar.env) $ | nindent 12 }}
+              value: "{{ $.Values.airflowHome }}"
+          {{- if $.Values.workers.logGroomerSidecar.env }}
+              {{- tpl (toYaml $.Values.workers.logGroomerSidecar.env) $ | nindent 12 }}
           {{- end }}
-          resources: {{- toYaml .Values.workers.logGroomerSidecar.resources | nindent 12 }}
+          resources: {{- toYaml $.Values.workers.logGroomerSidecar.resources | nindent 12 }}
           volumeMounts:
             - name: logs
-              mountPath: {{ template "airflow_logs" . }}
-              {{- if .Values.logs.persistence.subPath }}
-              subPath: {{ .Values.logs.persistence.subPath }}
+              mountPath: {{ template "airflow_logs" $ }}
+              {{- if $.Values.logs.persistence.subPath }}
+              subPath: {{ $.Values.logs.persistence.subPath }}
               {{- end }}
-            {{- if .Values.volumeMounts }}
-              {{- toYaml .Values.volumeMounts | nindent 12 }}
+            {{- if $.Values.volumeMounts }}
+              {{- toYaml $.Values.volumeMounts | nindent 12 }}
             {{- end }}
-            {{- if .Values.workers.extraVolumeMounts }}
-              {{- tpl (toYaml .Values.workers.extraVolumeMounts) . | nindent 12 }}
+            {{- if $.Values.workers.extraVolumeMounts }}
+              {{- tpl (toYaml $.Values.workers.extraVolumeMounts) $ | nindent 12 }}
             {{- end }}
-            {{- if or .Values.webserver.webserverConfig .Values.webserver.webserverConfigConfigMapName }}
-              {{- include "airflow_webserver_config_mount" . | nindent 12 }}
+            {{- if or $.Values.webserver.webserverConfig $.Values.webserver.webserverConfigConfigMapName }}
+              {{- include "airflow_webserver_config_mount" $ | nindent 12 }}
             {{- end }}
         {{- end }}
-        {{- if .Values.workers.kerberosSidecar.enabled }}
+        {{- if $.Values.workers.kerberosSidecar.enabled }}
         - name: worker-kerberos
-          image: {{ template "airflow_image" . }}
-          imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
+          image: {{ template "airflow_image" $ }}
+          imagePullPolicy: {{ $.Values.images.airflow.pullPolicy }}
           securityContext: {{ $containerSecurityContextKerberosSidecar | nindent 12 }}
           {{- if $containerLifecycleHooksKerberosSidecar }}
-          lifecycle: {{- tpl (toYaml $containerLifecycleHooksKerberosSidecar) . | nindent 12 }}
+          lifecycle: {{- tpl (toYaml $containerLifecycleHooksKerberosSidecar) $ | nindent 12 }}
           {{- end }}
           args: ["kerberos"]
-          resources: {{- toYaml .Values.workers.kerberosSidecar.resources | nindent 12 }}
+          resources: {{- toYaml $.Values.workers.kerberosSidecar.resources | nindent 12 }}
           volumeMounts:
             - name: logs
-              mountPath: {{ template "airflow_logs" . }}
-              {{- if .Values.logs.persistence.subPath }}
-              subPath: {{ .Values.logs.persistence.subPath }}
+              mountPath: {{ template "airflow_logs" $ }}
+              {{- if $.Values.logs.persistence.subPath }}
+              subPath: {{ $.Values.logs.persistence.subPath }}
               {{- end }}
-            {{- include "airflow_config_mount" . | nindent 12 }}
+            {{- include "airflow_config_mount" $ | nindent 12 }}
             - name: config
-              mountPath: {{ .Values.kerberos.configPath | quote }}
+              mountPath: {{ $.Values.kerberos.configPath | quote }}
               subPath: krb5.conf
               readOnly: true
             - name: kerberos-keytab
               subPath: "kerberos.keytab"
-              mountPath: {{ .Values.kerberos.keytabPath | quote }}
+              mountPath: {{ $.Values.kerberos.keytabPath | quote }}
               readOnly: true
             - name: kerberos-ccache
-              mountPath: {{ .Values.kerberos.ccacheMountPath | quote }}
+              mountPath: {{ $.Values.kerberos.ccacheMountPath | quote }}
               readOnly: false
-            {{- if .Values.volumeMounts }}
-              {{- toYaml .Values.volumeMounts | nindent 12 }}
+            {{- if $.Values.volumeMounts }}
+              {{- toYaml $.Values.volumeMounts | nindent 12 }}
             {{- end }}
-            {{- if .Values.workers.extraVolumeMounts }}
-              {{- tpl (toYaml .Values.workers.extraVolumeMounts) . | nindent 12 }}
+            {{- if $.Values.workers.extraVolumeMounts }}
+              {{- tpl (toYaml $.Values.workers.extraVolumeMounts) $ | nindent 12 }}
             {{- end }}
-            {{- if or .Values.webserver.webserverConfig .Values.webserver.webserverConfigConfigMapName }}
-              {{- include "airflow_webserver_config_mount" . | nindent 12 }}
+            {{- if or $.Values.webserver.webserverConfig $.Values.webserver.webserverConfigConfigMapName }}
+              {{- include "airflow_webserver_config_mount" $ | nindent 12 }}
             {{- end }}
-          envFrom: {{- include "custom_airflow_environment_from" . | default "\n  []" | indent 10 }}
+          envFrom: {{- include "custom_airflow_environment_from" $ | default "\n  []" | indent 10 }}
           env:
             - name: KRB5_CONFIG
-              value:  {{ .Values.kerberos.configPath | quote }}
+              value:  {{ $.Values.kerberos.configPath | quote }}
             - name: KRB5CCNAME
-              value:  {{ include "kerberos_ccache_path" . | quote }}
-            {{- include "custom_airflow_environment" . | indent 10 }}
-            {{- include "standard_airflow_environment" . | indent 10 }}
+              value:  {{ include "kerberos_ccache_path" $ | quote }}
+            {{- include "custom_airflow_environment" $ | indent 10 }}
+            {{- include "standard_airflow_environment" $ | indent 10 }}
         {{- end }}
-        {{- if .Values.workers.extraContainers }}
-          {{- tpl (toYaml .Values.workers.extraContainers) . | nindent 8 }}
+        {{- if $.Values.workers.extraContainers }}
+          {{- tpl (toYaml $.Values.workers.extraContainers) $ | nindent 8 }}
         {{- end }}
       volumes:
-        {{- if .Values.volumes }}
-          {{- toYaml .Values.volumes | nindent 8 }}
+        {{- if $.Values.volumes }}
+          {{- toYaml $.Values.volumes | nindent 8 }}
         {{- end }}
-        {{- if .Values.workers.extraVolumes }}
-          {{- tpl (toYaml .Values.workers.extraVolumes) . | nindent 8 }}
+        {{- if $.Values.workers.extraVolumes }}
+          {{- tpl (toYaml $.Values.workers.extraVolumes) $ | nindent 8 }}
         {{- end }}
         - name: config
           configMap:
-            name: {{ template "airflow_config" . }}
-        {{- if or .Values.webserver.webserverConfig .Values.webserver.webserverConfigConfigMapName }}
+            name: {{ template "airflow_config" $ }}
+        {{- if or $.Values.webserver.webserverConfig $.Values.webserver.webserverConfigConfigMapName }}
         - name: webserver-config
           configMap:
-            name: {{ template "airflow_webserver_config_configmap_name" . }}
+            name: {{ template "airflow_webserver_config_configmap_name" $ }}
         {{- end }}
-        {{- if .Values.kerberos.enabled }}
+        {{- if $.Values.kerberos.enabled }}
         - name: kerberos-keytab
           secret:
-            secretName: {{ include "kerberos_keytab_secret" . | quote }}
+            secretName: {{ include "kerberos_keytab_secret" $ | quote }}
         - name: kerberos-ccache
           emptyDir: {}
         {{- end }}
-        {{- if .Values.dags.persistence.enabled }}
+        {{- if $.Values.dags.persistence.enabled }}
         - name: dags
           persistentVolumeClaim:
-            claimName: {{ template "airflow_dags_volume_claim" . }}
-        {{- else if .Values.dags.gitSync.enabled }}
+            claimName: {{ template "airflow_dags_volume_claim" $ }}
+        {{- else if $.Values.dags.gitSync.enabled }}
         - name: dags
-          emptyDir: {{- toYaml (default (dict) .Values.dags.gitSync.emptyDirConfig) | nindent 12 }}
-        {{- if or .Values.dags.gitSync.sshKeySecret .Values.dags.gitSync.sshKey}}
-          {{- include "git_sync_ssh_key_volume" . | indent 8 }}
+          emptyDir: {{- toYaml (default (dict) $.Values.dags.gitSync.emptyDirConfig) | nindent 12 }}
+        {{- if or $.Values.dags.gitSync.sshKeySecret $.Values.dags.gitSync.sshKey}}
+          {{- include "git_sync_ssh_key_volume" $ | indent 8 }}
         {{- end }}
         {{- end }}
-  {{- if .Values.logs.persistence.enabled }}
+  {{- if $.Values.logs.persistence.enabled }}
         - name: logs
           persistentVolumeClaim:
-            claimName: {{ template "airflow_logs_volume_claim" . }}
+            claimName: {{ template "airflow_logs_volume_claim" $ }}
   {{- else if not $persistence }}
         - name: logs
-          emptyDir: {{- toYaml (default (dict) .Values.logs.emptyDirConfig) | nindent 12 }}
+          emptyDir: {{- toYaml (default (dict) $.Values.logs.emptyDirConfig) | nindent 12 }}
   {{- else }}
   volumeClaimTemplates:
     - apiVersion: v1
       kind: PersistentVolumeClaim
       metadata:
         name: logs
-        {{- if .Values.workers.persistence.annotations }}
-        annotations: {{- toYaml .Values.workers.persistence.annotations | nindent 10 }}
+        {{- if $.Values.workers.persistence.annotations }}
+        annotations: {{- toYaml $.Values.workers.persistence.annotations | nindent 10 }}
         {{- end }}
       spec:
-        {{- if .Values.workers.persistence.storageClassName }}
-        storageClassName: {{ tpl .Values.workers.persistence.storageClassName . | quote }}
+        {{- if $.Values.workers.persistence.storageClassName }}
+        storageClassName: {{ tpl $.Values.workers.persistence.storageClassName $ | quote }}
         {{- end }}
         accessModes: ["ReadWriteOnce"]
         resources:
           requests:
-            storage: {{ .Values.workers.persistence.size }}
-    {{- with .Values.workers.volumeClaimTemplates }}
+            storage: {{ $.Values.workers.persistence.size }}
+    {{- with $.Values.workers.volumeClaimTemplates }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -27,8 +27,8 @@
 
 {{- /* Build worker groups list: use celeryQueueGroups if defined, otherwise create default worker */ -}}
 {{- $workerGroups := list }}
-{{- if .Values.workers.celeryQueueGroups }}
-  {{- $workerGroups = .Values.workers.celeryQueueGroups }}
+{{- if .Values.workers.celery.celeryQueueGroups }}
+  {{- $workerGroups = .Values.workers.celery.celeryQueueGroups }}
 {{- else }}
   {{- $defaultWorker := dict
     "name" ""

--- a/chart/templates/workers/worker-service.yaml
+++ b/chart/templates/workers/worker-service.yaml
@@ -21,28 +21,56 @@
 ## Airflow Worker Service
 #################################
 {{- if or (contains "CeleryExecutor" .Values.executor) (contains "CeleryKubernetesExecutor" .Values.executor) }}
+
+{{- /* Build worker groups list: use celeryQueueGroups if defined, otherwise create default worker */ -}}
+{{- $workerGroups := list }}
+{{- if .Values.workers.celeryQueueGroups }}
+  {{- $workerGroups = .Values.workers.celeryQueueGroups }}
+{{- else }}
+  {{- $defaultWorker := dict "name" "" }}
+  {{- $workerGroups = list $defaultWorker }}
+{{- end }}
+
+{{- /* Loop through all worker groups (either celeryQueueGroups or default) */ -}}
+{{- range $groupIndex, $workerGroup := $workerGroups }}
+{{- if $groupIndex }}
+---
+{{- end }}
+
+{{- /* Set variables based on whether this is default worker or custom group */ -}}
+{{- $isDefaultWorker := eq $workerGroup.name "" }}
+{{- $workerName := ternary "worker" (printf "worker-%s" $workerGroup.name) $isDefaultWorker }}
+{{- $groupLabels := $workerGroup.labels | default dict }}
+
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "airflow.fullname" . }}-worker
+  name: {{ include "airflow.fullname" $ }}-{{ $workerName }}
   labels:
     tier: airflow
     component: worker
-    release: {{ .Release.Name }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    heritage: {{ .Release.Service }}
-    {{- if or (.Values.labels) (.Values.workers.labels) }}
-      {{- mustMerge .Values.workers.labels .Values.labels | toYaml | nindent 4 }}
+    {{- if not $isDefaultWorker }}
+    worker-group: {{ $workerGroup.name }}
+    {{- end }}
+    release: {{ $.Release.Name }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    heritage: {{ $.Release.Service }}
+    {{- if or ($.Values.labels) ($.Values.workers.labels) ($groupLabels) }}
+      {{- mustMerge $groupLabels $.Values.workers.labels $.Values.labels | toYaml | nindent 4 }}
     {{- end }}
 spec:
   clusterIP: None
   selector:
     tier: airflow
     component: worker
-    release: {{ .Release.Name }}
+    {{- if not $isDefaultWorker }}
+    worker-group: {{ $workerGroup.name }}
+    {{- end }}
+    release: {{ $.Release.Name }}
   ports:
     - name: worker-logs
       protocol: TCP
-      port: {{ .Values.ports.workerLogs }}
-      targetPort: {{ .Values.ports.workerLogs }}
+      port: {{ $.Values.ports.workerLogs }}
+      targetPort: {{ $.Values.ports.workerLogs }}
+{{- end }}
 {{- end }}

--- a/chart/templates/workers/worker-service.yaml
+++ b/chart/templates/workers/worker-service.yaml
@@ -22,24 +22,24 @@
 #################################
 {{- if or (contains "CeleryExecutor" .Values.executor) (contains "CeleryKubernetesExecutor" .Values.executor) }}
 
-{{- /* Build worker groups list: use celeryQueueGroups if defined, otherwise create default worker */ -}}
+{{- /* Build worker groups list: use queueGroups if defined, otherwise create default worker */ -}}
 {{- $workerGroups := list }}
-{{- if .Values.workers.celery.celeryQueueGroups }}
-  {{- $workerGroups = .Values.workers.celery.celeryQueueGroups }}
+{{- if .Values.workers.celery.queueGroups }}
+  {{- $workerGroups = .Values.workers.celery.queueGroups }}
 {{- else }}
-  {{- $defaultWorker := dict "name" "" }}
-  {{- $workerGroups = list $defaultWorker }}
+  {{- $baseWorker := dict "name" "" }}
+  {{- $workerGroups = list $baseWorker }}
 {{- end }}
 
-{{- /* Loop through all worker groups (either celeryQueueGroups or default) */ -}}
+{{- /* Loop through all worker groups (either queueGroups or default) */ -}}
 {{- range $groupIndex, $workerGroup := $workerGroups }}
 {{- if $groupIndex }}
 ---
 {{- end }}
 
 {{- /* Set variables based on whether this is default worker or custom group */ -}}
-{{- $isDefaultWorker := eq $workerGroup.name "" }}
-{{- $workerName := ternary "worker" (printf "worker-%s" $workerGroup.name) $isDefaultWorker }}
+{{- $isBaseWorker := eq $workerGroup.name "" }}
+{{- $workerName := ternary "worker" (printf "worker-%s" $workerGroup.name) $isBaseWorker }}
 {{- $groupLabels := $workerGroup.labels | default dict }}
 
 apiVersion: v1
@@ -49,7 +49,7 @@ metadata:
   labels:
     tier: airflow
     component: worker
-    {{- if not $isDefaultWorker }}
+    {{- if not $isBaseWorker }}
     worker-group: {{ $workerGroup.name }}
     {{- end }}
     release: {{ $.Release.Name }}
@@ -63,7 +63,7 @@ spec:
   selector:
     tier: airflow
     component: worker
-    {{- if not $isDefaultWorker }}
+    {{- if not $isBaseWorker }}
     worker-group: {{ $workerGroup.name }}
     {{- end }}
     release: {{ $.Release.Name }}

--- a/chart/templates/workers/worker-service.yaml
+++ b/chart/templates/workers/worker-service.yaml
@@ -24,8 +24,8 @@
 
 {{- /* Build worker groups list: use celeryQueueGroups if defined, otherwise create default worker */ -}}
 {{- $workerGroups := list }}
-{{- if .Values.workers.celeryQueueGroups }}
-  {{- $workerGroups = .Values.workers.celeryQueueGroups }}
+{{- if .Values.workers.celery.celeryQueueGroups }}
+  {{- $workerGroups = .Values.workers.celery.celeryQueueGroups }}
 {{- else }}
   {{- $defaultWorker := dict "name" "" }}
   {{- $workerGroups = list $defaultWorker }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2605,7 +2605,7 @@
                                 }
                             }
                         },
-                        "celeryQueueGroups": {
+                        "queueGroups": {
                             "description": "Celery queue groups for different queues and node assignments. When defined, ONLY these worker groups will be created (no default worker deployment). Each worker group creates a separate Deployment assigned to specific nodes and queues.",
                             "type": "array",
                             "default": [],

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2568,88 +2568,6 @@
                     "type": "boolean",
                     "default": false
                 },
-                "celeryQueueGroups": {
-                    "description": "Celery queue groups for different queues and node assignments. When defined, ONLY these worker groups will be created (no default worker deployment). Each worker group creates a separate Deployment assigned to specific nodes and queues.",
-                    "type": "array",
-                    "default": [],
-                    "items": {
-                        "type": "object",
-                        "required": [
-                            "name",
-                            "queues",
-                            "replicas"
-                        ],
-                        "additionalProperties": false,
-                        "properties": {
-                            "name": {
-                                "description": "Unique name for the worker group",
-                                "type": "string"
-                            },
-                            "queues": {
-                                "description": "Comma-separated list of Celery queues",
-                                "type": "string"
-                            },
-                            "replicas": {
-                                "description": "Number of worker replicas",
-                                "type": "integer"
-                            },
-                            "nodeSelector": {
-                                "description": "Node selector for pod assignment",
-                                "type": "object",
-                                "additionalProperties": {
-                                    "type": "string"
-                                }
-                            },
-                            "affinity": {
-                                "description": "Affinity rules",
-                                "$ref": "#/definitions/io.k8s.api.core.v1.Affinity"
-                            },
-                            "tolerations": {
-                                "description": "Tolerations for node taints",
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/definitions/io.k8s.api.core.v1.Toleration"
-                                }
-                            },
-                            "topologySpreadConstraints": {
-                                "description": "Pod topology spread constraints",
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/definitions/io.k8s.api.core.v1.TopologySpreadConstraint"
-                                }
-                            },
-                            "resources": {
-                                "description": "CPU, memory, and other resource requests/limits",
-                                "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements"
-                            },
-                            "labels": {
-                                "description": "Additional labels for pods",
-                                "type": "object",
-                                "additionalProperties": {
-                                    "type": "string"
-                                }
-                            },
-                            "podAnnotations": {
-                                "description": "Additional pod annotations",
-                                "type": "object",
-                                "additionalProperties": {
-                                    "type": "string"
-                                }
-                            },
-                            "priorityClassName": {
-                                "description": "Priority class name",
-                                "type": "string"
-                            },
-                            "env": {
-                                "description": "Additional environment variables",
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/definitions/io.k8s.api.core.v1.EnvVar"
-                                }
-                            }
-                        }
-                    }
-                },
                 "celery": {
                     "description": "Airflow Celery Workers configuration.",
                     "type": "object",
@@ -2683,6 +2601,88 @@
                                     "default": {},
                                     "additionalProperties": {
                                         "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "celeryQueueGroups": {
+                            "description": "Celery queue groups for different queues and node assignments. When defined, ONLY these worker groups will be created (no default worker deployment). Each worker group creates a separate Deployment assigned to specific nodes and queues.",
+                            "type": "array",
+                            "default": [],
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "name",
+                                    "queues",
+                                    "replicas"
+                                ],
+                                "additionalProperties": false,
+                                "properties": {
+                                    "name": {
+                                        "description": "Unique name for the worker group",
+                                        "type": "string"
+                                    },
+                                    "queues": {
+                                        "description": "Comma-separated list of Celery queues",
+                                        "type": "string"
+                                    },
+                                    "replicas": {
+                                        "description": "Number of worker replicas",
+                                        "type": "integer"
+                                    },
+                                    "nodeSelector": {
+                                        "description": "Node selector for pod assignment",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "affinity": {
+                                        "description": "Affinity rules",
+                                        "$ref": "#/definitions/io.k8s.api.core.v1.Affinity"
+                                    },
+                                    "tolerations": {
+                                        "description": "Tolerations for node taints",
+                                        "type": "array",
+                                        "items": {
+                                            "$ref": "#/definitions/io.k8s.api.core.v1.Toleration"
+                                        }
+                                    },
+                                    "topologySpreadConstraints": {
+                                        "description": "Pod topology spread constraints",
+                                        "type": "array",
+                                        "items": {
+                                            "$ref": "#/definitions/io.k8s.api.core.v1.TopologySpreadConstraint"
+                                        }
+                                    },
+                                    "resources": {
+                                        "description": "CPU, memory, and other resource requests/limits",
+                                        "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements"
+                                    },
+                                    "labels": {
+                                        "description": "Additional labels for pods",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "podAnnotations": {
+                                        "description": "Additional pod annotations",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "priorityClassName": {
+                                        "description": "Priority class name",
+                                        "type": "string"
+                                    },
+                                    "env": {
+                                        "description": "Additional environment variables",
+                                        "type": "array",
+                                        "items": {
+                                            "$ref": "#/definitions/io.k8s.api.core.v1.EnvVar"
+                                        }
                                     }
                                 }
                             }

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2568,6 +2568,88 @@
                     "type": "boolean",
                     "default": false
                 },
+                "celeryQueueGroups": {
+                    "description": "Celery queue groups for different queues and node assignments. When defined, ONLY these worker groups will be created (no default worker deployment). Each worker group creates a separate Deployment assigned to specific nodes and queues.",
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "type": "object",
+                        "required": [
+                            "name",
+                            "queues",
+                            "replicas"
+                        ],
+                        "additionalProperties": false,
+                        "properties": {
+                            "name": {
+                                "description": "Unique name for the worker group",
+                                "type": "string"
+                            },
+                            "queues": {
+                                "description": "Comma-separated list of Celery queues",
+                                "type": "string"
+                            },
+                            "replicas": {
+                                "description": "Number of worker replicas",
+                                "type": "integer"
+                            },
+                            "nodeSelector": {
+                                "description": "Node selector for pod assignment",
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "string"
+                                }
+                            },
+                            "affinity": {
+                                "description": "Affinity rules",
+                                "$ref": "#/definitions/io.k8s.api.core.v1.Affinity"
+                            },
+                            "tolerations": {
+                                "description": "Tolerations for node taints",
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/io.k8s.api.core.v1.Toleration"
+                                }
+                            },
+                            "topologySpreadConstraints": {
+                                "description": "Pod topology spread constraints",
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/io.k8s.api.core.v1.TopologySpreadConstraint"
+                                }
+                            },
+                            "resources": {
+                                "description": "CPU, memory, and other resource requests/limits",
+                                "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements"
+                            },
+                            "labels": {
+                                "description": "Additional labels for pods",
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "string"
+                                }
+                            },
+                            "podAnnotations": {
+                                "description": "Additional pod annotations",
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "string"
+                                }
+                            },
+                            "priorityClassName": {
+                                "description": "Priority class name",
+                                "type": "string"
+                            },
+                            "env": {
+                                "description": "Additional environment variables",
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/io.k8s.api.core.v1.EnvVar"
+                                }
+                            }
+                        }
+                    }
+                },
                 "celery": {
                     "description": "Airflow Celery Workers configuration.",
                     "type": "object",

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2606,7 +2606,7 @@
                             }
                         },
                         "queueGroups": {
-                            "description": "Celery queue groups for different queues and node assignments. When defined, ONLY these worker groups will be created (no default worker deployment). Each worker group creates a separate Deployment assigned to specific nodes and queues.",
+                            "description": "Celery queue groups for different queues and node assignments. When defined, ONLY these worker groups will be created (no default worker deployment). Each worker group creates a separate Deployment assigned to specific nodes and queues. However, autoscaling (KEDA and HPA) is unsupported; you must use a fixed number of workers.",
                             "type": "array",
                             "default": [],
                             "items": {
@@ -2678,7 +2678,7 @@
                                         "type": "string"
                                     },
                                     "env": {
-                                        "description": "Additional environment variables",
+                                        "description": "Additional environment variables used to customize the behavior of workers for each queue group. For instance, set AIRFLOW__CELERY__WORKER_CONCURRENCY to override concurrency for a specific worker group.",
                                         "type": "array",
                                         "items": {
                                             "$ref": "#/definitions/io.k8s.api.core.v1.EnvVar"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -707,6 +707,7 @@ workers:
     annotations: {}
 
   # Allow KEDA autoscaling for Airflow Celery workers
+  # Note: KEDA autoscaling is not supported when using workers.celery.queueGroups
   keda:
     enabled: false
     namespaceLabels: {}
@@ -753,6 +754,7 @@ workers:
     usePgbouncer: true
 
   # Allow HPA for Airflow Celery workers (KEDA must be disabled)
+  # Note: HPA autoscaling is not supported when using workers.celery.queueGroups
   hpa:
     enabled: false
 
@@ -1017,6 +1019,9 @@ workers:
     # Celery queue groups for different queues and node assignments
     # When defined, ONLY these worker groups will be created (no default worker deployment)
     # Each worker group creates a separate Deployment assigned to specific nodes and queues
+    # Note: All worker groups share the same base Celery command line definition. To customize settings,
+    # use the 'env' field to set environment variables (e.g., AIRFLOW__CELERY__WORKER_CONCURRENCY).
+    # IMPORTANT: KEDA and HPA autoscaling are not currently supported when using queueGroups.
     queueGroups: []
     # queueGroups:
     # - name: base-workers

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1017,9 +1017,9 @@ workers:
     # Celery queue groups for different queues and node assignments
     # When defined, ONLY these worker groups will be created (no default worker deployment)
     # Each worker group creates a separate Deployment assigned to specific nodes and queues
-    celeryQueueGroups: []
-    # celeryQueueGroups:
-    # - name: default-workers
+    queueGroups: []
+    # queueGroups:
+    # - name: base-workers
     #   queues: "default,email,notifications"
     #   replicas: 3
     #   resources:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1000,34 +1000,6 @@ workers:
   # If true, dedicated Service Accounts for every worker type will be created.
   useWorkerDedicatedServiceAccounts: false
 
-  # Celery queue groups for different queues and node assignments
-  # When defined, ONLY these worker groups will be created (no default worker deployment)
-  # Each worker group creates a separate Deployment assigned to specific nodes and queues
-  celeryQueueGroups: []
-  # celeryQueueGroups:
-  # - name: default-workers
-  #   queues: "default,email,notifications"
-  #   replicas: 3
-  #   resources:
-  #     requests:
-  #       memory: "512Mi"
-  #       cpu: "500m"
-  #     limits:
-  #       memory: "1Gi"
-  #       cpu: "1"
-  # - name: heavy-workers
-  #   queues: "reports,batch_processing"
-  #   replicas: 2
-  #   nodeSelector:
-  #     workload: "compute-intensive"
-  #   resources:
-  #     requests:
-  #       memory: "2Gi"
-  #       cpu: "2"
-  #     limits:
-  #       memory: "4Gi"
-  #       cpu: "4"
-
   celery:
     # Create ServiceAccount for Airflow Celery workers
     serviceAccount:
@@ -1041,6 +1013,34 @@ workers:
       name: ~
       # Annotations to add to worker kubernetes service account.
       annotations: {}
+
+    # Celery queue groups for different queues and node assignments
+    # When defined, ONLY these worker groups will be created (no default worker deployment)
+    # Each worker group creates a separate Deployment assigned to specific nodes and queues
+    celeryQueueGroups: []
+    # celeryQueueGroups:
+    # - name: default-workers
+    #   queues: "default,email,notifications"
+    #   replicas: 3
+    #   resources:
+    #     requests:
+    #       memory: "512Mi"
+    #       cpu: "500m"
+    #     limits:
+    #       memory: "1Gi"
+    #       cpu: "1"
+    # - name: heavy-workers
+    #   queues: "reports,batch_processing"
+    #   replicas: 2
+    #   nodeSelector:
+    #     workload: "compute-intensive"
+    #   resources:
+    #     requests:
+    #       memory: "2Gi"
+    #       cpu: "2"
+    #     limits:
+    #       memory: "4Gi"
+    #       cpu: "4"
 
   kubernetes:
     # Create ServiceAccount for pods created with pod-template-file

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1000,6 +1000,69 @@ workers:
   # If true, dedicated Service Accounts for every worker type will be created.
   useWorkerDedicatedServiceAccounts: false
 
+  # Celery queue groups for different queues and node assignments
+  # When defined, ONLY these worker groups will be created (no default worker deployment)
+  # Each worker group creates a separate Deployment assigned to specific nodes and queues
+  # celeryQueueGroups: []
+  # Example configuration:
+  # celeryQueueGroups:
+  #   # GPU workers for ML/AI tasks
+  #   - name: gpu-workers
+  #     # Celery queues to listen to (comma-separated)
+  #     queues: "gpu_tasks"
+  #     # Number of replicas for this worker group
+  #     replicas: 2
+  #     # Node selector to assign pods to specific nodes
+  #     nodeSelector:
+  #       accelerator: nvidia-tesla-t4
+  #     # Tolerations for this worker group
+  #     tolerations:
+  #       - key: nvidia.com/gpu
+  #         operator: Exists
+  #     # Resources for this worker group
+  #     resources:
+  #       requests:
+  #         memory: "8Gi"
+  #         cpu: "4"
+  #         nvidia.com/gpu: "1"
+  #       limits:
+  #         memory: "16Gi"
+  #         cpu: "8"
+  #         nvidia.com/gpu: "1"
+  #
+  #   # High-priority workers on dedicated nodes
+  #   - name: high-priority
+  #     queues: "high_priority,urgent"
+  #     replicas: 3
+  #     nodeSelector:
+  #       workload-type: high-priority
+  #     tolerations:
+  #       - key: "dedicated"
+  #         operator: "Equal"
+  #         value: "high-priority"
+  #         effect: "NoSchedule"
+  #     resources:
+  #       requests:
+  #         memory: "4Gi"
+  #         cpu: "2"
+  #       limits:
+  #         memory: "8Gi"
+  #         cpu: "4"
+  #
+  # Available configuration options for each worker group:
+  #   - name: (required) Unique name for the worker group
+  #   - queues: (required) Comma-separated list of Celery queues
+  #   - replicas: (required) Number of worker replicas
+  #   - nodeSelector: (optional) Node selector for pod assignment
+  #   - affinity: (optional) Affinity rules
+  #   - tolerations: (optional) Tolerations for node taints
+  #   - topologySpreadConstraints: (optional) Pod topology spread constraints
+  #   - resources: (optional) CPU, memory, and other resource requests/limits
+  #   - labels: (optional) Additional labels for pods
+  #   - podAnnotations: (optional) Additional pod annotations
+  #   - priorityClassName: (optional) Priority class name
+  #   - env: (optional) Additional environment variables
+
   celery:
     # Create ServiceAccount for Airflow Celery workers
     serviceAccount:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1003,65 +1003,30 @@ workers:
   # Celery queue groups for different queues and node assignments
   # When defined, ONLY these worker groups will be created (no default worker deployment)
   # Each worker group creates a separate Deployment assigned to specific nodes and queues
-  # celeryQueueGroups: []
-  # Example configuration:
+  celeryQueueGroups: []
   # celeryQueueGroups:
-  #   # GPU workers for ML/AI tasks
-  #   - name: gpu-workers
-  #     # Celery queues to listen to (comma-separated)
-  #     queues: "gpu_tasks"
-  #     # Number of replicas for this worker group
-  #     replicas: 2
-  #     # Node selector to assign pods to specific nodes
-  #     nodeSelector:
-  #       accelerator: nvidia-tesla-t4
-  #     # Tolerations for this worker group
-  #     tolerations:
-  #       - key: nvidia.com/gpu
-  #         operator: Exists
-  #     # Resources for this worker group
-  #     resources:
-  #       requests:
-  #         memory: "8Gi"
-  #         cpu: "4"
-  #         nvidia.com/gpu: "1"
-  #       limits:
-  #         memory: "16Gi"
-  #         cpu: "8"
-  #         nvidia.com/gpu: "1"
-  #
-  #   # High-priority workers on dedicated nodes
-  #   - name: high-priority
-  #     queues: "high_priority,urgent"
-  #     replicas: 3
-  #     nodeSelector:
-  #       workload-type: high-priority
-  #     tolerations:
-  #       - key: "dedicated"
-  #         operator: "Equal"
-  #         value: "high-priority"
-  #         effect: "NoSchedule"
-  #     resources:
-  #       requests:
-  #         memory: "4Gi"
-  #         cpu: "2"
-  #       limits:
-  #         memory: "8Gi"
-  #         cpu: "4"
-  #
-  # Available configuration options for each worker group:
-  #   - name: (required) Unique name for the worker group
-  #   - queues: (required) Comma-separated list of Celery queues
-  #   - replicas: (required) Number of worker replicas
-  #   - nodeSelector: (optional) Node selector for pod assignment
-  #   - affinity: (optional) Affinity rules
-  #   - tolerations: (optional) Tolerations for node taints
-  #   - topologySpreadConstraints: (optional) Pod topology spread constraints
-  #   - resources: (optional) CPU, memory, and other resource requests/limits
-  #   - labels: (optional) Additional labels for pods
-  #   - podAnnotations: (optional) Additional pod annotations
-  #   - priorityClassName: (optional) Priority class name
-  #   - env: (optional) Additional environment variables
+  # - name: default-workers
+  #   queues: "default,email,notifications"
+  #   replicas: 3
+  #   resources:
+  #     requests:
+  #       memory: "512Mi"
+  #       cpu: "500m"
+  #     limits:
+  #       memory: "1Gi"
+  #       cpu: "1"
+  # - name: heavy-workers
+  #   queues: "reports,batch_processing"
+  #   replicas: 2
+  #   nodeSelector:
+  #     workload: "compute-intensive"
+  #   resources:
+  #     requests:
+  #       memory: "2Gi"
+  #       cpu: "2"
+  #     limits:
+  #       memory: "4Gi"
+  #       cpu: "4"
 
   celery:
     # Create ServiceAccount for Airflow Celery workers


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
## Summary
This PR adds support for multiple Celery worker groups. Each group can now be independently configured to target specific queues and use distinct resource settings
> The goal is to achieve **fine-grained** control over task distribution by assigning queues to specific worker nodes. 

## Changes
**New Configuration**: `workers.celeryQueueGroups`
Added support for defining multiple worker deployments through the `workers.celeryQueueGroups` configuration. Each group can specify:
- `name`: (required) Unique name for the worker group
- `queues`: (required) Comma-separated list of Celery queues
- `replicas`: (required) Number of worker replicas
- `nodeSelector`: (optional)
- `affinity`: (optional)
- `tolerations`: (optional)
- `topologySpreadConstraints`: (optional)
- `resources`: (optional) 
- `labels`: (optional)
- `podAnnotations`: (optional)
- `priorityClassName`: (optional)
- `env`: (optional)

**`worker-deployment.yaml` Logic**
- Modified the worker deployment template to loop through all configured worker groups
- For default behavior (no `celeryQueueGroups` defined), the template maintains original setup using existing `workers.* configuration`
- Each worker group creates a separate Deployment/StatefulSet with:
  - Unique name suffix based on group name (e.g., airflow-worker-high-priority)
  -  **worker-group** label for identification
  - **Queue-specific command arguments**: `exec airflow celery worker --queues <group-queues>`
  -  Custom resource configurations override default settings per group

**`worker-service.yaml` Logic**
- Extended service template to create separate services for each worker group
- Each service is scoped to its corresponding worker group using the `worker-group` label selector
- Service naming follows the pattern: `{{ airflow.fullname }}-worker-<group-name>`

closes: #56591

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
