### PR TITLE
Fix: Handle SQLAlchemy_URI for Apache Impala 

### DIFF
--- a/providers/apache/impala/src/airflow/providers/apache/impala/hooks/impala.py
+++ b/providers/apache/impala/src/airflow/providers/apache/impala/hooks/impala.py
@@ -51,14 +51,14 @@ class ImpalaHook(DbApiHook):
     def sqlalchemy_url(self) -> URL:
         """Return a `sqlalchemy.engine.URL` object constructed from the connection."""
         conn = self.get_connection(self.get_conn_id())
-        extra = conn.extra_desjson or {}
+        extra = conn.extra_dejson or {}
         
         required_attrs = ["host", "login"]
         for attr in required_attrs:
             if getattr(conn, attr) is None:
                 raise ValueError(f"Impala Connection Error: '{attr}' is missing in the connection")
         
-        query = {k: v for k, v in extra.items() if v is not None and k not in ["__extra__"]}
+        query = {k: str(v) for k, v in extra.items() if v is not None and k not in ["__extra__"]}
         
         return URL.create(
             drivername="impala",

--- a/providers/apache/impala/src/airflow/providers/apache/impala/hooks/impala.py
+++ b/providers/apache/impala/src/airflow/providers/apache/impala/hooks/impala.py
@@ -67,7 +67,7 @@ class ImpalaHook(DbApiHook):
             host=str(conn.host),
             port=conn.port or 21050,
             database=conn.schema,
-            query=query,
+            query=query
         )
         
     def get_uri(self) -> str:

--- a/providers/apache/impala/src/airflow/providers/apache/impala/hooks/impala.py
+++ b/providers/apache/impala/src/airflow/providers/apache/impala/hooks/impala.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from impala.dbapi import connect
+from sqlalchemy.engine import URL
 
 from airflow.providers.common.sql.hooks.sql import DbApiHook
 
@@ -45,3 +46,35 @@ class ImpalaHook(DbApiHook):
             database=connection.schema,
             **connection.extra_dejson,
         )
+        
+    @property
+    def sqlalchemy_url(self) -> URL:
+        """Return a `sqlalchemy.engine.URL` object constructed from the connection."""
+        conn = self.get_connection(self.get_conn_id())
+        extra = conn.extra_desjson or {}
+        
+        required_attrs = ["host", "login"]
+        for attr in required_attrs:
+            if getattr(conn, attr) is None:
+                raise ValueError(f"Impala Connection Error: '{attr}' is missing in the connection")
+        
+        query = {k: v for k, v in extra.items() if v is not None and k not in ["__extra__"]}
+        
+        return URL.create(
+            drivername="impala",
+            username=conn.login,
+            password=conn.password or "",
+            host=str(conn.host),
+            port=conn.port or 21050,
+            database=conn.schema,
+            query=query,
+        )
+        
+    def get_uri(self) -> str:
+        """Return a SQLAlchemy engine URL as a string."""
+        return self.sqlalchemy_url.render_as_string(hide_password=False)
+
+
+        
+        
+        

--- a/providers/apache/impala/src/airflow/providers/apache/impala/hooks/impala.py
+++ b/providers/apache/impala/src/airflow/providers/apache/impala/hooks/impala.py
@@ -58,7 +58,7 @@ class ImpalaHook(DbApiHook):
             if getattr(conn, attr) is None:
                 raise ValueError(f"Impala Connection Error: '{attr}' is missing in the connection")
 
-        query = {k: str(v) for k, v in extra.items() if v is not None and k not in ["__extra__"]}
+        query = {k: str(v) for k, v in extra.items() if v is not None and k != "__extra__"}
 
         return URL.create(
             drivername="impala",

--- a/providers/apache/impala/src/airflow/providers/apache/impala/hooks/impala.py
+++ b/providers/apache/impala/src/airflow/providers/apache/impala/hooks/impala.py
@@ -46,20 +46,20 @@ class ImpalaHook(DbApiHook):
             database=connection.schema,
             **connection.extra_dejson,
         )
