### PR TITLE
Migrate Apache providers & Elasticsearch to ``common.compat``

### DIFF
--- a/providers/apache/beam/src/airflow/providers/apache/beam/hooks/beam.py
+++ b/providers/apache/beam/src/airflow/providers/apache/beam/hooks/beam.py
@@ -35,7 +35,7 @@ from typing import TYPE_CHECKING
 from packaging.version import Version
 
 from airflow.exceptions import AirflowConfigException, AirflowException
-from airflow.providers.apache.beam.version_compat import BaseHook
+from airflow.providers.common.compat.sdk import BaseHook
 from airflow.providers.common.compat.standard.utils import prepare_virtualenv
 
 if TYPE_CHECKING:

--- a/providers/apache/beam/src/airflow/providers/apache/beam/operators/beam.py
+++ b/providers/apache/beam/src/airflow/providers/apache/beam/operators/beam.py
@@ -34,14 +34,13 @@ from airflow.configuration import conf
 from airflow.exceptions import AirflowException, AirflowOptionalProviderFeatureException
 from airflow.providers.apache.beam.hooks.beam import BeamHook, BeamRunnerType
 from airflow.providers.apache.beam.triggers.beam import BeamJavaPipelineTrigger, BeamPythonPipelineTrigger
-from airflow.providers.apache.beam.version_compat import BaseOperator
+from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.providers_manager import ProvidersManager
 from airflow.utils.helpers import convert_camel_to_snake, exactly_one
 from airflow.version import version
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
-
+    from airflow.providers.common.compat.sdk import Context
 GOOGLE_PROVIDER = ProvidersManager().providers.get("apache-airflow-providers-google")
 
 

--- a/providers/apache/beam/src/airflow/providers/apache/beam/version_compat.py
+++ b/providers/apache/beam/src/airflow/providers/apache/beam/version_compat.py
@@ -31,14 +31,6 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 
 AIRFLOW_V_3_1_PLUS = get_base_airflow_version_tuple() >= (3, 1, 0)
 
-if AIRFLOW_V_3_1_PLUS:
-    from airflow.sdk import BaseHook, BaseOperator
-else:
-    from airflow.hooks.base import BaseHook  # type: ignore[attr-defined,no-redef]
-    from airflow.models import BaseOperator
-
 __all__ = [
     "AIRFLOW_V_3_1_PLUS",
-    "BaseHook",
-    "BaseOperator",
 ]

--- a/providers/apache/cassandra/pyproject.toml
+++ b/providers/apache/cassandra/pyproject.toml
@@ -61,11 +61,19 @@ dependencies = [
     "cassandra-driver>=3.29.1",
 ]
 
+# The optional dependencies should be modified in place in the generated file
+# Any change in the dependencies is preserved when the file is regenerated
+[project.optional-dependencies]
+"common.compat" = [
+    "apache-airflow-providers-common-compat"
+]
+
 [dependency-groups]
 dev = [
     "apache-airflow",
     "apache-airflow-task-sdk",
     "apache-airflow-devel-common",
+    "apache-airflow-providers-common-compat",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
 ]
 

--- a/providers/apache/cassandra/src/airflow/providers/apache/cassandra/hooks/cassandra.py
+++ b/providers/apache/cassandra/src/airflow/providers/apache/cassandra/hooks/cassandra.py
@@ -31,7 +31,7 @@ from cassandra.policies import (
     WhiteListRoundRobinPolicy,
 )
 
-from airflow.providers.apache.cassandra.version_compat import BaseHook
+from airflow.providers.common.compat.sdk import BaseHook
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 Policy: TypeAlias = DCAwareRoundRobinPolicy | RoundRobinPolicy | TokenAwarePolicy | WhiteListRoundRobinPolicy

--- a/providers/apache/cassandra/src/airflow/providers/apache/cassandra/sensors/record.py
+++ b/providers/apache/cassandra/src/airflow/providers/apache/cassandra/sensors/record.py
@@ -21,10 +21,10 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 from airflow.providers.apache.cassandra.hooks.cassandra import CassandraHook
-from airflow.providers.apache.cassandra.version_compat import BaseSensorOperator
+from airflow.providers.common.compat.sdk import BaseSensorOperator
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.providers.common.compat.sdk import Context
 
 
 class CassandraRecordSensor(BaseSensorOperator):

--- a/providers/apache/cassandra/src/airflow/providers/apache/cassandra/sensors/table.py
+++ b/providers/apache/cassandra/src/airflow/providers/apache/cassandra/sensors/table.py
@@ -21,10 +21,10 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 from airflow.providers.apache.cassandra.hooks.cassandra import CassandraHook
-from airflow.providers.apache.cassandra.version_compat import BaseSensorOperator
+from airflow.providers.common.compat.sdk import BaseSensorOperator
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.providers.common.compat.sdk import Context
 
 
 class CassandraTableSensor(BaseSensorOperator):

--- a/providers/apache/cassandra/src/airflow/providers/apache/cassandra/version_compat.py
+++ b/providers/apache/cassandra/src/airflow/providers/apache/cassandra/version_compat.py
@@ -35,20 +35,7 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 AIRFLOW_V_3_1_PLUS: bool = get_base_airflow_version_tuple() >= (3, 1, 0)
 
-
-if AIRFLOW_V_3_1_PLUS:
-    from airflow.sdk import BaseHook
-else:
-    from airflow.hooks.base import BaseHook  # type: ignore[attr-defined,no-redef]
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import BaseSensorOperator
-else:
-    from airflow.sensors.base import BaseSensorOperator  # type: ignore[no-redef]
-
 __all__ = [
     "AIRFLOW_V_3_0_PLUS",
     "AIRFLOW_V_3_1_PLUS",
-    "BaseHook",
-    "BaseSensorOperator",
 ]

--- a/providers/apache/flink/pyproject.toml
+++ b/providers/apache/flink/pyproject.toml
@@ -62,12 +62,20 @@ dependencies = [
     "apache-airflow-providers-cncf-kubernetes>=5.1.0",
 ]
 
+# The optional dependencies should be modified in place in the generated file
+# Any change in the dependencies is preserved when the file is regenerated
+[project.optional-dependencies]
+"common.compat" = [
+    "apache-airflow-providers-common-compat"
+]
+
 [dependency-groups]
 dev = [
     "apache-airflow",
     "apache-airflow-task-sdk",
     "apache-airflow-devel-common",
     "apache-airflow-providers-cncf-kubernetes",
+    "apache-airflow-providers-common-compat",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
 ]
 

