### PR TITLE
Remove global from kerberos

### DIFF
--- a/airflow-core/src/airflow/security/kerberos.py
+++ b/airflow-core/src/airflow/security/kerberos.py
@@ -40,11 +40,10 @@ import shlex
 import subprocess
 import sys
 import time
+from functools import cache
 
 from airflow.configuration import conf
 from airflow.utils.net import get_hostname
-
-NEED_KRB181_WORKAROUND: bool | None = None
 
 log = logging.getLogger(__name__)
 
@@ -124,10 +123,7 @@ def renew_from_kt(principal: str | None, keytab: str, exit_on_fail: bool = True)
             else:
                 return subp.returncode
 
-    global NEED_KRB181_WORKAROUND
-    if NEED_KRB181_WORKAROUND is None:
-        NEED_KRB181_WORKAROUND = detect_conf_var()
-    if NEED_KRB181_WORKAROUND:
+    if detect_conf_var():
         # (From: HUE-640). Kerberos clock have seconds level granularity. Make sure we
         # renew the ticket after the initial valid time.
         time.sleep(1.5)
@@ -173,6 +169,7 @@ def perform_krb181_workaround(principal: str):
     return ret
 
 
+@cache
 def detect_conf_var() -> bool:
     """
     Autodetect the Kerberos ticket configuration.

--- a/airflow-core/tests/unit/security/test_kerberos.py
+++ b/airflow-core/tests/unit/security/test_kerberos.py
@@ -36,7 +36,6 @@ class TestKerberos:
     def fresh_detect_conf_var(self):
         """Clear cache of kerberos detection function."""
         detect_conf_var.cache_clear()
-        return None
 
     @pytest.mark.parametrize(
         ("kerberos_config", "expected_cmd"),

--- a/airflow-core/tests/unit/security/test_kerberos.py
+++ b/airflow-core/tests/unit/security/test_kerberos.py
@@ -32,6 +32,12 @@ pytestmark = pytest.mark.db_test
 
 
 class TestKerberos:
+    @pytest.fixture(autouse=True)
+    def fresh_detect_conf_var(self):
+        """Clear cache of kerberos detection function."""
+        detect_conf_var.cache_clear()
+        return None
+
     @pytest.mark.parametrize(
         ("kerberos_config", "expected_cmd"),
         [
@@ -92,7 +98,6 @@ class TestKerberos:
         expected_cmd_text = " ".join(shlex.quote(f) for f in expected_cmd)
 
         with conf_vars(kerberos_config), caplog.at_level(logging.INFO, logger=kerberos.log.name):
-            detect_conf_var.cache_clear()
             caplog.clear()
             mock_subprocess.Popen.return_value.__enter__.return_value.returncode = 0
             mock_subprocess.call.return_value = 0
@@ -126,7 +131,6 @@ class TestKerberos:
         mock_subprocess.call.return_value = 0
 
         with caplog.at_level(logging.INFO, logger=kerberos.log.name):
-            detect_conf_var.cache_clear()
             caplog.clear()
             renew_from_kt(principal="test-principal", keytab="keytab")
             assert caplog.messages == [
@@ -167,7 +171,6 @@ class TestKerberos:
         mock_subp.stdout = mock.MagicMock(name="stdout", **{"readlines.return_value": ["STDOUT"]})
         mock_subp.stderr = mock.MagicMock(name="stderr", **{"readlines.return_value": ["STDERR"]})
 
-        detect_conf_var.cache_clear()
         caplog.clear()
         with pytest.raises(SystemExit) as ctx:
             renew_from_kt(principal="test-principal", keytab="keytab")
@@ -216,7 +219,6 @@ class TestKerberos:
         mock_subprocess.Popen.return_value.__enter__.return_value.returncode = 0
         mock_subprocess.call.return_value = 1
 
-        detect_conf_var.cache_clear()
         caplog.clear()
         with pytest.raises(SystemExit) as ctx:
             renew_from_kt(principal="test-principal", keytab="keytab")


### PR DESCRIPTION
As I was attempting to clean code toward ruff rule PLW0603 (https://docs.astral.sh/ruff/rules/global-statement/) I noticed that some code is a bit... outdated to be refactored. Making some smaller PRs for the cleanup of PLW0603 assuming easier to review

This PR attempts to remove the `global` keyword from kerberos module. It was mainly used as a cache, so replaced it with functools.cache