### PR TITLE
[CI]: prevent run of workflow 'ci-amd-arm' failing on clones

### DIFF
--- a/.github/workflows/ci-amd-arm.yml
+++ b/.github/workflows/ci-amd-arm.yml
@@ -52,6 +52,7 @@ jobs:
     name: "Build info"
     # At build-info stage we do not yet have outputs so we need to hard-code the runs-on to public runners
     runs-on: ["ubuntu-22.04"]
+    if: ${{ github.repository == 'apache/airflow' }}
     env:
       GITHUB_CONTEXT: ${{ toJson(github) }}
     outputs:


### PR DESCRIPTION
Hi,

PR similar to my previous one: https://github.com/apache/airflow/pull/57436

The `ci-amd-arm` Github workflow runs automatically on schedule  even on clones of original repo.

Such executions on clones will fail because original repo has definitions for secrets that clones don't have.

The added condition prevents such executions when not on apache/airflow

---