### PR TITLE
Shorten German Translation of Asset in Navigation

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/de/README.md
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/de/README.md
@@ -61,7 +61,8 @@ Für die Deutsche Übersetzung wurden die folgenden Terme wie folgt übersetzt
   Da der Begriff in Airflow 3 neu eingeführt wurde steht er derzeit nicht fest.
   Daher eignet er sich zu der inhaltlich passenden Übersetzung. Um neue
   Benutzer nicht zu verwirren wird der durch Airflow definierte Originalterm in
-  Klammern wenn möglich mitgeführt.
+  Klammern wenn möglich mitgeführt. Einzig in der Navigationsleiste ist der Begriff
+  ohne die englische Referenz um den Text kurz zu halten.
 - `Asset Event` --> `Ereignis zu Datenset (Asset)`: Logische Konsequenz der
   Übersetzung von -->"Asset" ohne einen sperrigen Begriff wie
   "Datenssatz-Ereignis" zu erzeugen.

--- a/airflow-core/src/airflow/ui/public/i18n/locales/de/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/de/common.json
@@ -127,7 +127,7 @@
   },
   "nav": {
     "admin": "Verwaltung",
-    "assets": "Datensets (Assets)",
+    "assets": "Datensets",
     "browse": "Browsen",
     "dags": "Dags",
     "docs": "Doku",


### PR DESCRIPTION
As of rework of the navigation in #57455 the German translation for "Asset" is too long, therefore I propose to shorten the term to fit into the visual space.

FYI @TJaniF @m1racoli 

Airflow 3.1.0:
<img width="106" height="454" alt="image" src="https://github.com/user-attachments/assets/06d3f06f-f8f6-421b-b884-ccdbd8482d02" />

After PR 57455 / Airflow 3.1.2rc1:
<img width="94" height="143" alt="image" src="https://github.com/user-attachments/assets/008c2dce-df97-482d-97a5-d59eec20a5fa" />

After this PR:
<img width="103" height="272" alt="image" src="https://github.com/user-attachments/assets/996c85e0-dfa5-4cf0-8848-a8f1079052ae" />