### PR TITLE
Move container-related functions from PodManager to a separate file

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -67,6 +67,7 @@ def _load_body_to_dict(body: str) -> dict:
         raise AirflowException(f"Exception when loading resource definition: {e}\n")
     return body_dict
 
+
 class PodOperatorHookProtocol(Protocol):
     """
     Protocol to define methods relied upon by KubernetesPodOperator.
@@ -95,6 +96,7 @@ class PodOperatorHookProtocol(Protocol):
 
     def get_xcom_sidecar_container_resources(self) -> str | None:
         """Return the xcom sidecar resources that defined in the connection."""
+
 
 class KubernetesHook(BaseHook, PodOperatorHookProtocol):
     """

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -23,7 +23,7 @@ import tempfile
 from collections.abc import Generator
 from functools import cached_property
 from time import sleep
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 import aiofiles
 import requests
@@ -39,8 +39,7 @@ from airflow.exceptions import AirflowException, AirflowNotFoundException
 from airflow.models import Connection
 from airflow.providers.cncf.kubernetes.kube_client import _disable_verify_ssl, _enable_tcp_keepalive
 from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import should_retry_creation
-from airflow.providers.cncf.kubernetes.utils.pod_manager import (
-    PodOperatorHookProtocol,
+from airflow.providers.cncf.kubernetes.utils.container import (
     container_is_completed,
     container_is_running,
 )
@@ -68,6 +67,34 @@ def _load_body_to_dict(body: str) -> dict:
         raise AirflowException(f"Exception when loading resource definition: {e}\n")
     return body_dict
 
+class PodOperatorHookProtocol(Protocol):
+    """
+    Protocol to define methods relied upon by KubernetesPodOperator.
+
+    Subclasses of KubernetesPodOperator, such as GKEStartPodOperator, may use
+    hooks that don't extend KubernetesHook.  We use this protocol to document the
+    methods used by KPO and ensure that these methods exist on such other hooks.
+    """
+
+    @property
+    def core_v1_client(self) -> client.CoreV1Api:
+        """Get authenticated client object."""
+
+    @property
+    def is_in_cluster(self) -> bool:
+        """Expose whether the hook is configured with ``load_incluster_config`` or not."""
+
+    def get_pod(self, name: str, namespace: str) -> V1Pod:
+        """Read pod object from kubernetes API."""
+
+    def get_namespace(self) -> str | None:
+        """Return the namespace that defined in the connection."""
+
+    def get_xcom_sidecar_container_image(self) -> str | None:
+        """Return the xcom sidecar image that defined in the connection."""
+
+    def get_xcom_sidecar_container_resources(self) -> str | None:
+        """Return the xcom sidecar resources that defined in the connection."""
 
 class KubernetesHook(BaseHook, PodOperatorHookProtocol):
     """

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -75,7 +75,6 @@ from airflow.providers.cncf.kubernetes.utils.pod_manager import (
     PodLaunchFailedException,
     PodManager,
     PodNotFoundException,
-    PodOperatorHookProtocol,
     PodPhase,
     container_is_succeeded,
     get_container_termination_message,
@@ -95,6 +94,7 @@ if TYPE_CHECKING:
     import jinja2
     from pendulum import DateTime
 
+    from airflow.providers.cncf.kubernetes.hooks.kubernetes import PodOperatorHookProtocol
     from airflow.providers.cncf.kubernetes.secret import Secret
 
     try:

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -69,6 +69,10 @@ from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import (
 from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator
 from airflow.providers.cncf.kubernetes.triggers.pod import KubernetesPodTrigger
 from airflow.providers.cncf.kubernetes.utils import xcom_sidecar
+from airflow.providers.cncf.kubernetes.utils.container import (
+    container_is_succeeded,
+    get_container_termination_message,
+)
 from airflow.providers.cncf.kubernetes.utils.pod_manager import (
     EMPTY_XCOM_RESULT,
     OnFinishAction,
@@ -76,8 +80,6 @@ from airflow.providers.cncf.kubernetes.utils.pod_manager import (
     PodManager,
     PodNotFoundException,
     PodPhase,
-    container_is_succeeded,
-    get_container_termination_message,
 )
 from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_1_PLUS, XCOM_RETURN_KEY
 

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/container.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/container.py
@@ -1,0 +1,121 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Helper functions for inspecting and interacting with containers in a Kubernetes Pod."""
+
+from __future__ import annotations
+
+from contextlib import suppress
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from kubernetes.client.models.v1_container_status import V1ContainerStatus
+    from kubernetes.client.models.v1_pod import V1Pod
+
+
+def get_container_status(pod: V1Pod, container_name: str) -> V1ContainerStatus | None:
+    """Retrieve container status."""
+    if pod and pod.status:
+        container_statuses = []
+        if pod.status.container_statuses:
+            container_statuses.extend(pod.status.container_statuses)
+        if pod.status.init_container_statuses:
+            container_statuses.extend(pod.status.init_container_statuses)
+
+    else:
+        container_statuses = None
+
+    if container_statuses:
+        # In general the variable container_statuses can store multiple items matching different containers.
+        # The following generator expression yields all items that have name equal to the container_name.
+        # The function next() here calls the generator to get only the first value. If there's nothing found
+        # then None is returned.
+        return next((x for x in container_statuses if x.name == container_name), None)
+    return None
+
+
+def container_is_running(pod: V1Pod, container_name: str) -> bool:
+    """
+    Examine V1Pod ``pod`` to determine whether ``container_name`` is running.
+
+    If that container is present and running, returns True.  Returns False otherwise.
+    """
+    container_status = get_container_status(pod, container_name)
+    if not container_status:
+        return False
+    return container_status.state.running is not None
+
+
+def container_is_completed(pod: V1Pod, container_name: str) -> bool:
+    """
+    Examine V1Pod ``pod`` to determine whether ``container_name`` is completed.
+
+    If that container is present and completed, returns True.  Returns False otherwise.
+    """
+    container_status = get_container_status(pod, container_name)
+    if not container_status:
+        return False
+    return container_status.state.terminated is not None
+
+
+def container_is_succeeded(pod: V1Pod, container_name: str) -> bool:
+    """
+    Examine V1Pod ``pod`` to determine whether ``container_name`` is completed and succeeded.
+
+    If that container is present and completed and succeeded, returns True.  Returns False otherwise.
+    """
+    if not container_is_completed(pod, container_name):
+        return False
+
+    container_status = get_container_status(pod, container_name)
+    if not container_status:
+        return False
+    return container_status.state.terminated.exit_code == 0
+
+
+def container_is_wait(pod: V1Pod, container_name: str) -> bool:
+    """
+    Examine V1Pod ``pod`` to determine whether ``container_name`` is waiting.
+
+    If that container is present and waiting, returns True.  Returns False otherwise.
+    """
+    container_status = get_container_status(pod, container_name)
+    if not container_status:
+        return False
+
+    return container_status.state.waiting is not None
+
+
+def container_is_terminated(pod: V1Pod, container_name: str) -> bool:
+    """
+    Examine V1Pod ``pod`` to determine whether ``container_name`` is terminated.
+
+    If that container is present and terminated, returns True.  Returns False otherwise.
+    """
+    container_statuses = pod.status.container_statuses if pod and pod.status else None
+    if not container_statuses:
+        return False
+    container_status = next((x for x in container_statuses if x.name == container_name), None)
+    if not container_status:
+        return False
+    return container_status.state.terminated is not None
+
+
+def get_container_termination_message(pod: V1Pod, container_name: str):
+    with suppress(AttributeError, TypeError):
+        container_statuses = pod.status.container_statuses
+        container_status = next((x for x in container_statuses if x.name == container_name), None)
+        return container_status.state.terminated.message if container_status else None

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/container.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/container.py
@@ -77,11 +77,8 @@ def container_is_succeeded(pod: V1Pod, container_name: str) -> bool:
 
     If that container is present and completed and succeeded, returns True.  Returns False otherwise.
     """
-    if not container_is_completed(pod, container_name):
-        return False
-
     container_status = get_container_status(pod, container_name)
-    if not container_status:
+    if not container_status or container_status.state.terminated is None:
         return False
     return container_status.state.terminated.exit_code == 0
 

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_container.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_container.py
@@ -1,0 +1,172 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from airflow.providers.cncf.kubernetes.utils.container import (
+    container_is_running,
+    container_is_succeeded,
+    container_is_terminated,
+)
+
+
+@pytest.mark.parametrize(
+    "container_state, expected_is_terminated",
+    [("waiting", False), ("running", False), ("terminated", True)],
+)
+def test_container_is_terminated_with_waiting_state(container_state, expected_is_terminated):
+    container_status = MagicMock()
+    container_status.configure_mock(
+        **{
+            "name": "base",
+            "state.waiting": True if container_state == "waiting" else None,
+            "state.running": True if container_state == "running" else None,
+            "state.terminated": True if container_state == "terminated" else None,
+        }
+    )
+    pod_info = MagicMock()
+    pod_info.status.container_statuses = [container_status]
+    assert container_is_terminated(pod_info, "base") == expected_is_terminated
+
+
+def params_for_test_container_is_running():
+    """The `container_is_running` method is designed to handle an assortment of bad objects
+    returned from `read_pod`.  E.g. a None object, an object `e` such that `e.status` is None,
+    an object `e` such that `e.status.container_statuses` is None, and so on.  This function
+    emits params used in `test_container_is_running` to verify this behavior.
+
+    We create mock classes not derived from MagicMock because with an instance `e` of MagicMock,
+    tests like `e.hello is not None` are always True.
+    """
+
+    class RemotePodMock:
+        pass
+
+    class ContainerStatusMock:
+        def __init__(self, name):
+            self.name = name
+
+    def remote_pod(running=None, not_running=None):
+        e = RemotePodMock()
+        e.status = RemotePodMock()
+        e.status.container_statuses = []
+        e.status.init_container_statuses = []
+        for r in not_running or []:
+            e.status.container_statuses.append(container(r, False))
+        for r in running or []:
+            e.status.container_statuses.append(container(r, True))
+        return e
+
+    def container(name, running):
+        c = ContainerStatusMock(name)
+        c.state = RemotePodMock()
+        c.state.running = {"a": "b"} if running else None
+        return c
+
+    pod_mock_list = []
+    pod_mock_list.append(pytest.param(None, False, id="None remote_pod"))
+    p = RemotePodMock()
+    p.status = None
+    pod_mock_list.append(pytest.param(p, False, id="None remote_pod.status"))
+    p = RemotePodMock()
+    p.status = RemotePodMock()
+    p.status.container_statuses = []
+    p.status.init_container_statuses = []
+    pod_mock_list.append(pytest.param(p, False, id="empty remote_pod.status.container_statuses"))
+    pod_mock_list.append(pytest.param(remote_pod(), False, id="filter empty"))
+    pod_mock_list.append(pytest.param(remote_pod(None, ["base"]), False, id="filter 0 running"))
+    pod_mock_list.append(pytest.param(remote_pod(["hello"], ["base"]), False, id="filter 1 not running"))
+    pod_mock_list.append(pytest.param(remote_pod(["base"], ["hello"]), True, id="filter 1 running"))
+    return pod_mock_list
+
+
+@pytest.mark.parametrize("remote_pod, result", params_for_test_container_is_running())
+def test_container_is_running(remote_pod, result):
+    """The `container_is_running` function is designed to handle an assortment of bad objects
+    returned from `read_pod`.  E.g. a None object, an object `e` such that `e.status` is None,
+    an object `e` such that `e.status.container_statuses` is None, and so on.  This test
+    verifies the expected behavior."""
+    assert container_is_running(remote_pod, "base") is result
+
+
+def params_for_test_container_is_succeeded():
+    """The `container_is_succeeded` method is designed to handle an assortment of bad objects
+    returned from `read_pod`.  E.g. a None object, an object `e` such that `e.status` is None,
+    an object `e` such that `e.status.container_statuses` is None, and so on.  This function
+    emits params used in `test_container_is_succeeded` to verify this behavior.
+    We create mock classes not derived from MagicMock because with an instance `e` of MagicMock,
+    tests like `e.hello is not None` are always True.
+    """
+
+    class RemotePodMock:
+        pass
+
+    class ContainerStatusMock:
+        def __init__(self, name):
+            self.name = name
+
+    def remote_pod(succeeded=None, not_succeeded=None):
+        e = RemotePodMock()
+        e.status = RemotePodMock()
+        e.status.container_statuses = []
+        e.status.init_container_statuses = []
+        for r in not_succeeded or []:
+            e.status.container_statuses.append(container(r, False))
+        for r in succeeded or []:
+            e.status.container_statuses.append(container(r, True))
+        return e
+
+    def container(name, succeeded):
+        c = ContainerStatusMock(name)
+        c.state = RemotePodMock()
+        c.state.terminated = SimpleNamespace(**{"exit_code": 0}) if succeeded else None
+        return c
+
+    pod_mock_list = []
+    pod_mock_list.append(pytest.param(None, False, id="None remote_pod"))
+    p = RemotePodMock()
+    p.status = None
+    pod_mock_list.append(pytest.param(p, False, id="None remote_pod.status"))
+    p = RemotePodMock()
+    p.status = RemotePodMock()
+    p.status.container_statuses = None
+    p.status.init_container_statuses = []
+
+    pod_mock_list.append(pytest.param(p, False, id="None remote_pod.status.container_statuses"))
+    p = RemotePodMock()
+    p.status = RemotePodMock()
+    p.status.container_statuses = []
+    p.status.init_container_statuses = []
+    pod_mock_list.append(pytest.param(p, False, id="empty remote_pod.status.container_statuses"))
+    pod_mock_list.append(pytest.param(remote_pod(), False, id="filter empty"))
+    pod_mock_list.append(pytest.param(remote_pod(None, ["base"]), False, id="filter 0 succeeded"))
+    pod_mock_list.append(pytest.param(remote_pod(["hello"], ["base"]), False, id="filter 1 not succeeded"))
+    pod_mock_list.append(pytest.param(remote_pod(["base"], ["hello"]), True, id="filter 1 succeeded"))
+    return pod_mock_list
+
+
+@pytest.mark.parametrize("remote_pod, result", params_for_test_container_is_succeeded())
+def test_container_is_succeeded(remote_pod, result):
+    """The `container_is_succeeded` function is designed to handle an assortment of bad objects
+    returned from `read_pod`.  E.g. a None object, an object `e` such that `e.status` is None,
+    an object `e` such that `e.status.container_statuses` is None, and so on.  This test
+    verifies the expected behavior."""
+    assert container_is_succeeded(remote_pod, "base") is result

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_pod_manager.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_pod_manager.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import logging
 from datetime import datetime
 from json.decoder import JSONDecodeError
-from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
 from unittest import mock
 from unittest.mock import MagicMock, PropertyMock
@@ -35,9 +34,6 @@ from airflow.providers.cncf.kubernetes.utils.pod_manager import (
     PodLogsConsumer,
     PodManager,
     PodPhase,
-    container_is_running,
-    container_is_succeeded,
-    container_is_terminated,
 )
 from airflow.utils.timezone import utc
 
@@ -611,24 +607,6 @@ class TestPodManager:
         assert ret.last_log_time == pendulum.datetime(2021, 1, 1, tz="UTC")
         assert ret.running is exp_running
 
-    @pytest.mark.parametrize(
-        "container_state, expected_is_terminated",
-        [("waiting", False), ("running", False), ("terminated", True)],
-    )
-    def test_container_is_terminated_with_waiting_state(self, container_state, expected_is_terminated):
-        container_status = MagicMock()
-        container_status.configure_mock(
-            **{
-                "name": "base",
-                "state.waiting": True if container_state == "waiting" else None,
-                "state.running": True if container_state == "running" else None,
-                "state.terminated": True if container_state == "terminated" else None,
-            }
-        )
-        pod_info = MagicMock()
-        pod_info.status.container_statuses = [container_status]
-        assert container_is_terminated(pod_info, "base") == expected_is_terminated
-
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.kubernetes_stream")
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.extract_xcom_kill")
     def test_extract_xcom_success(self, mock_exec_xcom_kill, mock_kubernetes_stream):
@@ -720,66 +698,6 @@ class TestPodManager:
         mock_container_is_running.return_value = True
         self.pod_manager.await_xcom_sidecar_container_start(pod=mock_pod)
         mock_container_is_running.assert_any_call(mock_pod, "airflow-xcom-sidecar")
-
-
-def params_for_test_container_is_running():
-    """The `container_is_running` method is designed to handle an assortment of bad objects
-    returned from `read_pod`.  E.g. a None object, an object `e` such that `e.status` is None,
-    an object `e` such that `e.status.container_statuses` is None, and so on.  This function
-    emits params used in `test_container_is_running` to verify this behavior.
-
-    We create mock classes not derived from MagicMock because with an instance `e` of MagicMock,
-    tests like `e.hello is not None` are always True.
-    """
-
-    class RemotePodMock:
-        pass
-
-    class ContainerStatusMock:
-        def __init__(self, name):
-            self.name = name
-
-    def remote_pod(running=None, not_running=None):
-        e = RemotePodMock()
-        e.status = RemotePodMock()
-        e.status.container_statuses = []
-        e.status.init_container_statuses = []
-        for r in not_running or []:
-            e.status.container_statuses.append(container(r, False))
-        for r in running or []:
-            e.status.container_statuses.append(container(r, True))
-        return e
-
-    def container(name, running):
-        c = ContainerStatusMock(name)
-        c.state = RemotePodMock()
-        c.state.running = {"a": "b"} if running else None
-        return c
-
-    pod_mock_list = []
-    pod_mock_list.append(pytest.param(None, False, id="None remote_pod"))
-    p = RemotePodMock()
-    p.status = None
-    pod_mock_list.append(pytest.param(p, False, id="None remote_pod.status"))
-    p = RemotePodMock()
-    p.status = RemotePodMock()
-    p.status.container_statuses = []
-    p.status.init_container_statuses = []
-    pod_mock_list.append(pytest.param(p, False, id="empty remote_pod.status.container_statuses"))
-    pod_mock_list.append(pytest.param(remote_pod(), False, id="filter empty"))
-    pod_mock_list.append(pytest.param(remote_pod(None, ["base"]), False, id="filter 0 running"))
-    pod_mock_list.append(pytest.param(remote_pod(["hello"], ["base"]), False, id="filter 1 not running"))
-    pod_mock_list.append(pytest.param(remote_pod(["base"], ["hello"]), True, id="filter 1 running"))
-    return pod_mock_list
-
-
-@pytest.mark.parametrize("remote_pod, result", params_for_test_container_is_running())
-def test_container_is_running(remote_pod, result):
-    """The `container_is_running` function is designed to handle an assortment of bad objects
-    returned from `read_pod`.  E.g. a None object, an object `e` such that `e.status` is None,
-    an object `e` such that `e.status.container_statuses` is None, and so on.  This test
-    verifies the expected behavior."""
-    assert container_is_running(remote_pod, "base") is result
 
 
 class TestPodLogsConsumer:
@@ -958,68 +876,3 @@ class TestPodLogsConsumer:
         # second read
         with time_machine.travel(mock_read_pod_at_1):
             assert consumer.read_pod() == expected_read_pods[1]
-
-
-def params_for_test_container_is_succeeded():
-    """The `container_is_succeeded` method is designed to handle an assortment of bad objects
-    returned from `read_pod`.  E.g. a None object, an object `e` such that `e.status` is None,
-    an object `e` such that `e.status.container_statuses` is None, and so on.  This function
-    emits params used in `test_container_is_succeeded` to verify this behavior.
-    We create mock classes not derived from MagicMock because with an instance `e` of MagicMock,
-    tests like `e.hello is not None` are always True.
-    """
-
-    class RemotePodMock:
-        pass
-
-    class ContainerStatusMock:
-        def __init__(self, name):
-            self.name = name
-
-    def remote_pod(succeeded=None, not_succeeded=None):
-        e = RemotePodMock()
-        e.status = RemotePodMock()
-        e.status.container_statuses = []
-        e.status.init_container_statuses = []
-        for r in not_succeeded or []:
-            e.status.container_statuses.append(container(r, False))
-        for r in succeeded or []:
-            e.status.container_statuses.append(container(r, True))
-        return e
-
-    def container(name, succeeded):
-        c = ContainerStatusMock(name)
-        c.state = RemotePodMock()
-        c.state.terminated = SimpleNamespace(**{"exit_code": 0}) if succeeded else None
-        return c
-
-    pod_mock_list = []
-    pod_mock_list.append(pytest.param(None, False, id="None remote_pod"))
-    p = RemotePodMock()
-    p.status = None
-    pod_mock_list.append(pytest.param(p, False, id="None remote_pod.status"))
-    p = RemotePodMock()
-    p.status = RemotePodMock()
-    p.status.container_statuses = None
-    p.status.init_container_statuses = []
-
-    pod_mock_list.append(pytest.param(p, False, id="None remote_pod.status.container_statuses"))
-    p = RemotePodMock()
-    p.status = RemotePodMock()
-    p.status.container_statuses = []
-    p.status.init_container_statuses = []
-    pod_mock_list.append(pytest.param(p, False, id="empty remote_pod.status.container_statuses"))
-    pod_mock_list.append(pytest.param(remote_pod(), False, id="filter empty"))
-    pod_mock_list.append(pytest.param(remote_pod(None, ["base"]), False, id="filter 0 succeeded"))
-    pod_mock_list.append(pytest.param(remote_pod(["hello"], ["base"]), False, id="filter 1 not succeeded"))
-    pod_mock_list.append(pytest.param(remote_pod(["base"], ["hello"]), True, id="filter 1 succeeded"))
-    return pod_mock_list
-
-
-@pytest.mark.parametrize("remote_pod, result", params_for_test_container_is_succeeded())
-def test_container_is_succeeded(remote_pod, result):
-    """The `container_is_succeeded` function is designed to handle an assortment of bad objects
-    returned from `read_pod`.  E.g. a None object, an object `e` such that `e.status` is None,
-    an object `e` such that `e.status.container_statuses` is None, and so on.  This test
-    verifies the expected behavior."""
-    assert container_is_succeeded(remote_pod, "base") is result


### PR DESCRIPTION
# Overview

We are preparing an update to the KubernetesPodTriggerer workflow to align its startup behavior with that of the synchronous workflow. As part of this effort, we are introducing this preparation PR.

This PR moves certain container-related functions from PodManager to a new container.py module. This refactoring helps resolve circular import issues, as both the Hook and PodManager can now import these shared functions from container.py. In upcoming PRs, we plan to unify the code paths so that both the Triggerer (async) and synchronous workflows use the same logic to start pods. This change also lays the groundwork for introducing an AsyncPodManager that will utilize functions from the AsyncKubernetesHook.

We welcome your feedback on this change

# Details of change:

* Move container-related functions from PodManager to container.py
* Update PodManager and Hook to import these functions from the container.py
* Move the PodOperatorHookProtocol class to the hook module.

