### PR TITLE
Revert "Fix main. Fix `test_athena_sql.py` (#56974)"

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/athena_sql.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/athena_sql.py
@@ -155,17 +155,15 @@ class AthenaSQLHook(AwsBaseHook, DbApiHook):
         conn_params = self._get_conn_params()
         creds = self.get_credentials(region_name=conn_params["region_name"])
 
-        return str(
-            URL.create(
-                f"awsathena+{conn_params['driver']}",
-                username=creds.access_key,
-                password=creds.secret_key,
-                host=f"athena.{conn_params['region_name']}.{conn_params['aws_domain']}",
-                port=443,
-                database=conn_params["schema_name"],
-                query={"aws_session_token": creds.token, **self.conn.extra_dejson},
-            )
-        )
+        return URL.create(
+            f"awsathena+{conn_params['driver']}",
+            username=creds.access_key,
+            password=creds.secret_key,
+            host=f"athena.{conn_params['region_name']}.{conn_params['aws_domain']}",
+            port=443,
+            database=conn_params["schema_name"],
+            query={"aws_session_token": creds.token, **self.conn.extra_dejson},
+        ).render_as_string(hide_password=False)
 
     def get_conn(self) -> AthenaConnection:
         """Get a ``pyathena.Connection`` object."""

--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/athena_sql.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/athena_sql.py
@@ -150,19 +150,21 @@ class AthenaSQLHook(AwsBaseHook, DbApiHook):
             aws_domain=self.conn.extra_dejson.get("aws_domain", "amazonaws.com"),
         )
 
-    def get_uri(self) -> URL:
+    def get_uri(self) -> str:
         """Overridden to use the Athena dialect as driver name."""
         conn_params = self._get_conn_params()
         creds = self.get_credentials(region_name=conn_params["region_name"])
 
