### PR TITLE
Fix Extra Links translation key.

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/ExtraLinks.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/ExtraLinks.tsx
@@ -23,7 +23,7 @@ import { useParams } from "react-router-dom";
 import { useTaskInstanceServiceGetExtraLinks } from "openapi/queries";
 
 export const ExtraLinks = () => {
-  const { t: translate } = useTranslation();
+  const { t: translate } = useTranslation("dag");
   const { dagId = "", mapIndex = "-1", runId = "", taskId = "" } = useParams();
 
   const { data } = useTaskInstanceServiceGetExtraLinks({
@@ -35,7 +35,7 @@ export const ExtraLinks = () => {
 
   return data && Object.keys(data.extra_links).length > 0 ? (
     <Box py={1}>
-      <Heading size="sm">{translate("dag.extraLinks")}</Heading>
+      <Heading size="sm">{translate("extraLinks")}</Heading>
       <HStack gap={2} py={2}>
         {Object.entries(data.extra_links).map(([key, value], _) =>
           value === null ? undefined : (


### PR DESCRIPTION
The "Extra Links" header is not translated and rendered as "dag.extraLinks" . The PR updates the key so that the translation is displayed.