### PR TITLE
Format multiline config values with indentation in AirflowConfigParser

### DIFF
--- a/airflow-core/src/airflow/configuration.py
+++ b/airflow-core/src/airflow/configuration.py
@@ -590,6 +590,10 @@ class AirflowConfigParser(ConfigParser):
                 value = "\n# ".join(value_lines)
                 file.write(f"# {option} = {value}\n")
             else:
+                if "\n" in value:
+                    indent = " " * 4
+                    lines = value.splitlines()
+                    value = "\n".join([lines[0]] + [f"{indent}{line}" for line in lines[1:]])
                 file.write(f"{option} = {value}\n")
         if needs_separation:
             file.write("\n")


### PR DESCRIPTION
Related: #57355

# Why
The code here doesn't handle indentation and leads to a `configparser.ParsingError`.

https://github.com/apache/airflow/blob/8695fc533d5efd07952a670cafbb0f120639d0ba/airflow-core/src/airflow/configuration.py#L592-L593

# How
Add indentation when the value contains `\n`.

# What
The output is shown below:
```console
root@177f2f0ad9ed:/opt/airflow# airflow config list --include-descriptions --include-examples | grep "dag_bundle_config_list" -A 10
/opt/airflow/airflow-core/src/airflow/dag_processing/dagbag.py:40 DeprecationWarning: airflow.exceptions.AirflowDagCycleException is deprecated. Use airflow.sdk.exceptions.AirflowDagCycleException instead.
# Example: dag_bundle_config_list = [
#       {
#         "name": "my-git-repo",
#         "classpath": "airflow.providers.git.bundles.git.GitDagBundle",
#         "kwargs": {
#           "subdir": "dags",
#           "tracking_ref": "main",
#           "refresh_interval": 0
#         }
#       }
#     ]
dag_bundle_config_list = [
    {
    "name": "dags-folder",
    "classpath": "airflow.dag_processing.bundles.local.LocalDagBundle",
    "kwargs": {}
    }
    ]

# How often (in seconds) to refresh, or look for new files, in a DAG bundle.
refresh_interval = 300
```

I think we don't need modify it like a JSON-style indenting here, because [configparser](https://docs.python.org/3/library/configparser.html) only checks the INI structure.

Validation (no errors):
```console
root@177f2f0ad9ed:/opt/airflow# python - <<'PY'
import configparser, pathlib, sys
p = configparser.ConfigParser()
p.read(pathlib.Path("airflow_new.cfg"))
PY
root@177f2f0ad9ed:/opt/airflow# 
```