### PR TITLE
Fix `MwaaTaskCompletedTrigger`

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/mwaa.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/mwaa.py
@@ -303,7 +303,6 @@ class MwaaTaskSensor(AwsBaseSensor[MwaaHook]):
                     external_task_id=self.external_task_id,
                     success_states=self.success_states,
                     failure_states=self.failure_states,
-                    airflow_version=self.airflow_version,
                     waiter_delay=int(self.poke_interval),
                     waiter_max_attempts=self.max_retries,
                     aws_conn_id=self.aws_conn_id,

--- a/providers/amazon/src/airflow/providers/amazon/aws/triggers/mwaa.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/triggers/mwaa.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 from collections.abc import Collection
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 from airflow.providers.amazon.aws.hooks.mwaa import MwaaHook
 from airflow.providers.amazon.aws.triggers.base import AwsBaseWaiterTrigger
@@ -121,8 +121,6 @@ class MwaaTaskCompletedTrigger(AwsBaseWaiterTrigger):
         ``{airflow.utils.state.TaskInstanceState.SUCCESS}`` (templated)
     :param failure_states: Collection of task instance states that would make this task marked as failed and raise an
         AirflowException, default is ``{airflow.utils.state.TaskInstanceState.FAILED}`` (templated)
-    :param airflow_version: The Airflow major version the MWAA environment runs.
-            This parameter is only used if the local web token method is used to call Airflow API. (templated)
     :param waiter_delay: The amount of time in seconds to wait between attempts. (default: 60)
     :param waiter_max_attempts: The maximum number of attempts to be made. (default: 720)
     :param aws_conn_id: The Airflow connection used for AWS credentials.
@@ -137,7 +135,6 @@ class MwaaTaskCompletedTrigger(AwsBaseWaiterTrigger):
         external_task_id: str,
         success_states: Collection[str] | None = None,
         failure_states: Collection[str] | None = None,
-        airflow_version: Literal[2, 3] | None = None,
         waiter_delay: int = 60,
         waiter_max_attempts: int = 720,
         **kwargs,
@@ -168,7 +165,6 @@ class MwaaTaskCompletedTrigger(AwsBaseWaiterTrigger):
                 "Name": external_env_name,
                 "Path": f"/dags/{external_dag_id}/dagRuns/{external_dag_run_id}/taskInstances/{external_task_id}",
                 "Method": "GET",
-                "airflow_version": airflow_version,
             },
             failure_message=f"The task {external_task_id} of DAG run {external_dag_run_id} of DAG {external_dag_id} in MWAA environment {external_env_name} failed with state",
             status_message="State of DAG run",


### PR DESCRIPTION
`MwaaTaskCompletedTrigger` does not need the airflow version to run. This bug was introduced by me in #57443.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
