### PR TITLE
Fixes inconsistency with hook_params for sensor

### DIFF
--- a/providers/dbt/cloud/tests/unit/dbt/cloud/sensors/test_dbt.py
+++ b/providers/dbt/cloud/tests/unit/dbt/cloud/sensors/test_dbt.py
@@ -58,6 +58,7 @@ class TestDbtCloudJobRunSensor:
             account_id=ACCOUNT_ID,
             timeout=30,
             poke_interval=15,
+            hook_params={"retry_limit": 3, "retry_delay": 2.0},
         )
 
     def test_init(self):
@@ -65,6 +66,7 @@ class TestDbtCloudJobRunSensor:
         assert self.sensor.run_id == RUN_ID
         assert self.sensor.timeout == 30
         assert self.sensor.poke_interval == 15
+        assert self.sensor.hook_params == {"retry_limit": 3, "retry_delay": 2.0}
 
     @pytest.mark.parametrize(
         argnames=("job_run_status", "expected_poke_result"),


### PR DESCRIPTION
This pull request adds support for `hook_params` to the `DbtCloudJobRunSensor`, enhancing its flexibility and aligning it with other operators in the `dbt.cloud` provider.
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
