### PR TITLE
Ensure dag.test uses serialized dag for testing

### DIFF
--- a/airflow-core/tests/unit/models/test_dag.py
+++ b/airflow-core/tests/unit/models/test_dag.py
@@ -53,6 +53,7 @@ from airflow.models.dag import (
     get_asset_triggered_next_run_info,
     get_next_data_interval,
 )
+from airflow.models.dagbag import DBDagBag
 from airflow.models.dagbundle import DagBundleModel
 from airflow.models.dagrun import DagRun
 from airflow.models.serialized_dag import SerializedDagModel
@@ -185,7 +186,6 @@ class TestDag:
         """
         DAG.test() should auto-parse and sync the DAG if it's not serialized yet.
         """
-        from airflow.models.dagbag import DBDagBag
 
         dag_id = "test_example_bash_operator"
 
@@ -194,7 +194,7 @@ class TestDag:
 
         # Ensure not serialized yet
         assert DBDagBag().get_latest_version_of_dag(dag_id, session=session) is None
-        assert session.query(DagRun).filter(DagRun.dag_id == dag_id).scalar() is None
+        assert session.scalar(select(DagRun).where(DagRun.dag_id == dag_id)) is None
 
         dr = dag.test()
         assert dr is not None
@@ -202,7 +202,7 @@ class TestDag:
         # Serialized DAG should now exist and DagRun would be created
         ser = DBDagBag().get_latest_version_of_dag(dag_id, session=session)
         assert ser is not None
-        assert session.query(DagRun).filter(DagRun.dag_id == dag_id).scalar() is not None
+        assert session.scalar(select(DagRun).where(DagRun.dag_id == dag_id)) is not None
 
     def teardown_method(self) -> None:
         clear_db_runs()

--- a/airflow-core/tests/unit/models/test_dag.py
+++ b/airflow-core/tests/unit/models/test_dag.py
@@ -181,7 +181,7 @@ class TestDag:
         clear_db_assets()
 
     @conf_vars({("core", "load_examples"): "false"})
-    def test_dag_test_auto_parses_when_not_serialized(self, testing_dag_bundle, session):
+    def test_dag_test_auto_parses_when_not_serialized(self, test_dags_bundle, session):
         """
         DAG.test() should auto-parse and sync the DAG if it's not serialized yet.
         """
@@ -189,11 +189,12 @@ class TestDag:
 
         dag_id = "test_example_bash_operator"
 
+        dagbag = DagBag(dag_folder=os.fspath(TEST_DAGS_FOLDER), include_examples=False)
+        dag = dagbag.dags.get(dag_id)
+
         # Ensure not serialized yet
         assert DBDagBag().get_latest_version_of_dag(dag_id, session=session) is None
         assert session.query(DagRun).filter(DagRun.dag_id == dag_id).scalar() is None
-
-        dag = DAG(dag_id=dag_id, schedule=None)
 
         dr = dag.test()
         assert dr is not None

--- a/task-sdk/src/airflow/sdk/definitions/dag.py
+++ b/task-sdk/src/airflow/sdk/definitions/dag.py
@@ -1209,6 +1209,7 @@ class DAG:
 
                 manager = DagBundlesManager()
                 manager.sync_bundles_to_db(session=session)
+                session.commit()
                 # sync all bundles? or use the dags-folder bundle?
                 # What if the test dag is in a different bundle?
                 for bundle in manager.get_all_dag_bundles():

--- a/task-sdk/src/airflow/sdk/definitions/dag.py
+++ b/task-sdk/src/airflow/sdk/definitions/dag.py
@@ -1197,17 +1197,37 @@ class DAG:
             data_interval = (
                 self.timetable.infer_manual_data_interval(run_after=logical_date) if logical_date else None
             )
-            scheduler_dag = SerializedDAG.deserialize_dag(SerializedDAG.serialize_dag(self))  # type: ignore[arg-type]
-            # Preserve callback functions from original Dag since they're lost during serialization
-            # and yes it is a hack for now! It is a tradeoff for code simplicity.
-            # Without it, we need "Scheduler Dag" (Serialized dag) for the scheduler bits
-            #   -- dep check, scheduling tis
-            # and need real dag to get and run callbacks without having to load the dag model
+            from airflow.models.dagbag import DBDagBag
 
