### PR TITLE
use the term exception instead of error for FastAPI related methods

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/app.py
+++ b/airflow-core/src/airflow/api_fastapi/app.py
@@ -27,7 +27,7 @@ from starlette.routing import Mount
 from airflow.api_fastapi.common.dagbag import create_dag_bag
 from airflow.api_fastapi.core_api.app import (
     init_config,
-    init_error_handlers,
+    init_exception_handlers,
     init_flask_plugins,
     init_middlewares,
     init_ui_plugins,
@@ -89,7 +89,7 @@ def create_app(apps: str = "all") -> FastAPI:
     if "execution" in apps_list or "all" in apps_list:
         task_exec_api_app = create_task_execution_api_app()
         task_exec_api_app.state.dag_bag = dag_bag
-        init_error_handlers(task_exec_api_app)
+        init_exception_handlers(task_exec_api_app)
         app.mount("/execution", task_exec_api_app)
 
     if "core" in apps_list or "all" in apps_list:
@@ -99,7 +99,7 @@ def create_app(apps: str = "all") -> FastAPI:
         init_flask_plugins(app)
         init_ui_plugins(app)
         init_views(app)  # Core views need to be the last routes added - it has a catch all route
-        init_error_handlers(app)
+        init_exception_handlers(app)
         init_middlewares(app)
 
     init_config(app)

--- a/airflow-core/src/airflow/api_fastapi/common/exceptions.py
+++ b/airflow-core/src/airflow/api_fastapi/common/exceptions.py
@@ -35,8 +35,8 @@ T = TypeVar("T", bound=Exception)
 log = logging.getLogger(__name__)
 
 
-class BaseErrorHandler(Generic[T], ABC):
-    """Base class for error handlers."""
+class BaseExceptionHandler(Generic[T], ABC):
+    """Base class for exception handlers."""
 
     def __init__(self, exception_cls: T) -> None:
         self.exception_cls = exception_cls
@@ -53,7 +53,7 @@ class _DatabaseDialect(Enum):
     POSTGRES = "postgres"
 
 
-class _UniqueConstraintErrorHandler(BaseErrorHandler[IntegrityError]):
+class _UniqueConstraintExceptionHandler(BaseExceptionHandler[IntegrityError]):
     """Exception raised when trying to insert a duplicate value in a unique column."""
 
     unique_constraint_error_prefix_dict: dict[_DatabaseDialect, str] = {
@@ -104,8 +104,8 @@ class _UniqueConstraintErrorHandler(BaseErrorHandler[IntegrityError]):
         return False
 
 
-class DagErrorHandler(BaseErrorHandler[DeserializationError]):
-    """Handler for Dag related errors."""
+class DagExceptionHandler(BaseExceptionHandler[DeserializationError]):
+    """Handler for Dag related exceptions."""
 
     def __init__(self):
         super().__init__(DeserializationError)
@@ -118,4 +118,4 @@ class DagErrorHandler(BaseErrorHandler[DeserializationError]):
         )
 
 
-ERROR_HANDLERS = [_UniqueConstraintErrorHandler(), DagErrorHandler()]
+EXCEPTION_HANDLERS = [_UniqueConstraintExceptionHandler(), DagExceptionHandler()]

--- a/airflow-core/src/airflow/api_fastapi/core_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/app.py
@@ -174,10 +174,10 @@ def init_config(app: FastAPI) -> None:
     app.state.secret_key = get_signing_key("api", "secret_key")
 
 
-def init_error_handlers(app: FastAPI) -> None:
-    from airflow.api_fastapi.common.exceptions import ERROR_HANDLERS
+def init_exception_handlers(app: FastAPI) -> None:
+    from airflow.api_fastapi.common.exceptions import EXCEPTION_HANDLERS
 
-    for handler in ERROR_HANDLERS:
+    for handler in EXCEPTION_HANDLERS:
         app.add_exception_handler(handler.exception_cls, handler.exception_handler)
 
 


### PR DESCRIPTION
I think, using the term "exception" is consistent with what FastAPI, Starlette uses. "error" seems to be used in fab related methods. 

But,We can just choose it to be "error" and just close this PR