### PR TITLE
Improve clarity on api workers recommendation in docs

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1423,7 +1423,7 @@ api:
       description: |
         Number of workers to run on the API server. Should be roughly equal to the number of
         cpu cores available. If you need to scale the API server, strongly consider deploying multiple API
-        servers instead of increasing the number of workers; See github.com/apache/airflow/issues/52270.
+        servers instead of increasing the number of workers; See https://github.com/apache/airflow/issues/52270.
       version_added: ~
       type: integer
       example: ~

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1421,9 +1421,9 @@ api:
       default: "8080"
     workers:
       description: |
-        Number of workers to run on the API server. Should be roughly equal to the number of
-        cpu cores available. If you need to scale the API server, strongly consider deploying multiple API
-        servers instead of increasing the number of workers; See https://github.com/apache/airflow/issues/52270.
+        Number of workers to run on the API server. Should be roughly equal to the number of cpu cores
+        available. If you need to scale the API server, strongly consider deploying multiple API servers
+        instead of increasing the number of workers; See https://github.com/apache/airflow/issues/52270.
       version_added: ~
       type: integer
       example: ~

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1422,8 +1422,8 @@ api:
     workers:
       description: |
         Number of workers to run on the API server. Should be roughly equal to the number of
-        cpu cores available. If you need to scale the API server, consider deploying multiple API
-        servers instead of increasing the number of workers.
+        cpu cores available. If you need to scale the API server, strongly consider deploying multiple API
+        servers instead of increasing the number of workers; See github.com/apache/airflow/issues/52270.
       version_added: ~
       type: integer
       example: ~


### PR DESCRIPTION
Improves documentation on API_WORKERS to help future users avoid the issues discovered in #52270.
#55707 was originally submitted by @jedcunningham to address this issue but the language therein does not adequately deter nor explain why one should avoid increasing the api workers.

This PR does 2 things. First it modifies to the docs to more strongly advocate for avoiding increasing the workers and secondly, and imo more importantly, it cites the issue for why this recommendation is in place.

Note: This config change helped us mitigate #56635 but I do not believe it is the root cause of that issue.
