### PR TITLE
use AIRFLOW__CELERY__POOL=solo when debugging celery-worker

### DIFF
--- a/scripts/in_container/bin/run_tmux
+++ b/scripts/in_container/bin/run_tmux
@@ -24,6 +24,10 @@ if [[ ${BACKEND} != "sqlite"  ]]; then
     export AIRFLOW__CORE__EXECUTOR=${AIRFLOW__CORE__EXECUTOR:-LocalExecutor}
 fi
 
+# If debugging the Celery worker, default Celery pool to solo unless overridden
+if [[ ${BREEZE_DEBUG_CELERY_WORKER} == "true" ]]; then
+    export AIRFLOW__CELERY__POOL=${AIRFLOW__CELERY__POOL:-solo}
+fi
 
 export TMUX_TMPDIR=~/.tmux/tmp
 if [ -e ~/.tmux/tmp ]; then
@@ -110,6 +114,7 @@ if [[ ${INTEGRATION_CELERY} == "true" ]]; then
     tmux split-window -h
     if [[ ${BREEZE_DEBUG_CELERY_WORKER} == "true" ]]; then
         tmux set-option -p @airflow_component "Celery Worker(Debug Mode)"
+
         tmux send-keys "debugpy --listen 0.0.0.0:${BREEZE_DEBUG_CELERY_WORKER_PORT} --wait-for-client -m airflow celery worker" C-m
     else
     tmux set-option -p @airflow_component "Celery Worker"

--- a/scripts/in_container/bin/run_tmux
+++ b/scripts/in_container/bin/run_tmux
@@ -24,7 +24,6 @@ if [[ ${BACKEND} != "sqlite"  ]]; then
     export AIRFLOW__CORE__EXECUTOR=${AIRFLOW__CORE__EXECUTOR:-LocalExecutor}
 fi
 
-# If debugging the Celery worker, default Celery pool to solo unless overridden
 if [[ ${BREEZE_DEBUG_CELERY_WORKER} == "true" ]]; then
     export AIRFLOW__CELERY__POOL=${AIRFLOW__CELERY__POOL:-solo}
 fi


### PR DESCRIPTION
by default, we use pre-fork and ~~Its not possible~~ to debug these as each of them run in separate process. Changing it to solo as this makes tasks to run in main thread in sequential order. Should be helpful when debugging. I'm trying to make this work. But, as of now, https://github.com/apache/airflow/issues/56865 is blocking me to continue. 