### PR TITLE
Update provider yaml prek hook script to use actual location

### DIFF
--- a/scripts/ci/prek/check_provider_yaml_files.py
+++ b/scripts/ci/prek/check_provider_yaml_files.py
@@ -35,7 +35,10 @@ from common_prek_utils import (
 
 initialize_breeze_prek(__name__, __file__)
 
-files_to_test = sys.argv[1:]
+# Due to recent work to move provider prek hooks to providers/.pre-commit-config.yaml, paths are now relative to providers/
+# directory (e.g., "airbyte/provider.yaml"). Prepend "providers/" so they're relative to the Airflow root directory as expected
+# by run_provider_yaml_files_check.py prek hook
+files_to_test = [f"providers/{f}" for f in sys.argv[1:]]
 cmd_result = run_command_via_breeze_shell(
     ["python3", "/opt/airflow/scripts/in_container/run_provider_yaml_files_check.py", *files_to_test],
     backend="sqlite",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Fixing static check failure in main:
```
Validate provider.yaml files.....................................................Failed
- hook id: check-provider-yaml-valid
- exit code: 1
  Using 'uv' to install Airflow


  Using airflow version from current sources

  /opt/airflow/airflow-core/src/airflow/dag_processing/dagbag.py:40 DeprecationWarning: airflow.exceptions.AirflowDagCycleException is deprecated. Use airflow.sdk.exceptions.AirflowDagCycleException instead.
  Verifying packages on Architecture.ARM architecture. Platform: aarch64.
  Traceback (most recent call last):
    File "/opt/airflow/scripts/in_container/run_provider_yaml_files_check.py", line 733, in <module>
      all_parsed_yaml_files: dict[str, dict] = _load_package_data(paths)
    File "/opt/airflow/scripts/in_container/run_provider_yaml_files_check.py", line 134, in _load_package_data
      with open(provider_yaml_path) as yaml_file:
  FileNotFoundError: [Errno 2] No such file or directory: '/opt/airflow/airbyte/provider.yaml'

  Error 1 returned
  /opt/hostedtoolcache/Python/3.10.19/arm64/lib/python3.10/tempfile.py:869: ResourceWarning: Implicitly cleaning up <TemporaryDirectory '/tmp/tmp2a48q81w'>
    _warnings.warn(warn_message, ResourceWarning)
```

When the pre-commit hook runs from the `providers/.pre-commit-config.yaml` file, it passes file paths relative to the providers/ directory (e.g., airbyte/provider.yaml). However, the script `run_provider_yaml_files_check.py` inside breeze expects paths relative to root directory. This caused it to look for `/opt/airflow/airbyte/provider.yaml` instead of `/opt/airflow/providers/airbyte/provider.yaml`


In breeze shell:
```
root@4548c6611747:/opt/airflow# ls /opt/airflow/airbyte/provider.yaml
ls: cannot access '/opt/airflow/airbyte/provider.yaml': No such file or directory
root@4548c6611747:/opt/airflow# ls /opt/airflow/providers/airbyte/provider.yaml
/opt/airflow/providers/airbyte/provider.yaml
```

As a solution for the time being, modified script to prepend `providers/` to all file paths before passing them to the breeze container. 


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
