### PR TITLE
Properly name the regular/remote leg tests

### DIFF
--- a/.github/workflows/additional-prod-image-tests.yml
+++ b/.github/workflows/additional-prod-image-tests.yml
@@ -196,6 +196,7 @@ jobs:
     name: "Test e2e integration tests with PROD image"
     uses: ./.github/workflows/airflow-e2e-tests.yml
     with:
+      workflow-name: "Regular e2e test"
       runners: ${{ inputs.runners }}
       platform: ${{ inputs.platform }}
       default-python-version: "${{ inputs.default-python-version }}"
@@ -205,6 +206,7 @@ jobs:
     name: "Remote logging tests with PROD image"
     uses: ./.github/workflows/airflow-e2e-tests.yml
     with:
+      workflow-name: "Remote logging e2e test"
       runners: ${{ inputs.runners }}
       platform: ${{ inputs.platform }}
       default-python-version: "${{ inputs.default-python-version }}"

--- a/.github/workflows/airflow-e2e-tests.yml
+++ b/.github/workflows/airflow-e2e-tests.yml
@@ -24,6 +24,10 @@ permissions:
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
     inputs:
+      workflow-name:
+        description: "Name of the test"
+        type: string
+        required: true
       runners:
         description: "The array of labels (in json form) determining runners."
         type: string
@@ -51,6 +55,10 @@ on:  # yamllint disable-line rule:truthy
 
   workflow_call:
     inputs:
+      workflow-name:
+        description: "Name of the test"
+        type: string
+        required: true
       runners:
         description: "The array of labels (in json form) determining runners."
         required: true
@@ -79,7 +87,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   test-e2e-integration-tests:
     timeout-minutes: 60
-    name: "Test e2e integration tests with PROD image"
+    name: ${{ inputs.name }}
     runs-on: ${{ fromJSON(inputs.runners) }}
     env:
       PYTHON_MAJOR_MINOR_VERSION: "${{ inputs.default-python-version }}"


### PR DESCRIPTION
GitHub action uses name derived from the composit workflow not from running workflow, so we must pass the name of tests down as input parameter to be able to distinguish the two test types by name.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
