### PR TITLE
Migrate apache/druid provider to common.compat

### DIFF
--- a/providers/apache/drill/pyproject.toml
+++ b/providers/apache/drill/pyproject.toml
@@ -59,7 +59,7 @@ requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=2.10.0",
     "apache-airflow-providers-common-sql>=1.26.0",
-    "apache-airflow-providers-common-compat>=1.7.4",    # + TODO: bump to next version
+    "apache-airflow-providers-common-compat>=1.8.0",
     # Workaround until we get https://github.com/JohnOmernik/sqlalchemy-drill/issues/94 fixed.
     "sqlalchemy-drill>=1.1.0,!=1.1.6,!=1.1.7",
 ]
@@ -70,7 +70,6 @@ dev = [
     "apache-airflow-task-sdk",
     "apache-airflow-devel-common",
     "apache-airflow-providers-common-sql",
-    "apache-airflow-providers-common-compat",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
     "apache-airflow-providers-common-sql[pandas,polars]",
 ]

--- a/providers/apache/drill/pyproject.toml
+++ b/providers/apache/drill/pyproject.toml
@@ -59,6 +59,7 @@ requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=2.10.0",
     "apache-airflow-providers-common-sql>=1.26.0",
+    "apache-airflow-providers-common-compat>=1.7.4",    # + TODO: bump to next version
     # Workaround until we get https://github.com/JohnOmernik/sqlalchemy-drill/issues/94 fixed.
     "sqlalchemy-drill>=1.1.0,!=1.1.6,!=1.1.7",
 ]
@@ -69,6 +70,7 @@ dev = [
     "apache-airflow-task-sdk",
     "apache-airflow-devel-common",
     "apache-airflow-providers-common-sql",
+    "apache-airflow-providers-common-compat",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
     "apache-airflow-providers-common-sql[pandas,polars]",
 ]

--- a/providers/apache/druid/pyproject.toml
+++ b/providers/apache/druid/pyproject.toml
@@ -59,6 +59,7 @@ requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=2.10.0",
     "apache-airflow-providers-common-sql>=1.26.0",
+    "apache-airflow-providers-common-compat>=1.7.4",    # + TODO: bump to next version
     "pydruid>=0.6.6",
 ]
 
@@ -76,6 +77,7 @@ dev = [
     "apache-airflow-devel-common",
     "apache-airflow-providers-apache-hive",
     "apache-airflow-providers-common-sql",
+    "apache-airflow-providers-common-compat",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
     "apache-airflow-providers-common-sql[pandas,polars]",
 ]

--- a/providers/apache/druid/pyproject.toml
+++ b/providers/apache/druid/pyproject.toml
@@ -76,8 +76,8 @@ dev = [
     "apache-airflow-task-sdk",
     "apache-airflow-devel-common",
     "apache-airflow-providers-apache-hive",
-    "apache-airflow-providers-common-sql",
     "apache-airflow-providers-common-compat",
+    "apache-airflow-providers-common-sql",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
     "apache-airflow-providers-common-sql[pandas,polars]",
 ]

--- a/providers/apache/druid/pyproject.toml
+++ b/providers/apache/druid/pyproject.toml
@@ -59,7 +59,7 @@ requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=2.10.0",
     "apache-airflow-providers-common-sql>=1.26.0",
-    "apache-airflow-providers-common-compat>=1.7.4",    # + TODO: bump to next version
+    "apache-airflow-providers-common-compat>=1.8.0",
     "pydruid>=0.6.6",
 ]
 

--- a/providers/apache/druid/src/airflow/providers/apache/druid/hooks/druid.py
+++ b/providers/apache/druid/src/airflow/providers/apache/druid/hooks/druid.py
@@ -27,7 +27,7 @@ import requests
 from pydruid.db import connect
 
 from airflow.exceptions import AirflowException
-from airflow.providers.apache.druid.version_compat import BaseHook
+from airflow.providers.common.compat.sdk import BaseHook
 from airflow.providers.common.sql.hooks.sql import DbApiHook
 
 if TYPE_CHECKING:

--- a/providers/apache/druid/src/airflow/providers/apache/druid/operators/druid.py
+++ b/providers/apache/druid/src/airflow/providers/apache/druid/operators/druid.py
@@ -21,10 +21,10 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 from airflow.providers.apache.druid.hooks.druid import DruidHook, IngestionType
-from airflow.providers.apache.druid.version_compat import BaseOperator
+from airflow.providers.common.compat.sdk import BaseOperator
 
 if TYPE_CHECKING:
-    from airflow.providers.apache.druid.version_compat import Context
+    from airflow.providers.common.compat.sdk import Context
 
 
 class DruidOperator(BaseOperator):

--- a/providers/apache/druid/src/airflow/providers/apache/druid/transfers/hive_to_druid.py
+++ b/providers/apache/druid/src/airflow/providers/apache/druid/transfers/hive_to_druid.py
@@ -23,8 +23,8 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 from airflow.providers.apache.druid.hooks.druid import DruidHook
-from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.providers.apache.hive.hooks.hive import HiveCliHook, HiveMetastoreHook
+from airflow.providers.common.compat.sdk import BaseOperator
 
 if TYPE_CHECKING:
     from airflow.providers.common.compat.sdk import Context

--- a/providers/apache/druid/src/airflow/providers/apache/druid/transfers/hive_to_druid.py
+++ b/providers/apache/druid/src/airflow/providers/apache/druid/transfers/hive_to_druid.py
@@ -23,11 +23,11 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 from airflow.providers.apache.druid.hooks.druid import DruidHook
-from airflow.providers.apache.druid.version_compat import BaseOperator
+from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.providers.apache.hive.hooks.hive import HiveCliHook, HiveMetastoreHook
 
 if TYPE_CHECKING:
-    from airflow.providers.apache.druid.version_compat import Context
+    from airflow.providers.common.compat.sdk import Context
 
 LOAD_CHECK_INTERVAL = 5
 DEFAULT_TARGET_PARTITION_SIZE = 5000000

--- a/providers/apache/druid/src/airflow/providers/apache/druid/version_compat.py
+++ b/providers/apache/druid/src/airflow/providers/apache/druid/version_compat.py
@@ -35,22 +35,7 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 AIRFLOW_V_3_1_PLUS: bool = get_base_airflow_version_tuple() >= (3, 1, 0)
 
-if AIRFLOW_V_3_1_PLUS:
-    from airflow.sdk import BaseHook
-else:
-    from airflow.hooks.base import BaseHook  # type: ignore[attr-defined,no-redef]
-
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import BaseOperator
-    from airflow.sdk.definitions.context import Context
-else:
-    from airflow.models import BaseOperator
-    from airflow.utils.context import Context
-
 __all__ = [
     "AIRFLOW_V_3_0_PLUS",
     "AIRFLOW_V_3_1_PLUS",
-    "BaseHook",
-    "BaseOperator",
-    "Context",
 ]


### PR DESCRIPTION
This PR is a part of [https://github.com/apache/airflow/issues/57018](https://github.com/apache/airflow/issues/57018) about provider apache/druid.

Replace version-specific conditional imports with apache/druid layer. 
This standardizes compatibility handling across Airflow 2.x and 3.x.

Foundational Work: See PR [https://github.com/apache/airflow/pull/56884](https://github.com/apache/airflow/pull/56884) for the architectural changes that established this pattern.
