### PR TITLE
Fix formatting in production-guide.rst

### DIFF
--- a/chart/docs/production-guide.rst
+++ b/chart/docs/production-guide.rst
@@ -157,7 +157,7 @@ Two additional Kubernetes Secret required to PgBouncer able to properly work in 
 
 .. code-block:: text
 
-  "{ external_database_host }" "{ external_database_pass }"
+  "{ external_database_username }" "{ external_database_pass }"
 
 The ``values.yaml`` should looks like this
 


### PR DESCRIPTION
Correct formatting in the helm chard production guide for the pgbouncer `users.txt` file. This is following the official [pgbouncer doc on auth file formats](https://www.pgbouncer.org/config.html#authentication-file-format).