### PR TITLE
Extract prek hooks for Common.Compat provider

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -465,12 +465,6 @@ repos:
         entry: ./scripts/ci/prek/check_airflow_imports.py
           --pattern '^openlineage\.client\.(facet|run)'
           --message "You should import from `airflow.providers.common.compat.openlineage.facet` instead."
-      - id: check-common-compat-sdk-imports-in-sync
-        name: Check common.compat sdk TYPE_CHECKING matches runtime maps
-        language: python
-        files: ^providers/common/compat/src/airflow/providers/common/compat/sdk\.py$
-        pass_filenames: false
-        entry: ./scripts/ci/prek/check_common_compat_lazy_imports.py
       - id: check-airflow-providers-bug-report-template
         name: Sort airflow-bug-report provider list
         language: python

--- a/providers/common/compat/.pre-commit-config.yaml
+++ b/providers/common/compat/.pre-commit-config.yaml
@@ -25,4 +25,4 @@ repos:
         language: python
         files: ^src/airflow/providers/common/compat/sdk\.py$
         pass_filenames: false
-        entry: ../../scripts/ci/prek/check_common_compat_lazy_imports.py
+        entry: ../../../scripts/ci/prek/check_common_compat_lazy_imports.py

--- a/providers/common/compat/.pre-commit-config.yaml
+++ b/providers/common/compat/.pre-commit-config.yaml
@@ -23,6 +23,6 @@ repos:
       - id: check-common-compat-sdk-imports-in-sync
         name: Check common.compat sdk TYPE_CHECKING matches runtime maps
         language: python
-        files: ^providers/common/compat/src/airflow/providers/common/compat/sdk\.py$
+        files: ^src/airflow/providers/common/compat/sdk\.py$
         pass_filenames: false
         entry: ../../scripts/ci/prek/check_common_compat_lazy_imports.py

--- a/providers/common/compat/.pre-commit-config.yaml
+++ b/providers/common/compat/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+---
+default_stages: [pre-commit, pre-push]
+minimum_prek_version: '0.0.28'
+repos:
+  - repo: local
+    hooks:
+      - id: check-common-compat-sdk-imports-in-sync
+        name: Check common.compat sdk TYPE_CHECKING matches runtime maps
+        language: python
+        files: ^providers/common/compat/src/airflow/providers/common/compat/sdk\.py$
+        pass_filenames: false
+        entry: ../../scripts/ci/prek/check_common_compat_lazy_imports.py


### PR DESCRIPTION
Fast follower of https://github.com/apache/airflow/pull/57181

As prek is supporting monorepo now and go SDK was the front-runner, common-compat provider is now the next piece that with this PR is proposed to be split-out from global pre-commit hook list into the provider space.