### PR TITLE
Migrate redis provider to ``common.compat``

### DIFF
--- a/providers/redis/pyproject.toml
+++ b/providers/redis/pyproject.toml
@@ -58,6 +58,7 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.10.0",
+    "apache-airflow-providers-common-compat>=1.7.4",    # + TODO: bump to next version
     # 5.0.2 excluded due to breaking changes which fixed in https://github.com/redis/redis-py/pull/3176
     "redis>=4.5.2,!=4.5.5,!=5.0.2",
 ]
@@ -74,6 +75,7 @@ dev = [
     "apache-airflow",
     "apache-airflow-task-sdk",
     "apache-airflow-devel-common",
+    "apache-airflow-providers-common-compat",
     "apache-airflow-providers-common-messaging",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
 ]

--- a/providers/redis/src/airflow/providers/redis/hooks/redis.py
+++ b/providers/redis/src/airflow/providers/redis/hooks/redis.py
@@ -23,7 +23,7 @@ from typing import Any
 
 from redis import Redis
 
-from airflow.providers.redis.version_compat import BaseHook
+from airflow.providers.common.compat.sdk import BaseHook
 
 DEFAULT_SSL_CERT_REQS = "required"
 ALLOWED_SSL_CERT_REQS = [DEFAULT_SSL_CERT_REQS, "optional", "none"]

--- a/providers/redis/src/airflow/providers/redis/operators/redis_publish.py
+++ b/providers/redis/src/airflow/providers/redis/operators/redis_publish.py
@@ -20,15 +20,11 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
+from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.providers.redis.hooks.redis import RedisHook
-from airflow.providers.redis.version_compat import BaseOperator
 
 if TYPE_CHECKING:
-    try:
-        from airflow.sdk.definitions.context import Context
-    except ImportError:
-        # TODO: Remove once provider drops support for Airflow 2
-        from airflow.utils.context import Context
+    from airflow.providers.common.compat.sdk import Context
 
 
 class RedisPublishOperator(BaseOperator):

--- a/providers/redis/src/airflow/providers/redis/sensors/redis_key.py
+++ b/providers/redis/src/airflow/providers/redis/sensors/redis_key.py
@@ -20,15 +20,11 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
+from airflow.providers.common.compat.sdk import BaseSensorOperator
 from airflow.providers.redis.hooks.redis import RedisHook
-from airflow.providers.redis.version_compat import BaseSensorOperator
 
 if TYPE_CHECKING:
-    try:
-        from airflow.sdk.definitions.context import Context
-    except ImportError:
-        # TODO: Remove once provider drops support for Airflow 2
-        from airflow.utils.context import Context
+    from airflow.providers.common.compat.sdk import Context
 
 
 class RedisKeySensor(BaseSensorOperator):

--- a/providers/redis/src/airflow/providers/redis/sensors/redis_pub_sub.py
+++ b/providers/redis/src/airflow/providers/redis/sensors/redis_pub_sub.py
@@ -21,15 +21,11 @@ from collections.abc import Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING
 
+from airflow.providers.common.compat.sdk import BaseSensorOperator
 from airflow.providers.redis.hooks.redis import RedisHook
-from airflow.providers.redis.version_compat import BaseSensorOperator
 
 if TYPE_CHECKING:
-    try:
-        from airflow.sdk.definitions.context import Context
-    except ImportError:
-        # TODO: Remove once provider drops support for Airflow 2
-        from airflow.utils.context import Context
+    from airflow.providers.common.compat.sdk import Context
 
 
 class RedisPubSubSensor(BaseSensorOperator):

--- a/providers/redis/src/airflow/providers/redis/version_compat.py
+++ b/providers/redis/src/airflow/providers/redis/version_compat.py
@@ -35,15 +35,4 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 AIRFLOW_V_3_1_PLUS: bool = get_base_airflow_version_tuple() >= (3, 1, 0)
 
-if AIRFLOW_V_3_1_PLUS:
-    from airflow.sdk import BaseHook
-else:
-    from airflow.hooks.base import BaseHook  # type: ignore[attr-defined,no-redef]
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import BaseOperator, BaseSensorOperator
-else:
-    from airflow.models import BaseOperator
-    from airflow.sensors.base import BaseSensorOperator  # type: ignore[no-redef]
-
-__all__ = ["BaseOperator", "BaseSensorOperator", "BaseHook"]
+__all__ = ["AIRFLOW_V_3_0_PLUS", "AIRFLOW_V_3_1_PLUS"]

--- a/providers/redis/tests/unit/redis/log/test_redis_task_handler.py
+++ b/providers/redis/tests/unit/redis/log/test_redis_task_handler.py
@@ -23,6 +23,7 @@ from unittest.mock import patch
 import pytest
 
 from airflow.models import DagRun, TaskInstance
+from airflow.providers.common.compat.sdk import timezone
 from airflow.providers.redis.log.redis_task_handler import RedisTaskHandler
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.utils.session import create_session
@@ -40,10 +41,8 @@ from tests_common.test_utils.version_compat import (
 
 if AIRFLOW_V_3_1_PLUS:
     from airflow.sdk import DAG
-    from airflow.sdk.timezone import datetime
 else:
     from airflow.models import DAG
-    from airflow.utils.timezone import datetime  # type: ignore[no-redef]
 
 
 class TestRedisTaskHandler:
@@ -56,7 +55,7 @@ class TestRedisTaskHandler:
 
     @pytest.fixture
     def ti(self):
-        date = datetime(2020, 1, 1)
+        date = timezone.datetime(2020, 1, 1)
         dag = DAG(dag_id="dag_for_testing_redis_task_handler", schedule=None, start_date=date)
         task = EmptyOperator(task_id="task_for_testing_redis_log_handler", dag=dag)
         if AIRFLOW_V_3_0_PLUS:


### PR DESCRIPTION
Replace version-specific conditional imports with common.compat layer. This standardizes compatibility handling across Airflow 2.x and 3.x.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
