### PR TITLE
feat(providers_google): Add 'job' to CloudBatchSubmitJobOperator template_fields

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/operators/cloud_batch.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/cloud_batch.py
@@ -58,7 +58,7 @@ class CloudBatchSubmitJobOperator(GoogleCloudBaseOperator):
 
     """
 
-    template_fields = ("project_id", "region", "gcp_conn_id", "impersonation_chain", "job_name")
+    template_fields = ("project_id", "region", "gcp_conn_id", "impersonation_chain", "job_name", "job")
 
     def __init__(
         self,


### PR DESCRIPTION
### Summary

This PR adds the `'job'` field to `template_fields` in `CloudBatchSubmitJobOperator`.
This allows users to dynamically template the `job` parameter using Jinja variables, improving flexibility when submitting Google Cloud Batch jobs.

### Related Issue

closes: #37217

### Changes

* Added `'job'` to `template_fields` of `CloudBatchSubmitJobOperator`.
* Verified that templating now works correctly for job configurations.

### Tests

* Existing operator tests cover template rendering; no new tests are required since this change only exposes an additional field to templating.

### Checklist

* [x] Unit tests pass locally (`prek --all-files`)
* [x] Documentation not affected (no user-facing doc changes needed)
* [x] Follows [[Airflow’s contribution guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)
