### PR TITLE
Add hover rotation animation to AirflowPin

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.tsx
@@ -149,12 +149,14 @@ export const Nav = () => {
         <Box mb={3}>
           <NavLink to="/">
             <AirflowPin
+              _motionSafe={{
+                _hover: {
+                  transform: "rotate(360deg)",
+                  transition: "transform 0.8s ease-in-out"
+                }
+              }}
               height="35px"
               width="35px"
-              _hover={{
-                transform: "rotate(360deg)",
-                transition: "transform 0.8s ease-in-out"
-              }}
             />
           </NavLink>
         </Box>

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.tsx
@@ -148,7 +148,14 @@ export const Nav = () => {
       <Flex alignItems="center" flexDir="column" width="100%">
         <Box mb={3}>
           <NavLink to="/">
-            <AirflowPin height="35px" width="35px" />
+            <AirflowPin
+              height="35px"
+              width="35px"
+              _hover={{
+                transform: "rotate(360deg)",
+                transition: "transform 0.8s ease-in-out"
+              }}
+            />
           </NavLink>
         </Box>
         <NavButton icon={<FiHome size="28px" />} title={translate("nav.home")} to="/" />


### PR DESCRIPTION
In Airflow 2.x, the Airflow pin used to spin when hovered over, but it seems to have been removed in Airflow 3.x, 
so I added it!


https://github.com/user-attachments/assets/a5df8e6b-5e0e-43d1-82a6-8c07750edd78


https://github.com/user-attachments/assets/8626e1fd-9860-4764-b77f-4ff8b422139d


https://github.com/user-attachments/assets/65427ff6-1360-4dc0-a3b8-980f2872b04f



<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
