### PR TITLE
Fix connection retrieval in `DagProcessorManager` for bundle initialization

### DIFF
--- a/airflow-core/src/airflow/dag_processing/processor.py
+++ b/airflow-core/src/airflow/dag_processing/processor.py
@@ -174,6 +174,10 @@ def _pre_import_airflow_modules(file_path: str, log: FilteringBoundLogger) -> No
 
 
 def _parse_file_entrypoint():
+    # Mark as client-side (runs user DAG code)
+    # Prevents inheriting server context from parent DagProcessorManager
+    os.environ["_AIRFLOW_PROCESS_CONTEXT"] = "client"
+
     import structlog
 
     from airflow.sdk.execution_time import comms, task_runner


### PR DESCRIPTION
The dag_processor was unable to retrieve connections from the database,
causing GitHook (and other hooks) to fail with:
  AirflowNotFoundException: The conn_id `<conn_id>` isn't defined

Root cause: DagProcessorManager was running in FALLBACK context, which only
loads EnvironmentVariablesBackend, not MetastoreBackend. This meant
connections stored in the database were inaccessible.

The `DagProcessorManager` (parent process) needs database access for connection
retrieval during bundle initialization (e.g., `GitDagBundle.__init__` → `GitHook`
needs git credentials). Child `DagFileProcessorProcess` instances run user code
and should remain isolated from direct database access.

This ensures correct secrets backend chains (when no external secrets backend is configured):
- Manager (parent): `EnvironmentVariablesBackend` → `MetastoreBackend` (database access)
- Parser (child): `EnvironmentVariablesBackend`

Note: This is temporary until AIP-92 removes direct DB access from DagProcessorManager.
Long-term, the manager should use the Execution API instead of direct database access.

Affects: DAG bundle processing with GitHook and any other hooks that rely on
database-stored connections during bundle initialization in the manager process.