### PR TITLE
Fix text selection jumping in logs pane to match text editor behavior

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
@@ -100,6 +100,11 @@ export const TaskLogContent = ({ error, isLoading, logError, parsedLogs, wrap }:
     }
   }, [isLoading, rowVirtualizer, hash, parsedLogs]);
 
+  useLayoutEffect(() => {
+    // Force remeasurement when wrap changes since item heights will change
+    rowVirtualizer.measure();
+  }, [wrap, rowVirtualizer]);
+
   const handleScrollTo = (to: "bottom" | "top") => {
     if (parsedLogs.length > 0) {
       rowVirtualizer.scrollToIndex(to === "bottom" ? parsedLogs.length - 1 : 0);
@@ -126,7 +131,7 @@ export const TaskLogContent = ({ error, isLoading, logError, parsedLogs, wrap }:
         position="relative"
         py={3}
         ref={parentRef}
-        textWrap={wrap ? "pre" : "nowrap"}
+        textWrap={wrap ? "pre-wrap" : "nowrap"}
         width="100%"
       >
         <VStack
@@ -135,6 +140,7 @@ export const TaskLogContent = ({ error, isLoading, logError, parsedLogs, wrap }:
           h={`${rowVirtualizer.getTotalSize()}px`}
           minH="100%"
           position="relative"
+          width="100%"
         >
           {rowVirtualizer.getVirtualItems().map((virtualRow) => (
             <Box
@@ -152,11 +158,11 @@ export const TaskLogContent = ({ error, isLoading, logError, parsedLogs, wrap }:
               data-index={virtualRow.index}
               data-testid={`virtualized-item-${virtualRow.index}`}
               key={virtualRow.key}
-              minWidth={wrap ? "100%" : "max-content"}
+              minWidth="100%"
               position="absolute"
               ref={rowVirtualizer.measureElement}
               top={`${virtualRow.start}px`}
-              width="100%"
+              width={wrap ? "100%" : "max-content"}
             >
               {parsedLogs[virtualRow.index] ?? undefined}
             </Box>

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
@@ -129,7 +129,13 @@ export const TaskLogContent = ({ error, isLoading, logError, parsedLogs, wrap }:
         textWrap={wrap ? "pre" : "nowrap"}
         width="100%"
       >
-        <VStack alignItems="flex-start" gap={0} h={`${rowVirtualizer.getTotalSize()}px`}>
+        <VStack
+          alignItems="flex-start"
+          gap={0}
+          h={`${rowVirtualizer.getTotalSize()}px`}
+          minH="100%"
+          position="relative"
+        >
           {rowVirtualizer.getVirtualItems().map((virtualRow) => (
             <Box
               _ltr={{
@@ -146,14 +152,23 @@ export const TaskLogContent = ({ error, isLoading, logError, parsedLogs, wrap }:
               data-index={virtualRow.index}
               data-testid={`virtualized-item-${virtualRow.index}`}
               key={virtualRow.key}
+              minWidth={wrap ? "100%" : "max-content"}
               position="absolute"
               ref={rowVirtualizer.measureElement}
               top={`${virtualRow.start}px`}
-              width={wrap ? "100%" : "max-content"}
+              width="100%"
             >
               {parsedLogs[virtualRow.index] ?? undefined}
             </Box>
           ))}
+          <Box
+            bottom={0}
+            left={0}
+            minH={`calc(100% - ${rowVirtualizer.getTotalSize()}px)`}
+            position="absolute"
+            top={`${rowVirtualizer.getTotalSize()}px`}
+            width="100%"
+          />
         </VStack>
       </Code>
 


### PR DESCRIPTION
  When selecting text by clicking and dragging in the logs pane, the
  selection would jump unexpectedly when clicking in empty space at
  the end of lines or below the last log line. This was caused by the
  virtualized list rendering with absolutely positioned elements that
  didn't extend to fill available space.

  Changes:
  - Make log line containers full width to enable selection in empty areas
  - Add invisible filler element below last log line to prevent EOF jump
  - Ensure minimum height covers all empty space at bottom of container

  The logs pane now behaves like traditional text editors (e.g. Notepad)
  where users can click anywhere and drag to select multiple lines without
  the selection jumping.

Before:
https://github.com/user-attachments/assets/6ee6aa15-90b7-42ec-b41e-2f3f2dcacf7f

After: 
https://github.com/user-attachments/assets/42062183-d28c-4126-800a-45150c9cc1be

