### PR TITLE
Use correct API_VERSION for task sdk integration tests

### DIFF
--- a/task-sdk-tests/tests/task_sdk_tests/conftest.py
+++ b/task-sdk-tests/tests/task_sdk_tests/conftest.py
@@ -283,6 +283,14 @@ def airflow_test_setup(docker_compose_setup):
 
 
 @pytest.fixture(scope="session")
+def task_sdk_api_version():
+    """Get the API version from the installed Task SDK."""
+    from airflow.sdk.api.datamodels._generated import API_VERSION
+
+    return API_VERSION
+
+
+@pytest.fixture(scope="session")
 def auth_token(airflow_test_setup):
     """Get the auth token from setup."""
     return airflow_test_setup["auth_token"]

--- a/task-sdk-tests/tests/task_sdk_tests/constants.py
+++ b/task-sdk-tests/tests/task_sdk_tests/constants.py
@@ -29,24 +29,4 @@ DOCKER_IMAGE = os.environ.get("DOCKER_IMAGE") or DEFAULT_DOCKER_IMAGE
 DOCKER_COMPOSE_HOST_PORT = os.environ.get("HOST_PORT", "localhost:8080")
 TASK_SDK_HOST_PORT = os.environ.get("TASK_SDK_HOST_PORT", "localhost:8080")
 
-
-# This represents the Execution API schema version, NOT the Task SDK package version.
-#
-# Purpose:
-# - Defines the API contract between Task SDK and Airflow's Execution API
-# - Enables backward compatibility when API schemas evolve
-# - Uses calver format (YYYY-MM-DD) based on expected release dates
-#
-# Usage:
-# - Sent as "Airflow-API-Version" header with every API request
-# - Server uses this to determine which schema version to serve
-# - Allows older Task SDK versions to work with newer Airflow servers
-#
-# Version vs Package Version:
-# - API Version: "2025-09-23" (schema compatibility)
-# - Package Version: "1.1.0" (Task SDK release version)
-#
-# Keep this in sync with: task-sdk/src/airflow/sdk/api/datamodels/_generated.py
-TASK_SDK_API_VERSION = "2025-09-23"
-
 DOCKER_COMPOSE_FILE_PATH = TASK_SDK_TESTS_ROOT / "docker" / "docker-compose.yaml"

--- a/task-sdk-tests/tests/task_sdk_tests/test_task_sdk_health.py
+++ b/task-sdk-tests/tests/task_sdk_tests/test_task_sdk_health.py
@@ -17,17 +17,14 @@
 from __future__ import annotations
 
 from task_sdk_tests import console
-from task_sdk_tests.constants import (
-    TASK_SDK_API_VERSION,
-)
 
 
-def test_task_sdk_health(sdk_client):
+def test_task_sdk_health(sdk_client, task_sdk_api_version):
     """Test Task SDK health check using session setup."""
     client = sdk_client
 
     console.print("[yellow]Making health check request...")
-    response = client.get("health/ping", headers={"Airflow-API-Version": TASK_SDK_API_VERSION})
+    response = client.get("health/ping", headers={"Airflow-API-Version": task_sdk_api_version})
 
     console.print(" Health Check Response ".center(72, "="))
     console.print(f"[bright_blue]Status Code:[/] {response.status_code}")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

We should not be defining `API_VERSION` as a constant but get it from the "right" task sdk that was installed as part of the integration tests. 

This opens doors to install any version of task sdk too.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
