### PR TITLE
Fix dag list cache invalidation on favouriting a dag

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -164,6 +164,7 @@ const createColumns = (
     header: "",
   },
   {
+    accessorKey: "favourite",
     cell: ({ row: { original } }) => (
       <FavoriteDagButton dagId={original.dag_id} isFavorite={original.is_favorite} withText={false} />
     ),

--- a/airflow-core/src/airflow/ui/src/queries/useToggleFavoriteDag.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useToggleFavoriteDag.ts
@@ -35,10 +35,13 @@ export const useToggleFavoriteDag = (dagId: string) => {
       queryKey: [useDagServiceGetDagsUiKey, UseDagServiceGetDagDetailsKeyFn({ dagId }, [{ dagId }])],
     });
 
-    // Invalidate the specific DAG details query for this DAG
-    await queryClient.invalidateQueries({
-      queryKey: UseDagServiceGetDagDetailsKeyFn({ dagId }, [{ dagId }]),
-    });
+    const queryKeys = [
+      // Invalidate the specific DAG details query for this DAG and DAGs list query.
+      UseDagServiceGetDagDetailsKeyFn({ dagId }, [{ dagId }]),
+      [useDagServiceGetDagsUiKey],
+    ];
+
+    await Promise.all(queryKeys.map((key) => queryClient.invalidateQueries({ queryKey: key })));
   }, [queryClient, dagId]);
 
   const favoriteMutation = useDagServiceFavoriteDag({


### PR DESCRIPTION
Built on top of https://github.com/apache/airflow/pull/57037 that needs to be merged first.

This fixes issue when setting a dag as favourite from the dag list page, list wouldn't be refetched with the appropriate favourite values.

### Before
https://github.com/user-attachments/assets/6345b4cb-e729-4457-bb9d-4a0000f95f30

### After
https://github.com/user-attachments/assets/357d2204-b6f7-4413-a2db-da49eee4b490

