### PR TITLE
Fix task SDK connection error handling to match airflow-core behavior

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -160,7 +160,7 @@ def _get_connection(conn_id: str) -> Connection:
                 _mask_connection_secrets(conn)
                 return conn
         except Exception:
-            log.exception(
+            log.debug(
                 "Unable to retrieve connection from secrets backend (%s). "
                 "Checking subsequent secrets backend.",
                 type(secrets_backend).__name__,
@@ -206,7 +206,7 @@ async def _async_get_connection(conn_id: str) -> Connection:
                 return conn
         except Exception:
             # If one backend fails, try the next one
-            log.exception(
+            log.debug(
                 "Unable to retrieve connection from secrets backend (%s). "
                 "Checking subsequent secrets backend.",
                 type(secrets_backend).__name__,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Unusual, but when `Connection.get(None)` is called, the stacktrace looks like:

```
[2025-09-30 16:58:30] WARNING - Skipping masking for a secret as it's too short (<5 chars) source=airflow._shared.secrets_masker.secrets_masker loc=secrets_masker.py:546
[2025-09-30 16:58:30] ERROR - Unable to retrieve connection from secrets backend (EnvironmentVariablesBackend). Checking subsequent secrets backend. source=task loc=context.py:162
AttributeError: 'NoneType' object has no attribute 'upper'
File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/context.py", line 156 in _get_connection

File "/opt/airflow/airflow-core/src/airflow/secrets/base_secrets.py", line 76 in get_connection

File "/opt/airflow/airflow-core/src/airflow/secrets/environment_variables.py", line 34 in get_conn_value

[2025-09-30 16:58:30] ERROR - Task failed with exception source=task loc=task_runner.py:993
ValidationError: 1 validation error for GetConnection
conn_id
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.11/v/string_type
File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py", line 919 in run

File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py", line 1306 in _execute_task

File "/opt/airflow/task-sdk/src/airflow/sdk/bases/operator.py", line 416 in wrapper

File "/opt/airflow/providers/standard/src/airflow/providers/standard/operators/python.py", line 216 in execute

File "/opt/airflow/providers/standard/src/airflow/providers/standard/operators/python.py", line 239 in execute_callable

File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/callback_runner.py", line 82 in run

File "/files/dags/print_sensitive_data.py", line 13 in print_sensitive

File "/opt/airflow/task-sdk/src/airflow/sdk/definitions/connection.py", line 226 in get

File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/context.py", line 183 in _get_connection

File "/usr/python/lib/python3.10/site-packages/pydantic/main.py", line 253 in __init__
```




This is because when a connection is not found, the secrets backend failures log verbosely (log.exception) and continues to API call, allowing cryptic errors to bubble up. Changed that to `log.debug`, so that the task SDK now raises clean `AirflowNotFoundException` instead of cryptic `AttributeError`, matching airflow-core's  error handling.

Example after:

```
from airflow.sdk import Connection as SDKConnection
SDKConnection.get(None)
Traceback (most recent call last):
  File "/Users/amoghdesai/Documents/OSS/repos/airflow/.venv/lib/python3.12/site-packages/IPython/core/interactiveshell.py", line 3699, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-9-21c62a62b135>", line 1, in <module>
    SDKConnection.get(None)
  File "/Users/amoghdesai/Documents/OSS/repos/airflow/task-sdk/src/airflow/sdk/definitions/connection.py", line 226, in get
    return _get_connection(conn_id)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/amoghdesai/Documents/OSS/repos/airflow/task-sdk/src/airflow/sdk/execution_time/context.py", line 172, in _get_connection
    raise AirflowNotFoundException(f"The conn_id `{conn_id}` isn't defined")
airflow.exceptions.AirflowNotFoundException: The conn_id `None` isn't defined
```


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
