### PR TITLE
Enable PT011 rule to prvoider tests

### DIFF
--- a/providers/amazon/tests/unit/amazon/aws/operators/test_eventbridge.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_eventbridge.py
@@ -156,7 +156,7 @@ class TestEventBridgePutRuleOperator:
             event_pattern="invalid json",
         )
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="`event_pattern` must be a valid JSON string."):
             operator.execute(None)
 
     def test_template_fields(self):

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_lambda_function.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_lambda_function.py
@@ -42,6 +42,7 @@ IMAGE_URI = "image_uri"
 LOG_RESPONSE = base64.b64encode(b"FOO\n\nBAR\n\n").decode()
 BAD_LOG_RESPONSE = LOG_RESPONSE[:-3]
 NO_LOG_RESPONSE_SENTINEL = type("NoLogResponseSentinel", (), {})()
+LAMBDA_FUNC_NO_EXECUTION = "Lambda function did not execute"
 
 
 class TestLambdaCreateFunctionOperator:
@@ -275,7 +276,7 @@ class TestLambdaInvokeFunctionOperator:
         )
         hook_mock().invoke_lambda.return_value = {"ResponseMetadata": "", "StatusCode": 404}
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=LAMBDA_FUNC_NO_EXECUTION):
             operator.execute(None)
 
     @patch.object(LambdaInvokeFunctionOperator, "hook", new_callable=mock.PropertyMock)
@@ -291,7 +292,7 @@ class TestLambdaInvokeFunctionOperator:
             "Payload": Mock(),
         }
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=LAMBDA_FUNC_NO_EXECUTION):
             operator.execute(None)
 
     def test_template_fields(self):

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_sagemaker_base.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_sagemaker_base.py
@@ -188,7 +188,7 @@ class TestSageMakerBaseOperator:
     def test_check_if_resource_exists_raises_when_it_is_not_validation_exception(self):
         describe_func = MagicMock(side_effect=ValueError("different exception"))
 
-        with pytest.raises(ValueError) as context:
+        with pytest.raises(ValueError, match="different exception") as context:
             self.sagemaker._check_if_resource_exists("job_123", "job", describe_func)
 
         assert str(context.value) == "different exception"

--- a/providers/amazon/tests/unit/amazon/aws/sensors/test_ec2.py
+++ b/providers/amazon/tests/unit/amazon/aws/sensors/test_ec2.py
@@ -42,7 +42,7 @@ class TestEC2InstanceStateSensor:
 
     def test_init_invalid_target_state(self):
         invalid_target_state = "target_state_test"
-        with pytest.raises(ValueError) as ctx:
+        with pytest.raises(ValueError, match=f"Invalid target_state: {invalid_target_state}") as ctx:
             EC2InstanceStateSensor(
                 task_id="task_test",
                 target_state=invalid_target_state,

--- a/providers/amazon/tests/unit/amazon/aws/sensors/test_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/sensors/test_s3.py
@@ -491,7 +491,7 @@ class TestS3KeysUnchangedSensor:
         )
 
     def test_reschedule_mode_not_allowed(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Cannot set mode to 'reschedule'. Only 'poke' is acceptable"):
             S3KeysUnchangedSensor(
                 task_id="sensor_2",
                 bucket_name="test-bucket",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
issue: Enable Even More PyDocStyle Checks #40567
@ferruzzi
This PR is for enable PT011 rule:
PT011: all instances of pytest.raises should include a match term to make sure they are catching the right error.
https://docs.astral.sh/ruff/rules/pytest-raises-too-broad/
There are 102 files changes is need.
So, I separate to many PR, which contains about 5 file changes for easy review.
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
