### PR TITLE
Clean up some root discovery in prek scripts

### DIFF
--- a/scripts/ci/prek/boring_cyborg.py
+++ b/scripts/ci/prek/boring_cyborg.py
@@ -29,6 +29,7 @@ import sys
 from pathlib import Path
 
 import yaml
+from common_prek_utils import AIRFLOW_ROOT_PATH
 from termcolor import colored
 
 if __name__ not in ("__main__", "__mp_main__"):
@@ -39,8 +40,7 @@ if __name__ not in ("__main__", "__mp_main__"):
 
 CONFIG_KEY = "labelPRBasedOnFilePath"
 
-repo_root = Path(__file__).parents[3]
-cyborg_config_path = repo_root / ".github" / "boring-cyborg.yml"
+cyborg_config_path = AIRFLOW_ROOT_PATH / ".github" / "boring-cyborg.yml"
 cyborg_config = yaml.safe_load(cyborg_config_path.read_text())
 if CONFIG_KEY not in cyborg_config:
     raise SystemExit(f"Missing section {CONFIG_KEY}")
@@ -50,7 +50,7 @@ errors = []
 for label, patterns in cyborg_config[CONFIG_KEY].items():
     for pattern in patterns:
         try:
-            next(Path(repo_root).glob(pattern))
+            next(Path(AIRFLOW_ROOT_PATH).glob(pattern))
             continue
         except StopIteration:
             yaml_path = f"{CONFIG_KEY}.{label}"
@@ -60,7 +60,7 @@ for label, patterns in cyborg_config[CONFIG_KEY].items():
 
 # Check for missing providers
 EXCEPTIONS = ["edge3"]
-providers_root = repo_root / "providers"
+providers_root = AIRFLOW_ROOT_PATH / "providers"
 for p in providers_root.glob("**/provider.yaml"):
     provider_name = str(p.parent.relative_to(providers_root)).replace("/", "-")
     expected_key = f"provider:{provider_name}"
@@ -71,7 +71,7 @@ for p in providers_root.glob("**/provider.yaml"):
 
 # Check for missing translations
 EXCEPTIONS = ["en"]
-for p in repo_root.glob("airflow-core/src/airflow/ui/public/i18n/locales/*"):
+for p in AIRFLOW_ROOT_PATH.glob("airflow-core/src/airflow/ui/public/i18n/locales/*"):
     if p.is_dir():
         lang_id = p.name
         expected_key = f"translation:{lang_id}"

--- a/scripts/ci/prek/chart_schema.py
+++ b/scripts/ci/prek/chart_schema.py
@@ -21,14 +21,15 @@ import json
 import sys
 from pathlib import Path
 
+from common_prek_utils import AIRFLOW_ROOT_PATH
+
 if __name__ not in ("__main__", "__mp_main__"):
     raise SystemExit(
         "This file is intended to be executed as an executable program. You cannot use it as a module."
         f"To run this script, run the ./{__file__} command"
     )
 
