### PR TITLE
Add number of queries guard in public dag tags list endpoints

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_tags.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_tags.py
@@ -28,6 +28,7 @@ from airflow.utils.session import provide_session
 from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
+from tests_common.test_utils.asserts import assert_queries_count
 from tests_common.test_utils.db import (
     clear_db_dag_bundles,
     clear_db_dags,
@@ -245,7 +246,8 @@ class TestDagTags(TestDagEndpoint):
     def test_get_dag_tags(
         self, test_client, query_params, expected_status_code, expected_dag_tags, expected_total_entries
     ):
-        response = test_client.get("/dagTags", params=query_params)
+        with assert_queries_count(3 if expected_status_code == 200 else 2):
+            response = test_client.get("/dagTags", params=query_params)
         assert response.status_code == expected_status_code
         if expected_status_code != 200:
             return


### PR DESCRIPTION
Add number of db queries guard in list endpoint, preventing further N+1 queries problem

No N+1 queries problem detected.