### PR TITLE
Enable PT011 rule to prvoider tests

### DIFF
--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_batch_waiters.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_batch_waiters.py
@@ -106,9 +106,8 @@ class TestBatchWaiters:
         assert waiters == ["JobComplete", "JobExists", "JobRunning"]
 
         # test errors when requesting a waiter with the wrong name
-        with pytest.raises(ValueError) as ctx:
+        with pytest.raises(ValueError, match="Waiter does not exist: JobExist"):
             model.get_waiter("JobExist")
-        assert "Waiter does not exist: JobExist" in str(ctx.value)
 
         # test some default waiter properties
         waiter = model.get_waiter("JobExists")

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_eventbridge.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_eventbridge.py
@@ -39,7 +39,7 @@ class TestEventBridgeHook:
 
     def test_put_rule_with_bad_json_fails(self):
         hook = EventBridgeHook(aws_conn_id="aws_default")
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="`event_pattern` must be a valid JSON string."):
             hook.put_rule(
                 name="test",
                 event_pattern="invalid json",

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_redshift_data.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_redshift_data.py
@@ -32,6 +32,9 @@ from airflow.providers.amazon.aws.hooks.redshift_data import (
 SQL = "sql"
 DATABASE = "database"
 STATEMENT_ID = "statement_id"
+EXACTLY_ONE_REQUIRED_ERROR_MSG = (
+    "Exactly one of cluster_identifier, workgroup_name, or session_id must be provided"
+)
 
 
 class TestRedshiftDataHook:
@@ -81,7 +84,7 @@ class TestRedshiftDataHook:
         cluster_identifier = "cluster_identifier"
         workgroup_name = "workgroup_name"
         hook = RedshiftDataHook()
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=EXACTLY_ONE_REQUIRED_ERROR_MSG):
             hook.execute_query(
                 database=DATABASE,
                 cluster_identifier=cluster_identifier,
@@ -109,7 +112,7 @@ class TestRedshiftDataHook:
         cluster_identifier = "cluster_identifier"
         workgroup_name = "workgroup_name"
         hook = RedshiftDataHook()
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=EXACTLY_ONE_REQUIRED_ERROR_MSG):
             hook.execute_query(
                 database=DATABASE,
                 cluster_identifier=cluster_identifier,
@@ -125,7 +128,7 @@ class TestRedshiftDataHook:
         cluster_identifier = "cluster_identifier"
         workgroup_name = "workgroup_name"
         hook = RedshiftDataHook()
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=EXACTLY_ONE_REQUIRED_ERROR_MSG):
             hook.execute_query(
                 database=DATABASE,
                 cluster_identifier=cluster_identifier,

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_s3.py
@@ -55,6 +55,8 @@ try:
 except ImportError:
     BASEHOOK_PATCH_PATH = "airflow.hooks.base.BaseHook"
 
+KEY_VALUE_SPECIFICATION_ERROR = "Key and Value must be specified as a pair. Only one of the two had a value"
+
 
 @pytest.fixture
 def mocked_s3_res():
@@ -1413,9 +1415,8 @@ class TestAwsS3Hook:
         test_bucket_name_with_key = fake_s3_hook.test_function_with_key("s3://foo/bar.csv")
         assert test_bucket_name_with_key == ("foo", "bar.csv")
 
-        with pytest.raises(ValueError) as ctx:
+        with pytest.raises(ValueError, match="Missing key parameter!"):
             fake_s3_hook.test_function_with_test_key("s3://foo/bar.csv")
-        assert isinstance(ctx.value, ValueError)
 
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.NamedTemporaryFile")
     def test_download_file(self, mock_temp_file, tmp_path):
@@ -1601,7 +1602,7 @@ class TestAwsS3Hook:
         hook = S3Hook(extra_args={"unknown_s3_args": "value"})
         path = tmp_path / "testfile"
         path.write_text("Content")
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Invalid extra_args key 'unknown_s3_args'"):
             hook.load_file_obj(path.open("rb"), "my_key", s3_bucket, acl_policy="public-read")
 
     def test_should_pass_extra_args(self, s3_bucket, tmp_path):
@@ -1726,7 +1727,7 @@ class TestAwsS3Hook:
 
         hook.create_bucket(bucket_name="new_bucket")
         key = "Color"
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=KEY_VALUE_SPECIFICATION_ERROR):
             hook.put_bucket_tagging(bucket_name="new_bucket", key=key)
 
     @mock_aws
@@ -1734,7 +1735,7 @@ class TestAwsS3Hook:
         hook = S3Hook()
         hook.create_bucket(bucket_name="new_bucket")
         value = "Color"
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=KEY_VALUE_SPECIFICATION_ERROR):
             hook.put_bucket_tagging(bucket_name="new_bucket", value=value)
 
     @mock_aws
@@ -1743,7 +1744,7 @@ class TestAwsS3Hook:
         hook.create_bucket(bucket_name="new_bucket")
         tag_set = [{"Key": "Color", "Value": "Green"}]
         key = "Color"
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=KEY_VALUE_SPECIFICATION_ERROR):
             hook.put_bucket_tagging(bucket_name="new_bucket", key=key, tag_set=tag_set)
 
     @mock_aws
@@ -1752,7 +1753,7 @@ class TestAwsS3Hook:
         hook.create_bucket(bucket_name="new_bucket")
         tag_set = [{"Key": "Color", "Value": "Green"}]
         value = "Green"
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=KEY_VALUE_SPECIFICATION_ERROR):
             hook.put_bucket_tagging(bucket_name="new_bucket", value=value, tag_set=tag_set)
 
     @mock_aws


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
issue: Enable Even More PyDocStyle Checks #40567
@ferruzzi
This PR is for enable PT011 rule:
PT011: all instances of pytest.raises should include a match term to make sure they are catching the right error.
https://docs.astral.sh/ruff/rules/pytest-raises-too-broad/
There are 102 files changes is need.
So, I separate to many PR, which contains about 5 file changes for easy review.
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
