### PR TITLE
Fix MSSQLToGCSOperator MSSQL BIT data type conversion to Parquet boolean

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/transfers/mssql_to_gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/mssql_to_gcs.py
@@ -67,7 +67,7 @@ class MSSQLToGCSOperator(BaseSQLToGCSOperator):
 
     ui_color = "#e0a98c"
 
-    type_map = {2: "BOOLEAN", 3: "INTEGER", 4: "TIMESTAMP", 5: "NUMERIC"}
+    type_map = {2: "BOOL", 3: "INTEGER", 4: "TIMESTAMP", 5: "NUMERIC"}
 
     def __init__(
         self,

--- a/providers/google/tests/unit/google/cloud/transfers/test_mssql_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_mssql_to_gcs.py
@@ -35,6 +35,7 @@ MSSQL_CONN_ID = "mssql_conn_test"
 SQL = "select 1"
 BUCKET = "gs://test"
 JSON_FILENAME = "test_{}.ndjson"
+PARQUET_FILENAME = "test_{}.parquet"
 GZIP = False
 
 ROWS = [
@@ -253,3 +254,53 @@ class TestMsSqlToGoogleCloudStorageOperator:
         assert len(lineage.job_facets) == 1
         assert lineage.job_facets["sql"].query == sql
         assert lineage.run_facets == {}
+
+    @mock.patch("airflow.providers.google.cloud.transfers.mssql_to_gcs.MsSqlHook")
+    @mock.patch("airflow.providers.google.cloud.transfers.sql_to_gcs.GCSHook")
+    def test_bit_to_boolean_field_conversion(self, gcs_hook_mock_class, mssql_hook_mock_class):
+        """Test successful run of execute function for Parquet format with boolean fields.
+
+        This test verifies that MSSQL tables with columns of type "BIT" can exported
+        using the bit_fields parameter, resulting in boolean fields in the Parquet file.
+        """
+        import pyarrow
+
+        op = MSSQLToGCSOperator(
+            task_id=TASK_ID,
+            mssql_conn_id=MSSQL_CONN_ID,
+            sql=SQL,
+            bucket=BUCKET,
+            filename=PARQUET_FILENAME,
+            export_format="parquet",
+            bit_fields=["some_binary", "some_bit"],
+        )
+
+        mssql_hook_mock = mssql_hook_mock_class.return_value
+        mssql_hook_mock.get_conn().cursor().__iter__.return_value = iter(ROWS)
+        mssql_hook_mock.get_conn().cursor().description = CURSOR_DESCRIPTION
+
+        gcs_hook_mock = gcs_hook_mock_class.return_value
+
+        upload_called = False
+
+        def _assert_upload(bucket, obj, tmp_filename, mime_type=None, gzip=False, metadata=None):
+            nonlocal upload_called
+            upload_called = True
+            assert bucket == BUCKET
+            assert obj == PARQUET_FILENAME.format(0)
+            assert mime_type == "application/octet-stream"
+            assert gzip == GZIP
+
+            parquet_file = pyarrow.parquet.ParquetFile(tmp_filename)
+            schema = parquet_file.schema_arrow
+            # Verify that bit fields are mapped to boolean type in parquet schema
+            assert schema.field("some_binary").type.equals(pyarrow.bool_())
+            assert schema.field("some_bit").type.equals(pyarrow.bool_())
+
+        gcs_hook_mock.upload.side_effect = _assert_upload
+
+        op.execute(None)
+
+        assert upload_called, "Expected upload to be called"
+        mssql_hook_mock_class.assert_called_once_with(mssql_conn_id=MSSQL_CONN_ID)
+        mssql_hook_mock.get_conn().cursor().execute.assert_called_once_with(SQL)

--- a/providers/google/tests/unit/google/cloud/transfers/test_mssql_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_mssql_to_gcs.py
@@ -57,14 +57,14 @@ SCHEMA_FILENAME = "schema_test.json"
 SCHEMA_JSON = [
     b'[{"mode": "NULLABLE", "name": "some_str", "type": "STRING"}, ',
     b'{"mode": "NULLABLE", "name": "some_num", "type": "INTEGER"}, ',
-    b'{"mode": "NULLABLE", "name": "some_binary", "type": "BOOLEAN"}, ',
-    b'{"mode": "NULLABLE", "name": "some_bit", "type": "BOOLEAN"}]',
+    b'{"mode": "NULLABLE", "name": "some_binary", "type": "BOOL"}, ',
+    b'{"mode": "NULLABLE", "name": "some_bit", "type": "BOOL"}]',
 ]
 
 SCHEMA_JSON_BIT_FIELDS = [
     b'[{"mode": "NULLABLE", "name": "some_str", "type": "STRING"}, ',
     b'{"mode": "NULLABLE", "name": "some_num", "type": "INTEGER"}, ',
-    b'{"mode": "NULLABLE", "name": "some_binary", "type": "BOOLEAN"}, ',
+    b'{"mode": "NULLABLE", "name": "some_binary", "type": "BOOL"}, ',
     b'{"mode": "NULLABLE", "name": "some_bit", "type": "INTEGER"}]',
 ]
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #57461
related: #29902

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->

---

# Fix MSSQLToGCSOperator MSSQL BIT data type conversion to Parquet boolean closes #57461

## Summary

Fixes `ArrowTypeError: Expected bytes, got a 'bool' object` when exporting MSSQL bit fields to Parquet format using `MSSQLToGCSOperator`.

### Issue

- Issue: #57461
- Problem: The `MSSQLToGCSOperator` incorrectly mapped MSSQL bit fields (type 2) to `"BOOLEAN"` in the `type_map`, but the base class `BaseSQLToGCSOperator._convert_parquet_schema()` expects `"BOOL"` for boolean types.

### Root Cause

The `type_map` property in `MSSQLToGCSOperator` had an incorrect type mapping:

- **Before**: `type_map = {2: "BOOLEAN", ...}`
- **After**: `type_map = {2: "BOOL", ...}`

This mismatch caused PyArrow schema conversion to fail when processing bit fields in Parquet format exports.

### Impact

- **Affected Users**: Users exporting MSSQL bit fields to Parquet format using `MSSQLToGCSOperator`
- **Breaking Changes**: None (this is a bug fix)
- **Other Export Formats**: CSV and JSON formats are unaffected (they don't use this type mapping)

### Related Issues/PRs

closes: #57461
related: #29902 #11874

### Additional Notes

Users can temporarily work around this issue by creating a custom operator that overrides the `type_map` property:

```python
class FixedMSSQLToGCSOperator(MSSQLToGCSOperator):
    type_map = {2: "BOOL", 3: "INTEGER", 4: "TIMESTAMP", 5: "NUMERIC"}
```

However, this fix makes the workaround unnecessary.

## Changes Made

### 1. Fixed Type Mapping (`mssql_to_gcs.py`)

- Changed `type_map` from `{2: "BOOLEAN"}` to `{2: "BOOL"}` to match the expected type key in `BaseSQLToGCSOperator._convert_parquet_schema()`

### 2. Updated Tests (`test_mssql_to_gcs.py`)

- Updated `SCHEMA_JSON` and `SCHEMA_JSON_BIT_FIELDS` constants to use `"BOOL"` instead of `"BOOLEAN"` to match the fix
- Added new test `test_exec_success_parquet_with_bit_fields()` to verify that bit fields can be exported to Parquet format without errors

### Files Changed

1. `providers/google/src/airflow/providers/google/cloud/transfers/mssql_to_gcs.py` (line 70)
   - Changed `type_map = {2: "BOOLEAN", ...}` to `type_map = {2: "BOOL", ...}`

2. `providers/google/tests/unit/google/cloud/transfers/test_mssql_to_gcs.py`
   - Updated schema constants to use `"BOOL"` instead of `"BOOLEAN"`
   - Added `test_exec_success_parquet_with_bit_fields()` test

## Testing

The fix has been tested and verified:

- ✅ Tested manually with a DAG exporting MSSQL bit fields to Parquet format
- ✅ Unit tests updated to reflect the correct type mapping
- ✅ New test case added to prevent regression

Command to test the changes:

```sh
$ breeze testing providers-tests --skip-db-tests providers/google/tests/unit/google/cloud/transfers/test_mssql_to_gcs.py
...
```
