### PR TITLE
Enable PT011 rule to airflow-core tests

### DIFF
--- a/airflow-core/tests/unit/serialization/test_serialized_objects.py
+++ b/airflow-core/tests/unit/serialization/test_serialized_objects.py
@@ -694,7 +694,7 @@ def test_encode_timezone():
     from airflow.serialization.serialized_objects import encode_timezone
 
     assert encode_timezone(FixedTimezone(0)) == "UTC"
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="DAG timezone should be a pendulum.tz.Timezone"):
         encode_timezone(object())
 
 

--- a/airflow-core/tests/unit/utils/test_db.py
+++ b/airflow-core/tests/unit/utils/test_db.py
@@ -519,7 +519,7 @@ class TestAutocommitEngineForMySQL:
             assert settings.prepare_engine_args != original_prepare
 
             # Now check that ValueError is raised
-            with pytest.raises(ValueError):
+            with pytest.raises(ValueError, match="Test exception"):
                 raise ValueError("Test exception")
 
         # Verify cleanup still happened despite exception

--- a/airflow-core/tests/unit/utils/test_helpers.py
+++ b/airflow-core/tests/unit/utils/test_helpers.py
@@ -42,6 +42,8 @@ from tests_common.test_utils.db import clear_db_dags, clear_db_runs
 if TYPE_CHECKING:
     from airflow.jobs.job import Job
 
+CHUNK_SIZE_POSITIVE_INT = "Chunk size must be a positive integer"
+
 
 @pytest.fixture
 def clear_db():
@@ -72,10 +74,10 @@ class TestHelpers:
         assert rendered_filename == expected_filename
 
     def test_chunks(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=CHUNK_SIZE_POSITIVE_INT):
             list(helpers.chunks([1, 2, 3], 0))
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=CHUNK_SIZE_POSITIVE_INT):
             list(helpers.chunks([1, 2, 3], -3))
 
         assert list(helpers.chunks([], 5)) == []
@@ -188,7 +190,7 @@ class TestHelpers:
             assert_exactly_one(*row)
 
     def test_exactly_one_should_fail(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Not supported for iterable args"):
             exactly_one([True, False])
 
     def test_at_most_one(self):

--- a/airflow-core/tests/unit/utils/test_operator_helpers.py
+++ b/airflow-core/tests/unit/utils/test_operator_helpers.py
@@ -131,10 +131,8 @@ def test_make_kwargs_callable_conflict():
     args = ["20200101"]
     kwargs = {"ds_nodash": "20200101"}
 
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match="ds_nodash"):
         kwargs_callable(*args, **kwargs)
-
-    assert "ds_nodash" in str(exc_info)
 
 
 @pytest.mark.parametrize(

--- a/airflow-core/tests/unit/utils/test_trigger_rule.py
+++ b/airflow-core/tests/unit/utils/test_trigger_rule.py
@@ -39,5 +39,5 @@ class TestTriggerRule:
         assert TriggerRule.is_valid(TriggerRule.ALL_DONE_MIN_ONE_SUCCESS)
         assert len(TriggerRule.all_triggers()) == 13
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="'NOT_EXIST_TRIGGER_RULE' is not a valid TriggerRule"):
             TriggerRule("NOT_EXIST_TRIGGER_RULE")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
issue: Enable Even More PyDocStyle Checks #40567
@ferruzzi
This PR is for enable PT011 rule:
PT011: all instances of pytest.raises should include a match term to make sure they are catching the right error.
https://docs.astral.sh/ruff/rules/pytest-raises-too-broad/
There are 102 files changes is need.
So, I separate to many PR, which contains about 5 file changes for easy review.
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
