### PR TITLE
Remove direct dependency on thrift

### DIFF
--- a/providers/apache/hive/pyproject.toml
+++ b/providers/apache/hive/pyproject.toml
@@ -64,7 +64,6 @@ dependencies = [
     'pandas>=2.1.2; python_version <"3.13"',
     'pandas>=2.2.3; python_version >="3.13"',
     "pyhive[hive_pure_sasl]>=0.7.0",
-    "thrift>=0.11.0",
     "jmespath>=0.7.0",
 ]
 


### PR DESCRIPTION
The thrift `dependency` comes directly from upstream
https://github.com/dropbox/PyHive/blob/ac09074a652fd50e10b57a7f0bbc4f6410961301/setup.py#L49
We don't use it directly in hive provider