### PR TITLE
Add settings to auto-apply linting, fix linting errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,8 +171,6 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
-.vscode/*
-!.vscode/extensions.json
 /.vite/
 # Exclude the ui .vite dir
 airflow-core/src/airflow/ui/.vite/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "esbenp.prettier-vscode",
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,38 @@
+{
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.eslint": "explicit"
+    }
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.eslint": "explicit"
+    }
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.eslint": "explicit"
+    }
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.eslint": "explicit"
+    }
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+}

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.tsx
@@ -145,15 +145,15 @@ export const Nav = () => {
       width={16}
       zIndex={2}
     >
-      <Flex alignItems="center" flexDir="column" width="100%" gap={1}>
-        <Box asChild boxSize={14} display="flex" alignItems="center" justifyContent="center">
-          <Link to="/" title={translate("nav.home")}>
+      <Flex alignItems="center" flexDir="column" gap={1} width="100%">
+        <Box alignItems="center" asChild boxSize={14} display="flex" justifyContent="center">
+          <Link title={translate("nav.home")} to="/">
             <AirflowPin
               _motionSafe={{
                 _hover: {
                   transform: "rotate(360deg)",
-                  transition: "transform 0.8s ease-in-out"
-                }
+                  transition: "transform 0.8s ease-in-out",
+                },
               }}
               boxSize={8}
             />

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/NavButton.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/NavButton.tsx
@@ -17,8 +17,8 @@
  * under the License.
  */
 import { Box, type BoxProps, Button, Icon, type IconProps, Link, type ButtonProps } from "@chakra-ui/react";
