### PR TITLE
Add retry for e2e test_remote_logging_s3

### DIFF
--- a/airflow-e2e-tests/tests/airflow_e2e_tests/remote_log_tests/test_remote_logging.py
+++ b/airflow-e2e-tests/tests/airflow_e2e_tests/remote_log_tests/test_remote_logging.py
@@ -92,7 +92,7 @@ class TestRemoteLogging:
         if len(response["Contents"]) < self.task_count:
             pytest.fail(
                 f"Expected at least {self.task_count} log files in S3 bucket {bucket_name}, "
-                f"but found {len(response['Contents'])}."
+                f"but found {len(response['Contents'])} objects: {[obj.get('Key') for obj in response.get('Contents', [])]}"
             )
 
         # s3 key format: dag_id=example_xcom/run_id=manual__2025-09-29T23:32:09.457215+00:00/task_id=bash_pull/attempt=1.log

--- a/airflow-e2e-tests/tests/airflow_e2e_tests/remote_log_tests/test_remote_logging.py
+++ b/airflow-e2e-tests/tests/airflow_e2e_tests/remote_log_tests/test_remote_logging.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import time
 from datetime import datetime, timezone
 
 import boto3
@@ -27,6 +28,9 @@ from airflow_e2e_tests.e2e_test_utils.clients import AirflowClient
 class TestRemoteLogging:
     airflow_client = AirflowClient()
     dag_id = "example_xcom_test"
+    task_count = 6
+    retry_delay_seconds = 1
+    max_retries = 5
 
     def test_dag_unpause(self):
         self.airflow_client.un_pause_dag(
@@ -72,8 +76,24 @@ class TestRemoteLogging:
         bucket_name = "test-airflow-logs"
         response = s3_client.list_objects_v2(Bucket=bucket_name)
 
+        # Wait for logs to be available in S3
+        for _ in range(self.max_retries):
+            response = s3_client.list_objects_v2(Bucket=bucket_name)
+            contents = response.get("Contents", [])
+            if len(contents) >= self.task_count:
+                break
+
+            print(f"Expected at least {self.task_count} log files, found {len(contents)}. Retrying...")
+            time.sleep(self.retry_delay_seconds)
+
         if "Contents" not in response:
             pytest.fail("No objects found in S3 bucket %s", bucket_name)
+
+        if len(response["Contents"]) < self.task_count:
+            pytest.fail(
+                f"Expected at least {self.task_count} log files in S3 bucket {bucket_name}, "
+                f"but found {len(response['Contents'])}."
+            )
 
         # s3 key format: dag_id=example_xcom/run_id=manual__2025-09-29T23:32:09.457215+00:00/task_id=bash_pull/attempt=1.log
 

--- a/airflow-e2e-tests/tests/airflow_e2e_tests/remote_log_tests/test_remote_logging.py
+++ b/airflow-e2e-tests/tests/airflow_e2e_tests/remote_log_tests/test_remote_logging.py
@@ -29,7 +29,7 @@ class TestRemoteLogging:
     airflow_client = AirflowClient()
     dag_id = "example_xcom_test"
     task_count = 6
-    retry_delay_seconds = 1
+    retry_interval_in_seconds = 1
     max_retries = 5
 
     def test_dag_unpause(self):
@@ -84,7 +84,7 @@ class TestRemoteLogging:
                 break
 
             print(f"Expected at least {self.task_count} log files, found {len(contents)}. Retrying...")
-            time.sleep(self.retry_delay_seconds)
+            time.sleep(self.retry_interval_in_seconds)
 
         if "Contents" not in response:
             pytest.fail("No objects found in S3 bucket %s", bucket_name)


### PR DESCRIPTION

related: #56191

The `test_remote_logging` e2e test is flaky because some of the logs are not yet uploaded to S3 before we validating log file names.

Example fail run: https://github.com/apache/airflow/actions/runs/18613327530/job/53075269841?pr=55962
```
=========================== short test summary info ============================
FAILED tests/airflow_e2e_tests/remote_log_tests/test_remote_logging.py::TestRemoteLogging::test_remote_logging_s3 - AssertionError: None of the log sources ['/opt/airflow/logs/dag_id=example_xcom_test/run_id=manual__2025-10-18T09:13:28.389807+00:00/task_id=bash_pull/attempt=1.log'] were found in S3 bucket logs ['s3://test-airflow-logs/dag_id=example_xcom_test/run_id=manual__2025-10-18T09:13:28.389807+00:00/task_id=bash_push/attempt=1.log', 's3://test-airflow-logs/dag_id=example_xcom_test/run_id=manual__2025-10-18T09:13:28.389807+00:00/task_id=pull_value_from_bash_push/attempt=1.log', 's3://test-airflow-logs/dag_id=example_xcom_test/run_id=manual__2025-10-18T09:13:28.389807+00:00/task_id=puller/attempt=1.log', 's3://test-airflow-logs/dag_id=example_xcom_test/run_id=manual__2025-10-18T09:13:28.389807+00:00/task_id=push/attempt=1.log', 's3://test-airflow-logs/dag_id=example_xcom_test/run_id=manual__2025-10-18T09:13:28.389807+00:00/task_id=push_by_returning/attempt=1.log']
assert False
 +  where False = any(<generator object TestRemoteLogging.test_remote_logging_s3.<locals>.<genexpr> at 0x7f6276c88dd0>)
=================== 1 failed, 1 passed, 1 warning in 46.40s ====================
```

## What

Add a retry mechanism to verify that a minimum number of TaskInstance logs are present in S3 before proceeding with validation.