### PR TITLE
Enable PT011 rule to airflow-core tests

### DIFF
--- a/airflow-core/tests/unit/models/test_dagrun.py
+++ b/airflow-core/tests/unit/models/test_dagrun.py
@@ -2805,7 +2805,7 @@ def test_dag_run_id_config(session, dag_maker, pattern, run_id, result):
         if result:
             dag_maker.create_dagrun(run_id=run_id, run_type=run_type)
         else:
-            with pytest.raises(ValueError):
+            with pytest.raises(ValueError, match=r"The run_id provided '.+' does not match regex pattern"):
                 dag_maker.create_dagrun(run_id=run_id, run_type=run_type)
 
 

--- a/airflow-core/tests/unit/models/test_deadline.py
+++ b/airflow-core/tests/unit/models/test_deadline.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import re
 from datetime import datetime, timedelta
 from unittest import mock
 
@@ -551,13 +552,12 @@ class TestDeadlineReference:
     def test_deadline_missing_required_kwargs(self, reference, session):
         """Test that deadlines raise appropriate errors for missing required parameters."""
         if reference.required_kwargs:
-            with pytest.raises(ValueError) as raised_exception:
+            with pytest.raises(
+                ValueError, match=re.escape(f"{reference.__class__.__name__} is missing required parameters:")
+            ) as raised_exception:
                 reference.evaluate_with(session=session, **self.DEFAULT_ARGS)
-            expected_substrings = {
-                f"{reference.__class__.__name__} is missing required parameters: ",
-                *reference.required_kwargs,
-            }
-            assert all(substring in str(raised_exception.value) for substring in expected_substrings)
+
+            assert all(substring in str(raised_exception.value) for substring in reference.required_kwargs)
         else:
             # Let the lack of an exception here effectively assert that no exception is raised.
             reference.evaluate_with(session=session, **self.DEFAULT_ARGS)

--- a/airflow-core/tests/unit/models/test_taskinstance.py
+++ b/airflow-core/tests/unit/models/test_taskinstance.py
@@ -221,7 +221,7 @@ class TestTaskInstance:
         op.dag = dag
 
         # no reassignment
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="can not be changed"):
             op.dag = dag2
 
         # but assigning the same dag is ok
@@ -243,7 +243,9 @@ class TestTaskInstance:
         assert [i.has_dag() for i in [op1, op2, op3, op4]] == [False, False, True, True]
 
         # can't combine operators with no dags
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError, match="Tried to create relationships between tasks that don't have Dags yet"
+        ):
             op1.set_downstream(op2)
 
         # op2 should infer dag from op1

--- a/airflow-core/tests/unit/models/test_xcom_arg.py
+++ b/airflow-core/tests/unit/models/test_xcom_arg.py
@@ -123,9 +123,8 @@ class TestXComArgBuild:
     def test_xcom_key_getitem_not_str(self, dag_maker):
         python_op = build_python_op(dag_maker)
         actual = XComArg(python_op)
-        with pytest.raises(ValueError) as ctx:
+        with pytest.raises(ValueError, match="XComArg only supports str lookup, received int"):
             actual[1]
-        assert str(ctx.value) == "XComArg only supports str lookup, received int"
 
     def test_xcom_key_getitem(self, dag_maker):
         python_op = build_python_op(dag_maker)

--- a/airflow-core/tests/unit/serialization/test_dag_serialization.py
+++ b/airflow-core/tests/unit/serialization/test_dag_serialization.py
@@ -1064,8 +1064,6 @@ class TestStringifiedDAGs:
             },
         }
         SerializedDAG.validate_schema(serialized)
-        with pytest.raises(ValueError) as ctx:
-            SerializedDAG.from_dict(serialized)
         message = (
             "Timetable class "
             "'tests_common.test_utils.timetables.CustomSerializationTimetable' "
@@ -1073,7 +1071,8 @@ class TestStringifiedDAGs:
             "you have a top level database access that disrupted the session. "
             "Please check the airflow best practices documentation."
         )
-        assert str(ctx.value) == message
+        with pytest.raises(ValueError, match=message):
+            SerializedDAG.from_dict(serialized)
 
     @pytest.mark.parametrize(
         "val, expected",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
issue: Enable Even More PyDocStyle Checks #40567
@ferruzzi
This PR is for enable PT011 rule:
PT011: all instances of pytest.raises should include a match term to make sure they are catching the right error.
https://docs.astral.sh/ruff/rules/pytest-raises-too-broad/
There are 102 files changes is need.
So, I separate to many PR, which contains about 5 file changes for easy review.
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
