### PR TITLE
Fix deprecated GitHub API authentication in airflow-github script

### DIFF
--- a/dev/airflow-github
+++ b/dev/airflow-github
@@ -39,7 +39,7 @@ from typing import TYPE_CHECKING
 
 import git
 import rich_click as click
-from github import Github
+from github import Auth, Github
 from packaging import version
 from rich.console import Console
 from rich.progress import Progress
@@ -309,7 +309,7 @@ def compare(target_version, github_token, previous_version=None, show_uncherrypi
 
     repo = git.Repo(".", search_parent_directories=True)
 
-    github_handler = Github(github_token)
+    github_handler = Github(auth=Auth.Token(github_token))
 
     # Fetch PRs and Issues separately, with merged PRs identified upfront
     merged_prs: list[Issue] = list(
@@ -469,7 +469,7 @@ def changelog(previous_version, target_version, github_token, disable_progress_b
     if disable_progress_bar:
         print(f"Processing {len(log)} commits")
 
-    gh = Github(github_token)
+    gh = Github(auth=Auth.Token(github_token))
     gh_repo = gh.get_repo("apache/airflow")
     sections = defaultdict(list)
     with open("RELEASE_NOTES.rst") as file:
@@ -509,7 +509,7 @@ def needs_categorization(previous_version, target_version, show_skipped, show_fi
     repo = git.Repo(".", search_parent_directories=True)
     log = get_commits_between(repo, previous_version, target_version)
 
-    gh = Github(github_token)
+    gh = Github(auth=Auth.Token(github_token))
     gh_repo = gh.get_repo("apache/airflow")
     for commit in log:
         tickets = pr_title_re.findall(commit["subject"])


### PR DESCRIPTION
Replace deprecated `login_or_token` parameter with `Auth.Token()` to eliminate deprecation warnings when running the airflow-github compare command.

```
❯ uv run --script dev/airflow-github compare 3.1.1 --previous-version 3.1.0 --unmerged --show-commits
/Users/kaxilnaik/Documents/GitHub/astronomer/airflow/dev/airflow-github:312: DeprecationWarning: Argument login_or_token is deprecated, please use auth=github.Auth.Token(...) instead
  github_handler = Github(github_token)
```

Updates all three `Github()` instantiations in `compare`, `changelog`, and `needs_categorization` functions to use the new auth parameter.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
