### PR TITLE
Migrate neo4j provider to common.compat

### DIFF
--- a/providers/neo4j/pyproject.toml
+++ b/providers/neo4j/pyproject.toml
@@ -58,6 +58,7 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.10.0",
+    "apache-airflow-providers-common-compat>=1.7.4",    # + TODO: bump to next version
     "neo4j>=5.20.0",
 ]
 
@@ -66,6 +67,7 @@ dev = [
     "apache-airflow",
     "apache-airflow-task-sdk",
     "apache-airflow-devel-common",
+    "apache-airflow-providers-common-compat",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
 ]
 

--- a/providers/neo4j/pyproject.toml
+++ b/providers/neo4j/pyproject.toml
@@ -58,7 +58,7 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.10.0",
-    "apache-airflow-providers-common-compat>=1.7.4",    # + TODO: bump to next version
+    "apache-airflow-providers-common-compat>=1.8.0",
     "neo4j>=5.20.0",
 ]
 

--- a/providers/neo4j/src/airflow/providers/neo4j/operators/neo4j.py
+++ b/providers/neo4j/src/airflow/providers/neo4j/operators/neo4j.py
@@ -20,8 +20,8 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
+from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.providers.neo4j.hooks.neo4j import Neo4jHook
-from airflow.providers.neo4j.version_compat import BaseOperator
 
 if TYPE_CHECKING:
     try:

--- a/providers/neo4j/src/airflow/providers/neo4j/version_compat.py
+++ b/providers/neo4j/src/airflow/providers/neo4j/version_compat.py
@@ -34,12 +34,6 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import BaseOperator
-else:
-    from airflow.models import BaseOperator
-
 __all__ = [
     "AIRFLOW_V_3_0_PLUS",
-    "BaseOperator",
 ]


### PR DESCRIPTION
This PR is a part of https://github.com/apache/airflow/issues/57018 about provider neo4j.

Replace version-specific conditional imports with apache/druid layer.
This standardizes compatibility handling across Airflow 2.x and 3.x.