### PR TITLE
Enable PT011 rule to airflow-core tests

### DIFF
--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -548,7 +548,7 @@ class TestCliDags:
         assert dagrun.logical_date.isoformat(timespec="microseconds") == "2021-06-04T01:00:00.000001+00:00"
 
     def test_trigger_dag_invalid_conf(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"Expecting value: line \d+ column \d+ \(char \d+\)"):
             dag_command.dag_trigger(
                 self.parser.parse_args(
                     [

--- a/airflow-core/tests/unit/core/test_configuration.py
+++ b/airflow-core/tests/unit/core/test_configuration.py
@@ -350,7 +350,10 @@ sql_alchemy_conn = airflow
         assert asdict["test"]["sql_alchemy_conn"] == "< hidden >"
         # If display_sensitive is false, then include_cmd, include_env,include_secrets must all be True
         # This ensures that cmd and secrets env are hidden at the appropriate method and no surprises
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="If display_sensitive is false, then include_env, include_cmds, include_secret must all be set as True",
+        ):
             test_conf.as_dict(display_sensitive=False, include_cmds=False)
         # Test that one of include_cmds, include_env, include_secret can be false when display_sensitive
         # is True

--- a/airflow-core/tests/unit/core/test_otel_logger.py
+++ b/airflow-core/tests/unit/core/test_otel_logger.py
@@ -42,6 +42,8 @@ INVALID_STAT_NAME_CASES = [
     ("test/$tats", "contains invalid characters"),
 ]
 
+RATE_MUST_BE_POSITIVE_MSG = "rate must be a positive value"
+
 
 @pytest.fixture
 def name():
@@ -136,7 +138,7 @@ class TestOtelMetrics:
         # This one should not increment because random() will return a value higher than `rate`
         self.stats.incr(name, rate=0.5)
         # This one should raise an exception for a negative `rate` value
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=RATE_MUST_BE_POSITIVE_MSG):
             self.stats.incr(name, rate=-0.5)
 
         assert mock_random.call_count == 2
@@ -170,7 +172,7 @@ class TestOtelMetrics:
         # This one should not decrement because random() will return a value higher than `rate`
         self.stats.decr(name, rate=0.5)
         # This one should raise an exception for a negative `rate` value
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=RATE_MUST_BE_POSITIVE_MSG):
             self.stats.decr(name, rate=-0.5)
 
         assert mock_random.call_count == 2
@@ -215,7 +217,7 @@ class TestOtelMetrics:
         # This one should not increment because random() will return a value higher than `rate`
         self.stats.gauge(name, value=1, rate=0.5)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=RATE_MUST_BE_POSITIVE_MSG):
             self.stats.gauge(name, value=1, rate=-0.5)
 
         assert mock_random.call_count == 2

--- a/airflow-core/tests/unit/executors/test_base_executor.py
+++ b/airflow-core/tests/unit/executors/test_base_executor.py
@@ -53,7 +53,7 @@ def test_is_production_default_value():
 
 
 def test_invalid_slotspool():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="parallelism is set to 0 or lower"):
         BaseExecutor(0)
 
 
@@ -254,7 +254,7 @@ def test_debug_dump(caplog):
 
 def test_base_executor_cannot_send_callback():
     executor = BaseExecutor()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Callback sink is not ready"):
         executor.send_callback(mock.Mock(spec=CallbackRequest))
 
 

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -180,7 +180,7 @@ def test_capacity_decode():
     ]
     for input_str in variants:
         job = Job()
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Capacity number .+ is invalid"):
             TriggererJobRunner(job=job, capacity=input_str)
 
 

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -180,7 +180,7 @@ def test_capacity_decode():
     ]
     for input_str in variants:
         job = Job()
-        with pytest.raises(ValueError, match="Capacity number .+ is invalid"):
+        with pytest.raises(ValueError, match=r"Capacity number .+ is invalid"):
             TriggererJobRunner(job=job, capacity=input_str)
 
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
issue: Enable Even More PyDocStyle Checks #40567
@ferruzzi
This PR is for enable PT011 rule:
PT011: all instances of pytest.raises should include a match term to make sure they are catching the right error.
https://docs.astral.sh/ruff/rules/pytest-raises-too-broad/
There are 102 files changes is need.
So, I separate to many PR, which contains about 5 file changes for easy review.

**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
