### PR TITLE
Fab provider SQLA1 -> SQLA2: Mypy fix core_api/routes/public/pools.py

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/pools.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/pools.py
@@ -69,7 +69,7 @@ def delete_pool(
     if pool_name == "default_pool":
         raise HTTPException(status.HTTP_400_BAD_REQUEST, "Default Pool can't be deleted")
 
-    affected_count = cast(CursorResult, session.execute(delete(Pool).where(Pool.pool == pool_name)))
+    affected_count = cast("CursorResult", session.execute(delete(Pool).where(Pool.pool == pool_name)))
 
     if affected_count.rowcount == 0:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"The Pool with name: `{pool_name}` was not found")

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/pools.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/pools.py
@@ -16,10 +16,11 @@
 # under the License.
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, cast
 
 from fastapi import Depends, HTTPException, Query, status
 from sqlalchemy import delete, select
+from sqlalchemy.engine import CursorResult
 
 from airflow.api_fastapi.common.db.common import SessionDep, paginated_select
 from airflow.api_fastapi.common.parameters import (
@@ -68,9 +69,9 @@ def delete_pool(
     if pool_name == "default_pool":
         raise HTTPException(status.HTTP_400_BAD_REQUEST, "Default Pool can't be deleted")
 
-    affected_count = session.execute(delete(Pool).where(Pool.pool == pool_name)).rowcount
+    affected_count = cast(CursorResult, session.execute(delete(Pool).where(Pool.pool == pool_name)))
 
-    if affected_count == 0:
+    if affected_count.rowcount == 0:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"The Pool with name: `{pool_name}` was not found")
 
 
@@ -117,7 +118,7 @@ def get_pools(
         session=session,
     )
 
-    pools = session.scalars(pools_select)
+    pools = list(session.scalars(pools_select))
 
     return PoolCollectionResponse(
         pools=pools,


### PR DESCRIPTION
Fixes 2 MyPy errors shown below in `api_fastapi/core_api/routes/public/pools.py`.
Part of #56735 .

CursorResult casts for the rowcount MyPy error were done according to the recommended approach in the [SQLAlchemy 2.0 changelog](https://docs.sqlalchemy.org/en/20/changelog/changelog_20.html#change-0651b868cdc88d28c57469affceaf05f) and mentioned in an issue [here](https://github.com/sqlalchemy/sqlalchemy/issues/12913). If cast() is not the preferred approach for fixing these errors, I can add `type:ignore[attr-defined]` instead. 

<img width="1203" height="258" alt="image" src="https://github.com/user-attachments/assets/8a5336fa-518d-4f20-aa5a-8706459fb46f" />
