### PR TITLE
SQLA1 -> SQLA2: Mypy fix execution_api/routes/hitl.py

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/hitl.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/hitl.py
@@ -110,7 +110,9 @@ def update_hitl_detail(
 ) -> HITLDetailResponse:
     """Update the response part of a Human-in-the-loop detail for a specific Task Instance."""
     ti_id_str = str(task_instance_id)
-    hitl_detail_model_result = session.execute(select(HITLDetail).where(HITLDetail.ti_id == ti_id_str)).scalar()
+    hitl_detail_model_result = session.execute(
+        select(HITLDetail).where(HITLDetail.ti_id == ti_id_str)
+    ).scalar()
     hitl_detail_model = _check_hitl_detail_exists(hitl_detail_model_result)
     if hitl_detail_model.response_received:
         raise HTTPException(

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/hitl.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/hitl.py
@@ -86,7 +86,7 @@ def upsert_hitl_detail(
     return HITLDetailRequest.model_validate(hitl_detail_model)
 
 
-def _check_hitl_detail_exists(hitl_detail_model: HITLDetail) -> None:
+def _check_hitl_detail_exists(hitl_detail_model: HITLDetail | None) -> HITLDetail:
     if not hitl_detail_model:
         raise HTTPException(
             status.HTTP_404_NOT_FOUND,
@@ -99,6 +99,8 @@ def _check_hitl_detail_exists(hitl_detail_model: HITLDetail) -> None:
             },
         )
 
+    return hitl_detail_model
+
 
 @router.patch("/{task_instance_id}")
 def update_hitl_detail(
@@ -108,8 +110,8 @@ def update_hitl_detail(
 ) -> HITLDetailResponse:
     """Update the response part of a Human-in-the-loop detail for a specific Task Instance."""
     ti_id_str = str(task_instance_id)
-    hitl_detail_model = session.execute(select(HITLDetail).where(HITLDetail.ti_id == ti_id_str)).scalar()
-    _check_hitl_detail_exists(hitl_detail_model)
+    hitl_detail_model_result = session.execute(select(HITLDetail).where(HITLDetail.ti_id == ti_id_str)).scalar()
+    hitl_detail_model = _check_hitl_detail_exists(hitl_detail_model_result)
     if hitl_detail_model.response_received:
         raise HTTPException(
             status.HTTP_409_CONFLICT,
@@ -135,8 +137,8 @@ def get_hitl_detail(
 ) -> HITLDetailResponse:
     """Get Human-in-the-loop detail for a specific Task Instance."""
     ti_id_str = str(task_instance_id)
-    hitl_detail_model = session.execute(
+    hitl_detail_model_result = session.execute(
         select(HITLDetail).where(HITLDetail.ti_id == ti_id_str),
     ).scalar()
-    _check_hitl_detail_exists(hitl_detail_model)
+    hitl_detail_model = _check_hitl_detail_exists(hitl_detail_model_result)
     return HITLDetailResponse.from_hitl_detail_orm(hitl_detail_model)


### PR DESCRIPTION
Fixes 8 MyPy errors shown below in `execution_api/routes/hitl.py`.
Part of #56735.


<img width="561" height="242" alt="image" src="https://github.com/user-attachments/assets/56acc5c7-7c07-4020-bc27-1bdd2a55bfb8" />
<img width="560" height="257" alt="image" src="https://github.com/user-attachments/assets/a751b778-c172-4c71-912f-79d841941a45" />

Fixing the errors above gives rise to a type mismatch of `chosen_options` between `HITLDetail` and `UpdateHITLDetailPayload` models. Not entirely sure how to resolve that since `HITLDetail.chosen_options` is of type `Mapped[dict | None]` and `UpdateHITLDetailPayload.chosen_options` is `list[str]`.

<img width="606" height="95" alt="image" src="https://github.com/user-attachments/assets/6c889e41-c2a3-4635-85ac-ad8e07dca7db" />
