### PR TITLE
Prioritize custom serializers over built-in ones. (#56736)

### DIFF
--- a/airflow-core/docs/authoring-and-scheduling/serializers.rst
+++ b/airflow-core/docs/authoring-and-scheduling/serializers.rst
@@ -28,9 +28,9 @@ like ``str`` and ``int`` and it loops over iterables. When things become more co
 
 Airflow out of the box supports three ways of custom serialization. Primitives are returned as is, without
 additional encoding, e.g. a ``str`` remains a ``str``. When it is not a primitive (or iterable thereof) Airflow
-looks for a registered serializer and deserializer in the namespace of ``airflow.serialization.serializers``.
-If not found it will look in the class for a ``serialize()`` method or in case of deserialization a
-``deserialize(data, version: int)`` method. Finally, if the class is either decorated with ``@dataclass``
+first looks in the class for a ``serialize()`` method or in case of deserialization a ``deserialize(data, version: int)`` method.
+Next airflow checks for a registered serializer and deserializer in the namespace of ``airflow.serialization.serializers``.
+Finally, if the class is either decorated with ``@dataclass``
 or ``@attr.define`` it will use the public methods for those decorators.
 
 If you are looking to extend Airflow with a new serializer, it is good to know when to choose what way of serialization.

--- a/airflow-core/newsfragments/56881.significant.rst
+++ b/airflow-core/newsfragments/56881.significant.rst
@@ -1,21 +1,8 @@
-.. Write a short and imperative summary of this changes
+Prioritize custom SerDe methods defined in classes over the built-in SerDe methods.
 
-Custom SerDe methods defined on classes now take precedence over the built-in SerDe methods.
-
-.. Provide additional contextual information
-Previously, the SerDe precedence prioritized built-in serializers in airflow-core over those that users defined
+Previously, the SerDe logic prioritized built-in serializers in airflow-core over those that users defined
 in their classes with the ``serialize(self)`` and ``deserialize(data: dict, version: int)`` methods.
 This behavior has been changed to always use custom SerDe methods before considering built-in SerDe methods.
-
-.. Check the type of change that applies to this change
-.. Dag changes: requires users to change their Dag code
-.. Config changes: requires users to change their Airflow config
-.. API changes: requires users to change their Airflow REST API calls
-.. CLI changes: requires users to change their Airflow CLI usage
-.. Behaviour changes: the existing code won't break, but the behavior is different
-.. Plugin changes: requires users to change their Airflow plugin implementation
-.. Dependency changes: requires users to change their dependencies (e.g., Postgres 12)
-.. Code interface changes: requires users to change other implementations (e.g., auth manager)
 
 * Types of change
 
@@ -27,12 +14,3 @@ This behavior has been changed to always use custom SerDe methods before conside
   * [ ] Plugin changes
   * [ ] Dependency changes
   * [ ] Code interface changes
-
-.. List the migration rules needed for this change (see https://github.com/apache/airflow/issues/41641)
-
-.. * Migration rules needed
-
-.. e.g.,
-.. * Remove context key ``execution_date``
-.. * context key ``triggering_dataset_events`` → ``triggering_asset_events``
-.. * Remove method ``airflow.providers_manager.ProvidersManager.initialize_providers_dataset_uri_resources`` → ``airflow.providers_manager.ProvidersManager.initialize_providers_asset_uri_resources``

--- a/airflow-core/newsfragments/56881.significant.rst
+++ b/airflow-core/newsfragments/56881.significant.rst
@@ -1,0 +1,38 @@
+.. Write a short and imperative summary of this changes
+
+Custom SerDe methods defined on classes now take precedence over the built-in SerDe methods.
+
+.. Provide additional contextual information
+Previously, the SerDe precedence prioritized built-in serializers in airflow-core over those that users defined
+in their classes with the ``serialize(self)`` and ``deserialize(data: dict, version: int)`` methods.
+This behavior has been changed to always use custom SerDe methods before considering built-in SerDe methods.
+
+.. Check the type of change that applies to this change
+.. Dag changes: requires users to change their Dag code
+.. Config changes: requires users to change their Airflow config
+.. API changes: requires users to change their Airflow REST API calls
+.. CLI changes: requires users to change their Airflow CLI usage
+.. Behaviour changes: the existing code won't break, but the behavior is different
+.. Plugin changes: requires users to change their Airflow plugin implementation
+.. Dependency changes: requires users to change their dependencies (e.g., Postgres 12)
+.. Code interface changes: requires users to change other implementations (e.g., auth manager)
+
+* Types of change
+
+  * [ ] Dag changes
+  * [ ] Config changes
+  * [ ] API changes
+  * [ ] CLI changes
+  * [x] Behaviour changes
+  * [ ] Plugin changes
+  * [ ] Dependency changes
+  * [ ] Code interface changes
+
+.. List the migration rules needed for this change (see https://github.com/apache/airflow/issues/41641)
+
+.. * Migration rules needed
+
+.. e.g.,
+.. * Remove context key ``execution_date``
+.. * context key ``triggering_dataset_events`` → ``triggering_asset_events``
+.. * Remove method ``airflow.providers_manager.ProvidersManager.initialize_providers_dataset_uri_resources`` → ``airflow.providers_manager.ProvidersManager.initialize_providers_asset_uri_resources``

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -931,7 +931,9 @@ class TestCliDags:
             tis = dr.get_task_instances()
             assert next(x for x in tis if x.task_id == "abc").state == "success"
 
-    @mock.patch("airflow.sdk.execution_time.task_runner._execute_task")
+    @mock.patch(
+        "airflow.sdk.execution_time.task_runner._execute_task", return_value="dummy task return value"
+    )
     def test_dag_test_with_mark_success(self, mock__execute_task):
         """
         option `--mark-success-pattern` should mark matching tasks as success without executing them.

--- a/airflow-core/tests/unit/serialization/test_serde.py
+++ b/airflow-core/tests/unit/serialization/test_serde.py
@@ -33,16 +33,20 @@ from airflow.sdk.definitions.asset import Asset
 from airflow.serialization.serde import (
     CLASSNAME,
     DATA,
+    PYDANTIC_MODEL_QUALNAME,
     SCHEMA_ID,
     VERSION,
+    _deserializers,
     _get_patterns,
     _get_regexp_patterns,
     _match,
     _match_glob,
     _match_regexp,
+    _serializers,
     deserialize,
     serialize,
 )
+from airflow.serialization.typing import is_pydantic_model
 from airflow.utils.module_loading import import_string, iter_namespace, qualname
 
 from tests_common.test_utils.config import conf_vars
@@ -191,6 +195,18 @@ class T:
 class C:
     def __call__(self):
         return None
+
+
+class PydanticModelWithCustomSerDe(BaseModel):
+    ignored_field_in_serialization: int = 0
+    x: str
+
+    @staticmethod
+    def deserialize(data: dict, version: int):
+        return PydanticModelWithCustomSerDe(ignored_field_in_serialization=-1, x=data["x"])
+
+    def serialize(self) -> dict:
+        return {"x": self.x}
 
 
 @pytest.mark.usefixtures("recalculate_patterns")
@@ -511,3 +527,21 @@ class TestSerDe:
             TypeError, match="cannot serialize object of type <class 'unit.serialization.test_serde.C'>"
         ):
             serialize(i)
+
+    def test_custom_serde_methods_are_prioritized_over_builtins(self):
+        """
+        There is a built-in SerDe for pydantic classes.
+        Test that the custom defined SerDe methods take precedence over the built-in ones.
+        """
+        orig = PydanticModelWithCustomSerDe(ignored_field_in_serialization=200, x="SerDe Test")
+
+        assert is_pydantic_model(orig)
+        assert PYDANTIC_MODEL_QUALNAME in _serializers
+        assert PYDANTIC_MODEL_QUALNAME in _deserializers
+
+        serialized = serialize(orig)
+        assert "ignored_field_in_serialization" not in serialized
+        deserialized: PydanticModelWithCustomSerDe = deserialize(serialized)
+        assert deserialized.ignored_field_in_serialization == -1
+        assert deserialized.x == orig.x
+        assert type(orig) is type(deserialized)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This came up during discussion of #56736
It is a bit counter-intuitive that the built-in serializers are prioritized over those that users explicitly define in their classes. 
This PR changes the order that those serializers and deserializers are considered. 
Very interestingly with this change the `serialize` method actually matches its docstring, which listed the order that this PR establishes and therefore was wrong.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
