### PR TITLE
Add wildcard support for dag_id and dag_run_id in bulk ti endpoint

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/common.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/common.py
@@ -28,7 +28,6 @@ from typing import Annotated, Any, Generic, Literal, TypeVar, Union
 from pydantic import Discriminator, Field, Tag
 
 from airflow.api_fastapi.core_api.base import BaseModel, StrictBaseModel
-from airflow.api_fastapi.core_api.datamodels.task_instances import BulkTaskInstanceBody
 
 # Common Bulk Data Models
 T = TypeVar("T")
@@ -92,7 +91,7 @@ class BulkDeleteAction(BulkBaseAction[T]):
     """Bulk Delete entity serializer for request bodies."""
 
     action: Literal[BulkAction.DELETE] = Field(description="The action to be performed on the entities.")
-    entities: list[Union[str, BulkTaskInstanceBody]] = Field(
+    entities: list[Union[str, T]] = Field(
         ...,
         description="A list of entity id/key or entity objects to be deleted.",
     )

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/common.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/common.py
@@ -28,6 +28,7 @@ from typing import Annotated, Any, Generic, Literal, TypeVar, Union
 from pydantic import Discriminator, Field, Tag
 
 from airflow.api_fastapi.core_api.base import BaseModel, StrictBaseModel
+from airflow.api_fastapi.core_api.datamodels.task_instances import BulkTaskInstanceBody
 
 # Common Bulk Data Models
 T = TypeVar("T")
@@ -91,7 +92,7 @@ class BulkDeleteAction(BulkBaseAction[T]):
     """Bulk Delete entity serializer for request bodies."""
 
     action: Literal[BulkAction.DELETE] = Field(description="The action to be performed on the entities.")
-    entities: list[Union[str, T]] = Field(
+    entities: list[Union[str, BulkTaskInstanceBody]] = Field(
         ...,
         description="A list of entity id/key or entity objects to be deleted.",
     )

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/task_instances.py
@@ -219,3 +219,5 @@ class BulkTaskInstanceBody(PatchTaskInstanceBody, StrictBaseModel):
 
     task_id: str
     map_index: int | None = None
+    dag_id: str | None = None
+    dag_run_id: str | None = None

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -9405,6 +9405,16 @@ components:
           - type: integer
           - type: 'null'
           title: Map Index
+        dag_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Dag Id
+        dag_run_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Dag Run Id
       additionalProperties: false
       type: object
       required:

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -9275,7 +9275,7 @@ components:
           items:
             anyOf:
             - type: string
-            - $ref: '#/components/schemas/BulkTaskInstanceBody'
+            - $ref: '#/components/schemas/ConnectionBody'
           type: array
           title: Entities
           description: A list of entity id/key or entity objects to be deleted.
@@ -9299,7 +9299,7 @@ components:
           items:
             anyOf:
             - type: string
-            - $ref: '#/components/schemas/BulkTaskInstanceBody'
+            - $ref: '#/components/schemas/PoolBody'
           type: array
           title: Entities
           description: A list of entity id/key or entity objects to be deleted.
@@ -9323,7 +9323,7 @@ components:
           items:
             anyOf:
             - type: string
-            - $ref: '#/components/schemas/BulkTaskInstanceBody'
+            - $ref: '#/components/schemas/VariableBody'
           type: array
           title: Entities
           description: A list of entity id/key or entity objects to be deleted.

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -9275,7 +9275,7 @@ components:
           items:
             anyOf:
             - type: string
-            - $ref: '#/components/schemas/ConnectionBody'
+            - $ref: '#/components/schemas/BulkTaskInstanceBody'
           type: array
           title: Entities
           description: A list of entity id/key or entity objects to be deleted.
@@ -9299,7 +9299,7 @@ components:
           items:
             anyOf:
             - type: string
-            - $ref: '#/components/schemas/PoolBody'
+            - $ref: '#/components/schemas/BulkTaskInstanceBody'
           type: array
           title: Entities
           description: A list of entity id/key or entity objects to be deleted.
@@ -9323,7 +9323,7 @@ components:
           items:
             anyOf:
             - type: string
-            - $ref: '#/components/schemas/VariableBody'
+            - $ref: '#/components/schemas/BulkTaskInstanceBody'
           type: array
           title: Entities
           description: A list of entity id/key or entity objects to be deleted.

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/public/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/public/task_instances.py
@@ -17,11 +17,13 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 import structlog
 from fastapi import HTTPException, Query, status
 from fastapi.exceptions import RequestValidationError
 from pydantic import ValidationError
-from sqlalchemy import select
+from sqlalchemy import select, tuple_
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.session import Session
 
@@ -167,31 +169,131 @@ class BulkTaskInstanceService(BulkService[BulkTaskInstanceBody]):
         self.dag_bag = dag_bag
         self.user = user
 
-    def categorize_task_instances(
-        self, task_keys: set[tuple[str, int]]
-    ) -> tuple[dict[tuple[str, int], TI], set[tuple[str, int]], set[tuple[str, int]]]:
+    def _extract_task_identifiers(
+        self, entity: str | BulkTaskInstanceBody
+    ) -> tuple[str, str, str, int | None]:
         """
-        Categorize the given task_ids into matched_task_keys and not_found_task_keys based on existing task_ids.
+        Extract task identifiers from an id or entity object.
 
-        :param task_keys: set of task_keys (tuple of task_id and map_index)
+        :param entity: Task identifier as string or BulkTaskInstanceBody object
+        :return: tuple of (dag_id, dag_run_id, task_id, map_index)
+        """
+        if isinstance(entity, str):
+            dag_id = self.dag_id
+            dag_run_id = self.dag_run_id
+            task_id = entity
+            map_index = None
+        else:
+            dag_id = entity.dag_id if entity.dag_id else self.dag_id
+            dag_run_id = entity.dag_run_id if entity.dag_run_id else self.dag_run_id
+            task_id = entity.task_id
+            map_index = entity.map_index
+
+        return dag_id, dag_run_id, task_id, map_index
+
+    def _categorize_entities(
+        self,
+        entities: Sequence[str | BulkTaskInstanceBody],
+        results: BulkActionResponse,
+    ) -> tuple[set[tuple[str, str, str, int]], set[tuple[str, str, str]]]:
+        """
+        Validate entities and categorize them into specific and all map index update sets.
+
+        :param entities: Sequence of entities to validate
+        :param results: BulkActionResponse object to track errors
+        :return: tuple of (specific_map_index_task_keys, all_map_index_task_keys)
+        """
+        specific_map_index_task_keys = set()
+        all_map_index_task_keys = set()
+
+        for entity in entities:
+            dag_id, dag_run_id, task_id, map_index = self._extract_task_identifiers(entity)
+
+            # Validate that we have specific values, not wildcards
+            if dag_id == "~" or dag_run_id == "~":
+                if isinstance(entity, str):
+                    error_msg = f"When using wildcard in path, dag_id and dag_run_id must be specified in BulkTaskInstanceBody object, not as string for task_id: {entity}"
+                else:
+                    error_msg = f"When using wildcard in path, dag_id and dag_run_id must be specified in request body for task_id: {entity.task_id}"
+                results.errors.append(
+                    {
+                        "error": error_msg,
+                        "status_code": status.HTTP_400_BAD_REQUEST,
+                    }
+                )
+                continue
+
+            # Separate logic for "update all" vs "update specific"
+            if map_index is not None:
+                specific_map_index_task_keys.add((dag_id, dag_run_id, task_id, map_index))
+            else:
+                all_map_index_task_keys.add((dag_id, dag_run_id, task_id))
+
+        return specific_map_index_task_keys, all_map_index_task_keys
+
+    def _categorize_task_instances(
+        self, task_keys: set[tuple[str, str, str, int]]
+    ) -> tuple[
+        dict[tuple[str, str, str, int], TI], set[tuple[str, str, str, int]], set[tuple[str, str, str, int]]
+    ]:
+        """
+        Categorize the given task_keys into matched and not_found based on existing task instances.
+
+        :param task_keys: set of task_keys (tuple of dag_id, dag_run_id, task_id, and map_index)
         :return: tuple of (task_instances_map, matched_task_keys, not_found_task_keys)
         """
-        query = select(TI).where(
-            TI.dag_id == self.dag_id,
-            TI.run_id == self.dag_run_id,
-            TI.task_id.in_([task_id for task_id, _ in task_keys]),
-        )
+        # Filter at database level using exact tuple matching instead of fetching all combinations
+        # and filtering in Python
+        task_keys_list = list(task_keys)
+        query = select(TI).where(tuple_(TI.dag_id, TI.run_id, TI.task_id, TI.map_index).in_(task_keys_list))
+
         task_instances = self.session.scalars(query).all()
         task_instances_map = {
-            (ti.task_id, ti.map_index if ti.map_index is not None else -1): ti for ti in task_instances
+            (ti.dag_id, ti.run_id, ti.task_id, ti.map_index if ti.map_index is not None else -1): ti
+            for ti in task_instances
         }
-        matched_task_keys = {
-            (task_id, map_index)
-            for (task_id, map_index) in task_instances_map.keys()
-            if (task_id, map_index) in task_keys
-        }
-        not_found_task_keys = {(task_id, map_index) for task_id, map_index in task_keys} - matched_task_keys
+        matched_task_keys = set(task_instances_map.keys())
+        not_found_task_keys = task_keys - matched_task_keys
         return task_instances_map, matched_task_keys, not_found_task_keys
+
+    def _perform_update(
+        self,
+        entity: BulkTaskInstanceBody,
+        dag_id: str,
+        dag_run_id: str,
+        task_id: str,
+        map_index: int,
+        results: BulkActionResponse,
+        update_mask: list[str] | None = Query(None),
+    ) -> None:
+        dag, tis, data = _patch_ti_validate_request(
+            dag_id=dag_id,
+            dag_run_id=dag_run_id,
+            task_id=task_id,
+            dag_bag=self.dag_bag,
+            body=entity,
+            session=self.session,
+            update_mask=update_mask,
+        )
+
+        for key, _ in data.items():
+            if key == "new_state":
+                _patch_task_instance_state(
+                    task_id=task_id,
+                    dag_run_id=dag_run_id,
+                    dag=dag,
+                    task_instance_body=entity,
+                    session=self.session,
+                    data=data,
+                )
+            elif key == "note":
+                _patch_task_instance_note(
+                    task_instance_body=entity,
+                    tis=tis,
+                    user=self.user,
+                )
+
+        results.success.append(f"{task_id}[{map_index}]")
 
     def handle_bulk_create(
         self, action: BulkCreateAction[BulkTaskInstanceBody], results: BulkActionResponse
@@ -207,55 +309,99 @@ class BulkTaskInstanceService(BulkService[BulkTaskInstanceBody]):
         self, action: BulkUpdateAction[BulkTaskInstanceBody], results: BulkActionResponse
     ) -> None:
         """Bulk Update Task Instances."""
-        to_update_task_keys = {
-            (task_instance.task_id, task_instance.map_index if task_instance.map_index is not None else -1)
-            for task_instance in action.entities
-        }
-        _, _, not_found_task_keys = self.categorize_task_instances(to_update_task_keys)
+        # Validate and categorize entities into specific and all map index update sets
+        update_specific_map_index_task_keys, update_all_map_index_task_keys = self._categorize_entities(
+            action.entities, results
+        )
 
         try:
-            for task_instance_body in action.entities:
-                task_key = (
-                    task_instance_body.task_id,
-                    task_instance_body.map_index if task_instance_body.map_index is not None else -1,
+            specific_entity_map = {
+                (entity.dag_id, entity.dag_run_id, entity.task_id, entity.map_index): entity
+                for entity in action.entities
+                if entity.map_index is not None
+            }
+            all_map_entity_map = {
+                (entity.dag_id, entity.dag_run_id, entity.task_id): entity
+                for entity in action.entities
+                if entity.map_index is None
+            }
+
+            # Handle updates for specific map_index task instances
+            if update_specific_map_index_task_keys:
+                _, matched_task_keys, not_found_task_keys = self._categorize_task_instances(
+                    update_specific_map_index_task_keys
                 )
 
-                if task_key in not_found_task_keys:
-                    if action.action_on_non_existence == BulkActionNotOnExistence.FAIL:
+                if action.action_on_non_existence == BulkActionNotOnExistence.FAIL and not_found_task_keys:
+                    not_found_task_ids = [
+                        {"dag_id": dag_id, "dag_run_id": run_id, "task_id": task_id, "map_index": map_index}
+                        for dag_id, run_id, task_id, map_index in not_found_task_keys
+                    ]
+                    raise HTTPException(
+                        status_code=status.HTTP_404_NOT_FOUND,
+                        detail=f"The task instances with these identifiers: {not_found_task_ids} were not found",
+                    )
+
+                for dag_id, dag_run_id, task_id, map_index in matched_task_keys:
+                    entity = specific_entity_map.get((dag_id, dag_run_id, task_id, map_index))
+
+                    if entity is not None:
+                        self._perform_update(
+                            dag_id=dag_id,
+                            dag_run_id=dag_run_id,
+                            task_id=task_id,
+                            map_index=map_index,
+                            entity=entity,
+                            results=results,
+                            update_mask=action.update_mask,
+                        )
+
+            # Handle updates for all map indexes
+            if update_all_map_index_task_keys:
+                all_dag_ids = {dag_id for dag_id, _, _ in update_all_map_index_task_keys}
+                all_run_ids = {run_id for _, run_id, _ in update_all_map_index_task_keys}
+                all_task_ids = {task_id for _, _, task_id in update_all_map_index_task_keys}
+
+                batch_task_instances = self.session.scalars(
+                    select(TI).where(
+                        TI.dag_id.in_(all_dag_ids),
+                        TI.run_id.in_(all_run_ids),
+                        TI.task_id.in_(all_task_ids),
+                    )
+                ).all()
+
+                # Group task instances by (dag_id, run_id, task_id)
+                task_instances_by_key: dict[tuple[str, str, str], list[TI]] = {}
+                for ti in batch_task_instances:
+                    key = (ti.dag_id, ti.run_id, ti.task_id)
+                    task_instances_by_key.setdefault(key, []).append(ti)
+
+                for dag_id, run_id, task_id in update_all_map_index_task_keys:
+                    all_task_instances = task_instances_by_key.get((dag_id, run_id, task_id), [])
+
+                    if (
+                        not all_task_instances
+                        and action.action_on_non_existence == BulkActionNotOnExistence.FAIL
+                    ):
                         raise HTTPException(
                             status_code=status.HTTP_404_NOT_FOUND,
-                            detail=f"The Task Instance with dag_id: `{self.dag_id}`, run_id: `{self.dag_run_id}`, task_id: `{task_instance_body.task_id}` and map_index: `{task_instance_body.map_index}` was not found",
-                        )
-                    if action.action_on_non_existence == BulkActionNotOnExistence.SKIP:
-                        continue
-
-                dag, tis, data = _patch_ti_validate_request(
-                    dag_id=self.dag_id,
-                    dag_run_id=self.dag_run_id,
-                    task_id=task_instance_body.task_id,
-                    dag_bag=self.dag_bag,
-                    body=task_instance_body,
-                    session=self.session,
-                    map_index=task_instance_body.map_index,
-                    update_mask=None,
-                )
-
-                for key, _ in data.items():
-                    if key == "new_state":
-                        _patch_task_instance_state(
-                            task_id=task_instance_body.task_id,
-                            dag_run_id=self.dag_run_id,
-                            dag=dag,
-                            task_instance_body=task_instance_body,
-                            session=self.session,
-                            data=data,
-                        )
-                    elif key == "note":
-                        _patch_task_instance_note(
-                            task_instance_body=task_instance_body, tis=tis, user=self.user
+                            detail=f"No task instances found for dag_id: {dag_id}, run_id: {run_id}, task_id: {task_id}",
                         )
 
-                results.success.append(task_instance_body.task_id)
+                    entity = all_map_entity_map.get((dag_id, run_id, task_id))
+
+                    if entity is not None:
+                        for ti in all_task_instances:
+                            self._perform_update(
+                                dag_id=dag_id,
+                                dag_run_id=run_id,
+                                task_id=task_id,
+                                map_index=ti.map_index if ti.map_index is not None else -1,
+                                entity=entity,
+                                results=results,
+                                update_mask=action.update_mask,
+                            )
+
         except ValidationError as e:
             results.errors.append({"error": f"{e.errors()}"})
         except HTTPException as e:
@@ -265,41 +411,35 @@ class BulkTaskInstanceService(BulkService[BulkTaskInstanceBody]):
         self, action: BulkDeleteAction[BulkTaskInstanceBody], results: BulkActionResponse
     ) -> None:
         """Bulk delete task instances."""
-        delete_all_map_indexes: set[str] = set()
-        delete_specific_task_keys: set[tuple[str, int]] = set()
-
-        for entity in action.entities:
-            if isinstance(entity, str):
-                # String task ID - remove all task instances for this task
-                delete_all_map_indexes.add(entity)
-            else:
-                # BulkTaskInstanceBody object
-                if entity.map_index is None:
-                    delete_all_map_indexes.add(entity.task_id)
-                else:
-                    delete_specific_task_keys.add((entity.task_id, entity.map_index))
+        # Validate and categorize entities into specific and all map index delete sets
+        delete_specific_map_index_task_keys, delete_all_map_index_task_keys = self._categorize_entities(
+            action.entities, results
+        )
 
         try:
-            # Handle deletion of specific (task_id, map_index) pairs
-            if delete_specific_task_keys:
-                _, matched_task_keys, not_found_task_keys = self.categorize_task_instances(
-                    delete_specific_task_keys
+            # Handle deletion of specific (dag_id, dag_run_id, task_id, map_index) tuples
+            if delete_specific_map_index_task_keys:
+                _, matched_task_keys, not_found_task_keys = self._categorize_task_instances(
+                    delete_specific_map_index_task_keys
                 )
-                not_found_task_ids = [f"{task_id}[{map_index}]" for task_id, map_index in not_found_task_keys]
+                not_found_task_ids = [
+                    {"dag_id": dag_id, "dag_run_id": run_id, "task_id": task_id, "map_index": map_index}
+                    for dag_id, run_id, task_id, map_index in not_found_task_keys
+                ]
 
                 if action.action_on_non_existence == BulkActionNotOnExistence.FAIL and not_found_task_keys:
                     raise HTTPException(
                         status_code=status.HTTP_404_NOT_FOUND,
-                        detail=f"The task instances with these task_ids: {not_found_task_ids} were not found",
+                        detail=f"The task instances with these identifiers: {not_found_task_ids} were not found",
                     )
 
-                for task_id, map_index in matched_task_keys:
-                    result = (
+                for dag_id, run_id, task_id, map_index in matched_task_keys:
+                    ti = (
                         self.session.execute(
                             select(TI).where(
+                                TI.dag_id == dag_id,
+                                TI.run_id == run_id,
                                 TI.task_id == task_id,
-                                TI.dag_id == self.dag_id,
-                                TI.run_id == self.dag_run_id,
                                 TI.map_index == map_index,
                             )
                         )
@@ -307,32 +447,47 @@ class BulkTaskInstanceService(BulkService[BulkTaskInstanceBody]):
                         .one_or_none()
                     )
 
-                    if result:
-                        existing_task_instance = result
-                        self.session.delete(existing_task_instance)
+                    if ti:
+                        self.session.delete(ti)
                         results.success.append(f"{task_id}[{map_index}]")
 
-            # Handle deletion of all map indexes for certain task_ids
-            for task_id in delete_all_map_indexes:
-                all_task_instances = self.session.scalars(
+            # Handle deletion of all map indexes for certain (dag_id, dag_run_id, task_id) tuples
+            if delete_all_map_index_task_keys:
+                all_dag_ids = {dag_id for dag_id, _, _ in delete_all_map_index_task_keys}
+                all_run_ids = {run_id for _, run_id, _ in delete_all_map_index_task_keys}
+                all_task_ids = {task_id for _, _, task_id in delete_all_map_index_task_keys}
+
+                batch_task_instances = self.session.scalars(
                     select(TI).where(
-                        TI.task_id == task_id,
-                        TI.dag_id == self.dag_id,
-                        TI.run_id == self.dag_run_id,
+                        TI.dag_id.in_(all_dag_ids),
+                        TI.run_id.in_(all_run_ids),
+                        TI.task_id.in_(all_task_ids),
                     )
                 ).all()
 
-                if not all_task_instances and action.action_on_non_existence == BulkActionNotOnExistence.FAIL:
-                    raise HTTPException(
-                        status_code=status.HTTP_404_NOT_FOUND,
-                        detail=f"No task instances found for task_id: {task_id}",
-                    )
+                # Group task instances by (dag_id, run_id, task_id) for efficient lookup
+                task_instances_by_key: dict[tuple[str, str, str], list[TI]] = {}
+                for ti in batch_task_instances:
+                    key = (ti.dag_id, ti.run_id, ti.task_id)
+                    task_instances_by_key.setdefault(key, []).append(ti)
 
-                for ti in all_task_instances:
-                    self.session.delete(ti)
+                for dag_id, run_id, task_id in delete_all_map_index_task_keys:
+                    all_task_instances = task_instances_by_key.get((dag_id, run_id, task_id), [])
 
-                if all_task_instances:
-                    results.success.append(task_id)
+                    if (
+                        not all_task_instances
+                        and action.action_on_non_existence == BulkActionNotOnExistence.FAIL
+                    ):
+                        raise HTTPException(
+                            status_code=status.HTTP_404_NOT_FOUND,
+                            detail=f"No task instances found for dag_id: {dag_id}, run_id: {run_id}, task_id: {task_id}",
+                        )
+
+                    for ti in all_task_instances:
+                        self.session.delete(ti)
+
+                    if all_task_instances:
+                        results.success.append(task_id)
 
         except HTTPException as e:
             results.errors.append({"error": f"{e.detail}", "status_code": e.status_code})

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/public/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/public/task_instances.py
@@ -293,7 +293,7 @@ class BulkTaskInstanceService(BulkService[BulkTaskInstanceBody]):
                     user=self.user,
                 )
 
-        results.success.append(f"{task_id}[{map_index}]")
+        results.success.append(f"{dag_id}.{dag_run_id}.{task_id}[{map_index}]")
 
     def handle_bulk_create(
         self, action: BulkCreateAction[BulkTaskInstanceBody], results: BulkActionResponse
@@ -449,7 +449,7 @@ class BulkTaskInstanceService(BulkService[BulkTaskInstanceBody]):
 
                     if ti:
                         self.session.delete(ti)
-                        results.success.append(f"{task_id}[{map_index}]")
+                        results.success.append(f"{dag_id}.{run_id}.{task_id}[{map_index}]")
 
             # Handle deletion of all map indexes for certain (dag_id, dag_run_id, task_id) tuples
             if delete_all_map_index_task_keys:
@@ -485,9 +485,7 @@ class BulkTaskInstanceService(BulkService[BulkTaskInstanceBody]):
 
                     for ti in all_task_instances:
                         self.session.delete(ti)
-
-                    if all_task_instances:
-                        results.success.append(task_id)
+                        results.success.append(f"{dag_id}.{run_id}.{task_id}[{ti.map_index}]")
 
         except HTTPException as e:
             results.errors.append({"error": f"{e.detail}", "status_code": e.status_code})

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -863,7 +863,7 @@ export const $BulkDeleteAction_ConnectionBody_ = {
                         type: 'string'
                     },
                     {
-                        '$ref': '#/components/schemas/ConnectionBody'
+                        '$ref': '#/components/schemas/BulkTaskInstanceBody'
                     }
                 ]
             },
@@ -897,7 +897,7 @@ export const $BulkDeleteAction_PoolBody_ = {
                         type: 'string'
                     },
                     {
-                        '$ref': '#/components/schemas/PoolBody'
+                        '$ref': '#/components/schemas/BulkTaskInstanceBody'
                     }
                 ]
             },
@@ -931,7 +931,7 @@ export const $BulkDeleteAction_VariableBody_ = {
                         type: 'string'
                     },
                     {
-                        '$ref': '#/components/schemas/VariableBody'
+                        '$ref': '#/components/schemas/BulkTaskInstanceBody'
                     }
                 ]
             },

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -863,7 +863,7 @@ export const $BulkDeleteAction_ConnectionBody_ = {
                         type: 'string'
                     },
                     {
-                        '$ref': '#/components/schemas/BulkTaskInstanceBody'
+                        '$ref': '#/components/schemas/ConnectionBody'
                     }
                 ]
             },
