### PR TITLE
improve deferrable KPO handling of deleted pods in between polls

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -967,6 +967,10 @@ class KubernetesPodOperator(BaseOperator):
     def _clean(self, event: dict[str, Any], result: dict | None, context: Context) -> None:
         if event["status"] == "running":
             return
+
+        if self.pod is None:
+            return
+
         istio_enabled = self.is_istio_enabled(self.pod)
         # Skip await_pod_completion when the event is 'timeout' due to the pod can hang
         # on the ErrImagePull or ContainerCreating step and it will never complete

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
@@ -143,7 +143,12 @@ class KubernetesPodTrigger(BaseTrigger):
 
     async def run(self) -> AsyncIterator[TriggerEvent]:
         """Get current pod status and yield a TriggerEvent."""
-        self.log.info("Checking pod %r in namespace %r.", self.pod_name, self.pod_namespace)
+        self.log.info(
+            "Checking pod %r in namespace %r.",
+            self.pod_name,
+            self.pod_namespace,
+            poll_interval=self.poll_interval,
+        )
         try:
             state = await self._wait_for_pod_start()
             if state == ContainerState.TERMINATED:

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
@@ -183,6 +183,11 @@ class KubernetesPodTrigger(BaseTrigger):
             )
             return
         except Exception as e:
+            self.log.exception(
+                "Unexpected error while waiting for pod %s in namespace %s",
+                self.pod_name,
+                self.pod_namespace,
+            )
             yield TriggerEvent(
                 {
                     "name": self.pod_name,

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
@@ -144,10 +144,10 @@ class KubernetesPodTrigger(BaseTrigger):
     async def run(self) -> AsyncIterator[TriggerEvent]:
         """Get current pod status and yield a TriggerEvent."""
         self.log.info(
-            "Checking pod %r in namespace %r.",
+            "Checking pod %r in namespace %r with poll interval %r.",
             self.pod_name,
             self.pod_namespace,
-            poll_interval=self.poll_interval,
+            self.poll_interval,
         )
         try:
             state = await self._wait_for_pod_start()


### PR DESCRIPTION
While `KubernetesPodTrigger` is polling the KPO pod, in case of large values for `poll_interval` (i.e 900 seconds) it can happen that the completed podhas been already been cleaned up in-between polls. This causes the following chain of events:

1. 404 pod not found error inside `KubernetesPodTrigger`
2. `KubernetesPodOperator.trigger_reentry` ending up in another 404 pod not found in `self.hook.get_pod`
3.  `KubernetesPodOperator._clean` being called as part of the `finally` block
4. `KubernetesPodOperator.pod_manager.await_pod_completion` failing to handle `self.pod == None` ending up in `AttributeError: 'NoneType' object has no attribute 'metadata'`
5. the stack trace of the original error in 1. is never properly printed

We improve this situation with the following adjustments:

* log the original exception with stack trace in the trigger for better visibility of the original error
* log the actual poll interval being used when starting the trigger
* return from `KubernetesPodOperator._call` early if `self.pod` is `None`
