### PR TITLE
Auto-compile UI assets on Breeze start-airflow command

### DIFF
--- a/scripts/in_container/install_airflow_and_providers.py
+++ b/scripts/in_container/install_airflow_and_providers.py
@@ -492,30 +492,21 @@ def compile_ui_assets(installation_spec: InstallationSpec, ui_directory: Path, h
             return
 
     # ensure dependencies for UI assets compilation
-    need_node = shutil.which("node") is None
-    need_yarn = shutil.which("yarn") is None
     need_pnpm = shutil.which("pnpm") is None
-
-    if need_node:
-        console.print("[bright_blue]Installing Node.js directly from official setup script")
+    if need_pnpm:
+        console.print("[bright_blue]Installing pnpm directly from official setup script")
         run_command(
             [
                 "bash",
                 "-c",
-                "curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && apt-get install -y nodejs",
+                'wget -qO- https://get.pnpm.io/install.sh | ENV="$HOME/.bashrc" SHELL="$(which bash)" bash -',
             ],
             github_actions=False,
             shell=False,
             check=True,
         )
     else:
-        console.print("[bright_blue]Node.js already installed")
-
-    if need_yarn or need_pnpm:
-        console.print("[bright_blue]Installing Yarn and PNPM globally via npm")
-        run_command(["npm", "install", "-g", "yarn", "pnpm"], github_actions=False, shell=False, check=True)
-    else:
-        console.print("[bright_blue]Yarn and PNPM already installed")
+        console.print("[bright_blue]pnpm already installed")
 
     # install UI assets compilation dependencies
     env = os.environ.copy()

--- a/scripts/in_container/install_airflow_and_providers.py
+++ b/scripts/in_container/install_airflow_and_providers.py
@@ -404,10 +404,6 @@ def find_installation_spec(
             github_repository=github_repository,
             python_version=python_version,
         )
-        console.print(
-            "[yellow]Note that installing airflow from branch has no assets compiled, so you will"
-            "not be able to run UI (we might add asset compilation for this case later if needed)."
-        )
     elif use_airflow_version in ["wheel", "sdist"] and not use_distributions_from_dist:
         console.print(
             "[red]USE_AIRFLOW_VERSION cannot be 'wheel' or 'sdist' without --use-distributions-from-dist"

--- a/scripts/in_container/install_airflow_and_providers.py
+++ b/scripts/in_container/install_airflow_and_providers.py
@@ -351,6 +351,7 @@ def find_installation_spec(
         else:
             airflow_ctl_constraints_location = None
         airflow_ctl_distribution = airflow_ctl_spec
+        compile_ui_assets = False
     elif use_airflow_version == "none" or use_airflow_version == "":
         console.print("\n[bright_blue]Skipping airflow package installation\n")
         airflow_distribution_spec = None
@@ -359,6 +360,7 @@ def find_installation_spec(
         airflow_task_sdk_distribution = None
         airflow_ctl_distribution = None
         airflow_ctl_constraints_location = None
+        compile_ui_assets = False
     elif repo_match := re.match(GITHUB_REPO_BRANCH_PATTERN, use_airflow_version):
         owner, repo, branch = repo_match.groups()
         console.print(f"\nInstalling airflow from GitHub: {use_airflow_version}\n")
@@ -410,6 +412,7 @@ def find_installation_spec(
         )
         sys.exit(1)
     else:
+        compile_ui_assets = False
         console.print(f"\nInstalling airflow via apache-airflow=={use_airflow_version}")
         airflow_distribution_spec = f"apache-airflow{airflow_extras}=={use_airflow_version}"
         airflow_core_distribution_spec = (
@@ -462,7 +465,7 @@ def find_installation_spec(
         airflow_task_sdk_distribution=airflow_task_sdk_distribution,
         airflow_ctl_distribution=airflow_ctl_distribution,
         airflow_ctl_constraints_location=airflow_ctl_constraints_location,
-        compile_ui_assets=compile_ui_assets or None,
+        compile_ui_assets=compile_ui_assets,
         provider_distributions=provider_distributions_list,
         provider_constraints_location=get_providers_constraints_location(
             providers_constraints_mode=providers_constraints_mode,


### PR DESCRIPTION

closes: #54453
related: #54070

## Why

After #54070, we are able to use specific airflow-core version for `start-airflow` command but when we access Airflow UI, it will always show internal server error. Since the UI dist will not be compiled when running `start-airflow` command.

## How

1. download tarball of source code that `--use-airflow-version` provided ( `/opt/airflow/.build/airflow.tar.gz`
2. extract to `/opt/airflow/.build/airflow_source` directory
3. copy source code of
  - Core UI to `/opt/airflow/airflow-core/src/airflow/ui`
  - Simple Auth Manager UI to `/opt/airflow/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui`
4. install `node` and `pnpm` if not existed
5. run `pnpm run build` in both UI directories
6. copy UI dist from Airflow Core Sources Path (`/opt/airflow/airflow-core/...`) to Airflow Installation  Path (e.g. `/usr/python/lib/python3.10/site-packages/airflow/...`)
  

## What

After this PR, if we run `breeze start-airflow` with any `--use-airflow-version <owner/repo:branch>` we could access the UI without API Server response internal error.

For example:
```bash
breeze start-airflow --backend postgres --load-example-dags --mount-sources providers-and-tests --use-airflow-version jason810496/airflow:ci/breeze/compile-ui-assets
```

