### PR TITLE
Extract prek hooks for Task-SDK

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -642,12 +642,6 @@ repos:
         entry: ./scripts/ci/prek/check_base_operator_partial_arguments.py
         pass_filenames: false
         files: ^airflow-core/src/airflow/models/(?:base|mapped)operator\.py$
-      - id: check-init-decorator-arguments
-        name: Sync model __init__ and decorator arguments
-        language: python
-        entry: ./scripts/ci/prek/check_init_decorator_arguments.py
-        pass_filenames: false
-        files: ^task-sdk/src/airflow/sdk/definitions/dag\.py$|^task-sdk/src/airflow/sdk/definitions/decorators/task_group\.py$
       - id: check-template-context-variable-in-sync
         name: Sync template context variable refs
         language: python
@@ -1157,21 +1151,6 @@ repos:
         entry: ./scripts/ci/prek/mypy_folder.py airflow-core
         pass_filenames: false
         files: ^airflow-core/.*\.py$
-        require_serial: true
-      - id: mypy-task-sdk
-        stages: ['pre-push']
-        name: Run mypy for task-sdk
-        language: python
-        entry: ./scripts/ci/prek/mypy.py
-        files: ^task-sdk/.*\.py$
-        require_serial: true
-      - id: mypy-task-sdk
-        stages: ['manual']
-        name: Run mypy for task-sdk (manual)
-        language: python
-        entry: ./scripts/ci/prek/mypy_folder.py task-sdk
-        pass_filenames: false
-        files: ^.*\.py$
         require_serial: true
       - id: mypy-devel-common
         stages: ['pre-push']

--- a/task-sdk/.pre-commit-config.yaml
+++ b/task-sdk/.pre-commit-config.yaml
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+---
+default_stages: [pre-commit, pre-push]
+minimum_prek_version: '0.0.28'
+repos:
+  - repo: local
+    hooks:
+      - id: check-init-decorator-arguments
+        name: Sync model __init__ and decorator arguments
+        language: python
+        entry: ../scripts/ci/prek/check_init_decorator_arguments.py
+        pass_filenames: false
+        files: ^src/airflow/sdk/definitions/dag\.py$|^src/airflow/sdk/definitions/decorators/task_group\.py$
+      - id: mypy-task-sdk
+        stages: ['pre-push']
+        name: Run mypy for task-sdk
+        language: python
+        entry: ../scripts/ci/prek/mypy.py
+        files: ^.*\.py$
+        require_serial: true
+      - id: mypy-task-sdk
+        stages: ['manual']
+        name: Run mypy for task-sdk (manual)
+        language: python
+        entry: ../scripts/ci/prek/mypy_folder.py task-sdk
+        pass_filenames: false
+        files: ^.*\.py$
+        require_serial: true


### PR DESCRIPTION
Following https://github.com/apache/airflow/pull/57181 this is now a batch for all prek hooks that are "just" solely for providers to split out from root:

As prek is supporting monorepo now and go SDK was the front-runner, Task SDK is now the next piece that with this PR is proposed to be split-out from global pre-commit hook list into the provider space.