@@ -897,7 +897,7 @@ export const $BulkDeleteAction_PoolBody_ = {
                         type: 'string'
                     },
                     {
-                        '$ref': '#/components/schemas/BulkTaskInstanceBody'
+                        '$ref': '#/components/schemas/PoolBody'
                     }
                 ]
             },
@@ -931,7 +931,7 @@ export const $BulkDeleteAction_VariableBody_ = {
                         type: 'string'
                     },
                     {
-                        '$ref': '#/components/schemas/BulkTaskInstanceBody'
+                        '$ref': '#/components/schemas/VariableBody'
                     }
                 ]
             },

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -1053,6 +1053,28 @@ export const $BulkTaskInstanceBody = {
                 }
             ],
             title: 'Map Index'
+        },
+        dag_id: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Dag Id'
+        },
+        dag_run_id: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Dag Run Id'
         }
     },
     additionalProperties: false,

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -269,7 +269,7 @@ export type BulkDeleteAction_ConnectionBody_ = {
     /**
      * A list of entity id/key or entity objects to be deleted.
      */
-    entities: Array<(string | BulkTaskInstanceBody)>;
+    entities: Array<(string | ConnectionBody)>;
     action_on_non_existence?: BulkActionNotOnExistence;
 };
 
@@ -281,7 +281,7 @@ export type BulkDeleteAction_PoolBody_ = {
     /**
      * A list of entity id/key or entity objects to be deleted.
      */
-    entities: Array<(string | BulkTaskInstanceBody)>;
+    entities: Array<(string | PoolBody)>;
     action_on_non_existence?: BulkActionNotOnExistence;
 };
 
