### PR TITLE
Fab provider SQLA1 -> SQLA2: Fix api_fastapi/core_api/routes/public/assets.py

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
@@ -18,10 +18,11 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Annotated
+from typing import TYPE_CHECKING, Annotated, cast
 
 from fastapi import Depends, HTTPException, status
 from sqlalchemy import and_, delete, func, select
+from sqlalchemy.engine import CursorResult
 from sqlalchemy.orm import joinedload, subqueryload
 
 from airflow._shared.timezones import timezone
@@ -245,7 +246,7 @@ def get_asset_aliases(
     )
 
     return AssetAliasCollectionResponse(
-        asset_aliases=session.scalars(asset_aliases_select),
+        asset_aliases=list(session.scalars(asset_aliases_select)),
         total_entries=total_entries,
     )
 
@@ -336,7 +337,7 @@ def get_asset_events(
     assets_events = session.scalars(assets_event_select)
 
     return AssetEventCollectionResponse(
-        asset_events=assets_events,
+        asset_events=list(assets_events),
         total_entries=total_entries,
     )
 
@@ -611,7 +612,7 @@ def delete_asset_queued_events(
         asset_id=asset_id, before=before, permitted_dag_ids=readable_dags_filter.value
     )
     delete_stmt = delete(AssetDagRunQueue).where(*where_clause).execution_options(synchronize_session="fetch")
-    result = session.execute(delete_stmt)
+    result = cast(CursorResult, session.execute(delete_stmt))
     if result.rowcount == 0:
         raise HTTPException(
             status.HTTP_404_NOT_FOUND,
@@ -645,7 +646,7 @@ def delete_dag_asset_queued_events(
     )
 
     delete_statement = delete(AssetDagRunQueue).where(*where_clause)
-    result = session.execute(delete_statement)
+    result = cast(CursorResult, session.execute(delete_statement))
 
     if result.rowcount == 0:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"Queue event with dag_id: `{dag_id}` was not found")
@@ -680,7 +681,7 @@ def delete_dag_asset_queued_event(
     delete_statement = (
         delete(AssetDagRunQueue).where(*where_clause).execution_options(synchronize_session="fetch")
     )
-    result = session.execute(delete_statement)
+    result = cast(CursorResult, session.execute(delete_statement))
     if result.rowcount == 0:
         raise HTTPException(
             status.HTTP_404_NOT_FOUND,

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
@@ -612,7 +612,7 @@ def delete_asset_queued_events(
         asset_id=asset_id, before=before, permitted_dag_ids=readable_dags_filter.value
     )
     delete_stmt = delete(AssetDagRunQueue).where(*where_clause).execution_options(synchronize_session="fetch")
-    result = cast(CursorResult, session.execute(delete_stmt))
+    result = cast("CursorResult", session.execute(delete_stmt))
     if result.rowcount == 0:
         raise HTTPException(
             status.HTTP_404_NOT_FOUND,
@@ -646,7 +646,7 @@ def delete_dag_asset_queued_events(
     )
 
     delete_statement = delete(AssetDagRunQueue).where(*where_clause)
-    result = cast(CursorResult, session.execute(delete_statement))
+    result = cast("CursorResult", session.execute(delete_statement))
 
     if result.rowcount == 0:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"Queue event with dag_id: `{dag_id}` was not found")
@@ -681,7 +681,7 @@ def delete_dag_asset_queued_event(
     delete_statement = (
         delete(AssetDagRunQueue).where(*where_clause).execution_options(synchronize_session="fetch")
     )
-    result = cast(CursorResult, session.execute(delete_statement))
+    result = cast("CursorResult", session.execute(delete_statement))
     if result.rowcount == 0:
         raise HTTPException(
             status.HTTP_404_NOT_FOUND,


### PR DESCRIPTION
Fixes 5 MyPy errors shown below in `api_fastapi/core_api/routes/public/assets.py`.
Part of #56735.

CursorResult casts are done according to the recommended approach for these MyPy errors in the [SQLAlchemy 2.0 changelog](https://docs.sqlalchemy.org/en/20/changelog/changelog_20.html#change-0651b868cdc88d28c57469affceaf05f) and mentioned in an issue [here](https://github.com/sqlalchemy/sqlalchemy/issues/12913). If cast() is not the preferred approach for fixing these errors, I can add `type:ignore[attr-defined]` instead. 

<img width="1098" height="572" alt="image" src="https://github.com/user-attachments/assets/e83e4ea5-890b-4c1b-875e-1bf09842c054" />