### PR TITLE
Move subprocess utility closer to usage in python venv operators

### DIFF
--- a/providers/standard/src/airflow/providers/standard/operators/python.py
+++ b/providers/standard/src/airflow/providers/standard/operators/python.py
@@ -51,12 +51,15 @@ from airflow.exceptions import (
 from airflow.models.variable import Variable
 from airflow.providers.common.compat.sdk import context_merge
 from airflow.providers.standard.hooks.package_index import PackageIndexHook
-from airflow.providers.standard.utils.python_virtualenv import prepare_virtualenv, write_python_script
+from airflow.providers.standard.utils.python_virtualenv import (
+    _execute_in_subprocess,
+    prepare_virtualenv,
+    write_python_script,
+)
 from airflow.providers.standard.version_compat import AIRFLOW_V_3_0_PLUS, BaseOperator
 from airflow.utils import hashlib_wrapper
 from airflow.utils.file import get_unique_dag_module_name
 from airflow.utils.operator_helpers import KeywordParameters
-from airflow.utils.process_utils import execute_in_subprocess
 
 if AIRFLOW_V_3_0_PLUS:
     from airflow.providers.standard.operators.branch import BaseBranchOperator
@@ -572,7 +575,7 @@ class _BasePythonVirtualenvOperator(PythonOperator, metaclass=ABCMeta):
                     os.fspath(termination_log_path),
                     os.fspath(airflow_context_path),
                 ]
