### PR TITLE
Fix DAG bundle retrieval from S3

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/s3.py
@@ -1774,6 +1774,8 @@ class S3Hook(AwsBaseHook):
         local_s3_objects = []
         s3_bucket = self.get_bucket(bucket_name)
         for obj in s3_bucket.objects.filter(Prefix=s3_prefix):
+            if obj.key.endswith("/"):
+                continue
             obj_path = Path(obj.key)
             local_target_path = local_dir.joinpath(obj_path.relative_to(s3_prefix))
             if not local_target_path.parent.exists():

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_s3.py
@@ -1800,6 +1800,7 @@ class TestAwsS3Hook:
 
         s3_client.put_object(Bucket=s3_bucket, Key="dag_01.py", Body=b"test data")
         s3_client.put_object(Bucket=s3_bucket, Key="dag_02.py", Body=b"test data")
+        s3_client.put_object(Bucket=s3_bucket, Key="subproject1/", Body=b"")
         s3_client.put_object(Bucket=s3_bucket, Key="subproject1/dag_a.py", Body=b"test data")
         s3_client.put_object(Bucket=s3_bucket, Key="subproject1/dag_b.py", Body=b"test data")
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---


This fixes the case where DAGs stored in S3 are not retrieved. `bucket.objects` returns prefix objects:

```
>>> objects =  bucket.objects.filter(Prefix='dags/')
>>> for obj in objects:
...     print(obj)
...
s3.ObjectSummary(bucket_name='bucket', key='dags/')
s3.ObjectSummary(bucket_name='bucket', key='dags/simple.py')
```

The `dags/` object should not be copied as regular files.

Current unit tests [do not include](https://github.com/apache/airflow/blob/44f8479b1597e8882c8985c601b4e40abbc024bb/providers/amazon/tests/unit/amazon/aws/hooks/test_s3.py#L1801-L1804) the prefix object so the tests passes. However, it does not work when using actual S3 service.

You can reproduce the failure by adding the prefix object in the unit test. 

fixes: #57176 

Note that the delimiter is hardcoded as `/`. This is technically not true for all bucket uses. However, since the rest of the code also hardcode delimiter as `/`, I've left it as-is. 