### PR TITLE
[v3-1-test] Add query guard in public asset list endpoints (#57438)

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
@@ -182,6 +182,7 @@ def get_assets(
             subqueryload(AssetModel.scheduled_dags),
             subqueryload(AssetModel.producing_tasks),
             subqueryload(AssetModel.consuming_tasks),
+            subqueryload(AssetModel.aliases),
         )
     )
 
@@ -304,7 +305,9 @@ def get_asset_events(
         session=session,
     )
 
-    assets_event_select = assets_event_select.options(subqueryload(AssetEvent.created_dagruns))
+    assets_event_select = assets_event_select.options(
+        subqueryload(AssetEvent.created_dagruns), joinedload(AssetEvent.asset)
+    )
     assets_events = session.scalars(assets_event_select)
 
     return AssetEventCollectionResponse(

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
@@ -252,7 +252,9 @@ class TestGetAssets(TestAssets):
         assert len(session.query(AssetModel).all()) == 3
         assert len(session.query(AssetActive).all()) == 2
 
-        response = test_client.get("/assets")
+        with assert_queries_count(7):
+            response = test_client.get("/assets")
+
         assert response.status_code == 200
         response_data = response.json()
         tz_datetime_format = from_datetime_to_zulu_without_ms(DEFAULT_DATE)
@@ -585,7 +587,9 @@ class TestGetAssetAliases(TestAssetAliases):
         asset_aliases = session.query(AssetAliasModel).all()
         assert len(asset_aliases) == 2
 
-        response = test_client.get("/assets/aliases")
+        with assert_queries_count(2):
+            response = test_client.get("/assets/aliases")
+
         assert response.status_code == 200
         response_data = response.json()
         assert response_data == {
@@ -668,7 +672,10 @@ class TestGetAssetEvents(TestAssets):
         assets = session.query(AssetEvent).all()
         session.commit()
         assert len(assets) == 2
-        response = test_client.get("/assets/events")
+
+        with assert_queries_count(3):
+            response = test_client.get("/assets/events")
+
         assert response.status_code == 200
         response_data = response.json()
         assert response_data == {
@@ -1002,9 +1009,10 @@ class TestGetDagAssetQueuedEvents(TestQueuedEventEndpoint):
         (asset,) = self.create_assets(session=session, num=1)
         self._create_asset_dag_run_queues(dag_id, asset.id, session)
 
-        response = test_client.get(
-            f"/dags/{dag_id}/assets/queuedEvents",
-        )
+        with assert_queries_count(4):
+            response = test_client.get(
+                f"/dags/{dag_id}/assets/queuedEvents",
+            )
 
         assert response.status_code == 200
         assert response.json() == {
@@ -1262,7 +1270,9 @@ class TestGetAssetQueuedEvents(TestQueuedEventEndpoint):
         (asset,) = self.create_assets(session=session, num=1)
         self._create_asset_dag_run_queues(dag_id, asset.id, session)
 
-        response = test_client.get(f"/assets/{asset.id}/queuedEvents")
+        with assert_queries_count(3):
+            response = test_client.get(f"/assets/{asset.id}/queuedEvents")
+
         assert response.status_code == 200
         assert response.json() == {
             "queued_events": [


### PR DESCRIPTION
(cherry picked from commit 942063a2200d7515e4a5ab2d920591cb4c45dad3)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
