### PR TITLE
fix postgresql extra

### DIFF
--- a/providers/presto/README.rst
+++ b/providers/presto/README.rst
@@ -56,7 +56,7 @@ PIP package                              Version required
 ``apache-airflow``                       ``>=2.10.0``
 ``apache-airflow-providers-common-sql``  ``>=1.26.0``
 ``presto-python-client``                 ``>=0.8.4``
-``pandas[postgres]``                     ``>=2.1.2; python_version < "3.13"``
+``pandas[postgresql]``                   ``>=2.1.2; python_version < "3.13"``
 ``pandas``                               ``>=2.2.3; python_version >= "3.13"``
 =======================================  =====================================
 

--- a/providers/presto/docs/index.rst
+++ b/providers/presto/docs/index.rst
@@ -104,7 +104,7 @@ PIP package                              Version required
 ``apache-airflow``                       ``>=2.10.0``
 ``apache-airflow-providers-common-sql``  ``>=1.26.0``
 ``presto-python-client``                 ``>=0.8.4``
-``pandas[postgres]``                     ``>=2.1.2; python_version < "3.13"``
+``pandas[postgresql]``                   ``>=2.1.2; python_version < "3.13"``
 ``pandas``                               ``>=2.2.3; python_version >= "3.13"``
 =======================================  =====================================
 

--- a/providers/presto/pyproject.toml
+++ b/providers/presto/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
     "apache-airflow>=2.10.0",
     "apache-airflow-providers-common-sql>=1.26.0",
     "presto-python-client>=0.8.4",
-    'pandas[postgres]>=2.1.2; python_version <"3.13"',
+    'pandas[postgresql]>=2.1.2; python_version <"3.13"',
     'pandas>=2.2.3; python_version >="3.13"',
 ]
 


### PR DESCRIPTION
earlier, whenever i was running `uv sync`, i noticed the warning: 
```
warning: The package `pandas==2.1.4` does not have an extra named `postgres`
```

<img width="928" height="258" alt="image" src="https://github.com/user-attachments/assets/e4d3c32d-60fa-4eb0-b02e-7ac31d99beda" />



I checked pandas repo's pyproject.toml and see that its `postgresql`, not `postgres` - https://github.com/pandas-dev/pandas/blob/81f8d5d3199d0ec3f94ad7eb8015e183b1681275/pyproject.toml#L73