### PR TITLE
Revert virtualenv connections/variables access and logging as test are failing in CI

### DIFF
--- a/providers/standard/src/airflow/providers/standard/utils/python_virtualenv_script.jinja2
+++ b/providers/standard/src/airflow/providers/standard/utils/python_virtualenv_script.jinja2
@@ -38,16 +38,6 @@ if sys.version_info >= (3,6):
         {# Airflow is not available in this environment, therefore we won't
          # be able to integrate any plugin macros. #}
         pass
-
-try:
-    from airflow.sdk.execution_time import task_runner
-except ModuleNotFoundError:
-    pass
-else:
-  {#- We are in an Airflow 3.x env, try and set up supervisor comms so virtual env can still access tasks etc! #}
-  reinit_supervisor_comms = getattr(task_runner, "reinit_supervisor_comms", None)
-  if reinit_supervisor_comms:
-      reinit_supervisor_comms()
 {% endif %}
 
 # Script
@@ -59,10 +49,12 @@ else:
 import types
 
 {{ modified_dag_module_name }}  = types.ModuleType("{{ modified_dag_module_name }}")
+
 {{ modified_dag_module_name }}.{{ python_callable }} = {{ python_callable }}
+
 sys.modules["{{modified_dag_module_name}}"] = {{modified_dag_module_name}}
 
-{%- endif -%}
+{% endif%}
 
 {% if op_args or op_kwargs %}
 with open(sys.argv[1], "rb") as file:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
Revert virtualenv connections/variables access and logging as tests are failing in https://github.com/apache/airflow/actions/runs/18896380254. The issue here is that it's a socket initialisation error that occurs when CommsDecoder tries to create a socket from stdin (file descriptor 0) in subprocess environments where stdin is not a socket.

This reverts commit fb8b59046c56345f4fb89c110859f7e7a1da89fd (PR #57213) which allowed virtualenv code to access connections/variables and send logs via supervisor comms reinitialization.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
