### PR TITLE
Add Content-Type to Request Header in Task SDK calls

### DIFF
--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -896,6 +896,10 @@ class Client(httpx.Client):
     )
     def request(self, *args, **kwargs):
         """Implement a convenience for httpx.Client.request with a retry layer."""
+        # Set content type as convenience if not already set
+        if "content" in kwargs and "headers" not in kwargs:
+            kwargs["headers"] = {"content-type": "application/json"}
+
         return super().request(*args, **kwargs)
 
     # We "group" or "namespace" operations by what they operate on, rather than a flat namespace with all


### PR DESCRIPTION
We deployed Airflow3 today first time together with Edge Worker in our environment. (I know way too late, but still now getting started...)

We received HTTP 403 from the client as our WAF rejected calls with POST/PATH w/o appropriate content-type sent with the request.

Whereas technically not needed and we know how communication runs between client and server, we needed to add an exception to make remote deployment via Edge possible.

Therefore I'd suggest - even if technically not needed - to add a proper content-type to request header if a body is sent This will lower trouble in other deployments hard to debug on WAF and especially in security hardened environment.