@@ -293,7 +293,7 @@ export type BulkDeleteAction_VariableBody_ = {
     /**
      * A list of entity id/key or entity objects to be deleted.
      */
-    entities: Array<(string | BulkTaskInstanceBody)>;
+    entities: Array<(string | VariableBody)>;
     action_on_non_existence?: BulkActionNotOnExistence;
 };
 

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -269,7 +269,7 @@ export type BulkDeleteAction_ConnectionBody_ = {
     /**
      * A list of entity id/key or entity objects to be deleted.
      */
-    entities: Array<(string | ConnectionBody)>;
+    entities: Array<(string | BulkTaskInstanceBody)>;
     action_on_non_existence?: BulkActionNotOnExistence;
 };
 
@@ -281,7 +281,7 @@ export type BulkDeleteAction_PoolBody_ = {
     /**
      * A list of entity id/key or entity objects to be deleted.
      */
-    entities: Array<(string | PoolBody)>;
+    entities: Array<(string | BulkTaskInstanceBody)>;
     action_on_non_existence?: BulkActionNotOnExistence;
 };
 
@@ -293,7 +293,7 @@ export type BulkDeleteAction_VariableBody_ = {
     /**
      * A list of entity id/key or entity objects to be deleted.
      */
-    entities: Array<(string | VariableBody)>;
+    entities: Array<(string | BulkTaskInstanceBody)>;
     action_on_non_existence?: BulkActionNotOnExistence;
 };
 

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -331,6 +331,8 @@ export type BulkTaskInstanceBody = {
     include_past?: boolean;
     task_id: string;
     map_index?: number | null;
+    dag_id?: string | null;
+    dag_run_id?: string | null;
 };
 
 export type BulkUpdateAction_BulkTaskInstanceBody_ = {

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -5191,7 +5191,7 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
                 },
                 {
                     "delete": {
-                        "success": [TASK_ID],
+                        "success": [f"{DAG_ID}.{RUN_ID}.{TASK_ID}[-1]"],
                         "errors": [],
                     }
                 },
