### PR TITLE
Migrate github provider to ``common.compat``

### DIFF
--- a/providers/github/pyproject.toml
+++ b/providers/github/pyproject.toml
@@ -58,6 +58,7 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.10.0",
+    "apache-airflow-providers-common-compat>=1.7.4",    # + TODO: bump to next version
     "PyGithub>=2.1.1",
 ]
 
@@ -66,6 +67,7 @@ dev = [
     "apache-airflow",
     "apache-airflow-task-sdk",
     "apache-airflow-devel-common",
+    "apache-airflow-providers-common-compat",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
 ]
 

--- a/providers/github/src/airflow/providers/github/hooks/github.py
+++ b/providers/github/src/airflow/providers/github/hooks/github.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING
 from github import Github as GithubClient
 
 from airflow.exceptions import AirflowException
-from airflow.providers.github.version_compat import BaseHook
+from airflow.providers.common.compat.sdk import BaseHook
 
 
 class GithubHook(BaseHook):

--- a/providers/github/src/airflow/providers/github/operators/github.py
+++ b/providers/github/src/airflow/providers/github/operators/github.py
@@ -23,11 +23,11 @@ from typing import TYPE_CHECKING, Any
 from github import GithubException
 
 from airflow.exceptions import AirflowException
+from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.providers.github.hooks.github import GithubHook
-from airflow.providers.github.version_compat import BaseOperator
 
 if TYPE_CHECKING:
-    from airflow.providers.github.version_compat import Context
+    from airflow.providers.common.compat.sdk import Context
 
 
 class GithubOperator(BaseOperator):

--- a/providers/github/src/airflow/providers/github/sensors/github.py
+++ b/providers/github/src/airflow/providers/github/sensors/github.py
@@ -23,11 +23,11 @@ from typing import TYPE_CHECKING, Any
 from github import GithubException
 
 from airflow.exceptions import AirflowException
+from airflow.providers.common.compat.sdk import BaseSensorOperator
 from airflow.providers.github.hooks.github import GithubHook
-from airflow.providers.github.version_compat import BaseSensorOperator
 
 if TYPE_CHECKING:
-    from airflow.providers.github.version_compat import Context
+    from airflow.providers.common.compat.sdk import Context
 
 
 class GithubSensor(BaseSensorOperator):

--- a/providers/github/src/airflow/providers/github/version_compat.py
+++ b/providers/github/src/airflow/providers/github/version_compat.py
@@ -35,25 +35,4 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 AIRFLOW_V_3_1_PLUS: bool = get_base_airflow_version_tuple() >= (3, 1, 0)
 
-if AIRFLOW_V_3_1_PLUS:
-    from airflow.sdk import BaseHook
-else:
-    from airflow.hooks.base import BaseHook  # type: ignore[attr-defined,no-redef]
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import BaseOperator, BaseSensorOperator
-    from airflow.sdk.definitions.context import Context
-else:
-    from airflow.models import BaseOperator
-    from airflow.sensors.base import BaseSensorOperator  # type: ignore[no-redef]
-    from airflow.utils.context import Context
-
-
-__all__ = [
-    "AIRFLOW_V_3_0_PLUS",
-    "AIRFLOW_V_3_1_PLUS",
-    "BaseHook",
-    "BaseOperator",
-    "BaseSensorOperator",
-    "Context",
-]
+__all__ = ["AIRFLOW_V_3_0_PLUS", "AIRFLOW_V_3_1_PLUS"]


### PR DESCRIPTION
Replace version-specific conditional imports with ``common.compat`` layer. This standardizes compatibility handling across Airflow 2.x and 3.x.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
