### PR TITLE
Refine the visual design, interaction, and accessibility of the global navigation

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Nav/AdminButton.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/AdminButton.tsx
@@ -79,7 +79,7 @@ export const AdminButton = ({
   return (
     <Menu.Root positioning={{ placement: "right" }}>
       <Menu.Trigger asChild>
-        <NavButton icon={<FiSettings size={28} />} title={translate("nav.admin")} />
+        <NavButton icon={FiSettings} title={translate("nav.admin")} />
       </Menu.Trigger>
       <Menu.Content>
         {menuItems}

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/BrowseButton.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/BrowseButton.tsx
@@ -70,7 +70,7 @@ export const BrowseButton = ({
   return (
     <Menu.Root positioning={{ placement: "right" }}>
       <Menu.Trigger asChild>
-        <NavButton icon={<FiGlobe size={28} />} title={translate("nav.browse")} />
+        <NavButton icon={FiGlobe} title={translate("nav.browse")} />
       </Menu.Trigger>
       <Menu.Content>
         {menuItems}

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/DocsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/DocsButton.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Link } from "@chakra-ui/react";
+import { Box, Icon, Link } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 import { FiBookOpen, FiExternalLink } from "react-icons/fi";
 
@@ -61,7 +61,7 @@ export const DocsButton = ({
   return (
     <Menu.Root positioning={{ placement: "right" }}>
       <Menu.Trigger asChild>
-        <NavButton icon={<FiBookOpen size={28} />} title={translate("nav.docs")} />
+        <NavButton icon={FiBookOpen} title={translate("nav.docs")} />
       </Menu.Trigger>
       <Menu.Content>
         {links
@@ -73,17 +73,18 @@ export const DocsButton = ({
                 href={link.href}
                 rel="noopener noreferrer"
                 target="_blank"
+                textDecoration="none"
               >
-                {translate(`docs.${link.key}`)}
-                <FiExternalLink />
+                <Box flex="1">{translate(`docs.${link.key}`)}</Box>
+                <Icon as={FiExternalLink} boxSize={4} color="fg.muted" />
               </Link>
             </Menu.Item>
           ))}
         {version === undefined ? undefined : (
           <Menu.Item asChild key={version} value={version}>
             <Link aria-label={version} href={versionLink} rel="noopener noreferrer" target="_blank">
-              {version}
-              <FiExternalLink />
+              <Box flex="1">{version}</Box>
+              <Icon as={FiExternalLink} boxSize={4} color="fg.muted" />
             </Link>
           </Menu.Item>
         )}

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.tsx
@@ -19,7 +19,7 @@
 import { Box, Flex, VStack } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 import { FiDatabase, FiHome } from "react-icons/fi";
-import { NavLink } from "react-router-dom";
+import { Link } from "react-router-dom";
 
 import {
   useAuthLinksServiceGetAuthMenus,
@@ -140,14 +140,14 @@ export const Nav = () => {
       height="100%"
       justifyContent="space-between"
       position="fixed"
-      py={3}
+      py={1}
       top={0}
-      width={20}
+      width={16}
       zIndex={2}
     >
-      <Flex alignItems="center" flexDir="column" width="100%">
-        <Box mb={3}>
-          <NavLink to="/">
+      <Flex alignItems="center" flexDir="column" width="100%" gap={1}>
+        <Box asChild boxSize={14} display="flex" alignItems="center" justifyContent="center">
+          <Link to="/" title={translate("nav.home")}>
             <AirflowPin
               _motionSafe={{
                 _hover: {
@@ -155,21 +155,20 @@ export const Nav = () => {
                   transition: "transform 0.8s ease-in-out"
                 }
               }}
-              height="35px"
-              width="35px"
+              boxSize={8}
             />
-          </NavLink>
+          </Link>
         </Box>
-        <NavButton icon={<FiHome size="28px" />} title={translate("nav.home")} to="/" />
+        <NavButton icon={FiHome} title={translate("nav.home")} to="/" />
         <NavButton
           disabled={!authLinks?.authorized_menu_items.includes("Dags")}
-          icon={<DagIcon height="28px" width="28px" />}
+          icon={DagIcon}
           title={translate("nav.dags")}
           to="dags"
         />
         <NavButton
           disabled={!authLinks?.authorized_menu_items.includes("Assets")}
-          icon={<FiDatabase size="28px" />}
+          icon={FiDatabase}
           title={translate("nav.assets")}
           to="assets"
         />
@@ -184,7 +183,7 @@ export const Nav = () => {
         <SecurityButton />
         <PluginMenus navItems={navItemsWithLegacy} />
       </Flex>
-      <Flex flexDir="column">
+      <Flex flexDir="column" gap={1}>
         <DocsButton
           externalViews={docsItems}
           showAPI={authLinks?.authorized_menu_items.includes("Docs")}

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/PluginMenus.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/PluginMenus.tsx
@@ -53,7 +53,7 @@ export const PluginMenus = ({ navItems }: { readonly navItems: Array<NavItemResp
   return navItems.length >= 2 ? (
     <Menu.Root positioning={{ placement: "right" }}>
       <Menu.Trigger>
-        <NavButton as={Box} icon={<LuPlug />} title={translate("nav.plugins")} />
+        <NavButton as={Box} icon={LuPlug} title={translate("nav.plugins")} />
       </Menu.Trigger>
       <Menu.Content>
         {buttons.map((navItem) => (

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/SecurityButton.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/SecurityButton.tsx
@@ -36,7 +36,7 @@ export const SecurityButton = () => {
   return (
     <Menu.Root positioning={{ placement: "right" }}>
       <Menu.Trigger asChild>
-        <NavButton icon={<FiLock size={28} />} title={translate("nav.security")} />
+        <NavButton icon={FiLock} title={translate("nav.security")} />
       </Menu.Trigger>
       <Menu.Content>
         {authLinks.extra_menu_items.map(({ text }) => {

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/TimezoneMenuItem.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/TimezoneMenuItem.tsx
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { Box, Icon } from "@chakra-ui/react";
 import dayjs from "dayjs";
 import timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
@@ -48,8 +49,8 @@ export const TimezoneMenuItem = ({ onOpen }: { readonly onOpen: () => void }) =>
 
   return (
     <Menu.Item onClick={onOpen} value="timezone">
-      <FiClock size={20} style={{ marginRight: "8px" }} />
-      {translate("timezone")}: {dayjs(time).tz(selectedTimezone).format("HH:mm z (Z)")}
+      <Icon as={FiClock} boxSize={4} />
+      <Box flex="1">{translate("timezone")}: {dayjs(time).tz(selectedTimezone).format("HH:mm z (Z)")}</Box>
     </Menu.Item>
   );
 };

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/UserSettingsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/UserSettingsButton.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useDisclosure } from "@chakra-ui/react";
+import { Box, Icon, useDisclosure } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 import {
   FiGrid,
@@ -55,9 +55,29 @@ type ColorMode = (typeof COLOR_MODES)[keyof typeof COLOR_MODES];
 export const UserSettingsButton = ({ externalViews }: { readonly externalViews: Array<NavItemResponse> }) => {
   const { i18n, t: translate } = useTranslation();
   const { selectedTheme, setColorMode } = useColorMode();
+
+  const colorModeOptions = [
+    {
+      icon: FiSun,
+      label: translate("appearance.lightMode"),
+      value: COLOR_MODES.LIGHT,
+    },
+    {
+      icon: FiMoon,
+      label: translate("appearance.darkMode"),
+      value: COLOR_MODES.DARK,
+    },
+    {
+      icon: FiMonitor,
+      label: translate("appearance.systemMode"),
+      value: COLOR_MODES.SYSTEM,
+    },
+  ];
+
   const { onClose: onCloseTimezone, onOpen: onOpenTimezone, open: isOpenTimezone } = useDisclosure();
   const { onClose: onCloseLogout, onOpen: onOpenLogout, open: isOpenLogout } = useDisclosure();
   const { onClose: onCloseLanguage, onOpen: onOpenLanguage, open: isOpenLanguage } = useDisclosure();
+
   const [dagView, setDagView] = useLocalStorage<"graph" | "grid">("default_dag_view", "grid");
 
   const theme = selectedTheme ?? COLOR_MODES.SYSTEM;
@@ -65,79 +85,58 @@ export const UserSettingsButton = ({ externalViews }: { readonly externalViews: 
   const isRTL = i18n.dir() === "rtl";
 
   return (
-    <Menu.Root positioning={{ placement: "right" }}>
-      <Menu.Trigger asChild>
-        <NavButton icon={<FiUser size={28} />} title={translate("user")} />
-      </Menu.Trigger>
-      <Menu.Content>
-        <Menu.Item onClick={onOpenLanguage} value="language">
-          <FiGlobe size={20} style={{ marginRight: "8px" }} />
-          {translate("selectLanguage")}
-        </Menu.Item>
-        <Menu.Root>
-          <Menu.TriggerItem>
-            <FiEye size={20} style={{ marginRight: "8px" }} />
-            {translate("appearance.appearance")}
-            {isRTL ? (
-              <FiChevronLeft size={20} style={{ marginRight: "auto" }} />
-            ) : (
-              <FiChevronRight size={20} style={{ marginLeft: "auto" }} />
-            )}
-          </Menu.TriggerItem>
-          <Menu.Content>
-            <Menu.RadioItemGroup
-              onValueChange={(element) => setColorMode(element.value as ColorMode)}
-              value={theme}
-            >
-              <Menu.RadioItem value={COLOR_MODES.LIGHT}>
-                <FiSun size={20} style={{ marginRight: "8px" }} />
-                {translate("appearance.lightMode")}
-                <Menu.ItemIndicator />
-              </Menu.RadioItem>
-              <Menu.RadioItem value={COLOR_MODES.DARK}>
-                <FiMoon size={20} style={{ marginRight: "8px" }} />
-                {translate("appearance.darkMode")}
-                <Menu.ItemIndicator />
-              </Menu.RadioItem>
-              <Menu.RadioItem value={COLOR_MODES.SYSTEM}>
-                <FiMonitor size={20} style={{ marginRight: "8px" }} />
-                {translate("appearance.systemMode")}
-                <Menu.ItemIndicator />
-              </Menu.RadioItem>
-            </Menu.RadioItemGroup>
-          </Menu.Content>
-        </Menu.Root>
-        <Menu.Item
-          onClick={() => (dagView === "grid" ? setDagView("graph") : setDagView("grid"))}
-          value={dagView}
-        >
-          {dagView === "grid" ? (
-            <>
-              <MdOutlineAccountTree size={20} style={{ marginRight: "8px" }} />
-              {translate("defaultToGraphView")}
-            </>
-          ) : (
-            <>
-              <FiGrid size={20} style={{ marginRight: "8px" }} />
-              {translate("defaultToGridView")}
-            </>
-          )}
-        </Menu.Item>
-        <TimezoneMenuItem onOpen={onOpenTimezone} />
-        {externalViews.map((view) => (
-          <PluginMenuItem {...view} key={view.name} />
-        ))}
-        <Menu.Item onClick={onOpenLogout} value="logout">
-          <FiLogOut
-            size={20}
-            style={{ marginRight: "8px", transform: isRTL ? "rotate(180deg)" : undefined }}
-          />
-          {translate("logout")}
-        </Menu.Item>
-      </Menu.Content>
+    <>
+      <Menu.Root positioning={{ placement: "right" }}>
+        <Menu.Trigger asChild>
+          <NavButton icon={FiUser} title={translate("user")} />
+        </Menu.Trigger>
+        <Menu.Content>
+          <Menu.Item onClick={onOpenLanguage} value="language">
+            <Icon as={FiGlobe} boxSize={4} />
+            <Box flex="1">{translate("selectLanguage")}</Box>
+          </Menu.Item>
+          <Menu.Root>
+            <Menu.TriggerItem>
+              <Icon as={FiEye} boxSize={4} />
+              <Box flex="1">{translate("appearance.appearance")}</Box>
+              <Icon as={isRTL ? FiChevronLeft : FiChevronRight} boxSize={4} color="fg.muted" />
+            </Menu.TriggerItem>
+            <Menu.Content>
+              <Menu.RadioItemGroup
+                onValueChange={(element) => setColorMode(element.value as ColorMode)}
+                value={theme}
+              >
+                {colorModeOptions.map(({ icon, label, value }) => (
+                  <Menu.RadioItem key={value} value={value}>
+                    <Icon as={icon} boxSize={4} />
+                    <Box flex="1">{label}</Box>
+                    <Menu.ItemIndicator color="fg.muted" />
+                  </Menu.RadioItem>
+                ))}
+              </Menu.RadioItemGroup>
+            </Menu.Content>
+          </Menu.Root>
+          <Menu.Item
+            onClick={() => (dagView === "grid" ? setDagView("graph") : setDagView("grid"))}
+            value={dagView}
+          >
+            <Icon as={dagView === "grid" ? MdOutlineAccountTree : FiGrid} boxSize={4} />
+            <Box flex="1">{dagView === "grid" ? translate("defaultToGraphView") : translate("defaultToGridView")}</Box>
+          </Menu.Item>
+          <TimezoneMenuItem onOpen={onOpenTimezone} />
+          {externalViews.map((view) => (
+            <PluginMenuItem {...view} key={view.name} />
+          ))}
+          <Menu.Separator />
+          <Menu.Item onClick={onOpenLogout} value="logout">
+            <Icon as={FiLogOut} boxSize={4} transform={isRTL ? "rotate(180deg)" : undefined} />
+            <Box flex="1">{translate("logout")}</Box>
+          </Menu.Item>
+        </Menu.Content>
+      </Menu.Root>
       <LanguageModal isOpen={isOpenLanguage} onClose={onCloseLanguage} />
       <TimezoneModal isOpen={isOpenTimezone} onClose={onCloseTimezone} />
       <LogoutModal isOpen={isOpenLogout} onClose={onCloseLogout} />
-    </Menu.Root>
+    </>
   );
 };


### PR DESCRIPTION
## Refines the visual presentation of the global navigation

While some of the changes in this PR have a subjective nature to them, I believe the sum makes for an objectively better user experience.

- Reduced the overall width of the nav bar from 80px to 64px wide. Airflow has many horizontally dense views and the current nav was using an unnecessarily large amount of it.
- Improved the continuity and visual cadence of the navigation items. These changes make the presentation look more intentional:
  - The Airflow logo previously had different x and y margins surrounding it, making it appear smashed to the top of the bar.
  - The nav items previously had slightly different x and y paddings, making them rectangles. Now they are squares
- Tightened the location of the Docs and User nav items closer to the bottom to make them appear pinned (which they are) instead of floating.
- Tweaked the hover, focus, and active interaction states to be more polished.

| Dark mode - Before | Dark mode - After | Light mode - Before | Light mode - After |
|--|--|--|--|
| <img width="153" height="826" alt="image" src="https://github.com/user-attachments/assets/2cad0e51-8252-4a23-85eb-c738006fc2b3" /> | <img width="152" height="825" alt="image" src="https://github.com/user-attachments/assets/135bbcad-a7b4-4c13-9d1f-e9b8d1721ccc" /> | <img width="153" height="827" alt="image" src="https://github.com/user-attachments/assets/b455625a-0c0f-4b10-92b0-ab5dacc553a3" /> | <img width="152" height="826" alt="image" src="https://github.com/user-attachments/assets/24bf1f04-30ec-425f-b867-4865a8dea7ab" /> |


| Docs menu - Before | Docs menu - After |
|--|--|
| <img width="280" height="214" alt="image" src="https://github.com/user-attachments/assets/ff8ec7e4-b537-4cab-a055-04123cc8d3df" /> | <img width="259" height="170" alt="image" src="https://github.com/user-attachments/assets/14abf53b-4f8b-43f2-ab96-6eba9f319bc2" /> |
|<img width="279" height="210" alt="image" src="https://github.com/user-attachments/assets/5c6418df-aad4-49dd-a911-a003389eb1b9" /> | <img width="263" height="171" alt="image" src="https://github.com/user-attachments/assets/93b67163-f8ae-43fe-becd-084bc86748e9" /> | 


| User menu - Before | User menu - After |
|--|--|
| <img width="584" height="191" alt="image" src="https://github.com/user-attachments/assets/52fde6f7-3230-424b-9b93-fccac4be53c7" />| <img width="543" height="198" alt="image" src="https://github.com/user-attachments/assets/eb797296-f2ef-41c4-8712-005ef04e3a81" />|
|<img width="586" height="191" alt="image" src="https://github.com/user-attachments/assets/7770e02f-250a-4380-b4e6-ddd2a540d410" />  |<img width="542" height="196" alt="image" src="https://github.com/user-attachments/assets/6195f64f-ce61-4436-b548-ca8f892dd0e0" /> | 

## Improves nav item accessibility

Observe how each nav item was receiving focus twice each time I pressed tab on my keyboard:

| Nav item tabbing - Before | Nav item tabbing - After |
|--|--|
| ![Zight Recording 2025-10-28 at 06 17 37 PM](https://github.com/user-attachments/assets/37e255ab-602b-44fb-9b22-8b44c7cd700c)| ![Zight Recording 2025-10-28 at 06 16 31 PM](https://github.com/user-attachments/assets/c64355b8-4aef-4dc0-8fb8-8a994571d373)| 

This was due to undesirable markup nesting with anchors wrapping buttons. This was resolved so that each nav item is only an anchor or only button (where appropriate), utilizing Chakra's `asChild` prop to accomplish this aswell as some additional refactoring of the `NavButton` component.

| Nav item markup - Before | Nav item markup - After | 
|--|--|
| <img width="407" height="106" alt="image" src="https://github.com/user-attachments/assets/deed0df5-1075-49f6-b909-10c1762ee915" />|<img width="529" height="129" alt="image" src="https://github.com/user-attachments/assets/00c3694c-84b2-47dd-ac82-1ad7aea15da7" /> | 

## Testing

Added proper overflow handling and title tags for languages that might have overly long labels on them:

<img width="320" height="368" alt="image" src="https://github.com/user-attachments/assets/b92c19ad-a0f1-4726-bbbc-0baffc6a77d5" />


I confirmed no regressions with RTL languages:

<img width="1512" height="827" alt="image" src="https://github.com/user-attachments/assets/45431b64-ffad-458e-a1dc-ef9849dd2499" />


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
