### PR TITLE
Replace last pylint usage by ruff rule

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1044,24 +1044,6 @@ repos:
           - "B101,B301,B324,B403,B404,B603"
           - "--severity-level"
           - "high"  # TODO: remove this line when we fix all the issues
-      - id: pylint
-        name: pylint
-        description: "Pylint is a static code analyser for Python 2 or 3."
-        entry: pylint
-        language: python
-        language_version: python3
-        types: [python]
-        additional_dependencies: ['pylint==3.1.0']
-        require_serial: true
-        files: ^airflow-core/src/airflow/.*
-        exclude:
-          airflow/example_dags/.*
-        args:
-          # Use pylint only for the specific check, which are not available into the ruff
-          - "--disable=all"
-          # W0133: "Exception statement has no effect"
-          # see: https://github.com/astral-sh/ruff/issues/10145
-          - "--enable=W0133"
       - id: check-no-fab-migrations
         language: pygrep
         name: Check no migration is done on FAB related table

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -619,6 +619,7 @@ extend-select = [
     "RET506", # Unnecessary {branch} after raise statement
     "RET507", # Unnecessary {branch} after continue statement
     "RET508", # Unnecessary {branch} after break statement
+    "PLW0133", # Missing raise statement on exception
 ]
 ignore = [
     "D100", # Unwanted; Docstring at the top of every file.


### PR DESCRIPTION
While I was pushing some prek hooks into subfolders I noticed that there was ONE check left for pylint... which actually is availabel in ruff since a while. Just with a different name/ID.

Now this is the point to migrate over and fully drop pylint from the toolchain and dependencies. Whohooo!

There might be a couple more PLW* rules we could apply on the codebase, but will take this as a follow-up PR...