### PR TITLE
Don't fetch ImportError until modal opens. Use limit as 1 since the UI shows total_entries value and rest of the response is ignored.

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/DAGImportErrors.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/DAGImportErrors.tsx
@@ -33,7 +33,7 @@ export const DAGImportErrors = ({ iconOnly = false }: { readonly iconOnly?: bool
 
   const isRTL = i18n.dir() === "rtl";
 
-  const { data, error, isLoading } = useImportErrorServiceGetImportErrors();
+  const { data, error, isLoading } = useImportErrorServiceGetImportErrors({ limit: 1 });
   const importErrorsCount = data?.total_entries ?? 0;
 
   if (isLoading) {

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/DAGImportErrorsModal.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/DAGImportErrorsModal.tsx
@@ -39,11 +39,15 @@ export const DAGImportErrorsModal: React.FC<ImportDAGErrorModalProps> = ({ onClo
   const [page, setPage] = useState(1);
   const [searchQuery, setSearchQuery] = useState("");
 
-  const { data } = useImportErrorServiceGetImportErrors({
-    filenamePattern: searchQuery || undefined,
-    limit: PAGE_LIMIT,
-    offset: PAGE_LIMIT * (page - 1),
-  });
+  const { data } = useImportErrorServiceGetImportErrors(
+    {
+      filenamePattern: searchQuery || undefined,
+      limit: PAGE_LIMIT,
+      offset: PAGE_LIMIT * (page - 1),
+    },
+    undefined,
+    { enabled: open },
+  );
 
   const { t: translate } = useTranslation(["dashboard", "components"]);
 

--- a/airflow-core/src/airflow/ui/src/utils/query.ts
+++ b/airflow-core/src/airflow/ui/src/utils/query.ts
@@ -51,6 +51,7 @@ export const useAutoRefresh = ({
     {
       dagId: dagId ?? "~",
       state: ["running", "queued"],
+      limit: 1,
     },
     undefined,
     // Scale back refetching to 10x longer if there are no pending runs (eg: every 3 secs for active runs, otherwise 30 secs)


### PR DESCRIPTION
* In order to show the count of import errors the API call is made with default limit value and then `total_entries` is the value used with rest of the response unused. Using limit as 1 fetches only one entry but the `total_entries` remains the same. In an instance with 500 dag import errors 1.46 kB (25.23kB uncompressed) in 268ms became 539 bytes (543 bytes uncompressed) in 50ms.
* Don't fetch import errors until the modal is open. This opens up a slot in browser to be used for another request during dashboard and dags list page.
* In order to check for auto refresh in case of pending runs the queries are made to fetch dagruns in running or queued state. The default limit fetches the dagrun entries which are not used in the UI. Similar to import errors use limit 1 can be used since the underlying check is only about being greater than zero for auto refresh. In scenarios with many running/queued dagruns this will result in efficient decision about whether to auto refresh or not since only one entry needs to be fetched to make the decision. It also reduces the amount of rows fetched from database. In an instance with 8 dagruns in running state 1.85kB (19.49 kB uncompressed) in 300ms became 570 bytes (800 bytes uncompressed) in 170ms.