### PR TITLE
fix tableau operator run tasks execution

### DIFF
--- a/providers/tableau/src/airflow/providers/tableau/operators/tableau.py
+++ b/providers/tableau/src/airflow/providers/tableau/operators/tableau.py
@@ -122,7 +122,13 @@ class TableauOperator(BaseOperator):
             if self.resource == "tasks" and self.method == "run":
                 task_item = resource.get_by_id(resource_id)
                 response = method(task_item)
-                job_item = JobItem.from_response(response, tableau_hook.server.namespace)[0]
+                job_items = JobItem.from_response(response, tableau_hook.server.namespace)
+                if not isinstance(job_items, list) or not len(job_items):
+                    self.log.error(
+                        "Failed to parse Tableau API response. Expected a list of JobItem, got: %s", job_items
+                    )
+                    raise AirflowException("Unexpected API response")
+                job_item = job_items[0]
             else:
                 job_item = method(resource_id)
 

--- a/providers/tableau/src/airflow/providers/tableau/operators/tableau.py
+++ b/providers/tableau/src/airflow/providers/tableau/operators/tableau.py
@@ -136,7 +136,9 @@ class TableauOperator(BaseOperator):
                 check_interval=self.check_interval,
                 target_state=TableauJobFinishCode.SUCCESS,
             ):
-                raise TableauJobFailedException(f"The Tableau Refresh {self.resource} Job failed!")
+                raise TableauJobFailedException(
+                    f"The Tableau {self.resource} {self.method} Job failed! Job ID: {job_id}"
+                )
 
         return job_id
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #42248

This pull request fixes the bug in `TableauOperator` where the operator was calling `tableau_hook.server.tasks.run(...)` method and passing in the Tableau Task ID string (the `resource_id` variable), while the method expects a `tableauserverclient.models.TaskItem` object instead:

https://github.com/tableau/server-client-python/blob/development/tableauserverclient/server/endpoint/tasks_endpoint.py#L119

For a more detailed description of the bug, please refer to #42248

<!-- Please keep an empty line above the dashes. -->
---
