### PR TITLE
feat: adds support for OpenTelemetry standard environment variables f…

### DIFF
--- a/airflow-core/docs/administration-and-deployment/logging-monitoring/metrics.rst
+++ b/airflow-core/docs/administration-and-deployment/logging-monitoring/metrics.rst
@@ -75,6 +75,17 @@ Add the following lines to your configuration file e.g. ``airflow.cfg``
     otel_interval_milliseconds = 30000  # The interval between exports, defaults to 60000
     otel_ssl_active = False
 
+.. note::
+
+    To support the OpenTelemetry exporter standard, the ``metrics`` configurations are transparently superseded by use of standard OpenTelemetry SDK environment variables.
+
+    - ``OTEL_EXPORTER_OTLP_ENDPOINT`` and ``OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`` supersede ``otel_host``, ``otel_port`` and ``otel_ssl_active``
+    - ``OTEL_METRIC_EXPORT_INTERVAL`` supersedes ``otel_interval_milliseconds``
+
+    See the OpenTelemetry `exporter protocol specification <https://opentelemetry.io/docs/specs/otel/protocol/exporter/#configuration-options>`_  and
+    `SDK environment variable documentation <https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#periodic-exporting-metricreader>`_ for more information.
+
+
 Enable Https
 -----------------
 

--- a/airflow-core/docs/administration-and-deployment/logging-monitoring/metrics.rst
+++ b/airflow-core/docs/administration-and-deployment/logging-monitoring/metrics.rst
@@ -77,7 +77,7 @@ Add the following lines to your configuration file e.g. ``airflow.cfg``
 
 .. note::
 
-    To support the OpenTelemetry exporter standard, the ``metrics`` configurations are transparently superseded by use of standard OpenTelemetry SDK environment variables.
+    To support the OpenTelemetry exporter standard, the ``metrics`` configurations are transparently overridden by use of standard OpenTelemetry SDK environment variables.
 
     - ``OTEL_EXPORTER_OTLP_ENDPOINT`` and ``OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`` supersede ``otel_host``, ``otel_port`` and ``otel_ssl_active``
     - ``OTEL_METRIC_EXPORT_INTERVAL`` supersedes ``otel_interval_milliseconds``

--- a/airflow-core/docs/administration-and-deployment/logging-monitoring/traces.rst
+++ b/airflow-core/docs/administration-and-deployment/logging-monitoring/traces.rst
@@ -43,6 +43,15 @@ Add the following lines to your configuration file e.g. ``airflow.cfg``
     otel_ssl_active = False
     otel_task_log_event = True
 
+.. note::
+
+    To support the OpenTelemetry exporter standard, the ``traces`` configurations are transparently superseded by use of standard OpenTelemetry SDK environment variables.
+
+    - ``OTEL_EXPORTER_OTLP_ENDPOINT`` and ``OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`` supersede ``otel_host``, ``otel_port`` and ``otel_ssl_active``
+
+    See the OpenTelemetry `exporter protocol specification <https://opentelemetry.io/docs/specs/otel/protocol/exporter/#configuration-options>`_  and
+    `SDK environment variable documentation <https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#periodic-exporting-metricreader>`_ for more information.
+
 Enable Https
 -----------------
 

--- a/airflow-core/docs/administration-and-deployment/logging-monitoring/traces.rst
+++ b/airflow-core/docs/administration-and-deployment/logging-monitoring/traces.rst
@@ -47,7 +47,7 @@ Add the following lines to your configuration file e.g. ``airflow.cfg``
 
     To support the OpenTelemetry exporter standard, the ``traces`` configurations are transparently superseded by use of standard OpenTelemetry SDK environment variables.
 
-    - ``OTEL_EXPORTER_OTLP_ENDPOINT`` and ``OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`` supersede ``otel_host``, ``otel_port`` and ``otel_ssl_active``
+    - ``OTEL_EXPORTER_OTLP_ENDPOINT`` and ``OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`` overridden ``otel_host``, ``otel_port`` and ``otel_ssl_active``
 
     See the OpenTelemetry `exporter protocol specification <https://opentelemetry.io/docs/specs/otel/protocol/exporter/#configuration-options>`_  and
     `SDK environment variable documentation <https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#periodic-exporting-metricreader>`_ for more information.

--- a/airflow-core/src/airflow/traces/otel_tracer.py
+++ b/airflow-core/src/airflow/traces/otel_tracer.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import random
 from contextlib import AbstractContextManager
 from typing import TYPE_CHECKING
@@ -333,7 +334,10 @@ def get_otel_tracer(cls, use_simple_processor: bool = False) -> OtelTrace:
     tag_string = cls.get_constant_tags()
 
     protocol = "https" if ssl_active else "http"
-    endpoint = f"{protocol}://{host}:{port}/v1/traces"
+    # Allow transparent support for standard OpenTelemetry SDK environment variables.
+    # https://opentelemetry.io/docs/specs/otel/protocol/exporter/#configuration-options
+    endpoint = os.environ.get("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", f"{protocol}://{host}:{port}/v1/traces")
+
     log.info("[OTLPSpanExporter] Connecting to OpenTelemetry Collector at %s", endpoint)
     log.info("Should use simple processor: %s", use_simple_processor)
     return OtelTrace(


### PR DESCRIPTION
The current OpenTelemetry implementation has a fairly rigid configuration specification for endpoint host/port and export interval. While this is probably okay for most configurations, there are cases in which endpoints do not conform with the standard implied by Airflow's implementation. See https://prometheus.io/docs/guides/opentelemetry/#send-opentelemetry-metrics-to-the-prometheus-server for an example of how the API URL can stray from the basic "/v1/metrics" route, yet still be entirely valid.

Instead of adding new configuration values to the metrics and traces sections, this PR adds transparent support for all standard OpenTelemetry environment variables (so far) that would otherwise be overridden by Airflow's configuration.

This change includes the support for:

- OTEL_EXPORTER_OTLP_ENDPOINT
- OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
- OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
- OTEL_METRIC_EXPORT_INTERVAL