+            scheduler_dag = DBDagBag().get_latest_version_of_dag(dag_id=self.dag_id, session=session)
+            if not scheduler_dag:
+                from airflow.dag_processing.bundles.manager import DagBundlesManager
+                from airflow.dag_processing.dagbag import DagBag, sync_bag_to_db
+                from airflow.sdk.definitions._internal.dag_parsing_context import (
+                    _airflow_parsing_context_manager,
+                )
+
+                manager = DagBundlesManager()
+                manager.sync_bundles_to_db(session=session)
+                # sync all bundles? or use the dags-folder bundle?
+                # What if the test dag is in a different bundle?
+                for bundle in manager.get_all_dag_bundles():
+                    if not bundle.is_initialized:
+                        bundle.initialize()
+                    with _airflow_parsing_context_manager(dag_id=self.dag_id):
+                        dagbag = DagBag(
+                            dag_folder=bundle.path, bundle_path=bundle.path, include_examples=False
+                        )
+                        sync_bag_to_db(dagbag, bundle.name, bundle.version)
+                    scheduler_dag = DBDagBag().get_latest_version_of_dag(dag_id=self.dag_id, session=session)
+                    if scheduler_dag:
+                        break
+            if not scheduler_dag:
+                raise RuntimeError("Dag not found after syncing to DB")
             # Scheduler DAG shouldn't have these attributes, but assigning them
             # here is an easy hack to get this test() thing working.
-            scheduler_dag.on_success_callback = self.on_success_callback  # type: ignore[attr-defined]
-            scheduler_dag.on_failure_callback = self.on_failure_callback  # type: ignore[attr-defined]
+            scheduler_dag.on_success_callback = self.on_success_callback  # type: ignore[attr-defined, union-attr]
+            scheduler_dag.on_failure_callback = self.on_failure_callback  # type: ignore[attr-defined, union-attr]
 
             dr: DagRun = get_or_create_dagrun(
                 dag=scheduler_dag,

--- a/task-sdk/src/airflow/sdk/definitions/dag.py
+++ b/task-sdk/src/airflow/sdk/definitions/dag.py
@@ -1202,7 +1202,7 @@ class DAG:
             scheduler_dag = DBDagBag().get_latest_version_of_dag(dag_id=self.dag_id, session=session)
             if not scheduler_dag:
                 from airflow.dag_processing.bundles.manager import DagBundlesManager
-                from airflow.dag_processing.dagbag import DagBag
+                from airflow.dag_processing.dagbag import DagBag, sync_bag_to_db
                 from airflow.sdk.definitions._internal.dag_parsing_context import (
                     _airflow_parsing_context_manager,
                 )
@@ -1219,13 +1219,8 @@ class DAG:
                         dagbag = DagBag(
                             dag_folder=bundle.path, bundle_path=bundle.path, include_examples=False
                         )
-                        try:
-                            from airflow.dag_processing.dagbag import sync_bag_to_db
-
-                            sync_bag_to_db(dagbag, bundle.name, bundle.version)
-                        except ImportError:
-                            # backwards compatibility for 3.1
-                            dagbag.sync_bag_to_db(bundle.name, bundle.version)  # type: ignore[attr-defined]
+                        sync_bag_to_db(dagbag, bundle.name, bundle.version)
+                        # type: ignore[attr-defined]
                     scheduler_dag = DBDagBag().get_latest_version_of_dag(dag_id=self.dag_id, session=session)
                     if scheduler_dag:
                         break


### PR DESCRIPTION
While `dag test` command uses serialized dag, dag.test was using
in-memory serialized dag making direct usage of dag.test method
resulting in error.

This PR fixes this and ensures dag.test parses dag if the dag is not
parsed

Closes: https://github.com/apache/airflow/issues/56657
