### PR TITLE
fix(logging): Fix LOGGING_LEVEL in settings.py

### DIFF
--- a/airflow-core/src/airflow/settings.py
+++ b/airflow-core/src/airflow/settings.py
@@ -89,7 +89,7 @@ HEADER = "\n".join(
     ]
 )
 
-LOGGING_LEVEL = logging.INFO
+LOGGING_LEVEL = conf.get("logging", "logging_level")
 
 # the prefix to append to gunicorn worker processes after init
 GUNICORN_WORKER_READY_PREFIX = "[ready] "

--- a/task-sdk/src/airflow/sdk/log.py
+++ b/task-sdk/src/airflow/sdk/log.py
@@ -83,8 +83,6 @@ def configure_logging(
     from airflow.configuration import conf
 
     if log_level == "DEFAULT":
-        log_level = "INFO"
-
         log_level = conf.get("logging", "logging_level", fallback="INFO")
 
     # If colored_console_log is not explicitly set, read from configuration


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
## What does this PR do?
This PR updates how `LOGGING_LEVEL` is setup in settings.py.

## Motivations
While trying to debug the scheduler executor, it looked like to me some logs weren't surfaced even though I passed the `AIRFLOW__LOGGING_LOGGING_LEVEL=DEBUG` . I think this is due to this default parameter setup to `INFO` and not overrode by the [logging configuration](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#logging-level)


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