-PROJECT_SOURCE_ROOT_DIR = Path(__file__).resolve().parents[3]
-CHART_DIR = PROJECT_SOURCE_ROOT_DIR / "chart"
+CHART_DIR = AIRFLOW_ROOT_PATH / "chart"
 KNOWN_INVALID_TYPES = {
     # I don't know the data structure for this type with 100 certainty. We have no tests.
     "$['properties']['ingress']['properties']['web']['properties']['precedingPaths']",

--- a/scripts/ci/prek/check_aiobotocore_optional.py
+++ b/scripts/ci/prek/check_aiobotocore_optional.py
@@ -32,8 +32,6 @@ from pathlib import Path
 import yaml
 from rich.console import Console
 
-AIRFLOW_SOURCES = Path(__file__).parents[3]
-
 console = Console(color_system="standard", width=200)
 
 if __name__ == "__main__":

--- a/scripts/ci/prek/check_airflow_v_imports_in_tests.py
+++ b/scripts/ci/prek/check_airflow_v_imports_in_tests.py
@@ -31,6 +31,8 @@ import ast
 import sys
 from pathlib import Path
 
+from common_prek_utils import AIRFLOW_ROOT_PATH
+
 sys.path.insert(0, str(Path(__file__).parent.resolve()))  # make sure common_prek_utils is imported
 from common_prek_utils import console
 
@@ -68,7 +70,7 @@ def main():
     if len(sys.argv) > 1:
         test_files = [Path(f) for f in sys.argv[1:]]
     else:
-        base = Path(__file__).parents[3] / "providers"
+        base = AIRFLOW_ROOT_PATH / "providers"
         test_files = list(base.glob("**/tests/**/*.py"))
         console.print(test_files)
     all_errors = []

--- a/scripts/ci/prek/check_init_in_tests.py
+++ b/scripts/ci/prek/check_init_in_tests.py
@@ -24,10 +24,10 @@
 from __future__ import annotations
 
 import os
-import pathlib
 import sys
 from pathlib import Path
 
+from common_prek_utils import AIRFLOW_ROOT_PATH
 from rich.console import Console
 
 if __name__ not in ("__main__", "__mp_main__"):
@@ -36,9 +36,6 @@ if __name__ not in ("__main__", "__mp_main__"):
         f"To execute this script, run ./{__file__} [FILE] ..."
     )
 
-ROOT_DIR = pathlib.Path(__file__).resolve().parents[3]
-
-
 console = Console(color_system="standard", width=200)
 
 errors: list[str] = []
@@ -46,7 +43,7 @@ errors: list[str] = []
 added = False
 
 if __name__ == "__main__":
-    for dirname, sub_dirs, _ in os.walk(ROOT_DIR / "tests"):
+    for dirname, sub_dirs, _ in os.walk(AIRFLOW_ROOT_PATH / "tests"):
         dir = Path(dirname)
         sub_dirs[:] = [
             subdir for subdir in sub_dirs if subdir not in {"__pycache__", "test_logs", "test_zip"}

--- a/scripts/ci/prek/mypy.py
+++ b/scripts/ci/prek/mypy.py
@@ -31,6 +31,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.resolve()))
 
 from common_prek_utils import (
+    AIRFLOW_ROOT_PATH,
     console,
     initialize_breeze_prek,
     pre_process_files,
@@ -46,7 +47,7 @@ if not files_to_test:
 
 # TODO(potiuk): add suspended providers exclusion
 
-repo_root = Path(__file__).parents[3].resolve()
+repo_root = AIRFLOW_ROOT_PATH.resolve()
 cmd = [
     "bash",
     "-c",

--- a/scripts/ci/prek/supported_versions.py
+++ b/scripts/ci/prek/supported_versions.py
@@ -26,10 +26,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from common_prek_utils import AIRFLOW_ROOT_PATH
 from tabulate import tabulate
-
-AIRFLOW_SOURCES = Path(__file__).resolve().parents[3]
-
 
 HEADERS = (
     "Version",
@@ -59,7 +57,7 @@ def replace_text_between(file: Path, start: str, end: str, replacement_text: str
 
 if __name__ == "__main__":
     replace_text_between(
-        file=AIRFLOW_SOURCES / "README.md",
+        file=AIRFLOW_ROOT_PATH / "README.md",
         start="<!-- Beginning of auto-generated table -->\n",
         end="<!-- End of auto-generated table -->\n",
         replacement_text="\n"
@@ -69,7 +67,7 @@ if __name__ == "__main__":
         + "\n\n",
     )
     replace_text_between(
-        file=AIRFLOW_SOURCES / "airflow-core" / "docs" / "installation" / "supported-versions.rst",
+        file=AIRFLOW_ROOT_PATH / "airflow-core" / "docs" / "installation" / "supported-versions.rst",
         start=" .. Beginning of auto-generated table\n",
         end=" .. End of auto-generated table\n",
         replacement_text="\n"


### PR DESCRIPTION
While moving some prek-hooks to subfolders I noticed that the resolution of the repo root is a bit inconsistenly in all prek scripts. This PR attempts to consolidate to all use AIRFLOW_ROOT_PATH consistently from common_prek_utils