### PR TITLE
Update French locale for 3.1.1

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/components.json
@@ -96,10 +96,15 @@
   },
   "limitedList": "+{{count}} supplémentaires",
   "limitedList.allItems": "Tous les {{count}} éléments :",
+  "limitedList.allTags_many": "Tous les éléments ({{count}}) :",
+  "limitedList.allTags_one": "Tous les éléments (1) :",
+  "limitedList.allTags_other": "Tous les éléments ({{count}}) :",
   "limitedList.clickToInteract": "Cliquez sur une étiquette pour filtrer les Dags",
   "limitedList.clickToOpenFull": "Cliquez sur \"+{{count}} supplémentaires\" pour ouvrir la vue complète",
   "limitedList.copyPasteText": "Vous pouvez copier et coller le texte ci-dessus",
-  "limitedList.showingItems": "Affichage de {{count}} éléments",
+  "limitedList.showingItems_many": "Affichage de {{count}} éléments",
+  "limitedList.showingItems_one": "Affichage de 1 élément",
+  "limitedList.showingItems_other": "Affichage de {{count}} éléments",
   "logs": {
     "file": "Fichier",
     "location": "ligne {{line}} dans {{name}}"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/dag.json
@@ -10,6 +10,7 @@
     "hourly": "Toutes les heures",
     "legend": {
       "less": "Moins",
+      "mixed": "Mixte",
       "more": "Plus"
     },
     "navigation": {
@@ -19,6 +20,7 @@
       "previousYear": "Année précédente"
     },
     "noData": "Aucune donnée disponible",
+    "noFailedRuns": "Aucun Run échoué",
     "noRuns": "Aucun Run",
     "totalRuns": "Total des Runs",
     "week": "Semaine {{weekNumber}}",


### PR DESCRIPTION
Just the `3.1.1` piece that will be backported and complete french translation for 3.1.1 release.

With this diff, on `v3-1-test` branch:
<img width="1881" height="924" alt="Screenshot 2025-10-22 at 11 54 27" src="https://github.com/user-attachments/assets/d0c6ee6c-5e31-42dc-aa91-1912a46f2da8" />
