### PR TITLE
Migrate FAB POST /roles to FastAPI

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/datamodels/roles.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/datamodels/roles.py
@@ -43,7 +43,7 @@ class ActionResourceResponse(BaseModel):
 class RoleBody(StrictBaseModel):
     """Incoming payload for creating/updating a role."""
 
-    name: str
+    name: str = Field(min_length=1)
     permissions: list[ActionResourceResponse] = Field(
         default_factory=list, alias="actions", validation_alias="actions"
     )

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/datamodels/roles.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/datamodels/roles.py
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from pydantic import Field
+
+from airflow.api_fastapi.core_api.base import BaseModel, StrictBaseModel
+
+
+class ActionOut(BaseModel):
+    """Outgoing representation of an action (permission name)."""
+
+    name: str
+
+
+class ResourceOut(BaseModel):
+    """Outgoing representation of a resource."""
+
+    name: str
+
+
+class ActionResourceOut(BaseModel):
+    """Pairing of an action with a resource."""
+
+    action: ActionOut
+    resource: ResourceOut
+
+
+class RoleIn(StrictBaseModel):
+    """Incoming payload for creating/updating a role."""
+
+    name: str
+    permissions: list[ActionResourceOut] = Field(
+        default_factory=list, alias="actions", validation_alias="actions"
+    )
+
+
+class RoleOut(BaseModel):
+    """Outgoing representation of a role and its permissions."""
+
+    name: str
+    permissions: list[ActionResourceOut] = Field(default_factory=list, serialization_alias="actions")
+
+
+class RoleCollectionOut(BaseModel):
+    """Collection wrapper for roles with total count."""
+
+    roles: list[RoleOut]
+    total_entries: int

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/datamodels/roles.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/datamodels/roles.py
@@ -21,43 +21,36 @@ from pydantic import Field
 from airflow.api_fastapi.core_api.base import BaseModel, StrictBaseModel
 
 
-class ActionOut(BaseModel):
+class ActionResponse(BaseModel):
     """Outgoing representation of an action (permission name)."""
 
     name: str
 
 
-class ResourceOut(BaseModel):
+class ResourceResponse(BaseModel):
     """Outgoing representation of a resource."""
 
     name: str
 
 
-class ActionResourceOut(BaseModel):
+class ActionResourceResponse(BaseModel):
     """Pairing of an action with a resource."""
 
-    action: ActionOut
-    resource: ResourceOut
+    action: ActionResponse
+    resource: ResourceResponse
 
 
-class RoleIn(StrictBaseModel):
+class RoleBody(StrictBaseModel):
     """Incoming payload for creating/updating a role."""
 
     name: str
