### PR TITLE
[API] Use BulkTaskInstanceBody for patching tis with new state

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
@@ -918,13 +918,25 @@ def patch_task_instance(
         dag_id, dag_run_id, task_id, dag_bag, body, session, map_index, update_mask
     )
 
+    # Create BulkTaskInstanceBody object with map_index field
+    bulk_ti_body = BulkTaskInstanceBody(
+        task_id=task_id,
+        map_index=map_index,
+        new_state=body.new_state,
+        note=body.note,
+        include_upstream=body.include_upstream,
+        include_downstream=body.include_downstream,
+        include_future=body.include_future,
+        include_past=body.include_past,
+    )
+
     for key, _ in data.items():
         if key == "new_state":
             _patch_task_instance_state(
                 task_id=task_id,
                 dag_run_id=dag_run_id,
                 dag=dag,
-                task_instance_body=body,
+                task_instance_body=bulk_ti_body,
                 data=data,
                 session=session,
             )

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
@@ -918,20 +918,20 @@ def patch_task_instance(
         dag_id, dag_run_id, task_id, dag_bag, body, session, map_index, update_mask
     )
 
-    # Create BulkTaskInstanceBody object with map_index field
-    bulk_ti_body = BulkTaskInstanceBody(
-        task_id=task_id,
-        map_index=map_index,
-        new_state=body.new_state,
-        note=body.note,
-        include_upstream=body.include_upstream,
-        include_downstream=body.include_downstream,
-        include_future=body.include_future,
-        include_past=body.include_past,
-    )
-
     for key, _ in data.items():
         if key == "new_state":
+            # Create BulkTaskInstanceBody object with map_index field
+            bulk_ti_body = BulkTaskInstanceBody(
+                task_id=task_id,
+                map_index=map_index,
+                new_state=body.new_state,
+                note=body.note,
+                include_upstream=body.include_upstream,
+                include_downstream=body.include_downstream,
+                include_future=body.include_future,
+                include_past=body.include_past,
+            )
+
             _patch_task_instance_state(
                 task_id=task_id,
                 dag_run_id=dag_run_id,

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -3904,8 +3904,13 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
         ti = TaskInstance(
             task=tis[0].task, run_id=tis[0].run_id, map_index=map_index, dag_version_id=tis[0].dag_version_id
         )
+        ti_2 = TaskInstance(
+            task=tis[0].task, run_id=tis[0].run_id, map_index=map_index + 1, dag_version_id=tis[0].dag_version_id
+        )
         ti.rendered_task_instance_fields = RTIF(ti, render_templates=False)
+        ti_2.rendered_task_instance_fields = RTIF(ti_2, render_templates=False)
         session.add(ti)
+        session.add(ti_2)
         session.commit()
 
         response = test_client.patch(
@@ -3919,6 +3924,11 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
         response2 = test_client.get(f"{self.ENDPOINT_URL}/{map_index}")
         assert response2.status_code == 200
         assert response2.json()["state"] == self.NEW_STATE
+
+        response3 = test_client.get(f"{self.ENDPOINT_URL}/{map_index + 1}")
+        assert response3.status_code == 200
+        assert response3.json()["state"] != self.NEW_STATE
+        assert response3.json()["state"] is None
 
     def test_should_update_mapped_task_instance_summary_state(self, test_client, session):
         tis = self.create_task_instances(session)

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -3905,7 +3905,10 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
             task=tis[0].task, run_id=tis[0].run_id, map_index=map_index, dag_version_id=tis[0].dag_version_id
         )
         ti_2 = TaskInstance(
-            task=tis[0].task, run_id=tis[0].run_id, map_index=map_index + 1, dag_version_id=tis[0].dag_version_id
+            task=tis[0].task,
+            run_id=tis[0].run_id,
+            map_index=map_index + 1,
+            dag_version_id=tis[0].dag_version_id,
         )
         ti.rendered_task_instance_fields = RTIF(ti, render_templates=False)
         ti_2.rendered_task_instance_fields = RTIF(ti_2, render_templates=False)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: 57101

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


<!-- Please keep an empty line above the dashes. -->
This PR updates patchTaskInstace API to use map_index when updating the ti states. For dynamic tasks, map_index was not getting honoured due to the use of PatchTaskInstanceBody (which lacks map_index attribute). 
Closes [57061](https://github.com/apache/airflow/issues/57101)

Logic: Previously PatchTaskInstanceBody model was being passed _patch_task_instance_state method, which lacks map_index information. To fix this issue, BulkTaskInstanceBody model is implemented and used instead


---
