### PR TITLE
Fix(i18n dev tool): Preserve key structure when adding plural forms in add_keys

### DIFF
--- a/dev/i18n/check_translations_completeness.py
+++ b/dev/i18n/check_translations_completeness.py
@@ -563,8 +563,8 @@ def add_missing_translations(language: str, summary: dict[str, LocaleSummary], c
                     # Add all plural forms at the current level (not nested)
                     for suffix in suffixes:
                         plural_key = base + suffix
-                        key_name = plural_key.split(".")[-1]
                         if plural_key in missing_keys:
+                            key_name = k  # This preserves the original structure
                             if isinstance(v, dict):
                                 dst[key_name] = {}
                                 add_keys(v, dst[key_name], plural_key)
@@ -574,7 +574,7 @@ def add_missing_translations(language: str, summary: dict[str, LocaleSummary], c
                 if full_key in missing_keys:
                     if isinstance(v, dict):
                         dst[k] = {}
-                        add_keys(v, dst[k], full_key)
+                        add_keys(v, dst[k], k)
                     else:
                         dst[k] = f"TODO: translate: {v}"
                 else:


### PR DESCRIPTION
## Problem
In add_keys, plural keys (_one, _other, etc.) were added using `plural_key.split(".")[-1]` as `key_name`,
which caused the original dictionary structure to be lost.

<img width="2168" height="1397" alt="image" src="https://github.com/user-attachments/assets/a114774f-2f86-4616-a5df-b479725c17f0" />

## Changes
Set `key_name = k` to preserve the original key hierarchy

<img width="2056" height="1286" alt="image" src="https://github.com/user-attachments/assets/d6922f60-1dff-4660-af6a-38ded0d2787a" />


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
