### PR TITLE
Remove global from Fernet Crypto tooling

### DIFF
--- a/airflow-core/src/airflow/models/crypto.py
+++ b/airflow-core/src/airflow/models/crypto.py
@@ -77,7 +77,7 @@ class _RealFernet:
 
     is_encrypted = True
 
-    def __init__(self, fernet: MultiFernet | Fernet):
+    def __init__(self, fernet: MultiFernet):
         self._fernet = fernet
 
     def decrypt(self, msg: bytes | str, ttl: int | None = None) -> bytes:
@@ -87,6 +87,10 @@ class _RealFernet:
     def encrypt(self, msg: bytes) -> bytes:
         """Encrypt with Fernet."""
         return self._fernet.encrypt(msg)
+
+    def rotate(self, msg: bytes | str) -> bytes:
+        """Rotate the Fernet key for the given message."""
+        return self._fernet.rotate(msg)
 
 
 @cache

--- a/airflow-core/src/airflow/models/crypto.py
+++ b/airflow-core/src/airflow/models/crypto.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import logging
+from functools import cache
 from typing import Protocol
 
 from airflow.configuration import conf
@@ -29,14 +30,18 @@ log = logging.getLogger(__name__)
 class FernetProtocol(Protocol):
     """This class is only used for TypeChecking (for IDEs, mypy, etc)."""
 
-    def decrypt(self, b):
+    is_encrypted: bool
+
+    def decrypt(self, msg: bytes | str, ttl: int | None = None) -> bytes:
         """Decrypt with Fernet."""
+        ...
 
-    def encrypt(self, b):
+    def encrypt(self, msg: bytes) -> bytes:
         """Encrypt with Fernet."""
+        ...
 
 
-class NullFernet:
+class _NullFernet:
     """
     A "Null" encryptor class that doesn't encrypt or decrypt but that presents a similar interface to Fernet.
 
@@ -47,19 +52,45 @@ class NullFernet:
 
     is_encrypted = False
 
-    def decrypt(self, b):
+    def decrypt(self, msg: bytes | str, ttl: int | None = None) -> bytes:
         """Decrypt with Fernet."""
-        return b
+        if isinstance(msg, bytes):
+            return msg
+        if isinstance(msg, str):
+            return msg.encode("utf-8")
+        raise ValueError(f"Expected bytes or str, got {type(msg)}")
 
-    def encrypt(self, b):
+    def encrypt(self, msg: bytes) -> bytes:
         """Encrypt with Fernet."""
-        return b
+        return msg
 
 
-_fernet: FernetProtocol | None = None
+class _RealFernet:
+    """
+    A wrapper around the real Fernet to set is_encrypted to True.
+
+    This class is only used internally to avoid changing the interface of
+    the get_fernet function.
+    """
+
+    from cryptography.fernet import Fernet, MultiFernet
+
+    is_encrypted = True
+
+    def __init__(self, fernet: MultiFernet | Fernet):
+        self._fernet = fernet
+
+    def decrypt(self, msg: bytes | str, ttl: int | None = None) -> bytes:
+        """Decrypt with Fernet."""
+        return self._fernet.decrypt(msg, ttl)
+
+    def encrypt(self, msg: bytes) -> bytes:
+        """Encrypt with Fernet."""
+        return self._fernet.encrypt(msg)
 
 
-def get_fernet():
+@cache
+def get_fernet() -> FernetProtocol:
     """
     Deferred load of Fernet key.
 
@@ -71,22 +102,13 @@ def get_fernet():
     """
     from cryptography.fernet import Fernet, MultiFernet
 
-    global _fernet
-
-    if _fernet:
-        return _fernet
-
     try:
         fernet_key = conf.get("core", "FERNET_KEY")
         if not fernet_key:
             log.warning("empty cryptography key - values will not be stored encrypted.")
-            _fernet = NullFernet()
-        else:
-            _fernet = MultiFernet(
-                [Fernet(fernet_part.encode("utf-8")) for fernet_part in fernet_key.split(",")]
-            )
-            _fernet.is_encrypted = True
+            return _NullFernet()
+
+        fernet = MultiFernet([Fernet(fernet_part.encode("utf-8")) for fernet_part in fernet_key.split(",")])
+        return _RealFernet(fernet)
     except (ValueError, TypeError) as value_error:
         raise AirflowException(f"Could not create Fernet object: {value_error}")
-
-    return _fernet

--- a/airflow-core/tests/unit/always/test_connection.py
+++ b/airflow-core/tests/unit/always/test_connection.py
@@ -118,6 +118,7 @@ class TestConnection:
         is set to a non-base64-encoded string and the extra is stored without
         encryption.
         """
