### PR TITLE
Switch my focus in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@
 /providers/cncf/kubernetes/ @dstandish @jedcunningham
 
 # Helm Chart
-/chart/ @dstandish @jedcunningham @hussein-awala
+/chart/ @dstandish @jedcunningham @hussein-awala @jscheffl
 
 # Docs
 /docs/*.py @potiuk @ashb @gopidesupavan @amoghrajesh @jscheffl @bugraoz93 @kaxil @eladkal @jason810496
@@ -30,7 +30,7 @@
 /airflow-core/src/airflow/api_fastapi/auth/ @vincbeck
 
 # UI
-/airflow-core/src/airflow/ui/ @bbovenzi @pierrejeambrun @ryanahamilton @jscheffl @shubhamraj-git
+/airflow-core/src/airflow/ui/ @bbovenzi @pierrejeambrun @ryanahamilton @shubhamraj-git
 
 # Translation Owners (i18n)
 # Note: Non committer engaged translators are listed in comments prevent making file syntax invalid


### PR DESCRIPTION
As discussed in Slack we need a bit more "manpower" on helm chart. As we gained a couple of contributors in React/UI and my competence in TS is still... limited it might be better if I help and focus on the helm-chart.

Hope I can focus a bit more as many many messages and PR are building-up per day. Maybe still in future I'll help in UI for smaller things :-D

FYI @jason810496 / @choo121600 would you add yourself for `/airflow-core/src/airflow/ui/` to signal that you help maintaining and review?