### PR TITLE
Add number of queries guard in public dag warnings list endpoint

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_warning.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_warning.py
@@ -23,6 +23,7 @@ from airflow.models.dag import DagModel
 from airflow.models.dagwarning import DagWarning
 from airflow.utils.session import provide_session
 
+from tests_common.test_utils.asserts import assert_queries_count
 from tests_common.test_utils.db import clear_db_dag_warnings, clear_db_dags
 
 pytestmark = pytest.mark.db_test
@@ -88,7 +89,8 @@ class TestGetDagWarnings:
         ],
     )
     def test_get_dag_warnings(self, test_client, query_params, expected_total_entries, expected_messages):
-        response = test_client.get("/dagWarnings", params=query_params)
+        with assert_queries_count(3):
+            response = test_client.get("/dagWarnings", params=query_params)
         assert response.status_code == 200
         response_json = response.json()
         assert response_json["total_entries"] == expected_total_entries


### PR DESCRIPTION
Add number of db queries guard in list endpoint, preventing further N+1 queries problem

No N+1 queries problem detected.

