### PR TITLE
Extract prek hooks for Helm

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -124,19 +124,11 @@ repos:
           - scripts/ci/license-templates/LICENSE.txt
           - --fuzzy-match-generates-todo
       - id: insert-license
-        name: Add license for all Helm template files
-        files: ^chart/templates/.*
-        args:
-          - --comment-style
-          - "{{/*||*/}}"
-          - --license-filepath
-          - scripts/ci/license-templates/LICENSE.txt
-          - --fuzzy-match-generates-todo
-      - id: insert-license
         name: Add license for all YAML files except Helm templates
         exclude: >
           (?x)
-          ^\.github/.*$|^chart/templates/.*|
+          ^\.github/.*$|
+          ^chart/templates/.*|
           .*reproducible_build\.yaml$|
           ^.*/v2.*\.yaml$|
           ^.*/openapi/_private_ui.*\.yaml$|
@@ -195,14 +187,6 @@ repos:
         entry: ./dev/i18n/check_translations_completeness.py
         stages: ['manual']
         language: python
-        pass_filenames: false
-        require_serial: true
-      - id: update-chart-dependencies
-        name: Update chart dependencies to latest (manual)
-        entry: ./scripts/ci/prek/update_chart_dependencies.py
-        stages: ['manual']
-        language: python
-        files: ^\.pre-commit-config\.yaml$|^scripts/ci/prek/update_build_dependencies\.py$
         pass_filenames: false
         require_serial: true
       - id: check-taskinstance-tis-attrs
@@ -264,15 +248,6 @@ repos:
           ^dev/breeze/doc/images/output.*$|
           ^.*/openapi-gen/.*$|
           ^airflow-ctl/docs/images/.*\.svg$
-      - id: pretty-format-json
-        name: Format JSON files
-        args:
-          - --autofix
-          - --no-sort-keys
-          - --indent
-          - "4"
-        files: ^chart/values\.schema\.json$|^chart/values_schema\.schema\.json$
-        pass_filenames: true
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: 3a6eb0fadf60b3cccfd80bad9dbb6fae7e47b316  # frozen: v1.10.0
     hooks:
@@ -745,26 +720,6 @@ repos:
         files: ^\.pre-commit-config\.yaml$|^docs/spelling_wordlist\.txt$
         require_serial: true
         pass_filenames: false
-      - id: lint-helm-chart
-        name: Lint Helm Chart
-        entry: ./scripts/ci/prek/lint_helm.py
-        language: python
-        pass_filenames: false
-        files: ^chart
-        require_serial: true
-      - id: validate-chart-annotations
-        name: Validate chart annotations
-        entry: ./scripts/ci/prek/validate_chart_annotations.py
-        language: python
-        pass_filenames: false
-        files: ^chart/Chart\.yaml$
-      - id: kubeconform
-        name: Kubeconform check on our helm chart
-        entry: ./scripts/ci/prek/check_kubeconform.py
-        language: python
-        pass_filenames: false
-        files: ^chart
-        require_serial: true
       - id: shellcheck
         name: Check Shell scripts syntax correctness
         language: docker_image
@@ -885,34 +840,6 @@ repos:
           ^scripts/ci/docker-compose/.+-config\.ya?ml$
         require_serial: true
       - id: lint-json-schema
-        name: Lint chart/values.schema.json
-        entry: ./scripts/ci/prek/lint_json_schema.py
-        args:
-          - --spec-file
-          - chart/values_schema.schema.json
-          - chart/values.schema.json
-        language: python
-        pass_filenames: false
-        files: ^chart/values\.schema\.json$|^chart/values_schema\.schema\.json$
-        require_serial: true
-      - id: update-vendored-in-k8s-json-schema
-        name: Vendor k8s definitions into values.schema.json
-        entry: ./scripts/ci/prek/vendor_k8s_json_schema.py
-        language: python
-        files: ^chart/values\.schema\.json$
-      - id: lint-json-schema
-        name: Lint chart/values.yaml
-        entry: ./scripts/ci/prek/lint_json_schema.py
-        args:
-          - --enforce-defaults
-          - --spec-file
-          - chart/values.schema.json
-          - chart/values.yaml
-        language: python
-        pass_filenames: false
-        files: ^chart/values\.yaml$|^chart/values\.schema\.json$
-        require_serial: true
-      - id: lint-json-schema
         name: Lint config_templates/config.yml
         entry: ./scripts/ci/prek/lint_json_schema.py
         args:
@@ -949,13 +876,6 @@ repos:
         language: python
         pass_filenames: true
         files: ^airflow-core/src/airflow/.*\.py$
-      - id: lint-chart-schema
-        name: Lint chart/values.schema.json file
-        entry: ./scripts/ci/prek/chart_schema.py
-        language: python
-        pass_filenames: false
-        files: ^chart/values\.schema\.json$
-        require_serial: true
       - id: update-inlined-dockerfile-scripts
         name: Inline Dockerfile and Dockerfile.ci scripts
         entry: ./scripts/ci/prek/inline_scripts_in_docker.py

