### PR TITLE
Move provider examples to their respective folders

### DIFF
--- a/airflow-core/src/airflow/dag_processing/dagbag.py
+++ b/airflow-core/src/airflow/dag_processing/dagbag.py
@@ -618,12 +618,12 @@ class DagBag(LoggingMixin):
 
         files_to_parse = list_py_file_paths(dag_folder, safe_mode=safe_mode)
 
-        if include_examples:
-            from airflow import example_dags
+        # if include_examples:
+        #     from airflow import example_dags
 
-            example_dag_folder = next(iter(example_dags.__path__))
+        #     example_dag_folder = next(iter(example_dags.__path__))
 
-            files_to_parse.extend(list_py_file_paths(example_dag_folder, safe_mode=safe_mode))
+        #     files_to_parse.extend(list_py_file_paths(example_dag_folder, safe_mode=safe_mode))
 
         for filepath in files_to_parse:
             try:

--- a/airflow-core/src/airflow/example_dags/standard
+++ b/airflow-core/src/airflow/example_dags/standard
@@ -1,1 +1,0 @@
-../../../../providers/standard/src/airflow/providers/standard/example_dags

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_parsing.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_parsing.py
@@ -56,7 +56,7 @@ class TestDagParsingEndpoint:
         assert response.status_code == 201
         parsing_requests = session.scalars(select(DagPriorityParsingRequest)).all()
         assert len(parsing_requests) == 1
-        assert parsing_requests[0].bundle_name == "dags-folder"
+        assert parsing_requests[0].bundle_name == "example_dags"
         assert parsing_requests[0].relative_fileloc == test_dag.relative_fileloc
         _check_last_log(session, dag_id=None, event="reparse_dag_file", logical_date=None)
 
@@ -65,7 +65,7 @@ class TestDagParsingEndpoint:
         assert response.status_code == 409
         parsing_requests = session.scalars(select(DagPriorityParsingRequest)).all()
         assert len(parsing_requests) == 1
-        assert parsing_requests[0].bundle_name == "dags-folder"
+        assert parsing_requests[0].bundle_name == "example_dags"
         assert parsing_requests[0].relative_fileloc == test_dag.relative_fileloc
         _check_last_log(session, dag_id=None, event="reparse_dag_file", logical_date=None)
 

--- a/airflow-core/tests/unit/cli/commands/test_task_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_task_command.py
@@ -349,7 +349,8 @@ class TestCliTasks:
         )
 
     def test_task_states_for_dag_run(self):
-        dag2 = DagBag().dags["example_python_operator"]
+        from airflow.providers.standard.example_dags.example_python_operator import dag as dag2
+
         lazy_deserialized_dag2 = LazyDeserializedDAG.from_dag(dag2)
 
         SerializedDagModel.write_dag(lazy_deserialized_dag2, bundle_name="testing")

--- a/airflow-core/tests/unit/models/test_dagcode.py
+++ b/airflow-core/tests/unit/models/test_dagcode.py
@@ -71,10 +71,10 @@ class TestDagCode:
 
     def _write_two_example_dags(self, session):
         example_dags = make_example_dags(example_dags_module)
-        bash_dag = example_dags["example_bash_operator"]
-        sync_dag_to_db(bash_dag, session=session)
-        dag_version = DagVersion.get_latest_version("example_bash_operator")
-        x = DagCode(dag_version, bash_dag.fileloc)
+        xcomargs_dag = example_dags["example_xcom_args"]
+        sync_dag_to_db(xcomargs_dag, session=session)
+        dag_version = DagVersion.get_latest_version("example_xcom_args")
+        x = DagCode(dag_version, xcomargs_dag.fileloc)
         session.add(x)
         session.commit()
         xcom_dag = example_dags["example_xcom"]
@@ -83,7 +83,7 @@ class TestDagCode:
         x = DagCode(dag_version, xcom_dag.fileloc)
         session.add(x)
         session.commit()
