### PR TITLE
Deprecate subprocess exec utils from airflow core

### DIFF
--- a/airflow-core/src/airflow/utils/process_utils.py
+++ b/airflow-core/src/airflow/utils/process_utils.py
@@ -29,6 +29,7 @@ import signal
 import subprocess
 import sys
 
+from airflow import DeprecatedImportWarning
 from airflow.utils.platform import IS_WINDOWS
 
 if not IS_WINDOWS:
@@ -173,7 +174,18 @@ def execute_in_subprocess(cmd: list[str], cwd: str | None = None, env: dict | No
     :param env: Additional environment variables to set for the subprocess. If None,
         the subprocess will inherit the current environment variables of the parent process
         (``os.environ``)
+
+    .. deprecated:: 3.2.0
+        This function is deprecated. Please implement your own subprocess execution logic,
+        reference the one present in standard / google providers.
     """
+    import warnings
+
+    warnings.warn(
+        "The function `execute_in_subprocess` is deprecated and will be removed in a future version.",
+        DeprecatedImportWarning,
+        stacklevel=2,
+    )
     execute_in_subprocess_with_kwargs(cmd, cwd=cwd, env=env)
 
 
@@ -184,7 +196,18 @@ def execute_in_subprocess_with_kwargs(cmd: list[str], **kwargs) -> None:
     :param cmd: command and arguments to run
 
     All other keyword args will be passed directly to subprocess.Popen
+
+    .. deprecated:: 3.2.0
+        This function is deprecated. Please implement your own subprocess execution logic,
+        reference the one present in standard / google providers.
     """
+    import warnings
+
+    warnings.warn(
+        "The function `execute_in_subprocess_with_kwargs` is deprecated and will be removed in a future version.",
+        DeprecatedImportWarning,
+        stacklevel=2,
+    )
     log.info("Executing cmd: %s", " ".join(shlex.quote(c) for c in cmd))
     with subprocess.Popen(
         cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=0, close_fds=True, **kwargs


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Building up on top of https://github.com/apache/airflow/pull/57187 and https://github.com/apache/airflow/pull/57189, there are no more usages of these utilities. 

Adding a deprecation warning to warn users to move away from using these if they are using it. There are some related unit tests too, which I am not so sure if we should remove now or later because technically this bit of code still will work until we wipe it off the repo.

This is how the deprecation warning looks like:
```
execute_in_subprocess(cmd=["bash", "-c", "echo CAT; echo KITTY;"])
<ipython-input-3-0c1513dd948a>:1 DeprecatedImportWarning: The function `execute_in_subprocess` is deprecated and will be removed in a future version.
/Users/amoghdesai/Documents/OSS/repos/airflow/airflow-core/src/airflow/utils/process_utils.py:188 DeprecatedImportWarning: The function `execute_in_subprocess_with_kwargs` is deprecated and will be removed in a future version.
[2025-10-24T11:18:13.833774Z] {process_utils.py:209} INFO - Executing cmd: bash -c 'echo CAT; echo KITTY;'
[2025-10-24T11:18:13.844192Z] {process_utils.py:213} INFO - Output:
[2025-10-24T11:18:13.851401Z] {process_utils.py:217} INFO - CAT
[2025-10-24T11:18:13.851532Z] {process_utils.py:217} INFO - KITTY
execute_in_subprocess_with_kwargs(cmd=["bash", "-c", "echo CAT; echo KITTY;"])
<ipython-input-4-46ee57e90afd>:1 DeprecatedImportWarning: The function `execute_in_subprocess_with_kwargs` is deprecated and will be removed in a future version.
[2025-10-24T11:18:23.570528Z] {process_utils.py:209} INFO - Executing cmd: bash -c 'echo CAT; echo KITTY;'
[2025-10-24T11:18:23.578198Z] {process_utils.py:213} INFO - Output:
[2025-10-24T11:18:23.582314Z] {process_utils.py:217} INFO - CAT
[2025-10-24T11:18:23.582415Z] {process_utils.py:217} INFO - KITTY
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
