### PR TITLE
Helm: generate jwt-secret on installation only

### DIFF
--- a/chart/templates/secrets/jwt-secret.yaml
+++ b/chart/templates/secrets/jwt-secret.yaml
@@ -35,10 +35,13 @@ metadata:
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.jwtSecretAnnotations }}
   annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-weight": "0"
+    {{- with .Values.jwtSecretAnnotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 type: Opaque
 data:
   jwt-secret: {{ (.Values.jwtSecret) | default (randAlphaNum 32) | b64enc | quote }}

--- a/helm-tests/tests/helm_tests/security/test_jwt_secret.py
+++ b/helm-tests/tests/helm_tests/security/test_jwt_secret.py
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import base64
+
+import jmespath
+from chart_utils.helm_template_generator import render_chart
+
+
+class TestJwtSecret:
+    """Tests jwt secret."""
+
+    def test_should_add_annotations_to_jwt_secret(self):
+        """Test that annotations are properly added to JWT secret and the secret is correctly encoded.
+
+        This test verifies that:
+        1. Custom annotations can be added to the JWT secret
+        2. The JWT secret is properly base64 encoded in the template
+        3. The decoded secret matches the input value
+        """
+        # Create JWT secret with custom annotation
+        docs = render_chart(
+            values={
+                "jwtSecret": "verysecret",
+                "jwtSecretAnnotations": {"test_annotation": "test_annotation_value"},
+            },
+            show_only=["templates/secrets/jwt-secret.yaml"],
+        )[0]
+        assert "annotations" in jmespath.search("metadata", docs)
+        assert jmespath.search("metadata.annotations", docs)["test_annotation"] == "test_annotation_value"
+
+        # Extract and decode the JWT secret
+        jwt_secret_b64 = jmespath.search('data."jwt-secret"', docs).strip('"')
+        jwt_secret = base64.b64decode(jwt_secret_b64).decode()
+
+        # Verify the decoded secret matches original input
+        assert jwt_secret == "verysecret"


### PR DESCRIPTION
**What:**

Use a pre-install Helm hook to generate the jwt-secret only once during installation, instead of regenerating it on each upgrade.

**Why:**
Currently, the jwt-secret is regenerated on every Helm upgrade. This can lead to inconsistent JWT secrets across Airflow components and result in authentication or communication failures.

Related discussion: https://github.com/apache/airflow/discussions/54178

Problem Scenarios
1. Multiple Airflow API Server Replicas
   - Example: Modify Helm values (e.g., change StatsD resource allocation) — this triggers an upgrade but does not redeploy the API server pods.
   - If one API server pod is manually restarted, it receives a new jwt-secret, while others still use the previous one.
   - Result: UI becomes inaccessible due to an infinite redirect loop with InvalidSignatureError: Signature verification failed.

2. Scheduler and Worker Using Different JWT Secrets
   - Similar scenario — Helm upgrade without redeployment of Scheduler/Worker pods.
   - Restarting either component causes a mismatch in JWT secrets.
     Result: Tasks fail with InvalidSignatureError: Signature verification failed.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
