### PR TITLE
Better highlighting of selected task instance and edges in grid view 

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/Graph/Edge.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Graph/Edge.tsx
@@ -27,7 +27,7 @@ import type { EdgeData } from "./reactflowUtils";
 type Props = EdgeType<EdgeData>;
 
 const CustomEdge = ({ data }: Props) => {
-  const [strokeColor] = useToken("colors", ["border.inverted"]);
+  const [strokeColor, blueColor] = useToken("colors", ["border.inverted", "blue.500"]);
 
   if (data === undefined) {
     return undefined;
@@ -60,9 +60,10 @@ const CustomEdge = ({ data }: Props) => {
         <LinePath
           data={[section.startPoint, ...(section.bendPoints ?? []), section.endPoint]}
           key={section.id}
-          stroke={strokeColor}
+          stroke={rest.isSelected ? blueColor : strokeColor}
           strokeDasharray={rest.isSetupTeardown ? "10,5" : undefined}
-          strokeWidth={rest.isSelected ? 2 : 1}
+          strokeWidth={rest.isSelected ? 3 : 1}
+          style={rest.isSelected ? { filter: `drop-shadow(0 0 4px ${blueColor})` } : undefined}
           x={(point: ElkPoint) => point.x}
           y={(point: ElkPoint) => point.y}
         />

--- a/airflow-core/src/airflow/ui/src/components/Graph/Edge.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Graph/Edge.tsx
@@ -63,7 +63,6 @@ const CustomEdge = ({ data }: Props) => {
           stroke={rest.isSelected ? blueColor : strokeColor}
           strokeDasharray={rest.isSetupTeardown ? "10,5" : undefined}
           strokeWidth={rest.isSelected ? 3 : 1}
-          style={rest.isSelected ? { filter: `drop-shadow(0 0 4px ${blueColor})` } : undefined}
           x={(point: ElkPoint) => point.x}
           y={(point: ElkPoint) => point.y}
         />

--- a/airflow-core/src/airflow/ui/src/components/Graph/TaskNode.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Graph/TaskNode.tsx
@@ -75,11 +75,10 @@ export const TaskNode = ({
             // Alternate background color for nested open groups
             bg={isOpen && depth !== undefined && depth % 2 === 0 ? "bg.muted" : "bg"}
             borderColor={
-              taskInstance?.state ? `${taskInstance.state}.solid` : isSelected ? "blue.500" : "border"
+              isSelected ? "blue.500" : taskInstance?.state ? `${taskInstance.state}.solid` : "border"
             }
             borderRadius={5}
             borderWidth={isSelected ? 4 : 2}
-            boxShadow={isSelected ? "0 0 12px 4px var(--chakra-colors-blue-400)" : undefined}
             height={`${height + (isSelected ? 4 : 0)}px`}
             justifyContent="space-between"
             overflow="hidden"

--- a/airflow-core/src/airflow/ui/src/components/Graph/TaskNode.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Graph/TaskNode.tsx
@@ -75,10 +75,11 @@ export const TaskNode = ({
             // Alternate background color for nested open groups
             bg={isOpen && depth !== undefined && depth % 2 === 0 ? "bg.muted" : "bg"}
             borderColor={
-              taskInstance?.state ? `${taskInstance.state}.solid` : isSelected ? "border.inverted" : "border"
+              taskInstance?.state ? `${taskInstance.state}.solid` : isSelected ? "blue.500" : "border"
             }
             borderRadius={5}
             borderWidth={isSelected ? 4 : 2}
+            boxShadow={isSelected ? "0 0 12px 4px var(--chakra-colors-blue-400)" : undefined}
             height={`${height + (isSelected ? 4 : 0)}px`}
             justifyContent="space-between"
             overflow="hidden"


### PR DESCRIPTION
  The previous bold border didn't provide enough visual distinction for
  selected tasks and their connections. This change adds a blue glow effect
  and color highlighting to make selected elements stand out clearly.


https://github.com/user-attachments/assets/1a5f146c-00ae-4fd2-ad44-acf615dcd4bc

<img width="1918" height="1031" alt="image" src="https://github.com/user-attachments/assets/2e4d14af-40fb-41bf-b459-7d461545da0f" />

<img width="1915" height="1031" alt="image" src="https://github.com/user-attachments/assets/12ed45a3-39cb-44a1-a06f-81b8019d4be0" />

