### PR TITLE
Extract prek hooks for Edge provider

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -950,13 +950,6 @@ repos:
         entry: ./scripts/ci/prek/compile_provider_assets.py fab
         pass_filenames: false
         additional_dependencies: ['yarn@1.22.21']
-      - id: compile-edge-assets
-        name: Compile Edge provider assets
-        language: node
-        files: ^providers/edge3/.*/www/
-        entry: ./scripts/ci/prek/compile_provider_assets.py edge
-        pass_filenames: false
-        additional_dependencies: ['yarn@1.22.21']
       - id: compile-ui-assets-dev
         name: Compile ui assets in dev mode (manual)
         language: node
@@ -1323,22 +1316,6 @@ repos:
         additional_dependencies: ['pnpm@9.7.1']
         pass_filenames: true
         require_serial: true
-      - id: ts-compile-lint-edge-ui
-        name: Compile / format / lint edge UI
-        description: TS types generation / ESLint / Prettier new UI files in Edge Provider
-        language: node
-        files: |
-          (?x)
-          ^providers/edge3/src/airflow/providers/edge3/plugins/www/.*\.(js|ts|tsx|yaml|css|json)$|
-          ^providers/edge3/src/airflow/providers/edge3/openapi/v2-edge-generated.yaml$
-        exclude: |
-          (?x)
-          ^providers/edge3/src/airflow/providers/edge3/plugins/www/node-modules/.*|
-          ^providers/edge3/src/airflow/providers/edge3/plugins/www/.pnpm-store
-        entry: ./scripts/ci/prek/ts_compile_lint_edge.py
-        additional_dependencies: ['pnpm@9.7.1']
-        pass_filenames: true
-        require_serial: true
         ## ADD MOST PREK HOOK ABOVE THAT LINE
         # The below prek hooks are those requiring CI image to be built
       - id: mypy-dev
@@ -1445,12 +1422,6 @@ repos:
         entry: ./scripts/ci/prek/generate_openapi_spec_providers.py fab
         pass_filenames: false
         files: ^providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/.*\.py$
-      - id: generate-openapi-spec-edge
-        name: Generate the FastAPI API spec for Edge
-        language: python
-        entry: ./scripts/ci/prek/generate_openapi_spec_providers.py edge
-        pass_filenames: false
-        files: ^providers/edge3/src/airflow/providers/edge3/worker_api/.*\.py$
       - id: generate-openapi-spec-keycloak
         name: Generate the FastAPI API spec for Keycloak
         language: python

--- a/providers/edge3/.pre-commit-config.yaml
+++ b/providers/edge3/.pre-commit-config.yaml
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+---
+default_stages: [pre-commit, pre-push]
+minimum_prek_version: '0.0.28'
+repos:
+  - repo: local
+    hooks:
+      - id: generate-openapi-spec-edge
+        name: Generate the FastAPI API spec for Edge
+        language: python
+        entry: ../../scripts/ci/prek/generate_openapi_spec_providers.py edge
+        pass_filenames: false
+        files: ^src/airflow/providers/edge3/worker_api/.*\.py$
+      - id: ts-compile-lint-edge-ui
+        name: Compile / format / lint edge UI
+        description: TS types generation / ESLint / Prettier new UI files in Edge Provider
+        language: node
+        files: |
+          (?x)
+          ^src/airflow/providers/edge3/plugins/www/.*\.(js|ts|tsx|yaml|css|json)$|
+          ^src/airflow/providers/edge3/openapi/v2-edge-generated.yaml$
+        exclude: |
+          (?x)
+          ^src/airflow/providers/edge3/plugins/www/node-modules/.*|
+          ^src/airflow/providers/edge3/plugins/www/.pnpm-store
+        entry: ../../scripts/ci/prek/ts_compile_lint_edge.py
+        additional_dependencies: ['pnpm@9.7.1']
+        pass_filenames: true
+        require_serial: true
+      - id: compile-edge-assets
+        name: Compile Edge provider assets
+        language: node
+        files: ^src/airflow/providers/edge3/plugins/www
+        entry: ../../scripts/ci/prek/compile_provider_assets.py edge
+        pass_filenames: false
+        additional_dependencies: ['yarn@1.22.21']


### PR DESCRIPTION
As prek is supporting monorepo now and go SDK was the fron-runner, edge provider is now the second piece that with this PR is proposed to be split-out from global pre-commit hook list into the provider space.