@@ -5216,7 +5216,7 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
                 },
                 {
                     "delete": {
-                        "success": [f"{TASK_ID}[-1]"],
+                        "success": [f"{DAG_ID}.{RUN_ID}.{TASK_ID}[-1]"],
                         "errors": [],
                     }
                 },
@@ -5348,7 +5348,11 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
                 },
                 {
                     "delete": {
-                        "success": [TASK_ID],
+                        "success": [
+                            f"{DAG_ID}.{RUN_ID}.{TASK_ID}[0]",
+                            f"{DAG_ID}.{RUN_ID}.{TASK_ID}[1]",
+                            f"{DAG_ID}.{RUN_ID}.{TASK_ID}[2]",
+                        ],
                         "errors": [],
                     }
                 },
@@ -5371,7 +5375,10 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
                 },
                 {
                     "delete": {
-                        "success": ["another_task[-1]", TASK_ID],
+                        "success": [
+                            f"{DAG_ID}.{RUN_ID}.another_task[-1]",
+                            f"{DAG_ID}.{RUN_ID}.{TASK_ID}[-1]",
+                        ],
                         "errors": [],
                     }
                 },
@@ -5401,7 +5408,7 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
                 },
                 {
                     "update": {
-                        "success": [TASK_ID],
+                        "success": [f"{DAG_ID}.{RUN_ID}.{TASK_ID}[-1]"],
                         "errors": [],
                     }
                 },
@@ -5463,7 +5470,7 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
                 },
                 {
                     "update": {
-                        "success": [TASK_ID],
+                        "success": [f"{DAG_ID}.{RUN_ID}.{TASK_ID}[100]"],
                         "errors": [],
                     }
                 },
@@ -5612,7 +5619,7 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
                 },
                 {
                     "update": {
-                        "success": [TASK_ID],
+                        "success": [f"{DAG_ID}.{RUN_ID}.{TASK_ID}[-1]"],
                         "errors": [
                             {
                                 "error": f"The Task Instance with dag_id: `{DAG_ID}`, run_id: `{RUN_ID}`, task_id: `non_existent_task` and map_index: `None` was not found",
@@ -5621,7 +5628,7 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
                         ],
                     },
                     "delete": {
-                        "success": [TASK_ID],
+                        "success": [f"{DAG_ID}.{RUN_ID}.{TASK_ID}[-1]"],
                         "errors": [
                             {
                                 "error": f"No task instances found for dag_id: {DAG_ID}, run_id: {RUN_ID}, task_id: non_existent_task",
@@ -5677,7 +5684,10 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
                 },
                 {
                     "delete": {
-                        "success": [TASK_ID, BASH_TASK_ID],
+                        "success": [
+                            f"{DAG_ID}.{RUN_ID}.{TASK_ID}[-1]",
+                            f"{BASH_DAG_ID}.{RUN_ID}.{BASH_TASK_ID}[-1]",
+                        ],
                         "errors": [],
                     }
                 },
@@ -5713,7 +5723,10 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
                 },
                 {
                     "update": {
-                        "success": [BASH_TASK_ID, TASK_ID],
+                        "success": [
+                            f"{BASH_DAG_ID}.{RUN_ID}.{BASH_TASK_ID}[-1]",
+                            f"{DAG_ID}.{RUN_ID}.{TASK_ID}[-1]",
+                        ],
                         "errors": [],
                     }
                 },

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -5170,9 +5170,12 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
     TASK_ID = "print_the_context"
     RUN_ID = "TEST_DAG_RUN_ID"
     ENDPOINT_URL = f"/dags/{DAG_ID}/dagRuns/{RUN_ID}/taskInstances"
+    BASH_DAG_ID = "example_bash_operator"
+    BASH_TASK_ID = "also_run_this"
+    WILDCARD_ENDPOINT = "/dags/~/dagRuns/~/taskInstances"
 
     @pytest.mark.parametrize(
-        ("default_ti", "actions", "expected_results"),
+        ("default_ti", "actions", "expected_results", "endpoint_url", "setup_dags"),
         [
             pytest.param(
                 [{"task_id": TASK_ID, "state": State.SUCCESS}],
@@ -5192,6 +5195,8 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
                         "errors": [],
                     }
                 },
+                None,
+                None,
                 id="delete-success",
             ),
             pytest.param(
@@ -5215,6 +5220,8 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
                         "errors": [],
                     }
                 },
+                None,
+                None,
                 id="delete-with-entity-success",
             ),
             pytest.param(
@@ -5236,6 +5243,8 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
                         "errors": [],
                     }
                 },
+                None,
+                None,
                 id="delete-skip",
             ),
             pytest.param(
@@ -5260,6 +5269,8 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
                         "errors": [],
                     }
                 },
+                None,
+                None,
                 id="delete-with-entity-skip",
             ),
             pytest.param(
@@ -5279,12 +5290,14 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
                         "success": [],
                         "errors": [
                             {
-                                "error": "No task instances found for task_id: non_existent_task",
+                                "error": f"No task instances found for dag_id: {DAG_ID}, run_id: {RUN_ID}, task_id: non_existent_task",
                                 "status_code": 404,
                             }
                         ],
                     }
                 },
+                None,
+                None,
                 id="delete-failure",
             ),
             pytest.param(
@@ -5307,12 +5320,14 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
                         "success": [],
                         "errors": [
                             {
-                                "error": "The task instances with these task_ids: ['non_existent_task[-1]'] were not found",
+                                "error": f"The task instances with these identifiers: [{{'dag_id': '{DAG_ID}', 'dag_run_id': '{RUN_ID}', 'task_id': 'non_existent_task', 'map_index': -1}}] were not found",
                                 "status_code": 404,
                             }
                         ],
                     }
                 },
+                None,
+                None,
                 id="delete-with-entity-failure",
             ),
             pytest.param(
@@ -5337,6 +5352,8 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
                         "errors": [],
                     }
                 },
+                None,
+                None,
                 id="delete-all-map-indexes",
             ),
             pytest.param(
@@ -5358,6 +5375,8 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
                         "errors": [],
                     }
                 },
+                None,
+                None,
                 id="mixed-string-and-object",
             ),
             pytest.param(
@@ -5386,6 +5405,8 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
                         "errors": [],
                     }
                 },
+                None,
+                None,
                 id="update-success",
             ),
             pytest.param(
@@ -5415,6 +5436,8 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
                         "errors": [],
                     }
                 },
