### PR TITLE
Bugfix/support Subpath w/o Execution API Url

### DIFF
--- a/providers/edge3/docs/deployment.rst
+++ b/providers/edge3/docs/deployment.rst
@@ -52,7 +52,7 @@ Minimum Airflow configuration settings for the Edge Worker to make it running is
 
   - ``execution_api_server_url``: If not set, the base URL from ``edge.api_url`` will be used. For example,
     when ``edge.api_url`` is set to ``https://your-hostname-and-port/subpath/edge_worker/v1/rpcapi``, it will
-    default to ``https://your-hostname-and-port/subpath/execution/`` (starting from version 3.0.0).
+    default to ``https://your-hostname-and-port/subpath/execution/`` (starting from version Airflow version 3.0.0).
   - ``executor``: Executor must be set or added to be ``airflow.providers.edge3.executors.EdgeExecutor``
   - ``internal_api_secret_key``: An encryption key must be set on api-server and Edge Worker component as
     shared secret to authenticate traffic. It should be a random string like the fernet key

--- a/providers/edge3/docs/deployment.rst
+++ b/providers/edge3/docs/deployment.rst
@@ -51,8 +51,8 @@ Minimum Airflow configuration settings for the Edge Worker to make it running is
 - Section ``[core]``
 
   - ``execution_api_server_url``: If not set, the base URL from ``edge.api_url`` will be used. For example,
-    when ``edge.api_url`` is set to ``https://your-hostname-and-port/edge_worker/v1/rpcapi``, it will
-    default to ``https://your-hostname-and-port/execution/``.
+    when ``edge.api_url`` is set to ``https://your-hostname-and-port/subpath/edge_worker/v1/rpcapi``, it will
+    default to ``https://your-hostname-and-port/subpath/execution/`` (starting from version 3.0.0).
   - ``executor``: Executor must be set or added to be ``airflow.providers.edge3.executors.EdgeExecutor``
   - ``internal_api_secret_key``: An encryption key must be set on api-server and Edge Worker component as
     shared secret to authenticate traffic. It should be a random string like the fernet key

--- a/providers/edge3/src/airflow/providers/edge3/cli/worker.py
+++ b/providers/edge3/src/airflow/providers/edge3/cli/worker.py
@@ -188,7 +188,7 @@ class EdgeWorker:
         return execution_api_server_url
 
     @staticmethod
-    def _run_job_via_supervisor(workload) -> int:
+    def _run_job_via_supervisor(workload, execution_api_server_url) -> int:
         from airflow.sdk.execution_time.supervisor import supervise
 
         # Ignore ctrl-c in this process -- we don't want to kill _this_ one. we let tasks run to completion
@@ -205,7 +205,7 @@ class EdgeWorker:
                 dag_rel_path=workload.dag_rel_path,
                 bundle_info=workload.bundle_info,
                 token=workload.token,
-                server=EdgeWorker._execution_api_server_url(),
+                server=execution_api_server_url,
                 log_path=workload.log_path,
             )
             return 0
@@ -221,7 +221,7 @@ class EdgeWorker:
         workload: ExecuteTask = edge_job.command
         process = Process(
             target=EdgeWorker._run_job_via_supervisor,
-            kwargs={"workload": workload},
+            kwargs={"workload": workload, "execution_api_server_url": EdgeWorker._execution_api_server_url()},
         )
         process.start()
         base_log_folder = conf.get("logging", "base_log_folder", fallback="NOT AVAILABLE")

--- a/providers/edge3/tests/unit/edge3/cli/test_worker.py
+++ b/providers/edge3/tests/unit/edge3/cli/test_worker.py
@@ -167,12 +167,12 @@ class TestEdgeWorker:
         "configs, expected_url",
         [
             (
-                {("edge", "api_url"): "https://api-endpoint"},
-                "https://api-endpoint/execution/",
+                {("edge", "api_url"): "https://api-host/edge_worker/v1/rpcapi"},
+                "https://api-host/execution",
             ),
             (
-                {("edge", "api_url"): "https://api:1234/endpoint"},
-                "https://api:1234/execution/",
+                {("edge", "api_url"): "https://api:1234/subpath/edge_worker/v1/rpcapi"},
+                "https://api:1234/subpath/execution",
             ),
             (
                 {
@@ -183,16 +183,24 @@ class TestEdgeWorker:
             ),
         ],
     )
+    def test_execution_api_server_url(
+        self,
+        configs,
+        expected_url,
+    ):
+        with conf_vars(configs):
+            EdgeWorker._execution_api_server_url.cache_clear()
+            url = EdgeWorker._execution_api_server_url()
+            assert url == expected_url
+
     @patch("airflow.sdk.execution_time.supervisor.supervise")
     @patch("airflow.providers.edge3.cli.worker.Process")
     @patch("airflow.providers.edge3.cli.worker.Popen")
-    def test_use_execution_api_server_url(
+    def test_supervise_launch(
         self,
         mock_popen,
         mock_process,
         mock_supervise,
-        configs,
-        expected_url,
         worker_with_job: EdgeWorker,
     ):
         mock_popen.side_effect = [MagicMock()]
@@ -200,13 +208,12 @@ class TestEdgeWorker:
         mock_process.side_effect = [mock_process_instance]
 
         edge_job = EdgeWorker.jobs.pop().edge_job
-        with conf_vars(configs):
-            worker_with_job._launch_job(edge_job)
+        worker_with_job._launch_job(edge_job)
 
-            mock_process_callback = mock_process.call_args.kwargs["target"]
-            mock_process_callback(workload=MagicMock())
+        mock_process_callback = mock_process.call_args.kwargs["target"]
+        mock_process_callback(workload=MagicMock(), execution_api_server_url="http://mock-url")
 
-            assert mock_supervise.call_args.kwargs["server"] == expected_url
+        assert mock_supervise.call_args.kwargs["server"] == "http://mock-url"
 
     @pytest.mark.parametrize(
         "reserve_result, fetch_result, expected_calls",

--- a/providers/edge3/tests/unit/edge3/cli/test_worker.py
+++ b/providers/edge3/tests/unit/edge3/cli/test_worker.py
@@ -193,6 +193,7 @@ class TestEdgeWorker:
             url = EdgeWorker._execution_api_server_url()
             assert url == expected_url
 
+    @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Test requires Airflow 3+")
     @patch("airflow.sdk.execution_time.supervisor.supervise")
     @patch("airflow.providers.edge3.cli.worker.Process")
     @patch("airflow.providers.edge3.cli.worker.Popen")


### PR DESCRIPTION
We noticed that the execution URL needs to be added explicitly when deploying to a sub-path. This is a "burden" for Edge because other workers which are running inK8s (e.g. Celery) still benefit from an internal API endpoint.

If not provided the grepping of the execution API URL is now following the edge API URL per default and includes support of sub-path. Also the URL is logged (once) which makes error triaging easier.

FYI @dheerajturaga 