-    permissions: list[ActionResourceOut] = Field(
+    permissions: list[ActionResourceResponse] = Field(
         default_factory=list, alias="actions", validation_alias="actions"
     )
 
 
-class RoleOut(BaseModel):
+class RoleResponse(BaseModel):
     """Outgoing representation of a role and its permissions."""
 
     name: str
-    permissions: list[ActionResourceOut] = Field(default_factory=list, serialization_alias="actions")
-
-
-class RoleCollectionOut(BaseModel):
-    """Collection wrapper for roles with total count."""
-
-    roles: list[RoleOut]
-    total_entries: int
+    permissions: list[ActionResourceResponse] = Field(default_factory=list, serialization_alias="actions")

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/openapi/v2-fab-auth-manager-generated.yaml
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/openapi/v2-fab-auth-manager-generated.yaml
@@ -126,18 +126,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPExceptionResponse'
+        '422':
+          description: Unprocessable Entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
         '500':
           description: Internal Server Error
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPExceptionResponse'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
       security:
       - OAuth2PasswordBearer: []
       - HTTPBearer: []
@@ -225,6 +225,7 @@ components:
       properties:
         name:
           type: string
+          minLength: 1
           title: Name
         actions:
           items:

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/openapi/v2-fab-auth-manager-generated.yaml
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/openapi/v2-fab-auth-manager-generated.yaml
@@ -82,8 +82,89 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /auth/fab/v1/roles:
+    post:
+      tags:
+      - FabAuthManager
+      summary: Create Role
+      description: Create a new role (actions can be empty).
+      operationId: create_role
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RoleIn'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RoleOut'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - OAuth2PasswordBearer: []
+      - HTTPBearer: []
 components:
   schemas:
+    ActionOut:
+      properties:
+        name:
+          type: string
+          title: Name
+      type: object
+      required:
+      - name
+      title: ActionOut
+      description: Outgoing representation of an action (permission name).
+    ActionResourceOut:
+      properties:
+        action:
+          $ref: '#/components/schemas/ActionOut'
+        resource:
+          $ref: '#/components/schemas/ResourceOut'
+      type: object
+      required:
+      - action
+      - resource
+      title: ActionResourceOut
+      description: Pairing of an action with a resource.
     HTTPExceptionResponse:
       properties:
         detail:
@@ -130,6 +211,47 @@ components:
       - access_token
       title: LoginResponse
       description: API Token serializer for responses.
+    ResourceOut:
+      properties:
+        name:
+          type: string
+          title: Name
+      type: object
+      required:
+      - name
+      title: ResourceOut
+      description: Outgoing representation of a resource.
+    RoleIn:
+      properties:
+        name:
+          type: string
+          title: Name
+        actions:
+          items:
+            $ref: '#/components/schemas/ActionResourceOut'
+          type: array
+          title: Actions
+      additionalProperties: false
+      type: object
+      required:
+      - name
+      title: RoleIn
+      description: Incoming payload for creating/updating a role.
+    RoleOut:
+      properties:
+        name:
+          type: string
+          title: Name
+        actions:
+          items:
+            $ref: '#/components/schemas/ActionResourceOut'
+          type: array
+          title: Actions
+      type: object
+      required:
+      - name
+      title: RoleOut
+      description: Outgoing representation of a role and its permissions.
     ValidationError:
       properties:
         loc:
@@ -151,3 +273,21 @@ components:
       - msg
       - type
       title: ValidationError
+  securitySchemes:
+    OAuth2PasswordBearer:
+      type: oauth2
+      description: To authenticate Airflow API requests, clients must include a JWT
+        (JSON Web Token) in the Authorization header of each request. This token is
+        used to verify the identity of the client and ensure that they have the appropriate
+        permissions to access the requested resources. You can use the endpoint ``POST
+        /auth/token`` in order to generate a JWT token. Upon successful authentication,
+        the server will issue a JWT token that contains the necessary information
+        (such as user identity and scope) to authenticate subsequent requests. To
+        learn more about Airflow public API authentication, please read https://airflow.apache.org/docs/apache-airflow/stable/security/api.html.
+      flows:
+        password:
+          scopes: {}
+          tokenUrl: /auth/token
+    HTTPBearer:
+      type: http
+      scheme: bearer

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/openapi/v2-fab-auth-manager-generated.yaml
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/openapi/v2-fab-auth-manager-generated.yaml
@@ -126,18 +126,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPExceptionResponse'
-        '422':
-          description: Unprocessable Entity
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPExceptionResponse'
         '500':
           description: Internal Server Error
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPExceptionResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
       security:
       - OAuth2PasswordBearer: []
       - HTTPBearer: []

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/openapi/v2-fab-auth-manager-generated.yaml
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/openapi/v2-fab-auth-manager-generated.yaml
@@ -93,7 +93,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RoleIn'
+              $ref: '#/components/schemas/RoleBody'
         required: true
       responses:
         '200':
@@ -101,7 +101,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RoleOut'
+                $ref: '#/components/schemas/RoleResponse'
         '400':
           description: Bad Request
           content:
@@ -143,7 +143,19 @@ paths:
       - HTTPBearer: []
 components:
   schemas:
-    ActionOut:
+    ActionResourceResponse:
+      properties:
+        action:
+          $ref: '#/components/schemas/ActionResponse'
+        resource:
+          $ref: '#/components/schemas/ResourceResponse'
+      type: object
+      required:
+      - action
+      - resource
+      title: ActionResourceResponse
+      description: Pairing of an action with a resource.
+    ActionResponse:
       properties:
         name:
           type: string
@@ -151,20 +163,8 @@ components:
       type: object
       required:
       - name
-      title: ActionOut
+      title: ActionResponse
       description: Outgoing representation of an action (permission name).
-    ActionResourceOut:
-      properties:
-        action:
-          $ref: '#/components/schemas/ActionOut'
-        resource:
-          $ref: '#/components/schemas/ResourceOut'
-      type: object
-      required:
-      - action
-      - resource
-      title: ActionResourceOut
-      description: Pairing of an action with a resource.
     HTTPExceptionResponse:
       properties:
         detail:
@@ -211,7 +211,7 @@ components:
       - access_token
       title: LoginResponse
       description: API Token serializer for responses.
-    ResourceOut:
+    ResourceResponse:
       properties:
         name:
           type: string
@@ -219,38 +219,38 @@ components:
       type: object
       required:
       - name
-      title: ResourceOut
+      title: ResourceResponse
       description: Outgoing representation of a resource.
-    RoleIn:
+    RoleBody:
       properties:
         name:
           type: string
           title: Name
         actions:
           items:
-            $ref: '#/components/schemas/ActionResourceOut'
+            $ref: '#/components/schemas/ActionResourceResponse'
           type: array
           title: Actions
       additionalProperties: false
       type: object
       required:
       - name
-      title: RoleIn
+      title: RoleBody
       description: Incoming payload for creating/updating a role.
-    RoleOut:
+    RoleResponse:
       properties:
         name:
           type: string
           title: Name
         actions:
           items:
-            $ref: '#/components/schemas/ActionResourceOut'
+            $ref: '#/components/schemas/ActionResourceResponse'
           type: array
           title: Actions
       type: object
       required:
       - name
-      title: RoleOut
+      title: RoleResponse
       description: Outgoing representation of a role and its permissions.
     ValidationError:
       properties:

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/routes/roles.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/routes/roles.py
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from fastapi import Depends
+from starlette import status
+from starlette.exceptions import HTTPException
+
+from airflow.api_fastapi.app import get_auth_manager
+from airflow.api_fastapi.common.router import AirflowRouter
+from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
+from airflow.api_fastapi.core_api.security import get_user
+from airflow.providers.fab.auth_manager.api_fastapi.datamodels.roles import RoleIn, RoleOut
+from airflow.providers.fab.auth_manager.api_fastapi.services.roles import FABAuthManagerRoles
+from airflow.providers.fab.auth_manager.cli_commands.utils import get_application_builder
+from airflow.providers.fab.www.security import permissions
+
+roles_router = AirflowRouter(prefix="/fab/v1", tags=["FabAuthManager"])
+
+
+def requires_fab_custom_view(method: str, resource_name: str):
+    def _check(user=Depends(get_user)):
+        if not get_auth_manager().is_authorized_custom_view(
+            method=method, resource_name=resource_name, user=user
+        ):
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+
+    return _check
+
+
+@roles_router.post(
+    "/roles",
+    response_model=RoleOut,
+    status_code=status.HTTP_200_OK,
+    responses=create_openapi_http_exception_doc(
+        [
+            status.HTTP_400_BAD_REQUEST,
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+            status.HTTP_409_CONFLICT,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+        ]
+    ),
+    dependencies=[Depends(requires_fab_custom_view("POST", permissions.RESOURCE_ROLE))],
+)
+def create_role(body: RoleIn) -> RoleOut:
+    """Create a new role (actions can be empty)."""
+    with get_application_builder():
+        return FABAuthManagerRoles.create_role(body=body)

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/routes/roles.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/routes/roles.py
@@ -16,43 +16,33 @@
 # under the License.
 from __future__ import annotations
 
-from fastapi import Depends
-from starlette import status
-from starlette.exceptions import HTTPException
+from typing import TYPE_CHECKING
 
-from airflow.api_fastapi.app import get_auth_manager
+from fastapi import Depends, status
+
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
-from airflow.api_fastapi.core_api.security import get_user
 from airflow.providers.fab.auth_manager.api_fastapi.datamodels.roles import RoleBody, RoleResponse
+from airflow.providers.fab.auth_manager.api_fastapi.security import requires_fab_custom_view
 from airflow.providers.fab.auth_manager.api_fastapi.services.roles import FABAuthManagerRoles
 from airflow.providers.fab.auth_manager.cli_commands.utils import get_application_builder
 from airflow.providers.fab.www.security import permissions
 
+if TYPE_CHECKING:
+    from airflow.providers.fab.auth_manager.api_fastapi.datamodels.roles import RoleBody, RoleResponse
+
+
 roles_router = AirflowRouter(prefix="/fab/v1", tags=["FabAuthManager"])
-
-
-def requires_fab_custom_view(method: str, resource_name: str):
-    def _check(user=Depends(get_user)):
-        if not get_auth_manager().is_authorized_custom_view(
-            method=method, resource_name=resource_name, user=user
-        ):
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
-
-    return _check
 
 
 @roles_router.post(
     "/roles",
-    response_model=RoleResponse,
-    status_code=status.HTTP_200_OK,
     responses=create_openapi_http_exception_doc(
         [
             status.HTTP_400_BAD_REQUEST,
             status.HTTP_401_UNAUTHORIZED,
             status.HTTP_403_FORBIDDEN,
             status.HTTP_409_CONFLICT,
-            status.HTTP_422_UNPROCESSABLE_CONTENT,
             status.HTTP_500_INTERNAL_SERVER_ERROR,
         ]
     ),

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/routes/roles.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/routes/roles.py
@@ -52,6 +52,7 @@ def requires_fab_custom_view(method: str, resource_name: str):
             status.HTTP_401_UNAUTHORIZED,
             status.HTTP_403_FORBIDDEN,
             status.HTTP_409_CONFLICT,
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
             status.HTTP_500_INTERNAL_SERVER_ERROR,
         ]
     ),

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/routes/roles.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/routes/roles.py
@@ -24,7 +24,7 @@ from airflow.api_fastapi.app import get_auth_manager
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
 from airflow.api_fastapi.core_api.security import get_user
