### PR TITLE
fix: ensure EksPodOperator uses AWS connection (#56689)

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/eks.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/eks.py
@@ -1055,7 +1055,16 @@ class EksPodOperator(KubernetesPodOperator):
         super().__init__(
             in_cluster=self.in_cluster,
             namespace=self.namespace,
+     # Remove aws_conn_id and region from kwargs to avoid passing them to KubernetesPodOperator
+        kwargs.pop("aws_conn_id", None)
+        kwargs.pop("region", None)
+        super().__init__(
+            in_cluster=self.in_cluster,
+            namespace=self.namespace,
             name=self.pod_name,
+            trigger_kwargs={"eks_cluster_name": cluster_name},
+            **kwargs,
+        )        name=self.pod_name,
             trigger_kwargs={"eks_cluster_name": cluster_name},
             **k # Remove aws_conn_id and region from kwargs to avoid passing them to KubernetesPodOperator
         kwargs.pop("aws_conn_id", None)
@@ -1068,7 +1077,7 @@ wargs,
             raise AirflowException("The config_file is not an allowed parameter for the EksPodOperator.")
 
     def execute(self, context: Context):
-        eks_hook = EksHook(
+       eks_hook = EksHook(
             aws_conn_id=self.aws_conn_id,
             region_name=self.region,
         )

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/eks.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/eks.py
@@ -1057,7 +1057,10 @@ class EksPodOperator(KubernetesPodOperator):
             namespace=self.namespace,
             name=self.pod_name,
             trigger_kwargs={"eks_cluster_name": cluster_name},
-            **kwargs,
+            **k # Remove aws_conn_id and region from kwargs to avoid passing them to KubernetesPodOperator
+        kwargs.pop("aws_conn_id", None)
+        kwargs.pop("region", None)
+wargs,
         )
         # There is no need to manage the kube_config file, as it will be generated automatically.
         # All Kubernetes parameters (except config_file) are also valid for the EksPodOperator.

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/eks.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/eks.py
@@ -1052,10 +1052,7 @@ class EksPodOperator(KubernetesPodOperator):
         self.pod_name = pod_name
         self.aws_conn_id = aws_conn_id
         self.region = region
-        super().__init__(
-            in_cluster=self.in_cluster,
-            namespace=self.namespace,
-     # Remove aws_conn_id and region from kwargs to avoid passing them to KubernetesPodOperator
+        # Remove aws_conn_id and region from kwargs to avoid passing them to KubernetesPodOperator
         kwargs.pop("aws_conn_id", None)
         kwargs.pop("region", None)
         super().__init__(
@@ -1064,12 +1061,6 @@ class EksPodOperator(KubernetesPodOperator):
             name=self.pod_name,
             trigger_kwargs={"eks_cluster_name": cluster_name},
             **kwargs,
-        )        name=self.pod_name,
-            trigger_kwargs={"eks_cluster_name": cluster_name},
-            **k # Remove aws_conn_id and region from kwargs to avoid passing them to KubernetesPodOperator
-        kwargs.pop("aws_conn_id", None)
-        kwargs.pop("region", None)
-wargs,
         )
         # There is no need to manage the kube_config file, as it will be generated automatically.
         # All Kubernetes parameters (except config_file) are also valid for the EksPodOperator.

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/eks.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/eks.py
@@ -1068,7 +1068,7 @@ class EksPodOperator(KubernetesPodOperator):
             raise AirflowException("The config_file is not an allowed parameter for the EksPodOperator.")
 
     def execute(self, context: Context):
-       eks_hook = EksHook(
+        eks_hook = EksHook(
             aws_conn_id=self.aws_conn_id,
             region_name=self.region,
         )


### PR DESCRIPTION
Remove aws_conn_id and region from kwargs before passing to KubernetesPodOperator. This ensures the operator uses the specified AWS connection and region, fixing issue #56689.