### PR TITLE
Improve UX for adding custom DeadlineReferences

### DIFF
--- a/airflow-core/docs/howto/deadline-alerts.rst
+++ b/airflow-core/docs/howto/deadline-alerts.rst
@@ -330,8 +330,8 @@ Custom References
 
 The built-in references handle most common scenarios. However, you may need to create custom
 references for specific integrations like calendars or other data sources. To do this, create
-a class that inherits from BaseDeadlineReference, add the @deadline_reference decorator, and
-implement an _evaluate_with() method.
+a class that inherits from BaseDeadlineReference, add the ``@deadline_reference`` decorator, and
+implement an ``_evaluate_with()`` method.
 
 
 **Creating a Custom Reference**

--- a/airflow-core/docs/howto/deadline-alerts.rst
+++ b/airflow-core/docs/howto/deadline-alerts.rst
@@ -328,21 +328,21 @@ Custom References
 ^^^^^^^^^^^^^^^^^
 
 While the built-in references should cover most use cases, and more will be released over time, you
-can create custom references.  This may be useful if you have calendar integrations or other sources
-that you want to use as a reference.  You can create custom references by implementing a class that
-inherits from BaseDeadlineReference, give it am _evaluate_with() method, and register it.  There are
-two ways to accomplish this.  The recommended way is to use the ``@deadline_reference`` decorator
+can create custom references. This may be useful if you have calendar integrations or other sources
+that you want to use as a reference. You can create custom references by implementing a class that
+inherits from BaseDeadlineReference, give it am _evaluate_with() method, and register it. There are
+two ways to accomplish this. The recommended way is to use the ``@deadline_reference`` decorator
 but for more complicated implementations, the ``register_custom_reference()`` method is available.
 
-**Recommended: Using the decorator**
+**Recommended: Using the ``@deadline_reference`` decorator**
 
 .. code-block:: python
 
-    from airflow._shared.timezones.timezone import datetime
     from airflow.models.deadline import ReferenceModels
     from sqlalchemy.orm import Session
 
     from airflow.sdk.definitions.deadline import DeadlineReference, deadline_reference
+    from airflow.sdk.timezone import datetime
 
 
     # By default, the evaluate_with method will be executed when the dagrun is created.

--- a/airflow-core/tests/unit/models/test_deadline.py
+++ b/airflow-core/tests/unit/models/test_deadline.py
@@ -556,7 +556,7 @@ class TestCustomDeadlineReference:
         assert custom_ref.__class__ is self.MyCustomRef
 
         # Should behave like built-in references.
-        assert hasattr(custom_ref, '_evaluate_with')
+        assert hasattr(custom_ref, "_evaluate_with")
         assert callable(custom_ref._evaluate_with)
 
     def test_register_custom_reference_default_timing(self):

--- a/airflow-core/tests/unit/models/test_deadline.py
+++ b/airflow-core/tests/unit/models/test_deadline.py
@@ -609,7 +609,11 @@ class TestCustomDeadlineReference:
         invalid_timing = ("not", "a", "valid", "timing")
 
         with pytest.raises(
-            ValueError, match=r"Invalid timing value; must be a valid DeadlineReference.TYPES option"
+            ValueError,
+            match=re.escape(
+                f"Invalid deadline reference type {invalid_timing}; "
+                f"must be a valid DeadlineReference.TYPES option."
+            ),
         ):
             DeadlineReference.register_custom_reference(self.MyCustomRef, invalid_timing)
 
@@ -709,7 +713,11 @@ class TestDeadlineReferenceDecorator:
         invalid_timing = ("not", "a", "valid", "timing")
 
         with pytest.raises(
-            ValueError, match="Invalid timing value; must be a valid DeadlineReference.TYPES option"
+            ValueError,
+            match=re.escape(
+                f"Invalid deadline reference type {invalid_timing}; "
+                f"must be a valid DeadlineReference.TYPES option."
+            ),
         ):
 
             @deadline_reference(invalid_timing)

--- a/airflow-core/tests/unit/models/test_deadline.py
+++ b/airflow-core/tests/unit/models/test_deadline.py
@@ -30,17 +30,8 @@ from airflow.models import DagRun
 from airflow.models.deadline import Deadline, ReferenceModels, _fetch_from_db
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.sdk import timezone
-from airflow.sdk.definitions.deadline import (
-    AsyncCallback,
-    DeadlineReference,
-    SyncCallback,
-    deadline_reference,
-)
-from airflow.triggers.base import TriggerEvent
-from airflow.triggers.deadline import PAYLOAD_BODY_KEY, PAYLOAD_STATUS_KEY
-from airflow.sdk.definitions.deadline import AsyncCallback, DeadlineReference, SyncCallback
 from airflow.sdk.definitions.callback import AsyncCallback, SyncCallback
-from airflow.sdk.definitions.deadline import DeadlineReference
+from airflow.sdk.definitions.deadline import DeadlineReference, deadline_reference
 from airflow.utils.state import DagRunState
 
 from tests_common.test_utils import db

--- a/task-sdk/src/airflow/sdk/definitions/deadline.py
+++ b/task-sdk/src/airflow/sdk/definitions/deadline.py
@@ -225,7 +225,7 @@ class DeadlineReference:
             cls.TYPES.DAGRUN_QUEUED = cls.TYPES.DAGRUN_QUEUED + (reference_class,)
         else:
             raise ValueError(
-                "Invalid deadline reference type {deadline_references_type} value; "
+                f"Invalid deadline reference type {deadline_reference_type}; "
                 "must be a valid DeadlineReference.TYPES option."
             )
 