-from airflow.providers.fab.auth_manager.api_fastapi.datamodels.roles import RoleIn, RoleOut
+from airflow.providers.fab.auth_manager.api_fastapi.datamodels.roles import RoleBody, RoleResponse
 from airflow.providers.fab.auth_manager.api_fastapi.services.roles import FABAuthManagerRoles
 from airflow.providers.fab.auth_manager.cli_commands.utils import get_application_builder
 from airflow.providers.fab.www.security import permissions
@@ -44,7 +44,7 @@ def requires_fab_custom_view(method: str, resource_name: str):
 
 @roles_router.post(
     "/roles",
-    response_model=RoleOut,
+    response_model=RoleResponse,
     status_code=status.HTTP_200_OK,
     responses=create_openapi_http_exception_doc(
         [
@@ -57,7 +57,7 @@ def requires_fab_custom_view(method: str, resource_name: str):
     ),
     dependencies=[Depends(requires_fab_custom_view("POST", permissions.RESOURCE_ROLE))],
 )
-def create_role(body: RoleIn) -> RoleOut:
+def create_role(body: RoleBody) -> RoleResponse:
     """Create a new role (actions can be empty)."""
     with get_application_builder():
         return FABAuthManagerRoles.create_role(body=body)

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/security.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/security.py
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from fastapi import Depends, HTTPException, status
+
+from airflow.api_fastapi.app import get_auth_manager
+from airflow.api_fastapi.core_api.security import get_user
+
+
+def requires_fab_custom_view(method: str, resource_name: str):
+    def _check(user=Depends(get_user)):
+        if not get_auth_manager().is_authorized_custom_view(
+            method=method, resource_name=resource_name, user=user
+        ):
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+
+    return _check

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/services/roles.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/services/roles.py
@@ -1,0 +1,80 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+from starlette import status
+from starlette.exceptions import HTTPException
+
+from airflow.api_fastapi.app import get_auth_manager
+from airflow.providers.fab.auth_manager.api_fastapi.datamodels.roles import RoleIn, RoleOut
+
+if TYPE_CHECKING:
+    from airflow.providers.fab.auth_manager.fab_auth_manager import FabAuthManager
+    from airflow.providers.fab.auth_manager.security_manager.override import FabAirflowSecurityManagerOverride
+
+
+class FABAuthManagerRoles:
+    """Service layer for FAB Auth Manager role operations (create, validate, sync)."""
+
+    @staticmethod
+    def _check_action_and_resource(
+        sm: FabAirflowSecurityManagerOverride,
+        perms: list[tuple[str, str]],
+    ) -> None:
+        for action_name, resource_name in perms:
+            if not sm.get_action(action_name):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"The specified action: {action_name!r} was not found",
+                )
+            if not sm.get_resource(resource_name):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"The specified resource: {resource_name!r} was not found",
+                )
+
+    @classmethod
+    def create_role(cls, body: RoleIn) -> RoleOut:
+        if not body or not body.name:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Role name must be provided")
+
+        security_manager = cast("FabAuthManager", get_auth_manager()).security_manager
+        sm: FabAirflowSecurityManagerOverride = cast("FabAirflowSecurityManagerOverride", security_manager)
+
+        existing = sm.find_role(name=body.name)
+        if existing:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Role with name {body.name!r} already exists; please update with the PATCH endpoint",
+            )
+
+        perms: list[tuple[str, str]] = [(ar.action.name, ar.resource.name) for ar in (body.permissions or [])]
+
+        cls._check_action_and_resource(sm, perms)
+
+        sm.bulk_sync_roles([{"role": body.name, "perms": perms}])
+
+        created = sm.find_role(name=body.name)
+        if not created:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Role was not created due to an unexpected error.",
+            )
+
+        return RoleOut.model_validate(created)

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/services/roles.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/services/roles.py
@@ -18,8 +18,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from starlette import status
-from starlette.exceptions import HTTPException
+from fastapi import HTTPException, status
 
 from airflow.providers.fab.auth_manager.api_fastapi.datamodels.roles import RoleBody, RoleResponse
 from airflow.providers.fab.www.utils import get_fab_auth_manager

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/services/roles.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/services/roles.py
@@ -16,16 +16,15 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from starlette import status
 from starlette.exceptions import HTTPException
 
