### PR TITLE
Fix HITL operators failing when using notifiers

### DIFF
--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -48,6 +48,7 @@ from airflow.sdk.api.datamodels._generated import (
     ConnectionResponse,
     DagRunStateResponse,
     DagRunType,
+    HITLDetailRequest,
     HITLDetailResponse,
     HITLUser,
     InactiveAssetsResponse,
@@ -77,7 +78,6 @@ from airflow.sdk.execution_time.comms import (
     CreateHITLDetailPayload,
     DRCount,
     ErrorResponse,
-    HITLDetailRequestResult,
     OKResponse,
     PreviousDagRunResult,
     SkipDownstreamTasks,
@@ -754,7 +754,7 @@ class HITLOperations:
         multiple: bool = False,
         params: dict[str, Any] | None = None,
         assigned_users: list[HITLUser] | None = None,
-    ) -> HITLDetailRequestResult:
+    ) -> HITLDetailRequest:
         """Add a Human-in-the-loop response that waits for human response for a specific Task Instance."""
         payload = CreateHITLDetailPayload(
             ti_id=ti_id,
@@ -770,7 +770,7 @@ class HITLOperations:
             f"/hitlDetails/{ti_id}",
             content=payload.model_dump_json(),
         )
-        return HITLDetailRequestResult.model_validate_json(resp.read())
+        return HITLDetailRequest.model_validate_json(resp.read())
 
     def update_response(
         self,

--- a/task-sdk/src/airflow/sdk/execution_time/comms.py
+++ b/task-sdk/src/airflow/sdk/execution_time/comms.py
@@ -584,6 +584,17 @@ class HITLDetailRequestResult(HITLDetailRequest):
 
     type: Literal["HITLDetailRequestResult"] = "HITLDetailRequestResult"
 
+    @classmethod
+    def from_api_response(cls, hitl_request: HITLDetailRequest) -> HITLDetailRequestResult:
+        """
+        Get HITLDetailRequestResult from HITLDetailRequest (API response).
+
+        HITLDetailRequest is the API response model. We convert it to HITLDetailRequestResult
+        for communication between the Supervisor and task process, adding the discriminator field
+        required for the tagged union deserialization.
+        """
+        return cls(**hitl_request.model_dump(exclude_defaults=True), type="HITLDetailRequestResult")
+
 
 ToTask = Annotated[
     AssetResult

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -94,6 +94,7 @@ from airflow.sdk.execution_time.comms import (
     GetXComCount,
     GetXComSequenceItem,
     GetXComSequenceSlice,
+    HITLDetailRequestResult,
     InactiveAssetsResult,
     MaskSecret,
     PrevSuccessfulDagRunResult,
@@ -1383,7 +1384,7 @@ class ActivitySubprocess(WatchedSubprocess):
                 # Since we've sent the message, return. Nothing else in this ifelse/switch should return directly
                 return
         elif isinstance(msg, CreateHITLDetailPayload):
-            resp = self.client.hitl.add_response(
+            hitl_detail_request = self.client.hitl.add_response(
                 ti_id=msg.ti_id,
                 options=msg.options,
                 subject=msg.subject,
@@ -1393,7 +1394,8 @@ class ActivitySubprocess(WatchedSubprocess):
                 multiple=msg.multiple,
                 assigned_users=msg.assigned_users,
             )
-            self.send_msg(resp, request_id=req_id, error=None, **dump_opts)
+            resp = HITLDetailRequestResult.from_api_response(hitl_detail_request)
+            dump_opts = {"exclude_unset": True}
         elif isinstance(msg, MaskSecret):
             mask_secret(msg.value, msg.name)
         else:

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -39,6 +39,7 @@ from airflow.sdk.api.datamodels._generated import (
     ConnectionResponse,
     DagRunState,
     DagRunStateResponse,
+    HITLDetailRequest,
     HITLDetailResponse,
     HITLUser,
     TerminalTIState,
@@ -49,7 +50,6 @@ from airflow.sdk.exceptions import ErrorType
 from airflow.sdk.execution_time.comms import (
     DeferTask,
     ErrorResponse,
-    HITLDetailRequestResult,
     OKResponse,
     PreviousDagRunResult,
     RescheduleTask,
@@ -1300,7 +1300,7 @@ class TestHITLOperations:
             params=None,
             multiple=False,
         )
-        assert isinstance(result, HITLDetailRequestResult)
+        assert isinstance(result, HITLDetailRequest)
         assert result.ti_id == ti_id
         assert result.options == ["Approval", "Reject"]
         assert result.subject == "This is subject"

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -2242,9 +2242,7 @@ REQUEST_TEST_CASES = [
             "subject": "This is subject",
             "body": "This is body",
             "defaults": ["Approve"],
-            "multiple": False,
             "params": {},
-            "assigned_users": None,
             "type": "HITLDetailRequestResult",
         },
         client_mock=ClientMock(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: https://github.com/apache/airflow/issues/57437 


## Problem and Root cause

The root cause for this failure and resulting error like this:

```shell script
[2025-10-29 19:17:32] ERROR - Task failed with exception source=task loc=task_runner.py:996
AirflowException: SMTP connection is not found.
File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py", line 934 in run

File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py", line 1331 in _execute_task

File "/opt/airflow/task-sdk/src/airflow/sdk/bases/operator.py", line 416 in wrapper

File "/opt/airflow/providers/standard/src/airflow/providers/standard/operators/hitl.py", line 152 in execute

File "/opt/airflow/task-sdk/src/airflow/sdk/bases/notifier.py", line 138 in __call__

File "/opt/airflow/providers/smtp/src/airflow/providers/smtp/notifications/smtp.py", line 152 in notify

File "/opt/airflow/providers/smtp/src/airflow/providers/smtp/hooks/smtp.py", line 80 in __enter__

File "/opt/airflow/providers/smtp/src/airflow/providers/smtp/hooks/smtp.py", line 120 in get_conn

AirflowNotFoundException: The conn_id `smtp_default` isn't defined
File "/opt/airflow/providers/smtp/src/airflow/providers/smtp/hooks/smtp.py", line 118 in get_conn

File "/opt/airflow/task-sdk/src/airflow/sdk/bases/hook.py", line 61 in get_connection

File "/opt/airflow/task-sdk/src/airflow/sdk/definitions/connection.py", line 225 in get

File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/context.py", line 175 in _get_connection
```

was a type mismatch between API response and client expectations in SDK.

The client's `add_response()` method tried to parse API JSON directly as `HITLDetailRequestResult`:

But the API returns JSON **without a `type` field**:
```json
{
  "ti_id": "...",
  "options": [...],
  "subject": "...",
  // NO "type" field
}
```

`HITLDetailRequestResult` is part of a discriminated union (`ToTask`) that requires a `type` discriminator field for Pydantic to deserialize correctly. Since the API doesn't include this field, validation failed.


This issue can be fixed by correcting the types sent across between client <=> supervisor. Client returns `HITLDetailRequest`, supervisor converts to `HITLDetailRequestResult` (similar pattern to XCom req/resp) by using a `from_api_response` defined on `HITLDetailRequestResult`


## Testing

Used this DAG:

```python

from airflow import DAG
from airflow.providers.smtp.notifications.smtp import send_smtp_notification
from datetime import datetime

from airflow.providers.standard.operators.empty import EmptyOperator
from airflow.providers.standard.operators.hitl import HITLBranchOperator

with DAG(
    dag_id="hitl_example",
    schedule=None,
    start_date=datetime(2024, 1, 1),
    catchup=False,
) as dag:

    send_invoices_export = EmptyOperator(
        task_id="send_invoices_export",
    )

    abort_export_creation = EmptyOperator(
        task_id="abort_export_creation",
    )

    review_export_task = HITLBranchOperator(
            task_id = "review_export",
            subject="Please check the export provided in S3 bucket. See the previous task for detailed errors.",
            options=["send_invoices_export", "abort_export_creation"],
            notifiers=[
                send_smtp_notification(
                    from_email="your_mail@example.com",
                    to="my_mail@example.com",
                    subject="Export needs to be checked",
                    html_content="Please check the export provided in S3 bucket"
                )
            ]
        )

    review_export_task >> [abort_export_creation, send_invoices_export]

```

Created an SMTP connection with host as: `mailpit`, port as `1025`

<img width="2556" height="874" alt="image" src="https://github.com/user-attachments/assets/ebf63539-533f-4957-a299-06dc8ab53872" />


Flow:

<img width="1724" height="898" alt="image" src="https://github.com/user-attachments/assets/76ee1b47-7b72-40b9-8746-24166d42d9cf" />

Notifier sent this email:

<img width="1724" height="898" alt="image" src="https://github.com/user-attachments/assets/b6ab3cd9-3521-4785-a925-490625d5689d" />



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
