### PR TITLE
Add secret masking for Jinja template rendering exceptions

### DIFF
--- a/task-sdk/src/airflow/sdk/definitions/_internal/abstractoperator.py
+++ b/task-sdk/src/airflow/sdk/definitions/_internal/abstractoperator.py
@@ -32,7 +32,6 @@ import methodtools
 
 from airflow.configuration import conf
 from airflow.sdk import TriggerRule, WeightRule
-from airflow.sdk._shared.secrets_masker import redact
 from airflow.sdk.definitions._internal.mixins import DependencyMixin
 from airflow.sdk.definitions._internal.node import DAGNode
 from airflow.sdk.definitions._internal.setup_teardown import SetupTeardownContext
@@ -306,6 +305,8 @@ class AbstractOperator(Templater, DAGNode):
                     rendered_content = self.render_template(value, context, jinja_env, seen_oids)
             except Exception:
                 # Mask sensitive values in the template before logging
+                from airflow.sdk._shared.secrets_masker import redact
+
                 masked_value = redact(value)
                 log.exception(
                     "Exception rendering Jinja template for task '%s', field '%s'. Template: %r",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
Add secret masking for Jinja template rendering exceptions

This brings back the secret masking functionality that was present in Airflow 2.11.0
but was missing in Airflow 3. When Jinja template rendering fails, sensitive values
in the template are now properly masked as '***' in the error logs.

I have functionally tested this change with following DAG:
```
from datetime import datetime
from airflow.sdk import DAG
from airflow.sdk.bases.operator import BaseOperator


class TestOperator(BaseOperator):
    template_fields = ("my_password", "my_api_key", "my_secret")

    def __init__(
        self,
        my_password: str = "",
        my_api_key: str = "",
        my_secret: str = "",
        **kwargs
    ):
        super().__init__(**kwargs)
        self.my_password = my_password
        self.my_api_key = my_api_key
        self.my_secret = my_secret

    def execute(self, context):
        self.log.info(f"Password: {self.my_password}")
        self.log.info(f"API Key: {self.my_api_key}")
        self.log.info(f"Secret: {self.my_secret}")
        return "success"


class MaskingOperator(BaseOperator):
    template_fields = ("message",)

    def __init__(self, message: str = "", **kwargs):
        super().__init__(**kwargs)
        self.message = message

    def execute(self, context):
        from airflow.sdk.log import mask_secret
        
        mask_secret("super_secret_pass_12345", "password")
        mask_secret("my_api_key_67890_abcdef", "api_key")
        
        self.log.info(f"Message with secret: {self.message}")
        self.log.info("Direct log: super_secret_pass_12345 and my_api_key_67890_abcdef")
        return "success"


dag = DAG(
    dag_id="test_secret_masking",
    description="Test secret masking",
    start_date=datetime(2025, 11, 1),
    catchup=False,
    tags=["test", "secret-masking"],
)

test_task_4 = TestOperator(
    task_id="test_successful_render_no_masking",
    my_password="super_secret_pass_12345",
    my_api_key="my_api_key_67890_abcdef",
    my_secret="ultra_secret_token_xyz",
    dag=dag,
)

test_task_5 = MaskingOperator(
    task_id="test_successful_with_masking",
    message="Contains secrets: super_secret_pass_12345 and my_api_key_67890_abcdef",
    dag=dag,
)

```
For second task following is the log:
```
Log message source details sources=["/root/airflow/logs/dag_id=test_secret_masking/run_id=manual__2025-11-06T10:40:17+00:00/task_id=test_successful_with_masking/attempt=1.log"]
[2025-11-06 16:25:18] INFO - DAG bundles loaded: dags-folder source=airflow.dag_processing.bundles.manager.DagBundlesManager loc=manager.py:209
[2025-11-06 16:25:18] INFO - Filling up the DagBag from /files/dags/test_secret_masker.py source=airflow.dag_processing.dagbag.DagBag loc=dagbag.py:629
[2025-11-06 16:25:18] INFO - Message with secret: Contains secrets: *** and *** source=airflow.task.operators.unusual_prefix_c9af686d420fba94b90b38b88c79d3ef82d68a9e_test_secret_masker.MaskingOperator loc=test_secret_masker.py:41
[2025-11-06 16:25:18] INFO - Direct log: *** and *** source=airflow.task.operators.unusual_prefix_c9af686d420fba94b90b38b88c79d3ef82d68a9e_test_secret_masker.MaskingOperator loc=test_secret_masker.py:42
[2025-11-06 16:25:18] INFO - Pushing xcom ti=RuntimeTaskInstance(id=UUID('019a58c0-bfec-7c7d-bc4f-027ae2faa2e3'), task_id='test_successful_with_masking', dag_id='test_secret_masking', run_id='manual__2025-11-06T10:40:17+00:00', try_number=1, dag_version_id=UUID('019a58c0-1cf0-7307-8a16-038e3899b361'), map_index=-1, hostname='ca6fcedf0ff0', context_carrier={}, task=<Task(MaskingOperator): test_successful_with_masking>, bundle_instance=LocalDagBundle(name=dags-folder), max_tries=0, start_date=datetime.datetime(2025, 11, 6, 10, 40, 18, 731621, tzinfo=datetime.timezone.utc), end_date=None, state=<TaskInstanceState.RUNNING: 'running'>, is_mapped=False, rendered_map_index=None) source=task loc=task_runner.py:1377

```
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
