### PR TITLE
Add number of queries guard in public providers list endpoints

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_providers.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_providers.py
@@ -22,6 +22,8 @@ import pytest
 
 from airflow.providers_manager import ProviderInfo
 
+from tests_common.test_utils.asserts import assert_queries_count
+
 pytestmark = pytest.mark.db_test
 
 MOCK_PROVIDERS = {
@@ -64,7 +66,8 @@ class TestGetProviders:
     def test_should_respond_200(
         self, mock_provider, test_client, query_params, expected_total_entries, expected_package_name
     ):
-        response = test_client.get("/providers", params=query_params)
+        with assert_queries_count(0):
+            response = test_client.get("/providers", params=query_params)
 
         assert response.status_code == 200
         body = response.json()


### PR DESCRIPTION
Implement N+1 queries guard on list providers endpoint. 

No problem detected.