### PR TITLE
Migrate cncf/kubernetes provider to ``common.compat``

### DIFF
--- a/providers/cncf/kubernetes/pyproject.toml
+++ b/providers/cncf/kubernetes/pyproject.toml
@@ -59,6 +59,7 @@ requires-python = ">=3.10"
 dependencies = [
     "aiofiles>=23.2.0",
     "apache-airflow>=2.10.0",
+    "apache-airflow-providers-common-compat>=1.7.4",    # + TODO: bump to next version
     "asgiref>=3.5.2",
     "cryptography>=41.0.0",
     # The Kubernetes API is known to introduce problems when upgraded to a MAJOR version. Airflow Core
@@ -79,6 +80,7 @@ dev = [
     "apache-airflow",
     "apache-airflow-task-sdk",
     "apache-airflow-devel-common",
+    "apache-airflow-providers-common-compat",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
 ]
 

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/decorators/kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/decorators/kubernetes.py
@@ -31,7 +31,7 @@ from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperato
 from airflow.providers.cncf.kubernetes.python_kubernetes_script import (
     write_python_script,
 )
-from airflow.providers.cncf.kubernetes.version_compat import (
+from airflow.providers.common.compat.sdk import (
     DecoratedOperator,
     TaskDecorator,
     task_decorator_factory,

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/decorators/kubernetes_cmd.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/decorators/kubernetes_cmd.py
@@ -21,7 +21,7 @@ from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING
 
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
-from airflow.providers.cncf.kubernetes.version_compat import (
+from airflow.providers.common.compat.sdk import (
     DecoratedOperator,
     TaskDecorator,
     context_merge,

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -43,7 +43,7 @@ from airflow.providers.cncf.kubernetes.utils.container import (
     container_is_completed,
     container_is_running,
 )
-from airflow.providers.cncf.kubernetes.version_compat import BaseHook
+from airflow.providers.common.compat.sdk import BaseHook
 from airflow.utils import yaml
 
 if TYPE_CHECKING:

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -81,7 +81,8 @@ from airflow.providers.cncf.kubernetes.utils.pod_manager import (
     PodNotFoundException,
     PodPhase,
 )
-from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_1_PLUS, XCOM_RETURN_KEY
+from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_1_PLUS
+from airflow.providers.common.compat.sdk import XCOM_RETURN_KEY
 
 if AIRFLOW_V_3_1_PLUS:
     from airflow.sdk import BaseOperator

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/sensors/spark_kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/sensors/spark_kubernetes.py
@@ -25,12 +25,7 @@ from kubernetes import client
 
 from airflow.exceptions import AirflowException
 from airflow.providers.cncf.kubernetes.hooks.kubernetes import KubernetesHook
-from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_0_PLUS
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import BaseSensorOperator
-else:
-    from airflow.sensors.base import BaseSensorOperator  # type: ignore[no-redef]
+from airflow.providers.common.compat.sdk import BaseSensorOperator
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/version_compat.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/version_compat.py
@@ -35,34 +35,4 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 AIRFLOW_V_3_1_PLUS = get_base_airflow_version_tuple() >= (3, 1, 0)
 
-if AIRFLOW_V_3_1_PLUS:
-    from airflow.models.xcom import XCOM_RETURN_KEY
-    from airflow.sdk import BaseHook
-    from airflow.sdk.definitions.context import context_merge
-else:
-    from airflow.hooks.base import BaseHook  # type: ignore[attr-defined,no-redef]
-    from airflow.utils.context import context_merge  # type: ignore[attr-defined, no-redef]
-    from airflow.utils.xcom import XCOM_RETURN_KEY  # type: ignore[no-redef]
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk.bases.decorator import DecoratedOperator, TaskDecorator, task_decorator_factory
-else:
-    from airflow.decorators.base import (  # type: ignore[no-redef]
-        DecoratedOperator,
-        TaskDecorator,
-        task_decorator_factory,
-    )
-
-# BaseOperator and BaseSensorOperator removed from version_compat to avoid circular imports
-# Import them directly in files that need them instead
-
-__all__ = [
-    "AIRFLOW_V_3_0_PLUS",
-    "AIRFLOW_V_3_1_PLUS",
-    "BaseHook",
-    "DecoratedOperator",
-    "TaskDecorator",
-    "task_decorator_factory",
-    "XCOM_RETURN_KEY",
-    "context_merge",
-]
+__all__ = ["AIRFLOW_V_3_0_PLUS", "AIRFLOW_V_3_1_PLUS"]


### PR DESCRIPTION
Replace version-specific conditional imports with common.compat layer.

This PR migrates the cncf/kubernetes provider to use the centralized common.compat compatibility layer instead of local version_compat.py patterns.
