### PR TITLE
Small fix for vertex_ai_feature_store system test

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/feature_store.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/feature_store.py
@@ -179,7 +179,7 @@ class CreateFeatureOnlineStoreOperator(GoogleCloudBaseOperator, OperationHelper)
             gcp_conn_id=self.gcp_conn_id,
             impersonation_chain=self.impersonation_chain,
         )
-        self.log.info("Creating the Feature Online Store...")
+        self.log.info("Creating the Feature Online Store id: %s", self.feature_online_store_id)
         result_operation = hook.create_feature_online_store(
             project_id=self.project_id,
             location=self.location,

--- a/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_feature_store.py
+++ b/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_feature_store.py
@@ -23,8 +23,6 @@ Example Airflow DAG for Google Vertex AI Feature Store operations.
 from __future__ import annotations
 
 import os
-import random
-import string
 from datetime import datetime, timedelta
 
 from google.cloud.aiplatform_v1beta1 import FeatureOnlineStore, FeatureView, FeatureViewDataKey
@@ -64,10 +62,7 @@ BQ_VIEW_ID = "product_features_view"
 BQ_VIEW_FQN = f"{PROJECT_ID}.{BQ_DATASET_ID}.{BQ_VIEW_ID}"
 
 # Please take into consideration that max ID length is 60 symbols
-PREFIX_FEATURE_ONLINE_STORE_ID = "".join(
-    random.choice(string.ascii_letters + string.digits) for _ in range(20)
-)
-FEATURE_ONLINE_STORE_ID = f"feature_online_store_{PREFIX_FEATURE_ONLINE_STORE_ID}".replace("-", "_")
+FEATURE_ONLINE_STORE_ID = f"{ENV_ID}_fo_id".replace("-", "_")
 FEATURE_VIEW_ID = "feature_view_product"
 FEATURE_VIEW_DATA_KEY = {"key": "28098"}
 


### PR DESCRIPTION
Fix for vertex_ai_feature_store system tests to use ENV_ID when generating name for feature_store_online_id to make sure it will be unique
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
