### PR TITLE
Fix Databricks provider import error without fab provider

### DIFF
--- a/airflow-core/tests/unit/always/test_providers_manager.py
+++ b/airflow-core/tests/unit/always/test_providers_manager.py
@@ -277,12 +277,24 @@ class TestProviderManager:
     def test_connection_form_widgets(self):
         provider_manager = ProvidersManager()
         connections_form_widgets = list(provider_manager.connection_form_widgets.keys())
-        assert len(connections_form_widgets) > 29
+        # Connection form widgets use flask_appbuilder widgets, so they're only available when it's installed
+        try:
+            import flask_appbuilder  # noqa: F401
+
+            assert len(connections_form_widgets) > 29
+        except ImportError:
+            assert len(connections_form_widgets) == 0
 
     def test_field_behaviours(self):
         provider_manager = ProvidersManager()
         connections_with_field_behaviours = list(provider_manager.field_behaviours.keys())
-        assert len(connections_with_field_behaviours) > 16
+        # Field behaviours are often related to connection forms, only available when flask_appbuilder is installed
+        try:
+            import flask_appbuilder  # noqa: F401
+
+            assert len(connections_with_field_behaviours) > 16
+        except ImportError:
+            assert len(connections_with_field_behaviours) == 0
 
     def test_extra_links(self):
         provider_manager = ProvidersManager()

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_plugins.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_plugins.py
@@ -74,8 +74,9 @@ class TestGetPlugins:
 
         test_plugin = next((plugin for plugin in body["plugins"] if plugin["name"] == "test_plugin"), None)
         assert test_plugin is not None
