### PR TITLE
Fix task_log_sources naming for test_remote_logging_s3

### DIFF
--- a/airflow-e2e-tests/tests/airflow_e2e_tests/remote_log_tests/test_remote_logging.py
+++ b/airflow-e2e-tests/tests/airflow_e2e_tests/remote_log_tests/test_remote_logging.py
@@ -54,20 +54,8 @@ class TestRemoteLogging:
             f"DAG {TestRemoteLogging.dag_id} did not complete successfully. Final state: {state}"
         )
 
-        task_logs = self.airflow_client.get_task_logs(
-            dag_id=TestRemoteLogging.dag_id,
-            task_id="bash_pull",
-            run_id=resp["dag_run_id"],
-        )
-
-        task_log_sources = [
-            source for content in task_logs.get("content", [{}]) for source in content.get("sources", [])
-        ]
-        # remove "/opt/airflow/logs/" prefix from log source paths
-        # before: /opt/airflow/logs/dag_id=example_xcom_test/run_id=manual__2025-10-20T03:24:32.261538+00:00/task_id=bash_pull/attempt=1.log
-        # after: dag_id=example_xcom_test/run_id=manual__2025-10-20T03:24:32.261538+00:00/task_id=bash_pull/attempt=1.log
-        task_log_sources = [source.replace("/opt/airflow/logs/", "") for source in task_log_sources]
-
+        # This bucket will be created part of the docker-compose setup in
+        bucket_name = "test-airflow-logs"
         s3_client = boto3.client(
             "s3",
             endpoint_url="http://localhost:4566",
@@ -76,11 +64,7 @@ class TestRemoteLogging:
             region_name="us-east-1",
         )
 
-        # This bucket will be created part of the docker-compose setup in
-        bucket_name = "test-airflow-logs"
-        response = s3_client.list_objects_v2(Bucket=bucket_name)
-
-        # Wait for logs to be available in S3
+        # Wait for logs to be available in S3 before we call `get_task_logs`
         for _ in range(self.max_retries):
             response = s3_client.list_objects_v2(Bucket=bucket_name)
             contents = response.get("Contents", [])
@@ -90,14 +74,25 @@ class TestRemoteLogging:
             print(f"Expected at least {self.task_count} log files, found {len(contents)}. Retrying...")
             time.sleep(self.retry_interval_in_seconds)
 
-        if "Contents" not in response:
-            pytest.fail("No objects found in S3 bucket %s", bucket_name)
-
         if len(response["Contents"]) < self.task_count:
             pytest.fail(
                 f"Expected at least {self.task_count} log files in S3 bucket {bucket_name}, "
                 f"but found {len(response['Contents'])} objects: {[obj.get('Key') for obj in response.get('Contents', [])]}"
             )
+
+        task_logs = self.airflow_client.get_task_logs(
+            dag_id=TestRemoteLogging.dag_id,
+            task_id="bash_pull",
+            run_id=resp["dag_run_id"],
+        )
+
+        task_log_sources = [
+            source for content in task_logs.get("content", [{}]) for source in content.get("sources", [])
+        ]
+        response = s3_client.list_objects_v2(Bucket=bucket_name)
+
+        if "Contents" not in response:
+            pytest.fail("No objects found in S3 bucket %s", bucket_name)
 
         # s3 key format: dag_id=example_xcom/run_id=manual__2025-09-29T23:32:09.457215+00:00/task_id=bash_pull/attempt=1.log
 

--- a/airflow-e2e-tests/tests/airflow_e2e_tests/remote_log_tests/test_remote_logging.py
+++ b/airflow-e2e-tests/tests/airflow_e2e_tests/remote_log_tests/test_remote_logging.py
@@ -63,6 +63,10 @@ class TestRemoteLogging:
         task_log_sources = [
             source for content in task_logs.get("content", [{}]) for source in content.get("sources", [])
         ]
+        # remove "/opt/airflow/logs/" prefix from log source paths
+        # before: /opt/airflow/logs/dag_id=example_xcom_test/run_id=manual__2025-10-20T03:24:32.261538+00:00/task_id=bash_pull/attempt=1.log
+        # after: dag_id=example_xcom_test/run_id=manual__2025-10-20T03:24:32.261538+00:00/task_id=bash_pull/attempt=1.log
+        task_log_sources = [source.replace("/opt/airflow/logs/", "") for source in task_log_sources]
 
         s3_client = boto3.client(
             "s3",


### PR DESCRIPTION

related: #56811

## Why

After #56811, we can ensure there are 6 files present in S3 (the same amount of tasks in `example_xcom_test` Dag)  before validating source `task_log_sources` and `log_files`. However the any CI with `Additional PROD image tests / Remote logging tests with PROD image / test-e2e-integration-tests` is still failing.

IMO, the **main root cause is the `/opt/airflow/logs/` prefix in `task_log_sources`, which make the `any(source in log_files for source in task_log_sources)` condition always fail**.

Example fail runs: 
- https://github.com/apache/airflow/actions/runs/18640518241/job/53139796492#logs
- https://github.com/apache/airflow/actions/runs/18631048833/job/53116606752?pr=56848

```
=========================== short test summary info ============================
FAILED tests/airflow_e2e_tests/remote_log_tests/test_remote_logging.py::TestRemoteLogging::test_remote_logging_s3 - AssertionError: None of the log sources ['/opt/airflow/logs/dag_id=example_xcom_test/run_id=manual__2025-10-20T03:24:32.261538+00:00/task_id=bash_pull/attempt=1.log'] were found in S3 bucket logs ['s3://test-airflow-logs/dag_id=example_xcom_test/run_id=manual__2025-10-20T03:24:32.261538+00:00/task_id=bash_pull/attempt=1.log', 's3://test-airflow-logs/dag_id=example_xcom_test/run_id=manual__2025-10-20T03:24:32.261538+00:00/task_id=bash_push/attempt=1.log', 's3://test-airflow-logs/dag_id=example_xcom_test/run_id=manual__2025-10-20T03:24:32.261538+00:00/task_id=pull_value_from_bash_push/attempt=1.log', 's3://test-airflow-logs/dag_id=example_xcom_test/run_id=manual__2025-10-20T03:24:32.261538+00:00/task_id=puller/attempt=1.log', 's3://test-airflow-logs/dag_id=example_xcom_test/run_id=manual__2025-10-20T03:24:32.261538+00:00/task_id=push/attempt=1.log', 's3://test-airflow-logs/dag_id=example_xcom_test/run_id=manual__2025-10-20T03:24:32.261538+00:00/task_id=push_by_returning/attempt=1.log']
assert False
 +  where False = any(<generator object TestRemoteLogging.test_remote_logging_s3.<locals>.<genexpr> at 0x7fe6880d4c10>)
=================== 1 failed, 1 passed, 1 warning in 42.88s ====================
```
There are already 6 files in `log_files` (which _should_ be success) but the test still fail in above traceback.

## What


- Remove `/opt/airflow/logs/` prefix from `task_log_sources`
- `task_log_sources` format before fix:
  - `/opt/airflow/logs/dag_id=example_xcom_test/run_id=manual__2025-10-20T03:24:32.261538+00:00/task_id=bash_pull/attempt=1.log`
- `task_log_sources` format after fix:
  - `dag_id=example_xcom_test/run_id=manual__2025-10-20T03:24:32.261538+00:00/task_id=bash_pull/attempt=1.log`
- `log_files` format:
  - `s3://test-airflow-logs/dag_id=example_xcom_test/run_id=manual__2025-10-20T03:24:32.261538+00:00/task_id=bash_pull/attempt=1.log`