--- a/chart/.pre-commit-config.yaml
+++ b/chart/.pre-commit-config.yaml
@@ -1,0 +1,112 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+---
+default_stages: [pre-commit, pre-push]
+minimum_prek_version: '0.0.28'
+repos:
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    # replace hash with version once PR #103 merged comes in a release
+    rev: abdd8b62891099da34162217ecb3872d22184a51
+    hooks:
+      - id: insert-license
+        name: Add license for all Helm template files
+        files: ^templates/.*
+        args:
+          - --comment-style
+          - "{{/*||*/}}"
+          - --license-filepath
+          - scripts/ci/license-templates/LICENSE.txt
+          - --fuzzy-match-generates-todo
+  - repo: local
+    hooks:
+      - id: update-chart-dependencies
+        name: Update chart dependencies to latest (manual)
+        entry: ../scripts/ci/prek/update_chart_dependencies.py
+        stages: ['manual']
+        language: python
+        files: ^\.pre-commit-config\.yaml$|^../scripts/ci/prek/update_build_dependencies\.py$
+        pass_filenames: false
+        require_serial: true
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
+    hooks:
+      - id: pretty-format-json
+        name: Format JSON files
+        args:
+          - --autofix
+          - --no-sort-keys
+          - --indent
+          - "4"
+        files: ^chart/values\.schema\.json$|^chart/values_schema\.schema\.json$
+        pass_filenames: true
+  - repo: local
+    hooks:
+      - id: lint-helm-chart
+        name: Lint Helm Chart
+        entry: ../scripts/ci/prek/lint_helm.py
+        language: python
+        pass_filenames: false
+        files: ^.*
+        require_serial: true
+      - id: validate-chart-annotations
+        name: Validate chart annotations
+        entry: ../scripts/ci/prek/validate_chart_annotations.py
+        language: python
+        pass_filenames: false
+        files: ^Chart\.yaml$
+      - id: kubeconform
+        name: Kubeconform check on our helm chart
+        entry: ../scripts/ci/prek/check_kubeconform.py
+        language: python
+        pass_filenames: false
+        files: ^.*
+        require_serial: true
+      - id: lint-json-schema
+        name: Lint chart/values.schema.json
+        entry: ../scripts/ci/prek/lint_json_schema.py
+        args:
+          - --spec-file
+          - values_schema.schema.json
+          - values.schema.json
+        language: python
+        pass_filenames: false
+        files: ^values\.schema\.json$|^values_schema\.schema\.json$
+        require_serial: true
+      - id: update-vendored-in-k8s-json-schema
+        name: Vendor k8s definitions into values.schema.json
+        entry: ../scripts/ci/prek/vendor_k8s_json_schema.py
+        language: python
+        files: ^values\.schema\.json$
+      - id: lint-json-schema
+        name: Lint chart/values.yaml
+        entry: ../scripts/ci/prek/lint_json_schema.py
+        args:
+          - --enforce-defaults
+          - --spec-file
+          - values.schema.json
+          - values.yaml
+        language: python
+        pass_filenames: false
+        files: ^values\.yaml$|^values\.schema\.json$
+        require_serial: true
+      - id: lint-chart-schema
+        name: Lint chart/values.schema.json file
+        entry: ../scripts/ci/prek/chart_schema.py
+        language: python
+        pass_filenames: false
+        files: ^values\.schema\.json$
+        require_serial: true

--- a/chart/.pre-commit-config.yaml
+++ b/chart/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
           - --comment-style
           - "{{/*||*/}}"
           - --license-filepath
-          - scripts/ci/license-templates/LICENSE.txt
+          - ../scripts/ci/license-templates/LICENSE.txt
           - --fuzzy-match-generates-todo
   - repo: local
     hooks:

--- a/scripts/ci/prek/vendor_k8s_json_schema.py
+++ b/scripts/ci/prek/vendor_k8s_json_schema.py
@@ -28,12 +28,13 @@ import json
 from collections.abc import Iterator
 
 import requests
+from common_prek_utils import AIRFLOW_ROOT_PATH
 
 K8S_DEFINITIONS = (
     "https://raw.githubusercontent.com/yannh/kubernetes-json-schema"
     "/master/v1.29.0-standalone-strict/_definitions.json"
 )
-VALUES_SCHEMA_FILE = "chart/values.schema.json"
+VALUES_SCHEMA_FILE = AIRFLOW_ROOT_PATH / "chart/values.schema.json"
 
 
 with open(VALUES_SCHEMA_FILE) as f:


### PR DESCRIPTION
Following https://github.com/apache/airflow/pull/57181 this is now a batch for all prek hooks that are "just" solely for providers to split out from root:

As prek is supporting monorepo now and go SDK was the front-runner, Helm chart is now the next piece that with this PR is proposed to be split-out from global pre-commit hook list into the provider space.