+                None,
+                None,
                 id="update-skip",
             ),
             pytest.param(
@@ -5444,6 +5467,8 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
                         "errors": [],
                     }
                 },
+                None,
+                None,
                 id="update-success-mapped-task",
             ),
             pytest.param(
@@ -5471,12 +5496,14 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
                         "success": [],
                         "errors": [
                             {
-                                "error": "The Task Instance with dag_id: `example_python_operator`, run_id: `TEST_DAG_RUN_ID`, task_id: `non_existent_task` and map_index: `None` was not found",
+                                "error": f"The Task Instance with dag_id: `{DAG_ID}`, run_id: `{RUN_ID}`, task_id: `non_existent_task` and map_index: `None` was not found",
                                 "status_code": 404,
                             }
                         ],
                     }
                 },
+                None,
+                None,
                 id="update-failure",
             ),
             pytest.param(
@@ -5505,12 +5532,14 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
                         "success": [],
                         "errors": [
                             {
-                                "error": "The Task Instance with dag_id: `example_python_operator`, run_id: `TEST_DAG_RUN_ID`, task_id: `print_the_context` and map_index: `-100` was not found",
+                                "error": f"The Task Instance with dag_id: `{DAG_ID}`, run_id: `{RUN_ID}`, task_id: `{TASK_ID}` and map_index: `-100` was not found",
                                 "status_code": 404,
                             }
                         ],
                     }
                 },
+                None,
+                None,
                 id="update-failure-mapped-task",
             ),
             pytest.param(
@@ -5541,6 +5570,8 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
                         "errors": [],
                     }
                 },
+                None,
+                None,
                 id="update-failure-mapped-task-with-skip",
             ),
             pytest.param(
@@ -5584,7 +5615,7 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
                         "success": [TASK_ID],
                         "errors": [
                             {
-                                "error": "The Task Instance with dag_id: `example_python_operator`, run_id: `TEST_DAG_RUN_ID`, task_id: `non_existent_task` and map_index: `None` was not found",
+                                "error": f"The Task Instance with dag_id: `{DAG_ID}`, run_id: `{RUN_ID}`, task_id: `non_existent_task` and map_index: `None` was not found",
                                 "status_code": 404,
                             }
                         ],
@@ -5593,12 +5624,14 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
                         "success": [TASK_ID],
                         "errors": [
                             {
-                                "error": "No task instances found for task_id: non_existent_task",
+                                "error": f"No task instances found for dag_id: {DAG_ID}, run_id: {RUN_ID}, task_id: non_existent_task",
                                 "status_code": 404,
                             }
                         ],
                     },
                 },
+                None,
+                None,
                 id="update-delete-success",
             ),
             pytest.param(
@@ -5614,20 +5647,100 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
                         ],
                     }
                 },
+                None,
+                None,
                 id="create-failure",
+            ),
+            pytest.param(
+                [
+                    {"task_id": BASH_TASK_ID, "state": State.SUCCESS},
+                    {"task_id": TASK_ID, "state": State.SUCCESS},
+                ],
+                {
+                    "actions": [
+                        {
+                            "action": "delete",
+                            "entities": [
+                                {
+                                    "dag_id": BASH_DAG_ID,
+                                    "dag_run_id": RUN_ID,
+                                    "task_id": BASH_TASK_ID,
+                                },
+                                {
+                                    "dag_id": DAG_ID,
+                                    "dag_run_id": RUN_ID,
+                                    "task_id": TASK_ID,
+                                },
+                            ],
+                        }
+                    ]
+                },
+                {
+                    "delete": {
+                        "success": [TASK_ID, BASH_TASK_ID],
+                        "errors": [],
+                    }
+                },
+                WILDCARD_ENDPOINT,
+                [BASH_DAG_ID, DAG_ID],
+                id="wildcard-delete-across-dags",
+            ),
+            pytest.param(
+                [
+                    {"task_id": BASH_TASK_ID, "state": State.RUNNING},
+                    {"task_id": TASK_ID, "state": State.RUNNING},
+                ],
+                {
+                    "actions": [
+                        {
+                            "action": "update",
+                            "entities": [
+                                {
+                                    "dag_id": BASH_DAG_ID,
+                                    "dag_run_id": RUN_ID,
+                                    "task_id": BASH_TASK_ID,
+                                    "new_state": "success",
+                                },
+                                {
+                                    "dag_id": DAG_ID,
+                                    "dag_run_id": RUN_ID,
+                                    "task_id": TASK_ID,
+                                    "new_state": "success",
+                                },
+                            ],
+                        }
+                    ]
+                },
+                {
+                    "update": {
+                        "success": [BASH_TASK_ID, TASK_ID],
+                        "errors": [],
+                    }
+                },
+                WILDCARD_ENDPOINT,
+                [BASH_DAG_ID, DAG_ID],
+                id="wildcard-update-across-dags",
             ),
         ],
     )
-    def test_bulk_task_instances(self, test_client, session, default_ti, actions, expected_results):
-        self.create_task_instances(session, task_instances=default_ti)
-        response = test_client.patch(
-            self.ENDPOINT_URL,
-            json=actions,
-        )
+    def test_bulk_task_instances(
+        self, test_client, session, default_ti, actions, expected_results, endpoint_url, setup_dags
+    ):
+        # Setup task instances
+        if setup_dags:
+            for dag_id in setup_dags:
+                self.create_task_instances(
+                    session, task_instances=default_ti, dag_id=dag_id, update_extras=True
+                )
+        else:
+            self.create_task_instances(session, task_instances=default_ti)
+
+        url = endpoint_url or self.ENDPOINT_URL
+        response = test_client.patch(url, json=actions)
         assert response.status_code == 200
         response_data = response.json()
         for task_id, value in expected_results.items():
-            assert response_data[task_id] == value
+            assert sorted(response_data[task_id]) == sorted(value)
 
     def test_should_respond_401(self, unauthenticated_test_client):
         response = unauthenticated_test_client.patch(self.ENDPOINT_URL, json={})

--- a/airflow-core/tests/unit/api_fastapi/core_api/services/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/services/public/test_task_instances.py
@@ -19,7 +19,8 @@ from __future__ import annotations
 
 import pytest
 
-from airflow.api_fastapi.core_api.datamodels.common import BulkBody
+from airflow.api_fastapi.core_api.datamodels.common import BulkActionResponse, BulkBody
+from airflow.api_fastapi.core_api.datamodels.task_instances import BulkTaskInstanceBody
 from airflow.api_fastapi.core_api.services.public.task_instances import BulkTaskInstanceService
 from airflow.providers.standard.operators.bash import BashOperator
 
@@ -28,8 +29,10 @@ from tests_common.test_utils.db import (
 )
 
 pytestmark = pytest.mark.db_test
-DAG_ID = "TEST_DAG"
-DAG_RUN_ID = "TEST_DAG_RUN"
+DAG_ID_1 = "TEST_DAG_1"
+DAG_ID_2 = "TEST_DAG_2"
+DAG_RUN_ID_1 = "TEST_DAG_RUN_1"
+DAG_RUN_ID_2 = "TEST_DAG_RUN_2"
 TASK_ID_1 = "TEST_TASK_1"
 TASK_ID_2 = "TEST_TASK_2"
 