-import { useMemo, type ForwardRefExoticComponent, type RefAttributes } from "react";
-import { IconType } from "react-icons";
+import { type ReactNode, useMemo, type ForwardRefExoticComponent, type RefAttributes } from "react";
+import type { IconType } from "react-icons";
 import { Link as RouterLink, useMatch } from "react-router-dom";
 
 const commonLabelProps: BoxProps = {
@@ -31,63 +31,73 @@ const commonLabelProps: BoxProps = {
 };
 
 type NavButtonProps = {
-  readonly icon: IconType | ForwardRefExoticComponent<IconProps & RefAttributes<SVGSVGElement>>;
+  readonly icon: ForwardRefExoticComponent<IconProps & RefAttributes<SVGSVGElement>> | IconType;
   readonly isExternal?: boolean;
+  readonly pluginIcon?: ReactNode;
   readonly title: string;
   readonly to?: string;
 } & ButtonProps;
 
-export const NavButton = ({ icon, isExternal = false, title, to, ...rest }: NavButtonProps) => {
+export const NavButton = ({ icon, isExternal = false, pluginIcon, title, to, ...rest }: NavButtonProps) => {
   // Use useMatch to determine if the current route matches the button's destination
   // This provides the same functionality as NavLink's isActive prop
   // Only applies to buttons with a to prop (but needs to be before any return statements)
-  const match = to ? useMatch({
-    path: to,
-    end: to === "/" // Only exact match for root path
-  }) : undefined;
+  const match = useMatch({
+    end: to === "/", // Only exact match for root path
+    path: to ?? "",
+  });
   // Only applies to buttons with a to prop
-  const isActive = Boolean(match);
+  const isActive = Boolean(to) ? Boolean(match) : false;
 
-  const commonButtonProps = useMemo<ButtonProps>(() => ({
-    _expanded: isActive ? undefined : {
-      bg: "brand.emphasized", // Even darker for better light mode contrast
-      color: "fg",
-    },
-    _focus: isActive ? undefined : {
-      color: "fg",
-    },
-    _hover: isActive ? undefined : {
-      bg: "brand.emphasized", // Even darker for better light mode contrast
-      color: "fg",
-      _active: {
-        bg: "brand.solid",
-        color: "white",
-      },
-    },
-    alignItems: "center",
-    bg: isActive ? "brand.solid" : undefined,
-    borderRadius: "md",
-    borderWidth: 0,
-    boxSize: 14,
-    color: isActive ? "white" : "fg.muted",
-    colorPalette: "brand",
-    cursor: "pointer",
-    flexDir: "column",
-    gap: 0,
-    overflow: "hidden",
-    padding: 0,
-    textDecoration: "none",
-    title,
-    transition: "background-color 0.2s ease, color 0.2s ease",
-    variant: "plain",
-    whiteSpace: "wrap",
-    ...rest,
-  }), [isActive, rest, title]);
+  const commonButtonProps = useMemo<ButtonProps>(
+    () => ({
+      _expanded: isActive
+        ? undefined
+        : {
+            bg: "brand.emphasized", // Even darker for better light mode contrast
+            color: "fg",
+          },
+      _focus: isActive
+        ? undefined
+        : {
+            color: "fg",
+          },
+      _hover: isActive
+        ? undefined
+        : {
+            _active: {
+              bg: "brand.solid",
+              color: "white",
+            },
+            bg: "brand.emphasized", // Even darker for better light mode contrast
+            color: "fg",
+          },
+      alignItems: "center",
+      bg: isActive ? "brand.solid" : undefined,
+      borderRadius: "md",
+      borderWidth: 0,
+      boxSize: 14,
+      color: isActive ? "white" : "fg.muted",
+      colorPalette: "brand",
+      cursor: "pointer",
+      flexDir: "column",
+      gap: 0,
+      overflow: "hidden",
+      padding: 0,
+      textDecoration: "none",
+      title,
+      transition: "background-color 0.2s ease, color 0.2s ease",
+      variant: "plain",
+      whiteSpace: "wrap",
+      ...rest,
+    }),
+    [isActive, rest, title],
+  );
 
   if (to === undefined) {
     return (
       <Button {...commonButtonProps}>
-        <Icon as={icon} boxSize={5} />
+        {pluginIcon ?? <Icon as={icon} boxSize={5} />}
         <Box {...commonLabelProps}>{title}</Box>
       </Button>
     );
@@ -95,9 +105,9 @@ export const NavButton = ({ icon, isExternal = false, title, to, ...rest }: NavB
 
   if (isExternal) {
     return (
-      <Link href={to} asChild rel="noopener noreferrer" target="_blank">
+      <Link asChild href={to} rel="noopener noreferrer" target="_blank">
         <Button {...commonButtonProps}>
-          <Icon as={icon} boxSize={5} />
+          {pluginIcon ?? <Icon as={icon} boxSize={5} />}
           <Box {...commonLabelProps}>{title}</Box>
         </Button>
       </Link>
@@ -105,13 +115,9 @@ export const NavButton = ({ icon, isExternal = false, title, to, ...rest }: NavB
   }
 
   return (
-    <Button
-      as={Link}
-      asChild
-      {...commonButtonProps}
-    >
+    <Button as={Link} asChild {...commonButtonProps}>
       <RouterLink to={to}>
-        <Icon as={icon} boxSize={5} />
+        {pluginIcon ?? <Icon as={icon} boxSize={5} />}
         <Box {...commonLabelProps}>{title}</Box>
       </RouterLink>
     </Button>

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/PluginMenuItem.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/PluginMenuItem.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Link, Image, Menu } from "@chakra-ui/react";
+import { Link, Image, Menu, Icon, Box } from "@chakra-ui/react";
 import { FiExternalLink } from "react-icons/fi";
 import { LuPlug } from "react-icons/lu";
 import { RiArchiveStackLine } from "react-icons/ri";
@@ -46,11 +46,11 @@ export const PluginMenuItem = ({
   const displayIcon = colorMode === "dark" && typeof iconDarkMode === "string" ? iconDarkMode : icon;
   const pluginIcon =
     typeof displayIcon === "string" ? (
-      <Image height="20px" mr={topLevel ? 0 : 2} src={displayIcon} width="20px" />
+      <Image boxSize={5} src={displayIcon} />
     ) : urlRoute === "legacy-fab-views" ? (
-      <RiArchiveStackLine size="20px" style={{ marginRight: topLevel ? 0 : "8px" }} />
+      <Icon as={RiArchiveStackLine} boxSize={5} />
     ) : (
-      <LuPlug size="20px" style={{ marginRight: topLevel ? 0 : "8px" }} />
+      <Icon as={LuPlug} boxSize={5} />
     );
 
   const isExternal = urlRoute === undefined || urlRoute === null;
@@ -58,9 +58,10 @@ export const PluginMenuItem = ({
   if (topLevel) {
     return (
       <NavButton
-        icon={pluginIcon}
+        icon={LuPlug}
         isExternal={isExternal}
         key={name}
+        pluginIcon={pluginIcon}
         title={name}
         to={isExternal ? href : `plugin/${urlRoute}`}
       />
@@ -80,13 +81,15 @@ export const PluginMenuItem = ({
           width="100%"
         >
           {pluginIcon}
-          {name}
-          <FiExternalLink />
+          <Box flex="1">{name}</Box>
+          <Icon as={FiExternalLink} boxSize={4} color="fg.muted" />
         </Link>
       ) : (
         <RouterLink style={{ outline: "none" }} to={`plugin/${urlRoute}`}>
           {pluginIcon}
-          {name}
+          <Box flex="1" ml={2}>
+            {name}
+          </Box>
         </RouterLink>
       )}
     </Menu.Item>

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/PluginMenus.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/PluginMenus.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box } from "@chakra-ui/react";
+import { Box, Icon } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 import { FiChevronRight } from "react-icons/fi";
 import { LuPlug } from "react-icons/lu";
@@ -63,7 +63,7 @@ export const PluginMenus = ({ navItems }: { readonly navItems: Array<NavItemResp
           <Menu.Root key={key} positioning={{ placement: "right" }}>
             <Menu.TriggerItem display="flex" justifyContent="space-between">
               {key}
-              <FiChevronRight />
+              <Icon as={FiChevronRight} boxSize={4} color="fg.muted" />
             </Menu.TriggerItem>
             <Menu.Content>
               {menuButtons.map((navItem) => (

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/UserSettingsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/UserSettingsButton.tsx
@@ -121,7 +121,9 @@ export const UserSettingsButton = ({ externalViews }: { readonly externalViews: 
             value={dagView}
           >
             <Icon as={dagView === "grid" ? MdOutlineAccountTree : FiGrid} boxSize={4} />
-            <Box flex="1">{dagView === "grid" ? translate("defaultToGraphView") : translate("defaultToGridView")}</Box>
+            <Box flex="1">
+              {dagView === "grid" ? translate("defaultToGraphView") : translate("defaultToGridView")}
+            </Box>
           </Menu.Item>
           <TimezoneMenuItem onOpen={onOpenTimezone} />
           {externalViews.map((view) => (


### PR DESCRIPTION
Follow-up to #57455

When [attempting](https://github.com/apache/airflow/pull/57481) to back-port  #57455 into `v3-1-test`, merging was blocked by linting errors that were not shown by my IDE when authoring, nor did they become blocking when attempting to commit the code.

@bbovenzi is going to investigate why I was able to commit the invalid code, and in this PR, I am fixing the previously uncaught issues.

I added `.vscode/` config files that ensure auto-formatting occurs on-save for UI files. After I configured this, it resolved most of the issues automatically. These setting work for VS Code or any fork of it (like Cursor).

Most of the issues were related to prop ordering and indentations, but it did catch an issue in how the Plugin nav item icons are being rendered and I've fixed that as well.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