--- a/providers/apache/flink/src/airflow/providers/apache/flink/operators/flink_kubernetes.py
+++ b/providers/apache/flink/src/airflow/providers/apache/flink/operators/flink_kubernetes.py
@@ -21,13 +21,13 @@ from collections.abc import Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING
 
-from airflow.providers.apache.flink.version_compat import BaseOperator
+from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.providers.cncf.kubernetes.hooks.kubernetes import KubernetesHook
 
 if TYPE_CHECKING:
     from kubernetes.client import CoreV1Api
 
-    from airflow.providers.apache.flink.version_compat import Context
+    from airflow.providers.common.compat.sdk import Context
 
 
 class FlinkKubernetesOperator(BaseOperator):

--- a/providers/apache/flink/src/airflow/providers/apache/flink/operators/flink_kubernetes.py
+++ b/providers/apache/flink/src/airflow/providers/apache/flink/operators/flink_kubernetes.py
@@ -21,8 +21,8 @@ from collections.abc import Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING
 
-from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.providers.cncf.kubernetes.hooks.kubernetes import KubernetesHook
+from airflow.providers.common.compat.sdk import BaseOperator
 
 if TYPE_CHECKING:
     from kubernetes.client import CoreV1Api

--- a/providers/apache/flink/src/airflow/providers/apache/flink/sensors/flink_kubernetes.py
+++ b/providers/apache/flink/src/airflow/providers/apache/flink/sensors/flink_kubernetes.py
@@ -23,8 +23,8 @@ from typing import TYPE_CHECKING
 from kubernetes import client
 
 from airflow.exceptions import AirflowException
-from airflow.providers.common.compat.sdk import BaseSensorOperator
 from airflow.providers.cncf.kubernetes.hooks.kubernetes import KubernetesHook
+from airflow.providers.common.compat.sdk import BaseSensorOperator
 
 if TYPE_CHECKING:
     from airflow.providers.common.compat.sdk import Context

--- a/providers/apache/flink/src/airflow/providers/apache/flink/sensors/flink_kubernetes.py
+++ b/providers/apache/flink/src/airflow/providers/apache/flink/sensors/flink_kubernetes.py
@@ -23,11 +23,11 @@ from typing import TYPE_CHECKING
 from kubernetes import client
 
 from airflow.exceptions import AirflowException
-from airflow.providers.apache.flink.version_compat import BaseSensorOperator
+from airflow.providers.common.compat.sdk import BaseSensorOperator
 from airflow.providers.cncf.kubernetes.hooks.kubernetes import KubernetesHook
 
 if TYPE_CHECKING:
-    from airflow.providers.apache.flink.version_compat import Context
+    from airflow.providers.common.compat.sdk import Context
 
 
 class FlinkKubernetesSensor(BaseSensorOperator):

--- a/providers/apache/flink/src/airflow/providers/apache/flink/version_compat.py
+++ b/providers/apache/flink/src/airflow/providers/apache/flink/version_compat.py
@@ -34,17 +34,6 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import BaseOperator, BaseSensorOperator
-    from airflow.sdk.definitions.context import Context
-else:
-    from airflow.models import BaseOperator
-    from airflow.sensors.base import BaseSensorOperator  # type: ignore[no-redef]
-    from airflow.utils.context import Context
-
 __all__ = [
     "AIRFLOW_V_3_0_PLUS",
-    "BaseOperator",
-    "BaseSensorOperator",
-    "Context",
 ]

--- a/providers/apache/hdfs/pyproject.toml
+++ b/providers/apache/hdfs/pyproject.toml
@@ -64,11 +64,19 @@ dependencies = [
     'pandas>=2.2.3; python_version >="3.13"',
 ]
 
+# The optional dependencies should be modified in place in the generated file
+# Any change in the dependencies is preserved when the file is regenerated
+[project.optional-dependencies]
+"common.compat" = [
+    "apache-airflow-providers-common-compat"
+]
+
 [dependency-groups]
 dev = [
     "apache-airflow",
     "apache-airflow-task-sdk",
     "apache-airflow-devel-common",
+    "apache-airflow-providers-common-compat",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
 ]
 

--- a/providers/apache/hdfs/src/airflow/providers/apache/hdfs/hooks/webhdfs.py
+++ b/providers/apache/hdfs/src/airflow/providers/apache/hdfs/hooks/webhdfs.py
@@ -26,7 +26,7 @@ from hdfs import HdfsError, InsecureClient
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
-from airflow.providers.apache.hdfs.version_compat import BaseHook
+from airflow.providers.common.compat.sdk import BaseHook
 
 log = logging.getLogger(__name__)
 

--- a/providers/apache/hdfs/src/airflow/providers/apache/hdfs/sensors/web_hdfs.py
+++ b/providers/apache/hdfs/src/airflow/providers/apache/hdfs/sensors/web_hdfs.py
@@ -20,13 +20,13 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
-from airflow.providers.apache.hdfs.version_compat import BaseSensorOperator
+from airflow.providers.common.compat.sdk import BaseSensorOperator
 
 if TYPE_CHECKING:
     from hdfs import InsecureClient
     from hdfs.ext.kerberos import KerberosClient
 
-    from airflow.utils.context import Context
+    from airflow.providers.common.compat.sdk import Context
 
 
 class WebHdfsSensor(BaseSensorOperator):

--- a/providers/apache/hdfs/src/airflow/providers/apache/hdfs/version_compat.py
+++ b/providers/apache/hdfs/src/airflow/providers/apache/hdfs/version_compat.py
@@ -35,20 +35,7 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 AIRFLOW_V_3_1_PLUS: bool = get_base_airflow_version_tuple() >= (3, 1, 0)
 
-if AIRFLOW_V_3_1_PLUS:
-    from airflow.sdk import BaseHook
-else:
-    from airflow.hooks.base import BaseHook  # type: ignore[attr-defined,no-redef]
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import BaseSensorOperator
-else:
-    from airflow.sensors.base import BaseSensorOperator  # type: ignore[no-redef]
-
-
 __all__ = [
     "AIRFLOW_V_3_0_PLUS",
     "AIRFLOW_V_3_1_PLUS",
-    "BaseHook",
-    "BaseSensorOperator",
 ]

--- a/providers/apache/hive/pyproject.toml
+++ b/providers/apache/hive/pyproject.toml
@@ -58,6 +58,7 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.10.0",
+    "apache-airflow-providers-common-compat>=1.7.4",    # + TODO: bump to next version
     "apache-airflow-providers-common-sql>=1.26.0",
     "hmsclient>=0.1.0",
     'pandas>=2.1.2; python_version <"3.13"',
