### PR TITLE
Identify duplicate kubernetes section airflow configuration and mark them as deprecated

### DIFF
--- a/providers/cncf/kubernetes/provider.yaml
+++ b/providers/cncf/kubernetes/provider.yaml
@@ -210,6 +210,9 @@ config:
         type: string
         example: ~
         default: ""
+        deprecated: true
+        deprecation_reason: |
+          This configuration is deprecated. Use `pod_template_file` to specify container image instead.
       worker_container_tag:
         description: |
           The tag of the Kubernetes Image for the Worker to Run
@@ -217,6 +220,9 @@ config:
         type: string
         example: ~
         default: ""
+        deprecated: true
+        deprecation_reason: |
+          This configuration is deprecated. Use `pod_template_file` to specify the image tag instead.
       namespace:
         description: |
           The Kubernetes namespace where airflow workers should be created. Defaults to ``default``
@@ -224,6 +230,9 @@ config:
         type: string
         example: ~
         default: "default"
+        deprecated: true
+        deprecation_reason: |
+          This configuration is deprecated. Use `pod_template_file` to specify namespace instead.
       delete_worker_pods:
         description: |
           If True, all worker pods will be deleted upon termination

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/get_provider_info.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/get_provider_info.py
@@ -135,6 +135,8 @@ def get_provider_info():
                         "type": "string",
                         "example": None,
                         "default": "",
+                        "deprecated": True,
+                        "deprecation_reason": "This configuration is deprecated. Use `pod_template_file` to specify container image instead.\n",
                     },
                     "worker_container_tag": {
                         "description": "The tag of the Kubernetes Image for the Worker to Run\n",
@@ -142,6 +144,8 @@ def get_provider_info():
                         "type": "string",
                         "example": None,
                         "default": "",
+                        "deprecated": True,
+                        "deprecation_reason": "This configuration is deprecated. Use `pod_template_file` to specify the image tag instead.\n",
                     },
                     "namespace": {
                         "description": "The Kubernetes namespace where airflow workers should be created. Defaults to ``default``\n",
@@ -149,6 +153,8 @@ def get_provider_info():
                         "type": "string",
                         "example": None,
                         "default": "default",
+                        "deprecated": True,
+                        "deprecation_reason": "This configuration is deprecated. Use `pod_template_file` to specify namespace instead.\n",
                     },
                     "delete_worker_pods": {
                         "description": "If True, all worker pods will be deleted upon termination\n",

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/kube_config.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/kube_config.py
@@ -16,8 +16,10 @@
 # under the License.
 from __future__ import annotations
 
+import warnings
+
 from airflow.configuration import conf
-from airflow.exceptions import AirflowConfigException
+from airflow.exceptions import AirflowConfigException, AirflowProviderDeprecationWarning
 from airflow.settings import AIRFLOW_HOME
 
 
@@ -53,7 +55,21 @@ class KubeConfig:
             self.kubernetes_section, "worker_pods_creation_batch_size"
         )
         self.worker_container_repository = conf.get(self.kubernetes_section, "worker_container_repository")
+        if self.worker_container_repository:
+            warnings.warn(
+                "Configuration 'worker_container_repository' is deprecated. "
+                "Use 'pod_template_file' to specify the container image repository instead.",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
+            )
         self.worker_container_tag = conf.get(self.kubernetes_section, "worker_container_tag")
+        if self.worker_container_tag:
+            warnings.warn(
+                "Configuration 'worker_container_tag' is deprecated. "
+                "Use 'pod_template_file' to specify the container image tag instead.",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
+            )
         if self.worker_container_repository and self.worker_container_tag:
             self.kube_image = f"{self.worker_container_repository}:{self.worker_container_tag}"
         else:
@@ -64,6 +80,13 @@ class KubeConfig:
         # cluster has RBAC enabled, your scheduler may need service account permissions to
         # create, watch, get, and delete pods in this namespace.
         self.kube_namespace = conf.get(self.kubernetes_section, "namespace")
+        if self.kube_namespace and self.kube_namespace != "default":
+            warnings.warn(
+                "Configuration 'namespace' is deprecated. "
+                "Use 'pod_template_file' to specify the namespace instead.",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
+            )
         self.multi_namespace_mode = conf.getboolean(self.kubernetes_section, "multi_namespace_mode")
         if self.multi_namespace_mode and conf.get(
             self.kubernetes_section, "multi_namespace_mode_namespace_list"


### PR DESCRIPTION
closes: #36389

This pull request identifies and deprecates duplicate Airflow configuration entries under the Kubernetes section that were previously defined multiple times across the codebase.
These configurations included overlapping keys related to image repository, image tag, and namespace settings used by the Kubernetes Executor and Pod Operator.

Changes Done:

1. Marked the following duplicated configuration options as deprecated:

- worker_container_repository
- worker_container_tag
- worker_namespace

2. Added deprecated field annotations and inline comments referencing the canonical configurations.

3. Updated corresponding entries in provider_info.py and kubernetes_config.py to reflect deprecation status.

4. Cleaned up redundant imports and unified configuration references to the primary section.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
