### PR TITLE
Fix executor field not being captured for task instances

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Details.tsx
@@ -207,7 +207,7 @@ export const Details = () => {
           </Table.Row>
           <Table.Row>
             <Table.Cell>{translate("taskInstance.executor")}</Table.Cell>
-            <Table.Cell>{tryInstance?.executor_config}</Table.Cell>
+            <Table.Cell>{tryInstance?.executor}</Table.Cell>
           </Table.Row>
         </Table.Body>
       </Table.Root>


### PR DESCRIPTION
  The executor field was never populated with the actual executor name when
  tasks were run. This caused the field to remain NULL in the database and
  not display properly in the UI

Before:
<img width="640" height="144" alt="image" src="https://github.com/user-attachments/assets/3c335376-aa2e-4abc-96f1-61df69020f00" />


After:
<img width="1080" height="592" alt="image" src="https://github.com/user-attachments/assets/198dd2a6-3796-4811-82f7-a3e390900882" />

<img width="1723" height="657" alt="image" src="https://github.com/user-attachments/assets/250dc529-48b5-4424-9c3d-98222b88be03" />