-from airflow.api_fastapi.app import get_auth_manager
-from airflow.providers.fab.auth_manager.api_fastapi.datamodels.roles import RoleIn, RoleOut
+from airflow.providers.fab.auth_manager.api_fastapi.datamodels.roles import RoleBody, RoleResponse
+from airflow.providers.fab.www.utils import get_fab_auth_manager
 
 if TYPE_CHECKING:
-    from airflow.providers.fab.auth_manager.fab_auth_manager import FabAuthManager
     from airflow.providers.fab.auth_manager.security_manager.override import FabAirflowSecurityManagerOverride
 
 
@@ -34,30 +33,29 @@ class FABAuthManagerRoles:
 
     @staticmethod
     def _check_action_and_resource(
-        sm: FabAirflowSecurityManagerOverride,
+        security_manager: FabAirflowSecurityManagerOverride,
         perms: list[tuple[str, str]],
     ) -> None:
         for action_name, resource_name in perms:
-            if not sm.get_action(action_name):
+            if not security_manager.get_action(action_name):
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=f"The specified action: {action_name!r} was not found",
                 )
-            if not sm.get_resource(resource_name):
+            if not security_manager.get_resource(resource_name):
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=f"The specified resource: {resource_name!r} was not found",
                 )
 
     @classmethod
-    def create_role(cls, body: RoleIn) -> RoleOut:
-        if not body or not body.name:
+    def create_role(cls, body: RoleBody) -> RoleResponse:
+        if not body.name:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Role name must be provided")
 
-        security_manager = cast("FabAuthManager", get_auth_manager()).security_manager
-        sm: FabAirflowSecurityManagerOverride = cast("FabAirflowSecurityManagerOverride", security_manager)
+        security_manager = get_fab_auth_manager().security_manager
 
-        existing = sm.find_role(name=body.name)
+        existing = security_manager.find_role(name=body.name)
         if existing:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
@@ -66,15 +64,15 @@ class FABAuthManagerRoles:
 
         perms: list[tuple[str, str]] = [(ar.action.name, ar.resource.name) for ar in (body.permissions or [])]
 
-        cls._check_action_and_resource(sm, perms)
+        cls._check_action_and_resource(security_manager, perms)
 
-        sm.bulk_sync_roles([{"role": body.name, "perms": perms}])
+        security_manager.bulk_sync_roles([{"role": body.name, "perms": perms}])
 
-        created = sm.find_role(name=body.name)
+        created = security_manager.find_role(name=body.name)
         if not created:
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Role was not created due to an unexpected error.",
             )
 
-        return RoleOut.model_validate(created)
+        return RoleResponse.model_validate(created)

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/services/roles.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/services/roles.py
@@ -50,9 +50,6 @@ class FABAuthManagerRoles:
 
     @classmethod
     def create_role(cls, body: RoleBody) -> RoleResponse:
-        if not body.name:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Role name must be provided")
-
         security_manager = get_fab_auth_manager().security_manager
 
         existing = security_manager.find_role(name=body.name)

--- a/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
@@ -226,6 +226,7 @@ class FabAuthManager(BaseAuthManager[User]):
         from airflow.providers.fab.auth_manager.api_fastapi.routes.login import (
             login_router,
         )
+        from airflow.providers.fab.auth_manager.api_fastapi.routes.roles import roles_router
 
         flask_app = create_app(enable_plugins=False)
 
@@ -241,6 +242,7 @@ class FabAuthManager(BaseAuthManager[User]):
 
         # Add the login router to the FastAPI app
         app.include_router(login_router)
+        app.include_router(roles_router)
 
         app.mount("/", WSGIMiddleware(flask_app))
 

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/conftest.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/conftest.py
@@ -16,9 +16,13 @@
 # under the License.
 from __future__ import annotations
 
+import types
+from contextlib import contextmanager
+
 import pytest
 from fastapi.testclient import TestClient
 
+from airflow.api_fastapi.core_api.security import get_user as get_user_dep
 from airflow.providers.fab.auth_manager.fab_auth_manager import FabAuthManager
 
 
@@ -30,3 +34,37 @@ def fab_auth_manager():
 @pytest.fixture(scope="module")
 def test_client(fab_auth_manager):
     return TestClient(fab_auth_manager.get_fastapi_app())
