### PR TITLE
Enable ruff PLW0211 rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -594,7 +594,10 @@ extend-select = [
     "PLW0127", # Self-assignment of variable
     "PLW0128", # Redeclared variable {name} in assignment
     "PLW0129", # Asserting on an empty string literal will never pass
+    "PLW0131", # Named expression used without context
     "PLW0133", # Missing raise statement on exception
+    "PLW0177", # Comparing against a NaN value; use math.isnan instead
+    "PLW0211", # First argument of a static method should not be named {argument_name}
     "PLW0245", # super call is missing parentheses
     "PLW0406", # Module {name} imports itself
     "PLW0602", # Using global for {name} but no assignment is done

--- a/task-sdk/tests/task_sdk/execution_time/test_cache.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_cache.py
@@ -41,7 +41,7 @@ class TestSecretCache:
         SecretCache.init()
 
     @staticmethod
-    def teardown_method(self) -> None:
+    def teardown_method() -> None:
         SecretCache.reset()
 
     def test_cache_accessible_from_other_process(self):


### PR DESCRIPTION
While implementing https://github.com/apache/airflow/pull/57294 I realized that a couple of more ruff PLW rules might be interesting, this PR enables PLW0211

Alongside saw that PLW0131 and PLW0177 needed no fixes and enabled them as well

See also https://docs.astral.sh/ruff/rules/#warning-plw