### PR TITLE
Add number of queries guard in public import jobs endpoints

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_job.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_job.py
@@ -25,6 +25,7 @@ from airflow.jobs.scheduler_job_runner import SchedulerJobRunner
 from airflow.utils.session import provide_session
 from airflow.utils.state import State
 
+from tests_common.test_utils.asserts import assert_queries_count
 from tests_common.test_utils.db import clear_db_jobs
 from tests_common.test_utils.format_datetime import from_datetime_to_zulu
 
@@ -142,7 +143,8 @@ class TestGetJobs(TestJobEndpoint):
     ):
         # setup testcase at runtime based on the `testcase` parameter
         self.setup(testcase)
-        response = test_client.get("/jobs", params=query_params)
+        with assert_queries_count(2):
+            response = test_client.get("/jobs", params=query_params)
         assert response.status_code == expected_status_code
         if expected_status_code != 200:
             return


### PR DESCRIPTION
No N+1 queries problem detected.

Added queries guard in tests.