### PR TITLE
Fab provider SQLA1 -> SQLA2: Fix models/dagbundle MyPy error

### DIFF
--- a/airflow-core/src/airflow/models/dagbundle.py
+++ b/airflow-core/src/airflow/models/dagbundle.py
@@ -69,6 +69,9 @@ class DagBundleModel(Base, LoggingMixin):
 
             from airflow.configuration import conf
 
+            if not self.signed_url_template:
+                return None
+
             serializer = URLSafeSerializer(conf.get_mandatory_value("core", "fernet_key"))
             payload = serializer.loads(self.signed_url_template)
             if isinstance(payload, dict) and "url" in payload and "bundle_name" in payload:


### PR DESCRIPTION
Fixes MyPy error shown below in `airflow-core/src/models/dagbundle.py`.
Part of #56735.

<img width="1170" height="144" alt="image" src="https://github.com/user-attachments/assets/b2d6079c-9435-433e-96c7-6f3eab70759a" />