### PR TITLE
Add number of queries guard for public dag versions

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_versions.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_versions.py
@@ -108,7 +108,7 @@ def get_dag_versions(
 
     This endpoint allows specifying `~` as the dag_id to retrieve DAG Versions for all DAGs.
     """
-    query = select(DagVersion).options(joinedload(DagVersion.dag_model))
+    query = select(DagVersion).options(joinedload(DagVersion.dag_model), joinedload(DagVersion.bundle))
 
     if dag_id != "~":
         get_latest_version_of_dag(dag_bag, dag_id, session)


### PR DESCRIPTION
Built on top of https://github.com/apache/airflow/pull/57450 that needs to be merged first.

Add number of db queries guard in list endpoint, preventing further N+1 queries problem

No N+1 queries problem detected thanks to the `bundle_url` fix contained in the related PR..