### PR TITLE
Docs: Fix missing Airflow macro module list in template documentation

### DIFF
--- a/airflow-core/docs/templates-ref.rst
+++ b/airflow-core/docs/templates-ref.rst
@@ -188,7 +188,7 @@ Variable                            Description
 
 Some Airflow specific macros are also defined:
 
-.. automodule:: airflow.macros
+.. automodule:: airflow.sdk.execution_time.macros
     :members:
 
 .. _pendulum.DateTime: https://pendulum.eustace.io/docs/#introduction


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
related: #53545

This PR addresses an issue where the list of available Airflow macros is not being correctly exposed in the template documentation.

This problem occurred because the `airflow.macros` module has been deprecated in the latest version. The documentation was not updated to reflect this change, leading to the missing macro list.

This PR updates the documentation to reference the correct module paths, ensuring the macro list is displayed properly for the current version.

## Current document state
https://airflow.apache.org/docs/apache-airflow/3.1.1/templates-ref.html#macros
<img width="1860" height="789" alt="image" src="https://github.com/user-attachments/assets/99b14e8a-2f27-4ec5-afde-47fde818dd9b" />


## After changed
<img width="1847" height="880" alt="image" src="https://github.com/user-attachments/assets/7c60e65f-c322-4a5c-b695-4ccb0460acd7" />



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
