### PR TITLE
Eliminate serdag loading added in #56422

### DIFF
--- a/airflow-core/src/airflow/models/serialized_dag.py
+++ b/airflow-core/src/airflow/models/serialized_dag.py
@@ -418,7 +418,6 @@ class SerializedDagModel(Base):
             select(DagVersion)
             .where(DagVersion.dag_id == dag.dag_id)
             .options(joinedload(DagVersion.task_instances))
-            .options(joinedload(DagVersion.serialized_dag))
             .order_by(DagVersion.created_at.desc())
             .limit(1)
         )


### PR DESCRIPTION
It was wrong to load the serdag and not use it. The initial idea was to use the serdag at line 437 but was omitted. Thinking about it now, it will be faster to only load serdag when there's a TI associated with the dag version

