### PR TITLE
Fix wrong path pattern after moving prek check to chart folder

### DIFF
--- a/chart/.pre-commit-config.yaml
+++ b/chart/.pre-commit-config.yaml
@@ -51,7 +51,10 @@ repos:
           - --no-sort-keys
           - --indent
           - "4"
-        files: ^chart/values\.schema\.json$|^chart/values_schema\.schema\.json$
+        files:
+          (?x)
+          ^values\.schema\.json$|
+          ^values_schema\.schema\.json$
         pass_filenames: true
   - repo: local
     hooks:


### PR DESCRIPTION
Found one ups after merging helm chart rework for separation of prek checks. Files are now in subfolders and therefore check was skipped...