+        crypto.get_fernet.cache_clear()
         test_connection = Connection(extra='{"apache": "airflow"}')
         assert not test_connection.is_extra_encrypted
         assert test_connection.extra == '{"apache": "airflow"}'
@@ -127,6 +128,7 @@ class TestConnection:
         """
         Tests extras on a new connection with encryption.
         """
+        crypto.get_fernet.cache_clear()
         test_connection = Connection(extra='{"apache": "airflow"}')
         assert test_connection.is_extra_encrypted
         assert test_connection.extra == '{"apache": "airflow"}'
@@ -139,6 +141,7 @@ class TestConnection:
         key2 = Fernet.generate_key()
 
         with conf_vars({("core", "fernet_key"): key1.decode()}):
+            crypto.get_fernet.cache_clear()
             test_connection = Connection(extra='{"apache": "airflow"}')
             assert test_connection.is_extra_encrypted
             assert test_connection.extra == '{"apache": "airflow"}'
@@ -146,7 +149,7 @@ class TestConnection:
 
         # Test decrypt of old value with new key
         with conf_vars({("core", "fernet_key"): f"{key2.decode()},{key1.decode()}"}):
-            crypto._fernet = None
+            crypto.get_fernet.cache_clear()
             assert test_connection.extra == '{"apache": "airflow"}'
 
             # Test decrypt of new value with new key

--- a/airflow-core/tests/unit/models/test_variable.py
+++ b/airflow-core/tests/unit/models/test_variable.py
@@ -59,6 +59,7 @@ class TestVariable:
         """
         Test variables without encryption
         """
+        crypto.get_fernet.cache_clear()
         Variable.set(key="key", value="value", session=session)
         test_var = session.query(Variable).filter(Variable.key == "key").one()
         assert not test_var.is_encrypted
@@ -72,6 +73,7 @@ class TestVariable:
         """
         Test variables with encryption
         """
+        crypto.get_fernet.cache_clear()
         Variable.set(key="key", value="value", session=session)
         test_var = session.query(Variable).filter(Variable.key == "key").one()
         assert test_var.is_encrypted
@@ -86,6 +88,7 @@ class TestVariable:
         key2 = Fernet.generate_key()
 
         with conf_vars({("core", "fernet_key"): key1.decode()}):
+            crypto.get_fernet.cache_clear()
             Variable.set(key="key", value=test_value, session=session)
             test_var = session.query(Variable).filter(Variable.key == "key").one()
             assert test_var.is_encrypted
@@ -94,7 +97,7 @@ class TestVariable:
 
         # Test decrypt of old value with new key
         with conf_vars({("core", "fernet_key"): f"{key2.decode()},{key1.decode()}"}):
-            crypto._fernet = None
+            crypto.get_fernet.cache_clear()
             assert test_var.val == test_value
 
             # Test decrypt of new value with new key

--- a/airflow-core/tests/unit/models/test_variable.py
+++ b/airflow-core/tests/unit/models/test_variable.py
@@ -43,7 +43,6 @@ pytestmark = pytest.mark.db_test
 class TestVariable:
     @pytest.fixture(autouse=True)
     def setup_test_cases(self):
-        crypto._fernet = None
         db.clear_db_variables()
         SecretCache.reset()
         with conf_vars({("secrets", "use_cache"): "true"}):
@@ -52,7 +51,6 @@ class TestVariable:
             self.mask_secret = m
             yield
         db.clear_db_variables()
-        crypto._fernet = None
 
     @conf_vars({("core", "fernet_key"): "", ("core", "unit_test_mode"): "True"})
     def test_variable_no_encryption(self, session):


### PR DESCRIPTION
As I was attempting to clean code toward ruff rule PLW0603 (https://docs.astral.sh/ruff/rules/global-statement/) I noticed that some code is a bit... outdated to be refactored.

First proposal is to get rid of the global statement in the Fernet/crypto wrapper which just used the global variable as cache.

Whereas I would like to have feedback as well as in airflow-core/src/airflow/configuration.py:2108 actually we changed in the past to always generate a FERNET_KEY even if none is provided, so could we erase-out some complexity as we assume durnog start there will be always one FERNET_KEY being around?