### PR TITLE
Extract prek hooks for FAB provider

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -543,7 +543,6 @@ repos:
             (?x)
             ^airflow-ctl.*\.py$|
             ^airflow-core/src/airflow/models/.*\.py$|
-            ^providers/fab/.*\.py$|
             ^task_sdk.*\.py$
         pass_filenames: true
       - id: update-supported-versions
@@ -560,10 +559,9 @@ repos:
         files: >
           (?x)
           ^scripts/ci/prek/version_heads_map\.py$|
-          ^airflow-core/src/airflow/migrations/versions/.*$|^airflow-core/src/airflow/migrations/versions|
-          ^providers/fab/src/airflow/providers/fab/migrations/versions/.*$|^providers/fab/src/airflow/providers/fab/migrations/versions|
-          ^airflow-core/src/airflow/utils/db\.py$|
-          ^providers/fab/src/airflow/providers/fab/auth_manager/models/db\.py$
+          ^airflow-core/src/airflow/migrations/versions/.*$|
+          ^airflow-core/src/airflow/migrations/versions|
+          ^airflow-core/src/airflow/utils/db\.py$
       - id: update-version
         name: Update versions in docs
         entry: ./scripts/ci/prek/update_versions.py
@@ -943,13 +941,6 @@ repos:
         entry: ./scripts/ci/prek/compile_ui_assets.py
         pass_filenames: false
         additional_dependencies: ['pnpm@9.7.1']
-      - id: compile-fab-assets
-        name: Compile FAB provider assets
-        language: node
-        files: ^providers/fab/.*/www/
-        entry: ./scripts/ci/prek/compile_provider_assets.py fab
-        pass_filenames: false
-        additional_dependencies: ['yarn@1.22.21']
       - id: compile-ui-assets-dev
         name: Compile ui assets in dev mode (manual)
         language: node
@@ -1258,7 +1249,7 @@ repos:
           # W0133: "Exception statement has no effect"
           # see: https://github.com/astral-sh/ruff/issues/10145
           - "--enable=W0133"
-      - id: check-fab-migrations
+      - id: check-no-fab-migrations
         language: pygrep
         name: Check no migration is done on FAB related table
         description: >
@@ -1414,14 +1405,8 @@ repos:
         language: python
         entry: ./scripts/ci/prek/generate_openapi_spec.py
         pass_filenames: false
-        files: ^airflow-core/src/airflow/api_fastapi/.*\.py$|^airflow-core/src/airflow/api_fastapi/auth/managers/simple/.*\.py$|^providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/.*\.py$
+        files: ^airflow-core/src/airflow/api_fastapi/.*\.py$|^airflow-core/src/airflow/api_fastapi/auth/managers/simple/.*\.py$
         exclude: ^airflow-core/src/airflow/api_fastapi/execution_api/.*
-      - id: generate-openapi-spec-fab
-        name: Generate the FastAPI API spec for FAB
-        language: python
-        entry: ./scripts/ci/prek/generate_openapi_spec_providers.py fab
-        pass_filenames: false
-        files: ^providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/.*\.py$
       - id: check-i18n-json
         name: Check i18n files validity
         description: Check i18n files are valid json, have no TODOs, and auto-format them

--- a/providers/fab/.pre-commit-config.yaml
+++ b/providers/fab/.pre-commit-config.yaml
@@ -40,9 +40,9 @@ repos:
         pass_filenames: false
         files: >
           (?x)
-          ^providers/fab/src/airflow/providers/fab/migrations/versions/.*$|
-          ^providers/fab/src/airflow/providers/fab/migrations/versions|
-          ^providers/fab/src/airflow/providers/fab/auth_manager/models/db\.py$
+          ^src/airflow/providers/fab/migrations/versions/.*$|
+          ^src/airflow/providers/fab/migrations/versions|
+          ^src/airflow/providers/fab/auth_manager/models/db\.py$
       - id: prevent-deprecated-sqlalchemy-usage-fab
         name: Prevent deprecated sqlalchemy usage
         entry: ./scripts/ci/prek/prevent_deprecated_sqlalchemy_usage.py

--- a/providers/fab/.pre-commit-config.yaml
+++ b/providers/fab/.pre-commit-config.yaml
@@ -47,5 +47,5 @@ repos:
         name: Prevent deprecated sqlalchemy usage
         entry: ./scripts/ci/prek/prevent_deprecated_sqlalchemy_usage.py
         language: python
-        files: ^providers/fab/.*\.py$
+        files: ^.*\.py$
         pass_filenames: true

--- a/providers/fab/.pre-commit-config.yaml
+++ b/providers/fab/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
           ^src/airflow/providers/fab/auth_manager/models/db\.py$
       - id: prevent-deprecated-sqlalchemy-usage-fab
         name: Prevent deprecated sqlalchemy usage
-        entry: ./scripts/ci/prek/prevent_deprecated_sqlalchemy_usage.py
+        entry: ../../scripts/ci/prek/prevent_deprecated_sqlalchemy_usage.py
         language: python
         files: ^.*\.py$
         pass_filenames: true

--- a/providers/fab/.pre-commit-config.yaml
+++ b/providers/fab/.pre-commit-config.yaml
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+---
+default_stages: [pre-commit, pre-push]
+minimum_prek_version: '0.0.28'
+repos:
+  - repo: local
+    hooks:
+      - id: compile-fab-assets
+        name: Compile FAB provider assets
+        language: node
+        files: ^.*/www/
+        entry: ../../scripts/ci/prek/compile_provider_assets.py fab
+        pass_filenames: false
+        additional_dependencies: ['yarn@1.22.21']
+      - id: generate-openapi-spec-fab
+        name: Generate the FastAPI API spec for FAB
+        language: python
+        entry: ../../scripts/ci/prek/generate_openapi_spec_providers.py fab
+        pass_filenames: false
+        files: ^src/airflow/providers/fab/auth_manager/api_fastapi/.*\.py$
+      - id: check-revision-heads-map-fab
+        name: Check that the REVISION_HEADS_MAP is up-to-date
+        language: python
+        entry: ../../scripts/ci/prek/check_revision_heads_map.py
+        pass_filenames: false
+        files: >
+          (?x)
+          ^providers/fab/src/airflow/providers/fab/migrations/versions/.*$|
+          ^providers/fab/src/airflow/providers/fab/migrations/versions|
+          ^providers/fab/src/airflow/providers/fab/auth_manager/models/db\.py$
+      - id: prevent-deprecated-sqlalchemy-usage-fab
+        name: Prevent deprecated sqlalchemy usage
+        entry: ./scripts/ci/prek/prevent_deprecated_sqlalchemy_usage.py
+        language: python
+        files: ^providers/fab/.*\.py$
+        pass_filenames: true


### PR DESCRIPTION
As prek is supporting monorepo now and go SDK was the front-runner, fab provider is now the next piece that with this PR is proposed to be split-out from global pre-commit hook list into the provider space.