### PR TITLE
Fix potential test failures due to setting _warnings_showwarning in reset_logging

### DIFF
--- a/task-sdk/src/airflow/sdk/log.py
+++ b/task-sdk/src/airflow/sdk/log.py
@@ -251,8 +251,10 @@ def reset_logging():
     from airflow.sdk._shared.logging.structlog import structlog_processors
 
     global _warnings_showwarning
-    warnings.showwarning = _warnings_showwarning
-    _warnings_showwarning = None
+    if _warnings_showwarning is not None:
+        warnings.showwarning = _warnings_showwarning
+        _warnings_showwarning = None
+
     structlog_processors.cache_clear()
     logging_processors.cache_clear()
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Saw this kind of failure in the CI: https://github.com/apache/airflow/actions/runs/18870296357/job/53847708130

Error:
```shell script
_______________________________________________________ ERROR at setup of TestWatchedSubprocess.test_state_conflict_on_heartbeat[log_level=error] ________________________________________________________
[gw1] linux -- Python 3.13.9 /usr/local/bin/python3
/usr/python/lib/python3.13/warnings.py:107: in _showwarnmsg
    raise TypeError("warnings.showwarning() must be set to a "
E   TypeError: warnings.showwarning() must be set to a function or method
```

One thing of note is that most tests failed in TestWatchedSubprocess or TestWatchedSubprocessKill because they use
`capture_logging` fixture.

Root cause could be that `reset_logging()` unconditionally sets: `warnings.showwarning = _warnings_showwarning`
So when _warnings_showwarning is None, this sets warnings.showwarning to None, triggering the error when warnings
are emitted during tests.

We use this pattern everywhere across the file

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
