### PR TITLE
Bump `common.compat` provider to 1.8 for some providers

### DIFF
--- a/providers/cohere/pyproject.toml
+++ b/providers/cohere/pyproject.toml
@@ -58,14 +58,8 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.10.0",
+    "apache-airflow-providers-common-compat>=1.8.0",
     "cohere>=5.13.4",
-]
-
-# The optional dependencies should be modified in place in the generated file
-# Any change in the dependencies is preserved when the file is regenerated
-[project.optional-dependencies]
-"common.compat" = [
-    "apache-airflow-providers-common-compat>=1.7.4",  # + TODO: bump to next version
 ]
 
 [dependency-groups]

--- a/providers/facebook/pyproject.toml
+++ b/providers/facebook/pyproject.toml
@@ -58,7 +58,7 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.10.0",
-    "apache-airflow-providers-common-compat>=1.7.4",    # + TODO: bump to next version
+    "apache-airflow-providers-common-compat>=1.8.0",
     "facebook-business>=22.0.0",
 ]
 

--- a/providers/qdrant/pyproject.toml
+++ b/providers/qdrant/pyproject.toml
@@ -58,7 +58,7 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.10.0",
-    "apache-airflow-providers-common-compat>=1.7.4",  # + TODO: bump to next version
+    "apache-airflow-providers-common-compat>=1.8.0",
     "qdrant_client>=1.15.1",
 ]
 

--- a/providers/salesforce/pyproject.toml
+++ b/providers/salesforce/pyproject.toml
@@ -58,7 +58,7 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.10.0",
-    "apache-airflow-providers-common-compat>=1.7.4",  # + TODO: bump to next version
+    "apache-airflow-providers-common-compat>=1.8.0",
     "simple-salesforce>=1.0.0",
     'pandas>=2.1.2; python_version <"3.13"',
     'pandas>=2.2.3; python_version >="3.13"',

--- a/providers/segment/pyproject.toml
+++ b/providers/segment/pyproject.toml
@@ -58,7 +58,7 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.10.0",
-    "apache-airflow-providers-common-compat>=1.7.4",  # + TODO: bump to next version
+    "apache-airflow-providers-common-compat>=1.8.0",
     # segment-analytics-python is in mantaincnce mode.
     # Review changing to https://github.com/segmentio/public-api-sdk-python when ready? (currently in beta)
     "segment-analytics-python>=2.3.0",

--- a/providers/singularity/pyproject.toml
+++ b/providers/singularity/pyproject.toml
@@ -58,7 +58,7 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.10.0",
-    "apache-airflow-providers-common-compat>=1.7.4",  # + TODO: bump to next version
+    "apache-airflow-providers-common-compat>=1.8.0",
     "spython>=0.0.56",
 ]
 


### PR DESCRIPTION
Some of the provider changes merged in the last day after the new wave or providers used 1.7.4 -- now that version is bumped already for common provider, we can use 1.8.0.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
