### PR TITLE
Fix Managed Kafka system tests to use correct network name when creating a cluster

### DIFF
--- a/providers/google/tests/system/google/cloud/managed_kafka/example_managed_kafka_consumer_group.py
+++ b/providers/google/tests/system/google/cloud/managed_kafka/example_managed_kafka_consumer_group.py
@@ -18,6 +18,15 @@
 
 """
 Example Airflow DAG for Google Cloud Managed Service for Apache Kafka testing Topic operations.
+
+Requirements:
+    Operator to create a cluster requires GOOGLE_PROVIDER_NETWORK environmental variable
+    that will contain the name of the network that will be used for cluster creation.
+
+    Please, note that if you are running this operator in Google Cloud Composer, this value will be set
+    automatically and will not require any additional configuration.
+    In other cases, the network in which the cluster will be created should be the same as your machine
+    is running in.
 """
 
 from __future__ import annotations
@@ -59,6 +68,8 @@ from tests_common.test_utils.api_client_helpers import create_airflow_connection
 
 ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID", "default")
 PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT", "default")
+IS_COMPOSER = bool(os.environ.get("COMPOSER_ENVIRONMENT", ""))
+NETWORK = os.environ.get("GOOGLE_PROVIDER_NETWORK") if not IS_COMPOSER else "default"
 DAG_ID = "managed_kafka_consumer_group_operations"
 LOCATION = "us-central1"
 
@@ -67,7 +78,7 @@ CLUSTER_CONF = {
     "gcp_config": {
         "access_config": {
             "network_configs": [
-                {"subnet": f"projects/{PROJECT_ID}/regions/{LOCATION}/subnetworks/default"},
+                {"subnet": f"projects/{PROJECT_ID}/regions/{LOCATION}/subnetworks/{NETWORK}"},
             ],
         },
     },

--- a/providers/google/tests/system/google/cloud/managed_kafka/example_managed_kafka_topic.py
+++ b/providers/google/tests/system/google/cloud/managed_kafka/example_managed_kafka_topic.py
@@ -19,6 +19,15 @@
 
 """
 Example Airflow DAG for Google Cloud Managed Service for Apache Kafka testing Topic operations.
+
+Requirements:
+    Operator to create a cluster requires GOOGLE_PROVIDER_NETWORK environmental variable
+    that will contain the name of the network that will be used for cluster creation.
+
+    Please, note that if you are running this operator in Google Cloud Composer, this value will be set
+    automatically and will not require any additional configuration.
+    In other cases, the network in which the cluster will be created should be the same as your machine
+    is running in.
 """
 
 from __future__ import annotations
@@ -45,6 +54,8 @@ except ImportError:
 
 ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID", "default")
 PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT", "default")
+IS_COMPOSER = bool(os.environ.get("COMPOSER_ENVIRONMENT", ""))
+NETWORK = os.environ.get("GOOGLE_PROVIDER_NETWORK") if not IS_COMPOSER else "default"
 DAG_ID = "managed_kafka_topic_operations"
 LOCATION = "us-central1"
 
@@ -53,7 +64,7 @@ CLUSTER_CONF = {
     "gcp_config": {
         "access_config": {
             "network_configs": [
-                {"subnet": f"projects/{PROJECT_ID}/regions/{LOCATION}/subnetworks/default"},
+                {"subnet": f"projects/{PROJECT_ID}/regions/{LOCATION}/subnetworks/{NETWORK}"},
             ],
         },
     },


### PR DESCRIPTION
This PR adds logic to determine and use the correct network name for cluster creation, since cluster for Kafka should be created in the same network as the machine it is running in.
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
