### PR TITLE
[Providers][CNCF-Kubernetes] Move Hook functions to PodManager

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -75,7 +75,6 @@ from airflow.providers.cncf.kubernetes.utils.pod_manager import (
     PodLaunchFailedException,
     PodManager,
     PodNotFoundException,
-    PodOperatorHookProtocol,
     PodPhase,
     container_is_succeeded,
     get_container_termination_message,
@@ -95,6 +94,7 @@ if TYPE_CHECKING:
     import jinja2
     from pendulum import DateTime
 
+    from airflow.providers.cncf.kubernetes.hooks.kubernetes import PodOperatorHookProtocol
     from airflow.providers.cncf.kubernetes.secret import Secret
 
     try:

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/job.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/job.py
@@ -125,11 +125,11 @@ class KubernetesJobTrigger(BaseTrigger):
             xcom_results = []
             for pod_name in self.pod_names:
                 pod = await self.hook.get_pod(name=pod_name, namespace=self.pod_namespace)
-                await self.hook.wait_until_container_complete(
+                await self.pod_manager.wait_until_container_complete(
                     name=pod_name, namespace=self.pod_namespace, container_name=self.base_container_name
                 )
                 self.log.info("Checking if xcom sidecar container is started.")
-                await self.hook.wait_until_container_started(
+                await self.pod_manager.wait_until_container_started(
                     name=pod_name,
                     namespace=self.pod_namespace,
                     container_name=PodDefaults.SIDECAR_CONTAINER_NAME,
@@ -173,4 +173,4 @@ class KubernetesJobTrigger(BaseTrigger):
             config_file=self.config_file,
             cluster_context=self.cluster_context,
         )
-        return PodManager(kube_client=sync_hook.core_v1_client)
+        return PodManager(kube_hook=sync_hook)


### PR DESCRIPTION
# Overview

We are preparing an update to the KubernetesPodTriggerer workflow to align its startup behavior with that of the synchronous workflow. As part of this effort, we are introducing this preparation PR:

This PR relocates certain "higher-level" functions from the Hook to the PodManager. Currently, the Hook imports functions from the PodManager, but we believe the PodManager should instead use the Hook as its abstraction layer to the Kubernetes API. To keep this PR focused and manageable, we are only retaining self._client in the PodManager.

In subsequent PRs, we plan to unify the code paths so that both the Triggerer (async) and synchronous workflows use the same logic to start Pods. Without this change, we would encounter circular import issues.

We welcome your feedback on this change.

# Details of change:

* Move functions from Hook code to the PodManager which match the context of the PodManager
* Remove import from PodManager in the Hook code.

