### PR TITLE
[Docs]updates the Spark base image

### DIFF
--- a/providers/cncf/kubernetes/docs/operators.rst
+++ b/providers/cncf/kubernetes/docs/operators.rst
@@ -496,7 +496,7 @@ spark_job_template.yaml
 
     * kubernetes: This segment encompasses the task's Kubernetes resource configuration, directly corresponding to the Kubernetes API Documentation. Each resource type includes an example within the template.
 
-  * The designated base image to be utilized is ``gcr.io/spark-operator/spark-py:v3.1.1``.
+  * The designated base image to be utilized is ``apache/spark-py:v3.4.0``.
 
   * Ensure that the Spark code is either embedded within the image, mounted using a persistentVolume, or accessible from an external location such as an S3 bucket.
 
@@ -506,7 +506,7 @@ Next, create the task using the following:
 
     SparkKubernetesOperator(
         task_id="spark_task",
-        image="gcr.io/spark-operator/spark-py:v3.1.1",  # OR custom image using that
+        image="apache/spark-py:v3.4.0",  # OR custom image using that
         code_path="local://path/to/spark/code.py",
         application_file="spark_job_template.yaml",  # OR spark_job_template.json
         dag=dag,


### PR DESCRIPTION
## ✨ Summary

This PR updates the Spark base image reference used in the Airflow Spark-on-Kubernetes example to align with the latest officially maintained Apache Spark images and Python version requirements.

---

## 🧩 Changes

| Item | Old | New | Python Version |
|------|------|------|----------------|
| Base Image | `gcr.io/spark-operator/spark-py:v3.1.1` | `apache/spark-py:v3.4.0` | 3.10.6 |

- The legacy image (gcr.io/spark-operator/spark-py:v3.1.1) was built on an outdated Spark and Python base, and attempts to pull it from /artifacts/tags/spark-operator/us/gcr.io/spark-py/v3.1.1 failed due to registry access issues during migration.
- The updated image (`v3.4.0`) is based on **Ubuntu 22.04 (Jammy)** and ships with **Python 3.10.6**.  
- This update ensures compatibility with the latest **`apache-airflow-providers-cncf-kubernetes`**, which now requires **Python >= 3.10**.  

> Verified with:
> ```bash
> curl -s https://pypi.org/pypi/apache-airflow-providers-cncf-kubernetes/json \
>   | jq -r '.info.requires_python'
> # >=3.10
> ```

---

## 🧠 Rationale

- The older `gcr.io/spark-operator/spark-py:v3.1.1` image (Python 3.8.x) is deprecated and no longer maintained on GCR.  
- The official Apache image (`apache/spark-py`) on Docker Hub is now the actively maintained and recommended base for Spark 3.4+.  
- Verified the runtime environments manually:

```bash
docker run --rm apache/spark-py:v3.2.4 python3 -V
# Python 3.9.2

docker run --rm apache/spark-py:v3.4.0 python3 -V
# Python 3.10.6
```

<img width="1346" height="1878" alt="image" src="https://github.com/user-attachments/assets/678d9868-b63b-4aa5-952e-b321ef1d0f1f" />


<img width="716" height="979" alt="Screenshot 2025-10-14 at 12 05 35 AM" src="https://github.com/user-attachments/assets/1f0856ee-de59-410e-9a24-cb62fe091d74" />

<img width="3152" height="132" alt="image" src="https://github.com/user-attachments/assets/63f104dc-107b-49fe-a2dc-d03967ef4ef3" />


https://hub.docker.com/r/apache/spark-py/tags

`I checked all image tag`

<img width="1336" height="1576" alt="image" src="https://github.com/user-attachments/assets/970b6fc7-af36-4d1d-b45f-2ecbef21d7c4" />

<img width="1430" height="1658" alt="image" src="https://github.com/user-attachments/assets/fb3ba801-7c0e-46b5-ad7d-50fb38775c20" />




<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