@@ -57,57 +60,93 @@ class TestCategorizeTaskInstances(TestTaskInstanceEndpoint):
             return "test_user"
 
     @pytest.mark.parametrize(
-        (
-            "task_keys",
-            "expected_matched_keys",
-            "expected_not_found_keys",
-            "expected_matched_count",
-            "expected_not_found_count",
-        ),
+        "dags_to_create, dag_id, dag_run_id, task_keys, expected_matched_keys, expected_not_found_keys",
         [
             pytest.param(
-                {(TASK_ID_1, -1), (TASK_ID_2, -1)},
-                {(TASK_ID_1, -1), (TASK_ID_2, -1)},
+                [(DAG_ID_1, DAG_RUN_ID_1, [TASK_ID_1, TASK_ID_2])],
+                DAG_ID_1,
+                DAG_RUN_ID_1,
+                {(DAG_ID_1, DAG_RUN_ID_1, TASK_ID_1, -1), (DAG_ID_1, DAG_RUN_ID_1, TASK_ID_2, -1)},
+                {(DAG_ID_1, DAG_RUN_ID_1, TASK_ID_1, -1), (DAG_ID_1, DAG_RUN_ID_1, TASK_ID_2, -1)},
                 set(),
-                2,
-                0,
-                id="all_found",
+                id="single_dag_run_all_found",
             ),
             pytest.param(
-                {("nonexistent_task", -1), ("nonexistent_task", 0)},
+                [(DAG_ID_1, DAG_RUN_ID_1, [TASK_ID_1, TASK_ID_2])],
+                DAG_ID_1,
+                DAG_RUN_ID_1,
+                {(DAG_ID_1, DAG_RUN_ID_1, "nonexistent_task", -1)},
                 set(),
-                {("nonexistent_task", -1), ("nonexistent_task", 0)},
-                0,
-                2,
-                id="none_found",
+                {(DAG_ID_1, DAG_RUN_ID_1, "nonexistent_task", -1)},
+                id="single_dag_run_not_found",
             ),
             pytest.param(
-                {(TASK_ID_1, -1), (TASK_ID_1, 0)},
-                {(TASK_ID_1, -1)},
-                {(TASK_ID_1, 0)},
-                1,
-                1,
-                id="mixed_found_and_not_found",
+                [(DAG_ID_1, DAG_RUN_ID_1, [TASK_ID_1, TASK_ID_2])],
+                DAG_ID_1,
+                DAG_RUN_ID_1,
+                {(DAG_ID_1, DAG_RUN_ID_1, TASK_ID_1, -1), (DAG_ID_1, DAG_RUN_ID_1, TASK_ID_1, 0)},
+                {(DAG_ID_1, DAG_RUN_ID_1, TASK_ID_1, -1)},
+                {(DAG_ID_1, DAG_RUN_ID_1, TASK_ID_1, 0)},
+                id="single_dag_run_mixed_map_index",
             ),
-            pytest.param(set(), set(), set(), 0, 0, id="empty_input"),
+            pytest.param(
+                [(DAG_ID_1, DAG_RUN_ID_1, [TASK_ID_1]), (DAG_ID_2, DAG_RUN_ID_2, [TASK_ID_1])],
+                "~",
+                "~",
+                {(DAG_ID_1, DAG_RUN_ID_1, TASK_ID_1, -1), (DAG_ID_2, DAG_RUN_ID_2, TASK_ID_1, -1)},
+                {(DAG_ID_1, DAG_RUN_ID_1, TASK_ID_1, -1), (DAG_ID_2, DAG_RUN_ID_2, TASK_ID_1, -1)},
+                set(),
+                id="wildcard_multiple_dags_all_found",
+            ),
+            pytest.param(
+                [(DAG_ID_1, DAG_RUN_ID_1, [TASK_ID_1]), (DAG_ID_2, DAG_RUN_ID_2, [TASK_ID_1])],
+                "~",
+                "~",
+                {
+                    (DAG_ID_1, DAG_RUN_ID_1, TASK_ID_1, -1),
+                    (DAG_ID_2, DAG_RUN_ID_2, "nonexistent_task", -1),
+                },
+                {(DAG_ID_1, DAG_RUN_ID_1, TASK_ID_1, -1)},
+                {(DAG_ID_2, DAG_RUN_ID_2, "nonexistent_task", -1)},
+                id="wildcard_multiple_dags_mixed",
+            ),
+            pytest.param(
+                [(DAG_ID_1, DAG_RUN_ID_1, [TASK_ID_1, TASK_ID_2]), (DAG_ID_2, DAG_RUN_ID_2, [TASK_ID_1])],
+                "~",
+                "~",
+                {
+                    (DAG_ID_1, DAG_RUN_ID_1, TASK_ID_1, -1),
+                    (DAG_ID_1, DAG_RUN_ID_1, TASK_ID_2, -1),
+                    (DAG_ID_2, DAG_RUN_ID_2, TASK_ID_1, -1),
+                    (DAG_ID_2, DAG_RUN_ID_2, TASK_ID_2, -1),
+                },
+                {
+                    (DAG_ID_1, DAG_RUN_ID_1, TASK_ID_1, -1),
+                    (DAG_ID_1, DAG_RUN_ID_1, TASK_ID_2, -1),
+                    (DAG_ID_2, DAG_RUN_ID_2, TASK_ID_1, -1),
+                },
+                {(DAG_ID_2, DAG_RUN_ID_2, TASK_ID_2, -1)},
+                id="wildcard_partial_match_across_dags",
+            ),
         ],
     )
     def test_categorize_task_instances(
         self,
         session,
         dag_maker,
+        dags_to_create,
+        dag_id,
+        dag_run_id,
         task_keys,
         expected_matched_keys,
         expected_not_found_keys,
-        expected_matched_count,
-        expected_not_found_count,
     ):
         """Test categorize_task_instances with various scenarios."""
-        with dag_maker(dag_id=DAG_ID, session=session):
-            BashOperator(task_id=TASK_ID_1, bash_command="echo 1")
-            BashOperator(task_id=TASK_ID_2, bash_command="echo 2")
-
-        dag_maker.create_dagrun(run_id=DAG_RUN_ID)
+        for dag_id_to_create, run_id_to_create, task_ids in dags_to_create:
+            with dag_maker(dag_id=dag_id_to_create, session=session):
+                for task_id in task_ids:
+                    BashOperator(task_id=task_id, bash_command=f"echo {task_id}")
+            dag_maker.create_dagrun(run_id=run_id_to_create)
 
         session.commit()
 
@@ -116,15 +155,234 @@ class TestCategorizeTaskInstances(TestTaskInstanceEndpoint):
         service = BulkTaskInstanceService(
             session=session,
             request=bulk_request,
-            dag_id=DAG_ID,
-            dag_run_id=DAG_RUN_ID,
+            dag_id=dag_id,
+            dag_run_id=dag_run_id,
             dag_bag=dag_maker.dagbag,
             user=user,
         )
 
-        _, matched_task_keys, not_found_task_keys = service.categorize_task_instances(task_keys)
+        _, matched_task_keys, not_found_task_keys = service._categorize_task_instances(task_keys)
 
-        assert len(matched_task_keys) == expected_matched_count
-        assert len(not_found_task_keys) == expected_not_found_count
         assert matched_task_keys == expected_matched_keys
         assert not_found_task_keys == expected_not_found_keys
