### PR TITLE
Migrate remaining providers to common.compat compatibility layer in segment

### DIFF
--- a/providers/segment/pyproject.toml
+++ b/providers/segment/pyproject.toml
@@ -63,11 +63,17 @@ dependencies = [
     "segment-analytics-python>=2.3.0",
 ]
 
+[project.optional-dependencies]
+"common.compat" = [
+    "apache-airflow-providers-common-compat>=1.7.4",  # + TODO: bump to next version
+]
+
 [dependency-groups]
 dev = [
     "apache-airflow",
     "apache-airflow-task-sdk",
     "apache-airflow-devel-common",
+    "apache-airflow-providers-common-compat",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
 ]
 

--- a/providers/segment/pyproject.toml
+++ b/providers/segment/pyproject.toml
@@ -58,14 +58,10 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.10.0",
+    "apache-airflow-providers-common-compat>=1.7.4",  # + TODO: bump to next version
     # segment-analytics-python is in mantaincnce mode.
     # Review changing to https://github.com/segmentio/public-api-sdk-python when ready? (currently in beta)
     "segment-analytics-python>=2.3.0",
-]
-
-[project.optional-dependencies]
-"common.compat" = [
-    "apache-airflow-providers-common-compat>=1.7.4",  # + TODO: bump to next version
 ]
 
 [dependency-groups]

--- a/providers/segment/src/airflow/providers/segment/hooks/segment.py
+++ b/providers/segment/src/airflow/providers/segment/hooks/segment.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 import segment.analytics as analytics
 
 from airflow.exceptions import AirflowException
-from airflow.providers.segment.version_compat import BaseHook
+from airflow.providers.common.compat.sdk import BaseHook
 
 
 class SegmentHook(BaseHook):

--- a/providers/segment/src/airflow/providers/segment/operators/segment_track_event.py
+++ b/providers/segment/src/airflow/providers/segment/operators/segment_track_event.py
@@ -21,10 +21,10 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from airflow.providers.segment.hooks.segment import SegmentHook
-from airflow.providers.segment.version_compat import BaseOperator
+from airflow.providers.common.compat.sdk import BaseOperator
 
 if TYPE_CHECKING:
-    from airflow.providers.segment.version_compat import Context
+    from airflow.providers.common.compat.sdk import Context
 
 
 class SegmentTrackEventOperator(BaseOperator):

--- a/providers/segment/src/airflow/providers/segment/operators/segment_track_event.py
+++ b/providers/segment/src/airflow/providers/segment/operators/segment_track_event.py
@@ -20,8 +20,8 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
-from airflow.providers.segment.hooks.segment import SegmentHook
 from airflow.providers.common.compat.sdk import BaseOperator
+from airflow.providers.segment.hooks.segment import SegmentHook
 
 if TYPE_CHECKING:
     from airflow.providers.common.compat.sdk import Context

--- a/providers/segment/src/airflow/providers/segment/version_compat.py
+++ b/providers/segment/src/airflow/providers/segment/version_compat.py
@@ -35,22 +35,7 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 AIRFLOW_V_3_1_PLUS: bool = get_base_airflow_version_tuple() >= (3, 1, 0)
 
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import BaseOperator
-    from airflow.sdk.definitions.context import Context
-else:
-    from airflow.models import BaseOperator
-    from airflow.utils.context import Context
-
-if AIRFLOW_V_3_1_PLUS:
-    from airflow.sdk import BaseHook
-else:
-    from airflow.hooks.base import BaseHook  # type: ignore[attr-defined,no-redef]
-
-# Explicitly export these imports to protect them from being removed by linters
 __all__ = [
     "AIRFLOW_V_3_0_PLUS",
-    "BaseHook",
-    "BaseOperator",
-    "Context",
+    "AIRFLOW_V_3_1_PLUS",
 ]


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

Replace version-specific conditional imports with common.compat layer. This standardizes compatibility handling across Airflow 2.x and 3.x. 

This PR is a part of [57018](https://github.com/apache/airflow/issues/57018) about provider segment.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