+
+
+@pytest.fixture
+def override_deps(test_client):
+    """
+    Context-managed helper for app.dependency_overrides.
+
+    Usage:
+        with override_deps({dep_func: override_func, ...}):
+            # do requests
+    """
+    app = test_client.app
+
+    @contextmanager
+    def _use(mapping: dict):
+        for dep, override in mapping.items():
+            app.dependency_overrides[dep] = override
+        try:
+            yield
+        finally:
+            for dep in mapping.keys():
+                app.dependency_overrides.pop(dep, None)
+
+    return _use
+
+
+@pytest.fixture
+def as_user(override_deps):
+    @contextmanager
+    def _as(u=types.SimpleNamespace(id=1, username="tester")):
+        with override_deps({get_user_dep: lambda: u}):
+            yield u
+
+    return _as

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/datamodels/__init__.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/datamodels/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/datamodels/test_roles.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/datamodels/test_roles.py
@@ -1,0 +1,88 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import types
+
+import pytest
+from pydantic import ValidationError
+
+from airflow.providers.fab.auth_manager.api_fastapi.datamodels.roles import (
+    ActionResourceResponse,
+    ActionResponse,
+    ResourceResponse,
+    RoleBody,
+    RoleResponse,
+)
+
+
+class TestRoleModels:
+    def test_rolebody_accepts_actions_alias_and_maps_to_permissions(self):
+        data = {
+            "name": "viewer",
+            "actions": [
+                {"action": {"name": "can_read"}, "resource": {"name": "DAG"}},
+                {"action": {"name": "can_read"}, "resource": {"name": "Connection"}},
+            ],
+        }
+        body = RoleBody.model_validate(data)
+        assert body.name == "viewer"
+        # Field(validation_alias="actions") should populate `permissions`
+        assert len(body.permissions) == 2
+        assert body.permissions[0].action.name == "can_read"
+        assert body.permissions[0].resource.name == "DAG"
+
+    def test_rolebody_defaults_permissions_to_empty_when_actions_missing(self):
+        body = RoleBody.model_validate({"name": "empty"})
+        assert body.name == "empty"
+        assert body.permissions == []
+
+    def test_rolebody_name_min_length_enforced(self):
+        with pytest.raises(ValidationError):
+            RoleBody.model_validate({"name": "", "actions": []})
+
+    def test_roleresponse_serializes_permissions_under_actions_alias(self):
+        ar = ActionResourceResponse(
+            action=ActionResponse(name="can_read"),
+            resource=ResourceResponse(name="DAG"),
+        )
+        rr = RoleResponse(name="viewer", permissions=[ar])
+
+        dumped = rr.model_dump(by_alias=True)
+        # Field(serialization_alias="actions") should rename `permissions` -> `actions`
+        assert "actions" in dumped
+        assert "permissions" not in dumped
+        assert dumped["name"] == "viewer"
+        assert dumped["actions"][0]["action"]["name"] == "can_read"
+        assert dumped["actions"][0]["resource"]["name"] == "DAG"
+
+    def test_roleresponse_model_validate_from_simple_namespace(self):
+        # Service returns plain objects; ensure model_validate handles them
+        obj = types.SimpleNamespace(
+            name="viewer",
+            permissions=[
+                types.SimpleNamespace(
+                    action=types.SimpleNamespace(name="can_read"),
+                    resource=types.SimpleNamespace(name="DAG"),
+                )
+            ],
+        )
+        rr = RoleResponse.model_validate(obj)
+        assert rr.name == "viewer"
+        assert rr.permissions
+        first = rr.permissions[0]
+        assert first.action.name == "can_read"

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/routes/test_roles.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/routes/test_roles.py
@@ -17,33 +17,25 @@
 
 from __future__ import annotations
 
-import types
-from contextlib import contextmanager
+from contextlib import nullcontext as _noop_cm
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from airflow.api_fastapi.core_api.security import get_user
 from airflow.providers.fab.auth_manager.api_fastapi.datamodels.roles import RoleResponse
-
-
-@contextmanager
-def _noop_cm():
-    yield None
 
 
 @pytest.mark.db_test
 class TestRoles:
     @patch("airflow.providers.fab.auth_manager.api_fastapi.routes.roles.FABAuthManagerRoles")
-    @patch("airflow.providers.fab.auth_manager.api_fastapi.routes.roles.get_auth_manager")
+    @patch("airflow.providers.fab.auth_manager.api_fastapi.security.get_auth_manager")
     @patch(
         "airflow.providers.fab.auth_manager.api_fastapi.routes.roles.get_application_builder",
         return_value=_noop_cm(),
     )
-    def test_create_role(self, mock_get_application_builder, mock_get_auth_manager, mock_roles, test_client):
-        dummy_user = types.SimpleNamespace(id=1, username="tester")
-        test_client.app.dependency_overrides[get_user] = lambda: dummy_user
-
+    def test_create_role(
+        self, mock_get_application_builder, mock_get_auth_manager, mock_roles, test_client, as_user
+    ):
         mgr = MagicMock()
         mgr.is_authorized_custom_view.return_value = True
         mock_get_auth_manager.return_value = mgr
@@ -51,74 +43,62 @@ class TestRoles:
         dummy_out = RoleResponse(name="my_new_role", permissions=[])
         mock_roles.create_role.return_value = dummy_out
 
-        try:
+        with as_user():
             resp = test_client.post("/fab/v1/roles", json={"name": "my_new_role", "actions": []})
             assert resp.status_code == 200
             assert resp.json() == dummy_out.model_dump(by_alias=True)
             mock_roles.create_role.assert_called_once()
-        finally:
-            test_client.app.dependency_overrides.pop(get_user, None)
 
-    @patch("airflow.providers.fab.auth_manager.api_fastapi.routes.roles.get_auth_manager")
+    @patch("airflow.providers.fab.auth_manager.api_fastapi.routes.roles.FABAuthManagerRoles")
+    @patch("airflow.providers.fab.auth_manager.api_fastapi.security.get_auth_manager")
     @patch(
         "airflow.providers.fab.auth_manager.api_fastapi.routes.roles.get_application_builder",
         return_value=_noop_cm(),
     )
