### PR TITLE
Fix asset name overflow in DAG list view

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/DagsList/AssetSchedule.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/AssetSchedule.tsx
@@ -50,7 +50,7 @@ export const AssetSchedule = ({ assetExpression, dagId, latestRunAfter, timetabl
 
   if (!nextRunEvents.length) {
     return (
-      <HStack>
+      <HStack maxWidth="200px">
         <FiDatabase style={{ display: "inline" }} />
         <Text>{timetableSummary}</Text>
       </HStack>
@@ -61,7 +61,7 @@ export const AssetSchedule = ({ assetExpression, dagId, latestRunAfter, timetabl
 
   if (nextRunEvents.length === 1 && asset !== undefined) {
     return (
-      <HStack>
+      <HStack maxWidth="200px">
         <FiDatabase style={{ display: "inline" }} />
         <Link asChild color="fg.info" display="block" fontSize="sm" maxWidth="200px" truncate>
           <RouterLink to={`/assets/${asset.id}`}>{asset.name ?? asset.uri}</RouterLink>

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/AssetSchedule.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/AssetSchedule.tsx
@@ -50,8 +50,8 @@ export const AssetSchedule = ({ assetExpression, dagId, latestRunAfter, timetabl
 
   if (!nextRunEvents.length) {
     return (
-      <HStack maxWidth="200px">
-        <FiDatabase style={{ display: "inline" }} />
+      <HStack maxWidth="100%" overflow="hidden">
+        <FiDatabase style={{ display: "inline", flexShrink: 0 }} />
         <Text>{timetableSummary}</Text>
       </HStack>
     );
@@ -61,9 +61,23 @@ export const AssetSchedule = ({ assetExpression, dagId, latestRunAfter, timetabl
 
   if (nextRunEvents.length === 1 && asset !== undefined) {
     return (
-      <HStack maxWidth="200px">
-        <FiDatabase style={{ display: "inline" }} />
-        <Link asChild color="fg.info" display="block" fontSize="sm" maxWidth="200px" truncate>
+      <HStack maxWidth="100%" overflow="hidden">
+        <FiDatabase style={{ display: "inline", flexShrink: 0 }} />
+        <Link
+          asChild
+          color="fg.info"
+          css={{
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            WebkitBoxOrient: "vertical",
+            WebkitLineClamp: 2,
+            wordBreak: "break-word",
+          }}
+          display="-webkit-box"
+          flex="1"
+          fontSize="sm"
+          minWidth="0"
+        >
           <RouterLink to={`/assets/${asset.id}`}>{asset.name ?? asset.uri}</RouterLink>
         </Link>
       </HStack>

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/AssetSchedule.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/AssetSchedule.tsx
@@ -25,6 +25,7 @@ import { Link as RouterLink } from "react-router-dom";
 import { useAssetServiceNextRunAssets } from "openapi/queries";
 import { AssetExpression, type ExpressionType } from "src/components/AssetExpression";
 import type { NextRunEvent } from "src/components/AssetExpression/types";
+import { TruncatedText } from "src/components/TruncatedText";
 import { Button, Popover } from "src/components/ui";
 
 type Props = {
@@ -50,7 +51,7 @@ export const AssetSchedule = ({ assetExpression, dagId, latestRunAfter, timetabl
 
   if (!nextRunEvents.length) {
     return (
-      <HStack maxWidth="100%" overflow="hidden">
+      <HStack>
         <FiDatabase style={{ display: "inline", flexShrink: 0 }} />
         <Text>{timetableSummary}</Text>
       </HStack>
@@ -61,24 +62,12 @@ export const AssetSchedule = ({ assetExpression, dagId, latestRunAfter, timetabl
 
   if (nextRunEvents.length === 1 && asset !== undefined) {
     return (
-      <HStack maxWidth="100%" overflow="hidden">
+      <HStack>
         <FiDatabase style={{ display: "inline", flexShrink: 0 }} />
-        <Link
-          asChild
-          color="fg.info"
-          css={{
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            WebkitBoxOrient: "vertical",
-            WebkitLineClamp: 2,
-            wordBreak: "break-word",
-          }}
-          display="-webkit-box"
-          flex="1"
-          fontSize="sm"
-          minWidth="0"
-        >
-          <RouterLink to={`/assets/${asset.id}`}>{asset.name ?? asset.uri}</RouterLink>
+        <Link asChild color="fg.info" display="block" fontSize="sm">
+          <RouterLink to={`/assets/${asset.id}`}>
+            <TruncatedText minWidth={0} text={asset.name ?? asset.uri} />
+          </RouterLink>
         </Link>
       </HStack>
     );


### PR DESCRIPTION
**Description:**

Fixes asset names overlapping with the "Latest Run" field in the DAG list view by adding `maxWidth` constraints to `HStack` containers in the `AssetSchedule` component.

When DAGs have asset-based schedules with long asset names, the names were extending beyond their column boundaries and overlapping with the "Latest Run" timestamp field, making it difficult to read.

This change adds `maxWidth="200px"` to the `HStack` containers wrapping asset names in the `AssetSchedule` component, ensuring proper text truncation and preventing overlap with adjacent columns.

closes: #56669

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
