### PR TITLE
Copy task SDK integration test dags to compose location before job start

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/run_tests.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_tests.py
@@ -128,6 +128,7 @@ def run_docker_compose_tests(
         env["SKIP_DOCKER_COMPOSE_DELETION"] = "true"
     if include_success_outputs:
         env["INCLUDE_SUCCESS_OUTPUTS"] = "true"
+    env["AIRFLOW_UID"] = str(os.getuid())
     # since we are only running one test, we can print output directly with pytest -s
     command_result = run_command(
         ["uv", "run", "pytest", str(test_path), "-s", *pytest_args, *extra_pytest_args],

--- a/task-sdk-tests/tests/task_sdk_tests/conftest.py
+++ b/task-sdk-tests/tests/task_sdk_tests/conftest.py
@@ -97,7 +97,7 @@ def debug_environment():
 def docker_compose_setup(tmp_path_factory):
     """Start docker-compose once per session."""
     import os
-    from shutil import copyfile
+    from shutil import copyfile, copytree
 
     from python_on_whales import DockerClient, docker
 
@@ -105,6 +105,12 @@ def docker_compose_setup(tmp_path_factory):
     tmp_dir = tmp_path_factory.mktemp("airflow-task-sdk-test")
     tmp_docker_compose_file = tmp_dir / "docker-compose.yaml"
     copyfile(DOCKER_COMPOSE_FILE_PATH, tmp_docker_compose_file)
+
+    # Copy the DAGs folder to the temp directory so docker-compose can find it
+    from task_sdk_tests.constants import TASK_SDK_TESTS_ROOT
+
+    TASK_SDK_DAGS_FOLDER = TASK_SDK_TESTS_ROOT / "dags"
+    copytree(TASK_SDK_DAGS_FOLDER, tmp_dir / "dags", dirs_exist_ok=True)
 
     # Set environment variables
     os.environ["AIRFLOW_IMAGE_NAME"] = DOCKER_IMAGE


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Due to recent merge of https://github.com/apache/airflow/pull/56139, some changes came in that lead to failures in dag processor finding dags at the right location.

This solution ensures that:
* The test_dag.py file is available in the correct location for docker-compose to mount
* The docker-compose volume mount `${PWD}/dags:/opt/airflow/dags` will find the DAGs in the temporary directory

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
