### PR TITLE
Move subprocess utility closer to usage in google beam

### DIFF
--- a/providers/google/src/airflow/providers/google/go_module_utils.py
+++ b/providers/google/src/airflow/providers/google/go_module_utils.py
@@ -19,9 +19,40 @@
 
 from __future__ import annotations
 
+import logging
 import os
+import shlex
+import subprocess
 
-from airflow.utils.process_utils import execute_in_subprocess
+
+def _execute_in_subprocess(cmd: list[str], cwd: str | None = None, env: dict | None = None) -> None:
+    """
+    Execute a process and stream output to logger.
+
+    :param cmd: command and arguments to run
+    :param cwd: Current working directory passed to the Popen constructor
+    :param env: Additional environment variables to set for the subprocess.
+    """
+    log = logging.getLogger(__name__)
+    popen_args = {
+        "cwd": cwd,
+        "env": env,
+    }
+    kwargs = {k: v for k, v in popen_args.items() if v is not None}
+
+    log.info("Executing cmd: %s", " ".join(shlex.quote(c) for c in cmd))
+    with subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=0, close_fds=True, **kwargs
+    ) as proc:
+        log.info("Output:")
+        if proc.stdout:
+            with proc.stdout:
+                for line in iter(proc.stdout.readline, b""):
+                    log.info("%s", line.decode().rstrip())
+
+        exit_code = proc.wait()
+    if exit_code != 0:
+        raise subprocess.CalledProcessError(exit_code, cmd)
 
 
 def init_module(go_module_name: str, go_module_path: str) -> None:
@@ -36,7 +67,7 @@ def init_module(go_module_name: str, go_module_path: str) -> None:
     if os.path.isfile(os.path.join(go_module_path, "go.mod")):
         return
     go_mod_init_cmd = ["go", "mod", "init", go_module_name]
-    execute_in_subprocess(go_mod_init_cmd, cwd=go_module_path)
+    _execute_in_subprocess(go_mod_init_cmd, cwd=go_module_path)
 
 
 def install_dependencies(go_module_path: str) -> None:
@@ -46,4 +77,4 @@ def install_dependencies(go_module_path: str) -> None:
     :param go_module_path: The path to the directory containing the Go module.
     """
     go_mod_tidy = ["go", "mod", "tidy"]
-    execute_in_subprocess(go_mod_tidy, cwd=go_module_path)
+    _execute_in_subprocess(go_mod_tidy, cwd=go_module_path)

--- a/providers/google/src/airflow/providers/google/go_module_utils.py
+++ b/providers/google/src/airflow/providers/google/go_module_utils.py
@@ -25,7 +25,7 @@ import shlex
 import subprocess
 
 
-def _execute_in_subprocess(cmd: list[str], cwd: str | None = None, env: dict | None = None) -> None:
+def _execute_in_subprocess(cmd: list[str], cwd: str | None = None, env: dict[str, str] | None = None) -> None:
     """
     Execute a process and stream output to logger.
 
@@ -34,15 +34,16 @@ def _execute_in_subprocess(cmd: list[str], cwd: str | None = None, env: dict | N
     :param env: Additional environment variables to set for the subprocess.
     """
     log = logging.getLogger(__name__)
-    popen_args = {
-        "cwd": cwd,
-        "env": env,
-    }
-    kwargs = {k: v for k, v in popen_args.items() if v is not None}
 
     log.info("Executing cmd: %s", " ".join(shlex.quote(c) for c in cmd))
     with subprocess.Popen(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=0, close_fds=True, **kwargs
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        bufsize=0,
+        close_fds=True,
+        cwd=cwd,
+        env=env,
     ) as proc:
         log.info("Output:")
         if proc.stdout:

--- a/providers/google/tests/unit/google/test_go_module.py
+++ b/providers/google/tests/unit/google/test_go_module.py
@@ -23,14 +23,14 @@ from airflow.providers.google.go_module_utils import init_module, install_depend
 
 
 class TestGoModule:
-    @mock.patch("airflow.providers.google.go_module_utils.execute_in_subprocess")
+    @mock.patch("airflow.providers.google.go_module_utils._execute_in_subprocess")
     def test_should_init_go_module(self, mock_execute_in_subprocess):
         init_module(go_module_name="example.com/main", go_module_path="/home/example/go")
         mock_execute_in_subprocess.assert_called_once_with(
             ["go", "mod", "init", "example.com/main"], cwd="/home/example/go"
         )
 
-    @mock.patch("airflow.providers.google.go_module_utils.execute_in_subprocess")
+    @mock.patch("airflow.providers.google.go_module_utils._execute_in_subprocess")
     def test_should_install_module_dependencies(self, mock_execute_in_subprocess):
         install_dependencies(go_module_path="/home/example/go")
         mock_execute_in_subprocess.assert_called_once_with(["go", "mod", "tidy"], cwd="/home/example/go")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Google beam provider code was using: `from airflow.utils.process_utils import execute_in_subprocess` to perform some operations. This utility is only used by google and standard providers and they import it from airflow core creating an unnecessary import dependency between the distributions.

This import pattern also conflicts with our long term goal of having providers only ever use task SDK.


This is part of that cleanup effort and I will follow this task up with 2 more tasks:
1. Do same / similar for airflow standard provider
2. Cleanup positioning / wipe out that util if its not used in airflow core 

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
