### PR TITLE
Add better platform diagnostics to see which platform is used

### DIFF
--- a/.github/workflows/ci-amd-arm.yml
+++ b/.github/workflows/ci-amd-arm.yml
@@ -16,7 +16,7 @@
 # under the License.
 #
 ---
-name: Tests AMD/ARM
+name: Tests
 on:  # yamllint disable-line rule:truthy
   schedule:
     - cron: '28 1,3,7,9,13,15,19,21 * * *'
@@ -166,8 +166,27 @@ jobs:
         env:
           PR_LABELS: ${{ steps.source-run-info.outputs.pr-labels }}
           GITHUB_CONTEXT: ${{ toJson(github) }}
+
+  print-platform-arm:
+    name: "Platform: ARM"
+    needs: [build-info]
+    runs-on: ["ubuntu-22.04"]
+    if: needs.build-info.outputs.platform == 'linux/arm64'
+    steps:
+      - name: "Print architecture"
+        run: "echo '## Architecture: ARM' >> $GITHUB_STEP_SUMMARY"
+
+  print-platform-amd:
+    name: "Platform: AMD"
+    needs: [build-info]
+    runs-on: ["ubuntu-22.04"]
+    if: needs.build-info.outputs.platform == 'linux/amd64'
+    steps:
+      - name: "Print architecture"
+        run: "echo '## Architecture: AMD' >> $GITHUB_STEP_SUMMARY"
+
   run-pin-versions-hook:
-    name: "Run pin-versions hook"
+    name: "Pin actions"
     needs: [build-info]
     runs-on: ${{ fromJSON(needs.build-info.outputs.runner-type) }}
     if: needs.build-info.outputs.platform == 'linux/amd64'


### PR DESCRIPTION
We now have same workflow running for both ARM and AMD and we need a bit better diagnostics printed to distinguish those different run types.

* Tha name of the workflow is just changed to "Tests"
* There is a job added that should immediately show the platform in the left-sidebar of GitHub Actions
* The title containing platform is printed at the top of summary
  - before the constraints summary.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
