### PR TITLE
Fix grid links for tasks with retries

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridTI.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridTI.tsx
@@ -85,7 +85,11 @@ const Instance = ({ dagId, instance, isGroup, isMapped, onClick, runId, taskId }
     [dagId, isGroup, isMapped, location.pathname, runId, taskId],
   );
 
+  // Remove try_number query param when navigating to reset to the
+  // latest try of the task instance and avoid issues with invalid try numbers:
+  // https://github.com/apache/airflow/issues/56977
   searchParams.delete("try_number");
+  const redirectionSearch = searchParams.toString();
 
   return (
     <Flex
@@ -108,7 +112,7 @@ const Instance = ({ dagId, instance, isGroup, isMapped, onClick, runId, taskId }
         replace
         to={{
           pathname: getTaskUrl(),
-          search: searchParams.toString(),
+          search: redirectionSearch,
         }}
       >
         <Tooltip

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridTI.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridTI.tsx
@@ -20,7 +20,7 @@ import { Badge, Flex } from "@chakra-ui/react";
 import type { MouseEvent } from "react";
 import React, { useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { Link, useLocation, useParams } from "react-router-dom";
+import { Link, useLocation, useParams, useSearchParams } from "react-router-dom";
 
 import type { LightGridTaskInstanceSummary } from "openapi/requests/types.gen";
 import { StateIcon } from "src/components/StateIcon";
@@ -58,15 +58,16 @@ type Props = {
   readonly label: string;
   readonly onClick?: () => void;
   readonly runId: string;
-  readonly search: string;
   readonly taskId: string;
 };
 
-const Instance = ({ dagId, instance, isGroup, isMapped, onClick, runId, search, taskId }: Props) => {
+const Instance = ({ dagId, instance, isGroup, isMapped, onClick, runId, taskId }: Props) => {
   const { setHoveredTaskId } = useHover();
   const { groupId: selectedGroupId, taskId: selectedTaskId } = useParams();
   const { t: translate } = useTranslation();
   const location = useLocation();
+
+  const [searchParams] = useSearchParams();
 
   const onMouseEnter = handleMouseEnter(setHoveredTaskId);
   const onMouseLeave = handleMouseLeave(taskId, setHoveredTaskId);
@@ -83,6 +84,8 @@ const Instance = ({ dagId, instance, isGroup, isMapped, onClick, runId, search, 
       }),
     [dagId, isGroup, isMapped, location.pathname, runId, taskId],
   );
+
+  searchParams.delete("try_number");
 
   return (
     <Flex
@@ -105,7 +108,7 @@ const Instance = ({ dagId, instance, isGroup, isMapped, onClick, runId, search, 
         replace
         to={{
           pathname: getTaskUrl(),
-          search,
+          search: searchParams.toString(),
         }}
       >
         <Tooltip

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/TaskInstancesColumn.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/TaskInstancesColumn.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { Box } from "@chakra-ui/react";
-import { useParams, useSearchParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 
 import type { LightGridTaskInstanceSummary } from "openapi/requests/types.gen";
 
@@ -34,8 +34,6 @@ type Props = {
 
 export const TaskInstancesColumn = ({ nodes, onCellClick, runId, taskInstances }: Props) => {
   const { dagId = "" } = useParams();
-  const [searchParams] = useSearchParams();
-  const search = searchParams.toString();
 
   return nodes.map((node) => {
     // todo: how does this work with mapped? same task id for multiple tis
@@ -55,7 +53,6 @@ export const TaskInstancesColumn = ({ nodes, onCellClick, runId, taskInstances }
         label={node.label}
         onClick={onCellClick}
         runId={runId}
-        search={search}
         taskId={node.id}
       />
     );


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/56977

It's super cool to keep search params when navigating between tasks in the grid, so we can keep log filtering (source, level etc...), but try_number should always be reseted. This will cause the UI to default to the latest try_number and prevent the issue reported #56977

(also moved the searchparams hook down to the GridTI component, we were passing those as prop for no reason)