### PR TITLE
Migrate dingding provider to common.compat

### DIFF
--- a/providers/apache/druid/pyproject.toml
+++ b/providers/apache/druid/pyproject.toml
@@ -68,6 +68,9 @@ dependencies = [
 "apache.hive" = [
     "apache-airflow-providers-apache-hive"
 ]
+"common.compat" = [
+    "apache-airflow-providers-common-compat"
+]
 
 [dependency-groups]
 dev = [

--- a/providers/dingding/pyproject.toml
+++ b/providers/dingding/pyproject.toml
@@ -58,7 +58,7 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.10.0",
-    "apache-airflow-providers-common-compat>=1.7.4",    # + TODO: bump to next version
+    "apache-airflow-providers-common-compat>=1.8.0",
     "apache-airflow-providers-http",
 ]
 

--- a/providers/dingding/pyproject.toml
+++ b/providers/dingding/pyproject.toml
@@ -58,6 +58,7 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.10.0",
+    "apache-airflow-providers-common-compat>=1.7.4",    # + TODO: bump to next version
     "apache-airflow-providers-http",
 ]
 
@@ -67,6 +68,7 @@ dev = [
     "apache-airflow-task-sdk",
     "apache-airflow-devel-common",
     "apache-airflow-providers-http",
+    "apache-airflow-providers-common-compat",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
 ]
 

--- a/providers/dingding/pyproject.toml
+++ b/providers/dingding/pyproject.toml
@@ -67,8 +67,8 @@ dev = [
     "apache-airflow",
     "apache-airflow-task-sdk",
     "apache-airflow-devel-common",
-    "apache-airflow-providers-http",
     "apache-airflow-providers-common-compat",
+    "apache-airflow-providers-http",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
 ]
 

--- a/providers/dingding/src/airflow/providers/dingding/operators/dingding.py
+++ b/providers/dingding/src/airflow/providers/dingding/operators/dingding.py
@@ -21,10 +21,10 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from airflow.providers.dingding.hooks.dingding import DingdingHook
-from airflow.providers.dingding.version_compat import BaseOperator
+from airflow.providers.common.compat.sdk import BaseOperator
 
 if TYPE_CHECKING:
-    from airflow.providers.dingding.version_compat import Context
+    from airflow.providers.common.compat.sdk import Context
 
 
 class DingdingOperator(BaseOperator):

--- a/providers/dingding/src/airflow/providers/dingding/operators/dingding.py
+++ b/providers/dingding/src/airflow/providers/dingding/operators/dingding.py
@@ -20,8 +20,8 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
-from airflow.providers.dingding.hooks.dingding import DingdingHook
 from airflow.providers.common.compat.sdk import BaseOperator
+from airflow.providers.dingding.hooks.dingding import DingdingHook
 
 if TYPE_CHECKING:
     from airflow.providers.common.compat.sdk import Context

--- a/providers/dingding/src/airflow/providers/dingding/version_compat.py
+++ b/providers/dingding/src/airflow/providers/dingding/version_compat.py
@@ -29,15 +29,6 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import BaseOperator
-    from airflow.sdk.definitions.context import Context
-else:
-    from airflow.models import BaseOperator
-    from airflow.utils.context import Context
-
 __all__ = [
     "AIRFLOW_V_3_0_PLUS",
-    "BaseOperator",
-    "Context",
 ]


### PR DESCRIPTION
This PR is a part of https://github.com/apache/airflow/issues/57018 about provider dingding.

Replace version-specific conditional imports with apache/druid layer.
This standardizes compatibility handling across Airflow 2.x and 3.x.

Foundational Work: See PR https://github.com/apache/airflow/pull/56884 for the architectural changes that established this pattern.