### PR TITLE
Fix execution failures with NULL dag_run.conf during upgrades

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
@@ -298,7 +298,7 @@ class DagRun(StrictBaseModel):
     clear_number: int = 0
     run_type: DagRunType
     state: DagRunState
-    conf: Annotated[dict[str, Any], Field(default_factory=dict)]
+    conf: dict[str, Any] | None = None
     triggering_user_name: str | None = None
     consumed_asset_events: list[AssetEventDagRunReference]
 

--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py
@@ -26,11 +26,14 @@ from airflow.api_fastapi.execution_api.versions.v2025_08_10 import (
     AddIncludePriorDatesToGetXComSlice,
 )
 from airflow.api_fastapi.execution_api.versions.v2025_09_23 import AddDagVersionIdField
-from airflow.api_fastapi.execution_api.versions.v2025_10_10 import AddTriggeringUserNameField
+from airflow.api_fastapi.execution_api.versions.v2025_10_10 import (
+    AddTriggeringUserNameField,
+    MakeDagRunConfNullable,
+)
 
 bundle = VersionBundle(
     HeadVersion(),
-    Version("2025-10-10", AddTriggeringUserNameField),
+    Version("2025-10-10", AddTriggeringUserNameField, MakeDagRunConfNullable),
     Version("2025-09-23", AddDagVersionIdField),
     Version(
         "2025-08-10",

--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2025_10_10.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2025_10_10.py
@@ -34,3 +34,18 @@ class AddTriggeringUserNameField(VersionChange):
         """Remove the `triggering_user_name` field from the dag_run object when converting to the previous version."""
         if "dag_run" in response.body and isinstance(response.body["dag_run"], dict):
             response.body["dag_run"].pop("triggering_user_name", None)
+
+
+class MakeDagRunConfNullable(VersionChange):
+    """Make DagRun.conf field nullable to match database schema."""
+
+    description = __doc__
+
+    instructions_to_migrate_to_previous_version = ()
+
+    @convert_response_to_previous_version_for(TIRunContext)  # type: ignore[arg-type]
+    def ensure_conf_is_dict_in_dag_run(response: ResponseInfo) -> None:  # type: ignore[misc]
+        """Ensure conf is always a dict (never None) in previous versions."""
+        if "dag_run" in response.body and isinstance(response.body["dag_run"], dict):
+            if response.body["dag_run"].get("conf") is None:
+                response.body["dag_run"]["conf"] = {}

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -2408,3 +2408,30 @@ class TestInvactiveInletsAndOutlets:
         response = client.get(f"/execution/task-instances/{task1_ti.id}/validate-inlets-and-outlets")
         assert response.status_code == 200
         assert response.json() == {"inactive_assets": []}
+
+    def test_ti_run_with_null_conf(self, client, session, create_task_instance):
+        """Test that task instances can start when dag_run.conf is NULL."""
+        ti = create_task_instance(
+            task_id="test_ti_run_with_null_conf",
+            state=State.QUEUED,
+            dagrun_state=DagRunState.RUNNING,
+            session=session,
+        )
+        # Set conf to NULL to simulate Airflow 2.x upgrade or offline migration
+        ti.dag_run.conf = None
+        session.commit()
+
+        response = client.patch(
+            f"/execution/task-instances/{ti.id}/run",
+            json={
+                "state": "running",
+                "pid": 100,
+                "hostname": "test-hostname",
+                "unixname": "test-user",
+                "start_date": timezone.utcnow().isoformat(),
+            },
+        )
+
+        assert response.status_code == 200, f"Response: {response.text}"
+        context = response.json()
+        assert context["dag_run"]["conf"] is None


### PR DESCRIPTION
Task execution and scheduler operations failed when processing dag runs with NULL conf values in the database. This occurred during Airflow 2.x to 3.x upgrades where existing running DAG runs had NULL conf, and when clearing dag runs that were migrated with NULL conf during offline migrations.

The execution API DagRun datamodel required conf to be a dict, but the database schema allows NULL. This fix makes the conf field nullable to match the database schema, Core API datamodel, and Task SDK expectations.

For backward compatibility, older API versions (pre-2025-10-10) will receive an empty dict instead of None when conf is NULL.

Fixes #56707
Fixes #56705

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