-    def test_create_role_forbidden(self, mock_get_application_builder, mock_get_auth_manager, test_client):
-        dummy_user = types.SimpleNamespace(id=1, username="tester")
-        test_client.app.dependency_overrides[get_user] = lambda: dummy_user
-
+    def test_create_role_forbidden(
+        self, mock_get_application_builder, mock_get_auth_manager, mock_roles, test_client, as_user
+    ):
         mgr = MagicMock()
         mgr.is_authorized_custom_view.return_value = False
         mock_get_auth_manager.return_value = mgr
 
-        try:
+        with as_user():
             resp = test_client.post("/fab/v1/roles", json={"name": "r", "actions": []})
             assert resp.status_code == 403
-            assert resp.json()["detail"] == "Forbidden"
-        finally:
-            test_client.app.dependency_overrides.pop(get_user, None)
+            mock_roles.create_role.assert_not_called()
 
     @patch("airflow.providers.fab.auth_manager.api_fastapi.routes.roles.FABAuthManagerRoles")
-    @patch("airflow.providers.fab.auth_manager.api_fastapi.routes.roles.get_auth_manager")
+    @patch("airflow.providers.fab.auth_manager.api_fastapi.security.get_auth_manager")
     @patch(
         "airflow.providers.fab.auth_manager.api_fastapi.routes.roles.get_application_builder",
         return_value=_noop_cm(),
     )
     def test_create_role_validation_422_empty_name(
-        self, mock_get_application_builder, mock_get_auth_manager, mock_roles, test_client
+        self, mock_get_application_builder, mock_get_auth_manager, mock_roles, test_client, as_user
     ):
-        dummy_user = types.SimpleNamespace(id=1, username="tester")
-        test_client.app.dependency_overrides[get_user] = lambda: dummy_user
         mgr = MagicMock()
         mgr.is_authorized_custom_view.return_value = True
         mock_get_auth_manager.return_value = mgr
 
-        try:
+        with as_user():
             resp = test_client.post("/fab/v1/roles", json={"name": "", "actions": []})
             assert resp.status_code == 422
             mock_roles.create_role.assert_not_called()
-        finally:
-            test_client.app.dependency_overrides.pop(get_user, None)
 
     @patch("airflow.providers.fab.auth_manager.api_fastapi.routes.roles.FABAuthManagerRoles")
-    @patch("airflow.providers.fab.auth_manager.api_fastapi.routes.roles.get_auth_manager")
+    @patch("airflow.providers.fab.auth_manager.api_fastapi.security.get_auth_manager")
     @patch(
         "airflow.providers.fab.auth_manager.api_fastapi.routes.roles.get_application_builder",
         return_value=_noop_cm(),
     )
     def test_create_role_validation_422_missing_name(
-        self, mock_get_application_builder, mock_get_auth_manager, mock_roles, test_client
+        self, mock_get_application_builder, mock_get_auth_manager, mock_roles, test_client, as_user
     ):
-        dummy_user = types.SimpleNamespace(id=1, username="tester")
-        test_client.app.dependency_overrides[get_user] = lambda: dummy_user
         mgr = MagicMock()
         mgr.is_authorized_custom_view.return_value = True
         mock_get_auth_manager.return_value = mgr
 
-        try:
+        with as_user():
             resp = test_client.post("/fab/v1/roles", json={"actions": []})
             assert resp.status_code == 422
             mock_roles.create_role.assert_not_called()
-        finally:
-            test_client.app.dependency_overrides.pop(get_user, None)

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/routes/test_roles.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/routes/test_roles.py
@@ -78,3 +78,47 @@ class TestRoles:
             assert resp.json()["detail"] == "Forbidden"
         finally:
             test_client.app.dependency_overrides.pop(get_user, None)
