### PR TITLE
Add poll_interval attribute to HttpEventTrigger

### DIFF
--- a/providers/http/docs/triggers.rst
+++ b/providers/http/docs/triggers.rst
@@ -30,7 +30,7 @@ enabling event-driven DAGs based on API responses.
 How It Works
 ------------
 
-1. Sends requests to an API.
+1. Sends requests to an API at a frequency determined by ``poll_interval``.
 2. Uses the callable at ``response_check_path`` to evaluate the API response.
 3. If the callable returns ``True``, a ``TriggerEvent`` is emitted. This will trigger DAGs using this ``AssetWatcher`` for scheduling.
 
@@ -85,6 +85,7 @@ Here's an example of using the HttpEventTrigger in an AssetWatcher to monitor th
         http_conn_id="http_default",  # HTTP connection with https://api.github.com/ as the Host
         headers=headers,
         response_check_path="dags.check_airflow_releases.check_github_api_response",  # Path to the check_github_api_response callable
+        poll_interval=600,  # Poll API every 600 seconds
     )
 
     asset = Asset(
@@ -132,6 +133,9 @@ Parameters
 
 ``response_check_path``
     Path to callable that evaluates whether the API response passes the conditions set by the user to trigger DAGs
+
+``poll_interval``
+    How often, in seconds, the trigger should send a request to the API.
 
 
 Important Notes

--- a/providers/http/docs/triggers.rst
+++ b/providers/http/docs/triggers.rst
@@ -30,7 +30,7 @@ enabling event-driven DAGs based on API responses.
 How It Works
 ------------
 
-1. Sends requests to an API at a frequency determined by ``poll_interval``.
+1. Sends requests to an API every ``poll_interval`` seconds (default 60).
 2. Uses the callable at ``response_check_path`` to evaluate the API response.
 3. If the callable returns ``True``, a ``TriggerEvent`` is emitted. This will trigger DAGs using this ``AssetWatcher`` for scheduling.
 

--- a/providers/http/docs/triggers.rst
+++ b/providers/http/docs/triggers.rst
@@ -143,5 +143,6 @@ Important Notes
 
 1. A ``response_check_path`` value is required.
 2. The ``response_check_path`` must contain the path to an asynchronous callable. Synchronous callables will raise an exception.
-3. This trigger does not automatically record the previous API response.
-4. The previous response may have to be persisted manually though ``Variable.set()`` in the ``response_check_path`` callable to prevent the trigger from emitting events repeatedly for the same API response.
+3. The ``poll_interval`` defaults to 60 seconds. This may be changed to avoid hitting API rate limits.
+4. This trigger does not automatically record the previous API response.
+5. The previous response may have to be persisted manually though ``Variable.set()`` in the ``response_check_path`` callable to prevent the trigger from emitting events repeatedly for the same API response.

--- a/providers/http/src/airflow/providers/http/triggers/http.py
+++ b/providers/http/src/airflow/providers/http/triggers/http.py
@@ -253,6 +253,7 @@ class HttpEventTrigger(HttpTrigger, BaseEventTrigger):
     :param headers: Additional headers to be passed through as a dict.
     :param data: Payload to be uploaded or request parameters.
     :param extra_options: Additional kwargs to pass when creating a request.
+    :parama poll_interval: How often, in seconds, the trigger should send a request to the API.
     """
 
     def __init__(
@@ -265,9 +266,11 @@ class HttpEventTrigger(HttpTrigger, BaseEventTrigger):
         headers: dict[str, str] | None = None,
         data: dict[str, Any] | str | None = None,
         extra_options: dict[str, Any] | None = None,
+        poll_interval: float = 60.0,
     ):
         super().__init__(http_conn_id, auth_type, method, endpoint, headers, data, extra_options)
         self.response_check_path = response_check_path
+        self.poll_interval = poll_interval
 
     def serialize(self) -> tuple[str, dict[str, Any]]:
         """Serialize HttpEventTrigger arguments and classpath."""
@@ -276,12 +279,13 @@ class HttpEventTrigger(HttpTrigger, BaseEventTrigger):
             {
                 "http_conn_id": self.http_conn_id,
                 "method": self.method,
-                "auth_type": self.auth_type,
+                "auth_type": serialize_auth_type(self.auth_type),
                 "endpoint": self.endpoint,
                 "headers": self.headers,
                 "data": self.data,
                 "extra_options": self.extra_options,
                 "response_check_path": self.response_check_path,
+                "poll_interval": self.poll_interval,
             },
         )
 
@@ -293,6 +297,7 @@ class HttpEventTrigger(HttpTrigger, BaseEventTrigger):
                 response = await super()._get_response(hook)
                 if await self._run_response_check(response):
                     break
+                await asyncio.sleep(self.poll_interval)
             yield TriggerEvent(
                 {
                     "status": "success",

--- a/providers/http/tests/unit/http/triggers/test_http.py
+++ b/providers/http/tests/unit/http/triggers/test_http.py
@@ -43,6 +43,7 @@ TEST_HEADERS = {"Authorization": "Bearer test"}
 TEST_DATA = {"key": "value"}
 TEST_EXTRA_OPTIONS: dict[str, Any] = {}
 TEST_RESPONSE_CHECK_PATH = "mock.path"
+TEST_POLL_INTERVAL = 5
 
 
 @pytest.fixture
@@ -81,6 +82,7 @@ def event_trigger():
         data=TEST_DATA,
         extra_options=TEST_EXTRA_OPTIONS,
         response_check_path=TEST_RESPONSE_CHECK_PATH,
+        poll_interval=TEST_POLL_INTERVAL,
     )
 
 
@@ -232,6 +234,7 @@ class TestHttpEventTrigger:
             "data": TEST_DATA,
             "extra_options": TEST_EXTRA_OPTIONS,
             "response_check_path": TEST_RESPONSE_CHECK_PATH,
+            "poll_interval": TEST_POLL_INTERVAL,
         }
 
     @pytest.mark.asyncio


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->

This will add a poll_interval attribute to the HttpEventTrigger, which will allow the user to control how often the trigger sends a request to the API.

Previously, the trigger would constantly send requests, which could result in API rate limits being hit. The poll_interval config gives the user some control to prevent that.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
