### PR TITLE
[CI]: prevent run of workflow failing on clones

### DIFF
--- a/.github/workflows/ci-notification.yml
+++ b/.github/workflows/ci-notification.yml
@@ -39,6 +39,7 @@ jobs:
         branch: ["v3-1-test"]
         workflow-id: ["ci-amd-arm.yml"]
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'apache/airflow' }}
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2


### PR DESCRIPTION
The `ci-notification` Github workflow runs automatically on schedule twice a day even on clones of original repo.

Such executions on clones will fail because original repo has definitions for secrets that clones don't have.

The added condition prevents such executions when not on `apache/airflow`

---

