### PR TITLE
Extract prek hooks for airflowctl

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1069,22 +1069,6 @@ repos:
         pass_filenames: false
         files: ^.*\.py$
         require_serial: true
-      - id: mypy-airflow-ctl
-        stages: ['pre-push']
-        name: Run mypy for airflow-ctl
-        language: python
-        entry: ./scripts/ci/prek/mypy.py
-        files: ^airflow-ctl/src/airflowctl/.*\.py$|^airflow-ctl/tests/.*\.py$
-        exclude: .*generated.py
-        require_serial: true
-      - id: mypy-airflow-ctl
-        stages: ['manual']
-        name: Run mypy for airflow-ctl (manual)
-        language: python
-        entry: ./scripts/ci/prek/mypy_folder.py airflow-ctl
-        pass_filenames: false
-        files: ^.*\.py$
-        require_serial: true
       - id: generate-openapi-spec
         name: Generate the FastAPI API spec
         language: python
@@ -1141,13 +1125,6 @@ repos:
         require_serial: true
         pass_filenames: false
         files: ^airflow-core/src/airflow/config_templates/config\.yml$
-      - id: generate-airflowctl-help-images
-        name: Generate SVG from Airflow CTL Commands
-        entry: ./scripts/ci/prek/capture_airflowctl_help.py
-        language: python
-        pass_filenames: false
-        files:
-          ^airflow-ctl/src/airflowctl/ctl/cli_config.py$|airflow-ctl/src/airflowctl/api/operations.py|airflow-ctl/src/airflowctl/ctl/commands/.*\.py
       - id: check-airflow-version-checks-in-core
         language: pygrep
         name: No AIRFLOW_V_* imports in airflow-core

--- a/airflow-ctl/.pre-commit-config.yaml
+++ b/airflow-ctl/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
         require_serial: true
       - id: generate-airflowctl-help-images
         name: Generate SVG from Airflow CTL Commands
-        entry: ..scripts/ci/prek/capture_airflowctl_help.py
+        entry: ../scripts/ci/prek/capture_airflowctl_help.py
         language: python
         pass_filenames: false
         files:

--- a/airflow-ctl/.pre-commit-config.yaml
+++ b/airflow-ctl/.pre-commit-config.yaml
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+---
+default_stages: [pre-commit, pre-push]
+minimum_prek_version: '0.0.28'
+repos:
+  - repo: local
+    hooks:
+      - id: mypy-airflow-ctl
+        stages: ['pre-push']
+        name: Run mypy for airflow-ctl
+        language: python
+        entry: ../scripts/ci/prek/mypy.py
+        files:
+          (?x)
+          ^src/airflowctl/.*\.py$|
+          ^tests/.*\.py$
+        exclude: .*generated.py
+        require_serial: true
+      - id: mypy-airflow-ctl
+        stages: ['manual']
+        name: Run mypy for airflow-ctl (manual)
+        language: python
+        entry: ../scripts/ci/prek/mypy_folder.py airflow-ctl
+        pass_filenames: false
+        files: ^.*\.py$
+        require_serial: true
+      - id: generate-airflowctl-help-images
+        name: Generate SVG from Airflow CTL Commands
+        entry: ..scripts/ci/prek/capture_airflowctl_help.py
+        language: python
+        pass_filenames: false
+        files:
+          (?x)
+          ^src/airflowctl/ctl/cli_config.py$|
+          ^src/airflowctl/api/operations.py$|
+          ^src/airflowctl/ctl/commands/.*\.py$


### PR DESCRIPTION
Following https://github.com/apache/airflow/pull/57181 this is now a batch for all prek hooks that are "just" solely for providers to split out from root:

As prek is supporting monorepo now and go SDK was the front-runner, Airflow-CTL is now the next piece that with this PR is proposed to be split-out from global pre-commit hook list into the provider space.