### PR TITLE
Update Cadwyn migrations with v3-1-test changes

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py
@@ -26,14 +26,13 @@ from airflow.api_fastapi.execution_api.versions.v2025_08_10 import (
     AddIncludePriorDatesToGetXComSlice,
 )
 from airflow.api_fastapi.execution_api.versions.v2025_09_23 import AddDagVersionIdField
-from airflow.api_fastapi.execution_api.versions.v2025_10_10 import (
-    AddTriggeringUserNameField,
-    MakeDagRunConfNullable,
-)
+from airflow.api_fastapi.execution_api.versions.v2025_10_27 import MakeDagRunConfNullable
+from airflow.api_fastapi.execution_api.versions.v2026_01_01 import AddTriggeringUserNameField
 
 bundle = VersionBundle(
     HeadVersion(),
-    Version("2025-10-10", AddTriggeringUserNameField, MakeDagRunConfNullable),
+    Version("2026-01-01", AddTriggeringUserNameField),
+    Version("2025-10-27", MakeDagRunConfNullable),
     Version("2025-09-23", AddDagVersionIdField),
     Version(
         "2025-08-10",

--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2025_10_27.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2025_10_27.py
@@ -17,23 +17,9 @@
 
 from __future__ import annotations
 
-from cadwyn import ResponseInfo, VersionChange, convert_response_to_previous_version_for, schema
+from cadwyn import ResponseInfo, VersionChange, convert_response_to_previous_version_for
 
-from airflow.api_fastapi.execution_api.datamodels.taskinstance import DagRun, TIRunContext
-
-
-class AddTriggeringUserNameField(VersionChange):
-    """Add the `triggering_user_name` field to DagRun model."""
-
-    description = __doc__
-
-    instructions_to_migrate_to_previous_version = (schema(DagRun).field("triggering_user_name").didnt_exist,)
-
-    @convert_response_to_previous_version_for(TIRunContext)  # type: ignore[arg-type]
-    def remove_triggering_user_name_from_dag_run(response: ResponseInfo) -> None:  # type: ignore[misc]
-        """Remove the `triggering_user_name` field from the dag_run object when converting to the previous version."""
-        if "dag_run" in response.body and isinstance(response.body["dag_run"], dict):
-            response.body["dag_run"].pop("triggering_user_name", None)
+from airflow.api_fastapi.execution_api.datamodels.taskinstance import TIRunContext
 
 
 class MakeDagRunConfNullable(VersionChange):

--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_01_01.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_01_01.py
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from cadwyn import ResponseInfo, VersionChange, convert_response_to_previous_version_for, schema
+
+from airflow.api_fastapi.execution_api.datamodels.taskinstance import DagRun, TIRunContext
+
+
+class AddTriggeringUserNameField(VersionChange):
+    """Add the `triggering_user_name` field to DagRun model."""
+
+    description = __doc__
+
+    instructions_to_migrate_to_previous_version = (schema(DagRun).field("triggering_user_name").didnt_exist,)
+
+    @convert_response_to_previous_version_for(TIRunContext)  # type: ignore[arg-type]
+    def remove_triggering_user_name_from_dag_run(response: ResponseInfo) -> None:  # type: ignore[misc]
+        """Remove the `triggering_user_name` field from the dag_run object when converting to the previous version."""
+        if "dag_run" in response.body and isinstance(response.body["dag_run"], dict):
+            response.body["dag_run"].pop("triggering_user_name", None)

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2025_04_28/__init__.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2025_04_28/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -27,7 +27,7 @@ from uuid import UUID
 
 from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, JsonValue, RootModel
 
-API_VERSION: Final[str] = "2025-10-10"
+API_VERSION: Final[str] = "2026-01-01"
 
 
 class AssetAliasReferenceAssetEventDagRun(BaseModel):


### PR DESCRIPTION
After cherry-picking, the versions needs to change on one of the Cadwyn migrations.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
