### PR TITLE
Migrate retry handler in task SDK API client to use tenacity instead of retryhttp

### DIFF
--- a/task-sdk/pyproject.toml
+++ b/task-sdk/pyproject.toml
@@ -61,11 +61,7 @@ dependencies = [
     "python-dateutil>=2.7.0",
     "psutil>=6.1.0",
     "structlog>=25.4.0",
-    "retryhttp>=1.2.0,!=1.3.0",
     "greenback>=1.2.1",
-    # Requests is known to introduce breaking changes, so we pin it to a specific range
-    "requests>=2.31.0,<3",
-    "types-requests>=2.31.0",
     "tenacity>=8.3.0",
     # Start of shared timezones dependencies
     "pendulum>=3.1.0",

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -883,7 +883,7 @@ class Client(httpx.Client):
 
     @retry(
         retry=retry_if_exception(_should_retry_api_request),
-        stop=stop_after_attempt(7),
+        stop=stop_after_attempt(API_RETRIES),
         wait=_get_retry_wait_time,
         before_sleep=before_log(log, logging.WARNING),
         reraise=True,

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -199,21 +199,6 @@ class TestClient:
             assert response.status_code == 200
             assert len(responses) == 1
 
-    def test_retry_handling_overload(self):
-        with time_machine.travel("2023-01-01T00:00:00Z", tick=False):
-            responses: list[httpx.Response] = [
-                httpx.Response(
-                    429, text="I am really busy atm, please back-off", headers={"Retry-After": "37"}
-                ),
-                httpx.Response(200, json={"detail": "Recovered from error"}),
-                httpx.Response(400, json={"detail": "Should not get here"}),
-            ]
-            client = make_client_w_responses(responses)
-
-            response = client.get("http://error")
-            assert response.status_code == 200
-            assert len(responses) == 1
-
     def test_retry_handling_non_retry_error(self):
         with time_machine.travel("2023-01-01T00:00:00Z", tick=False):
             responses: list[httpx.Response] = [

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -25,12 +25,13 @@ from unittest import mock
 
 import httpx
 import pytest
+import time_machine
 import uuid6
 from task_sdk import make_client, make_client_w_dry_run, make_client_w_responses
 from uuid6 import uuid7
 
 from airflow.sdk import timezone
-from airflow.sdk.api.client import RemoteValidationError, ServerResponseError
+from airflow.sdk.api.client import Client, RemoteValidationError, ServerResponseError
 from airflow.sdk.api.datamodels._generated import (
     AssetEventsResponse,
     AssetResponse,
@@ -39,6 +40,7 @@ from airflow.sdk.api.datamodels._generated import (
     DagRunStateResponse,
     HITLDetailResponse,
     HITLUser,
+    TerminalTIState,
     VariableResponse,
     XComResponse,
 )
@@ -52,7 +54,6 @@ from airflow.sdk.execution_time.comms import (
     RescheduleTask,
     TaskRescheduleStartDate,
 )
-from airflow.utils.state import TerminalTIState
 
 if TYPE_CHECKING:
     from time_machine import TimeMachineFixture
@@ -98,6 +99,23 @@ class TestClient:
             make_client(httpx.MockTransport(handle_request))
 
         assert isinstance(err.value, FileNotFoundError)
+
+    @mock.patch("airflow.sdk.api.client.API_TIMEOUT", 60.0)
+    def test_timeout_configuration(self):
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(status_code=200)
+
+        client = make_client(httpx.MockTransport(handle_request))
+        assert client.timeout == httpx.Timeout(60.0)
+
+    def test_timeout_can_be_overridden(self):
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(status_code=200)
+
+        client = Client(
+            base_url="test://server", token="", transport=httpx.MockTransport(handle_request), timeout=120.0
+        )
+        assert client.timeout == httpx.Timeout(120.0)
 
     def test_error_parsing(self):
         responses = [
@@ -154,112 +172,72 @@ class TestClient:
         assert unpickled.response.status_code == 404
         assert unpickled.request.url == "http://error"
 
-    @mock.patch("time.sleep", return_value=None)
-    def test_retry_handling_unrecoverable_error(self, mock_sleep):
-        responses: list[httpx.Response] = [
-            *[httpx.Response(500, text="Internal Server Error")] * 6,
-            httpx.Response(200, json={"detail": "Recovered from error - but will fail before"}),
-            httpx.Response(400, json={"detail": "Should not get here"}),
-        ]
-        client = make_client_w_responses(responses)
+    def test_retry_handling_unrecoverable_error(self):
+        with time_machine.travel("2023-01-01T00:00:00Z", tick=False):
+            responses: list[httpx.Response] = [
+                *[httpx.Response(500, text="Internal Server Error")] * 6,
+                httpx.Response(200, json={"detail": "Recovered from error - but will fail before"}),
+                httpx.Response(400, json={"detail": "Should not get here"}),
+            ]
+            client = make_client_w_responses(responses)
 
-        with pytest.raises(httpx.HTTPStatusError) as err:
-            client.get("http://error")
-        assert not isinstance(err.value, ServerResponseError)
-        assert len(responses) == 3
-        assert mock_sleep.call_count == 4
+            with pytest.raises(httpx.HTTPStatusError) as err:
+                client.get("http://error")
+            assert not isinstance(err.value, ServerResponseError)
+            assert len(responses) == 3
 
-    @mock.patch("time.sleep", return_value=None)
-    def test_retry_handling_recovered(self, mock_sleep):
-        responses: list[httpx.Response] = [
-            *[httpx.Response(500, text="Internal Server Error")] * 2,
-            httpx.Response(200, json={"detail": "Recovered from error"}),
-            httpx.Response(400, json={"detail": "Should not get here"}),
-        ]
-        client = make_client_w_responses(responses)
+    def test_retry_handling_recovered(self):
+        with time_machine.travel("2023-01-01T00:00:00Z", tick=False):
+            responses: list[httpx.Response] = [
+                *[httpx.Response(500, text="Internal Server Error")] * 2,
+                httpx.Response(200, json={"detail": "Recovered from error"}),
+                httpx.Response(400, json={"detail": "Should not get here"}),
+            ]
+            client = make_client_w_responses(responses)
 
-        response = client.get("http://error")
-        assert response.status_code == 200
-        assert len(responses) == 1
-        assert mock_sleep.call_count == 2
+            response = client.get("http://error")
+            assert response.status_code == 200
+            assert len(responses) == 1
 
-    @mock.patch("time.sleep", return_value=None)
-    def test_retry_handling_overload(self, mock_sleep):
-        responses: list[httpx.Response] = [
-            httpx.Response(429, text="I am really busy atm, please back-off", headers={"Retry-After": "37"}),
-            httpx.Response(200, json={"detail": "Recovered from error"}),
-            httpx.Response(400, json={"detail": "Should not get here"}),
-        ]
-        client = make_client_w_responses(responses)
+    def test_retry_handling_overload(self):
+        with time_machine.travel("2023-01-01T00:00:00Z", tick=False):
+            responses: list[httpx.Response] = [
+                httpx.Response(
+                    429, text="I am really busy atm, please back-off", headers={"Retry-After": "37"}
+                ),
+                httpx.Response(200, json={"detail": "Recovered from error"}),
+                httpx.Response(400, json={"detail": "Should not get here"}),
+            ]
+            client = make_client_w_responses(responses)
 
-        response = client.get("http://error")
-        assert response.status_code == 200
-        assert len(responses) == 1
-        assert mock_sleep.call_count == 1
-        assert mock_sleep.call_args[0][0] == 37
+            response = client.get("http://error")
+            assert response.status_code == 200
+            assert len(responses) == 1
 
-    @mock.patch("time.sleep", return_value=None)
-    def test_retry_handling_non_retry_error(self, mock_sleep):
-        responses: list[httpx.Response] = [
-            httpx.Response(422, json={"detail": "Somehow this is a bad request"}),
-            httpx.Response(400, json={"detail": "Should not get here"}),
-        ]
-        client = make_client_w_responses(responses)
+    def test_retry_handling_non_retry_error(self):
+        with time_machine.travel("2023-01-01T00:00:00Z", tick=False):
+            responses: list[httpx.Response] = [
+                httpx.Response(422, json={"detail": "Somehow this is a bad request"}),
+                httpx.Response(400, json={"detail": "Should not get here"}),
+            ]
+            client = make_client_w_responses(responses)
 
-        with pytest.raises(ServerResponseError) as err:
-            client.get("http://error")
-        assert len(responses) == 1
-        assert mock_sleep.call_count == 0
-        assert err.value.args == ("Somehow this is a bad request",)
+            with pytest.raises(ServerResponseError) as err:
+                client.get("http://error")
+            assert len(responses) == 1
+            assert err.value.args == ("Somehow this is a bad request",)
 
-    @mock.patch("time.sleep", return_value=None)
-    def test_retry_handling_ok(self, mock_sleep):
-        responses: list[httpx.Response] = [
-            httpx.Response(200, json={"detail": "Recovered from error"}),
-            httpx.Response(400, json={"detail": "Should not get here"}),
-        ]
-        client = make_client_w_responses(responses)
+    def test_retry_handling_ok(self):
+        with time_machine.travel("2023-01-01T00:00:00Z", tick=False):
+            responses: list[httpx.Response] = [
+                httpx.Response(200, json={"detail": "Recovered from error"}),
+                httpx.Response(400, json={"detail": "Should not get here"}),
+            ]
+            client = make_client_w_responses(responses)
 
-        response = client.get("http://error")
-        assert response.status_code == 200
-        assert len(responses) == 1
-        assert mock_sleep.call_count == 0
-
-    @mock.patch("time.sleep", return_value=None)
-    def test_retry_handling_network_error(self, mock_sleep):
-        """Test that network errors trigger retry and eventually recover."""
-        call_count = 0
-
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            nonlocal call_count
-            call_count += 1
-            if call_count < 3:
-                raise httpx.NetworkError("Connection failed")
-            return httpx.Response(200, json={"detail": "Recovered from error"})
-
-        client = make_client(transport=httpx.MockTransport(handle_request))
-        response = client.get("http://error")
-        assert response.status_code == 200
-        assert call_count == 3
-        assert mock_sleep.call_count == 2
-
-    @mock.patch("time.sleep", return_value=None)
-    def test_retry_handling_timeout_error(self, mock_sleep):
-        """Test that timeout errors trigger retry and eventually recover."""
-        call_count = 0
-
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            nonlocal call_count
-            call_count += 1
-            if call_count < 3:
-                raise httpx.TimeoutException("Request timed out")
-            return httpx.Response(200, json={"detail": "Recovered from error"})
-
-        client = make_client(transport=httpx.MockTransport(handle_request))
-        response = client.get("http://error")
-        assert response.status_code == 200
-        assert call_count == 3
-        assert mock_sleep.call_count == 2
+            response = client.get("http://error")
+            assert response.status_code == 200
+            assert len(responses) == 1
 
     def test_token_renewal(self):
         responses: list[httpx.Response] = [
@@ -305,40 +283,40 @@ class TestTaskInstanceOperations:
     response parsing.
     """
 
-    @mock.patch("time.sleep", return_value=None)  # To have retries not slowing down tests
-    def test_task_instance_start(self, mock_sleep, make_ti_context):
-        # Simulate a successful response from the server that starts a task
-        ti_id = uuid6.uuid7()
-        start_date = "2024-10-31T12:00:00Z"
-        ti_context = make_ti_context(
-            start_date=start_date,
-            logical_date="2024-10-31T12:00:00Z",
-            run_type="manual",
-        )
+    def test_task_instance_start(self, make_ti_context):
+        with time_machine.travel("2023-01-01T00:00:00Z", tick=False):
+            # Simulate a successful response from the server that starts a task
+            ti_id = uuid6.uuid7()
+            start_date = "2024-10-31T12:00:00Z"
+            ti_context = make_ti_context(
+                start_date=start_date,
+                logical_date="2024-10-31T12:00:00Z",
+                run_type="manual",
+            )
 
-        # ...including a validation that retry really works
-        call_count = 0
+            # ...including a validation that retry really works
+            call_count = 0
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            nonlocal call_count
-            call_count += 1
-            if call_count < 3:
-                return httpx.Response(status_code=500, json={"detail": "Internal Server Error"})
-            if request.url.path == f"/task-instances/{ti_id}/run":
-                actual_body = json.loads(request.read())
-                assert actual_body["pid"] == 100
-                assert actual_body["start_date"] == start_date
-                assert actual_body["state"] == "running"
-                return httpx.Response(
-                    status_code=200,
-                    json=ti_context.model_dump(mode="json"),
-                )
-            return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+            def handle_request(request: httpx.Request) -> httpx.Response:
+                nonlocal call_count
+                call_count += 1
+                if call_count < 3:
+                    return httpx.Response(status_code=500, json={"detail": "Internal Server Error"})
+                if request.url.path == f"/task-instances/{ti_id}/run":
+                    actual_body = json.loads(request.read())
+                    assert actual_body["pid"] == 100
+                    assert actual_body["start_date"] == start_date
+                    assert actual_body["state"] == "running"
+                    return httpx.Response(
+                        status_code=200,
+                        json=ti_context.model_dump(mode="json"),
+                    )
+                return httpx.Response(status_code=400, json={"detail": "Bad Request"})
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
-        resp = client.task_instances.start(ti_id, 100, start_date)
-        assert resp == ti_context
-        assert call_count == 3
+            client = make_client(transport=httpx.MockTransport(handle_request))
+            resp = client.task_instances.start(ti_id, 100, start_date)
+            assert resp == ti_context
+            assert call_count == 3
 
     @pytest.mark.parametrize(
         "state", [state for state in TerminalTIState if state != TerminalTIState.SUCCESS]
@@ -581,31 +559,31 @@ class TestVariableOperations:
     response parsing.
     """
 
-    @mock.patch("time.sleep", return_value=None)  # To have retries not slowing down tests
-    def test_variable_get_success(self, mock_sleep):
-        # Simulate a successful response from the server with a variable
-        # ...including a validation that retry really works
-        call_count = 0
+    def test_variable_get_success(self):
+        with time_machine.travel("2023-01-01T00:00:00Z", tick=False):
+            # Simulate a successful response from the server with a variable
+            # ...including a validation that retry really works
+            call_count = 0
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            nonlocal call_count
-            call_count += 1
-            if call_count < 2:
-                return httpx.Response(status_code=500, json={"detail": "Internal Server Error"})
-            if request.url.path == "/variables/test_key":
-                return httpx.Response(
-                    status_code=200,
-                    json={"key": "test_key", "value": "test_value"},
-                )
-            return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+            def handle_request(request: httpx.Request) -> httpx.Response:
+                nonlocal call_count
+                call_count += 1
+                if call_count < 2:
+                    return httpx.Response(status_code=500, json={"detail": "Internal Server Error"})
+                if request.url.path == "/variables/test_key":
+                    return httpx.Response(
+                        status_code=200,
+                        json={"key": "test_key", "value": "test_value"},
+                    )
+                return httpx.Response(status_code=400, json={"detail": "Bad Request"})
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
-        result = client.variables.get(key="test_key")
+            client = make_client(transport=httpx.MockTransport(handle_request))
+            result = client.variables.get(key="test_key")
 
-        assert isinstance(result, VariableResponse)
-        assert result.key == "test_key"
-        assert result.value == "test_value"
-        assert call_count == 2
+            assert isinstance(result, VariableResponse)
+            assert result.key == "test_key"
+            assert result.value == "test_value"
+            assert call_count == 2
 
     def test_variable_not_found(self):
         # Simulate a 404 response from the server
@@ -630,26 +608,26 @@ class TestVariableOperations:
         assert resp.error == ErrorType.VARIABLE_NOT_FOUND
         assert resp.detail == {"key": "non_existent_var"}
 
-    @mock.patch("time.sleep", return_value=None)
-    def test_variable_get_500_error(self, mock_sleep):
-        # Simulate a response from the server returning a 500 error
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            if request.url.path == "/variables/test_key":
-                return httpx.Response(
-                    status_code=500,
-                    headers=[("content-Type", "application/json")],
-                    json={
-                        "reason": "internal_server_error",
-                        "message": "Internal Server Error",
-                    },
-                )
-            return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+    def test_variable_get_500_error(self):
+        with time_machine.travel("2023-01-01T00:00:00Z", tick=False):
+            # Simulate a response from the server returning a 500 error
+            def handle_request(request: httpx.Request) -> httpx.Response:
+                if request.url.path == "/variables/test_key":
+                    return httpx.Response(
+                        status_code=500,
+                        headers=[("content-Type", "application/json")],
+                        json={
+                            "reason": "internal_server_error",
+                            "message": "Internal Server Error",
+                        },
+                    )
+                return httpx.Response(status_code=400, json={"detail": "Bad Request"})
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
-        with pytest.raises(ServerResponseError):
-            client.variables.get(
-                key="test_key",
-            )
+            client = make_client(transport=httpx.MockTransport(handle_request))
+            with pytest.raises(ServerResponseError):
+                client.variables.get(
+                    key="test_key",
+                )
 
     def test_variable_set_success(self):
         # Simulate a successful response from the server when putting a variable
@@ -699,35 +677,35 @@ class TestXCOMOperations:
             pytest.param({"key": "test_key", "value": {"key2": "value2"}}, id="nested-dict-value"),
         ],
     )
-    @mock.patch("time.sleep", return_value=None)  # To have retries not slowing down tests
-    def test_xcom_get_success(self, mock_sleep, value):
-        # Simulate a successful response from the server when getting an xcom
-        # ...including a validation that retry really works
-        call_count = 0
+    def test_xcom_get_success(self, value):
+        with time_machine.travel("2023-01-01T00:00:00Z", tick=False):
+            # Simulate a successful response from the server when getting an xcom
+            # ...including a validation that retry really works
+            call_count = 0
 
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            nonlocal call_count
-            call_count += 1
-            if call_count < 3:
-                return httpx.Response(status_code=500, json={"detail": "Internal Server Error"})
-            if request.url.path == "/xcoms/dag_id/run_id/task_id/key":
-                return httpx.Response(
-                    status_code=201,
-                    json={"key": "test_key", "value": value},
-                )
-            return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+            def handle_request(request: httpx.Request) -> httpx.Response:
+                nonlocal call_count
+                call_count += 1
+                if call_count < 3:
+                    return httpx.Response(status_code=500, json={"detail": "Internal Server Error"})
+                if request.url.path == "/xcoms/dag_id/run_id/task_id/key":
+                    return httpx.Response(
+                        status_code=201,
+                        json={"key": "test_key", "value": value},
+                    )
+                return httpx.Response(status_code=400, json={"detail": "Bad Request"})
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
-        result = client.xcoms.get(
-            dag_id="dag_id",
-            run_id="run_id",
-            task_id="task_id",
-            key="key",
-        )
-        assert isinstance(result, XComResponse)
-        assert result.key == "test_key"
-        assert result.value == value
-        assert call_count == 3
+            client = make_client(transport=httpx.MockTransport(handle_request))
+            result = client.xcoms.get(
+                dag_id="dag_id",
+                run_id="run_id",
+                task_id="task_id",
+                key="key",
+            )
+            assert isinstance(result, XComResponse)
+            assert result.key == "test_key"
+            assert result.value == value
+            assert call_count == 3
 
     def test_xcom_get_success_with_map_index(self):
         # Simulate a successful response from the server when getting an xcom with map_index passed
@@ -778,29 +756,29 @@ class TestXCOMOperations:
         assert result.key == "test_key"
         assert result.value == "test_value"
 
-    @mock.patch("time.sleep", return_value=None)
-    def test_xcom_get_500_error(self, mock_sleep):
-        # Simulate a successful response from the server returning a 500 error
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            if request.url.path == "/xcoms/dag_id/run_id/task_id/key":
-                return httpx.Response(
-                    status_code=500,
-                    headers=[("content-Type", "application/json")],
-                    json={
-                        "reason": "invalid_format",
-                        "message": "XCom value is not a valid JSON",
-                    },
-                )
-            return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+    def test_xcom_get_500_error(self):
+        with time_machine.travel("2023-01-01T00:00:00Z", tick=False):
+            # Simulate a successful response from the server returning a 500 error
+            def handle_request(request: httpx.Request) -> httpx.Response:
+                if request.url.path == "/xcoms/dag_id/run_id/task_id/key":
+                    return httpx.Response(
+                        status_code=500,
+                        headers=[("content-Type", "application/json")],
+                        json={
+                            "reason": "invalid_format",
+                            "message": "XCom value is not a valid JSON",
+                        },
+                    )
+                return httpx.Response(status_code=400, json={"detail": "Bad Request"})
 
-        client = make_client(transport=httpx.MockTransport(handle_request))
-        with pytest.raises(ServerResponseError):
-            client.xcoms.get(
-                dag_id="dag_id",
-                run_id="run_id",
-                task_id="task_id",
-                key="key",
-            )
+            client = make_client(transport=httpx.MockTransport(handle_request))
+            with pytest.raises(ServerResponseError):
+                client.xcoms.get(
+                    dag_id="dag_id",
+                    run_id="run_id",
+                    task_id="task_id",
+                    key="key",
+                )
 
     @pytest.mark.parametrize(
         "values",


### PR DESCRIPTION

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Motivation

The task SDK uses httpx for HTTP operations but depends on `retryhttp` for retry logic. This brings in the entire `requests` library as a transitive dependency, even though it's never actually used. 

Memray reports also show some stats which can be improved.


For `import retryhttp`:

<img width="2557" height="883" alt="image" src="https://github.com/user-attachments/assets/e7f7f1d3-c9a8-46db-9052-6deb626cab32" />

<img width="1141" height="624" alt="image" src="https://github.com/user-attachments/assets/1ddad4b9-790c-4020-a41c-425b966ab3b1" />

<img width="1141" height="624" alt="image" src="https://github.com/user-attachments/assets/df6d5f18-6871-4314-ab92-ca9c5a7eb483" />

This is because retryhttp unconditionally imports both httpx and requests, even though we only use httpx.

The retry handler works fine, but it's unnecessary bloat. We're already using tenacity in sdk client, and we only use httpx, not requests, so might as well use tenacity for better memory results and reduced footprint.


## Alternatives Considered

### 1. Switch to stamina
- Modern, opinionated wrapper around tenacity
- Better ergonomics and async support

### 2. Use pure tenacity
- Zero new dependencies (tenacity already used)
- Maximum memory and size savings
- Full control over retry behavior

Went ahead and selected tenacity because it is a battle tested library already present in task sdk and is used often and there is no need for a new library when the benefits of memory footprint (Net savings: ~444KB vs ~544KB with pure tenacity) aren't significantly high.


## Changes of note

Migrated task SDK to use tenacity instead of retryhttp while maintaining total parity with what retryhttp offered. A lot of code thats written is inspired by code of retryhttp!

Tenacity is a generic retry library - it doesn't know anything about HTTP. It just retries when you tell it to, so to maintain parity, some wrappers and helpers had to be written.

**`_should_retry_api_request(exception)`**

This function determines which errors should trigger a retry. It replicates retryhttp's behavior of retrying on:
- Server errors (5xx status codes)
- Network failures (httpx.NetworkError)
- Timeouts (httpx.TimeoutException)

But NOT retrying on client errors like 404 or 401, which would be pointless.

NOTE: Behaviour for 429 status code (rate limit) has been removed because the API server doesn't support rate limiting as of now, and we can add that support to the client as we need it or as ready.


### How parity was maintained

The original retryhttp decorator looked like this:
```python
@retry(
    max_attempt_number=API_RETRIES,
    wait_server_errors=_default_wait,
    wait_network_errors=_default_wait,
    wait_timeouts=_default_wait,
    wait_rate_limited=wait_retry_after(fallback=_default_wait),
    before_sleep=before_log(log, logging.WARNING),
)
```

Each of those parameters mapped to specific HTTP behaviors. Our new decorator with tenacity:
```python
@retry(
    retry=retry_if_exception(_should_retry_api_request),
    stop=stop_after_attempt(API_RETRIES),
    wait=_get_retry_wait_time,
    before_sleep=before_log(log, logging.WARNING),
    reraise=True,
)
```

Removed from dependencies:
- `retryhttp`
- `requests`
- `types-requests`

## How this was tested

### Unit tests
All existing retry tests pass without modification:
- Server error recovery (500 errors with retry)
- Non-retryable errors (422 validation errors)
- Max retry attempts exhaustion

### Integration testing
Ran the task SDK against a live API server and killed the server mid request. The client correctly retried with exponential backoff and recovered when the server came back up, confirming network error handling works as expected.

<img width="1665" height="152" alt="image" src="https://github.com/user-attachments/assets/8a78fd22-ecfc-4c39-829a-eba0c62dfe65" />


## Benefits

### Memray results

Importing `import tenacity` and showing difference:

Flamegraph (now):
<img width="2559" height="833" alt="image" src="https://github.com/user-attachments/assets/351e231b-53e2-4817-95f4-5092b800e3e6" />


Flamegraph (earlier):

<img width="2557" height="883" alt="image" src="https://github.com/user-attachments/assets/e7f7f1d3-c9a8-46db-9052-6deb626cab32" />



Memory Graph (now):

<img width="1142" height="631" alt="image" src="https://github.com/user-attachments/assets/b5c0d18d-f5d4-4337-ac22-2d3d881db1bc" />


Memory Graph (before):

<img width="1141" height="624" alt="image" src="https://github.com/user-attachments/assets/1ddad4b9-790c-4020-a41c-425b966ab3b1" />

Stats (now):

<img width="1142" height="631" alt="image" src="https://github.com/user-attachments/assets/9bf0afc1-d17f-4557-839c-97bd0295dc3b" />


Stats (earlier):

<img width="1141" height="624" alt="image" src="https://github.com/user-attachments/assets/df6d5f18-6871-4314-ab92-ca9c5a7eb483" />


### Package size

INSTALLED DEPENDENCIES SIZE:
   Removed packages:
     • retryhttp ..................... 40K
     • requests ..................... 228K
     • urllib3 (dep of requests) .... 488K
     • charset_normalizer (dep) ..... 808K
     • idna (dep) ................... 352K
     • certifi (dep) ................ 296K
     ─────────────────────────────────────
     TOTAL DISK SAVINGS: ........... ~2.2 MB

Workers do not need to have these dependencies anymore.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
