### PR TITLE
Update release process for providers to use RAT 0.17

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -187,3 +187,32 @@ mocks/*
 
 # Kubernetes env
 .env
+
+# Doc files
+/docs/.latest-doc-only-change.txt
+/docs/redirects.txt
+/docs/integration-logos/*.svg
+/docs/img/*.md5sum
+/docs/img/*.svg
+
+# Log files
+*.log
+
+# md5 sum files
+.*\.md5sum
+
+# Generated files
+*generated.*
+/src/airflow/providers/keycloak/auth_manager/openapi/v2-keycloak-auth-manager-generated.yaml
+/src/airflow/providers/edge3/plugins/www/*
+/src/airflow/providers/edge3/openapi/v2-edge-generated.yaml
+/src/airflow/providers/fab/auth_manager/api_fastapi/openapi/v2-fab-auth-manager-generated.yaml
+/src/airflow/providers/fab/www/static/dist/*
+/any/dag_id=dag_for_testing_redis_task_handler/run_id=test/task_id=task_for_testing_redis_log_handler/attempt=1.log
+/src/airflow/providers/google/ads/.gitignore
+
+# Vendored-in code
+/src/airflow/providers/google/_vendor/*
+
+# Git ignore file
+.gitignore

--- a/dev/README_RELEASE_PROVIDERS.md
+++ b/dev/README_RELEASE_PROVIDERS.md
@@ -791,7 +791,7 @@ Set an environment variable: PATH_TO_SVN to the root of folder where you have pr
 
 ``` shell
 cd asf-dist/dev/airflow
-export PATH_TO_SVN=${pwd -P)
+export PATH_TO_SVN=$(pwd -P)
 ```
 
 Optionally you can use the [`check_files.py`](https://github.com/apache/airflow/blob/main/dev/check_files.py)
@@ -925,7 +925,7 @@ This can be done with the Apache RAT tool.
 # Get rat if you do not have it
 if command -v wget >/dev/null 2>&1; then
     echo "Using wget to download Apache RAT..."
-    wget -qO- https://dlcdn.apache.org//creadur/apache-rat-0.16.1/apache-rat-0.16.1-bin.tar.gz | gunzip | tar -C /tmp -xvf -
+    wget -qO- https://dlcdn.apache.org//creadur/apache-rat-0.17/apache-rat-0.17-bin.tar.gz | gunzip | tar -C /tmp -xvf -
 else
     echo "ERROR: wget not found. Install with: brew install wget (macOS) or apt-get install wget (Linux)"
     exit 1
@@ -941,15 +941,27 @@ done
 # Generate list of unpacked providers
 find . -type d -maxdepth 1 | grep -v "^.$"> /tmp/files.txt
 # Check licences
-for d in $(cat /tmp/files.txt)
+for d in $(cat /tmp/files.txt | sort)
 do
-  pushd $d
-  java -jar /tmp/apache-rat-0.16.1/apache-rat-0.16.1.jar -E ${AIRFLOW_REPO_ROOT}/.rat-excludes -d .  2>/dev/null | grep Unknown
-  popd >/dev/null
+  pushd $d 2>&1 >/dev/null
+  echo "Checking licences for $d"
+  java -jar /tmp/apache-rat-0.17/apache-rat-0.17.jar --input-exclude-file ${AIRFLOW_REPO_ROOT}/.rat-excludes .  2>/dev/null | grep '! '
+  popd 2>&1 >/dev/null
 done
 ```
 
-You should see only '0 Unknown licences"
+You should see output similar to:
+
+```
+Checking licences for ./apache_airflow_providers_airbyte-5.2.4
+Checking licences for ./apache_airflow_providers_alibaba-3.2.4
+Checking licences for ./apache_airflow_providers_amazon-9.16.0
+Checking licences for ./apache_airflow_providers_apache_beam-6.1.6
+Checking licences for ./apache_airflow_providers_apache_cassandra-3.8.3
+...
+```
+
+You will see there files that are considered problematic by RAT tool (RAT prints such files preceding them with "! ").
 
 Cleanup:
 
@@ -1050,6 +1062,7 @@ You should get output similar to:
 ```
 Checking apache-airflow-providers-google-1.0.0rc1.tar.gz.sha512
 Checking apache_airflow-providers-google-1.0.0rc1-py3-none-any.whl.sha512
+...
 ```
 
 ## Verify the release candidate by Contributors


### PR DESCRIPTION
RAT 0.17 has been released recently and it was quite a big change. While we cannot use archive check that was released in 0.17 due to bug https://issues.apache.org/jira/projects/RAT/issues/RAT-511 we should still switch to it as it is going to be used in the Apache Trusted Releases soon.

This change adds missing .rat-excludes and also updates the process to produce nicer output.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