+
+
+class TestExtractTaskIdentifiers(TestTaskInstanceEndpoint):
+    """Tests for the _extract_task_identifiers method in BulkTaskInstanceService."""
+
+    def setup_method(self):
+        self.clear_db()
+
+    def teardown_method(self):
+        self.clear_db()
+
+    class MockUser:
+        def get_id(self) -> str:
+            return "test_user"
+
+        def get_name(self) -> str:
+            return "test_user"
+
+    @pytest.mark.parametrize(
+        "entity, expected_dag_id, expected_dag_run_id, expected_task_id, expected_map_index",
+        [
+            pytest.param(
+                BulkTaskInstanceBody(task_id="task_1", dag_id=None, dag_run_id=None, map_index=None),
+                DAG_ID_1,
+                DAG_RUN_ID_1,
+                "task_1",
+                None,
+                id="object_entity_with_none_fields",
+            ),
+            pytest.param(
+                BulkTaskInstanceBody(task_id="task_2", dag_id=DAG_ID_2, dag_run_id=DAG_RUN_ID_2, map_index=5),
+                DAG_ID_2,
+                DAG_RUN_ID_2,
+                "task_2",
+                5,
+                id="object_entity_with_all_fields",
+            ),
+            pytest.param(
+                BulkTaskInstanceBody(task_id="task_3", dag_id=None, dag_run_id=None, map_index=None),
+                DAG_ID_1,
+                DAG_RUN_ID_1,
+                "task_3",
+                None,
+                id="object_entity_fallback_to_path_params",
+            ),
+        ],
+    )
+    def test_extract_task_identifiers(
+        self,
+        session,
+        dag_maker,
+        entity,
+        expected_dag_id,
+        expected_dag_run_id,
+        expected_task_id,
+        expected_map_index,
+    ):
+        """Test _extract_task_identifiers with different entity configurations."""
+
+        user = self.MockUser()
+        bulk_request = BulkBody(actions=[])
+        service = BulkTaskInstanceService(
+            session=session,
+            request=bulk_request,
+            dag_id=DAG_ID_1,
+            dag_run_id=DAG_RUN_ID_1,
+            dag_bag=dag_maker.dagbag,
+            user=user,
+        )
+
+        dag_id, dag_run_id, task_id, map_index = service._extract_task_identifiers(entity)
+
+        assert dag_id == expected_dag_id
+        assert dag_run_id == expected_dag_run_id
+        assert task_id == expected_task_id
+        assert map_index == expected_map_index
+
+
+class TestCategorizeEntities(TestTaskInstanceEndpoint):
+    """Tests for the _categorize_entities method in BulkTaskInstanceService."""
+
+    def setup_method(self):
+        self.clear_db()
+
+    def teardown_method(self):
+        self.clear_db()
+
+    class MockUser:
+        def get_id(self) -> str:
+            return "test_user"
+
+        def get_name(self) -> str:
+            return "test_user"
+
+    @pytest.mark.parametrize(
+        "entities, service_dag_id, service_dag_run_id, expected_specific_keys, expected_all_keys, expected_error_count",
+        [
+            pytest.param(
+                [
+                    BulkTaskInstanceBody(
+                        task_id="task_1", dag_id=DAG_ID_1, dag_run_id=DAG_RUN_ID_1, map_index=5
+                    )
+                ],
+                DAG_ID_1,
+                DAG_RUN_ID_1,
+                {(DAG_ID_1, DAG_RUN_ID_1, "task_1", 5)},
+                set(),
+                0,
+                id="single_entity_with_map_index",
+            ),
+            pytest.param(
+                [
+                    BulkTaskInstanceBody(
+                        task_id="task_1", dag_id=DAG_ID_1, dag_run_id=DAG_RUN_ID_1, map_index=None
+                    )
+                ],
+                DAG_ID_1,
+                DAG_RUN_ID_1,
+                set(),
+                {(DAG_ID_1, DAG_RUN_ID_1, "task_1")},
+                0,
+                id="single_entity_without_map_index",
+            ),
+            pytest.param(
+                [
+                    BulkTaskInstanceBody(
+                        task_id="task_1", dag_id=DAG_ID_1, dag_run_id=DAG_RUN_ID_1, map_index=5
+                    ),
+                    BulkTaskInstanceBody(
+                        task_id="task_2", dag_id=DAG_ID_1, dag_run_id=DAG_RUN_ID_1, map_index=None
+                    ),
+                ],
+                DAG_ID_1,
+                DAG_RUN_ID_1,
+                {(DAG_ID_1, DAG_RUN_ID_1, "task_1", 5)},
+                {(DAG_ID_1, DAG_RUN_ID_1, "task_2")},
+                0,
+                id="mixed_entities_with_and_without_map_index",
+            ),
+            pytest.param(
+                [
+                    BulkTaskInstanceBody(
+                        task_id="task_1", dag_id=DAG_ID_1, dag_run_id=DAG_RUN_ID_1, map_index=5
+                    ),
+                    BulkTaskInstanceBody(
+                        task_id="task_1", dag_id=DAG_ID_2, dag_run_id=DAG_RUN_ID_2, map_index=10
+                    ),
+                ],
+                DAG_ID_1,
+                DAG_RUN_ID_1,
+                {(DAG_ID_1, DAG_RUN_ID_1, "task_1", 5), (DAG_ID_2, DAG_RUN_ID_2, "task_1", 10)},
+                set(),
+                0,
+                id="multiple_entities_different_dags",
+            ),
+            pytest.param(
+                [BulkTaskInstanceBody(task_id="task_1", dag_id="~", dag_run_id=DAG_RUN_ID_1, map_index=None)],
+                "~",
+                "~",
+                set(),
+                set(),
+                1,
+                id="wildcard_in_dag_id_with_none_fields",
+            ),
+            pytest.param(
+                [BulkTaskInstanceBody(task_id="task_1", dag_id=DAG_ID_1, dag_run_id="~", map_index=None)],
+                "~",
+                "~",
+                set(),
+                set(),
+                1,
+                id="wildcard_in_dag_run_id_with_none_fields",
+            ),
+            pytest.param(
+                [
+                    BulkTaskInstanceBody(task_id="task_1", dag_id="~", dag_run_id="~", map_index=None),
+                    BulkTaskInstanceBody(
+                        task_id="task_2", dag_id=DAG_ID_1, dag_run_id=DAG_RUN_ID_1, map_index=5
+                    ),
+                ],
+                "~",
+                "~",
+                {(DAG_ID_1, DAG_RUN_ID_1, "task_2", 5)},
+                set(),
+                1,
+                id="wildcard_error_and_valid_entity",
+            ),
+        ],
+    )
+    def test_categorize_entities(
+        self,
+        session,
+        dag_maker,
+        entities,
+        service_dag_id,
+        service_dag_run_id,
+        expected_specific_keys,
+        expected_all_keys,
+        expected_error_count,
+    ):
+        """Test _categorize_entities with different entity configurations and wildcard validation."""
+
+        user = self.MockUser()
+        bulk_request = BulkBody(actions=[])
+        service = BulkTaskInstanceService(
+            session=session,
+            request=bulk_request,
+            dag_id=service_dag_id,
+            dag_run_id=service_dag_run_id,
+            dag_bag=dag_maker.dagbag,
+            user=user,
+        )
+
+        results = BulkActionResponse()
+        specific_map_index_task_keys, all_map_index_task_keys = service._categorize_entities(
+            entities, results
+        )
+
+        assert specific_map_index_task_keys == expected_specific_keys
+        assert all_map_index_task_keys == expected_all_keys
+        assert len(results.errors) == expected_error_count

