### PR TITLE
Fix 'mark_success_url' UndefinedError in failure emails 

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1217,7 +1217,6 @@ def _get_email_subject_content(
         "Exception:<br>{{exception_html}}<br>"
         'Log: <a href="{{ti.log_url}}">Link</a><br>'
         "Host: {{ti.hostname}}<br>"
-        'Mark success: <a href="{{ti.mark_success_url}}">Link</a><br>'
     )
 
     default_html_content_err = (
@@ -1225,7 +1224,6 @@ def _get_email_subject_content(
         "Exception:<br>Failed attempt to attach error logs<br>"
         'Log: <a href="{{ti.log_url}}">Link</a><br>'
         "Host: {{ti.hostname}}<br>"
-        'Mark success: <a href="{{ti.mark_success_url}}">Link</a><br>'
     )
 
     additional_context: dict[str, Any] = {


### PR DESCRIPTION
## Summary
When `email_on_failure=True`, tasks were failing with an `UndefinedError: ... has no attribute 'mark_success_url'`. This happened because the `RuntimeTaskInstance` object, which is used in this context, does not have the `mark_success_url` attribute, but the HTML email templates (`default_html_content` and `default_html_content_err`) were trying to access it.

This PR resolves the error by removing the "Mark Success" link from both templates in `airflow/models/taskinstance.py`, as recommended in the issue for the Airflow 3.1+ fix.

closes: #57507 

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
