### PR TITLE
Improve UI retry strategy on client errors

### DIFF
--- a/airflow-core/src/airflow/ui/src/queryClient.ts
+++ b/airflow-core/src/airflow/ui/src/queryClient.ts
@@ -26,16 +26,29 @@ if (OpenAPI.BASE.endsWith("/")) {
   OpenAPI.BASE = OpenAPI.BASE.slice(0, -1);
 }
 
+const RETRY_COUNT = 3;
+
+const retryFunction = (failureCount: number, error: unknown) => {
+  const { status } = error as { status?: number };
+
+  // Do not retry for client errors (4xx). 429 should be eventually retried though.
+  if (status !== undefined && status >= 400 && status < 500 && status !== 429) {
+    return false;
+  }
+
+  return failureCount < RETRY_COUNT;
+};
+
 export const client = new QueryClient({
   defaultOptions: {
     mutations: {
-      retry: 3,
+      retry: retryFunction,
     },
     queries: {
       initialDataUpdatedAt: new Date().setMinutes(-6), // make sure initial data is already expired
       refetchOnMount: true, // Refetches stale queries, not "always"
       refetchOnWindowFocus: false,
-      retry: 3,
+      retry: retryFunction,
       staleTime: 5 * 60 * 1000, // 5 minutes
     },
   },


### PR DESCRIPTION
This modify the query client to not retry request (both gets and mutations) when we receive a 4xx response from the server. (Client error), unless this is rate limiting.

Will prevent extra useless and allow UI error handling code to fail early, beside staying in 'isLoading' mode until all retries are exhausted.