### PR TITLE
UI: Add data interval override option for manual DAG runs

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/components.json
@@ -114,6 +114,11 @@
   "toggleTableView": "Show table view",
   "triggerDag": {
     "button": "Trigger",
+    "dataInterval": "Data Interval",
+    "dataIntervalAuto": "Inferred from Logical Date and Timetable",
+    "dataIntervalManual": "Specify Manually",
+    "intervalEnd": "End",
+    "intervalStart": "Start",
     "loading": "Loading Dag information...",
     "loadingFailed": "Failed to load Dag information. Please try again.",
     "runIdHelp": "Optional - will be generated if not provided",

--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGAdvancedOptions.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGAdvancedOptions.tsx
@@ -1,0 +1,84 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Input, Field, Stack } from "@chakra-ui/react";
+import { Controller, type Control } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+
+import EditableMarkdown from "./EditableMarkdown";
+import type { DagRunTriggerParams } from "./TriggerDAGForm";
+
+type TriggerDAGAdvancedOptionsProps = {
+  readonly control: Control<DagRunTriggerParams>;
+};
+
+const TriggerDAGAdvancedOptions = ({ control }: TriggerDAGAdvancedOptionsProps) => {
+  const { t: translate } = useTranslation(["common", "components"]);
+  const { t: rootTranslate } = useTranslation();
+
+  return (
+    <>
+      <Controller
+        control={control}
+        name="dagRunId"
+        render={({ field }) => (
+          <Field.Root mt={6} orientation="horizontal">
+            <Stack>
+              <Field.Label fontSize="md" style={{ flexBasis: "30%" }}>
+                {translate("runId")}
+              </Field.Label>
+            </Stack>
+            <Stack css={{ flexBasis: "70%" }}>
+              <Input {...field} size="sm" />
+              <Field.HelperText>{translate("components:triggerDag.runIdHelp")}</Field.HelperText>
+            </Stack>
+          </Field.Root>
+        )}
+      />
+
+      <Controller
+        control={control}
+        name="partitionKey"
+        render={({ field }) => (
+          <Field.Root mt={6} orientation="horizontal">
+            <Stack>
+              <Field.Label fontSize="md" style={{ flexBasis: "30%" }}>
+                {rootTranslate("dagRun.partitionKey")}
+              </Field.Label>
+            </Stack>
+            <Stack css={{ flexBasis: "70%" }}>
+              <Input {...field} size="sm" />
+            </Stack>
+          </Field.Root>
+        )}
+      />
+      <Controller
+        control={control}
+        name="note"
+        render={({ field }) => (
+          <Field.Root mt={6}>
+            <Field.Label fontSize="md">{translate("note.dagRun")}</Field.Label>
+            <EditableMarkdown field={field} placeholder={translate("note.placeholder")} />
+          </Field.Root>
+        )}
+      />
+    </>
+  );
+};
+
+export default TriggerDAGAdvancedOptions;