+
+    @patch("airflow.providers.fab.auth_manager.api_fastapi.routes.roles.FABAuthManagerRoles")
+    @patch("airflow.providers.fab.auth_manager.api_fastapi.routes.roles.get_auth_manager")
+    @patch(
+        "airflow.providers.fab.auth_manager.api_fastapi.routes.roles.get_application_builder",
+        return_value=_noop_cm(),
+    )
+    def test_create_role_validation_422_empty_name(
+        self, mock_get_application_builder, mock_get_auth_manager, mock_roles, test_client
+    ):
+        dummy_user = types.SimpleNamespace(id=1, username="tester")
+        test_client.app.dependency_overrides[get_user] = lambda: dummy_user
+        mgr = MagicMock()
+        mgr.is_authorized_custom_view.return_value = True
+        mock_get_auth_manager.return_value = mgr
+
+        try:
+            resp = test_client.post("/fab/v1/roles", json={"name": "", "actions": []})
+            assert resp.status_code == 422
+            mock_roles.create_role.assert_not_called()
+        finally:
+            test_client.app.dependency_overrides.pop(get_user, None)
+
+    @patch("airflow.providers.fab.auth_manager.api_fastapi.routes.roles.FABAuthManagerRoles")
+    @patch("airflow.providers.fab.auth_manager.api_fastapi.routes.roles.get_auth_manager")
+    @patch(
+        "airflow.providers.fab.auth_manager.api_fastapi.routes.roles.get_application_builder",
+        return_value=_noop_cm(),
+    )
+    def test_create_role_validation_422_missing_name(
+        self, mock_get_application_builder, mock_get_auth_manager, mock_roles, test_client
+    ):
+        dummy_user = types.SimpleNamespace(id=1, username="tester")
+        test_client.app.dependency_overrides[get_user] = lambda: dummy_user
+        mgr = MagicMock()
+        mgr.is_authorized_custom_view.return_value = True
+        mock_get_auth_manager.return_value = mgr
+
+        try:
+            resp = test_client.post("/fab/v1/roles", json={"actions": []})
+            assert resp.status_code == 422
+            mock_roles.create_role.assert_not_called()
+        finally:
+            test_client.app.dependency_overrides.pop(get_user, None)

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/routes/test_roles.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/routes/test_roles.py
@@ -1,0 +1,66 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from airflow.api_fastapi.core_api.security import get_user
+from airflow.providers.fab.auth_manager.api_fastapi.datamodels.roles import RoleOut
+
+
+@pytest.mark.db_test
+class TestRoles:
+    @patch("airflow.providers.fab.auth_manager.api_fastapi.routes.roles.get_auth_manager")
+    @patch("airflow.providers.fab.auth_manager.api_fastapi.routes.roles.FABAuthManagerRoles")
+    def test_create_role(self, mock_roles, mock_get_auth_manager, test_client):
+        dummy_user = types.SimpleNamespace(id=1, username="tester")
+        test_client.app.dependency_overrides[get_user] = lambda: dummy_user
+
+        mgr = MagicMock()
+        mgr.is_authorized_custom_view.return_value = True
+        mock_get_auth_manager.return_value = mgr
+
+        dummy_out = RoleOut(name="my_new_role", permissions=[])
+        mock_roles.create_role.return_value = dummy_out
+
+        try:
+            resp = test_client.post("/fab/v1/roles", json={"name": "my_new_role", "actions": []})
+            assert resp.status_code == 200
+            assert resp.json() == dummy_out.model_dump(by_alias=True)
+            mock_roles.create_role.assert_called_once()
+        finally:
+            test_client.app.dependency_overrides.pop(get_user, None)
+
+    @patch("airflow.providers.fab.auth_manager.api_fastapi.routes.roles.get_auth_manager")
+    def test_create_role_forbidden(self, mock_get_auth_manager, test_client):
+        dummy_user = types.SimpleNamespace(id=1, username="tester")
+        test_client.app.dependency_overrides[get_user] = lambda: dummy_user
+
+        mgr = MagicMock()
+        mgr.is_authorized_custom_view.return_value = False
+        mock_get_auth_manager.return_value = mgr
+
+        try:
+            resp = test_client.post("/fab/v1/roles", json={"name": "r", "actions": []})
+            assert resp.status_code == 403
+            assert resp.json()["detail"] == "Forbidden"
+        finally:
+            test_client.app.dependency_overrides.pop(get_user, None)

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_roles.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_roles.py
@@ -21,7 +21,7 @@ import types
 from unittest.mock import MagicMock, patch
 
 import pytest
-from starlette.exceptions import HTTPException
+from fastapi import HTTPException
 
 from airflow.providers.fab.auth_manager.api_fastapi.services.roles import FABAuthManagerRoles
 

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_roles.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_roles.py
@@ -1,0 +1,148 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+from starlette.exceptions import HTTPException
+
+from airflow.providers.fab.auth_manager.api_fastapi.services.roles import FABAuthManagerRoles
+
+
+@pytest.fixture
+def auth_manager():
+    return MagicMock()
+
+
+@pytest.fixture
+def security_manager():
+    sm = MagicMock()
+    sm.get_action.side_effect = lambda n: object() if n in {"can_read"} else None
+    sm.get_resource.side_effect = lambda n: object() if n in {"DAG"} else None
+    return sm
+
+
+def _make_role_obj(name: str, perms: list[tuple[str, str]]):
+    perm_objs = [
+        types.SimpleNamespace(
+            action=types.SimpleNamespace(name=a),
+            resource=types.SimpleNamespace(name=r),
+        )
+        for (a, r) in perms
+    ]
+    return types.SimpleNamespace(name=name, permissions=perm_objs)
+
+
+@patch("airflow.providers.fab.auth_manager.api_fastapi.services.roles.get_auth_manager")
+class TestRolesService:
+    def setup_method(self):
+        self.body_ok = types.SimpleNamespace(
+            name="roleA",
+            permissions=[
+                types.SimpleNamespace(
+                    action=types.SimpleNamespace(name="can_read"),
+                    resource=types.SimpleNamespace(name="DAG"),
+                )
+            ],
+        )
+        self.body_no_name = types.SimpleNamespace(name="", permissions=[])
+        self.body_bad_action = types.SimpleNamespace(
+            name="roleB",
+            permissions=[
+                types.SimpleNamespace(
+                    action=types.SimpleNamespace(name="no_such_action"),
+                    resource=types.SimpleNamespace(name="DAG"),
+                )
+            ],
+        )
+        self.body_bad_resource = types.SimpleNamespace(
+            name="roleC",
+            permissions=[
+                types.SimpleNamespace(
+                    action=types.SimpleNamespace(name="can_read"),
+                    resource=types.SimpleNamespace(name="NOPE"),
+                )
+            ],
+        )
+
+    def test_create_role_success(self, get_auth_manager, auth_manager, security_manager):
+        security_manager.find_role.side_effect = [
+            None,
+            _make_role_obj("roleA", [("can_read", "DAG")]),
+        ]
+        auth_manager.security_manager = security_manager
+        get_auth_manager.return_value = auth_manager
+
+        out = FABAuthManagerRoles.create_role(self.body_ok)
+
+        assert out.name == "roleA"
+        assert out.permissions
+        assert out.permissions[0].action.name == "can_read"
+        assert out.permissions[0].resource.name == "DAG"
+
+        security_manager.bulk_sync_roles.assert_called_once_with(
+            [{"role": "roleA", "perms": [("can_read", "DAG")]}]
+        )
+
+    def test_create_role_conflict(self, get_auth_manager, auth_manager, security_manager):
+        security_manager.find_role.return_value = object()
+        auth_manager.security_manager = security_manager
+        get_auth_manager.return_value = auth_manager
+
+        with pytest.raises(HTTPException) as ex:
+            FABAuthManagerRoles.create_role(self.body_ok)
+        assert ex.value.status_code == 409
+
+    def test_create_role_missing_name(self, get_auth_manager, auth_manager, security_manager):
+        auth_manager.security_manager = security_manager
+        get_auth_manager.return_value = auth_manager
+
+        with pytest.raises(HTTPException) as ex:
+            FABAuthManagerRoles.create_role(self.body_no_name)
+        assert ex.value.status_code == 400
+
+    def test_create_role_action_not_found(self, get_auth_manager, auth_manager, security_manager):
+        security_manager.find_role.return_value = None
+        auth_manager.security_manager = security_manager
+        get_auth_manager.return_value = auth_manager
+
+        with pytest.raises(HTTPException) as ex:
+            FABAuthManagerRoles.create_role(self.body_bad_action)
+        assert ex.value.status_code == 400
+        assert "action" in ex.value.detail
+
+    def test_create_role_resource_not_found(self, get_auth_manager, auth_manager, security_manager):
+        security_manager.find_role.return_value = None
+        auth_manager.security_manager = security_manager
+        get_auth_manager.return_value = auth_manager
+
+        with pytest.raises(HTTPException) as ex:
+            FABAuthManagerRoles.create_role(self.body_bad_resource)
+        assert ex.value.status_code == 400
+        assert "resource" in ex.value.detail
+
+    def test_create_role_unexpected_no_created(self, get_auth_manager, auth_manager, security_manager):
+        security_manager.find_role.side_effect = [None, None]
+        auth_manager.security_manager = security_manager
+        get_auth_manager.return_value = auth_manager
+
+        with pytest.raises(HTTPException) as ex:
+            FABAuthManagerRoles.create_role(self.body_ok)
+        assert ex.value.status_code == 500

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_roles.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_roles.py
@@ -62,7 +62,7 @@ class TestRolesService:
                 )
             ],
         )
