### PR TITLE
Async apprise notifier

### DIFF
--- a/providers/apprise/tests/unit/apprise/notifications/test_apprise.py
+++ b/providers/apprise/tests/unit/apprise/notifications/test_apprise.py
@@ -98,3 +98,26 @@ class TestAppriseNotifier:
             "config": None,
         }
         mock_apprise_hook.return_value.notify.assert_called_once()
+
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.apprise.notifications.apprise.AppriseHook")
+    async def test_async_apprise_notifier(self, mock_apprise_hook, create_dag_without_db):
+        mock_apprise_hook.return_value.async_notify = mock.AsyncMock()
+
+        notifier = send_apprise_notification(body="DISK at 99%", notify_type=NotifyType.FAILURE)
+
+        await notifier.async_notify({"dag": create_dag_without_db("test_notifier")})
+
+        call_args = mock_apprise_hook.return_value.async_notify.call_args.kwargs
+
+        assert call_args == {
+            "body": "DISK at 99%",
+            "notify_type": NotifyType.FAILURE,
+            "title": None,
+            "body_format": NotifyFormat.TEXT,
+            "tag": "all",
+            "attach": None,
+            "interpret_escapes": None,
+            "config": None,
+        }
+        mock_apprise_hook.return_value.async_notify.assert_called_once()


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


Add an asynchronous version of `AppriseNotifier.`

related: https://github.com/apache/airflow/issues/55237


I have successfully tested the `AppriseNotifier` with the following Dag which sends notifications to Discord:

```Python
from datetime import timedelta
from airflow import DAG
from airflow.sdk.definitions.deadline import AsyncCallback, DeadlineAlert, DeadlineReference
from airflow.providers.apprise.notifications.apprise import AppriseNotifier
from airflow.providers.standard.operators.empty import EmptyOperator
from airflow.sdk import task

with DAG(
    dag_id="deadline_apprise_alert_example",
    deadline=DeadlineAlert(
        reference=DeadlineReference.DAGRUN_QUEUED_AT,
        interval=timedelta(seconds=20),
        callback=AsyncCallback(
            AppriseNotifier,
            kwargs={
                "title": "🚨 Dag {{ dag_run.dag_id }} missed deadline at {{ deadline.deadline_time }}. DagRun: {{ dag_run }}",
                "body": "🚨 Body 🚨"
            },
        ),
    ),
):
    c = EmptyOperator(task_id="example_task")

    @task()
    def wait():
        import time
        time.sleep(60*5)

    
    c >> wait()


```



However, it seems to block the event loop for some time. I checked the Appprise codebase and it looked reasonable to me. It wraps the sync code in `loop.run_in_executor()`, but now somehow interferes with the internal airflow logic `greenback_shim()`. I need to investigate further.

Perhaps related to this https://github.com/apache/airflow/pull/57154

Here are some logs:

