### PR TITLE
Fix DAG bundle imports in subprocess operators

### DIFF
--- a/providers/standard/tests/unit/standard/operators/test_python.py
+++ b/providers/standard/tests/unit/standard/operators/test_python.py
@@ -959,7 +959,7 @@ def _callable_that_imports_from_bundle():
 
 @pytest.mark.execution_timeout(120)
 @pytest.mark.parametrize(
-    "opcls,pytest_marks,test_class_ref",
+    ("opcls", "pytest_marks", "test_class_ref"),
     [
         pytest.param(
             PythonVirtualenvOperator,

--- a/providers/standard/tests/unit/standard/operators/test_python.py
+++ b/providers/standard/tests/unit/standard/operators/test_python.py
@@ -942,17 +942,15 @@ virtualenv_string_args: list[str] = []
 
 @pytest.mark.execution_timeout(120)
 @pytest.mark.parametrize(
-    ("opcls", "pytest_marks", "test_class_ref"),
+    ("opcls", "test_class_ref"),
     [
         pytest.param(
             PythonVirtualenvOperator,
-            [pytest.mark.virtualenv_operator],
             lambda: TestPythonVirtualenvOperator,
             id="PythonVirtualenvOperator",
         ),
         pytest.param(
             ExternalPythonOperator,
-            [pytest.mark.external_python_operator],
             lambda: TestExternalPythonOperator,
             id="ExternalPythonOperator",
         ),
@@ -969,7 +967,7 @@ class TestDagBundleImportInSubprocess(BasePythonTest):
     @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Dag Bundle import fix is for Airflow 3.x+")
     @mock.patch("airflow.providers.standard.operators.python._execute_in_subprocess")
     def test_dag_bundle_import_in_subprocess(
-        self, mock_execute_subprocess, dag_maker, opcls, pytest_marks, test_class_ref, tmp_path
+        self, mock_execute_subprocess, dag_maker, opcls, test_class_ref, tmp_path
     ):
         """
         Tests that a callable in a subprocess can import modules from its

--- a/providers/standard/tests/unit/standard/operators/test_python.py
+++ b/providers/standard/tests/unit/standard/operators/test_python.py
@@ -939,6 +939,7 @@ class TestShortCircuitOperator(BasePythonTest):
 
 virtualenv_string_args: list[str] = []
 
+
 def _callable_that_imports_from_bundle():
     """
     A callable function for testing DAG bundle imports.
@@ -954,6 +955,7 @@ def _callable_that_imports_from_bundle():
         import sys
 
         return f"Failed to import: {e}. PYTHONPATH: {sys.path}"
+
 
 @pytest.mark.execution_timeout(120)
 class BaseTestPythonVirtualenvOperator(BasePythonTest):
@@ -1234,9 +1236,7 @@ class _TestDagBundleImportMixin:
 
             (module_dir / "__init__.py").touch()
             (lib_dir / "__init__.py").touch()
-            (lib_dir / "helper.py").write_text(
-                "def get_message():\n    return 'it works from bundle'"
-            )
+            (lib_dir / "helper.py").write_text("def get_message():\n    return 'it works from bundle'")
 
             # We need a real DAG to create a real TI context
             with dag_maker(self.dag_id, serialized=True):
@@ -1257,6 +1257,7 @@ class _TestDagBundleImportMixin:
             result = op.execute(context)
 
             assert result == "it works from bundle"
+
 
 venv_cache_path = tempfile.mkdtemp(prefix="venv_cache_path")
 

--- a/providers/standard/tests/unit/standard/operators/test_python.py
+++ b/providers/standard/tests/unit/standard/operators/test_python.py
@@ -950,7 +950,7 @@ def _callable_that_imports_from_bundle():
         from bug_test_dag_repro.lib.helper import get_message
 
         return get_message()
-    except Exception as e:
+    except ImportError as e:
         # This helps debug if the import fails during the test
         import sys
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

**closes: #56783**

Resolve `ModuleNotFoundError` for DAG bundle imports within standard operator subprocesses in Airflow 3.x.

## Problem
Subprocesses spawned by these operators don't have the DAG bundle path in `PYTHONPATH` (see #53617), causing imports to fail when modules from the bundle are imported inside the callable function.

## Solution
Extracts bundle path from task instance context during execution call
Add extracted bundle path to subprocess `PYTHONPATH` environment variable
Guard with `AIRFLOW_V_3_0_PLUS` check for backward compatibility