-        self.body_no_name = types.SimpleNamespace(name="", permissions=[])
+
         self.body_bad_action = types.SimpleNamespace(
             name="roleB",
             permissions=[
@@ -108,14 +108,6 @@ class TestRolesService:
         with pytest.raises(HTTPException) as ex:
             FABAuthManagerRoles.create_role(self.body_ok)
         assert ex.value.status_code == 409
-
-    def test_create_role_missing_name(self, get_fab_auth_manager, fab_auth_manager, security_manager):
-        fab_auth_manager.security_manager = security_manager
-        get_fab_auth_manager.return_value = fab_auth_manager
-
-        with pytest.raises(HTTPException) as ex:
-            FABAuthManagerRoles.create_role(self.body_no_name)
-        assert ex.value.status_code == 400
 
     def test_create_role_action_not_found(self, get_fab_auth_manager, fab_auth_manager, security_manager):
         security_manager.find_role.return_value = None

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/test_security.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/test_security.py
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from airflow.providers.fab.auth_manager.api_fastapi.security import requires_fab_custom_view
+
+
+class TestSecurityDependency:
+    @patch("airflow.providers.fab.auth_manager.api_fastapi.security.get_auth_manager")
+    def test_requires_fab_custom_view_allows_when_authorized(self, get_auth_manager):
+        mgr = MagicMock()
+        mgr.is_authorized_custom_view.return_value = True
+        get_auth_manager.return_value = mgr
+
+        check = requires_fab_custom_view(method="POST", resource_name="Role")
+        user = object()
+
+        assert check(user=user) is None
+        mgr.is_authorized_custom_view.assert_called_once_with(method="POST", resource_name="Role", user=user)
+
+    @patch("airflow.providers.fab.auth_manager.api_fastapi.security.get_auth_manager")
+    def test_requires_fab_custom_view_raises_403_when_unauthorized(self, get_auth_manager):
+        mgr = MagicMock()
+        mgr.is_authorized_custom_view.return_value = False
+        get_auth_manager.return_value = mgr
+
+        check = requires_fab_custom_view(method="DELETE", resource_name="Role")
+        with pytest.raises(HTTPException) as ex:
+            check(user=object())
+        assert ex.value.status_code == 403


### PR DESCRIPTION
# Why

- Align FAB provider with Airflow 3’s FastAPI-first direction and reduce remaining Connexion/Flask surface. This PR is a small step for issue #56730 by migrating a single endpoint first.

# How

- New FastAPI endpoint: implements `POST /auth/fab/v1/roles` using a router registered by `FabAuthManager.get_fastapi_app()`. Path and success status remain compatible (200 OK). The login FastAPI module serves as structural precedent.

- Data models: added Pydantic models in `api_fastapi/datamodels/roles.py` (`RoleBody`, `RoleResponse`, etc.). The JSON field `actions` is preserved via aliases while internal naming uses “permissions,” mirroring the Connexion schema.

- Service layer: `api_fastapi/services/roles.py#create_role` reproduces the legacy flow:
  1. validate role name
  2. conflict if role exists (409)
  3. validate action/resource pairs (422 on missing from Pydantic)
  4. `bulk_sync_roles`
  5. re-fetch or 500 on unexpected failure

- Authorization parity: introduced a FastAPI dependency that mirrors `requires_access_custom_view("POST", RESOURCE_ROLE)`; unauthorized → 401, forbidden → 403 (same semantics as FAB’s Connexion layer)

- OpenAPI docs: response map includes 400/401/403/409 and now 500 for the rare “created-but-not-found” case, consistent with the new service behavior. (FastAPI auto-generates the schema from code.)



<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
