### PR TITLE
[v3-1-test] Tests for message type consistency between various supervisor and task comms (#55665)

### DIFF
--- a/airflow-core/tests/unit/dag_processing/test_processor.py
+++ b/airflow-core/tests/unit/dag_processing/test_processor.py
@@ -21,6 +21,7 @@ import inspect
 import pathlib
 import sys
 import textwrap
+import typing
 import uuid
 from collections.abc import Callable
 from socket import socketpair
@@ -52,6 +53,8 @@ from airflow.dag_processing.processor import (
     DagFileParseRequest,
     DagFileParsingResult,
     DagFileProcessorProcess,
+    ToDagProcessor,
+    ToManager,
     _execute_dag_callbacks,
     _execute_email_callbacks,
     _execute_task_callbacks,
@@ -66,6 +69,8 @@ from airflow.sdk.execution_time import comms
 from airflow.sdk.execution_time.comms import (
     GetXCom,
     GetXComSequenceSlice,
+    ToSupervisor,
+    ToTask,
     XComResult,
     XComSequenceSliceResult,
 )
@@ -1510,3 +1515,82 @@ class TestExecuteEmailCallbacks:
         log.info.assert_called_once()
         info_call = log.info.call_args[0][0]
         assert "Email not sent - task configured with email_on_" in info_call
+
+
+class TestDagProcessingMessageTypes:
+    def test_message_types_in_dag_processor(self):
+        """
+        Test that ToSupervisor is a superset of ToManager and ToTask is a superset of ToDagProcessor.
+
+        This test ensures that when new message types are added to ToSupervisor or ToTask,
+        they are also properly handled in ToManager and ToDagProcessor.
+        """
+
+        def get_type_names(union_type):
+            union_args = typing.get_args(union_type.__args__[0])
+            return {arg.__name__ for arg in union_args}
+
+        supervisor_types = get_type_names(ToSupervisor)
+        task_types = get_type_names(ToTask)
+
+        manager_types = get_type_names(ToManager)
+        dag_processor_types = get_type_names(ToDagProcessor)
+
+        in_supervisor_but_not_in_manager = {
+            "DeferTask",
+            "DeleteXCom",
+            "GetAssetByName",
+            "GetAssetByUri",
+            "GetAssetEventByAsset",
+            "GetAssetEventByAssetAlias",
+            "GetDagRunState",
+            "GetDRCount",
+            "GetTaskRescheduleStartDate",
+            "GetTICount",
+            "GetTaskStates",
+            "RescheduleTask",
+            "RetryTask",
+            "SetRenderedFields",
+            "SetXCom",
+            "SkipDownstreamTasks",
+            "SucceedTask",
+            "ValidateInletsAndOutlets",
+            "TaskState",
+            "TriggerDagRun",
+            "ResendLoggingFD",
+            "CreateHITLDetailPayload",
+            "UpdateHITLDetail",
+            "GetHITLDetailResponse",
+        }
+
+        in_task_runner_but_not_in_dag_processing_process = {
+            "AssetResult",
+            "AssetEventsResult",
+            "DagRunStateResult",
+            "DRCount",
+            "SentFDs",
+            "StartupDetails",
+            "TaskRescheduleStartDate",
+            "TICount",
+            "TaskStatesResult",
+            "InactiveAssetsResult",
+            "CreateHITLDetailPayload",
+            "HITLDetailRequestResult",
+        }
+
+        supervisor_diff = supervisor_types - manager_types - in_supervisor_but_not_in_manager
+        task_diff = task_types - dag_processor_types - in_task_runner_but_not_in_dag_processing_process
+
+        assert not supervisor_diff, (
+            f"New message types in ToSupervisor not handled in ToManager: "
+            f"{len(supervisor_diff)} types found:\n"
+            + "\n".join(f"  - {t}" for t in sorted(supervisor_diff))
+            + "\n\nEither handle these types in ToManager or update in_supervisor_but_not_in_manager list."
+        )
+
+        assert not task_diff, (
+            f"New message types in ToTask not handled in ToDagProcessor: "
+            f"{len(task_diff)} types found:\n"
+            + "\n".join(f"  - {t}" for t in sorted(task_diff))
+            + "\n\nEither handle these types in ToDagProcessor or update in_task_runner_but_not_in_dag_processing_process list."
+        )


### PR DESCRIPTION


(cherry picked from commit 864b1782697bba631030c250ef9870645e34fa3c)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