--- a/task-sdk/src/airflow/sdk/definitions/deadline.py
+++ b/task-sdk/src/airflow/sdk/definitions/deadline.py
@@ -18,8 +18,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any, cast
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from airflow.models.deadline import DeadlineReferenceType, ReferenceModels
 from airflow.sdk.definitions.callback import AsyncCallback, Callback
@@ -27,6 +26,7 @@ from airflow.serialization.enums import DagAttributeTypes as DAT, Encoding
 from airflow.serialization.serde import deserialize, serialize
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from typing import TypeAlias
 
 logger = logging.getLogger(__name__)

--- a/task-sdk/src/airflow/sdk/definitions/deadline.py
+++ b/task-sdk/src/airflow/sdk/definitions/deadline.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Any, cast
 from typing import cast
 
 from airflow.models.deadline import DeadlineReferenceType, ReferenceModels
@@ -25,7 +26,12 @@ from airflow.sdk.definitions.callback import AsyncCallback, Callback
 from airflow.serialization.enums import DagAttributeTypes as DAT, Encoding
 from airflow.serialization.serde import deserialize, serialize
 
+if TYPE_CHECKING:
+    from typing import TypeAlias
+
 logger = logging.getLogger(__name__)
+
+DeadlineReferenceTuple: TypeAlias = tuple[type[ReferenceModels.BaseDeadlineReference], ...]
 
 
 class DeadlineAlertFields:
@@ -145,17 +151,17 @@ class DeadlineReference:
         """Collection of DeadlineReference types for type checking."""
 
         # Deadlines that should be created when the DagRun is created.
-        DAGRUN_CREATED = (
+        DAGRUN_CREATED: DeadlineReferenceTuple = (
             ReferenceModels.DagRunLogicalDateDeadline,
             ReferenceModels.FixedDatetimeDeadline,
             ReferenceModels.AverageRuntimeDeadline,
         )
 
         # Deadlines that should be created when the DagRun is queued.
-        DAGRUN_QUEUED = (ReferenceModels.DagRunQueuedAtDeadline,)
+        DAGRUN_QUEUED: DeadlineReferenceTuple = (ReferenceModels.DagRunQueuedAtDeadline,)
 
         # All DagRun-related deadline types.
-        DAGRUN = DAGRUN_CREATED + DAGRUN_QUEUED
+        DAGRUN: DeadlineReferenceTuple = DAGRUN_CREATED + DAGRUN_QUEUED
 
     from airflow.models.deadline import ReferenceModels
 
@@ -185,7 +191,11 @@ class DeadlineReference:
     )()
 
     @classmethod
-    def register_custom_reference(cls, reference_class: type, timing=None):
+    def register_custom_reference(
+        cls,
+        reference_class: type[ReferenceModels.BaseDeadlineReference],
+        timing: DeadlineReferenceTuple | None = None,
+    ):
         """
         Register a custom deadline reference class.
 
@@ -222,7 +232,7 @@ class DeadlineReference:
         return reference_class
 
 
-def deadline_reference(timing=None):
+def deadline_reference(timing: DeadlineReferenceTuple | None = None):
     """
     Decorate a class to register a custom deadline reference.
 


### PR DESCRIPTION
Greatly improves the user experience when creating a new DeadlineReference and the documentation for the process.  


Before this change, the process looked like this:

```python
from airflow._shared.timezones import timezone
from airflow.models.deadline import ReferenceModels
from sqlalchemy.orm import Session

from airflow.sdk.definitions.deadline import DeadlineReference


# Step 0: Create your new reference class.
class MyCustomRef(ReferenceModels.BaseDeadlineReference):
    def _evaluate_with(self, *, session: Session, **kwargs) -> datetime:
        new_deadline = some_business_logic()
        return new_deadline


# Step 1: Register the custom reference with ReferenceModels.
# This makes it discoverable by get_reference_class()
ReferenceModels.MyCustomRef = MyCustomRef

# Step 2: Add to the appropriate TYPES tuple for timing classification.
DeadlineReference.TYPES.DAGRUN_CREATED = DeadlineReference.TYPES.DAGRUN_CREATED + (MyCustomRef,)

# Step 3: Update the combined DAGRUN tuple.
DeadlineReference.TYPES.DAGRUN = DeadlineReference.TYPES.DAGRUN_CREATED + DeadlineReference.TYPES.DAGRUN_QUEUED

```

After these changes, that same custom reference user code will look like this:

```python
from airflow._shared.timezones import timezone
from airflow.models.deadline import ReferenceModels
from sqlalchemy.orm import Session

from airflow.sdk.definitions.deadline import DeadlineReference, deadline_reference

@deadline_reference()  # Optionally accepts a timing classification, defaults to DAGRUN_CREATED
class MyDecoratedCustomRef(ReferenceModels.BaseDeadlineReference):
    def _evaluate_with(self, *, session: Session, **kwargs) -> datetime:
        new_deadline = some_business_logic()
        return new_deadline
```

In use they are transparent from built-in deadlines:

```python
from datetime import timedelta, datetime

from airflow import DAG
from airflow.providers.slack.notifications.slack_webhook import SlackWebhookNotifier
from airflow.sdk import task
from airflow.sdk.definitions.deadline import DeadlineAlert, DeadlineReference, AsyncCallback

@task.bash(task_id='sleep_task')
def sleep_10_secs():
    return 'sleep 10'

with DAG(
    dag_id="custom_past_reference",
    tags=["slack", "custom_ref"],
    deadline=DeadlineAlert(
        reference=DeadlineReference.MyDecoratedCustomRef,
        interval=timedelta(seconds=1),
        callback=AsyncCallback(
            callback_callable=SlackWebhookNotifier,
            kwargs={"text": f"Custom reference deadline in the past; Alert should trigger!"},
        )
    )
):
    sleep_10_secs()
```