### PR TITLE
Enable PT011 rule to prvoider tests

### DIFF
--- a/providers/amazon/tests/unit/amazon/aws/system/utils/test_helpers.py
+++ b/providers/amazon/tests/unit/amazon/aws/system/utils/test_helpers.py
@@ -92,10 +92,8 @@ class TestAmazonSystemTestHelpers:
 
     def test_fetch_variable_no_value_found_raises_exception(self):
         # This would be the (None, None, None) test case from above.
-        with pytest.raises(ValueError) as raised_exception:
+        with pytest.raises(ValueError, match=NO_VALUE_MSG.format(key=ANY_STR)):
             utils.fetch_variable(key=ANY_STR, test_name=TEST_NAME)
-
-        assert NO_VALUE_MSG.format(key=ANY_STR) in str(raised_exception.value)
 
     ENV_ID_TEST_CASES = [
         # Happy Cases
@@ -129,10 +127,8 @@ class TestAmazonSystemTestHelpers:
             if not result == env_id:
                 assert LOWERCASE_ENV_ID_MSG in captured_output.getvalue()
         else:
-            with pytest.raises(ValueError) as raised_exception:
+            with pytest.raises(ValueError, match=INVALID_ENV_ID_MSG):
                 _validate_env_id(env_id)
-
-            assert INVALID_ENV_ID_MSG in str(raised_exception.value)
 
     def test_set_env_id_generates_if_required(self):
         # No environment variable nor SSM value has been found

--- a/providers/amazon/tests/unit/amazon/aws/transfers/test_redshift_to_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/transfers/test_redshift_to_s3.py
@@ -428,7 +428,9 @@ class TestRedshiftToS3Transfer:
             dag=None,
         )
 
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError, match="Please specify either a table or `select_query` to fetch the data."
+        ):
             op.execute(None)
 
     @pytest.mark.parametrize("table_as_file_name, expected_s3_key", [[True, "key/table_"], [False, "key"]])

--- a/providers/amazon/tests/unit/amazon/aws/triggers/test_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/triggers/test_s3.py
@@ -131,7 +131,7 @@ class TestS3KeysUnchangedTrigger:
         """
         Test if the S3KeysUnchangedTrigger raises Value error for negative inactivity_period.
         """
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="inactivity_period must be non-negative"):
             S3KeysUnchangedTrigger(bucket_name="test_bucket", prefix="test", inactivity_period=-100)
 
     @pytest.mark.asyncio

--- a/providers/amazon/tests/unit/amazon/aws/utils/test_openlineage.py
+++ b/providers/amazon/tests/unit/amazon/aws/utils/test_openlineage.py
@@ -164,5 +164,7 @@ def test_get_identity_column_lineage_facet_no_input_datasets():
     field_names = ["field1", "field2"]
     input_datasets = []
 
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="When providing `field_names` You must provide at least one `input_dataset`."
+    ):
         get_identity_column_lineage_facet(field_names=field_names, input_datasets=input_datasets)

--- a/providers/apache/hive/tests/unit/apache/hive/sensors/test_named_hive_partition.py
+++ b/providers/apache/hive/tests/unit/apache/hive/sensors/test_named_hive_partition.py
@@ -72,7 +72,7 @@ class TestNamedHivePartitionSensor:
 
     def test_parse_partition_name_incorrect(self):
         name = "incorrect.name"
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Could not parse incorrect.nameinto table, partition"):
             NamedHivePartitionSensor.parse_partition_name(name)
 
     def test_parse_partition_name_default(self):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
issue: Enable Even More PyDocStyle Checks #40567
@ferruzzi
This PR is for enable PT011 rule:
PT011: all instances of pytest.raises should include a match term to make sure they are catching the right error.
https://docs.astral.sh/ruff/rules/pytest-raises-too-broad/
There are 102 files changes is need.
So, I separate to many PR, which contains about 5 file changes for easy review.
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
