### PR TITLE
Fix socket error in PythonVirtualenvOperator subprocess environments

### DIFF
--- a/providers/standard/src/airflow/providers/standard/utils/python_virtualenv_script.jinja2
+++ b/providers/standard/src/airflow/providers/standard/utils/python_virtualenv_script.jinja2
@@ -47,7 +47,15 @@ else:
   {#- We are in an Airflow 3.x env, try and set up supervisor comms so virtual env can still access tasks etc! #}
   reinit_supervisor_comms = getattr(task_runner, "reinit_supervisor_comms", None)
   if reinit_supervisor_comms:
-      reinit_supervisor_comms()
+      try:
+          reinit_supervisor_comms()
+      except OSError as e:
+          if e.errno == 88:  # Socket operation on non-socket
+              # In subprocess environments (like PythonVirtualenvOperator), stdin may not be a socket
+              # This is expected behavior, supervisor communication is not available
+              pass
+          else:
+              raise
 {% endif %}
 
 # Script


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
This PR fixes the CI for broken test as part of https://github.com/apache/airflow/actions/runs/18896380254

This handles OSError 88 (Socket operation on non-socket) when reinit_supervisor_comms is called in subprocess environments where stdin is inherited as a file descriptor rather than a socket. This is expected behavior in test environments using subprocess.Popen() and supervisor communication is not available.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
