### PR TITLE
Remove global from serialization

### DIFF
--- a/airflow-core/tests/unit/models/test_connection.py
+++ b/airflow-core/tests/unit/models/test_connection.py
@@ -23,12 +23,14 @@ from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
+from cryptography.fernet import Fernet
 
 from airflow.exceptions import AirflowException, AirflowNotFoundException
 from airflow.models import Connection
 from airflow.sdk.exceptions import AirflowRuntimeError, ErrorType
 from airflow.sdk.execution_time.comms import ErrorResponse
 
+from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import clear_db_connections
 
 if TYPE_CHECKING:
@@ -196,6 +198,7 @@ class TestConnection:
             ),
         ],
     )
+    @conf_vars({("core", "fernet_key"): Fernet.generate_key().decode()})
     def test_get_uri(self, connection, expected_uri):
         assert connection.get_uri() == expected_uri
 

--- a/airflow-core/tests/unit/serialization/test_serialized_objects.py
+++ b/airflow-core/tests/unit/serialization/test_serialized_objects.py
@@ -737,6 +737,7 @@ class TestKubernetesImportAvoidance:
             pytest.skip("Kubernetes already imported, cannot test import avoidance")
 
         # Call _has_kubernetes() - should check sys.modules and return False without importing
+        _has_kubernetes.cache_clear()
         result = _has_kubernetes()
 
         assert result is False
@@ -747,6 +748,7 @@ class TestKubernetesImportAvoidance:
         pytest.importorskip("kubernetes")
 
         # Now k8s is imported, should return True
+        _has_kubernetes.cache_clear()
         result = _has_kubernetes()
 
         assert result is True


### PR DESCRIPTION
As I was attempting to clean code toward ruff rule PLW0603 (https://docs.astral.sh/ruff/rules/global-statement/) I noticed that some code is a bit... outdated to be refactored. Making some smaller PRs for the cleanup of PLW0603 assuming easier to review

This PR attempts to remove the global keyword from serialized objects module. It was mainly used as a cache, so replaced it with functools.cache
