### PR TITLE
Fix DAG processor crash with pre-import module optimization

### DIFF
--- a/airflow-core/src/airflow/dag_processing/processor.py
+++ b/airflow-core/src/airflow/dag_processing/processor.py
@@ -160,7 +160,7 @@ def _pre_import_airflow_modules(file_path: str, log: FilteringBoundLogger) -> No
     for module in iter_airflow_imports(file_path):
         try:
             importlib.import_module(module)
-        except ModuleNotFoundError as e:
+        except Exception as e:
             log.warning("Error when trying to pre-import module '%s' found in %s: %s", module, file_path, e)
 
 


### PR DESCRIPTION
The DAG processor would crash when `parsing_pre_import_modules=True` and a DAG imported a provider with missing optional dependencies. This occurred because providers raise `AirflowOptionalProviderFeatureException` for missing dependencies, but the pre-import code only caught `ModuleNotFoundError`.

This was a regression from Airflow 2.x where the original implementation correctly caught all exceptions. The pre-import optimization is non-critical and should never crash the DAG processor - any import errors are properly handled later during actual DAG parsing.

Airflow 2 code:

https://github.com/apache/airflow/blob/2.11.0/airflow/dag_processing/processor.py#L222-L242
https://github.com/apache/airflow/blob/2.11.0/airflow/dag_processing/processor.py#L393-L406

Specifically this line from 2.11.0
https://github.com/apache/airflow/blob/d9ed7b94d033dc61ee1c05aafb9f1c1f7b82cfb2/airflow/dag_processing/processor.py#L393-L406

Fixes #56755

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
