### PR TITLE
SerDe: Check more strictly for pydantic model

### DIFF
--- a/airflow-core/src/airflow/serialization/typing.py
+++ b/airflow-core/src/airflow/serialization/typing.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+from dataclasses import is_dataclass
 from typing import Any
 
 
@@ -29,4 +30,9 @@ def is_pydantic_model(cls: Any) -> bool:
     """
     # __pydantic_fields__ is always present on Pydantic V2 models and is a dict[str, FieldInfo]
     # __pydantic_validator__ is an internal validator object, always set after model build
-    return hasattr(cls, "__pydantic_fields__") and hasattr(cls, "__pydantic_validator__")
+    # Check if it is not a dataclass to prevent detecting pydantic dataclasses as pydantic models
+    return (
+        hasattr(cls, "__pydantic_fields__")
+        and hasattr(cls, "__pydantic_validator__")
+        and not is_dataclass(cls)
+    )

--- a/airflow-core/tests/unit/serialization/test_serde.py
+++ b/airflow-core/tests/unit/serialization/test_serde.py
@@ -28,6 +28,7 @@ import attr
 import pytest
 from packaging import version
 from pydantic import BaseModel
+from pydantic.dataclasses import dataclass as pydantic_dataclass
 
 from airflow.sdk.definitions.asset import Asset
 from airflow.serialization.serde import (
@@ -193,6 +194,13 @@ class C:
         return None
 
 
+@pydantic_dataclass
+class PydanticDataclass:
+    __version__: ClassVar[int] = 1
+    a: int
+    b: str
+
+
 @pytest.mark.usefixtures("recalculate_patterns")
 class TestSerDe:
     def test_ser_primitives(self):
@@ -307,6 +315,17 @@ class TestSerDe:
 
         d = deserialize(e)
         assert i.x == getattr(d, "x", None)
+
+    def test_serder_pydantic_dataclass(self):
+        orig = PydanticDataclass(a=5, b="SerDe Pydantic Dataclass Test")
+        serialized = serialize(orig)
+        assert orig.__version__ == serialized[VERSION]
+        assert qualname(orig) == serialized[CLASSNAME]
+        assert serialized[DATA]
+
+        decoded = deserialize(serialized)
+        assert orig.a == getattr(decoded, "a", None)
+        assert orig.b == getattr(decoded, "b", None)
 
     @conf_vars(
         {

--- a/airflow-core/tests/unit/serialization/test_serde.py
+++ b/airflow-core/tests/unit/serialization/test_serde.py
@@ -28,7 +28,6 @@ import attr
 import pytest
 from packaging import version
 from pydantic import BaseModel
-from pydantic.dataclasses import dataclass as pydantic_dataclass
 
 from airflow.sdk.definitions.asset import Asset
 from airflow.serialization.serde import (
@@ -194,13 +193,6 @@ class C:
         return None
 
 
-@pydantic_dataclass
-class PydanticDataclass:
-    __version__: ClassVar[int] = 1
-    a: int
-    b: str
-
-
 @pytest.mark.usefixtures("recalculate_patterns")
 class TestSerDe:
     def test_ser_primitives(self):
@@ -315,17 +307,6 @@ class TestSerDe:
 
         d = deserialize(e)
         assert i.x == getattr(d, "x", None)
-
-    def test_serder_pydantic_dataclass(self):
-        orig = PydanticDataclass(a=5, b="SerDe Pydantic Dataclass Test")
-        serialized = serialize(orig)
-        assert orig.__version__ == serialized[VERSION]
-        assert qualname(orig) == serialized[CLASSNAME]
-        assert serialized[DATA]
-
-        decoded = deserialize(serialized)
-        assert orig.a == getattr(decoded, "a", None)
-        assert orig.b == getattr(decoded, "b", None)
 
     @conf_vars(
         {


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Ensure that pydantic dataclasses are not detected as pydantic models.

As discussed in #56739 check more strictly for pydantic models and avoid detecting pydantic dataclasses as pydantic models. 
Went with the suggestion of @amoghrajesh and used stdlib dataclasses to check that the detected model is not a dataclass. 

Fixes:  #56739

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