```shell
2025-10-28T14:24:37.404582Z [info     ] Call the connection            [airflow.task.hooks.airflow.providers.apprise.hooks.apprise.AppriseHook] loc=triggerer_job_runner.py:735                                                  
2025-10-28T14:24:37.406809Z [warning  ] Executing <Task pending name='ID 5' coro=<greenback_shim() running at /usr/python/lib/python3.10/site-packages/greenback/_impl.py:116> wait_for=<Future pending cb=[shield.<locals>._oute
r_done_callback() at /usr/python/lib/python3.10/asyncio/tasks.py:864, Task.task_wakeup()] created at /usr/python/lib/python3.10/asyncio/base_events.py:429> created at /usr/python/lib/python3.10/asyncio/tasks.py:337> took 0.11
4 seconds [asyncio] loc=triggerer_job_runner.py:735                                                                                                                                                                              
2025-10-28T14:24:37.443966Z [warning  ] 'HTTP_422_UNPROCESSABLE_ENTITY' is deprecated. Use 'HTTP_422_UNPROCESSABLE_CONTENT' instead. [py.warnings] category=DeprecationWarning filename=/opt/airflow/airflow-core/src/airflow/api
_fastapi/execution_api/routes/__init__.py lineno=23                                                                                                                                                                              
2025-10-28T14:24:39.589208Z [warning  ] Executing <Task pending name='Task-3' coro=<Cadwyn.__call__() running at /usr/python/lib/python3.10/site-packages/cadwyn/applications.py:260> cb=[ASGIResponder.asgi_done_callback()] cre
ated at /usr/python/lib/python3.10/site-packages/a2wsgi/asgi.py:204> took 1.900 seconds [asyncio] loc=base_events.py:1904                                                                                                        
2025-10-28T14:24:39.665464Z [debug    ] [heartbeat]                    [airflow.jobs.job.Job] loc=job.py:256                                                                                                                     
2025-10-28T14:24:39.645365Z [debug    ] Connection Retrieved 'apprise_default' (via task-sdk) [airflow.sdk.bases.hook] loc=triggerer_job_runner.py:735                                                                           
2025-10-28T14:24:39.645535Z [info     ] Done the connection            [airflow.task.hooks.airflow.providers.apprise.hooks.apprise.AppriseHook] loc=triggerer_job_runner.py:735                                                  
2025-10-28T14:24:39.645609Z [info     ] Start get config from connection [airflow.task.hooks.airflow.providers.apprise.hooks.apprise.AppriseHook] loc=triggerer_job_runner.py:735                                                
2025-10-28T14:24:40.016679Z [info     ] Done                           [airflow.task.hooks.airflow.providers.apprise.hooks.apprise.AppriseHook] loc=triggerer_job_runner.py:735                                                  
2025-10-28T14:24:40.016812Z [info     ] Start async call               [airflow.task.hooks.airflow.providers.apprise.hooks.apprise.AppriseHook] loc=triggerer_job_runner.py:735                                                  
2025-10-28T14:24:40.017524Z [info     ] Notifying 1 service(s) asynchronously. [apprise] loc=triggerer_job_runner.py:735                                                                                                         
2025-10-28T14:24:40.018099Z [warning  ] Executing <Task pending name='ID 5' coro=<greenback_shim() running at /usr/python/lib/python3.10/site-packages/greenback/_impl.py:116> wait_for=<_GatheringFuture pending cb=[Task.task_w
akeup()] created at /usr/python/lib/python3.10/asyncio/tasks.py:665> created at /usr/python/lib/python3.10/asyncio/tasks.py:337> took 0.374 seconds [asyncio] loc=triggerer_job_runner.py:735                                    
2025-10-28T14:24:40.022058Z [info     ] Triggerer's async thread was blocked for 0.40 seconds, likely by a badly-written trigger. Set PYTHONASYNCIODEBUG=1 to get more information on overrunning coroutines. [airflow.jobs.trigg
erer_job_runner] loc=triggerer_job_runner.py:735                                                                                                                                                                                 
2025-10-28T14:24:40.437275Z [info     ] Sent Discord notification.     [apprise] loc=triggerer_job_runner.py:735                                                                                                                 
2025-10-28T14:24:40.438728Z [info     ] Done async call                [airflow.task.hooks.airflow.providers.apprise.hooks.apprise.AppriseHook] loc=triggerer_job_runner.py:735                                                  
2025-10-28T14:24:40.439098Z [info     ] Trigger fired event            [airflow.jobs.triggerer_job_runner] loc=triggerer_job_runner.py:735 name='ID 5' result="TriggerEvent<{'state': <DeadlineCallbackState.SUCCESS: 'success'>,
 'body': None}>"                                                                                                                                                                                                                 
2025-10-28T14:24:40.439703Z [info     ] trigger completed              [airflow.jobs.triggerer_job_runner] loc=triggerer_job_runner.py:735 name='ID 5'                                                                           
2025-10-28T14:24:45.058542Z [debug    ] [heartbeat]                    [airflow.jobs.job.Job] loc=job.py:256   
```




<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
