### PR TITLE
Enable PT011 rule to prvoider tests

### DIFF
--- a/devel-common/tests/unit/tests_common/test_utils/test_stream_capture_manager.py
+++ b/devel-common/tests/unit/tests_common/test_utils/test_stream_capture_manager.py
@@ -463,7 +463,7 @@ def test_exception_during_capture_with_pytest_raises(stdout_capture):
             assert "Log before exception" not in output
 
         # Now test that exception in capture context still works
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Test exception"):
             with stdout_capture:
                 raise ValueError("Test exception")
 

--- a/providers/amazon/tests/unit/amazon/aws/assets/test_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/assets/test_s3.py
@@ -38,7 +38,7 @@ def test_sanitize_uri():
 
 
 def test_sanitize_uri_no_netloc():
-    with pytest.raises(ValueError, match="URI format s3:// must contain"):
+    with pytest.raises(ValueError, match="URI format s3:// must contain a bucket name"):
         sanitize_uri(urllib.parse.urlsplit("s3://"))
 
 

--- a/providers/amazon/tests/unit/amazon/aws/assets/test_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/assets/test_s3.py
@@ -38,7 +38,7 @@ def test_sanitize_uri():
 
 
 def test_sanitize_uri_no_netloc():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="URI format s3:// must contain"):
         sanitize_uri(urllib.parse.urlsplit("s3://"))
 
 

--- a/providers/amazon/tests/unit/amazon/aws/executors/batch/test_batch_executor.py
+++ b/providers/amazon/tests/unit/amazon/aws/executors/batch/test_batch_executor.py
@@ -744,10 +744,8 @@ class TestBatchExecutorConfig:
         ],
     )
     def test_executor_config_exceptions(self, bad_config, mock_executor):
-        with pytest.raises(ValueError) as raised:
+        with pytest.raises(ValueError, match='Executor Config should never override "command'):
             mock_executor.execute_async(mock_airflow_key, mock_cmd, executor_config=bad_config)
-
-        assert raised.match('Executor Config should never override "command')
 
     def test_config_defaults_are_applied(self):
         submit_kwargs = batch_executor_config.build_submit_kwargs()

--- a/providers/amazon/tests/unit/amazon/aws/executors/ecs/test_ecs_executor.py
+++ b/providers/amazon/tests/unit/amazon/aws/executors/ecs/test_ecs_executor.py
@@ -1343,7 +1343,7 @@ class TestEcsExecutorConfig:
             (CONFIG_GROUP_NAME, AllEcsConfigKeys.SECURITY_GROUPS): "sg1,sg2",
         }
         with conf_vars(conf_overrides):
-            with pytest.raises(ValueError, match="At least one subnet is required to run a task."):
+            with pytest.raises(ValueError, match="At least one subnet is required to run a task"):
                 ecs_executor_config.build_task_kwargs(conf)
 
     # TODO: When merged this needs updating to the actually supported version

--- a/providers/amazon/tests/unit/amazon/aws/executors/ecs/test_ecs_executor.py
+++ b/providers/amazon/tests/unit/amazon/aws/executors/ecs/test_ecs_executor.py
@@ -1096,10 +1096,9 @@ class TestAwsEcsExecutor:
         ],
     )
     def test_executor_config_exceptions(self, bad_config, mock_executor, mock_cmd):
-        with pytest.raises(ValueError) as raised:
+        with pytest.raises(ValueError, match='Executor Config should never override "name" or "command"'):
             mock_executor.execute_async(mock_airflow_key, mock_cmd, executor_config=bad_config)
 
-        assert raised.match('Executor Config should never override "name" or "command"')
         assert len(mock_executor.pending_tasks) == 0
 
     @mock.patch.object(ecs_executor_config, "build_task_kwargs")
@@ -1344,9 +1343,8 @@ class TestEcsExecutorConfig:
             (CONFIG_GROUP_NAME, AllEcsConfigKeys.SECURITY_GROUPS): "sg1,sg2",
         }
         with conf_vars(conf_overrides):
-            with pytest.raises(ValueError) as raised:
+            with pytest.raises(ValueError, match="At least one subnet is required to run a task."):
                 ecs_executor_config.build_task_kwargs(conf)
-        assert raised.match("At least one subnet is required to run a task.")
 
     # TODO: When merged this needs updating to the actually supported version
     @pytest.mark.skipif(

--- a/providers/standard/tests/unit/standard/operators/test_hitl.py
+++ b/providers/standard/tests/unit/standard/operators/test_hitl.py
@@ -452,7 +452,7 @@ class TestApprovalOperator:
             )
 
     def test_init_with_multiple_set_to_true(self) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Passing multiple to ApprovalOperator is not allowed."):
             ApprovalOperator(
                 task_id="hitl_test",
                 subject="This is subject",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
issue: Enable Even More PyDocStyle Checks #40567
@ferruzzi
This PR is for enable PT011 rule:
PT011: all instances of pytest.raises should include a match term to make sure they are catching the right error.
https://docs.astral.sh/ruff/rules/pytest-raises-too-broad/
There are 102 files changes is need.
So, I separate to many PR, which contains about 5 file changes for easy review.
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
