### PR TITLE
Migrate sendgrid provider to ``common.compat``

### DIFF
--- a/providers/sendgrid/pyproject.toml
+++ b/providers/sendgrid/pyproject.toml
@@ -58,6 +58,7 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.10.0",
+    "apache-airflow-providers-common-compat>=1.7.4",    # + TODO: bump to next version
     # workaround conflicts with fab for Python 3.12 https://github.com/apache/airflow/pull/50221#issuecomment-2926765112
     # can be set to sendgrid>=6.12.3 when we upgrade to fab 5 and remove Werkzeug dependency
     "sendgrid>=6.12.3; python_version < '3.12'",
@@ -70,6 +71,7 @@ dev = [
     "apache-airflow",
     "apache-airflow-task-sdk",
     "apache-airflow-devel-common",
+    "apache-airflow-providers-common-compat",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
 ]
 

--- a/providers/sendgrid/src/airflow/providers/sendgrid/utils/emailer.py
+++ b/providers/sendgrid/src/airflow/providers/sendgrid/utils/emailer.py
@@ -38,7 +38,7 @@ from sendgrid.helpers.mail import (
     SandBoxMode,
 )
 
-from airflow.providers.sendgrid.version_compat import BaseHook
+from airflow.providers.common.compat.sdk import BaseHook
 from airflow.utils.email import get_email_address_list
 
 log = logging.getLogger(__name__)

--- a/providers/sendgrid/src/airflow/providers/sendgrid/version_compat.py
+++ b/providers/sendgrid/src/airflow/providers/sendgrid/version_compat.py
@@ -30,11 +30,4 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 AIRFLOW_V_3_1_PLUS: bool = get_base_airflow_version_tuple() >= (3, 1, 0)
 
-if AIRFLOW_V_3_1_PLUS:
-    from airflow.sdk import BaseHook
-else:
-    from airflow.hooks.base import BaseHook  # type: ignore[attr-defined,no-redef]
-
-__all__ = [
-    "BaseHook",
-]
+__all__ = ["AIRFLOW_V_3_0_PLUS", "AIRFLOW_V_3_1_PLUS"]


### PR DESCRIPTION
Replace version-specific conditional imports with common.compat layer.

This PR migrates the sendgrid provider to use the centralized common.compat compatibility layer instead of local version_compat.py patterns.