### PR TITLE
run fastapi app within the parent process in dev mode

### DIFF
--- a/airflow-core/src/airflow/cli/commands/api_server_command.py
+++ b/airflow-core/src/airflow/cli/commands/api_server_command.py
@@ -149,6 +149,7 @@ def api_server(args: Namespace):
             proxy_headers=args.proxy_headers,
             command="dev",
         )
+        return
 
     run_command_with_daemon_option(
         args=args,

--- a/airflow-core/src/airflow/cli/commands/api_server_command.py
+++ b/airflow-core/src/airflow/cli/commands/api_server_command.py
@@ -139,23 +139,16 @@ def api_server(args: Namespace):
     if args.dev:
         print(f"Starting the API server on port {args.port} and host {args.host} in development mode.")
         log.warning("Running in dev mode, ignoring uvicorn args")
-        from uvicorn import Config, Server
+        from fastapi_cli.cli import _run
 
-        from airflow.api_fastapi.main import app
-
-        log_config = args.log_config if args.log_config and args.log_config != "-" else None
-
-        config = Config(
-            app,
+        _run(
+            entrypoint="airflow.api_fastapi.main:app",
             port=args.port,
             host=args.host,
             reload=True,
             proxy_headers=args.proxy_headers,
-            log_config=log_config,
+            command="dev",
         )
-        server = Server(config)
-        server.run()
-        return
 
     run_command_with_daemon_option(
         args=args,

--- a/airflow-core/src/airflow/cli/commands/api_server_command.py
+++ b/airflow-core/src/airflow/cli/commands/api_server_command.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import logging
 import os
-import subprocess
 import sys
 import textwrap
 from collections.abc import Callable
@@ -140,40 +139,34 @@ def api_server(args: Namespace):
     if args.dev:
         print(f"Starting the API server on port {args.port} and host {args.host} in development mode.")
         log.warning("Running in dev mode, ignoring uvicorn args")
+        from uvicorn import Config, Server
 
-        run_args = [
-            "fastapi",
-            "dev",
-            "airflow-core/src/airflow/api_fastapi/main.py",
-            "--port",
-            str(args.port),
-            "--host",
-            str(args.host),
-        ]
+        from airflow.api_fastapi.main import app
 
-        if args.proxy_headers:
-            run_args.append("--proxy-headers")
+        log_config = args.log_config if args.log_config and args.log_config != "-" else None
 
-        if args.log_config and args.log_config != "-":
-            run_args.extend(["--log-config", args.log_config])
-
-        with subprocess.Popen(
-            run_args,
-            close_fds=True,
-        ) as process:
-            process.wait()
-    else:
-        run_command_with_daemon_option(
-            args=args,
-            process_name="api_server",
-            callback=lambda: _run_api_server(
-                args=args,
-                apps=apps,
-                num_workers=num_workers,
-                worker_timeout=worker_timeout,
-                proxy_headers=proxy_headers,
-            ),
+        config = Config(
+            app,
+            port=args.port,
+            host=args.host,
+            reload=True,
+            proxy_headers=args.proxy_headers,
+            log_config=log_config,
         )
+        server = Server(config)
+        server.run()
+        return
+    run_command_with_daemon_option(
+        args=args,
+        process_name="api_server",
+        callback=lambda: _run_api_server(
+            args=args,
+            apps=apps,
+            num_workers=num_workers,
+            worker_timeout=worker_timeout,
+            proxy_headers=proxy_headers,
+        ),
+    )
 
 
 def _get_ssl_cert_and_key_filepaths(cli_arguments) -> tuple[str | None, str | None]:

--- a/airflow-core/src/airflow/cli/commands/api_server_command.py
+++ b/airflow-core/src/airflow/cli/commands/api_server_command.py
@@ -156,6 +156,7 @@ def api_server(args: Namespace):
         server = Server(config)
         server.run()
         return
+
     run_command_with_daemon_option(
         args=args,
         process_name="api_server",

--- a/airflow-core/tests/unit/cli/commands/test_api_server_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_api_server_command.py
@@ -35,33 +35,14 @@ class TestCliApiServer(_CommonCLIUvicornTestClass):
     main_process_regexp = r"airflow api-server"
 
     @pytest.mark.parametrize(
-        "args, expected_command",
+        "args",
         [
             pytest.param(
                 ["api-server", "--port", "9092", "--host", "somehost", "--dev"],
-                [
-                    "fastapi",
-                    "dev",
-                    "airflow-core/src/airflow/api_fastapi/main.py",
-                    "--port",
-                    "9092",
-                    "--host",
-                    "somehost",
-                ],
                 id="dev mode with port and host",
             ),
             pytest.param(
                 ["api-server", "--port", "9092", "--host", "somehost", "--dev", "--proxy-headers"],
-                [
-                    "fastapi",
-                    "dev",
-                    "airflow-core/src/airflow/api_fastapi/main.py",
-                    "--port",
-                    "9092",
-                    "--host",
-                    "somehost",
-                    "--proxy-headers",
-                ],
                 id="dev mode with port, host and proxy headers",
             ),
             pytest.param(
@@ -75,31 +56,24 @@ class TestCliApiServer(_CommonCLIUvicornTestClass):
                     "--log-config",
                     "my_log_config.yaml",
                 ],
-                [
-                    "fastapi",
-                    "dev",
-                    "airflow-core/src/airflow/api_fastapi/main.py",
-                    "--port",
-                    "9092",
-                    "--host",
-                    "somehost",
-                    "--log-config",
-                    "my_log_config.yaml",
-                ],
                 id="dev mode with port, host and log config",
             ),
         ],
     )
-    def test_dev_arg(self, args, expected_command):
+    def test_dev_arg(self, args):
         with (
-            mock.patch("subprocess.Popen") as Popen,
+            mock.patch("fastapi_cli.cli._run") as mock_run,
         ):
             args = self.parser.parse_args(args)
             api_server_command.api_server(args)
 
-            Popen.assert_called_with(
-                expected_command,
-                close_fds=True,
+            mock_run.assert_called_with(
+                entrypoint="airflow.api_fastapi.main:app",
+                port=args.port,
+                host=args.host,
+                reload=True,
+                proxy_headers=args.proxy_headers,
+                command="dev",
             )
 
     @pytest.mark.parametrize(
@@ -137,7 +111,7 @@ class TestCliApiServer(_CommonCLIUvicornTestClass):
         with (
             mock.patch("os.environ", autospec=True) as mock_environ,
             mock.patch("uvicorn.run"),
-            mock.patch("subprocess.Popen"),
+            mock.patch("fastapi_cli.cli._run"),
         ):
             # Mock the environment variable with initial value or None
             mock_environ.get.return_value = original_env


### PR DESCRIPTION
As of now, in dev mode, we run fastapi app in a subprocess. This does not allow us to continue debugging the api-server in IDE. 

Subprocess here felt unnecessary as the sole purpose of the `airflow api-server` is to run the fastapi app. Instead, we can directly run with uvicorn.


According to [fastapi docs](https://fastapi.tiangolo.com/fastapi-cli/#fastapi-dev), `fastapi dev` will just run uvicorn with auto-reload on. so, we'll just initialize the server with auto-reload ON and run it.