--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -46,6 +46,8 @@ type TriggerDAGFormProps = {
 export type DagRunTriggerParams = {
   conf: string;
   dagRunId: string;
+  dataIntervalEnd: string;
+  dataIntervalStart: string;
   logicalDate: string;
   note: string;
   partitionKey: string | undefined;
@@ -63,10 +65,12 @@ const TriggerDAGForm = ({ dagDisplayName, dagId, isPaused, onClose, open }: Trig
 
   const { mutate: togglePause } = useTogglePause({ dagId });
 
-  const { control, handleSubmit, reset } = useForm<DagRunTriggerParams>({
+  const { control, handleSubmit, reset, watch } = useForm<DagRunTriggerParams>({
     defaultValues: {
       conf,
       dagRunId: "",
+      dataIntervalEnd: dayjs().startOf('minute').format(DEFAULT_DATETIME_FORMAT),
+      dataIntervalStart: dayjs().startOf('minute').format(DEFAULT_DATETIME_FORMAT),
       // Default logical date to now, show it in the selected timezone
       logicalDate: dayjs().format(DEFAULT_DATETIME_FORMAT),
       note: "",
@@ -87,6 +91,10 @@ const TriggerDAGForm = ({ dagDisplayName, dagId, isPaused, onClose, open }: Trig
   const resetDateError = () => {
     setErrors((prev) => ({ ...prev, date: undefined }));
   };
+
+  const dataIntervalStart = watch("dataIntervalStart");
+  const dataIntervalEnd = watch("dataIntervalEnd");
+  const dataIntervalInvalid = dayjs(dataIntervalStart).isAfter(dayjs(dataIntervalEnd));
 
   const onSubmit = (data: DagRunTriggerParams) => {
     if (unpause && isPaused) {
@@ -128,6 +136,40 @@ const TriggerDAGForm = ({ dagDisplayName, dagId, isPaused, onClose, open }: Trig
 
         <Controller
           control={control}
+          name="dataIntervalStart"
+          render={({ field }) => (
+            <Field.Root invalid={Boolean(errors.date) || dataIntervalInvalid} orientation="horizontal">
+              <Stack>
+                <Field.Label fontSize="md" style={{ flexBasis: "30%" }}>
+                  {translate("dagRun.dataIntervalStart")}
+                </Field.Label>
+              </Stack>
+              <Stack css={{ flexBasis: "70%" }}>
+                <DateTimeInput {...field} onBlur={resetDateError} size="sm" />
+              </Stack>              
+            </Field.Root>
+          )}
+        />
+
+        <Controller
+          control={control}
+          name="dataIntervalEnd"
+          render={({ field }) => (
+            <Field.Root invalid={Boolean(errors.date) || dataIntervalInvalid} orientation="horizontal">
+              <Stack>
+                <Field.Label fontSize="md" style={{ flexBasis: "30%" }}>
+                  {translate("dagRun.dataIntervalEnd")}
+                </Field.Label>
+              </Stack>
+              <Stack css={{ flexBasis: "70%" }}>
+                <DateTimeInput {...field} onBlur={resetDateError} size="sm" />
+              </Stack>
+            </Field.Root>
+          )}
+        />
+
+        <Controller
+          control={control}
           name="dagRunId"
           render={({ field }) => (
             <Field.Root mt={6} orientation="horizontal">
@@ -143,6 +185,7 @@ const TriggerDAGForm = ({ dagDisplayName, dagId, isPaused, onClose, open }: Trig
             </Field.Root>
           )}
         />
+
         <Controller
           control={control}
           name="partitionKey"

--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -138,7 +138,7 @@ const TriggerDAGForm = ({ dagDisplayName, dagId, isPaused, onClose, open }: Trig
           control={control}
           name="dataIntervalStart"
           render={({ field }) => (
-            <Field.Root invalid={Boolean(errors.date) || dataIntervalInvalid} orientation="horizontal">
+            <Field.Root invalid={Boolean(errors.date) || dataIntervalInvalid} mt={6} orientation="horizontal">
               <Stack>
                 <Field.Label fontSize="md" style={{ flexBasis: "30%" }}>
                   {translate("dagRun.dataIntervalStart")}
@@ -155,7 +155,7 @@ const TriggerDAGForm = ({ dagDisplayName, dagId, isPaused, onClose, open }: Trig
           control={control}
           name="dataIntervalEnd"
           render={({ field }) => (
-            <Field.Root invalid={Boolean(errors.date) || dataIntervalInvalid} orientation="horizontal">
+            <Field.Root invalid={Boolean(errors.date) || dataIntervalInvalid} mt={6} orientation="horizontal">
               <Stack>
                 <Field.Label fontSize="md" style={{ flexBasis: "30%" }}>
                   {translate("dagRun.dataIntervalEnd")}

--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Button, Box, Spacer, HStack, Input, Field, Stack } from "@chakra-ui/react";
+import { Button, Box, Spacer, HStack, Field, Stack, Text, VStack } from "@chakra-ui/react";
 import dayjs from "dayjs";
 import { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
@@ -33,29 +33,45 @@ import ConfigForm from "../ConfigForm";
 import { DateTimeInput } from "../DateTimeInput";
 import { ErrorAlert } from "../ErrorAlert";
 import { Checkbox } from "../ui/Checkbox";
-import EditableMarkdown from "./EditableMarkdown";
+import { RadioCardItem, RadioCardRoot } from "../ui/RadioCard";
+import TriggerDAGAdvancedOptions from "./TriggerDAGAdvancedOptions";
 
 type TriggerDAGFormProps = {
   readonly dagDisplayName: string;
   readonly dagId: string;
+  readonly hasSchedule: boolean;
   readonly isPaused: boolean;
   readonly onClose: () => void;
   readonly open: boolean;
 };
 
+type DataIntervalMode = "auto" | "manual";
+
 export type DagRunTriggerParams = {
   conf: string;
   dagRunId: string;
   dataIntervalEnd: string;
+  dataIntervalMode: DataIntervalMode;
   dataIntervalStart: string;
   logicalDate: string;
   note: string;
   partitionKey: string | undefined;
 };
 
-const TriggerDAGForm = ({ dagDisplayName, dagId, isPaused, onClose, open }: TriggerDAGFormProps) => {
+const dataIntervalModeOptions: Array<{ label: string; value: DataIntervalMode }> = [
+  { label: "components:triggerDag.dataIntervalAuto", value: "auto" },
+  { label: "components:triggerDag.dataIntervalManual", value: "manual" },
+];
+
+const TriggerDAGForm = ({
+  dagDisplayName,
+  dagId,
+  hasSchedule,
+  isPaused,
+  onClose,
+  open,
+}: TriggerDAGFormProps) => {
   const { t: translate } = useTranslation(["common", "components"]);
-  const { t: rootTranslate } = useTranslation();
   const [errors, setErrors] = useState<{ conf?: string; date?: unknown }>({});
   const [formError, setFormError] = useState(false);
   const initialParamsDict = useDagParams(dagId, open);
@@ -69,8 +85,9 @@ const TriggerDAGForm = ({ dagDisplayName, dagId, isPaused, onClose, open }: Trig
     defaultValues: {
       conf,
       dagRunId: "",
-      dataIntervalEnd: dayjs().startOf('minute').format(DEFAULT_DATETIME_FORMAT),
-      dataIntervalStart: dayjs().startOf('minute').format(DEFAULT_DATETIME_FORMAT),
+      dataIntervalEnd: "",
+      dataIntervalMode: "auto",
+      dataIntervalStart: "",
       // Default logical date to now, show it in the selected timezone
       logicalDate: dayjs().format(DEFAULT_DATETIME_FORMAT),
       note: "",
@@ -92,9 +109,13 @@ const TriggerDAGForm = ({ dagDisplayName, dagId, isPaused, onClose, open }: Trig
     setErrors((prev) => ({ ...prev, date: undefined }));
   };
 
+  const dataIntervalMode = watch("dataIntervalMode");
   const dataIntervalStart = watch("dataIntervalStart");
   const dataIntervalEnd = watch("dataIntervalEnd");
-  const dataIntervalInvalid = dayjs(dataIntervalStart).isAfter(dayjs(dataIntervalEnd));
+  const noDataInterval = !Boolean(dataIntervalStart) || !Boolean(dataIntervalEnd);
+  const dataIntervalInvalid =
+    dataIntervalMode === "manual" &&
+    (noDataInterval || dayjs(dataIntervalStart).isAfter(dayjs(dataIntervalEnd)));
 
   const onSubmit = (data: DagRunTriggerParams) => {
     if (unpause && isPaused) {
@@ -109,14 +130,9 @@ const TriggerDAGForm = ({ dagDisplayName, dagId, isPaused, onClose, open }: Trig
   };
 
   return (
-    <Box mt={8}>
-      <ConfigForm
-        control={control}
-        errors={errors}
-        initialParamsDict={initialParamsDict}
-        setErrors={setErrors}
-        setFormError={setFormError}
-      >
+    <>
+      <ErrorAlert error={errors.date ?? errorTrigger} />
+      <VStack alignItems="stretch" gap={2} pt={4}>
         <Controller
           control={control}
           name="logicalDate"
@@ -133,104 +149,96 @@ const TriggerDAGForm = ({ dagDisplayName, dagId, isPaused, onClose, open }: Trig
             </Field.Root>
           )}
         />
-
-        <Controller
+        <Spacer />
+        {hasSchedule ? (
+          <Box>
+            <Text fontSize="md" fontWeight="semibold" mb={3}>
+              {translate("components:triggerDag.dataInterval")}
+            </Text>
+            <Controller
+              control={control}
+              name="dataIntervalMode"
+              render={({ field }) => (
+                <RadioCardRoot defaultValue={String(field.value)} onChange={field.onChange}>
+                  <HStack align="stretch">
+                    {dataIntervalModeOptions.map((mode) => (
+                      <RadioCardItem
+                        colorPalette="brand"
+                        indicatorPlacement="start"
+                        key={mode.value}
+                        label={translate(mode.label)}
+                        value={mode.value}
+                      />
+                    ))}
+                  </HStack>
+                </RadioCardRoot>
+              )}
+            />
+            <Spacer />
+            {dataIntervalMode === "manual" ? (
+              <HStack alignItems="flex-start" mt={3} w="full">
+                <Controller
+                  control={control}
+                  name="dataIntervalStart"
+                  render={({ field }) => (
+                    <Field.Root invalid={Boolean(errors.date) || dataIntervalInvalid} required>
+                      <Field.Label>{translate("components:triggerDag.intervalStart")}</Field.Label>
+                      <DateTimeInput {...field} onBlur={resetDateError} size="sm" />
+                    </Field.Root>
+                  )}
+                />
+                <Controller
+                  control={control}
+                  name="dataIntervalEnd"
+                  render={({ field }) => (
+                    <Field.Root invalid={Boolean(errors.date) || dataIntervalInvalid} required>
+                      <Field.Label>{translate("components:triggerDag.intervalEnd")}</Field.Label>
+                      <DateTimeInput {...field} onBlur={resetDateError} size="sm" />
+                    </Field.Root>
+                  )}
+                />
+              </HStack>
+            ) : // eslint-disable-next-line unicorn/no-null
+            null}
+          </Box>
+        ) : // eslint-disable-next-line unicorn/no-null
+        null}
+        <Spacer />
+        {isPaused ? (
+          <>
+            <Checkbox
+              checked={unpause}
+              colorPalette="brand"
+              onChange={() => setUnpause(!unpause)}
+              wordBreak="break-all"
+            >
+              {translate("components:triggerDag.unpause", { dagDisplayName })}
+            </Checkbox>
+            <Spacer />
+          </>
+        ) : undefined}
+        <ConfigForm
           control={control}
-          name="dataIntervalStart"
-          render={({ field }) => (
-            <Field.Root invalid={Boolean(errors.date) || dataIntervalInvalid} mt={6} orientation="horizontal">
-              <Stack>
-                <Field.Label fontSize="md" style={{ flexBasis: "30%" }}>
-                  {translate("dagRun.dataIntervalStart")}
-                </Field.Label>
-              </Stack>
-              <Stack css={{ flexBasis: "70%" }}>
-                <DateTimeInput {...field} onBlur={resetDateError} size="sm" />
-              </Stack>              
-            </Field.Root>
-          )}
-        />
-
-        <Controller
-          control={control}
-          name="dataIntervalEnd"
-          render={({ field }) => (
-            <Field.Root invalid={Boolean(errors.date) || dataIntervalInvalid} mt={6} orientation="horizontal">
-              <Stack>
-                <Field.Label fontSize="md" style={{ flexBasis: "30%" }}>
-                  {translate("dagRun.dataIntervalEnd")}
-                </Field.Label>
-              </Stack>
-              <Stack css={{ flexBasis: "70%" }}>
-                <DateTimeInput {...field} onBlur={resetDateError} size="sm" />
-              </Stack>
-            </Field.Root>
-          )}
-        />
-
-        <Controller
-          control={control}
-          name="dagRunId"
-          render={({ field }) => (
-            <Field.Root mt={6} orientation="horizontal">
-              <Stack>
-                <Field.Label fontSize="md" style={{ flexBasis: "30%" }}>
-                  {translate("runId")}
-                </Field.Label>
-              </Stack>
-              <Stack css={{ flexBasis: "70%" }}>
-                <Input {...field} size="sm" />
-                <Field.HelperText>{translate("components:triggerDag.runIdHelp")}</Field.HelperText>
-              </Stack>
-            </Field.Root>
-          )}
-        />
-
-        <Controller
-          control={control}
-          name="partitionKey"
-          render={({ field }) => (
-            <Field.Root mt={6} orientation="horizontal">
-              <Stack>
-                <Field.Label fontSize="md" style={{ flexBasis: "30%" }}>
-                  {rootTranslate("dagRun.partitionKey")}
-                </Field.Label>
-              </Stack>
-              <Stack css={{ flexBasis: "70%" }}>
-                <Input {...field} size="sm" />
-              </Stack>
-            </Field.Root>
-          )}
-        />
-        <Controller
-          control={control}
-          name="note"
-          render={({ field }) => (
-            <Field.Root mt={6}>
-              <Field.Label fontSize="md">{translate("note.dagRun")}</Field.Label>
-              <EditableMarkdown field={field} placeholder={translate("note.placeholder")} />
-            </Field.Root>
-          )}
-        />
-      </ConfigForm>
-      {isPaused ? (
-        <Checkbox
-          checked={unpause}
-          colorPalette="brand"
-          onChange={() => setUnpause(!unpause)}
-          wordBreak="break-all"
+          errors={errors}
+          initialParamsDict={initialParamsDict}
+          setErrors={setErrors}
+          setFormError={setFormError}
         >
-          {translate("components:triggerDag.unpause", { dagDisplayName })}
-        </Checkbox>
-      ) : undefined}
-      <ErrorAlert error={errors.date ?? errorTrigger} />
+          <TriggerDAGAdvancedOptions control={control} />
+        </ConfigForm>
+      </VStack>
       <Box as="footer" display="flex" justifyContent="flex-end" mt={4}>
         <HStack w="full">
           <Spacer />
           <Button
             colorPalette="brand"
             disabled={
-              Boolean(errors.conf) || Boolean(errors.date) || formError || isPending || Boolean(errorTrigger)
+              Boolean(errors.conf) ||
+              Boolean(errors.date) ||
+              formError ||
+              isPending ||
+              Boolean(errorTrigger) ||
+              dataIntervalInvalid
             }
             onClick={() => void handleSubmit(onSubmit)()}
           >
@@ -238,7 +246,7 @@ const TriggerDAGForm = ({ dagDisplayName, dagId, isPaused, onClose, open }: Trig
           </Button>
         </HStack>
       </Box>
-    </Box>
+    </>
   );
 };
 

--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGModal.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGModal.tsx
@@ -125,6 +125,7 @@ const TriggerDAGModal: React.FC<TriggerDAGModalProps> = ({
                 <TriggerDAGForm
                   dagDisplayName={dagDisplayName}
                   dagId={dagId}
+                  hasSchedule={hasSchedule}
                   isPaused={isPaused}
                   onClose={onClose}
                   open={open}

--- a/airflow-core/src/airflow/ui/src/queries/useTrigger.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useTrigger.ts
@@ -80,9 +80,20 @@ export const useTrigger = ({ dagId, onSuccessConfirm }: { dagId: string; onSucce
     const parsedConfig = JSON.parse(dagRunRequestBody.conf) as Record<string, unknown>;
 
     const logicalDate = dagRunRequestBody.logicalDate ? new Date(dagRunRequestBody.logicalDate) : undefined;
-
     // eslint-disable-next-line unicorn/no-null
     const formattedLogicalDate = logicalDate?.toISOString() ?? null;
+
+    const dataIntervalStart = dagRunRequestBody.dataIntervalStart
+      ? new Date(dagRunRequestBody.dataIntervalStart)
+      : undefined;
+    // eslint-disable-next-line unicorn/no-null
+    const formattedDataIntervalStart = dataIntervalStart?.toISOString() ?? null;
+
+    const dataIntervalEnd = dagRunRequestBody.dataIntervalEnd
+      ? new Date(dagRunRequestBody.dataIntervalEnd)
+      : undefined;
+    // eslint-disable-next-line unicorn/no-null
+    const formattedDataIntervalEnd = dataIntervalEnd?.toISOString() ?? null;
 
     const checkDagRunId = dagRunRequestBody.dagRunId === "" ? undefined : dagRunRequestBody.dagRunId;
     const checkNote = dagRunRequestBody.note === "" ? undefined : dagRunRequestBody.note;
@@ -92,6 +103,8 @@ export const useTrigger = ({ dagId, onSuccessConfirm }: { dagId: string; onSucce
       requestBody: {
         conf: parsedConfig,
         dag_run_id: checkDagRunId,
+        data_interval_end: formattedDataIntervalEnd,
+        data_interval_start: formattedDataIntervalStart,
         logical_date: formattedLogicalDate,
         note: checkNote,
         partition_key: dagRunRequestBody.partitionKey ?? null,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
This PR modifies the modal for triggering a single DAG run manually. The primary change is to allow the user to specify the data interval manually.

List of changes:
- If the DAG has a timetable, added a section in the form for specifying the data interval. There are two options:
  - "Interred from Logical Data and Timetable" (default): This will set `data_interval_start` and `data_interval_end` as `null` in the API call (same as current behaviour
  - "Specify Manually": When selected, displayed 2 date/time pickers for the user to enter the date range. There is some validation: Both dates are mandatory and the end date should be greater or equal to start date.
- Moved "Logical Date" and "Data Interval" out of the "Advanced Options" section.
- Split `TriggerDAGForm` into two components, breaking `TriggerDGAdvancedOptions` to its own file.
- Added some new localisation strings to `components.json`.  I am not familiar with the process for adding translations, or any related automations; I have only included the English one.

***Screenshots**
DAG with time table - Default option:
<img width="911" height="640" alt="image" src="https://github.com/user-attachments/assets/046bf48c-1192-4c37-b3e9-da9c95fa9c3c" />

DAG with time table - Manual interval:
<img width="918" height="730" alt="image" src="https://github.com/user-attachments/assets/0a51db8e-f2dd-48aa-9307-2aacaa8b341d" />

DAG without time table:
<img width="918" height="858" alt="image" src="https://github.com/user-attachments/assets/b390bc39-dbee-4c3e-8743-98f062aab1c9" />


**Reasoning behind this change**
* `data_interval_start` and `data_interval_end` are optional when making the API call. This is not transparent to the user, I think it would be better UX if the user can see and alter the data interval that will be used when triggering a DAG.
* There is a comment in [here](https://github.com/apache/airflow/blob/main/airflow-core/src/airflow/models/dag.py#L145) that seems to infer that the data interval should always be defined when DAGs are automatically scheduled. If it is the case, it would make sense to have the same requirement for manual triggers.
* About putting "Logical Date" and "Data Interval" outside of "Advanced Options": This change might be controversial, I believe that those are such key parameters to DAG runs that they deserve being always displayed to the user. That makes the modal bigger as a consequence but it is still smaller than with the "Backfill" option. 

** Possible future improvements **
When selecting "Inferred Data Interval", it would be better UX to display to the user what this inferred interval is. It could be achieved by adding an API endpoint could be added to fetch the data interval for a specified logical date.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
