### PR TITLE
Migrate remaining providers to common.compat compatibility layer in facebook

### DIFF
--- a/providers/facebook/pyproject.toml
+++ b/providers/facebook/pyproject.toml
@@ -58,6 +58,7 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.10.0",
+    "apache-airflow-providers-common-compat>=1.7.4",    # + TODO: bump to next version
     "facebook-business>=22.0.0",
 ]
 
@@ -66,6 +67,7 @@ dev = [
     "apache-airflow",
     "apache-airflow-task-sdk",
     "apache-airflow-devel-common",
+    "apache-airflow-providers-common-compat",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
 ]
 

--- a/providers/facebook/src/airflow/providers/facebook/ads/hooks/ads.py
+++ b/providers/facebook/src/airflow/providers/facebook/ads/hooks/ads.py
@@ -29,7 +29,7 @@ from facebook_business.adobjects.adreportrun import AdReportRun
 from facebook_business.api import FacebookAdsApi
 
 from airflow.exceptions import AirflowException
-from airflow.providers.facebook.version_compat import BaseHook
+from airflow.providers.common.compat.sdk import BaseHook
 
 if TYPE_CHECKING:
     from facebook_business.adobjects.adsinsights import AdsInsights

--- a/providers/facebook/src/airflow/providers/facebook/version_compat.py
+++ b/providers/facebook/src/airflow/providers/facebook/version_compat.py
@@ -35,9 +35,7 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 AIRFLOW_V_3_1_PLUS: bool = get_base_airflow_version_tuple() >= (3, 1, 0)
 
-if AIRFLOW_V_3_1_PLUS:
-    from airflow.sdk import BaseHook
-else:
-    from airflow.hooks.base import BaseHook  # type: ignore[attr-defined,no-redef]
-
-__all__ = ["AIRFLOW_V_3_0_PLUS", "AIRFLOW_V_3_1_PLUS", "BaseHook"]
+__all__ = [
+    "AIRFLOW_V_3_0_PLUS",
+    "AIRFLOW_V_3_1_PLUS",
+]


### PR DESCRIPTION
This PR is a part of https://github.com/apache/airflow/issues/57018 about provider facebook.

Replace version-specific conditional imports with apache/druid layer.
This standardizes compatibility handling across Airflow 2.x and 3.x.

Foundational Work: See PR https://github.com/apache/airflow/pull/56884 for the architectural changes that established this pattern.