### PR TITLE
Add dependabot for plugin template as well

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,6 +53,16 @@ updates:
 
   - package-ecosystem: npm
     directories:
+      - /dev/react-plugin-tools/react_plugin_template
+    schedule:
+      interval: daily
+    groups:
+      ui-plugin-template-package-updates:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directories:
       - /providers/edge3/src/airflow/providers/edge3/plugins/www
     schedule:
       interval: daily


### PR DESCRIPTION
I noticed that we often forget to keep the UI plugin template in sync with the core, so adding a dependabot check here as well like we do for core and some provider plugins.