### PR TITLE
Remove `pytest.importorskip("flask_appbuilder")` from tests

### DIFF
--- a/airflow-core/tests/unit/always/test_example_dags.py
+++ b/airflow-core/tests/unit/always/test_example_dags.py
@@ -164,8 +164,6 @@ def relative_path(path):
 @pytest.mark.db_test
 @pytest.mark.parametrize("example", example_not_excluded_dags())
 def test_should_be_importable(example: str):
-    pytest.importorskip("flask_appbuilder")  # Remove after upgrading to FAB5
-
     dagbag = DagBag(
         dag_folder=example,
         include_examples=False,

--- a/airflow-core/tests/unit/always/test_providers_manager.py
+++ b/airflow-core/tests/unit/always/test_providers_manager.py
@@ -275,15 +275,11 @@ class TestProviderManager:
         assert [w.message for w in warning_records if "hook-class-names" in str(w.message)] == []
 
     def test_connection_form_widgets(self):
-        pytest.importorskip("flask_appbuilder")  # Remove after upgrading to FAB5
-
         provider_manager = ProvidersManager()
         connections_form_widgets = list(provider_manager.connection_form_widgets.keys())
         assert len(connections_form_widgets) > 29
 
     def test_field_behaviours(self):
-        pytest.importorskip("flask_appbuilder")  # Remove after upgrading to FAB5
-
         provider_manager = ProvidersManager()
         connections_with_field_behaviours = list(provider_manager.field_behaviours.keys())
         assert len(connections_with_field_behaviours) > 16

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_plugins.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_plugins.py
@@ -61,8 +61,6 @@ class TestGetPlugins:
     def test_should_respond_200(
         self, test_client, session, query_params, expected_total_entries, expected_names
     ):
-        pytest.importorskip("flask_appbuilder")  # Remove after upgrading to FAB5
-
         response = test_client.get("/plugins", params=query_params)
         assert response.status_code == 200
 
@@ -71,8 +69,6 @@ class TestGetPlugins:
         assert [plugin["name"] for plugin in body["plugins"]] == expected_names
 
     def test_external_views_model_validator(self, test_client):
-        pytest.importorskip("flask_appbuilder")  # Remove after upgrading to FAB5
-
         response = test_client.get("plugins")
         body = response.json()
 
@@ -120,8 +116,6 @@ class TestGetPlugins:
         assert response.status_code == 403
 
     def test_invalid_external_view_destination_should_log_warning_and_continue(self, test_client, caplog):
-        pytest.importorskip("flask_appbuilder")  # Remove after upgrading to FAB5
-
         caplog.set_level("WARNING", "airflow.api_fastapi.core_api.routes.public.plugins")
 
         response = test_client.get("/plugins")

--- a/airflow-core/tests/unit/plugins/test_plugins_manager.py
+++ b/airflow-core/tests/unit/plugins/test_plugins_manager.py
@@ -79,8 +79,6 @@ class TestPluginsManager:
         plugins_manager.plugins = []
 
     def test_no_log_when_no_plugins(self, caplog):
-        pytest.importorskip("flask_appbuilder")  # Remove after upgrading to FAB5
-
         with mock_plugin_manager(plugins=[]):
             from airflow import plugins_manager
 
@@ -120,8 +118,6 @@ class TestPluginsManager:
             assert "testplugin.py" in received_logs
 
     def test_should_warning_about_incompatible_plugins(self, caplog):
-        pytest.importorskip("flask_appbuilder")  # Remove after upgrading to FAB5
-
         class AirflowAdminViewsPlugin(AirflowPlugin):
             name = "test_admin_views_plugin"
 
@@ -156,8 +152,6 @@ class TestPluginsManager:
         ]
 
     def test_should_warning_about_conflicting_url_route(self, caplog):
-        pytest.importorskip("flask_appbuilder")  # Remove after upgrading to FAB5
-
         class TestPluginA(AirflowPlugin):
             name = "test_plugin_a"
 
@@ -185,8 +179,6 @@ class TestPluginsManager:
             assert len(plugins_manager.react_apps) == 0
 
     def test_should_warning_about_external_views_or_react_app_wrong_object(self, caplog):
-        pytest.importorskip("flask_appbuilder")  # Remove after upgrading to FAB5
-
         class TestPluginA(AirflowPlugin):
             name = "test_plugin_a"
 
@@ -224,8 +216,6 @@ class TestPluginsManager:
         ]
 
     def test_should_not_warning_about_fab_plugins(self, caplog):
-        pytest.importorskip("flask_appbuilder")  # Remove after upgrading to FAB5
-
         class AirflowAdminViewsPlugin(AirflowPlugin):
             name = "test_admin_views_plugin"
 
@@ -247,8 +237,6 @@ class TestPluginsManager:
         assert caplog.record_tuples == []
 
     def test_should_not_warning_about_fab_and_flask_admin_plugins(self, caplog):
-        pytest.importorskip("flask_appbuilder")  # Remove after upgrading to FAB5
-
         class AirflowAdminViewsPlugin(AirflowPlugin):
             name = "test_admin_views_plugin"
 
@@ -370,8 +358,6 @@ class TestPluginsManager:
 
     @skip_if_force_lowest_dependencies_marker
     def test_does_not_double_import_entrypoint_provider_plugins(self):
-        pytest.importorskip("flask_appbuilder")  # Remove after upgrading to FAB5
-
         from airflow import plugins_manager
 
         mock_entrypoint = mock.Mock()

--- a/airflow-core/tests/unit/serialization/test_dag_serialization.py
+++ b/airflow-core/tests/unit/serialization/test_dag_serialization.py
@@ -504,8 +504,6 @@ class TestStringifiedDAGs:
     @pytest.mark.db_test
     def test_serialization(self):
         """Serialization and deserialization should work for every DAG and Operator."""
-        pytest.importorskip("flask_appbuilder")  # Remove after upgrading to FAB5
-
         with warnings.catch_warnings():
             dags, import_errors = collect_dags()
         serialized_dags = {}

--- a/providers/databricks/tests/unit/databricks/sensors/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/sensors/test_databricks.py
@@ -21,8 +21,6 @@ from unittest import mock
 
 import pytest
 
-pytest.importorskip("flask_appbuilder")  # Remove after upgrading to FAB5
-
 from airflow.exceptions import AirflowException, TaskDeferred
 from airflow.providers.databricks.hooks.databricks import SQLStatementState
 from airflow.providers.databricks.sensors.databricks import DatabricksSQLStatementsSensor

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/test_utils.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/test_utils.py
@@ -81,7 +81,6 @@ def test_get_field_non_prefixed(input, expected):
 
 def test_add_managed_identity_connection_widgets():
     pytest.importorskip("airflow.providers.fab")
-    pytest.importorskip("flask_appbuilder")  # Remove after upgrading to FAB5
 
     class FakeHook:
         @classmethod


### PR DESCRIPTION
`Flask-appbuilder` was migrated to version 5 so these statements can be removed.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
