### PR TITLE
Fix DagRun translation file not found

### DIFF
--- a/airflow-core/src/airflow/ui/src/constants/filterConfigs.tsx
+++ b/airflow-core/src/airflow/ui/src/constants/filterConfigs.tsx
@@ -48,7 +48,7 @@ export enum FilterTypes {
 }
 
 export const useFilterConfigs = () => {
-  const { t: translate } = useTranslation(["browse", "common", "admin", "hitl", "dagRun"]);
+  const { t: translate } = useTranslation(["browse", "common", "admin", "hitl"]);
 
   const filterConfigMap = {
     [SearchParamsKeys.AFTER]: {


### PR DESCRIPTION
During the review of other PRs, I realized that we were loading a translation file that does not exist. 

This removed the loading of the `dagRun.json` translation file.