### PR TITLE
Relax Kubernetes client version support to <35.0.0

### DIFF
--- a/providers/cncf/kubernetes/pyproject.toml
+++ b/providers/cncf/kubernetes/pyproject.toml
@@ -70,9 +70,9 @@ dependencies = [
     # limiting minimum airflow version supported in cncf.kubernetes provider, due to the
     # potential breaking changes in Airflow Core as well (kubernetes is added as extra, so Airflow
     # core is not hard-limited via install-requirements, only by extra).
-    "kubernetes>=32.0.0,<34.0.0",
+    "kubernetes>=32.0.0,<35.0.0",
     # the version is limited to the next MAJOR version and should by synced with the kubernetes version
-    "kubernetes_asyncio>=32.0.0,<34.0.0",
+    "kubernetes_asyncio>=32.0.0,<35.0.0",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
We support K8s version 1.34 in main branch
Relaxing the client version restriction to match

https://github.com/kubernetes-client/python?tab=readme-ov-file#compatibility
[client 34.y.z](https://pypi.org/project/kubernetes/34.1.0/): Kubernetes 1.33 or below (+-), Kubernetes 1.34 (✓), Kubernetes 1.35 or above (+-)