### PR TITLE
AIP-67 - Multi Team: Gate multi team executor loader changes with feature flag

### DIFF
--- a/airflow-core/src/airflow/executors/executor_loader.py
+++ b/airflow-core/src/airflow/executors/executor_loader.py
@@ -211,7 +211,15 @@ class ExecutorLoader:
                 executor_names = team_executor_config.strip("=")
             else:
                 cls.block_use_of_multi_team()
-                team_name, executor_names = team_executor_config.split("=")
+                if conf.getboolean("core", "multi_team", fallback=False):
+                    team_name, executor_names = team_executor_config.split("=")
+                else:
+                    log.warning(
+                        "The 'multi_team' config is not enabled, but team executors were configured. "
+                        "The following team executor config will be ignored: %s",
+                        team_executor_config,
+                    )
+                    continue
 
             # Check for duplicate team names
             if team_name in seen_teams:

--- a/airflow-core/tests/unit/executors/test_executor_loader.py
+++ b/airflow-core/tests/unit/executors/test_executor_loader.py
@@ -239,7 +239,7 @@ class TestExecutorLoader:
             mock.patch.object(executor_loader.ExecutorLoader, "block_use_of_multi_team"),
             mock.patch.object(executor_loader.ExecutorLoader, "_validate_teams_exist_in_database"),
         ):
-            with conf_vars({("core", "executor"): executor_config}):
+            with conf_vars({("core", "executor"): executor_config, ("core", "multi_team"): "True"}):
                 executors = executor_loader.ExecutorLoader._get_executor_names()
                 assert executors == expected_executors_list
 
@@ -391,10 +391,11 @@ class TestExecutorLoader:
     def test_get_executor_names_set_module_variables(self):
         with conf_vars(
             {
+                ("core", "multi_team"): "True",
                 (
                     "core",
                     "executor",
-                ): "=CeleryExecutor,LocalExecutor,fake_exec:unit.executors.test_executor_loader.FakeExecutor;team_a=CeleryExecutor,unit.executors.test_executor_loader.FakeExecutor;team_b=fake_exec:unit.executors.test_executor_loader.FakeExecutor"
+                ): "=CeleryExecutor,LocalExecutor,fake_exec:unit.executors.test_executor_loader.FakeExecutor;team_a=CeleryExecutor,unit.executors.test_executor_loader.FakeExecutor;team_b=fake_exec:unit.executors.test_executor_loader.FakeExecutor",
             }
         ):
             celery_path = "airflow.providers.celery.executors.celery_executor.CeleryExecutor"
@@ -488,7 +489,7 @@ class TestExecutorLoader:
     def test_duplicate_team_names_should_fail(self, executor_config):
         """Test that duplicate team names in executor configuration raise an exception."""
         with mock.patch.object(executor_loader.ExecutorLoader, "block_use_of_multi_team"):
-            with conf_vars({("core", "executor"): executor_config}):
+            with conf_vars({("core", "executor"): executor_config, ("core", "multi_team"): "True"}):
                 with pytest.raises(
                     AirflowConfigException,
                     match=r"Team '.+' appears more than once in executor configuration",
@@ -529,7 +530,7 @@ class TestExecutorLoader:
             mock.patch.object(executor_loader.ExecutorLoader, "block_use_of_multi_team"),
             mock.patch.object(executor_loader.ExecutorLoader, "_validate_teams_exist_in_database"),
         ):
-            with conf_vars({("core", "executor"): executor_config}):
+            with conf_vars({("core", "executor"): executor_config, ("core", "multi_team"): "True"}):
                 configs = executor_loader.ExecutorLoader._get_team_executor_configs()
                 assert configs == expected_configs
 
@@ -586,7 +587,10 @@ class TestExecutorLoader:
             mock.patch.object(executor_loader.ExecutorLoader, "block_use_of_multi_team"),
         ):
             with conf_vars(
-                {("core", "executor"): "=CeleryExecutor;team_a=CeleryExecutor;team_b=LocalExecutor"}
+                {
+                    ("core", "executor"): "=CeleryExecutor;team_a=CeleryExecutor;team_b=LocalExecutor",
+                    ("core", "multi_team"): "True",
+                }
             ):
                 configs = executor_loader.ExecutorLoader._get_team_executor_configs()
 
@@ -608,7 +612,8 @@ class TestExecutorLoader:
                     (
                         "core",
                         "executor",
-                    ): "=CeleryExecutor;team_a=CeleryExecutor;team_b=LocalExecutor;team_c=KubernetesExecutor"
+                    ): "=CeleryExecutor;team_a=CeleryExecutor;team_b=LocalExecutor;team_c=KubernetesExecutor",
+                    ("core", "multi_team"): "True",
                 }
             ):
                 with pytest.raises(AirflowConfigException):


### PR DESCRIPTION
Do not attempt to load executors from other teams unless core.multi_team=True

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