--- a/airflow-core/tests/unit/api_fastapi/core_api/services/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/services/public/test_task_instances.py
@@ -60,7 +60,14 @@ class TestCategorizeTaskInstances(TestTaskInstanceEndpoint):
             return "test_user"
 
     @pytest.mark.parametrize(
-        "dags_to_create, dag_id, dag_run_id, task_keys, expected_matched_keys, expected_not_found_keys",
+        (
+            "dags_to_create",
+            "dag_id",
+            "dag_run_id",
+            "task_keys",
+            "expected_matched_keys",
+            "expected_not_found_keys",
+        ),
         [
             pytest.param(
                 [(DAG_ID_1, DAG_RUN_ID_1, [TASK_ID_1, TASK_ID_2])],
@@ -184,7 +191,7 @@ class TestExtractTaskIdentifiers(TestTaskInstanceEndpoint):
             return "test_user"
 
     @pytest.mark.parametrize(
-        "entity, expected_dag_id, expected_dag_run_id, expected_task_id, expected_map_index",
+        ("entity", "expected_dag_id", "expected_dag_run_id", "expected_task_id", "expected_map_index"),
         [
             pytest.param(
                 BulkTaskInstanceBody(task_id="task_1", dag_id=None, dag_run_id=None, map_index=None),
@@ -260,7 +267,14 @@ class TestCategorizeEntities(TestTaskInstanceEndpoint):
             return "test_user"
 
     @pytest.mark.parametrize(
-        "entities, service_dag_id, service_dag_run_id, expected_specific_keys, expected_all_keys, expected_error_count",
+        (
+            "entities",
+            "service_dag_id",
+            "service_dag_run_id",
+            "expected_specific_keys",
+            "expected_all_keys",
+            "expected_error_count",
+        ),
         [
             pytest.param(
                 [

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -1152,48 +1152,6 @@ class BulkCreateActionVariableBody(BaseModel):
     action_on_existence: BulkActionOnExistence | None = "fail"
 
 
-class BulkDeleteActionConnectionBody(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    action: Annotated[
-        Literal["delete"], Field(description="The action to be performed on the entities.", title="Action")
-    ]
-    entities: Annotated[
-        list[str | ConnectionBody],
-        Field(description="A list of entity id/key or entity objects to be deleted.", title="Entities"),
-    ]
-    action_on_non_existence: BulkActionNotOnExistence | None = "fail"
-
-
-class BulkDeleteActionPoolBody(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    action: Annotated[
-        Literal["delete"], Field(description="The action to be performed on the entities.", title="Action")
-    ]
-    entities: Annotated[
-        list[str | PoolBody],
-        Field(description="A list of entity id/key or entity objects to be deleted.", title="Entities"),
-    ]
-    action_on_non_existence: BulkActionNotOnExistence | None = "fail"
-
-
-class BulkDeleteActionVariableBody(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    action: Annotated[
-        Literal["delete"], Field(description="The action to be performed on the entities.", title="Action")
-    ]
-    entities: Annotated[
-        list[str | VariableBody],
-        Field(description="A list of entity id/key or entity objects to be deleted.", title="Entities"),
-    ]
-    action_on_non_existence: BulkActionNotOnExistence | None = "fail"
-
-
 class BulkTaskInstanceBody(BaseModel):
     """
     Request body for bulk update, and delete task instances.
@@ -1848,38 +1806,6 @@ class BackfillCollectionResponse(BaseModel):
     total_entries: Annotated[int, Field(title="Total Entries")]
 
 
-class BulkBodyConnectionBody(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    actions: Annotated[
-        list[
-            BulkCreateActionConnectionBody | BulkUpdateActionConnectionBody | BulkDeleteActionConnectionBody
-        ],
-        Field(title="Actions"),
-    ]
-
-
-class BulkBodyPoolBody(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    actions: Annotated[
-        list[BulkCreateActionPoolBody | BulkUpdateActionPoolBody | BulkDeleteActionPoolBody],
-        Field(title="Actions"),
-    ]
-
-
-class BulkBodyVariableBody(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    actions: Annotated[
-        list[BulkCreateActionVariableBody | BulkUpdateActionVariableBody | BulkDeleteActionVariableBody],
-        Field(title="Actions"),
-    ]
-
-
 class BulkCreateActionBulkTaskInstanceBody(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -1894,6 +1820,48 @@ class BulkCreateActionBulkTaskInstanceBody(BaseModel):
 
 
 class BulkDeleteActionBulkTaskInstanceBody(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    action: Annotated[
+        Literal["delete"], Field(description="The action to be performed on the entities.", title="Action")
+    ]
+    entities: Annotated[
+        list[str | BulkTaskInstanceBody],
+        Field(description="A list of entity id/key or entity objects to be deleted.", title="Entities"),
+    ]
+    action_on_non_existence: BulkActionNotOnExistence | None = "fail"
+
+
+class BulkDeleteActionConnectionBody(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    action: Annotated[
+        Literal["delete"], Field(description="The action to be performed on the entities.", title="Action")
+    ]
+    entities: Annotated[
+        list[str | BulkTaskInstanceBody],
+        Field(description="A list of entity id/key or entity objects to be deleted.", title="Entities"),
+    ]
+    action_on_non_existence: BulkActionNotOnExistence | None = "fail"
+
+
+class BulkDeleteActionPoolBody(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    action: Annotated[
+        Literal["delete"], Field(description="The action to be performed on the entities.", title="Action")
+    ]
+    entities: Annotated[
+        list[str | BulkTaskInstanceBody],
+        Field(description="A list of entity id/key or entity objects to be deleted.", title="Entities"),
+    ]
+    action_on_non_existence: BulkActionNotOnExistence | None = "fail"
+
+
+class BulkDeleteActionVariableBody(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -2019,5 +1987,37 @@ class BulkBodyBulkTaskInstanceBody(BaseModel):
             | BulkUpdateActionBulkTaskInstanceBody
             | BulkDeleteActionBulkTaskInstanceBody
         ],
+        Field(title="Actions"),
+    ]
+
+
+class BulkBodyConnectionBody(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    actions: Annotated[
+        list[
+            BulkCreateActionConnectionBody | BulkUpdateActionConnectionBody | BulkDeleteActionConnectionBody
+        ],
+        Field(title="Actions"),
+    ]
+
+
+class BulkBodyPoolBody(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    actions: Annotated[
+        list[BulkCreateActionPoolBody | BulkUpdateActionPoolBody | BulkDeleteActionPoolBody],
+        Field(title="Actions"),
+    ]
+
+
+class BulkBodyVariableBody(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    actions: Annotated[
+        list[BulkCreateActionVariableBody | BulkUpdateActionVariableBody | BulkDeleteActionVariableBody],
         Field(title="Actions"),
     ]

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -1152,6 +1152,48 @@ class BulkCreateActionVariableBody(BaseModel):
     action_on_existence: BulkActionOnExistence | None = "fail"
 
 
+class BulkDeleteActionConnectionBody(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    action: Annotated[
+        Literal["delete"], Field(description="The action to be performed on the entities.", title="Action")
+    ]
+    entities: Annotated[
+        list[str | ConnectionBody],
+        Field(description="A list of entity id/key or entity objects to be deleted.", title="Entities"),
+    ]
+    action_on_non_existence: BulkActionNotOnExistence | None = "fail"
+
+
+class BulkDeleteActionPoolBody(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    action: Annotated[
+        Literal["delete"], Field(description="The action to be performed on the entities.", title="Action")
+    ]
+    entities: Annotated[
+        list[str | PoolBody],
+        Field(description="A list of entity id/key or entity objects to be deleted.", title="Entities"),
+    ]
+    action_on_non_existence: BulkActionNotOnExistence | None = "fail"
+
+
+class BulkDeleteActionVariableBody(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    action: Annotated[
+        Literal["delete"], Field(description="The action to be performed on the entities.", title="Action")
+    ]
+    entities: Annotated[
+        list[str | VariableBody],
+        Field(description="A list of entity id/key or entity objects to be deleted.", title="Entities"),
+    ]
+    action_on_non_existence: BulkActionNotOnExistence | None = "fail"
+
+
 class BulkTaskInstanceBody(BaseModel):
     """
     Request body for bulk update, and delete task instances.
@@ -1806,6 +1848,38 @@ class BackfillCollectionResponse(BaseModel):
     total_entries: Annotated[int, Field(title="Total Entries")]
 
 
+class BulkBodyConnectionBody(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    actions: Annotated[
+        list[
+            BulkCreateActionConnectionBody | BulkUpdateActionConnectionBody | BulkDeleteActionConnectionBody
+        ],
+        Field(title="Actions"),
+    ]
+
+
+class BulkBodyPoolBody(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    actions: Annotated[
+        list[BulkCreateActionPoolBody | BulkUpdateActionPoolBody | BulkDeleteActionPoolBody],
+        Field(title="Actions"),
+    ]
+
+
+class BulkBodyVariableBody(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    actions: Annotated[
+        list[BulkCreateActionVariableBody | BulkUpdateActionVariableBody | BulkDeleteActionVariableBody],
+        Field(title="Actions"),
+    ]
+
+
 class BulkCreateActionBulkTaskInstanceBody(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -1820,48 +1894,6 @@ class BulkCreateActionBulkTaskInstanceBody(BaseModel):
 
 
 class BulkDeleteActionBulkTaskInstanceBody(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    action: Annotated[
-        Literal["delete"], Field(description="The action to be performed on the entities.", title="Action")
-    ]
-    entities: Annotated[
-        list[str | BulkTaskInstanceBody],
-        Field(description="A list of entity id/key or entity objects to be deleted.", title="Entities"),
-    ]
-    action_on_non_existence: BulkActionNotOnExistence | None = "fail"
-
-
-class BulkDeleteActionConnectionBody(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    action: Annotated[
-        Literal["delete"], Field(description="The action to be performed on the entities.", title="Action")
-    ]
-    entities: Annotated[
-        list[str | BulkTaskInstanceBody],
-        Field(description="A list of entity id/key or entity objects to be deleted.", title="Entities"),
-    ]
-    action_on_non_existence: BulkActionNotOnExistence | None = "fail"
-
-
-class BulkDeleteActionPoolBody(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    action: Annotated[
-        Literal["delete"], Field(description="The action to be performed on the entities.", title="Action")
-    ]
-    entities: Annotated[
-        list[str | BulkTaskInstanceBody],
-        Field(description="A list of entity id/key or entity objects to be deleted.", title="Entities"),
-    ]
-    action_on_non_existence: BulkActionNotOnExistence | None = "fail"
-
-
-class BulkDeleteActionVariableBody(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -1987,37 +2019,5 @@ class BulkBodyBulkTaskInstanceBody(BaseModel):
             | BulkUpdateActionBulkTaskInstanceBody
             | BulkDeleteActionBulkTaskInstanceBody
         ],
-        Field(title="Actions"),
-    ]
-
-
-class BulkBodyConnectionBody(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    actions: Annotated[
-        list[
-            BulkCreateActionConnectionBody | BulkUpdateActionConnectionBody | BulkDeleteActionConnectionBody
-        ],
-        Field(title="Actions"),
-    ]
-
-
-class BulkBodyPoolBody(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    actions: Annotated[
-        list[BulkCreateActionPoolBody | BulkUpdateActionPoolBody | BulkDeleteActionPoolBody],
-        Field(title="Actions"),
-    ]
-
-
-class BulkBodyVariableBody(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    actions: Annotated[
-        list[BulkCreateActionVariableBody | BulkUpdateActionVariableBody | BulkDeleteActionVariableBody],
         Field(title="Actions"),
     ]

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -1210,6 +1210,8 @@ class BulkTaskInstanceBody(BaseModel):
     include_past: Annotated[bool | None, Field(title="Include Past")] = False
     task_id: Annotated[str, Field(title="Task Id")]
     map_index: Annotated[int | None, Field(title="Map Index")] = None
+    dag_id: Annotated[str | None, Field(title="Dag Id")] = None
+    dag_run_id: Annotated[str | None, Field(title="Dag Run Id")] = None
 
 
 class BulkUpdateActionBulkTaskInstanceBody(BaseModel):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Why
The current bulk delete/update endpoint requires making separate N requests when operating across N DAGs, which:
- is inefficient and slow (e.g., deleting 500 TIs across 500 DAGs = 500 HTTP requests)
- Is not atomic - can lead to partial failures/successes that users don't expect

## How 

Support wildcard (~) matching for dag_id and dag_run_id in bulk task instance API endpoints


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
