### PR TITLE
Enable PT011 rule to provider tests

### DIFF
--- a/providers/apache/spark/tests/unit/apache/spark/hooks/test_spark_submit.py
+++ b/providers/apache/spark/tests/unit/apache/spark/hooks/test_spark_submit.py
@@ -536,11 +536,14 @@ class TestSparkSubmitHook:
         SparkSubmitHook(conn_id="spark_binary_set", spark_binary="another-custom-spark-submit")
 
     def test_resolve_connection_spark_binary_extra_not_allowed_runtime_error(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Please make sure your spark binary is one of the allowed ones and that it is available on the PATH",
+        ):
             SparkSubmitHook(conn_id="spark_custom_binary_set")
 
     def test_resolve_connection_spark_home_not_allowed_runtime_error(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="The `spark-home` extra is not allowed any more"):
             SparkSubmitHook(conn_id="spark_home_set")
 
     def test_resolve_connection_spark_binary_default_value_override(self):

--- a/providers/pagerduty/tests/unit/pagerduty/hooks/test_pagerduty_events.py
+++ b/providers/pagerduty/tests/unit/pagerduty/hooks/test_pagerduty_events.py
@@ -69,11 +69,14 @@ class TestPrepareEventData:
         assert even_data == exp_event_data
 
     def test_prepare_event_data_invalid_action(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Event action must be one of: trigger, acknowledge, resolve"):
             prepare_event_data(summary="test", severity="error", action="should_raise")
 
     def test_prepare_event_missing_dedup_key(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="The dedup_key property is required for action=acknowledge events, and it must be a string",
+        ):
             prepare_event_data(summary="test", severity="error", action="acknowledge")
 
 

--- a/task-sdk/tests/task_sdk/definitions/test_dag.py
+++ b/task-sdk/tests/task_sdk/definitions/test_dag.py
@@ -480,9 +480,10 @@ def test_continuous_schedule_interval_limits_max_active_runs(max_active_runs):
 
 
 def test_continuous_schedule_interval_limits_max_active_runs_error():
-    with pytest.raises(ValueError) as ctx:
+    with pytest.raises(
+        ValueError, match="Invalid max_active_runs: ContinuousTimetable requires max_active_runs <= 1"
+    ):
         DAG(dag_id="continuous", schedule="@continuous", max_active_runs=2)
-    assert str(ctx.value) == "Invalid max_active_runs: ContinuousTimetable requires max_active_runs <= 1"
 
 
 class TestDagDecorator:


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
issue: Enable Even More PyDocStyle Checks #40567
@ferruzzi
This PR is for enable PT011 rule:
PT011: all instances of pytest.raises should include a match term to make sure they are catching the right error.
https://docs.astral.sh/ruff/rules/pytest-raises-too-broad/
There are 102 files changes is need.
So, I separate to many PR, which contains about 5 file changes for easy review.
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