-                execute_in_subprocess(
+                _execute_in_subprocess(
                     cmd=cmd,
                     env=env_vars,
                 )

--- a/providers/standard/src/airflow/providers/standard/utils/python_virtualenv.py
+++ b/providers/standard/src/airflow/providers/standard/utils/python_virtualenv.py
@@ -134,7 +134,7 @@ def _index_urls_to_uv_env_vars(index_urls: list[str] | None = None) -> dict[str,
     return uv_index_env_vars
 
 
-def _execute_in_subprocess(cmd: list[str], cwd: str | None = None, env: dict | None = None) -> None:
+def _execute_in_subprocess(cmd: list[str], cwd: str | None = None, env: dict[str, str] | None = None) -> None:
     """
     Execute a process and stream output to logger.
 
@@ -143,15 +143,16 @@ def _execute_in_subprocess(cmd: list[str], cwd: str | None = None, env: dict | N
     :param env: Additional environment variables to set for the subprocess.
     """
     log = logging.getLogger(__name__)
-    popen_args = {
-        "cwd": cwd,
-        "env": env,
-    }
-    kwargs = {k: v for k, v in popen_args.items() if v is not None}
 
     log.info("Executing cmd: %s", " ".join(shlex.quote(c) for c in cmd))
     with subprocess.Popen(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=0, close_fds=True, **kwargs
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        bufsize=0,
+        close_fds=True,
+        cwd=cwd,
+        env=env,
     ) as proc:
         log.info("Output:")
         if proc.stdout:

--- a/providers/standard/src/airflow/providers/standard/utils/python_virtualenv.py
+++ b/providers/standard/src/airflow/providers/standard/utils/python_virtualenv.py
@@ -19,8 +19,11 @@
 
 from __future__ import annotations
 
+import logging
 import os
+import shlex
 import shutil
+import subprocess
 import warnings
 from pathlib import Path
 
@@ -28,7 +31,6 @@ import jinja2
 from jinja2 import select_autoescape
 
 from airflow.configuration import conf
-from airflow.utils.process_utils import execute_in_subprocess
 
 
 def _is_uv_installed() -> bool:
@@ -132,6 +134,36 @@ def _index_urls_to_uv_env_vars(index_urls: list[str] | None = None) -> dict[str,
     return uv_index_env_vars
 
 
+def _execute_in_subprocess(cmd: list[str], cwd: str | None = None, env: dict | None = None) -> None:
+    """
+    Execute a process and stream output to logger.
+
+    :param cmd: command and arguments to run
+    :param cwd: Current working directory passed to the Popen constructor
+    :param env: Additional environment variables to set for the subprocess.
+    """
+    log = logging.getLogger(__name__)
+    popen_args = {
+        "cwd": cwd,
+        "env": env,
+    }
+    kwargs = {k: v for k, v in popen_args.items() if v is not None}
+
+    log.info("Executing cmd: %s", " ".join(shlex.quote(c) for c in cmd))
+    with subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=0, close_fds=True, **kwargs
+    ) as proc:
+        log.info("Output:")
+        if proc.stdout:
+            with proc.stdout:
+                for line in iter(proc.stdout.readline, b""):
+                    log.info("%s", line.decode().rstrip())
+
+        exit_code = proc.wait()
+    if exit_code != 0:
+        raise subprocess.CalledProcessError(exit_code, cmd)
+
+
 def prepare_virtualenv(
     venv_directory: str,
     python_bin: str,
@@ -169,7 +201,7 @@ def prepare_virtualenv(
         venv_cmd = _generate_uv_cmd(venv_directory, python_bin, system_site_packages)
     else:
         venv_cmd = _generate_venv_cmd(venv_directory, python_bin, system_site_packages)
-    execute_in_subprocess(venv_cmd)
+    _execute_in_subprocess(venv_cmd)
 
     pip_cmd = None
     if requirements is not None and len(requirements) != 0:
@@ -188,7 +220,7 @@ def prepare_virtualenv(
             )
 
     if pip_cmd:
-        execute_in_subprocess(pip_cmd, env={**os.environ, **_index_urls_to_uv_env_vars(index_urls)})
+        _execute_in_subprocess(pip_cmd, env={**os.environ, **_index_urls_to_uv_env_vars(index_urls)})
 
     return f"{venv_directory}/bin/python"
 

--- a/providers/standard/tests/unit/standard/operators/test_python.py
+++ b/providers/standard/tests/unit/standard/operators/test_python.py
@@ -61,7 +61,7 @@ from airflow.providers.standard.operators.python import (
     _PythonVersionInfo,
     get_current_context,
 )
-from airflow.providers.standard.utils.python_virtualenv import execute_in_subprocess, prepare_virtualenv
+from airflow.providers.standard.utils.python_virtualenv import _execute_in_subprocess, prepare_virtualenv
 from airflow.utils.session import create_session
 from airflow.utils.state import DagRunState, State, TaskInstanceState
 from airflow.utils.types import NOTSET, DagRunType
@@ -1410,8 +1410,8 @@ class TestPythonVirtualenvOperator(BaseTestPythonVirtualenvOperator):
         self.run_as_task(f, system_site_packages=False, op_args=[4])
 
     @mock.patch(
-        "airflow.providers.standard.utils.python_virtualenv.execute_in_subprocess",
-        wraps=execute_in_subprocess,
+        "airflow.providers.standard.utils.python_virtualenv._execute_in_subprocess",
+        wraps=_execute_in_subprocess,
     )
     def test_with_index_urls(self, wrapped_execute_in_subprocess):
         def f(a):

--- a/providers/standard/tests/unit/standard/utils/test_python_virtualenv.py
+++ b/providers/standard/tests/unit/standard/utils/test_python_virtualenv.py
@@ -77,7 +77,7 @@ class TestPrepareVirtualenv:
         for term in unexpected_pip_conf_content:
             assert term not in generated_conf
 
-    @mock.patch("airflow.providers.standard.utils.python_virtualenv.execute_in_subprocess")
+    @mock.patch("airflow.providers.standard.utils.python_virtualenv._execute_in_subprocess")
     @conf_vars({("standard", "venv_install_method"): "pip"})
     def test_should_create_virtualenv_pip(self, mock_execute_in_subprocess):
         python_bin = prepare_virtualenv(
@@ -86,7 +86,7 @@ class TestPrepareVirtualenv:
         assert python_bin == "/VENV/bin/python"
         mock_execute_in_subprocess.assert_called_once_with(["pythonVER", "-m", "venv", "/VENV"])
 
-    @mock.patch("airflow.providers.standard.utils.python_virtualenv.execute_in_subprocess")
+    @mock.patch("airflow.providers.standard.utils.python_virtualenv._execute_in_subprocess")
     @conf_vars({("standard", "venv_install_method"): "uv"})
     def test_should_create_virtualenv_uv(self, mock_execute_in_subprocess):
         python_bin = prepare_virtualenv(
@@ -97,7 +97,7 @@ class TestPrepareVirtualenv:
             ["uv", "venv", "--allow-existing", "--seed", "--python", "pythonVER", "/VENV"]
         )
 
-    @mock.patch("airflow.providers.standard.utils.python_virtualenv.execute_in_subprocess")
+    @mock.patch("airflow.providers.standard.utils.python_virtualenv._execute_in_subprocess")
     @conf_vars({("standard", "venv_install_method"): "pip"})
     def test_should_create_virtualenv_with_system_packages_pip(self, mock_execute_in_subprocess):
         python_bin = prepare_virtualenv(
@@ -108,7 +108,7 @@ class TestPrepareVirtualenv:
             ["pythonVER", "-m", "venv", "/VENV", "--system-site-packages"]
         )
 
-    @mock.patch("airflow.providers.standard.utils.python_virtualenv.execute_in_subprocess")
+    @mock.patch("airflow.providers.standard.utils.python_virtualenv._execute_in_subprocess")
     @conf_vars({("standard", "venv_install_method"): "uv"})
     def test_should_create_virtualenv_with_system_packages_uv(self, mock_execute_in_subprocess):
         python_bin = prepare_virtualenv(
@@ -128,7 +128,7 @@ class TestPrepareVirtualenv:
             ]
         )
 
-    @mock.patch("airflow.providers.standard.utils.python_virtualenv.execute_in_subprocess")
+    @mock.patch("airflow.providers.standard.utils.python_virtualenv._execute_in_subprocess")
     @conf_vars({("standard", "venv_install_method"): "pip"})
     def test_pip_install_options_pip(self, mock_execute_in_subprocess):
         pip_install_options = ["--no-deps"]
@@ -146,7 +146,7 @@ class TestPrepareVirtualenv:
             env=mock.ANY,
         )
 
-    @mock.patch("airflow.providers.standard.utils.python_virtualenv.execute_in_subprocess")
+    @mock.patch("airflow.providers.standard.utils.python_virtualenv._execute_in_subprocess")
     @conf_vars({("standard", "venv_install_method"): "uv"})
     def test_pip_install_options_uv(self, mock_execute_in_subprocess):
         pip_install_options = ["--no-deps"]
@@ -172,7 +172,7 @@ class TestPrepareVirtualenv:
             env=mock.ANY,
         )
 
-    @mock.patch("airflow.providers.standard.utils.python_virtualenv.execute_in_subprocess")
+    @mock.patch("airflow.providers.standard.utils.python_virtualenv._execute_in_subprocess")
     @conf_vars({("standard", "venv_install_method"): "pip"})
     def test_should_create_virtualenv_with_extra_packages_pip(self, mock_execute_in_subprocess):
         python_bin = prepare_virtualenv(
@@ -189,7 +189,7 @@ class TestPrepareVirtualenv:
             ["/VENV/bin/pip", "install", "apache-beam[gcp]"], env=mock.ANY
         )
 
-    @mock.patch("airflow.providers.standard.utils.python_virtualenv.execute_in_subprocess")
+    @mock.patch("airflow.providers.standard.utils.python_virtualenv._execute_in_subprocess")
     @conf_vars({("standard", "venv_install_method"): "uv"})
     def test_should_create_virtualenv_with_extra_packages_uv(self, mock_execute_in_subprocess):
         python_bin = prepare_virtualenv(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

https://github.com/apache/airflow/pull/57187 but similar for standard provider.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
