### PR TITLE
Fix mypy type errors in Teradata provider for SQLAlchemy 2 upgrade

### DIFF
--- a/providers/teradata/src/airflow/providers/teradata/hooks/teradata.py
+++ b/providers/teradata/src/airflow/providers/teradata/hooks/teradata.py
@@ -212,7 +212,7 @@ class TeradataHook(DbApiHook):
             password=connection.password,
             host=connection.host,
             port=connection.port,
-            database=connection.schema,
+            database=connection.schema if connection.schema else None,
         )
 
     def get_uri(self) -> str:

--- a/providers/teradata/src/airflow/providers/teradata/hooks/teradata.py
+++ b/providers/teradata/src/airflow/providers/teradata/hooks/teradata.py
@@ -206,18 +206,14 @@ class TeradataHook(DbApiHook):
         connection = self.get_connection(self.get_conn_id())
         # Adding only teradatasqlalchemy supported connection parameters.
         # https://pypi.org/project/teradatasqlalchemy/#ConnectionParameters
-        url_kwargs = {
-            "drivername": "teradatasql",
-            "username": connection.login,
-            "password": connection.password,
-            "host": connection.host,
-            "port": connection.port,
-        }
-
-        if connection.schema:  # Only include database if it's not None or empty
-            url_kwargs["database"] = connection.schema
-
-        return URL.create(**url_kwargs)
+        return URL.create(
+            drivername="teradatasql",
+            username=connection.login,
+            password=connection.password,
+            host=connection.host,
+            port=connection.port,
+            database=connection.schema,
+        )
 
     def get_uri(self) -> str:
         """Override DbApiHook get_uri method for get_sqlalchemy_engine()."""


### PR DESCRIPTION
## Related issue

part of #56738

  ## Changes
  - Convert dictionary unpacking to direct parameter passing
  - Follows the same pattern used in postgres, vertica, ydb, and other providers

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
