### PR TITLE
Prevent unnecessary kubernetes client imports in workers

### DIFF
--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -28,6 +28,7 @@ import itertools
 import logging
 import math
 import re
+import sys
 import weakref
 from collections.abc import Collection, Iterable, Iterator, Mapping, Sequence
 from functools import cached_property, lru_cache
@@ -3813,6 +3814,11 @@ def _has_kubernetes() -> bool:
     global HAS_KUBERNETES
     if "HAS_KUBERNETES" in globals():
         return HAS_KUBERNETES
+
+    # Check if kubernetes is already imported before triggering expensive import
+    if "kubernetes.client" not in sys.modules:
+        HAS_KUBERNETES = False
+        return False
 
     # Loading kube modules is expensive, so delay it until the last moment
 

--- a/shared/secrets_masker/tests/secrets_masker/test_secrets_masker.py
+++ b/shared/secrets_masker/tests/secrets_masker/test_secrets_masker.py
@@ -1110,3 +1110,44 @@ class TestSecretsMaskerMerge:
         assert final_dict["api"]["api_key"] == "new_api_key_67890"  # User modification kept
         assert final_dict["api"]["timeout"] == 60  # User modification kept
         assert final_dict["app_name"] == "my_application"  # Unchanged
+
+
+class TestKubernetesImportAvoidance:
+    """Test that secrets masker doesn't import kubernetes unnecessarily."""
+
+    def test_no_k8s_import_when_not_needed(self):
+        """Ensure kubernetes is not imported when masking non-k8s secrets."""
+        # Ensure kubernetes is not already imported
+        k8s_modules = [m for m in sys.modules if m.startswith("kubernetes")]
+        if k8s_modules:
+            pytest.skip("Kubernetes already imported, cannot test import avoidance")
+
+        masker = SecretsMasker()
+        configure_secrets_masker_for_test(masker)
+
+        masker.add_mask("test_secret", "password")
+        redacted = masker.redact({"password": "test_secret", "user": "admin"})
+
+        assert redacted["password"] == "***"
+        assert redacted["user"] == "admin"
+
+        assert "kubernetes.client" not in sys.modules
+
+    def test_k8s_objects_still_detected_when_imported(self):
+        """Ensure V1EnvVar objects are still properly detected when k8s is imported."""
+        pytest.importorskip("kubernetes")
+
+        from kubernetes.client import V1EnvVar
+
+        # Create a V1EnvVar object with a sensitive name
+        env_var = V1EnvVar(name="password", value="secret123")
+
+        masker = SecretsMasker()
+        configure_secrets_masker_for_test(masker)
+
+        # Redact the V1EnvVar object - the name field is sensitive
+        redacted = masker.redact(env_var)
+
+        # Should be redacted since "password" is a sensitive field name
+        assert redacted["value"] == "***"
+        assert redacted["name"] == "password"


### PR DESCRIPTION
Workers no longer import the full kubernetes client library (~32-42 MB) when performing routine operations like secret masking and DAG serialization. The kubernetes client is only imported when actually processing kubernetes objects.

With the default 32 LocalExecutor workers, this could reduce memory usage by approximately 1 GB in deployments that don't all use k8s.

Part of #56641 (Kudos to @wjddn279 for investigation)

```py
import sys
import tracemalloc

assert 'kubernetes' not in sys.modules

tracemalloc.start()
snapshot_before = tracemalloc.take_snapshot()

from kubernetes.client import V1EnvVar

snapshot_after = tracemalloc.take_snapshot()

top_stats = snapshot_after.compare_to(snapshot_before, 'traceback')
print("[ Top 10 differences ]")
for stat in top_stats[:10]:
    print(stat)

total = sum(stat.size_diff for stat in top_stats)
print(f"\nTotal memory increase: {total / 1024 / 1024:.2f} MB")
```
Output: Total memory increase: 41.62 MB

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
