### PR TITLE
[v3-1-test] Add number of queries guard in public plugins list endpoints (#57562)

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_plugins.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_plugins.py
@@ -20,6 +20,7 @@ from unittest.mock import patch
 
 import pytest
 
+from tests_common.test_utils.asserts import assert_queries_count
 from tests_common.test_utils.markers import skip_if_force_lowest_dependencies_marker
 
 pytestmark = pytest.mark.db_test
@@ -63,7 +64,8 @@ class TestGetPlugins:
     ):
         pytest.importorskip("flask_appbuilder")  # Remove after upgrading to FAB5
 
-        response = test_client.get("/plugins", params=query_params)
+        with assert_queries_count(2):
+            response = test_client.get("/plugins", params=query_params)
         assert response.status_code == 200
 
         body = response.json()
@@ -73,7 +75,8 @@ class TestGetPlugins:
     def test_external_views_model_validator(self, test_client):
         pytest.importorskip("flask_appbuilder")  # Remove after upgrading to FAB5
 
-        response = test_client.get("plugins")
+        with assert_queries_count(2):
+            response = test_client.get("plugins")
         body = response.json()
 
         test_plugin = next((plugin for plugin in body["plugins"] if plugin["name"] == "test_plugin"), None)
@@ -156,7 +159,8 @@ class TestGetPluginImportErrors:
         new={"plugins/test_plugin.py": "something went wrong"},
     )
     def test_should_respond_200(self, test_client, session):
-        response = test_client.get("/plugins/importErrors")
+        with assert_queries_count(2):
+            response = test_client.get("/plugins/importErrors")
         assert response.status_code == 200
 
         body = response.json()


### PR DESCRIPTION
(cherry picked from commit caeb0373706a138f3fccb05ae4ca06013810e582)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
