### PR TITLE
SQLA2: Partially fix type hints in the edge3 provider

### DIFF
--- a/providers/edge3/pyproject.toml
+++ b/providers/edge3/pyproject.toml
@@ -58,6 +58,7 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.10.0",
+    "apache-airflow-providers-common-compat>=1.7.4",    # + TODO: bump to next version
     "pydantic>=2.11.0",
     "retryhttp>=1.2.0,!=1.3.0",
 ]
@@ -67,6 +68,7 @@ dev = [
     "apache-airflow",
     "apache-airflow-task-sdk",
     "apache-airflow-devel-common",
+    "apache-airflow-providers-common-compat",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
 ]
 

--- a/providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py
+++ b/providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py
@@ -351,7 +351,7 @@ class EdgeExecutor(BaseExecutor):
                         del self.last_reported_state[job.key]
                     self.fail(job.key)
                 else:
-                    self.last_reported_state[job.key] = job.state
+                    self.last_reported_state[job.key] = TaskInstanceState(job.state)
             if (
                 job.state == TaskInstanceState.SUCCESS
                 and job.last_update_t < (datetime.now() - timedelta(minutes=job_success_purge)).timestamp()

--- a/providers/edge3/src/airflow/providers/edge3/models/edge_job.py
+++ b/providers/edge3/src/airflow/providers/edge3/models/edge_job.py
@@ -19,12 +19,12 @@ from __future__ import annotations
 from datetime import datetime
 
 from sqlalchemy import (
-    Column,
     Index,
     Integer,
     String,
     text,
 )
+from sqlalchemy.orm import Mapped, mapped_column
 
 from airflow.models.base import Base, StringID
 from airflow.models.taskinstancekey import TaskInstanceKey
@@ -41,18 +41,20 @@ class EdgeJobModel(Base, LoggingMixin):
     """
 
     __tablename__ = "edge_job"
-    dag_id = Column(StringID(), primary_key=True, nullable=False)
-    task_id = Column(StringID(), primary_key=True, nullable=False)
-    run_id = Column(StringID(), primary_key=True, nullable=False)
-    map_index = Column(Integer, primary_key=True, nullable=False, server_default=text("-1"))
-    try_number = Column(Integer, primary_key=True, default=0)
-    state = Column(String(20))
-    queue = Column(String(256))
-    concurrency_slots = Column(Integer)
-    command = Column(String(2048))
-    queued_dttm = Column(UtcDateTime)
-    edge_worker = Column(String(64))
-    last_update = Column(UtcDateTime)
+    dag_id: Mapped[str] = mapped_column(StringID(), primary_key=True, nullable=False)
+    task_id: Mapped[str] = mapped_column(StringID(), primary_key=True, nullable=False)
+    run_id: Mapped[str] = mapped_column(StringID(), primary_key=True, nullable=False)
+    map_index: Mapped[int] = mapped_column(
+        Integer, primary_key=True, nullable=False, server_default=text("-1")
+    )
+    try_number: Mapped[int] = mapped_column(Integer, primary_key=True, default=0)
+    state: Mapped[str] = mapped_column(String(20))
+    queue: Mapped[str] = mapped_column(String(256))
+    concurrency_slots: Mapped[int] = mapped_column(Integer)
+    command: Mapped[str] = mapped_column(String(2048))
+    queued_dttm: Mapped[datetime | None] = mapped_column(UtcDateTime)
+    edge_worker: Mapped[str | None] = mapped_column(String(64))
+    last_update: Mapped[datetime | None] = mapped_column(UtcDateTime)
 
     def __init__(
         self,

--- a/providers/edge3/src/airflow/providers/edge3/models/edge_job.py
+++ b/providers/edge3/src/airflow/providers/edge3/models/edge_job.py
@@ -24,10 +24,11 @@ from sqlalchemy import (
     String,
     text,
 )
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped
 
 from airflow.models.base import Base, StringID
 from airflow.models.taskinstancekey import TaskInstanceKey
+from airflow.providers.common.compat.sqlalchemy.orm import mapped_column
 from airflow.providers.edge3.version_compat import timezone
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.sqlalchemy import UtcDateTime

--- a/providers/edge3/src/airflow/providers/edge3/models/edge_logs.py
+++ b/providers/edge3/src/airflow/providers/edge3/models/edge_logs.py
@@ -19,12 +19,12 @@ from __future__ import annotations
 from datetime import datetime
 
 from sqlalchemy import (
-    Column,
     Integer,
     Text,
     text,
 )
 from sqlalchemy.dialects.mysql import MEDIUMTEXT
+from sqlalchemy.orm import Mapped, mapped_column
 
 from airflow.models.base import Base, StringID
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -45,13 +45,15 @@ class EdgeLogsModel(Base, LoggingMixin):
     """
 
     __tablename__ = "edge_logs"
-    dag_id = Column(StringID(), primary_key=True, nullable=False)
-    task_id = Column(StringID(), primary_key=True, nullable=False)
-    run_id = Column(StringID(), primary_key=True, nullable=False)
-    map_index = Column(Integer, primary_key=True, nullable=False, server_default=text("-1"))
-    try_number = Column(Integer, primary_key=True, default=0)
-    log_chunk_time = Column(UtcDateTime, primary_key=True, nullable=False)
-    log_chunk_data = Column(Text().with_variant(MEDIUMTEXT(), "mysql"), nullable=False)
+    dag_id: Mapped[str] = mapped_column(StringID(), primary_key=True, nullable=False)
+    task_id: Mapped[str] = mapped_column(StringID(), primary_key=True, nullable=False)
+    run_id: Mapped[str] = mapped_column(StringID(), primary_key=True, nullable=False)
+    map_index: Mapped[int] = mapped_column(
+        Integer, primary_key=True, nullable=False, server_default=text("-1")
+    )
+    try_number: Mapped[int] = mapped_column(Integer, primary_key=True, default=0)
+    log_chunk_time: Mapped[datetime] = mapped_column(UtcDateTime, primary_key=True, nullable=False)
+    log_chunk_data: Mapped[str] = mapped_column(Text().with_variant(MEDIUMTEXT(), "mysql"), nullable=False)
 
     def __init__(
         self,

--- a/providers/edge3/src/airflow/providers/edge3/models/edge_logs.py
+++ b/providers/edge3/src/airflow/providers/edge3/models/edge_logs.py
@@ -24,9 +24,10 @@ from sqlalchemy import (
     text,
 )
 from sqlalchemy.dialects.mysql import MEDIUMTEXT
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped
 
 from airflow.models.base import Base, StringID
+from airflow.providers.common.compat.sqlalchemy.orm import mapped_column
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.sqlalchemy import UtcDateTime
 

--- a/providers/edge3/src/airflow/providers/edge3/models/edge_worker.py
+++ b/providers/edge3/src/airflow/providers/edge3/models/edge_worker.py
@@ -23,7 +23,8 @@ from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Column, Integer, String, delete, select
+from sqlalchemy import Integer, String, delete, select
+from sqlalchemy.orm import Mapped, mapped_column
 
 from airflow.exceptions import AirflowException
 from airflow.models.base import Base
@@ -35,6 +36,8 @@ from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.sqlalchemy import UtcDateTime
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
@@ -79,29 +82,29 @@ class EdgeWorkerModel(Base, LoggingMixin):
     """A Edge Worker instance which reports the state and health."""
 
     __tablename__ = "edge_worker"
-    worker_name = Column(String(64), primary_key=True, nullable=False)
-    state = Column(String(20))
-    maintenance_comment = Column(String(1024))
-    _queues = Column("queues", String(256))
-    first_online = Column(UtcDateTime)
-    last_update = Column(UtcDateTime)
-    jobs_active = Column(Integer, default=0)
-    jobs_taken = Column(Integer, default=0)
-    jobs_success = Column(Integer, default=0)
-    jobs_failed = Column(Integer, default=0)
-    sysinfo = Column(String(256))
+    worker_name: Mapped[str] = mapped_column(String(64), primary_key=True, nullable=False)
+    state: Mapped[EdgeWorkerState] = mapped_column(String(20))
+    maintenance_comment: Mapped[str | None] = mapped_column(String(1024))
+    _queues: Mapped[str | None] = mapped_column("queues", String(256))
+    first_online: Mapped[datetime | None] = mapped_column(UtcDateTime)
+    last_update: Mapped[datetime | None] = mapped_column(UtcDateTime)
+    jobs_active: Mapped[int] = mapped_column(Integer, default=0)
+    jobs_taken: Mapped[int] = mapped_column(Integer, default=0)
+    jobs_success: Mapped[int] = mapped_column(Integer, default=0)
+    jobs_failed: Mapped[int] = mapped_column(Integer, default=0)
+    sysinfo: Mapped[str | None] = mapped_column(String(256))
 
     def __init__(
         self,
         worker_name: str,
-        state: str,
+        state: str | EdgeWorkerState,
         queues: list[str] | None,
         first_online: datetime | None = None,
         last_update: datetime | None = None,
         maintenance_comment: str | None = None,
     ):
         self.worker_name = worker_name
-        self.state = state
+        self.state = EdgeWorkerState(state)
         self.queues = queues
         self.first_online = first_online or timezone.utcnow()
         self.last_update = last_update
@@ -139,14 +142,14 @@ class EdgeWorkerModel(Base, LoggingMixin):
                 queues.remove(queue_name)
         self.queues = queues
 
-    def update_state(self, state: str) -> None:
+    def update_state(self, state: str | EdgeWorkerState) -> None:
         """Update state field."""
-        self.state = state
+        self.state = EdgeWorkerState(state)
 
 
 def set_metrics(
     worker_name: str,
-    state: EdgeWorkerState,
+    state: str | EdgeWorkerState,
     jobs_active: int,
     concurrency: int,
     free_concurrency: int,
@@ -204,7 +207,7 @@ def reset_metrics(worker_name: str) -> None:
 @provide_session
 def _fetch_edge_hosts_from_db(
     hostname: str | None = None, states: list | None = None, session: Session = NEW_SESSION
-) -> list:
+) -> Sequence[EdgeWorkerModel]:
     query = select(EdgeWorkerModel)
     if states:
         query = query.where(EdgeWorkerModel.state.in_(states))

--- a/providers/edge3/src/airflow/providers/edge3/models/edge_worker.py
+++ b/providers/edge3/src/airflow/providers/edge3/models/edge_worker.py
@@ -24,10 +24,11 @@ from enum import Enum
 from typing import TYPE_CHECKING
 
 from sqlalchemy import Integer, String, delete, select
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped
 
 from airflow.exceptions import AirflowException
 from airflow.models.base import Base
+from airflow.providers.common.compat.sqlalchemy.orm import mapped_column
 from airflow.providers.edge3.version_compat import timezone
 from airflow.stats import Stats
 from airflow.utils.log.logging_mixin import LoggingMixin


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
related: #56738

This PR reduces the number of mypy violations from >100 to 21. 

<details><summary>Remaining violations</summary>
<p>

```none
# mypy providers/edge3/src/airflow/providers/edge3
providers/edge3/src/airflow/providers/edge3/models/edge_worker.py:232: error: Incompatible types in assignment (expression has type
"EdgeWorkerModel | None", variable has type "EdgeWorkerModel")  [assignment]
        worker: EdgeWorkerModel = session.scalar(query)
                                  ^~~~~~~~~~~~~~~~~~~~~
providers/edge3/src/airflow/providers/edge3/models/edge_worker.py:241: error: Incompatible types in assignment (expression has type
"EdgeWorkerModel | None", variable has type "EdgeWorkerModel")  [assignment]
        worker: EdgeWorkerModel = session.scalar(query)
                                  ^~~~~~~~~~~~~~~~~~~~~
providers/edge3/src/airflow/providers/edge3/models/edge_worker.py:250: error: Incompatible types in assignment (expression has type
"EdgeWorkerModel | None", variable has type "EdgeWorkerModel")  [assignment]
        worker: EdgeWorkerModel = session.scalar(query)
                                  ^~~~~~~~~~~~~~~~~~~~~
providers/edge3/src/airflow/providers/edge3/models/edge_worker.py:269: error: Incompatible types in assignment (expression has type
"EdgeWorkerModel | None", variable has type "EdgeWorkerModel")  [assignment]
        worker: EdgeWorkerModel = session.scalar(query)
                                  ^~~~~~~~~~~~~~~~~~~~~
providers/edge3/src/airflow/providers/edge3/models/edge_worker.py:287: error: Incompatible types in assignment (expression has type
"EdgeWorkerModel | None", variable has type "EdgeWorkerModel")  [assignment]
        worker: EdgeWorkerModel = session.scalar(query)
                                  ^~~~~~~~~~~~~~~~~~~~~
providers/edge3/src/airflow/providers/edge3/models/edge_worker.py:300: error: Incompatible types in assignment (expression has type
"EdgeWorkerModel | None", variable has type "EdgeWorkerModel")  [assignment]
        worker: EdgeWorkerModel = session.scalar(query)
                                  ^~~~~~~~~~~~~~~~~~~~~
providers/edge3/src/airflow/providers/edge3/models/edge_worker.py:316: error: Incompatible types in assignment (expression has type
"EdgeWorkerModel | None", variable has type "EdgeWorkerModel")  [assignment]
        worker: EdgeWorkerModel = session.scalar(query)
                                  ^~~~~~~~~~~~~~~~~~~~~
providers/edge3/src/airflow/providers/edge3/models/edge_job.py:96: error: Item "None" of "datetime | None" has no attribute "timestamp"
 [union-attr]
            return self.last_update.timestamp()
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~
providers/edge3/src/airflow/providers/edge3/worker_api/routes/worker.py:175: error: Incompatible types in assignment (expression has
type "EdgeWorkerModel | None", variable has type "EdgeWorkerModel")  [assignment]
        worker: EdgeWorkerModel = session.scalar(query)
                                  ^~~~~~~~~~~~~~~~~~~~~
providers/edge3/src/airflow/providers/edge3/worker_api/routes/worker.py:197: error: Incompatible types in assignment (expression has
type "EdgeWorkerModel | None", variable has type "EdgeWorkerModel")  [assignment]
        worker: EdgeWorkerModel = session.scalar(query)
                                  ^~~~~~~~~~~~~~~~~~~~~
providers/edge3/src/airflow/providers/edge3/worker_api/routes/worker.py:232: error: Incompatible types in assignment (expression has
type "EdgeWorkerModel | None", variable has type "EdgeWorkerModel")  [assignment]
        worker: EdgeWorkerModel = session.scalar(query)
                                  ^~~~~~~~~~~~~~~~~~~~~
providers/edge3/src/airflow/providers/edge3/worker_api/routes/ui.py:62: error: Incompatible types in assignment (expression has type
"ScalarResult[EdgeWorkerModel]", variable has type "list[EdgeWorkerModel]")  [assignment]
        workers: list[EdgeWorkerModel] = session.scalars(query)
                                         ^~~~~~~~~~~~~~~~~~~~~~
providers/edge3/src/airflow/providers/edge3/worker_api/routes/ui.py:94: error: Incompatible types in assignment (expression has type
"ScalarResult[EdgeJobModel]", variable has type "list[EdgeJobModel]")  [assignment]
        jobs: list[EdgeJobModel] = session.scalars(query)
                                   ^~~~~~~~~~~~~~~~~~~~~~
providers/edge3/src/airflow/providers/edge3/worker_api/routes/ui.py:103: error: Argument "state" to "Job" has incompatible type "str";
expected "TaskInstanceState"  [arg-type]
                state=j.state,
                      ^~~~~~~
providers/edge3/src/airflow/providers/edge3/worker_api/routes/jobs.py:81: error: Incompatible types in assignment (expression has type
"Query[Any]", variable has type "Select[tuple[EdgeJobModel]]")  [assignment]
        query = with_row_locks(query, of=EdgeJobModel, session=session, skip_locked=True)
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
providers/edge3/src/airflow/providers/edge3/worker_api/routes/jobs.py:81: error: Argument 1 to "with_row_locks" has incompatible type
"Select[tuple[EdgeJobModel]]"; expected "Query[Any]"  [arg-type]
        query = with_row_locks(query, of=EdgeJobModel, session=session, skip_locked=True)
                               ^~~~~
providers/edge3/src/airflow/providers/edge3/worker_api/routes/jobs.py:82: error: Incompatible types in assignment (expression has type
"EdgeJobModel | None", variable has type "EdgeJobModel")  [assignment]
        job: EdgeJobModel = session.scalar(query)
                            ^~~~~~~~~~~~~~~~~~~~~
providers/edge3/src/airflow/providers/edge3/worker_api/routes/jobs.py:152: error: Incompatible types in assignment (expression has type
"Update", variable has type "Select[tuple[EdgeJobModel]]")  [assignment]
            update(EdgeJobModel)
            ^
providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py:80: error: "TypeEngine[Any]" has no attribute "length" 
[attr-defined]
                        edge_job_command_len = column["type"].length
                                               ^~~~~~~~~~~~~~~~~~~~~
providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py:286: error: Incompatible types in assignment (expression has
type "str | None", variable has type "SQLCoreOperations[str] | str")  [assignment]
                job.state = ti.state if ti else TaskInstanceState.REMOVED
                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py:354: error: Incompatible types in assignment (expression has
type "str", target has type "TaskInstanceState")  [assignment]
                        self.last_reported_state[job.key] = job.state
                                                            ^~~~~~~~~
Found 21 errors in 6 files (checked 35 source files)
```

</p>
</details>

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
