### PR TITLE
EKS sensors before delete operations

### DIFF
--- a/providers/amazon/tests/system/amazon/aws/example_eks_with_fargate_in_one_step.py
+++ b/providers/amazon/tests/system/amazon/aws/example_eks_with_fargate_in_one_step.py
@@ -117,15 +117,6 @@ with DAG(
     # only describe the pod if the task above failed, to help diagnose
     describe_pod.trigger_rule = TriggerRule.ONE_FAILED
 
-    # Wait for fargate profile to be in stable state before deletion
-    await_fargate_profile_stable = EksFargateProfileStateSensor(
-        task_id="await_fargate_profile_stable",
-        trigger_rule=TriggerRule.ALL_DONE,
-        cluster_name=cluster_name,
-        fargate_profile_name=fargate_profile_name,
-        target_state=FargateProfileStates.ACTIVE,
-    )
-
     # An Amazon EKS cluster can not be deleted with attached resources such as nodegroups or Fargate profiles.
     # Setting the `force` to `True` will delete any attached resources before deleting the cluster.
     delete_cluster_and_fargate_profile = EksDeleteClusterOperator(
@@ -155,7 +146,6 @@ with DAG(
         start_pod,
         # TEST TEARDOWN
         describe_pod,
-        await_fargate_profile_stable,
         delete_cluster_and_fargate_profile,
         await_delete_cluster,
     )

--- a/providers/amazon/tests/system/amazon/aws/example_eks_with_fargate_profile.py
+++ b/providers/amazon/tests/system/amazon/aws/example_eks_with_fargate_profile.py
@@ -133,15 +133,6 @@ with DAG(
     # only describe the pod if the task above failed, to help diagnose
     describe_pod.trigger_rule = TriggerRule.ONE_FAILED
 
-    # Wait for fargate profile to be in stable state before deletion
-    await_fargate_profile_stable = EksFargateProfileStateSensor(
-        task_id="await_fargate_profile_stable",
-        trigger_rule=TriggerRule.ALL_DONE,
-        cluster_name=cluster_name,
-        fargate_profile_name=fargate_profile_name,
-        target_state=FargateProfileStates.ACTIVE,
-    )
-
     # [START howto_operator_eks_delete_fargate_profile]
     delete_fargate_profile = EksDeleteFargateProfileOperator(
         task_id="delete_eks_fargate_profile",
@@ -161,14 +152,6 @@ with DAG(
         target_state=FargateProfileStates.NONEXISTENT,
         trigger_rule=TriggerRule.ALL_DONE,
         poke_interval=10,
-    )
-
-    # Wait for cluster to be in stable state before deletion
-    await_cluster_stable = EksClusterStateSensor(
-        task_id="await_cluster_stable",
-        trigger_rule=TriggerRule.ALL_DONE,
-        cluster_name=cluster_name,
-        target_state=ClusterStates.ACTIVE,
     )
 
     delete_cluster = EksDeleteClusterOperator(
@@ -195,10 +178,8 @@ with DAG(
         start_pod,
         # TEARDOWN
         describe_pod,
-        await_fargate_profile_stable,
         delete_fargate_profile,  # part of the test AND teardown
         await_delete_fargate_profile,
-        await_cluster_stable,
         delete_cluster,
         await_delete_cluster,
     )

--- a/providers/amazon/tests/system/amazon/aws/example_eks_with_nodegroup_in_one_step.py
+++ b/providers/amazon/tests/system/amazon/aws/example_eks_with_nodegroup_in_one_step.py
@@ -134,15 +134,6 @@ with DAG(
     # only describe the pod if the task above failed, to help diagnose
     describe_pod.trigger_rule = TriggerRule.ONE_FAILED
 
-    # Wait for nodegroup to be in stable state before deletion
-    await_nodegroup_stable = EksNodegroupStateSensor(
-        task_id="await_nodegroup_stable",
-        trigger_rule=TriggerRule.ALL_DONE,
-        cluster_name=cluster_name,
-        nodegroup_name=nodegroup_name,
-        target_state=NodegroupStates.ACTIVE,
-    )
-
     # [START howto_operator_eks_force_delete_cluster]
     # An Amazon EKS cluster can not be deleted with attached resources such as nodegroups or Fargate profiles.
     # Setting the `force` to `True` will delete any attached resources before deleting the cluster.
@@ -175,7 +166,6 @@ with DAG(
         start_pod,
         # TEST TEARDOWN
         describe_pod,
-        await_nodegroup_stable,
         delete_nodegroup_and_cluster,
         await_delete_cluster,
         delete_launch_template(launch_template_name),

--- a/providers/amazon/tests/system/amazon/aws/example_eks_with_nodegroups.py
+++ b/providers/amazon/tests/system/amazon/aws/example_eks_with_nodegroups.py
@@ -159,15 +159,6 @@ with DAG(
     # only describe the pod if the task above failed, to help diagnose
     describe_pod.trigger_rule = TriggerRule.ONE_FAILED
 
-    # Wait for nodegroup to be in stable state before deletion
-    await_nodegroup_stable = EksNodegroupStateSensor(
-        task_id="await_nodegroup_stable",
-        trigger_rule=TriggerRule.ALL_DONE,
-        cluster_name=cluster_name,
-        nodegroup_name=nodegroup_name,
-        target_state=NodegroupStates.ACTIVE,
-    )
-
     # [START howto_operator_eks_delete_nodegroup]
     delete_nodegroup = EksDeleteNodegroupOperator(
         task_id="delete_nodegroup",
@@ -186,14 +177,6 @@ with DAG(
         cluster_name=cluster_name,
         nodegroup_name=nodegroup_name,
         target_state=NodegroupStates.NONEXISTENT,
-    )
-
-    # Wait for cluster to be in stable state before deletion
-    await_cluster_stable = EksClusterStateSensor(
-        task_id="await_cluster_stable",
-        trigger_rule=TriggerRule.ALL_DONE,
-        cluster_name=cluster_name,
-        target_state=ClusterStates.ACTIVE,
     )
 
     # [START howto_operator_eks_delete_cluster]
@@ -224,10 +207,8 @@ with DAG(
         start_pod,
         # TEST TEARDOWN
         describe_pod,
-        await_nodegroup_stable,
         delete_nodegroup,  # part of the test AND teardown
         await_delete_nodegroup,
-        await_cluster_stable,
         delete_cluster,  # part of the test AND teardown
         await_delete_cluster,
         delete_launch_template(launch_template_name),


### PR DESCRIPTION
Intermittently running into failures in the EKS tests because there's a race condition happening where the delete operator sometimes executes before upstream tasks are in a terminal state, so the whole Dag fails. I haven't investigated the root reason for the race condition but for now I'm adding a sensor to force the delete operators to wait.