### PR TITLE
Extract prek hooks for Keycloak provider

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1422,12 +1422,6 @@ repos:
         entry: ./scripts/ci/prek/generate_openapi_spec_providers.py fab
         pass_filenames: false
         files: ^providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/.*\.py$
-      - id: generate-openapi-spec-keycloak
-        name: Generate the FastAPI API spec for Keycloak
-        language: python
-        entry: ./scripts/ci/prek/generate_openapi_spec_providers.py keycloak
-        pass_filenames: false
-        files: ^providers/keycloak/src/airflow/providers/keycloak/auth_manager/.*\.py$
       - id: check-i18n-json
         name: Check i18n files validity
         description: Check i18n files are valid json, have no TODOs, and auto-format them

--- a/providers/keycloak/.pre-commit-config.yaml
+++ b/providers/keycloak/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+---
+default_stages: [pre-commit, pre-push]
+minimum_prek_version: '0.0.28'
+repos:
+  - repo: local
+    hooks:
+      - id: generate-openapi-spec-keycloak
+        name: Generate the FastAPI API spec for Keycloak
+        language: python
+        entry: ../../scripts/ci/prek/generate_openapi_spec_providers.py keycloak
+        pass_filenames: false
+        files: ^src/airflow/providers/keycloak/auth_manager/.*\.py$


### PR DESCRIPTION
Fast follower of #57181

As prek is supporting monorepo now and go SDK was the front-runner, keycloak provider is now the next piece that with this PR is proposed to be split-out from global pre-commit hook list into the provider space.