### PR TITLE
Fix Pagerduty tests for latest version 6.0.0

### DIFF
--- a/providers/pagerduty/tests/unit/pagerduty/hooks/test_pagerduty.py
+++ b/providers/pagerduty/tests/unit/pagerduty/hooks/test_pagerduty.py
@@ -17,6 +17,9 @@
 # under the License.
 from __future__ import annotations
 
+from unittest.mock import patch
+
+import pagerduty
 import pytest
 
 from airflow.models import Connection
@@ -57,7 +60,8 @@ class TestPagerdutyHook:
         hook = PagerdutyHook(token="pagerduty_param_token", pagerduty_conn_id=DEFAULT_CONN_ID)
         assert hook.token == "pagerduty_param_token", "token initialised."
 
-    def test_get_service(self, requests_mock):
+    @patch.object(pagerduty.RestApiV2Client, "rget")
+    def test_get_service(self, rget):
         hook = PagerdutyHook(pagerduty_conn_id=DEFAULT_CONN_ID)
         mock_response_body = {
             "id": "PZYX321",
@@ -67,7 +71,7 @@ class TestPagerdutyHook:
             "summary": "Apache Airflow",
             "self": "https://api.pagerduty.com/services/PZYX321",
         }
-        requests_mock.get("https://api.pagerduty.com/services/PZYX321", json={"service": mock_response_body})
+        rget.return_value = mock_response_body
         client = hook.client()
         resp = client.rget("/services/PZYX321")
         assert resp == mock_response_body

--- a/providers/pagerduty/tests/unit/pagerduty/hooks/test_pagerduty_events.py
+++ b/providers/pagerduty/tests/unit/pagerduty/hooks/test_pagerduty_events.py
@@ -18,9 +18,13 @@
 from __future__ import annotations
 
 from unittest import mock
+from unittest.mock import patch
 
+import httpx
+import pagerduty
 import pytest
 from aioresponses import aioresponses
+from pagerduty import EventsApiV2Client
 
 from airflow.models import Connection
 from airflow.providers.pagerduty.hooks.pagerduty_events import (
@@ -82,26 +86,52 @@ class TestPagerdutyEventsHook:
         hook = PagerdutyEventsHook(integration_key="override_key", pagerduty_events_conn_id=DEFAULT_CONN_ID)
         assert hook.integration_key == "override_key", "token initialised."
 
-    def test_create_change_event(self, requests_mock, events_connections):
+    @patch.object(pagerduty.EventsApiV2Client, "request")
+    def test_create_change_event(self, mock_request, events_connections):
+        """Test that create_change_event sends a valid change event and returns None"""
+
         hook = PagerdutyEventsHook(pagerduty_events_conn_id=DEFAULT_CONN_ID)
+
         mock_response_body = {
             "message": "Change event processed",
             "status": "success",
         }
-        requests_mock.post("https://events.pagerduty.com/v2/change/enqueue", json=mock_response_body)
+        mock_response = httpx.Response(
+            status_code=202,
+            json=mock_response_body,
+            request=httpx.Request("POST", "https://events.pagerduty.com/v2/change/enqueue"),
+        )
+        mock_request.return_value = mock_response
         resp = hook.create_change_event(summary="test", source="airflow")
+        mock_request.assert_called_once()
         assert resp is None, "No response expected for change event"
 
-    def test_send_event(self, requests_mock, events_connections):
+    @patch.object(EventsApiV2Client, "request")
+    def test_send_event_success(self, mock_request, events_connections):
+        """Test that send_event returns dedup_key on success"""
         hook = PagerdutyEventsHook(pagerduty_events_conn_id=DEFAULT_CONN_ID)
         dedup_key = "samplekeyhere"
+
         mock_response_body = {
             "status": "success",
             "message": "Event processed",
             "dedup_key": dedup_key,
         }
-        requests_mock.post("https://events.pagerduty.com/v2/enqueue", json=mock_response_body)
-        resp = hook.send_event(summary="test", source="airflow_test", severity="error", dedup_key=dedup_key)
+        mock_response = httpx.Response(
+            status_code=202,
+            json=mock_response_body,
+            request=httpx.Request("POST", "https://events.pagerduty.com/v2/enqueue"),
+        )
+        mock_request.return_value = mock_response
+
+        resp = hook.send_event(
+            summary="test",
+            source="airflow_test",
+            severity="error",
+            dedup_key=dedup_key,
+        )
+
+        mock_request.assert_called_once()
         assert resp == dedup_key
 
 

--- a/providers/pagerduty/tests/unit/pagerduty/hooks/test_pagerduty_events.py
+++ b/providers/pagerduty/tests/unit/pagerduty/hooks/test_pagerduty_events.py
@@ -101,6 +101,8 @@ class TestPagerdutyEventsHook:
             json=mock_response_body,
             request=httpx.Request("POST", "https://events.pagerduty.com/v2/change/enqueue"),
         )
+
+        mock_response.ok = True
         mock_request.return_value = mock_response
         resp = hook.create_change_event(summary="test", source="airflow")
         mock_request.assert_called_once()
@@ -122,6 +124,7 @@ class TestPagerdutyEventsHook:
             json=mock_response_body,
             request=httpx.Request("POST", "https://events.pagerduty.com/v2/enqueue"),
         )
+        mock_response.ok = True
         mock_request.return_value = mock_response
 
         resp = hook.send_event(


### PR DESCRIPTION
https://github.com/apache/airflow/actions/runs/18790093189

https://pypi.org/project/pagerduty/

Pagerduty released new version, which is using the httpx client internally. 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
