### PR TITLE
Caught if commands is not an airflowctl command in airflowctl integration tests

### DIFF
--- a/airflow-ctl-tests/tests/airflowctl_tests/conftest.py
+++ b/airflow-ctl-tests/tests/airflowctl_tests/conftest.py
@@ -235,7 +235,7 @@ def test_commands(login_command, date_param):
     # Define test commands to run with actual running API server
     return [
         login_command,
-        "backfill list",
+        "backfills list",
         "config get --section core --option executor",
         "connections create --connection-id=test_con --conn-type=mysql --password=TEST_PASS -o json",
         "connections list",

--- a/airflow-ctl-tests/tests/airflowctl_tests/test_airflowctl_commands.py
+++ b/airflow-ctl-tests/tests/airflowctl_tests/test_airflowctl_commands.py
@@ -63,7 +63,11 @@ def test_airflowctl_commands(login_command, login_output, test_commands):
         # This is a common error message that is thrown by client when something is wrong
         # Please ensure it is aligning with airflowctl.api.client.get_json_error
         airflowctl_client_server_response_error = "Server error"
-        if airflowctl_client_server_response_error in stdout_result:
+        airflowctl_command_error = "command error: argument GROUP_OR_COMMAND: invalid choice"
+        if (
+            airflowctl_client_server_response_error in stdout_result
+            or airflowctl_command_error in stdout_result
+        ):
             console.print(f"[red]❌ Output contained unexpected text for command '{command_from_config}'")
             console.print(f"[red]Did not expect to find:\n{airflowctl_client_server_response_error}\n")
             console.print(f"[red]But got:\n{stdout_result}\n")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
