### PR TITLE
Add number of queries guard for public hitls

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/hitl.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/hitl.py
@@ -253,8 +253,10 @@ def get_hitl_details(
         .join(TI.dag_run)
         .options(
             joinedload(HITLDetailModel.task_instance).options(
-                joinedload(TI.dag_run),
-            )
+                joinedload(TI.dag_run).joinedload(DagRun.dag_model),
+                joinedload(TI.task_instance_note),
+                joinedload(TI.dag_version),
+            ),
         )
     )
     if dag_id != "~":

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/hitl.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/hitl.py
@@ -53,6 +53,7 @@ from airflow.api_fastapi.core_api.datamodels.hitl import (
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
 from airflow.api_fastapi.core_api.security import GetUserDep, ReadableTIFilterDep, requires_access_dag
 from airflow.api_fastapi.logging.decorators import action_logging
+from airflow.models.dag_version import DagVersion
 from airflow.models.dagrun import DagRun
 from airflow.models.hitl import HITLDetail as HITLDetailModel, HITLUser
 from airflow.models.taskinstance import TaskInstance as TI
@@ -255,7 +256,7 @@ def get_hitl_details(
             joinedload(HITLDetailModel.task_instance).options(
                 joinedload(TI.dag_run).joinedload(DagRun.dag_model),
                 joinedload(TI.task_instance_note),
-                joinedload(TI.dag_version),
+                joinedload(TI.dag_version).joinedload(DagVersion.bundle),
             ),
         )
     )

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_hitl.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_hitl.py
@@ -34,6 +34,7 @@ from airflow.models.log import Log
 from airflow.sdk.execution_time.hitl import HITLUser
 from airflow.utils.state import TaskInstanceState
 
+from tests_common.test_utils.asserts import assert_queries_count
 from tests_common.test_utils.format_datetime import from_datetime_to_zulu_without_ms
 
 if TYPE_CHECKING:
@@ -528,7 +529,8 @@ class TestGetHITLDetailsEndpoint:
         test_client: TestClient,
         expected_sample_hitl_detail_dict: dict[str, Any],
     ) -> None:
-        response = test_client.get("/dags/~/dagRuns/~/hitlDetails")
+        with assert_queries_count(3):
+            response = test_client.get("/dags/~/dagRuns/~/hitlDetails")
         assert response.status_code == 200
         assert response.json() == {
             "hitl_details": [expected_sample_hitl_detail_dict],
@@ -597,7 +599,8 @@ class TestGetHITLDetailsEndpoint:
         params: dict[str, Any],
         expected_ti_count: int,
     ) -> None:
-        response = test_client.get("/dags/~/dagRuns/~/hitlDetails", params=params)
+        with assert_queries_count(3):
+            response = test_client.get("/dags/~/dagRuns/~/hitlDetails", params=params)
         assert response.status_code == 200
         assert response.json()["total_entries"] == expected_ti_count
         assert len(response.json()["hitl_details"]) == expected_ti_count


### PR DESCRIPTION
Built on top of https://github.com/apache/airflow/pull/57450 that needs to be merged first. Only the last commit is relevant.

Fixed multiple N+1 problem solved on the HILT list endpoint.