### PR TITLE
Add number of queries guard in public event logs list endpoints

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/event_logs.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/event_logs.py
@@ -128,7 +128,7 @@ def get_event_logs(
     event_pattern: Annotated[_SearchParam, Depends(search_param_factory(Log.event, "event_pattern"))],
 ) -> EventLogCollectionResponse:
     """Get all Event Logs."""
-    query = select(Log)
+    query = select(Log).options(joinedload(Log.task_instance), joinedload(Log.dag_model))
     event_logs_select, total_entries = paginated_select(
         statement=query,
         order_by=order_by,

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_event_logs.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_event_logs.py
@@ -23,6 +23,7 @@ import pytest
 from airflow.models.log import Log
 from airflow.utils.session import provide_session
 
+from tests_common.test_utils.asserts import assert_queries_count
 from tests_common.test_utils.db import clear_db_logs, clear_db_runs
 from tests_common.test_utils.format_datetime import from_datetime_to_zulu, from_datetime_to_zulu_without_ms
 
@@ -315,7 +316,8 @@ class TestGetEventLogs(TestEventLogsEndpoint):
     def test_get_event_logs(
         self, test_client, query_params, expected_status_code, expected_total_entries, expected_events
     ):
-        response = test_client.get("/eventLogs", params=query_params)
+        with assert_queries_count(2):
+            response = test_client.get("/eventLogs", params=query_params)
         assert response.status_code == expected_status_code
         if expected_status_code != 200:
             return


### PR DESCRIPTION
Add number of db queries guard in list endpoint, preventing further N+1 queries problem

N+1 queries problem detected and solved.