@@ -98,6 +99,7 @@ dev = [
     "apache-airflow-task-sdk",
     "apache-airflow-devel-common",
     "apache-airflow-providers-amazon",
+    "apache-airflow-providers-common-compat",
     "apache-airflow-providers-common-sql",
     "apache-airflow-providers-microsoft-mssql",
     "apache-airflow-providers-mysql",

--- a/providers/apache/hive/src/airflow/providers/apache/hive/hooks/hive.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/hooks/hive.py
@@ -33,7 +33,7 @@ from typing_extensions import overload
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException, AirflowProviderDeprecationWarning
-from airflow.providers.apache.hive.version_compat import (
+from airflow.providers.common.compat.sdk import (
     AIRFLOW_VAR_NAME_FORMAT_MAPPING,
     BaseHook,
 )

--- a/providers/apache/hive/src/airflow/providers/apache/hive/operators/hive.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/operators/hive.py
@@ -25,14 +25,14 @@ from typing import TYPE_CHECKING, Any
 
 from airflow.configuration import conf
 from airflow.providers.apache.hive.hooks.hive import HiveCliHook
-from airflow.providers.apache.hive.version_compat import (
+from airflow.providers.common.compat.sdk import (
     AIRFLOW_VAR_NAME_FORMAT_MAPPING,
     BaseOperator,
     context_to_airflow_vars,
 )
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.providers.common.compat.sdk import Context
 
 
 class HiveOperator(BaseOperator):

--- a/providers/apache/hive/src/airflow/providers/apache/hive/operators/hive_stats.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/operators/hive_stats.py
@@ -23,12 +23,12 @@ from typing import TYPE_CHECKING, Any
 
 from airflow.exceptions import AirflowException
 from airflow.providers.apache.hive.hooks.hive import HiveMetastoreHook
-from airflow.providers.apache.hive.version_compat import BaseOperator
+from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.providers.mysql.hooks.mysql import MySqlHook
 from airflow.providers.presto.hooks.presto import PrestoHook
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.providers.common.compat.sdk import Context
 
 
 class HiveStatsCollectionOperator(BaseOperator):

--- a/providers/apache/hive/src/airflow/providers/apache/hive/sensors/hive_partition.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/sensors/hive_partition.py
@@ -21,10 +21,10 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 from airflow.providers.apache.hive.hooks.hive import HiveMetastoreHook
-from airflow.providers.apache.hive.version_compat import BaseSensorOperator
+from airflow.providers.common.compat.sdk import BaseSensorOperator
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.providers.common.compat.sdk import Context
 
 
 class HivePartitionSensor(BaseSensorOperator):

--- a/providers/apache/hive/src/airflow/providers/apache/hive/sensors/metastore_partition.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/sensors/metastore_partition.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Any
 from airflow.providers.common.sql.sensors.sql import SqlSensor
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.providers.common.compat.sdk import Context
 
 
 class MetastorePartitionSensor(SqlSensor):

--- a/providers/apache/hive/src/airflow/providers/apache/hive/sensors/named_hive_partition.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/sensors/named_hive_partition.py
@@ -20,10 +20,10 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
-from airflow.providers.apache.hive.version_compat import BaseSensorOperator
+from airflow.providers.common.compat.sdk import BaseSensorOperator
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.providers.common.compat.sdk import Context
 
 
 class NamedHivePartitionSensor(BaseSensorOperator):

--- a/providers/apache/hive/src/airflow/providers/apache/hive/transfers/hive_to_mysql.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/transfers/hive_to_mysql.py
@@ -24,11 +24,11 @@ from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING
 
 from airflow.providers.apache.hive.hooks.hive import HiveServer2Hook
-from airflow.providers.apache.hive.version_compat import BaseOperator, context_to_airflow_vars
+from airflow.providers.common.compat.sdk import BaseOperator, context_to_airflow_vars
 from airflow.providers.mysql.hooks.mysql import MySqlHook
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.providers.common.compat.sdk import Context
 
 
 class HiveToMySqlOperator(BaseOperator):

--- a/providers/apache/hive/src/airflow/providers/apache/hive/transfers/hive_to_samba.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/transfers/hive_to_samba.py
@@ -24,11 +24,11 @@ from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING
 
 from airflow.providers.apache.hive.hooks.hive import HiveServer2Hook
-from airflow.providers.apache.hive.version_compat import BaseOperator, context_to_airflow_vars
+from airflow.providers.common.compat.sdk import BaseOperator, context_to_airflow_vars
 from airflow.providers.samba.hooks.samba import SambaHook
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.providers.common.compat.sdk import Context
 
 
 class HiveToSambaOperator(BaseOperator):

--- a/providers/apache/hive/src/airflow/providers/apache/hive/transfers/mssql_to_hive.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/transfers/mssql_to_hive.py
@@ -27,11 +27,11 @@ from typing import TYPE_CHECKING
 import pymssql
 
 from airflow.providers.apache.hive.hooks.hive import HiveCliHook
-from airflow.providers.apache.hive.version_compat import BaseOperator
+from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.providers.microsoft.mssql.hooks.mssql import MsSqlHook
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.providers.common.compat.sdk import Context
 
 
 class MsSqlToHiveOperator(BaseOperator):

--- a/providers/apache/hive/src/airflow/providers/apache/hive/transfers/mysql_to_hive.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/transfers/mysql_to_hive.py
@@ -37,11 +37,11 @@ except ImportError:
 
 
 from airflow.providers.apache.hive.hooks.hive import HiveCliHook
-from airflow.providers.apache.hive.version_compat import BaseOperator
+from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.providers.mysql.hooks.mysql import MySqlHook
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.providers.common.compat.sdk import Context
 
 
 class MySqlToHiveOperator(BaseOperator):

--- a/providers/apache/hive/src/airflow/providers/apache/hive/transfers/s3_to_hive.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/transfers/s3_to_hive.py
@@ -31,10 +31,10 @@ from typing import TYPE_CHECKING, Any
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.apache.hive.hooks.hive import HiveCliHook
-from airflow.providers.apache.hive.version_compat import BaseOperator
+from airflow.providers.common.compat.sdk import BaseOperator
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.providers.common.compat.sdk import Context
 
 
 class S3ToHiveOperator(BaseOperator):

--- a/providers/apache/hive/src/airflow/providers/apache/hive/transfers/vertica_to_hive.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/transfers/vertica_to_hive.py
@@ -25,11 +25,11 @@ from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, Any
 
 from airflow.providers.apache.hive.hooks.hive import HiveCliHook
-from airflow.providers.apache.hive.version_compat import BaseOperator
+from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.providers.vertica.hooks.vertica import VerticaHook
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.providers.common.compat.sdk import Context
 
 
 class VerticaToHiveOperator(BaseOperator):

--- a/providers/apache/hive/src/airflow/providers/apache/hive/version_compat.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/version_compat.py
@@ -22,6 +22,14 @@
 #
 from __future__ import annotations
 
+# Re-export from common.compat for backward compatibility
+from airflow.providers.common.compat.sdk import (
+    AIRFLOW_VAR_NAME_FORMAT_MAPPING,
+    BaseOperator,
+    BaseSensorOperator,
+    context_to_airflow_vars,
+)
+
 
 def get_base_airflow_version_tuple() -> tuple[int, int, int]:
     from packaging.version import Version
@@ -35,27 +43,9 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 AIRFLOW_V_3_1_PLUS: bool = get_base_airflow_version_tuple() >= (3, 1, 0)
 
-if AIRFLOW_V_3_1_PLUS:
-    from airflow.sdk import BaseHook
-else:
-    from airflow.hooks.base import BaseHook  # type: ignore[attr-defined,no-redef]
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import BaseOperator, BaseSensorOperator
-    from airflow.sdk.execution_time.context import AIRFLOW_VAR_NAME_FORMAT_MAPPING, context_to_airflow_vars
-else:
-    from airflow.models import BaseOperator
-    from airflow.sensors.base import BaseSensorOperator  # type: ignore[no-redef]
-    from airflow.utils.operator_helpers import (  # type: ignore[no-redef, attr-defined]
-        AIRFLOW_VAR_NAME_FORMAT_MAPPING,
-        context_to_airflow_vars,
-    )
-
-
 __all__ = [
     "AIRFLOW_V_3_0_PLUS",
     "AIRFLOW_V_3_1_PLUS",
-    "BaseHook",
     "BaseOperator",
     "BaseSensorOperator",
     "AIRFLOW_VAR_NAME_FORMAT_MAPPING",

--- a/providers/apache/hive/tests/system/apache/hive/example_twitter_dag.py
+++ b/providers/apache/hive/tests/system/apache/hive/example_twitter_dag.py
@@ -26,15 +26,8 @@ from datetime import date, datetime, timedelta
 
 from airflow import DAG
 from airflow.providers.apache.hive.operators.hive import HiveOperator
+from airflow.providers.common.compat.sdk import task
 from airflow.providers.standard.operators.bash import BashOperator
-
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import task
-else:
-    # Airflow 2 path
-    from airflow.decorators import task  # type: ignore[attr-defined,no-redef]
 
 # --------------------------------------------------------------------------------
 # Caveat: This Dag will not run because of missing scripts.

--- a/providers/apache/hive/tests/unit/apache/hive/hooks/test_hive.py
+++ b/providers/apache/hive/tests/unit/apache/hive/hooks/test_hive.py
@@ -31,6 +31,7 @@ from airflow.exceptions import AirflowException
 from airflow.models.connection import Connection
 from airflow.models.dag import DAG
 from airflow.providers.apache.hive.hooks.hive import HiveCliHook, HiveMetastoreHook, HiveServer2Hook
+from airflow.providers.common.compat.sdk import AIRFLOW_VAR_NAME_FORMAT_MAPPING
 from airflow.secrets.environment_variables import CONN_ENV_PREFIX
 from airflow.utils import timezone
 
@@ -43,13 +44,6 @@ from unit.apache.hive import (
     MockHiveServer2Hook,
     MockSubProcess,
 )
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk.execution_time.context import AIRFLOW_VAR_NAME_FORMAT_MAPPING
-else:
-    from airflow.utils.operator_helpers import (  # type: ignore[no-redef, attr-defined]
-        AIRFLOW_VAR_NAME_FORMAT_MAPPING,
-    )
 
 DEFAULT_DATE = timezone.datetime(2015, 1, 1)
 DEFAULT_DATE_ISO = DEFAULT_DATE.isoformat()

--- a/providers/apache/hive/tests/unit/apache/hive/transfers/test_hive_to_mysql.py
+++ b/providers/apache/hive/tests/unit/apache/hive/transfers/test_hive_to_mysql.py
@@ -24,15 +24,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from airflow.providers.apache.hive.transfers.hive_to_mysql import HiveToMySqlOperator
+from airflow.providers.common.compat.sdk import context_to_airflow_vars
 from airflow.utils import timezone
 
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 from unit.apache.hive import MockHiveServer2Hook, MockMySqlHook, TestHiveEnvironment
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk.execution_time.context import context_to_airflow_vars
-else:
-    from airflow.utils.operator_helpers import context_to_airflow_vars  # type: ignore[no-redef, attr-defined]
 
 DEFAULT_DATE = timezone.datetime(2015, 1, 1)
 

--- a/providers/apache/hive/tests/unit/apache/hive/transfers/test_hive_to_samba.py
+++ b/providers/apache/hive/tests/unit/apache/hive/transfers/test_hive_to_samba.py
@@ -23,20 +23,15 @@ from unittest.mock import MagicMock, Mock, PropertyMock, patch
 import pytest
 
 from airflow.providers.apache.hive.transfers.hive_to_samba import HiveToSambaOperator
+from airflow.providers.common.compat.sdk import context_to_airflow_vars
 from airflow.providers.samba.hooks.samba import SambaHook
 
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 from unit.apache.hive import (
     DEFAULT_DATE,
     MockConnectionCursor,
     MockHiveServer2Hook,
     TestHiveEnvironment,
 )
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk.execution_time.context import context_to_airflow_vars
-else:
-    from airflow.utils.operator_helpers import context_to_airflow_vars  # type: ignore[no-redef, attr-defined]
 
 
 class MockSambaHook(SambaHook):

--- a/providers/apache/iceberg/pyproject.toml
+++ b/providers/apache/iceberg/pyproject.toml
@@ -60,11 +60,19 @@ dependencies = [
     "apache-airflow>=2.10.0",
 ]
 
+# The optional dependencies should be modified in place in the generated file
+# Any change in the dependencies is preserved when the file is regenerated
+[project.optional-dependencies]
+"common.compat" = [
+    "apache-airflow-providers-common-compat"
+]
+
 [dependency-groups]
 dev = [
     "apache-airflow",
     "apache-airflow-task-sdk",
     "apache-airflow-devel-common",
+    "apache-airflow-providers-common-compat",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
     "pyiceberg>=0.5.0",
 ]

--- a/providers/apache/iceberg/src/airflow/providers/apache/iceberg/hooks/iceberg.py
+++ b/providers/apache/iceberg/src/airflow/providers/apache/iceberg/hooks/iceberg.py
@@ -21,7 +21,7 @@ from typing import Any, cast
 import requests
 from requests import HTTPError
 
-from airflow.providers.apache.iceberg.version_compat import BaseHook
+from airflow.providers.common.compat.sdk import BaseHook
 
 TOKENS_ENDPOINT = "oauth/tokens"
 

--- a/providers/apache/iceberg/src/airflow/providers/apache/iceberg/version_compat.py
+++ b/providers/apache/iceberg/src/airflow/providers/apache/iceberg/version_compat.py
@@ -34,12 +34,6 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 
 AIRFLOW_V_3_1_PLUS: bool = get_base_airflow_version_tuple() >= (3, 1, 0)
 
-if AIRFLOW_V_3_1_PLUS:
-    from airflow.sdk import BaseHook
-else:
-    from airflow.hooks.base import BaseHook  # type: ignore[attr-defined,no-redef]
-
 __all__ = [
     "AIRFLOW_V_3_1_PLUS",
-    "BaseHook",
 ]

--- a/providers/apache/impala/src/airflow/providers/apache/impala/version_compat.py
+++ b/providers/apache/impala/src/airflow/providers/apache/impala/version_compat.py
@@ -33,3 +33,7 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 
 
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
+
+__all__ = [
+    "AIRFLOW_V_3_0_PLUS",
+]

--- a/providers/apache/kafka/pyproject.toml
+++ b/providers/apache/kafka/pyproject.toml
@@ -70,12 +70,16 @@ dependencies = [
 "common.messaging" = [
     "apache-airflow-providers-common-messaging>=2.0.0"
 ]
+"common.compat" = [
+    "apache-airflow-providers-common-compat"
+]
 
 [dependency-groups]
 dev = [
     "apache-airflow",
     "apache-airflow-task-sdk",
     "apache-airflow-devel-common",
+    "apache-airflow-providers-common-compat",
     "apache-airflow-providers-common-messaging",
     "apache-airflow-providers-google",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)

--- a/providers/apache/kafka/src/airflow/providers/apache/kafka/hooks/base.py
+++ b/providers/apache/kafka/src/airflow/providers/apache/kafka/hooks/base.py
@@ -21,7 +21,7 @@ from typing import Any
 
 from confluent_kafka.admin import AdminClient
 
-from airflow.providers.apache.kafka.version_compat import BaseHook
+from airflow.providers.common.compat.sdk import BaseHook
 
 
 class KafkaBaseHook(BaseHook):

--- a/providers/apache/kafka/src/airflow/providers/apache/kafka/operators/consume.py
+++ b/providers/apache/kafka/src/airflow/providers/apache/kafka/operators/consume.py
@@ -22,7 +22,7 @@ from typing import Any
 
 from airflow.exceptions import AirflowException
 from airflow.providers.apache.kafka.hooks.consume import KafkaConsumerHook
-from airflow.providers.apache.kafka.version_compat import BaseOperator
+from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.utils.module_loading import import_string
 
 VALID_COMMIT_CADENCE = {"never", "end_of_batch", "end_of_operator"}

--- a/providers/apache/kafka/src/airflow/providers/apache/kafka/operators/produce.py
+++ b/providers/apache/kafka/src/airflow/providers/apache/kafka/operators/produce.py
@@ -23,7 +23,7 @@ from typing import Any
 
 from airflow.exceptions import AirflowException
 from airflow.providers.apache.kafka.hooks.produce import KafkaProducerHook
-from airflow.providers.apache.kafka.version_compat import BaseOperator
+from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.utils.module_loading import import_string
 
 local_logger = logging.getLogger("airflow")

--- a/providers/apache/kafka/src/airflow/providers/apache/kafka/sensors/kafka.py
+++ b/providers/apache/kafka/src/airflow/providers/apache/kafka/sensors/kafka.py
@@ -20,7 +20,7 @@ from collections.abc import Callable, Sequence
 from typing import Any
 
 from airflow.providers.apache.kafka.triggers.await_message import AwaitMessageTrigger
-from airflow.providers.apache.kafka.version_compat import BaseOperator
+from airflow.providers.common.compat.sdk import BaseOperator
 
 VALID_COMMIT_CADENCE = {"never", "end_of_batch", "end_of_operator"}
 

--- a/providers/apache/kafka/src/airflow/providers/apache/kafka/version_compat.py
+++ b/providers/apache/kafka/src/airflow/providers/apache/kafka/version_compat.py
@@ -35,18 +35,7 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 AIRFLOW_V_3_1_PLUS: bool = get_base_airflow_version_tuple() >= (3, 1, 0)
 
-if AIRFLOW_V_3_1_PLUS:
-    from airflow.sdk import BaseHook
-else:
-    from airflow.hooks.base import BaseHook  # type: ignore[attr-defined,no-redef]
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import BaseOperator
-else:
-    from airflow.models import BaseOperator
-
 __all__ = [
     "AIRFLOW_V_3_0_PLUS",
-    "BaseHook",
-    "BaseOperator",
+    "AIRFLOW_V_3_1_PLUS",
 ]

--- a/providers/apache/livy/src/airflow/providers/apache/livy/operators/livy.py
+++ b/providers/apache/livy/src/airflow/providers/apache/livy/operators/livy.py
@@ -25,14 +25,14 @@ from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.providers.apache.livy.hooks.livy import BatchState, LivyHook
 from airflow.providers.apache.livy.triggers.livy import LivyTrigger
-from airflow.providers.apache.livy.version_compat import BaseOperator
 from airflow.providers.common.compat.openlineage.utils.spark import (
     inject_parent_job_information_into_spark_properties,
     inject_transport_information_into_spark_properties,
 )
+from airflow.providers.common.compat.sdk import BaseOperator
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.providers.common.compat.sdk import Context
 
 
 class LivyOperator(BaseOperator):

--- a/providers/apache/livy/src/airflow/providers/apache/livy/sensors/livy.py
+++ b/providers/apache/livy/src/airflow/providers/apache/livy/sensors/livy.py
@@ -20,10 +20,10 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 from airflow.providers.apache.livy.hooks.livy import LivyHook
-from airflow.providers.apache.livy.version_compat import BaseSensorOperator
+from airflow.providers.common.compat.sdk import BaseSensorOperator
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.providers.common.compat.sdk import Context
 
 
 class LivySensor(BaseSensorOperator):

--- a/providers/apache/livy/src/airflow/providers/apache/livy/version_compat.py
+++ b/providers/apache/livy/src/airflow/providers/apache/livy/version_compat.py
@@ -34,10 +34,4 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import BaseOperator, BaseSensorOperator
-else:
-    from airflow.models import BaseOperator
-    from airflow.sensors.base import BaseSensorOperator  # type: ignore[no-redef]
-
-__all__ = ["AIRFLOW_V_3_0_PLUS", "BaseOperator", "BaseSensorOperator"]
+__all__ = ["AIRFLOW_V_3_0_PLUS"]

--- a/providers/apache/pig/pyproject.toml
+++ b/providers/apache/pig/pyproject.toml
@@ -60,11 +60,19 @@ dependencies = [
     "apache-airflow>=2.10.0",
 ]
 
+# The optional dependencies should be modified in place in the generated file
+# Any change in the dependencies is preserved when the file is regenerated
+[project.optional-dependencies]
+"common.compat" = [
+    "apache-airflow-providers-common-compat"
+]
+
 [dependency-groups]
 dev = [
     "apache-airflow",
     "apache-airflow-task-sdk",
     "apache-airflow-devel-common",
+    "apache-airflow-providers-common-compat",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
 ]
 

--- a/providers/apache/pig/src/airflow/providers/apache/pig/hooks/pig.py
+++ b/providers/apache/pig/src/airflow/providers/apache/pig/hooks/pig.py
@@ -22,7 +22,7 @@ from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import Any
 
 from airflow.exceptions import AirflowException
-from airflow.providers.apache.pig.version_compat import BaseHook
+from airflow.providers.common.compat.sdk import BaseHook
 
 
 class PigCliHook(BaseHook):

--- a/providers/apache/pig/src/airflow/providers/apache/pig/operators/pig.py
+++ b/providers/apache/pig/src/airflow/providers/apache/pig/operators/pig.py
@@ -22,10 +22,10 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 from airflow.providers.apache.pig.hooks.pig import PigCliHook
-from airflow.providers.apache.pig.version_compat import BaseOperator
+from airflow.providers.common.compat.sdk import BaseOperator
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.providers.common.compat.sdk import Context
 
 
 class PigOperator(BaseOperator):

--- a/providers/apache/pig/src/airflow/providers/apache/pig/version_compat.py
+++ b/providers/apache/pig/src/airflow/providers/apache/pig/version_compat.py
@@ -35,19 +35,7 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 AIRFLOW_V_3_1_PLUS: bool = get_base_airflow_version_tuple() >= (3, 1, 0)
 
-if AIRFLOW_V_3_1_PLUS:
-    from airflow.sdk import BaseHook
-else:
-    from airflow.hooks.base import BaseHook  # type: ignore[attr-defined,no-redef]
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import BaseOperator
-else:
-    from airflow.models import BaseOperator
-
 __all__ = [
     "AIRFLOW_V_3_0_PLUS",
     "AIRFLOW_V_3_1_PLUS",
-    "BaseHook",
-    "BaseOperator",
 ]

--- a/providers/apache/pinot/pyproject.toml
+++ b/providers/apache/pinot/pyproject.toml
@@ -62,11 +62,19 @@ dependencies = [
     "pinotdb>=5.1.0",
 ]
 
+# The optional dependencies should be modified in place in the generated file
+# Any change in the dependencies is preserved when the file is regenerated
+[project.optional-dependencies]
+"common.compat" = [
+    "apache-airflow-providers-common-compat"
+]
+
 [dependency-groups]
 dev = [
     "apache-airflow",
     "apache-airflow-task-sdk",
     "apache-airflow-devel-common",
+    "apache-airflow-providers-common-compat",
     "apache-airflow-providers-common-sql",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
     "apache-airflow-providers-common-sql[pandas,polars]"

--- a/providers/apache/pinot/src/airflow/providers/apache/pinot/hooks/pinot.py
+++ b/providers/apache/pinot/src/airflow/providers/apache/pinot/hooks/pinot.py
@@ -26,7 +26,7 @@ from urllib.parse import quote_plus
 from pinotdb import connect
 
 from airflow.exceptions import AirflowException
-from airflow.providers.apache.pinot.version_compat import BaseHook
+from airflow.providers.common.compat.sdk import BaseHook
 from airflow.providers.common.sql.hooks.sql import DbApiHook
 
 if TYPE_CHECKING:

--- a/providers/apache/pinot/src/airflow/providers/apache/pinot/version_compat.py
+++ b/providers/apache/pinot/src/airflow/providers/apache/pinot/version_compat.py
@@ -34,12 +34,6 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 
 AIRFLOW_V_3_1_PLUS: bool = get_base_airflow_version_tuple() >= (3, 1, 0)
 
-if AIRFLOW_V_3_1_PLUS:
-    from airflow.sdk import BaseHook
-else:
-    from airflow.hooks.base import BaseHook  # type: ignore[attr-defined,no-redef]
-
 __all__ = [
     "AIRFLOW_V_3_1_PLUS",
-    "BaseHook",
 ]

--- a/providers/apache/spark/src/airflow/providers/apache/spark/decorators/pyspark.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/decorators/pyspark.py
@@ -22,7 +22,7 @@ from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any
 
 from airflow.providers.apache.spark.hooks.spark_connect import SparkConnectHook
-from airflow.providers.apache.spark.version_compat import (
+from airflow.providers.common.compat.sdk import (
     BaseHook,
     DecoratedOperator,
     TaskDecorator,
@@ -31,8 +31,7 @@ from airflow.providers.apache.spark.version_compat import (
 from airflow.providers.common.compat.standard.operators import PythonOperator
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
-
+    from airflow.providers.common.compat.sdk import Context
 SPARK_CONTEXT_KEYS = ["spark", "sc"]
 
 

--- a/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_connect.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_connect.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from typing import Any, cast
 from urllib.parse import quote, urlparse, urlunparse
 
-from airflow.providers.apache.spark.version_compat import BaseHook
+from airflow.providers.common.compat.sdk import BaseHook
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 

--- a/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_sql.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_sql.py
@@ -21,7 +21,7 @@ import subprocess
 from typing import TYPE_CHECKING, Any
 
 from airflow.exceptions import AirflowException, AirflowNotFoundException
-from airflow.providers.apache.spark.version_compat import BaseHook
+from airflow.providers.common.compat.sdk import BaseHook
 
 if TYPE_CHECKING:
     try:

--- a/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -32,7 +32,7 @@ from typing import Any
 
 from airflow.configuration import conf as airflow_conf
 from airflow.exceptions import AirflowException
-from airflow.providers.apache.spark.version_compat import BaseHook
+from airflow.providers.common.compat.sdk import BaseHook
 from airflow.security.kerberos import renew_from_kt
 from airflow.utils.log.logging_mixin import LoggingMixin
 

--- a/providers/apache/spark/src/airflow/providers/apache/spark/operators/spark_jdbc.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/operators/spark_jdbc.py
@@ -23,7 +23,7 @@ from airflow.providers.apache.spark.hooks.spark_jdbc import SparkJDBCHook
 from airflow.providers.apache.spark.operators.spark_submit import SparkSubmitOperator
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.providers.common.compat.sdk import Context
 
 
 class SparkJDBCOperator(SparkSubmitOperator):

--- a/providers/apache/spark/src/airflow/providers/apache/spark/operators/spark_sql.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/operators/spark_sql.py
@@ -21,10 +21,10 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 from airflow.providers.apache.spark.hooks.spark_sql import SparkSqlHook
-from airflow.providers.apache.spark.version_compat import BaseOperator
+from airflow.providers.common.compat.sdk import BaseOperator
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.providers.common.compat.sdk import Context
 
 
 class SparkSqlOperator(BaseOperator):

--- a/providers/apache/spark/src/airflow/providers/apache/spark/operators/spark_submit.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/operators/spark_submit.py
@@ -22,15 +22,15 @@ from typing import TYPE_CHECKING, Any
 
 from airflow.configuration import conf
 from airflow.providers.apache.spark.hooks.spark_submit import SparkSubmitHook
-from airflow.providers.apache.spark.version_compat import BaseOperator
 from airflow.providers.common.compat.openlineage.utils.spark import (
     inject_parent_job_information_into_spark_properties,
     inject_transport_information_into_spark_properties,
 )
+from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.settings import WEB_COLORS
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.providers.common.compat.sdk import Context
 
 
 class SparkSubmitOperator(BaseOperator):

--- a/providers/apache/spark/src/airflow/providers/apache/spark/version_compat.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/version_compat.py
@@ -22,6 +22,15 @@
 #
 from __future__ import annotations
 
+# Re-export from common.compat for backward compatibility
+from airflow.providers.common.compat.sdk import (
+    BaseHook,
+    BaseOperator,
+    DecoratedOperator,
+    TaskDecorator,
+    task_decorator_factory,
+)
+
 
 def get_base_airflow_version_tuple() -> tuple[int, int, int]:
     from packaging.version import Version
@@ -34,22 +43,6 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 AIRFLOW_V_3_1_PLUS: bool = get_base_airflow_version_tuple() >= (3, 1, 0)
-
-if AIRFLOW_V_3_1_PLUS:
-    from airflow.sdk import BaseHook
-else:
-    from airflow.hooks.base import BaseHook  # type: ignore[attr-defined,no-redef]
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import BaseOperator
-    from airflow.sdk.bases.decorator import DecoratedOperator, TaskDecorator, task_decorator_factory
-else:
-    from airflow.decorators.base import (  # type: ignore[no-redef]
-        DecoratedOperator,
-        TaskDecorator,
-        task_decorator_factory,
-    )
-    from airflow.models import BaseOperator
 
 __all__ = [
     "AIRFLOW_V_3_0_PLUS",

--- a/providers/apache/tinkerpop/pyproject.toml
+++ b/providers/apache/tinkerpop/pyproject.toml
@@ -61,11 +61,19 @@ dependencies = [
     "gremlinpython>=3.7.3",
 ]
 
+# The optional dependencies should be modified in place in the generated file
+# Any change in the dependencies is preserved when the file is regenerated
+[project.optional-dependencies]
+"common.compat" = [
+    "apache-airflow-providers-common-compat"
+]
+
 [dependency-groups]
 dev = [
     "apache-airflow",
     "apache-airflow-task-sdk",
     "apache-airflow-devel-common",
+    "apache-airflow-providers-common-compat",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
 ]
 

--- a/providers/apache/tinkerpop/src/airflow/providers/apache/tinkerpop/hooks/gremlin.py
+++ b/providers/apache/tinkerpop/src/airflow/providers/apache/tinkerpop/hooks/gremlin.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Any
 
 from gremlin_python.driver.client import Client
 
-from airflow.providers.apache.tinkerpop.version_compat import BaseHook
+from airflow.providers.common.compat.sdk import BaseHook
 
 if TYPE_CHECKING:
     from airflow.models import Connection

--- a/providers/apache/tinkerpop/src/airflow/providers/apache/tinkerpop/operators/gremlin.py
+++ b/providers/apache/tinkerpop/src/airflow/providers/apache/tinkerpop/operators/gremlin.py
@@ -19,14 +19,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from airflow.providers.apache.tinkerpop.hooks.gremlin import GremlinHook
-from airflow.providers.apache.tinkerpop.version_compat import BaseOperator
+from airflow.providers.common.compat.sdk import BaseOperator
 
 if TYPE_CHECKING:
-    try:
-        from airflow.sdk.definitions.context import Context
-    except ImportError:
-        # TODO: Remove once provider drops support for Airflow 2
-        from airflow.utils.context import Context
+    from airflow.providers.common.compat.sdk import Context
 
 
 class GremlinOperator(BaseOperator):

--- a/providers/apache/tinkerpop/src/airflow/providers/apache/tinkerpop/version_compat.py
+++ b/providers/apache/tinkerpop/src/airflow/providers/apache/tinkerpop/version_compat.py
@@ -29,18 +29,7 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 AIRFLOW_V_3_1_PLUS: bool = get_base_airflow_version_tuple() >= (3, 1, 0)
 
-if AIRFLOW_V_3_1_PLUS:
-    from airflow.sdk import BaseHook
-else:
-    from airflow.hooks.base import BaseHook  # type: ignore[attr-defined,no-redef]
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import BaseOperator
-else:
-    from airflow.models import BaseOperator
-
 __all__ = [
     "AIRFLOW_V_3_0_PLUS",
-    "BaseHook",
-    "BaseOperator",
+    "AIRFLOW_V_3_1_PLUS",
 ]

--- a/providers/common/compat/src/airflow/providers/common/compat/sdk.py
+++ b/providers/common/compat/src/airflow/providers/common/compat/sdk.py
@@ -77,7 +77,10 @@ if TYPE_CHECKING:
     from airflow.sdk.definitions.context import context_merge as context_merge
     from airflow.sdk.definitions.mappedoperator import MappedOperator as MappedOperator
     from airflow.sdk.definitions.template import literal as literal
-    from airflow.sdk.execution_time.context import context_to_airflow_vars as context_to_airflow_vars
+    from airflow.sdk.execution_time.context import (
+        AIRFLOW_VAR_NAME_FORMAT_MAPPING as AIRFLOW_VAR_NAME_FORMAT_MAPPING,
+        context_to_airflow_vars as context_to_airflow_vars,
+    )
     from airflow.sdk.execution_time.timeout import timeout as timeout
     from airflow.sdk.execution_time.xcom import XCom as XCom
 
@@ -182,6 +185,10 @@ _IMPORT_MAP: dict[str, str | tuple[str, ...]] = {
     "Context": ("airflow.sdk", "airflow.utils.context"),
     "context_merge": ("airflow.sdk.definitions.context", "airflow.utils.context"),
     "context_to_airflow_vars": ("airflow.sdk.execution_time.context", "airflow.utils.operator_helpers"),
+    "AIRFLOW_VAR_NAME_FORMAT_MAPPING": (
+        "airflow.sdk.execution_time.context",
+        "airflow.utils.operator_helpers",
+    ),
     "get_current_context": ("airflow.sdk", "airflow.operators.python"),
     "get_parsing_context": ("airflow.sdk", "airflow.utils.dag_parsing_context"),
     # ============================================================================

--- a/providers/elasticsearch/pyproject.toml
+++ b/providers/elasticsearch/pyproject.toml
@@ -58,6 +58,7 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.10.0",
+    "apache-airflow-providers-common-compat>=1.7.4",    # + TODO: bump to next version
     "apache-airflow-providers-common-sql>=1.27.0",
     "elasticsearch>=8.10,<9",
 ]
@@ -67,6 +68,7 @@ dev = [
     "apache-airflow",
     "apache-airflow-task-sdk",
     "apache-airflow-devel-common",
+    "apache-airflow-providers-common-compat",
     "apache-airflow-providers-common-sql",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
     "apache-airflow-providers-common-sql[pandas,polars]",

--- a/providers/elasticsearch/src/airflow/providers/elasticsearch/hooks/elasticsearch.py
+++ b/providers/elasticsearch/src/airflow/providers/elasticsearch/hooks/elasticsearch.py
@@ -25,8 +25,8 @@ from urllib import parse
 
 from elasticsearch import Elasticsearch
 
+from airflow.providers.common.compat.sdk import BaseHook
 from airflow.providers.common.sql.hooks.sql import DbApiHook
-from airflow.providers.elasticsearch.version_compat import BaseHook
 
 if TYPE_CHECKING:
     from elastic_transport import ObjectApiResponse

--- a/providers/elasticsearch/src/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/providers/elasticsearch/src/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -41,28 +41,28 @@ from elasticsearch.exceptions import NotFoundError
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.models.dagrun import DagRun
+from airflow.providers.common.compat.sdk import timezone
 from airflow.providers.elasticsearch.log.es_json_formatter import ElasticsearchJSONFormatter
 from airflow.providers.elasticsearch.log.es_response import ElasticSearchResponse, Hit
-from airflow.providers.elasticsearch.version_compat import (
-    AIRFLOW_V_3_0_PLUS,
-    AIRFLOW_V_3_1_PLUS,
-    EsLogMsgType,
-)
+from airflow.providers.elasticsearch.version_compat import AIRFLOW_V_3_0_PLUS
 from airflow.utils.log.file_task_handler import FileTaskHandler
 from airflow.utils.log.logging_mixin import ExternalLoggingMixin, LoggingMixin
 from airflow.utils.module_loading import import_string
 from airflow.utils.session import create_session
-
-if AIRFLOW_V_3_1_PLUS:
-    from airflow.sdk import timezone
-else:
-    from airflow.utils import timezone  # type: ignore[attr-defined,no-redef]
 
 if TYPE_CHECKING:
     from datetime import datetime
 
     from airflow.models.taskinstance import TaskInstance, TaskInstanceKey
     from airflow.utils.log.file_task_handler import LogMetadata
+
+
+if AIRFLOW_V_3_0_PLUS:
+    from airflow.utils.log.file_task_handler import StructuredLogMessage
+
+    EsLogMsgType = list[StructuredLogMessage] | str
+else:
+    EsLogMsgType = list[tuple[str, str]]  # type: ignore[assignment,misc]
 
 
 LOG_LINE_DEFAULTS = {"exc_text": "", "stack_info": ""}

--- a/providers/elasticsearch/src/airflow/providers/elasticsearch/version_compat.py
+++ b/providers/elasticsearch/src/airflow/providers/elasticsearch/version_compat.py
@@ -35,16 +35,4 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 AIRFLOW_V_3_1_PLUS: bool = get_base_airflow_version_tuple() >= (3, 1, 0)
 
-if AIRFLOW_V_3_1_PLUS:
-    from airflow.sdk import BaseHook
-else:
-    from airflow.hooks.base import BaseHook  # type: ignore[attr-defined,no-redef]
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.utils.log.file_task_handler import StructuredLogMessage
-
-    EsLogMsgType = list[StructuredLogMessage] | str
-else:
-    EsLogMsgType = list[tuple[str, str]]  # type: ignore[assignment,misc]
-
-__all__ = ["AIRFLOW_V_3_0_PLUS", "AIRFLOW_V_3_1_PLUS", "BaseHook", "EsLogMsgType"]
+__all__ = ["AIRFLOW_V_3_0_PLUS", "AIRFLOW_V_3_1_PLUS"]

--- a/providers/elasticsearch/tests/system/elasticsearch/example_elasticsearch_query.py
+++ b/providers/elasticsearch/tests/system/elasticsearch/example_elasticsearch_query.py
@@ -24,16 +24,9 @@ import os
 from datetime import datetime
 
 from airflow import models
+from airflow.providers.common.compat.sdk import task
 from airflow.providers.elasticsearch.hooks.elasticsearch import ElasticsearchPythonHook, ElasticsearchSQLHook
 from airflow.providers.standard.operators.python import PythonOperator
-
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import task
-else:
-    # Airflow 2 path
-    from airflow.decorators import task  # type: ignore[attr-defined,no-redef]
 
 ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID")
 DAG_ID = "elasticsearch_dag"


### PR DESCRIPTION
Replace version-specific conditional imports with common.compat layer. This standardizes compatibility handling across Airflow 2.x and 3.x.

Special handling for hive (context helpers) and spark (decorators) where version_compat re-exports base classes from common.compat.

Migrated providers:
- beam, cassandra, drill, flink, hdfs, hive, iceberg, impala
- kafka, livy, pig, pinot, spark, tinkerpop
- elasticsearch


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
