### PR TITLE
Add Task-Level Resource Usage Metrics (CPU and Memory)

### DIFF
--- a/airflow-core/docs/administration-and-deployment/logging-monitoring/metrics.rst
+++ b/airflow-core/docs/administration-and-deployment/logging-monitoring/metrics.rst
@@ -258,7 +258,7 @@ Name                                                 Description
 ``pool.starving_tasks.<pool_name>``                  Number of starving tasks in the pool
 ``pool.starving_tasks``                              Number of starving tasks in the pool. Metric with pool_name tagging.
 ``task.cpu_usage_percent.<dag_id>.<task_id>``        CPU usage percentage of a task
-``task.memory_mb.<dag_id>.<task_id>``                Memory usage in MB (RSS) of a task
+``task.memory_usage_mb.<dag_id>.<task_id>``          Memory usage in MB (RSS) of a task
 ``triggers.running.<hostname>``                      Number of triggers currently running for a triggerer (described by hostname)
 ``triggers.running``                                 Number of triggers currently running for a triggerer (described by hostname).
                                                      Metric with hostname tagging.

--- a/airflow-core/docs/administration-and-deployment/logging-monitoring/metrics.rst
+++ b/airflow-core/docs/administration-and-deployment/logging-monitoring/metrics.rst
@@ -257,6 +257,8 @@ Name                                                 Description
 ``pool.scheduled_slots``                             Number of scheduled slots in the pool. Metric with pool_name tagging.
 ``pool.starving_tasks.<pool_name>``                  Number of starving tasks in the pool
 ``pool.starving_tasks``                              Number of starving tasks in the pool. Metric with pool_name tagging.
+``task.cpu_usage_percent.<dag_id>.<task_id>``        CPU usage percentage of a task
+``task.memory_mb.<dag_id>.<task_id>``                Memory usage in MB (RSS) of a task
 ``triggers.running.<hostname>``                      Number of triggers currently running for a triggerer (described by hostname)
 ``triggers.running``                                 Number of triggers currently running for a triggerer (described by hostname).
                                                      Metric with hostname tagging.


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
### Description
This PR adds resource usage monitoring at the task level, tracking CPU percentage and memory consumption during task execution.
> Just find out CPU & Memory usage metrics are removed in latest version. These two metrics are definitly needed.

### Changes
**The measurement works as follows:**
- `psutil.cpu_percent(interval=0)` returns the CPU usage since the last call
- First call establishes the baseline (typically returns 0.0)
- Second call returns the average CPU usage across the entire task execution
- Memory is a point-in-time snapshot, not an average
```bash
Time  Action                          CPU%    Memory
----  ------------------------------  ------  ------
0s    First _get_resource_usage()     0.0     20MB   (establish baseline)
      ↓
1s    _execute_task() starts            
2s    Task running...                  80%     50MB
3s    Task running...                  90%     100MB
4s    Task running...                  85%     120MB
...
10s   _execute_task() completes
      ↓
10s   Second _get_resource_usage()     75%     80MB   (recorded!)
      
      cpu_percent = 75%  ← average CPU usage from 0s to 10s
      memory_mb = 80MB   ← instantaneous memory at 10s
```

Related: #51602

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
