### PR TITLE
Further improve git provider's tagging

### DIFF
--- a/dev/README_RELEASE_PROVIDERS.md
+++ b/dev/README_RELEASE_PROVIDERS.md
@@ -365,9 +365,15 @@ rm -rf ${AIRFLOW_REPO_ROOT}/dist/*
 
 * Release candidate packages:
 
+Assume that your remote for apache repository is called `apache` you should now
+set tags for the providers in the repo.
+
+
 ```shell script
 breeze release-management prepare-provider-distributions  --include-removed-providers --distribution-format both
-breeze release-management tag-providers
+echo "Tagging with providers/${PACKAGE_DATE}"
+git tag -s providers/${PACKAGE_DATE} -m "Tag providers for ${PACKAGE_DATE}" --force
+git push apache providers/${PACKAGE_DATE}
 breeze release-management prepare-airflow-tarball --version ${PACKAGE_DATE} --distribution-name apache_airflow_providers
 ```
 
@@ -376,27 +382,15 @@ if you only build few packages, run:
 ```shell script
 breeze release-management prepare-provider-distributions  --include-removed-providers \
 --distribution-format both PACKAGE PACKAGE ....
-breeze release-management tag-providers
+echo "Tagging with providers/${PACKAGE_DATE}"
+git tag -s providers/${PACKAGE_DATE} -m "Tag providers for ${PACKAGE_DATE}" --force
+git push apache providers/${PACKAGE_DATE}
 breeze release-management prepare-airflow-tarball --version ${PACKAGE_DATE} --distribution-name apache_airflow_providers
 ```
 
 In case you want to also release a pre-installed provider that is in ``not-ready`` state (i.e. when
 you want to release it before you switch their state to ``ready``), you need to pass
 ``--include-not-ready-providers`` flag to the command above.
-
-.. note:
-
-  The "tag-providers" step assumes that your remote for apache repository is called `apache`.
-
-  Sometimes in cases when there is a connectivity issue to GitHub, it might be possible that local
-  tags get created  and lead to annoying errors. The default behaviour would be to clean such local tags up,
-  so you can re-run tag-providers command without issues, and it will force tag creation properly, overriding
-  existing tags.
-
-  If you want to disable this behaviour, use --no-clean-tags.
-
-
-
 
 * Sign all your packages
 
@@ -843,7 +837,7 @@ cd "${AIRFLOW_REPO_ROOT}"
 
 ```shell
 git fetch apache --tags
-git checkout providers/2025-10-20
+git checkout providers/2025-10-31
 ```
 
 3) Remove all the packages you have in dist folder
@@ -1303,10 +1297,10 @@ By that time the packages should be in your dist folder.
 
 ```shell script
 cd ${AIRFLOW_REPO_ROOT}
-git checkout <ONE_OF_THE_RC_TAGS_FOR_ONE_OF_THE_RELEASED_PROVIDERS>
+git checkout providers/YYYY-MM-DD
 ```
 
-example `git checkout providers-amazon/7.0.0rc2`
+example `git checkout providers/2025-10-31`
 
 Note you probably will see message `You are in 'detached HEAD' state.`
 This is expected, the RC tag is most likely behind the main branch.

--- a/dev/breeze/doc/09_release_management_tasks.rst
+++ b/dev/breeze/doc/09_release_management_tasks.rst
@@ -281,10 +281,10 @@ This command can be utilized to manage git tags for providers within the Airflow
 Sometimes in cases when there is a connectivity issue to GitHub, it might be possible that local tags get created and lead to annoying errors.
 The default behaviour would be to clean such local tags up.
 
-The flag ``--clean-local-tags`` can be used to delete the local tags.
+The flag ``--clean-tags`` can be used to delete the local tags.
 
 However, If you want to disable this behaviour, set the envvar CLEAN_LOCAL_TAGS to false or use the
-``--no-clean-local-tags`` flag.
+``--no-clean-tags`` flag.
 
 .. code-block:: bash
 

--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -1319,7 +1319,7 @@ def tag_providers(
     release_date = os.environ.get("PACKAGE_DATE", datetime.now().strftime("%Y-%m-%d"))
 
     if found_remote is None:
-        raise ValueError("Could not find remote configured to push to apache/airflow")
+        raise ValueError("Could not find the remote configured to push to apache/airflow")
 
     extra_flags = []
     tags = []
@@ -1337,17 +1337,7 @@ def tag_providers(
                     check=True,
                 )
                 tags.append(tag)
-    providers_date_tag = f"providers/{release_date}"
     if tags:
-        run_command(
-            ["git", "tag", providers_date_tag, *extra_flags, "-m", f"Release {release_date} of providers"],
-            check=True,
-        )
-        get_console().print()
-        get_console().print("\n[info]The providers release have been tagged with:[/]")
-        get_console().print(providers_date_tag)
-        get_console().print()
-        tags.append(providers_date_tag)
         push_result = run_command(
             ["git", "push", found_remote, *extra_flags, *tags],
             check=True,


### PR DESCRIPTION
There was an RC tagging problem with tagging providers when releasing this PR brings back tag-providers and separates tagging providers with date to a separate message

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
