### PR TITLE
remove outdated note from upgrading docs

### DIFF
--- a/airflow-core/docs/installation/upgrading_to_airflow3.rst
+++ b/airflow-core/docs/installation/upgrading_to_airflow3.rst
@@ -61,7 +61,7 @@ Step 1: Take care of prerequisites
 ----------------------------------
 
 - Make sure that you are on Airflow 2.7 or later. It is recommended to upgrade to latest 2.x and then to Airflow 3.
-- Make sure that your Python version is in the supported list. Airflow 3.0.0 supports the following Python versions: Python 3.9, 3.10, 3.11 and 3.12.
+- Make sure that your Python version is in the supported list.
 - Ensure that you are not using any features or functionality that have been :ref:`removed in Airflow 3<breaking-changes>`.
 
 


### PR DESCRIPTION
The line is specific to airflow 3.0.0 which is not right.
I don't think we need to mention/maintain again the list of supported versions... I think it's safe to assume that users who are following the upgrade guide already knows this (much like we don't specify k8s/postgresql/mysql supported versions)