### PR TITLE
Allow running DAG-related CLI commands without DB

### DIFF
--- a/airflow-core/newsfragments/57306.significant.rst
+++ b/airflow-core/newsfragments/57306.significant.rst
@@ -1,0 +1,32 @@
+Simplify DAG validation workflow by automatically using filesystem when database is empty
+
+The ``airflow dags list`` and ``airflow dags list-import-errors`` commands now automatically load from the filesystem when the database is empty or when specific paths are provided, eliminating the need for the ``--local`` flag in most cases.
+
+**New Features:**
+
+- Both commands now support ``--dagfile-path`` / ``-f`` to inspect a specific DAG file or directory (consistent with ``airflow dags test``)
+- Priority-based source detection: ``--dagfile-path`` > ``--bundle-name`` > local filesystem > database
+- Automatic filesystem fallback when database is empty (useful for local development and CI)
+
+**Deprecation:**
+
+The ``--local`` flag is now deprecated and will be removed in Airflow 4.0. The commands automatically determine the appropriate source, making the flag redundant.
+
+**Migration:**
+
+- If using ``airflow dags list --local``: Simply remove ``--local``, the command works the same way
+- For specific file or directory inspection: Use ``airflow dags list -f /path/to/dag.py`` or ``airflow dags list -f /path/to/dags_folder/``
+- The behavior remains unchanged - the ``--local`` flag still works with a deprecation warning
+
+This change provides a better user experience consistent with ``airflow dags test`` and simplifies DAG validation in CI/CD pipelines and pre-commit hooks.
+
+* Types of change
+
+  * [ ] Dag changes
+  * [ ] Config changes
+  * [ ] API changes
+  * [x] CLI changes
+  * [ ] Behaviour changes
+  * [ ] Plugin changes
+  * [ ] Dependency changes
+  * [ ] Code interface changes

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -167,6 +167,13 @@ ARG_BUNDLE_NAME = Arg(
     default=None,
     action="append",
 )
+ARG_DAGFILE_PATH = Arg(
+    (
+        "-f",
+        "--dagfile-path",
+    ),
+    help="Path to the dag file or directory. Can be absolute or relative to current directory",
+)
 ARG_START_DATE = Arg(("-s", "--start-date"), help="Override start_date YYYY-MM-DD", type=parsedate)
 ARG_END_DATE = Arg(("-e", "--end-date"), help="Override end_date YYYY-MM-DD", type=parsedate)
 ARG_OUTPUT_PATH = Arg(
@@ -233,7 +240,9 @@ ARG_SKIP_SERVE_LOGS = Arg(
 ARG_LIST_LOCAL = Arg(
     ("-l", "--local"),
     action="store_true",
-    help="Shows local parsed DAGs and their import errors, ignores content serialized in DB",
+    help="(DEPRECATED: Will be removed in Airflow 4.0) Shows local parsed DAGs and their import errors, "
+    "ignores content serialized in DB. This flag is now redundant as the command automatically uses "
+    "filesystem when appropriate.",
 )
 
 # list_dag_runs
@@ -361,13 +370,6 @@ ARG_TREAT_DAG_ID_AS_REGEX = Arg(
 )
 
 # test_dag
-ARG_DAGFILE_PATH = Arg(
-    (
-        "-f",
-        "--dagfile-path",
-    ),
-    help="Path to the dag file. Can be absolute or relative to current directory",
-)
 ARG_SHOW_DAGRUN = Arg(
     ("--show-dagrun",),
     help=(
@@ -995,13 +997,20 @@ DAGS_COMMANDS = (
         name="list",
         help="List all the DAGs",
         func=lazy_load_command("airflow.cli.commands.dag_command.dag_list_dags"),
-        args=(ARG_OUTPUT, ARG_VERBOSE, ARG_DAG_LIST_COLUMNS, ARG_BUNDLE_NAME, ARG_LIST_LOCAL),
+        args=(
+            ARG_OUTPUT,
+            ARG_VERBOSE,
+            ARG_DAG_LIST_COLUMNS,
+            ARG_BUNDLE_NAME,
+            ARG_DAGFILE_PATH,
+            ARG_LIST_LOCAL,
+        ),
     ),
     ActionCommand(
         name="list-import-errors",
         help="List all the DAGs that have import errors",
         func=lazy_load_command("airflow.cli.commands.dag_command.dag_list_import_errors"),
-        args=(ARG_BUNDLE_NAME, ARG_OUTPUT, ARG_VERBOSE, ARG_LIST_LOCAL),
+        args=(ARG_BUNDLE_NAME, ARG_OUTPUT, ARG_VERBOSE, ARG_DAGFILE_PATH, ARG_LIST_LOCAL),
     ),
     ActionCommand(
         name="report",


### PR DESCRIPTION
Refactors `airflow dags list` and `airflow dags list-import-errors` to automatically use filesystem when database is empty, eliminating the need for the `--local` flag in most cases.

Commands now follow priority-based source detection:
1. --dagfile-path/-f (specific file or directory)
2. --bundle-name (specific bundle)
3. Local filesystem (automatic when DB empty)
4. Database (fallback)

The `--local` flag is now deprecated (removal in Airflow 4.0) as the commands automatically determine the appropriate source.

Fixes #57306

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
