### PR TITLE
Fix AutoRefresh when only 1 dag run is running

### DIFF
--- a/airflow-core/src/airflow/ui/src/utils/query.ts
+++ b/airflow-core/src/airflow/ui/src/utils/query.ts
@@ -64,7 +64,8 @@ export const useAutoRefresh = ({
     },
   );
 
-  const pendingRuns = checkPendingRuns ? (dagRunData?.dag_runs ?? []).length > 1 : true;
+  const pendingRuns = checkPendingRuns ? (dagRunData?.dag_runs ?? []).length >= 1 : true;
+
   const paused = Boolean(dagId) ? dag?.is_paused : false;
 
   const canRefresh = autoRefreshInterval !== undefined && !paused && pendingRuns;


### PR DESCRIPTION
We should do AutoRefresh as long as at least 1 DagRun is in the running state. 

AutoRefresh was not working when only 1 DagRun was running.