-        return URL.create(
-            f"awsathena+{conn_params['driver']}",
-            username=creds.access_key,
-            password=creds.secret_key,
-            host=f"athena.{conn_params['region_name']}.{conn_params['aws_domain']}",
-            port=443,
-            database=conn_params["schema_name"],
-            query={"aws_session_token": creds.token, **self.conn.extra_dejson},
+        return str(
+            URL.create(
+                f"awsathena+{conn_params['driver']}",
+                username=creds.access_key,
+                password=creds.secret_key,
+                host=f"athena.{conn_params['region_name']}.{conn_params['aws_domain']}",
+                port=443,
+                database=conn_params["schema_name"],
+                query={"aws_session_token": creds.token, **self.conn.extra_dejson},
+            )
         )
 
     def get_conn(self) -> AthenaConnection:

--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/redshift_sql.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/redshift_sql.py
@@ -162,16 +162,14 @@ class RedshiftSQLHook(DbApiHook):
         port = conn_params.get("port")
         database = conn_params.get("database")
 
-        return str(
-            URL.create(
-                drivername="postgresql",
-                username=str(username) if username is not None else None,
-                password=str(password) if password is not None else None,
-                host=str(host) if host is not None else None,
-                port=int(port) if port is not None else None,
-                database=str(database) if database is not None else None,
-            )
-        )
+        return URL.create(
+            drivername="postgresql",
+            username=str(username) if username is not None else None,
+            password=str(password) if password is not None else None,
+            host=str(host) if host is not None else None,
+            port=int(port) if port is not None else None,
+            database=str(database) if database is not None else None,
+        ).render_as_string(hide_password=False)
 
     def get_sqlalchemy_engine(self, engine_kwargs=None):
         """Overridden to pass Redshift-specific arguments."""

--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/redshift_sql.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/redshift_sql.py
@@ -148,7 +148,7 @@ class RedshiftSQLHook(DbApiHook):
             login = cluster_creds["DbUser"]
         return login, token, port
 
-    def get_uri(self) -> URL:
+    def get_uri(self) -> str:
         """Overridden to use the Redshift dialect as driver name."""
         conn_params = self._get_conn_params()
 
@@ -162,13 +162,15 @@ class RedshiftSQLHook(DbApiHook):
         port = conn_params.get("port")
         database = conn_params.get("database")
 
-        return URL.create(
-            drivername="postgresql",
-            username=str(username) if username is not None else None,
-            password=str(password) if password is not None else None,
-            host=str(host) if host is not None else None,
-            port=int(port) if port is not None else None,
-            database=str(database) if database is not None else None,
+        return str(
+            URL.create(
+                drivername="postgresql",
+                username=str(username) if username is not None else None,
+                password=str(password) if password is not None else None,
+                host=str(host) if host is not None else None,
+                port=int(port) if port is not None else None,
+                database=str(database) if database is not None else None,
+            )
         )
 
     def get_sqlalchemy_engine(self, engine_kwargs=None):

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_athena_sql.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_athena_sql.py
@@ -24,8 +24,6 @@ from airflow.models import Connection
 from airflow.providers.amazon.aws.hooks.athena_sql import AthenaSQLHook
 from airflow.providers.amazon.aws.utils.connection_wrapper import AwsConnectionWrapper
 
-from tests_common.test_utils.version_compat import SQLALCHEMY_V_1_4
-
 REGION_NAME = "us-east-1"
 WORK_GROUP = "test-work-group"
 SCHEMA_NAME = "athena_sql_schema"
@@ -63,10 +61,7 @@ class TestAthenaSQLHookConn:
 
         mock_get_credentials.assert_called_once_with(region_name=REGION_NAME)
 
-        if SQLALCHEMY_V_1_4:
-            assert str(athena_uri) == expected_athena_uri
-        else:
-            assert athena_uri.render_as_string(hide_password=False) == expected_athena_uri
+        assert athena_uri == expected_athena_uri
 
     @mock.patch("airflow.providers.amazon.aws.hooks.athena_sql.AthenaSQLHook._get_conn_params")
     def test_get_uri_change_driver(self, mock_get_conn_params):
@@ -76,7 +71,7 @@ class TestAthenaSQLHookConn:
 
         athena_uri = self.db_hook.get_uri()
 
-        assert str(athena_uri).startswith("awsathena+arrow://")
+        assert athena_uri.startswith("awsathena+arrow://")
 
     @mock.patch("airflow.providers.amazon.aws.hooks.athena_sql.pyathena.connect")
     @mock.patch("airflow.providers.amazon.aws.hooks.athena_sql.AthenaSQLHook.get_session")

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_redshift_sql.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_redshift_sql.py
@@ -26,8 +26,6 @@ from airflow.models import Connection
 from airflow.providers.amazon.aws.hooks.redshift_sql import RedshiftSQLHook
 from airflow.utils.types import NOTSET
 
-from tests_common.test_utils.version_compat import SQLALCHEMY_V_1_4
-
 LOGIN_USER = "login"
 LOGIN_PASSWORD = "password"
 LOGIN_HOST = "host"
@@ -52,12 +50,9 @@ class TestRedshiftSQLHookConn:
         self.db_hook.get_connection.return_value = self.connection
 
     def test_get_uri(self):
-        x = self.db_hook.get_uri()
-        if SQLALCHEMY_V_1_4:
-            expected = "postgresql://login:password@host:5439/dev"
-        else:
-            expected = "postgresql://login:***@host:5439/dev"
-        assert str(x) == expected
+        db_uri = self.db_hook.get_uri()
+        expected = "postgresql://login:password@host:5439/dev"
+        assert db_uri == expected
 
     @mock.patch("airflow.providers.amazon.aws.hooks.redshift_sql.redshift_connector.connect")
     def test_get_conn(self, mock_connect):


### PR DESCRIPTION
Bring back sqla2 mypy fixes for athena and redshift

This reverts commit 1a654344f03a98e64ae835686d24cbfad58de48a.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
