### PR TITLE
fix: handle unmapped task deadlock when upstream tasks are removed

### DIFF
--- a/airflow-core/src/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow-core/src/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -501,9 +501,7 @@ class TriggerRuleDep(BaseTIDep):
                         )
                     )
             elif trigger_rule == TR.ALL_SUCCESS:
-                num_failures = upstream - success
-                if ti.map_index > -1:
-                    num_failures -= removed
+                num_failures = upstream - success - removed
                 if num_failures > 0:
                     yield self._failing_status(
                         reason=(
@@ -514,9 +512,7 @@ class TriggerRuleDep(BaseTIDep):
                         )
                     )
             elif trigger_rule == TR.ALL_FAILED:
-                num_success = upstream - failed - upstream_failed
-                if ti.map_index > -1:
-                    num_success -= removed
+                num_success = upstream - failed - upstream_failed - removed
                 if num_success > 0:
                     yield self._failing_status(
                         reason=(
@@ -537,9 +533,7 @@ class TriggerRuleDep(BaseTIDep):
                         )
                     )
             elif trigger_rule == TR.NONE_FAILED or trigger_rule == TR.NONE_FAILED_MIN_ONE_SUCCESS:
-                num_failures = upstream - success - skipped
-                if ti.map_index > -1:
-                    num_failures -= removed
+                num_failures = upstream - success - skipped - removed
                 if num_failures > 0:
                     yield self._failing_status(
                         reason=(
@@ -591,11 +585,8 @@ class TriggerRuleDep(BaseTIDep):
                     )
             elif trigger_rule == TR.ALL_DONE_MIN_ONE_SUCCESS:
                 # For this trigger rule, skipped tasks are not considered "done"
-                non_skipped_done = success + failed + upstream_failed + removed
-                non_skipped_upstream = upstream - skipped
-                if ti.map_index > -1:
-                    non_skipped_upstream -= removed
-                    non_skipped_done -= removed
+                non_skipped_done = success + failed + upstream_failed
+                non_skipped_upstream = upstream - skipped - removed
 
                 if skipped > 0:
                     yield self._failing_status(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #48816
related: #26518

While the issue of deadlock caused by removing upstream mapped tasks has been addressed in #26518, that PR only handled cases where the downstream tasks were also mapped. This PR addresses the task deadlock occurring on downstream unmapped tasks.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