-        return [bash_dag, xcom_dag]
+        return [xcomargs_dag, xcom_dag]
 
     def _write_example_dags(self):
         example_dags = make_example_dags(example_dags_module)
@@ -128,7 +128,9 @@ class TestDagCode:
         Test that code can be retrieved from DB when you do not have access to Code file.
         Source Code should at least exist in one of DB or File.
         """
-        example_dag = make_example_dags(example_dags_module).get("example_bash_operator")
+        from airflow.providers.standard import example_dags
+
+        example_dag = make_example_dags(example_dags).get("example_bash_operator")
         sync_dag_to_db(example_dag)
 
         # Mock that there is no access to the Dag File
@@ -141,7 +143,9 @@ class TestDagCode:
 
     def test_db_code_created_on_serdag_change(self, session, testing_dag_bundle):
         """Test new DagCode is created in DB when ser dag is changed"""
-        example_dag = make_example_dags(example_dags_module).get("example_bash_operator")
+        from airflow.providers.standard import example_dags
+
+        example_dag = make_example_dags(example_dags).get("example_bash_operator")
         sync_dag_to_db(example_dag, session=session).create_dagrun(
             run_id="test1",
             run_after=pendulum.datetime(2025, 1, 1, tz="UTC"),

--- a/airflow-core/tests/unit/models/test_serialized_dag.py
+++ b/airflow-core/tests/unit/models/test_serialized_dag.py
@@ -138,14 +138,14 @@ class TestSerializedDagModel:
     def test_serialized_dag_is_updated_if_dag_is_changed(self, testing_dag_bundle):
         """Test Serialized DAG is updated if DAG is changed"""
         example_dags = make_example_dags(example_dags_module)
-        example_bash_op_dag = example_dags.get("example_bash_operator")
+        example_params_trigger_ui = example_dags.get("example_params_trigger_ui")
         dag_updated = SDM.write_dag(
-            dag=LazyDeserializedDAG.from_dag(example_bash_op_dag),
+            dag=LazyDeserializedDAG.from_dag(example_params_trigger_ui),
             bundle_name="testing",
         )
         assert dag_updated is True
 
-        s_dag = SDM.get(example_bash_op_dag.dag_id)
+        s_dag = SDM.get(example_params_trigger_ui.dag_id)
         s_dag.dag.create_dagrun(
             run_id="test1",
             run_after=pendulum.datetime(2025, 1, 1, tz="UTC"),
@@ -157,28 +157,28 @@ class TestSerializedDagModel:
         # Test that if DAG is not changed, Serialized DAG is not re-written and last_updated
         # column is not updated
         dag_updated = SDM.write_dag(
-            dag=LazyDeserializedDAG.from_dag(example_bash_op_dag),
+            dag=LazyDeserializedDAG.from_dag(example_params_trigger_ui),
             bundle_name="testing",
         )
-        s_dag_1 = SDM.get(example_bash_op_dag.dag_id)
+        s_dag_1 = SDM.get(example_params_trigger_ui.dag_id)
 
         assert s_dag_1.dag_hash == s_dag.dag_hash
         assert s_dag.created_at == s_dag_1.created_at
         assert dag_updated is False
 
         # Update DAG
-        example_bash_op_dag.tags.add("new_tag")
-        assert example_bash_op_dag.tags == {"example", "example2", "new_tag"}
+        example_params_trigger_ui.tags.add("new_tag")
+        assert example_params_trigger_ui.tags == {"example", "new_tag", "params"}
 
         dag_updated = SDM.write_dag(
-            dag=LazyDeserializedDAG.from_dag(example_bash_op_dag),
+            dag=LazyDeserializedDAG.from_dag(example_params_trigger_ui),
             bundle_name="testing",
         )
-        s_dag_2 = SDM.get(example_bash_op_dag.dag_id)
+        s_dag_2 = SDM.get(example_params_trigger_ui.dag_id)
 
         assert s_dag.created_at != s_dag_2.created_at
         assert s_dag.dag_hash != s_dag_2.dag_hash
-        assert s_dag_2.data["dag"]["tags"] == ["example", "example2", "new_tag"]
+        assert s_dag_2.data["dag"]["tags"] == ["example", "new_tag", "params"]
         assert dag_updated is True
 
     def test_read_dags(self):
@@ -197,7 +197,7 @@ class TestSerializedDagModel:
         serialized_dags = SDM.read_all_dags()
         assert len(example_dags) == len(serialized_dags)
 
-        dag = example_dags.get("example_bash_operator")
+        dag = example_dags.get("example_params_trigger_ui")
         SerializedDAG.deserialize_dag(SerializedDAG.serialize_dag(dag=dag)).create_dagrun(
             run_id="test1",
             run_after=pendulum.datetime(2025, 1, 1, tz="UTC"),

--- a/devel-common/src/tests_common/test_utils/db.py
+++ b/devel-common/src/tests_common/test_utils/db.py
@@ -188,12 +188,11 @@ def parse_and_sync_to_db(folder: Path | str, include_examples: bool = False):
                 from airflow.dag_processing.dagbag import sync_bag_to_db
             except ImportError:
                 from airflow.models.dagbag import sync_bag_to_db  # type: ignore[no-redef, attribute-defined]
-
+            sync_bag_to_db(dagbag, "dags-folder", None, session=session)
             for bundle in DagBundlesManager().get_all_dag_bundles():
                 dagbag = DagBag(dag_folder=bundle.path, include_examples=include_examples)
                 sync_bag_to_db(dagbag, bundle.name, None, session=session)
 
-            sync_bag_to_db(dagbag, "dags-folder", None, session=session)
         elif AIRFLOW_V_3_0_PLUS:
             dagbag.sync_to_db("dags-folder", None, session)  # type: ignore[attr-defined]
         else:

--- a/devel-common/src/tests_common/test_utils/db.py
+++ b/devel-common/src/tests_common/test_utils/db.py
@@ -189,6 +189,10 @@ def parse_and_sync_to_db(folder: Path | str, include_examples: bool = False):
             except ImportError:
                 from airflow.models.dagbag import sync_bag_to_db  # type: ignore[no-redef, attribute-defined]
 
+            for bundle in DagBundlesManager().get_all_dag_bundles():
+                dagbag = DagBag(dag_folder=bundle.path, include_examples=include_examples)
+                sync_bag_to_db(dagbag, bundle.name, None, session=session)
+
             sync_bag_to_db(dagbag, "dags-folder", None, session=session)
         elif AIRFLOW_V_3_0_PLUS:
             dagbag.sync_to_db("dags-folder", None, session)  # type: ignore[attr-defined]

--- a/providers/arangodb/src/airflow/providers/arangodb/example_dags/search_all.sql
+++ b/providers/arangodb/src/airflow/providers/arangodb/example_dags/search_all.sql
@@ -1,0 +1,18 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/

--- a/providers/arangodb/src/airflow/providers/arangodb/example_dags/search_judy.sql
+++ b/providers/arangodb/src/airflow/providers/arangodb/example_dags/search_judy.sql
@@ -1,0 +1,18 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/

--- a/providers/standard/tests/unit/standard/operators/test_trigger_dagrun.py
+++ b/providers/standard/tests/unit/standard/operators/test_trigger_dagrun.py
@@ -101,7 +101,7 @@ class TestDagRunOperator:
             if AIRFLOW_V_3_0_PLUS:
                 from airflow.models.dagbundle import DagBundleModel
 
-                session.query(DagBundleModel).delete(synchronize_session=False)
+                session.query(DagBundleModel).filter_by(name="test_bundle").delete(synchronize_session=False)
             session.commit()
 
     @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Implementation is different for Airflow 2 & 3")


### PR DESCRIPTION
Fixes : #52469

1. Loading example DAGs purely as bundles
2. Removing the link(copy) between standard example_dags and `airflow-core/standard/example_dags`
3. Fixing testcases to use bundles instead of dagbag folders
5. fixing testcases to use example_dags from the standard module

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
