### PR TITLE
Update duration format to show milliseconds

### DIFF
--- a/airflow-core/src/airflow/ui/src/utils/datetimeUtils.test.ts
+++ b/airflow-core/src/airflow/ui/src/utils/datetimeUtils.test.ts
@@ -21,11 +21,11 @@ import { describe, it, expect } from "vitest";
 import { getDuration, renderDuration } from "./datetimeUtils";
 
 describe("getDuration", () => {
-  it("handles durations less than 10 seconds", () => {
+  it("handles durations less than 60 seconds", () => {
     const start = "2024-03-14T10:00:00.000Z";
-    const end = "2024-03-14T10:00:05.500Z";
+    const end = "2024-03-14T10:00:05.5111111Z";
 
-    expect(getDuration(start, end)).toBe("5.50s");
+    expect(getDuration(start, end)).toBe("00:00:05.511");
   });
 
   it("handles durations spanning multiple days", () => {

--- a/airflow-core/src/airflow/ui/src/utils/datetimeUtils.ts
+++ b/airflow-core/src/airflow/ui/src/utils/datetimeUtils.ts
@@ -31,9 +31,9 @@ export const renderDuration = (durationSeconds: number | null | undefined): stri
     return undefined;
   }
 
-  // If under 10 seconds, render as 9s
-  if (durationSeconds < 10) {
-    return `${durationSeconds.toFixed(2)}s`;
+  // If under 60 seconds, render milliseconds
+  if (durationSeconds < 60) {
+    return dayjs.duration(Number(durationSeconds.toFixed(3)), "seconds").format("HH:mm:ss.SSS");
   }
 
   // If under 1 day, render as HH:mm:ss otherwise include the number of days


### PR DESCRIPTION
Make the duration formats more consistent. Instead of making our own sub-10s format. When a duration is under a minute, we will include the milliseconds too.

<img width="154" height="959" alt="Screenshot 2025-10-17 at 10 45 34 AM" src="https://github.com/user-attachments/assets/271825f4-a86a-4896-bb13-ee7ecb162e85" />


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