-        
+
     @property
     def sqlalchemy_url(self) -> URL:
         """Return a `sqlalchemy.engine.URL` object constructed from the connection."""
         conn = self.get_connection(self.get_conn_id())
         extra = conn.extra_dejson or {}
-        
+
         required_attrs = ["host", "login"]
         for attr in required_attrs:
             if getattr(conn, attr) is None:
                 raise ValueError(f"Impala Connection Error: '{attr}' is missing in the connection")
-        
+
         query = {k: str(v) for k, v in extra.items() if v is not None and k not in ["__extra__"]}
-        
+
         return URL.create(
             drivername="impala",
             username=conn.login,
@@ -67,14 +67,9 @@ class ImpalaHook(DbApiHook):
             host=str(conn.host),
             port=conn.port or 21050,
             database=conn.schema,
-            query=query
+            query=query,
         )
-        
+
     def get_uri(self) -> str:
         """Return a SQLAlchemy engine URL as a string."""
         return self.sqlalchemy_url.render_as_string(hide_password=False)
-
-
-        
-        
-        

--- a/providers/apache/impala/tests/unit/apache/impala/hooks/test_impala_sql.py
+++ b/providers/apache/impala/tests/unit/apache/impala/hooks/test_impala_sql.py
@@ -16,24 +16,15 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-from airflow.providers.apache.impala.hooks.impala import ImpalaHook
-
-from impala.dbapi import connect
 import json
-import pytest
 from unittest import mock
+from unittest.mock import MagicMock, patch
+
+import pytest
 from sqlalchemy.engine.url import make_url
-from unittest.mock import patch, MagicMock
+
 from airflow.models import Connection
-from sqlalchemy.engine import URL
-
-from airflow.providers.common.sql.hooks.sql import DbApiHook
-
-if TYPE_CHECKING:
-    from impala.interface import Connection
-    
-    
+from airflow.providers.apache.impala.hooks.impala import ImpalaHook
 
 DEFAULT_CONN_ID = "impala_default"
 DEFAULT_HOST = "localhost"
@@ -44,7 +35,7 @@ DEFAULT_SCHEMA = "default_db"
 
 
 @pytest.fixture
-def mock_connection(create_connection_without_db)-> Connection:
+def mock_connection(create_connection_without_db) -> Connection:
     """create a mocked Airflow connection for Impala."""
     conn = Connection(
         conn_id=DEFAULT_CONN_ID,
@@ -58,13 +49,16 @@ def mock_connection(create_connection_without_db)-> Connection:
     create_connection_without_db(conn)
     return conn
 
+
 @pytest.fixture
-def impala_hook()-> ImpalaHook:
+def impala_hook() -> ImpalaHook:
     """Fixture for ImpalaHook with mocked connection"""
     return ImpalaHook(impala_conn_id=DEFAULT_CONN_ID)
 
+
 def get_cursor_descriptions(fields: list[str]) -> list[tuple[str]]:
     return [(field,) for field in fields]
+
 
 @pytest.mark.parametrize(
     "host, login, password, port, schema, extra_dict, expected_query",
@@ -107,17 +101,8 @@ def get_cursor_descriptions(fields: list[str]) -> list[tuple[str]]:
         ),
     ],
 )
-
 def test_sqlalchemy_url_property(
-    impala_hook,
-    mock_connection,
-    host,
-    login,
-    password,
-    port,
-    schema,
-    extra_dict,
-    expected_query
+    impala_hook, mock_connection, host, login, password, port, schema, extra_dict, expected_query
 ):
     """Tests various custom configurations passed via the 'extra' field."""
     mock_connection.host = host
