### PR TITLE
Remove '.git' folder from versions in GitDagBundle

### DIFF
--- a/airflow-core/newsfragments/57069.significant.rst
+++ b/airflow-core/newsfragments/57069.significant.rst
@@ -1,0 +1,16 @@
+Git provider: Remove '.git' folder from versions in GitDagBundle
+
+A new option(``prune_dotgit_folder``) has been added to the GitDagBundle to remove ``.git`` from
+versioned bundles by default to reduce disk usage; set prune_dotgit_folder=False to keep
+repo metadata in the dag bundle's versions folders.
+
+* Types of change
+
+  * [ ] Dag changes
+  * [ ] Config changes
+  * [ ] API changes
+  * [ ] CLI changes
+  * [x] Behaviour changes
+  * [ ] Plugin changes
+  * [ ] Dependency changes
+  * [ ] Code interface changes

--- a/providers/git/docs/bundles/index.rst
+++ b/providers/git/docs/bundles/index.rst
@@ -35,6 +35,7 @@ Example of using the GitDagBundle:
              "subdir": "dags",
              "tracking_ref": "main",
              "refresh_interval": 3600
+             "prune_dotgit_folder": True
          }
      }
     ]'

--- a/providers/git/src/airflow/providers/git/bundles/git.py
+++ b/providers/git/src/airflow/providers/git/bundles/git.py
@@ -49,7 +49,7 @@ class GitDagBundle(BaseDagBundle):
 
         The per-version clone is not a full "git" copy (it makes use of git's `--local` ability
         to share the object directory via hard links, but if you have a lot of current versions
-        running, or an especially large git repo setting this to True will save some disk space
+        running, or an especially large git repo leaving this as True will save some disk space
         at the expense of `git` operations not working in the bundle that Tasks run from.
     """
 

--- a/providers/git/src/airflow/providers/git/bundles/git.py
+++ b/providers/git/src/airflow/providers/git/bundles/git.py
@@ -45,7 +45,12 @@ class GitDagBundle(BaseDagBundle):
     :param subdir: Subdirectory within the repository where the DAGs are stored (Optional)
     :param git_conn_id: Connection ID for SSH/token based connection to the repository (Optional)
     :param repo_url: Explicit Git repository URL to override the connection's host. (Optional)
-    :param remove_git_repo_on_versions: Remove .git folder from the versions after cloning
+    :param remove_git_repo_on_versions: Remove .git folder from the versions after cloning.
+
+        The per-version clone is not a full "git" copy (it makes uses of git's `--local` ability
+        to share the object directory via hardlinks, but if you have a lot of current versions
+        running, or an especially large git repo setting this to False will save some disk space
+        at the expense of `git` operations not working in the bundle that Tasks run from.
     """
 
     supports_versioning = True

--- a/providers/git/src/airflow/providers/git/bundles/git.py
+++ b/providers/git/src/airflow/providers/git/bundles/git.py
@@ -45,7 +45,7 @@ class GitDagBundle(BaseDagBundle):
     :param subdir: Subdirectory within the repository where the DAGs are stored (Optional)
     :param git_conn_id: Connection ID for SSH/token based connection to the repository (Optional)
     :param repo_url: Explicit Git repository URL to override the connection's host. (Optional)
-    :param remove_git_folder_from_versions: Remove .git folder from the versions after cloning.
+    :param prune_dotgit_folder: Remove .git folder from the versions after cloning.
 
         The per-version clone is not a full "git" copy (it makes use of git's `--local` ability
         to share the object directory via hardlinks, but if you have a lot of current versions
@@ -62,7 +62,7 @@ class GitDagBundle(BaseDagBundle):
         subdir: str | None = None,
         git_conn_id: str | None = None,
         repo_url: str | None = None,
-        remove_git_folder_from_versions: bool = True,
+        prune_dotgit_folder: bool = True,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -75,7 +75,7 @@ class GitDagBundle(BaseDagBundle):
             self.repo_path = self.base_dir / "tracking_repo"
         self.git_conn_id = git_conn_id
         self.repo_url = repo_url
-        self.remove_git_folder_from_versions = remove_git_folder_from_versions
+        self.prune_dotgit_folder = prune_dotgit_folder
 
         self._log = log.bind(
             bundle_name=self.name,
@@ -123,7 +123,7 @@ class GitDagBundle(BaseDagBundle):
                     self.repo.remotes.origin.fetch()
                 self.repo.head.set_reference(str(self.repo.commit(self.version)))
                 self.repo.head.reset(index=True, working_tree=True)
-                if self.remove_git_folder_from_versions:
+                if self.prune_dotgit_folder:
                     shutil.rmtree(self.repo_path / ".git")
             else:
                 self.refresh()

--- a/providers/git/src/airflow/providers/git/bundles/git.py
+++ b/providers/git/src/airflow/providers/git/bundles/git.py
@@ -48,7 +48,7 @@ class GitDagBundle(BaseDagBundle):
     :param prune_dotgit_folder: Remove .git folder from the versions after cloning.
 
         The per-version clone is not a full "git" copy (it makes use of git's `--local` ability
-        to share the object directory via hardlinks, but if you have a lot of current versions
+        to share the object directory via hard links, but if you have a lot of current versions
         running, or an especially large git repo setting this to True will save some disk space
         at the expense of `git` operations not working in the bundle that Tasks run from.
     """

--- a/providers/git/src/airflow/providers/git/bundles/git.py
+++ b/providers/git/src/airflow/providers/git/bundles/git.py
@@ -45,6 +45,7 @@ class GitDagBundle(BaseDagBundle):
     :param subdir: Subdirectory within the repository where the DAGs are stored (Optional)
     :param git_conn_id: Connection ID for SSH/token based connection to the repository (Optional)
     :param repo_url: Explicit Git repository URL to override the connection's host. (Optional)
+    :param remove_git_repo_on_versions: Remove .git folder from the versions after cloning
     """
 
     supports_versioning = True
@@ -56,6 +57,7 @@ class GitDagBundle(BaseDagBundle):
         subdir: str | None = None,
         git_conn_id: str | None = None,
         repo_url: str | None = None,
+        remove_git_repo_on_versions: bool = True,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -68,6 +70,7 @@ class GitDagBundle(BaseDagBundle):
             self.repo_path = self.base_dir / "tracking_repo"
         self.git_conn_id = git_conn_id
         self.repo_url = repo_url
+        self.remove_git_repo_on_versions = remove_git_repo_on_versions
 
         self._log = log.bind(
             bundle_name=self.name,
@@ -115,6 +118,8 @@ class GitDagBundle(BaseDagBundle):
                     self.repo.remotes.origin.fetch()
                 self.repo.head.set_reference(str(self.repo.commit(self.version)))
                 self.repo.head.reset(index=True, working_tree=True)
+                if self.remove_git_repo_on_versions:
+                    shutil.rmtree(self.repo_path / ".git")
             else:
                 self.refresh()
             self.repo.close()

--- a/providers/git/src/airflow/providers/git/bundles/git.py
+++ b/providers/git/src/airflow/providers/git/bundles/git.py
@@ -45,11 +45,11 @@ class GitDagBundle(BaseDagBundle):
     :param subdir: Subdirectory within the repository where the DAGs are stored (Optional)
     :param git_conn_id: Connection ID for SSH/token based connection to the repository (Optional)
     :param repo_url: Explicit Git repository URL to override the connection's host. (Optional)
-    :param remove_git_repo_on_versions: Remove .git folder from the versions after cloning.
+    :param remove_git_folder_from_versions: Remove .git folder from the versions after cloning.
 
-        The per-version clone is not a full "git" copy (it makes uses of git's `--local` ability
+        The per-version clone is not a full "git" copy (it makes use of git's `--local` ability
         to share the object directory via hardlinks, but if you have a lot of current versions
-        running, or an especially large git repo setting this to False will save some disk space
+        running, or an especially large git repo setting this to True will save some disk space
         at the expense of `git` operations not working in the bundle that Tasks run from.
     """
 
@@ -62,7 +62,7 @@ class GitDagBundle(BaseDagBundle):
         subdir: str | None = None,
         git_conn_id: str | None = None,
         repo_url: str | None = None,
-        remove_git_repo_on_versions: bool = True,
+        remove_git_folder_from_versions: bool = True,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -75,7 +75,7 @@ class GitDagBundle(BaseDagBundle):
             self.repo_path = self.base_dir / "tracking_repo"
         self.git_conn_id = git_conn_id
         self.repo_url = repo_url
-        self.remove_git_repo_on_versions = remove_git_repo_on_versions
+        self.remove_git_folder_from_versions = remove_git_folder_from_versions
 
         self._log = log.bind(
             bundle_name=self.name,
@@ -123,7 +123,7 @@ class GitDagBundle(BaseDagBundle):
                     self.repo.remotes.origin.fetch()
                 self.repo.head.set_reference(str(self.repo.commit(self.version)))
                 self.repo.head.reset(index=True, working_tree=True)
-                if self.remove_git_repo_on_versions:
+                if self.remove_git_folder_from_versions:
                     shutil.rmtree(self.repo_path / ".git")
             else:
                 self.refresh()

--- a/providers/git/tests/unit/git/bundles/test_git.py
+++ b/providers/git/tests/unit/git/bundles/test_git.py
@@ -165,7 +165,7 @@ class TestGitDagBundle:
             git_conn_id=CONN_HTTPS,
             version=starting_commit.hexsha,
             tracking_ref=GIT_DEFAULT_BRANCH,
-            remove_git_folder_from_versions=False,
+            prune_dotgit_folder=False,
         )
         bundle.initialize()
 
@@ -197,7 +197,7 @@ class TestGitDagBundle:
             git_conn_id=CONN_HTTPS,
             version="test",
             tracking_ref=GIT_DEFAULT_BRANCH,
-            remove_git_folder_from_versions=False,
+            prune_dotgit_folder=False,
         )
         bundle.initialize()
         assert bundle.get_current_version() == starting_commit.hexsha
@@ -259,7 +259,7 @@ class TestGitDagBundle:
             git_conn_id=CONN_HTTPS,
             version=starting_commit.hexsha,
             tracking_ref=GIT_DEFAULT_BRANCH,
-            remove_git_folder_from_versions=False,
+            prune_dotgit_folder=False,
         )
         bundle.initialize()
 

--- a/providers/git/tests/unit/git/bundles/test_git.py
+++ b/providers/git/tests/unit/git/bundles/test_git.py
@@ -165,7 +165,7 @@ class TestGitDagBundle:
             git_conn_id=CONN_HTTPS,
             version=starting_commit.hexsha,
             tracking_ref=GIT_DEFAULT_BRANCH,
-            remove_git_repo_on_versions=False,
+            remove_git_folder_from_versions=False,
         )
         bundle.initialize()
 
@@ -197,7 +197,7 @@ class TestGitDagBundle:
             git_conn_id=CONN_HTTPS,
             version="test",
             tracking_ref=GIT_DEFAULT_BRANCH,
-            remove_git_repo_on_versions=False,
+            remove_git_folder_from_versions=False,
         )
         bundle.initialize()
         assert bundle.get_current_version() == starting_commit.hexsha
@@ -259,7 +259,7 @@ class TestGitDagBundle:
             git_conn_id=CONN_HTTPS,
             version=starting_commit.hexsha,
             tracking_ref=GIT_DEFAULT_BRANCH,
-            remove_git_repo_on_versions=False,
+            remove_git_folder_from_versions=False,
         )
         bundle.initialize()
 

--- a/providers/git/tests/unit/git/bundles/test_git.py
+++ b/providers/git/tests/unit/git/bundles/test_git.py
@@ -165,6 +165,7 @@ class TestGitDagBundle:
             git_conn_id=CONN_HTTPS,
             version=starting_commit.hexsha,
             tracking_ref=GIT_DEFAULT_BRANCH,
+            remove_git_repo_on_versions=False,
         )
         bundle.initialize()
 
@@ -196,6 +197,7 @@ class TestGitDagBundle:
             git_conn_id=CONN_HTTPS,
             version="test",
             tracking_ref=GIT_DEFAULT_BRANCH,
+            remove_git_repo_on_versions=False,
         )
         bundle.initialize()
         assert bundle.get_current_version() == starting_commit.hexsha
@@ -222,6 +224,47 @@ class TestGitDagBundle:
 
         files_in_repo = {f.name for f in bundle.path.iterdir() if f.is_file()}
         assert {"test_dag.py", "new_test.py"} == files_in_repo
+
+        assert_repo_is_closed(bundle)
+
+    @mock.patch("airflow.providers.git.bundles.git.GitHook")
+    def test_removes_git_dir_for_versioned_bundle_by_default(self, mock_githook, git_repo):
+        repo_path, repo = git_repo
+        mock_githook.return_value.repo_url = repo_path
+        starting_commit = repo.head.commit
+
+        bundle = GitDagBundle(
+            name="test",
+            git_conn_id=CONN_HTTPS,
+            version=starting_commit.hexsha,
+            tracking_ref=GIT_DEFAULT_BRANCH,
+        )
+        bundle.initialize()
+
+        assert not (bundle.repo_path / ".git").exists()
+
+        files_in_repo = {f.name for f in bundle.path.iterdir() if f.is_file()}
+        assert {"test_dag.py"} == files_in_repo
+
+        assert_repo_is_closed(bundle)
+
+    @mock.patch("airflow.providers.git.bundles.git.GitHook")
+    def test_keeps_git_dir_when_disabled(self, mock_githook, git_repo):
+        repo_path, repo = git_repo
+        mock_githook.return_value.repo_url = repo_path
+        starting_commit = repo.head.commit
+
+        bundle = GitDagBundle(
+            name="test",
+            git_conn_id=CONN_HTTPS,
+            version=starting_commit.hexsha,
+            tracking_ref=GIT_DEFAULT_BRANCH,
+            remove_git_repo_on_versions=False,
+        )
+        bundle.initialize()
+
+        assert (bundle.repo_path / ".git").exists()
+        assert bundle.get_current_version() == starting_commit.hexsha
 
         assert_repo_is_closed(bundle)
 


### PR DESCRIPTION
To reduce storage size, this PR removes the git repo in versions when they are created since the git repo is not necessary on versions.



