### PR TITLE
Docs: Clarify that XComs can only communicate across tasks.

### DIFF
--- a/airflow-core/docs/core-concepts/xcoms.rst
+++ b/airflow-core/docs/core-concepts/xcoms.rst
@@ -78,7 +78,7 @@ An example of pushing multiple XComs and pulling them individually:
 
 .. note::
 
-  If the first task run is not succeeded then on every retry task XComs will be cleared to make the task run idempotent.
+  If the first task was not successful then on every retry task XComs will be cleared to make the task run idempotent. XComs therefore can't be used to persist state across task retries or :doc:`./sensors` poke.
 
 
 Object Storage XCom Backend


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #57575

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

I tried to persist state across sensor pokes and wanted to use XComs for it.
See related: #57575
 
The Docs aren't very clear that it is not possible to pull an XCom that was pushed by the task itself. 
Also see this [SO post](https://stackoverflow.com/questions/67258269/use-xcom-pull-to-pull-a-keys-value-that-same-task-pushed-airflow)
I hope this change makes this more clear.

If somebody could tell me why this is the case and if there is a recommendation for persisting state across sensor pokes, I could add that to the sensor docs as well. 

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
