### PR TITLE
Fix FlexibleForm rendering when all params have sections

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FlexibleForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FlexibleForm.tsx
@@ -108,7 +108,7 @@ export const FlexibleForm = ({
     }
   };
 
-  return Object.entries(params).some(([, param]) => typeof param.schema.section !== "string") ? (
+  return Object.keys(params).length > 0 ? (
     Object.entries(params).map(([, secParam]) => {
       const currentSection = secParam.schema.section ?? flexibleFormDefaultSection;
 


### PR DESCRIPTION
The original logic checked failed when ALL params had sections, thus thus fix simplifies the conditional to check if there are any params at all.

This can be reproduced with the following DAG:
```
from airflow.sdk import dag, task, Param


@dag(
    schedule=None,
    params=dict(
        test1=Param(
            title="test1",
            type="integer",
            default=0,
            section="TestSection",  # NOTE: Toggle this and observe as no parameters are displayed in trigger UI.
        ),
        test2=Param(
            title="test2",
            type="integer",
            default=0,
            section="TestSection",
        ),
    ),
)
def demonstrate_params_with_no_sections_no_param_render():
    """
    If a DAG has parameters all in-section, and none outside a section, the parameters will
    not render on the trigger UI modal.
    """

    @task
    def simple() -> None: ...

    simple()

demonstrate_params_with_no_sections_no_param_render()
```

<img width="893" height="349" alt="Screenshot 2025-10-20 at 01 01 11" src="https://github.com/user-attachments/assets/9f17e3ea-ada9-4ae3-8921-56924e0da969" />

Note: This cannot be reproduced or validated with #56831 being merged.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