@@ -126,7 +111,7 @@ def test_sqlalchemy_url_property(
     mock_connection.port = port
     mock_connection.schema = schema
     mock_connection.extra = json.dumps(extra_dict) if extra_dict else None
-    
+
     with patch.object(impala_hook, "get_connection", return_value=mock_connection):
         url = impala_hook.sqlalchemy_url
     expected_password = password or ""
@@ -137,16 +122,15 @@ def test_sqlalchemy_url_property(
     assert url.port == port
     assert url.database == schema
     assert url.query == expected_query
-    
-        
+
+
 @pytest.mark.parametrize(
     "sql, expected_rows",
     [
         ("SELECT * FROM users", [("Alice", 1), ("Bob", 2)]),
         ("SELECT 1", [(1,)]),
-    ]
+    ],
 )
-
 def test_impala_run_query(impala_hook, mock_connection, sql, expected_rows):
     cursor = MagicMock()
     cursor.fetchall.return_value = expected_rows
@@ -165,21 +149,21 @@ def test_impala_run_query(impala_hook, mock_connection, sql, expected_rows):
 
     cursor.execute.assert_called_once_with(sql)
     assert result == expected_rows
-    
-    
+
+
 def test_get_sqlalchemy_engine(impala_hook, mock_connection, mocker):
     mock_create_engine = mocker.patch("airflow.providers.common.sql.hooks.sql.create_engine", autospec=True)
-    mock_engine=MagicMock()
+    mock_engine = MagicMock()
     mock_create_engine.return_value = mock_engine
-    
+
     with patch.object(impala_hook, "get_connection", return_value=mock_connection):
         engine = impala_hook.get_sqlalchemy_engine()
-        
+
     assert engine is mock_engine
-    
+
     call_args = mock_create_engine.call_args[1]
     actual_url = call_args["url"]
-    
+
     assert actual_url.drivername == "impala"
     assert actual_url.host == DEFAULT_HOST
     assert actual_url.username == DEFAULT_LOGIN
@@ -187,39 +171,33 @@ def test_get_sqlalchemy_engine(impala_hook, mock_connection, mocker):
     assert actual_url.port == DEFAULT_PORT
     assert actual_url.database == DEFAULT_SCHEMA
     assert actual_url.query == {}
-    
-    
+
+
 def test_get_url(impala_hook, mock_connection):
     """Ensure get_uri() returns correct formatted URI for Impala connection"""
-    
+
     mock_connection.host = "impala.company.com"
     mock_connection.port = 21050
     mock_connection.login = "user"
     mock_connection.password = "secret"
     mock_connection.schema = "analytics"
-    mock_connection.extra = json.dumps({"use_ssl":"True","auth_mechanism": "PLAIN"})
-    
+    mock_connection.extra = json.dumps({"use_ssl": "True", "auth_mechanism": "PLAIN"})
+
     with patch.object(impala_hook, "get_connection", return_value=mock_connection):
         uri = impala_hook.get_uri()
-        
-    expected_uri = (
-        "impala://user:secret@impala.company.com:21050/analytics?"
-        "use_ssl=True&auth_mechanism=PLAIN"
-    )
-    
+
+    expected_uri = "impala://user:secret@impala.company.com:21050/analytics?use_ssl=True&auth_mechanism=PLAIN"
+
     assert make_url(uri) == make_url(expected_uri)
-    
 
-@pytest.mark.parametrize(
-    "sql", ["", " ", "\n"]
-)
 
+@pytest.mark.parametrize("sql", ["", " ", "\n"])
 def test_run_with_empty_sql(impala_hook, sql):
     """Test that running an empty SQL string."""
     with pytest.raises(ValueError, match="List of SQL statements is empty"):
         impala_hook.run(sql)
-        
-        
+
+
 @pytest.fixture
 def impala_hook_with_timeout(create_connection_without_db):
     conn = Connection(
@@ -235,12 +213,13 @@ def impala_hook_with_timeout(create_connection_without_db):
     create_connection_without_db(conn)
     return ImpalaHook(impala_conn_id="impala_with_timeout")
 
+
 def test_execution_timeout_exceeded(impala_hook_with_timeout):
     test_sql = "SELECT * FROM big_table"
 
     with patch(
         "airflow.providers.apache.impala.hooks.impala.ImpalaHook.run",
-        side_effect=TimeoutError("Query exceeded execution timeout")
+        side_effect=TimeoutError("Query exceeded execution timeout"),
     ):
         with pytest.raises(TimeoutError, match="Query exceeded execution timeout"):
             impala_hook_with_timeout.run(sql=test_sql)

--- a/providers/apache/impala/tests/unit/apache/impala/hooks/test_impala_sql.py
+++ b/providers/apache/impala/tests/unit/apache/impala/hooks/test_impala_sql.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING
 from apache.impala.src.airflow.providers.apache.impala.hooks.impala import ImpalaHook
 
 from impala.dbapi import connect
+import json
 import pytest
 from sqlalchemy.engine.url import make_url
 from unittest.mock import patch, MagicMock
@@ -43,7 +44,7 @@ DEFAULT_SCHEMA = "default_db"
 
 @pytest.fixture
 def mock_connection(create_connection_without_db)-> Connection:
-    """create a mocked Airflwo connection for Impala."""
+    """create a mocked Airflow connection for Impala."""
     conn = Connection(
         conn_id=DEFAULT_CONN_ID,
         conn_type="impala",
@@ -59,4 +60,134 @@ def mock_connection(create_connection_without_db)-> Connection:
 @pytest.fixture
 def impala_hook()-> ImpalaHook:
     """Fixture for ImpalaHook with mocked connection"""
-    return ImpalaHook(imapala_conn_id=DEFAULT_CONN_ID)
+    return ImpalaHook(impala_conn_id=DEFAULT_CONN_ID)
+
+def get_cursor_descriptions(fields: list[str]) -> list[tuple[str]]:
+    return [(field,) for field in fields]
+
+@pytest.mark.parametrize(
+    "host, login, password, port, schema, extra_dict, expected_query",
+    [
+        # Basic Impala connection, no extras
+        (
+            "localhost",
+            "user",
+            "pass",
+            21050,
+            "default_db",
+            {},
+            {},
+        ),
+        # SSL enabled
+        (
+            "impala-secure.company.com",
+            "secure_user",
+            "secret",
+            21050,
+            "analytics",
+            {"use_ssl": True},
+            {"use_ssl": True},
+        ),
+        # Kerberos authentication
+        (
+            "impala-kerberos.company.com",
+            "kerb_user",
+            None,
+            21050,
+            "sales",
+            {"auth_mechanism": "GSSAPI", "kerberos_service_name": "impala"},
+            {"auth_mechanism": "GSSAPI", "kerberos_service_name": "impala"},
+        ),
+        # Connection with timeout
+        (
+            "impala.company.com",
+            "timeout_user",
+            "pw123",
+            21050,
+            "warehouse",
+            {"timeout": 30},
+            {"timeout": 30},
+        ),
+    ],
+)
+
+def test_sqlalchemy_url_property(
+    impala_hook,
+    mock_connection,
+    host,
+    login,
+    password,
+    port,
+    schema,
+    extra_dict,
+    expected_query
+):
+    """Tests various custom configurations passed via the 'extra' field."""
+    mock_connection.host = host
+    mock_connection.login = login
+    mock_connection.password = password
+    mock_connection.port = port
+    mock_connection.schema = schema
+    mock_connection.extra = json.dumps(extra_dict) if extra_dict else None
+    
+    with patch.object(impala_hook, "get_connection", return_value=mock_connection):
+        url = impala_hook.sqlalchemy_url
+        
+    assert url.drivername == "impala"
+    assert url.username == login
+    assert url.password == password or ""
+    assert url.host == host
+    assert url.port == port
+    assert url.database == schema
+    assert url.query == expected_query
+    
+        
+@pytest.mark.parametrize(
+    "sql, expected_rows",
+    [
+        ("SELECT * FROM users", [("Alice", 1), ("Bob", 2)]),
+        ("SELECT 1", [(1,)]),
+    ]
+)
+
+def test_impala_run_query(impala_hook, mock_connection, sql, expected_rows):
+    cursor = MagicMock()
+    cursor.fetchall.return_value = expected_rows
+    cursor.description = get_cursor_descriptions([f"col{i}" for i in range(len(expected_rows[0]))])
+
+    mock_conn = MagicMock()
+    mock_conn.host = mock_connection.host
+    mock_conn.login = mock_connection.login
+    mock_conn.password = mock_connection.password
+    mock_conn.schema = mock_connection.schema
+    mock_conn.cursor.return_value = cursor
+
+    with patch.object(impala_hook, "get_connection", return_value=mock_conn):
+        result = impala_hook.run(sql, handler=lambda cur: cur.fetchall())
+
+    cursor.execute.assert_called_once_with(sql)
+    assert result == expected_rows
+    
+    
+def test_get_sqlalchemy_engine(impala_hook, mock_connection, mocker):
+    mock_create_engine = mocker.patch("airflow.providers.common.sql.create_engine", autospec=True)
+    mock_engine=MagicMock()
+    mock_create_engine.return_value = mock_engine
+    
+    with patch.object(impala_hook, "get_connection", return_value=mock_connection):
+        engine = impala_hook.get_sqlalchemy_engine()
+        
+    assert engine is mock_engine
+    
+    call_args = mock_create_engine.call_args[1]
+    actual_url = call_args["url"]
+    
+    assert actual_url.drivername == "impala"
+    assert actual_url.host == DEFAULT_HOST
+    assert actual_url.username == DEFAULT_LOGIN
+    assert actual_url.password == DEFAULT_PASSWORD
+    assert actual_url.port == DEFAULT_PORT
+    assert actual_url.database == DEFAULT_SCHEMA
+    assert actual_url.query == {}
+    
+    

--- a/providers/apache/impala/tests/unit/apache/impala/hooks/test_impala_sql.py
+++ b/providers/apache/impala/tests/unit/apache/impala/hooks/test_impala_sql.py
@@ -17,11 +17,46 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from apache.impala.src.airflow.providers.apache.impala.hooks.impala import ImpalaHook
 
 from impala.dbapi import connect
+import pytest
+from sqlalchemy.engine.url import make_url
+from unittest.mock import patch, MagicMock
+from airflow.models import Connection
 from sqlalchemy.engine import URL
 
 from airflow.providers.common.sql.hooks.sql import DbApiHook
 
 if TYPE_CHECKING:
     from impala.interface import Connection
+    
+    
+
+DEFAULT_CONN_ID = "impala_default"
+DEFAULT_HOST = "localhost"
+DEFAULT_PORT = 21050
+DEFAULT_LOGIN = "user"
+DEFAULT_PASSWORD = "pass"
+DEFAULT_SCHEMA = "default_db"
+
+
+@pytest.fixture
+def mock_connection(create_connection_without_db)-> Connection:
+    """create a mocked Airflwo connection for Impala."""
+    conn = Connection(
+        conn_id=DEFAULT_CONN_ID,
+        conn_type="impala",
+        host=DEFAULT_HOST,
+        login=DEFAULT_LOGIN,
+        password=DEFAULT_PASSWORD,
+        port=DEFAULT_PORT,
+        schema=DEFAULT_SCHEMA,
+    )
+    create_connection_without_db(conn)
+    return conn
+
+@pytest.fixture
+def impala_hook()-> ImpalaHook:
+    """Fixture for ImpalaHook with mocked connection"""
+    return ImpalaHook(imapala_conn_id=DEFAULT_CONN_ID)

--- a/providers/apache/impala/tests/unit/apache/impala/hooks/test_impala_sql.py
+++ b/providers/apache/impala/tests/unit/apache/impala/hooks/test_impala_sql.py
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from impala.dbapi import connect
+from sqlalchemy.engine import URL
+
+from airflow.providers.common.sql.hooks.sql import DbApiHook
+
+if TYPE_CHECKING:
+    from impala.interface import Connection


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Implemented a SQLAlchemy-compatible sqlalchemy_url property in ImpalaHook.
Added get_uri() method to return a fully formatted URI for Impala connections.
Added unit tests to verify correctness of the sqlalchemy_url property and get_uri() output.
Ran prek pre-commit checks to ensure code quality and formatting.

Related : #38195
<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