-        assert test_plugin["external_views"] == [
-            # external_views
+
+        # Base external_view that is always present
+        expected_views = [
             {
                 "name": "Test IFrame Airflow Docs",
                 "href": "https://airflow.apache.org/",
@@ -85,27 +86,39 @@ class TestGetPlugins:
                 "destination": "nav",
                 "category": "browse",
             },
-            # appbuilder_menu_items
-            {
-                "category": "Search",
-                "destination": "nav",
-                "href": "https://www.google.com",
-                "icon": None,
-                "icon_dark_mode": None,
-                "name": "Google",
-                "url_route": None,
-            },
-            {
-                "category": None,
-                "destination": "nav",
-                "href": "https://www.apache.org/",
-                "icon": None,
-                "icon_dark_mode": None,
-                "label": "The Apache Software Foundation",
-                "name": "apache",
-                "url_route": None,
-            },
         ]
+
+        # The test plugin conditionally defines appbuilder_menu_items based on flask_appbuilder availability
+        try:
+            import flask_appbuilder  # noqa: F401
+
+            expected_views.extend(
+                [
+                    {
+                        "category": "Search",
+                        "destination": "nav",
+                        "href": "https://www.google.com",
+                        "icon": None,
+                        "icon_dark_mode": None,
+                        "name": "Google",
+                        "url_route": None,
+                    },
+                    {
+                        "category": None,
+                        "destination": "nav",
+                        "href": "https://www.apache.org/",
+                        "icon": None,
+                        "icon_dark_mode": None,
+                        "label": "The Apache Software Foundation",
+                        "name": "apache",
+                        "url_route": None,
+                    },
+                ]
+            )
+        except ImportError:
+            pass
+
+        assert test_plugin["external_views"] == expected_views
 
     def test_should_response_401(self, unauthenticated_test_client):
         response = unauthenticated_test_client.get("/plugins")

--- a/providers/databricks/pyproject.toml
+++ b/providers/databricks/pyproject.toml
@@ -98,13 +98,13 @@ dev = [
     "apache-airflow-devel-common",
     "apache-airflow-providers-common-compat",
     "apache-airflow-providers-common-sql",
-    "apache-airflow-providers-fab",
     "apache-airflow-providers-openlineage",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
     "deltalake>=1.1.3",
     "apache-airflow-providers-fab>=2.2.0; python_version < '3.13'",
     "apache-airflow-providers-microsoft-azure",
     "apache-airflow-providers-common-sql[pandas,polars]",
+    "apache-airflow-providers-fab",
 ]
 
 # To build docs:

--- a/providers/databricks/src/airflow/providers/databricks/plugins/databricks_workflow.py
+++ b/providers/databricks/src/airflow/providers/databricks/plugins/databricks_workflow.py
@@ -21,10 +21,6 @@ import os
 from typing import TYPE_CHECKING, Any
 from urllib.parse import unquote
 
-from flask import flash, redirect, request, url_for
-from flask_appbuilder import BaseView
-from flask_appbuilder.api import expose
-
 from airflow.exceptions import AirflowException, TaskInstanceNotFound
 from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance, TaskInstanceKey, clear_task_instances
@@ -86,7 +82,58 @@ def get_databricks_task_ids(
 # TODO: Need to re-think on how to support the currently unavailable repair functionality in Airflow 3. Probably a
 # good time to re-evaluate this would be once the plugin functionality is expanded in Airflow 3.1.
 if not AIRFLOW_V_3_0_PLUS:
+    from flask import flash, redirect, request, url_for
+    from flask_appbuilder import BaseView
+    from flask_appbuilder.api import expose
+
     from airflow.utils.session import NEW_SESSION, provide_session
+
+    class RepairDatabricksTasks(BaseView, LoggingMixin):
+        """Repair databricks tasks from Airflow."""
+
+        default_view = "repair"
+
+        @expose("/repair_databricks_job/<string:dag_id>/<string:run_id>", methods=("GET",))
+        @get_auth_decorator()
+        def repair(self, dag_id: str, run_id: str):
+            return_url = self._get_return_url(dag_id, run_id)
+
+            tasks_to_repair = request.values.get("tasks_to_repair")
+            self.log.info("Tasks to repair: %s", tasks_to_repair)
+            if not tasks_to_repair:
+                flash("No tasks to repair. Not sending repair request.")
+                return redirect(return_url)
+
+            databricks_conn_id = request.values.get("databricks_conn_id")
+            databricks_run_id = request.values.get("databricks_run_id")
+
+            if not databricks_conn_id:
+                flash("No Databricks connection ID provided. Cannot repair tasks.")
+                return redirect(return_url)
+
+            if not databricks_run_id:
+                flash("No Databricks run ID provided. Cannot repair tasks.")
+                return redirect(return_url)
+
+            self.log.info("Repairing databricks job %s", databricks_run_id)
+            res = _repair_task(
+                databricks_conn_id=databricks_conn_id,
+                databricks_run_id=int(databricks_run_id),
+                tasks_to_repair=tasks_to_repair.split(","),
+                logger=self.log,
+            )
+            self.log.info("Repairing databricks job query for run %s sent", databricks_run_id)
+
+            self.log.info("Clearing tasks to rerun in airflow")
+
+            run_id = unquote(run_id)
+            _clear_task_instances(dag_id, run_id, tasks_to_repair.split(","), self.log)
+            flash(f"Databricks repair job is starting!: {res}")
+            return redirect(return_url)
+
+        @staticmethod
+        def _get_return_url(dag_id: str, run_id: str) -> str:
+            return url_for("Airflow.grid", dag_id=dag_id, dag_run_id=run_id)
 
     def _get_dag(dag_id: str, session: Session):
         from airflow.models.serialized_dag import SerializedDagModel
@@ -140,46 +187,45 @@ if not AIRFLOW_V_3_0_PLUS:
             raise TaskInstanceNotFound("Task instance not found")
         return ti
 
+    def _repair_task(
+        databricks_conn_id: str,
+        databricks_run_id: int,
+        tasks_to_repair: list[str],
+        logger: Logger,
+    ) -> int:
+        """
+        Repair a Databricks task using the Databricks API.
 
-def _repair_task(
-    databricks_conn_id: str,
-    databricks_run_id: int,
-    tasks_to_repair: list[str],
-    logger: Logger,
-) -> int:
-    """
-    Repair a Databricks task using the Databricks API.
+        This function allows the Airflow retry function to create a repair job for Databricks.
+        It uses the Databricks API to get the latest repair ID before sending the repair query.
 
-    This function allows the Airflow retry function to create a repair job for Databricks.
-    It uses the Databricks API to get the latest repair ID before sending the repair query.
+        :param databricks_conn_id: The Databricks connection ID.
+        :param databricks_run_id: The Databricks run ID.
+        :param tasks_to_repair: A list of Databricks task IDs to repair.
+        :param logger: The logger to use for logging.
+        :return: None
+        """
+        hook = DatabricksHook(databricks_conn_id=databricks_conn_id)
 
-    :param databricks_conn_id: The Databricks connection ID.
-    :param databricks_run_id: The Databricks run ID.
-    :param tasks_to_repair: A list of Databricks task IDs to repair.
-    :param logger: The logger to use for logging.
-    :return: None
-    """
-    hook = DatabricksHook(databricks_conn_id=databricks_conn_id)
+        repair_history_id = hook.get_latest_repair_id(databricks_run_id)
+        logger.debug("Latest repair ID is %s", repair_history_id)
+        logger.debug(
+            "Sending repair query for tasks %s on run %s",
+            tasks_to_repair,
+            databricks_run_id,
+        )
 
-    repair_history_id = hook.get_latest_repair_id(databricks_run_id)
-    logger.debug("Latest repair ID is %s", repair_history_id)
-    logger.debug(
-        "Sending repair query for tasks %s on run %s",
-        tasks_to_repair,
-        databricks_run_id,
-    )
+        run_data = hook.get_run(databricks_run_id)
+        repair_json = {
+            "run_id": databricks_run_id,
+            "latest_repair_id": repair_history_id,
+            "rerun_tasks": tasks_to_repair,
+        }
 
-    run_data = hook.get_run(databricks_run_id)
-    repair_json = {
-        "run_id": databricks_run_id,
-        "latest_repair_id": repair_history_id,
-        "rerun_tasks": tasks_to_repair,
-    }
+        if "overriding_parameters" in run_data:
+            repair_json["overriding_parameters"] = run_data["overriding_parameters"]
 
-    if "overriding_parameters" in run_data:
-        repair_json["overriding_parameters"] = run_data["overriding_parameters"]
-
-    return hook.repair_run(repair_json)
+        return hook.repair_run(repair_json)
 
 
 def get_launch_task_id(task_group: TaskGroup) -> str:
@@ -459,54 +505,6 @@ class WorkflowJobRepairSingleTaskLink(BaseOperatorLink, LoggingMixin):
             "tasks_to_repair": task.databricks_task_key,
         }
         return url_for("RepairDatabricksTasks.repair", **query_params)
-
-
-class RepairDatabricksTasks(BaseView, LoggingMixin):
-    """Repair databricks tasks from Airflow."""
-
-    default_view = "repair"
-
-    @expose("/repair_databricks_job/<string:dag_id>/<string:run_id>", methods=("GET",))
-    @get_auth_decorator()
-    def repair(self, dag_id: str, run_id: str):
-        return_url = self._get_return_url(dag_id, run_id)
-
-        tasks_to_repair = request.values.get("tasks_to_repair")
-        self.log.info("Tasks to repair: %s", tasks_to_repair)
-        if not tasks_to_repair:
-            flash("No tasks to repair. Not sending repair request.")
-            return redirect(return_url)
-
-        databricks_conn_id = request.values.get("databricks_conn_id")
-        databricks_run_id = request.values.get("databricks_run_id")
-
-        if not databricks_conn_id:
-            flash("No Databricks connection ID provided. Cannot repair tasks.")
-            return redirect(return_url)
-
-        if not databricks_run_id:
-            flash("No Databricks run ID provided. Cannot repair tasks.")
-            return redirect(return_url)
-
-        self.log.info("Repairing databricks job %s", databricks_run_id)
-        res = _repair_task(
-            databricks_conn_id=databricks_conn_id,
-            databricks_run_id=int(databricks_run_id),
-            tasks_to_repair=tasks_to_repair.split(","),
-            logger=self.log,
-        )
-        self.log.info("Repairing databricks job query for run %s sent", databricks_run_id)
-
-        self.log.info("Clearing tasks to rerun in airflow")
-
-        run_id = unquote(run_id)
-        _clear_task_instances(dag_id, run_id, tasks_to_repair.split(","), self.log)
-        flash(f"Databricks repair job is starting!: {res}")
-        return redirect(return_url)
-
-    @staticmethod
-    def _get_return_url(dag_id: str, run_id: str) -> str:
-        return url_for("Airflow.grid", dag_id=dag_id, dag_run_id=run_id)
 
 
 class DatabricksWorkflowPlugin(AirflowPlugin):

--- a/providers/databricks/src/airflow/providers/databricks/plugins/databricks_workflow.py
+++ b/providers/databricks/src/airflow/providers/databricks/plugins/databricks_workflow.py
@@ -27,11 +27,6 @@ from airflow.models.taskinstance import TaskInstance, TaskInstanceKey, clear_tas
 from airflow.plugins_manager import AirflowPlugin
 from airflow.providers.databricks.hooks.databricks import DatabricksHook
 from airflow.providers.databricks.version_compat import AIRFLOW_V_3_0_PLUS, BaseOperatorLink, TaskGroup, XCom
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.providers.fab.www import auth
-else:
-    from airflow.www import auth  # type: ignore
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.state import TaskInstanceState
 
@@ -46,15 +41,6 @@ if TYPE_CHECKING:
 
 REPAIR_WAIT_ATTEMPTS = os.getenv("DATABRICKS_REPAIR_WAIT_ATTEMPTS", 20)
 REPAIR_WAIT_DELAY = os.getenv("DATABRICKS_REPAIR_WAIT_DELAY", 0.5)
-
-
-def get_auth_decorator():
-    if AIRFLOW_V_3_0_PLUS:
-        from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity
-    else:
-        from airflow.auth.managers.models.resource_details import DagAccessEntity
-
-    return auth.has_access_dag("POST", DagAccessEntity.RUN)
 
 
 def get_databricks_task_ids(
@@ -87,6 +73,12 @@ if not AIRFLOW_V_3_0_PLUS:
     from flask_appbuilder.api import expose
 
     from airflow.utils.session import NEW_SESSION, provide_session
+    from airflow.www import auth
+
+    def get_auth_decorator():
+        from airflow.auth.managers.models.resource_details import DagAccessEntity
+
+        return auth.has_access_dag("POST", DagAccessEntity.RUN)
 
     class RepairDatabricksTasks(BaseView, LoggingMixin):
         """Repair databricks tasks from Airflow."""

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/test_utils.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/test_utils.py
@@ -81,6 +81,8 @@ def test_get_field_non_prefixed(input, expected):
 
 def test_add_managed_identity_connection_widgets():
     pytest.importorskip("airflow.providers.fab")
+    # TODO: remove this because fab5 is available now, but it requires recursively fixing tests
+    pytest.importorskip("flask_appbuilder")
 
     class FakeHook:
         @classmethod


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


Databricks provider tests were failing with `ModuleNotFoundError: No module named 'flask_appbuilder'` when the fab provider was not installed, which is the default in Airflow 3.0+ and Python 3.13+.

This was introduced by commit 5a2e95af9c2a939dda5a005f081845e2a92a5717, which removed the pytest ignores for flask-appbuilder in various tests.

The `databricks_workflow.py` plugin had unconditional imports of `flask` and `flask_appbuilder` at module level, even though the repair functionality using these imports is only for Airflow 2.x and is explicitly disabled for Airflow 3.0+.

**Fix:**
- Moved `flask` and `flask_appbuilder` imports into the `if not AIRFLOW_V_3_0_PLUS:` conditional block
- Moved `_repair_task()` function and `RepairDatabricksTasks` class into the same conditional block

This follows the same pattern used in the edge3 provider plugin. The repair functionality still works in Airflow 2.x, and Databricks operators can now be imported in Airflow 3.0+ without the fab provider.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
