### PR TITLE
Fix Git corruption recovery by moving fetch into retry context

### DIFF
--- a/providers/git/src/airflow/providers/git/bundles/git.py
+++ b/providers/git/src/airflow/providers/git/bundles/git.py
@@ -175,9 +175,12 @@ class GitDagBundle(BaseDagBundle):
                     env=self.hook.env if self.hook else None,
                 )
             self.bare_repo = Repo(self.bare_repo_path)
+
+            # Fetch to ensure we have latest refs and validate repo integrity
+            self._fetch_bare_repo()
         except (InvalidGitRepositoryError, GitCommandError) as e:
             self._log.warning(
-                "Bare repository clone/open failed, cleaning up and retrying",
+                "Bare repository clone/open/fetch failed, cleaning up and retrying",
                 bare_repo_path=self.bare_repo_path,
                 exc=e,
             )

--- a/providers/git/tests/unit/git/bundles/test_git.py
+++ b/providers/git/tests/unit/git/bundles/test_git.py
@@ -377,7 +377,8 @@ class TestGitDagBundle:
             tracking_ref=GIT_DEFAULT_BRANCH,
         )
         bundle.initialize()
-        assert mock_gitRepo.return_value.remotes.origin.fetch.call_count == 2  # 1 in bare, 1 in main repo
+        # 1 in _clone_bare_repo_if_required, 1 in refresh() for bare repo, 1 in refresh() for working repo
+        assert mock_gitRepo.return_value.remotes.origin.fetch.call_count == 3
         mock_gitRepo.return_value.remotes.origin.fetch.reset_mock()
         bundle.refresh()
         assert mock_gitRepo.return_value.remotes.origin.fetch.call_count == 2
@@ -730,7 +731,9 @@ class TestGitDagBundle:
         EXPECTED_ENV = {"GIT_SSH_COMMAND": "ssh -i /id_rsa -o StrictHostKeyChecking=no"}
 
         mock_gitRepo.clone_from.side_effect = _fake_clone_from
-        mock_gitRepo.return_value = types.SimpleNamespace()
+        # Mock needs to support the fetch operation called in _clone_bare_repo_if_required
+        mock_repo_instance = mock.MagicMock()
+        mock_gitRepo.return_value = mock_repo_instance
 
         with mock.patch("airflow.providers.git.bundles.git.GitHook") as mock_githook:
             mock_githook.return_value.repo_url = "git@github.com:apache/airflow.git"


### PR DESCRIPTION
  Add _fetch_bare_repo into  _clone_bare_repo_if_required
  so that fetch failures (e.g., corrupted packs
  with unresolved deltas) trigger the existing @retry mechanism to clean up
  and re-clone the bare repository automatically.

  this resolves errors such as 
```
[2025-10-20 12:31:58] ERROR - Top level error
GitCommandError: Cmd('git') failed due to: exit code(128)
  cmdline: git fetch -v -- origin +refs/heads/*:refs/heads/* +refs/tags/*:refs/tags/*
  stderr: 'error: refs/heads/temp/07694dfc89033d3d0da25f5344f30c371a380c6f does not point to a valid object!
error: refs/heads/temp/07694dfc89033d3d0da25f5344f30c371a380c6f does not point to a valid object!
error: Could not read d29a5e4f1afe9994c4e6daf9c84ccbec8abc459e
fatal: pack has 193 unresolved deltas
fatal: fetch-pack: invalid index-pack output'
```
cc: @ephraimbuddy 