### PR TITLE
Attempt to limit setuptools for Snowflake snowpark

### DIFF
--- a/devel-common/pyproject.toml
+++ b/devel-common/pyproject.toml
@@ -119,7 +119,7 @@ dependencies = [
     "types-pytz>=2024.1.0.20240417",
     "types-redis>=4.6.0.20240425",
     "types-requests>=2.31.0",
-    "types-setuptools>=69.5.0.20240423",
+    "types-setuptools>=80.0.0.20250429",
     "types-tabulate>=0.9.0.20240106",
     "types-toml>=0.10.8.20240310",
 ]

--- a/providers/snowflake/pyproject.toml
+++ b/providers/snowflake/pyproject.toml
@@ -70,6 +70,7 @@ dependencies = [
     # can be removed when the pip resolver is improved
     "snowflake-snowpark-python>=1.17.0,<9999;python_version<'3.12'",
     "snowflake-snowpark-python>=1.27.0,<9999;python_version>='3.12' and python_version<'3.14'",
+    "setuptools>=80.0.0,<9999",
 ]
 
 # The optional dependencies should be modified in place in the generated file


### PR DESCRIPTION
Setuptools is used by many packages to build them but for snowpark it seems that setuptools is used to "do stuff" as well. Snowpark has a rather "low" expectations for setuptools, and setuptools releases are happening quite often an there are many releases after snowpark's minimum >=40.6.0 (released in 2018 and with way more than 100 releases afterwards). This might be one of the reasons that pip resolution hits "resolution too deep" error.

This PR adds lower-binding for setuptools to relatively new version (April 2025 - more than 6 months ago) in an attempt to limit the space of possible resolutions for `pip`. We also add the <9999 hack to signal pip that setuptools should be resolved early in the process, which should also limit the potential space that pip creates for resolution.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
