### PR TITLE
fix subject column for tagging in preparing providers release

### DIFF
--- a/dev/breeze/src/airflow_breeze/prepare_providers/provider_documentation.py
+++ b/dev/breeze/src/airflow_breeze/prepare_providers/provider_documentation.py
@@ -340,7 +340,12 @@ def _convert_git_changes_to_table(
     header = ""
     if not table_data:
         return header, []
-    table = tabulate(table_data, headers=headers, tablefmt="pipe" if markdown else "rst")
+    table = tabulate(
+        table_data,
+        headers=headers,
+        tablefmt="pipe" if markdown else "rst",
+        colalign=("left", "center", "left"),
+    )
     if not markdown:
         header += f"\n\n{version}\n" + "." * len(version) + "\n\n"
         release_date = table_data[0][1]

--- a/dev/breeze/tests/test_provider_documentation.py
+++ b/dev/breeze/tests/test_provider_documentation.py
@@ -197,7 +197,7 @@ LONG_HASH_123144 SHORT_HASH 2023-01-01 Description `with` pr (#12346)
 Latest change: 2023-01-01
 
 =============================================  ===========  ==================================
-Commit                                         Committed    Subject
+Commit                                          Committed   Subject
 =============================================  ===========  ==================================
 `SHORT_HASH <https://url/LONG_HASH_123144>`__  2023-01-01   ``Description 'with' no pr``
 `SHORT_HASH <https://url/LONG_HASH_123144>`__  2023-01-01   ``Description 'with' pr (#12345)``
@@ -215,8 +215,8 @@ LONG_HASH_123144 SHORT_HASH 2023-01-01 Description `with` pr (#12346)
 
 """,
             """
-| Commit                                     | Committed   | Subject                          |
-|:-------------------------------------------|:------------|:---------------------------------|
+| Commit                                     |  Committed  | Subject                          |
+|:-------------------------------------------|:-----------:|:---------------------------------|
 | [SHORT_HASH](https://url/LONG_HASH_123144) | 2023-01-01  | `Description 'with' no pr`       |
 | [SHORT_HASH](https://url/LONG_HASH_123144) | 2023-01-01  | `Description 'with' pr (#12345)` |
 | [SHORT_HASH](https://url/LONG_HASH_123144) | 2023-01-01  | `Description 'with' pr (#12346)` |


### PR DESCRIPTION
I really don't know why all of a sudden it doesn't show the Subject column fully. There were no changes to these files in long time (maybe some upstream library?) anyway this change fix the problem.

**Before:**
<img width="1020" height="261" alt="Screenshot 2025-10-20 at 11 09 30" src="https://github.com/user-attachments/assets/f9f6d4e3-f02b-461b-9f87-e496bdcbd296" />

**After:**
<img width="1413" height="273" alt="Screenshot 2025-10-20 at 16 42 49" src="https://github.com/user-attachments/assets/a1e91b1e-5d3b-4aeb-86d7-089d3e5c7662" />
