### PR TITLE
Feature/extract pre commit for airflow core

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -647,27 +647,6 @@ repos:
         entry: koalaman/shellcheck:v0.8.0 -x -a
         files: \.(bash|sh)$|^hooks/build$|^hooks/push$
         exclude: ^dev/breeze/autocomplete/.*$
-        # Note: Actually the compile-ui-assets prek hook would be best in airflow-core/.pre-commit-config.yaml
-        #       See also https://github.com/j178/prek/issues/973
-      - id: compile-ui-assets
-        name: Compile ui assets (manual)
-        language: node
-        stages: ['manual']
-        types_or: [javascript, ts, tsx]
-        files: ^airflow-core/src/airflow/ui/|^airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/
-        entry: ./scripts/ci/prek/compile_ui_assets.py
-        pass_filenames: false
-        additional_dependencies: ['pnpm@9.7.1']
-        # Note: Keeping compile-ui-assets-dev together with ^^^
-      - id: compile-ui-assets-dev
-        name: Compile ui assets in dev mode (manual)
-        language: node
-        stages: ['manual']
-        types_or: [javascript, ts, tsx]
-        files: ^airflow-core/src/airflow/ui/|^airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/
-        entry: ./scripts/ci/prek/compile_ui_assets_dev.py
-        pass_filenames: false
-        additional_dependencies: ['pnpm@9.7.1']
       - id: check-integrations-list-consistent
         name: Sync integrations list with docs
         entry: ./scripts/ci/prek/check_integrations_list.py

--- a/airflow-core/.pre-commit-config.yaml
+++ b/airflow-core/.pre-commit-config.yaml
@@ -97,6 +97,30 @@ repos:
         entry: ../scripts/ci/prek/decorator_operator_implements_custom_name.py
         pass_filenames: true
         files: ^src/airflow/.*\.py$
+      - id: compile-ui-assets
+        name: Compile ui assets (manual)
+        language: node
+        stages: ['manual']
+        types_or: [javascript, ts, tsx]
+        files:
+          (?x)
+          ^src/airflow/ui/|
+          ^src/airflow/api_fastapi/auth/managers/simple/ui/
+        entry: ../scripts/ci/prek/compile_ui_assets.py
+        pass_filenames: false
+        additional_dependencies: ['pnpm@9.7.1']
+      - id: compile-ui-assets-dev
+        name: Compile ui assets in dev mode (manual)
+        language: node
+        stages: ['manual']
+        types_or: [javascript, ts, tsx]
+        files:
+          (?x)
+          ^src/airflow/ui/|
+          ^src/airflow/api_fastapi/auth/managers/simple/ui/
+        entry: ../scripts/ci/prek/compile_ui_assets_dev.py
+        pass_filenames: false
+        additional_dependencies: ['pnpm@9.7.1']
       - id: check-tests-in-the-right-folders
         name: Check if tests are in the right folders
         entry: ../scripts/ci/prek/check_tests_in_right_folders.py

--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -272,7 +272,7 @@ PYYAML_VERSION = "6.0.3"
 AIRFLOW_BUILD_DOCKERFILE = f"""
 # syntax=docker/dockerfile:1.4
 FROM python:{DEFAULT_PYTHON_MAJOR_MINOR_VERSION}-slim-{ALLOWED_DEBIAN_VERSIONS[0]}
-RUN apt-get update && apt-get install -y --no-install-recommends git curl
+RUN apt-get update && apt-get install -y --no-install-recommends libatomic1 git curl
 RUN pip install uv=={UV_VERSION}
 RUN --mount=type=cache,id=cache-airflow-build-dockerfile-installation,target=/root/.cache/ \
   uv pip install --system ignore pip=={AIRFLOW_PIP_VERSION} hatch=={HATCH_VERSION} \


### PR DESCRIPTION
Following https://github.com/apache/airflow/pull/57181 this is now a batch for all prek hooks that are "just" solely for providers to split out from root:

As prek is supporting monorepo now and go SDK was the front-runner, Airflow-Core is now the next piece that with this PR is proposed to be split-out from global pre-commit hook list into the provider space.

Note: This is the crown and msot probably atm the last thing to move. Careful review please!