### PR TITLE
update celery broker_url config description

### DIFF
--- a/providers/celery/provider.yaml
+++ b/providers/celery/provider.yaml
@@ -169,8 +169,7 @@ config:
         default: "true"
       broker_url:
         description: |
-          The Celery broker URL. Celery supports RabbitMQ, Redis, Amazon SQS
-          and few other experimental brokers. See:
+          The Celery broker URL. Celery supports multiple broker types. See:
           https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/index.html#broker-overview
         version_added: ~
         type: string

--- a/providers/celery/provider.yaml
+++ b/providers/celery/provider.yaml
@@ -169,8 +169,9 @@ config:
         default: "true"
       broker_url:
         description: |
-          The Celery broker URL. Celery supports RabbitMQ, Redis and experimentally
-          a sqlalchemy database. Refer to the Celery documentation for more information.
+          The Celery broker URL. Celery supports RabbitMQ, Redis, Amazon SQS
+          and few other experimental brokers. See:
+          https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/index.html#broker-overview
         version_added: ~
         type: string
         sensitive: true

--- a/providers/celery/src/airflow/providers/celery/get_provider_info.py
+++ b/providers/celery/src/airflow/providers/celery/get_provider_info.py
@@ -96,7 +96,7 @@ def get_provider_info():
                         "default": "true",
                     },
                     "broker_url": {
-                        "description": "The Celery broker URL. Celery supports RabbitMQ, Redis, Amazon SQS\nand few other experimental brokers. See:\nhttps://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/index.html#broker-overview\n",
+                        "description": "The Celery broker URL. Celery supports multiple broker types. See:\nhttps://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/index.html#broker-overview\n",
                         "version_added": None,
                         "type": "string",
                         "sensitive": True,

--- a/providers/celery/src/airflow/providers/celery/get_provider_info.py
+++ b/providers/celery/src/airflow/providers/celery/get_provider_info.py
@@ -96,7 +96,7 @@ def get_provider_info():
                         "default": "true",
                     },
                     "broker_url": {
-                        "description": "The Celery broker URL. Celery supports RabbitMQ, Redis and experimentally\na sqlalchemy database. Refer to the Celery documentation for more information.\n",
+                        "description": "The Celery broker URL. Celery supports RabbitMQ, Redis, Amazon SQS\nand few other experimental brokers. See:\nhttps://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/index.html#broker-overview\n",
                         "version_added": None,
                         "type": "string",
                         "sensitive": True,


### PR DESCRIPTION
sqlalchemy is no longer experimental nor supported. Updated description as per celery docs