### PR TITLE
Remove global from settings part1

### DIFF
--- a/airflow-core/src/airflow/logging_config.py
+++ b/airflow-core/src/airflow/logging_config.py
@@ -131,8 +131,6 @@ def configure_logging():
         new_folder_permissions=new_folder_permissions,
     )
 
-    return logging_class_path
-
 
 def validate_logging_config():
     """Validate the provided Logging Config."""

--- a/task-sdk/tests/conftest.py
+++ b/task-sdk/tests/conftest.py
@@ -58,7 +58,7 @@ def pytest_configure(config: pytest.Config) -> None:
 
     import airflow.settings
 
-    airflow.settings.configure_policy_plugin_manager()
+    airflow.settings.get_policy_plugin_manager()
 
 
 @pytest.fixture(scope="session", autouse=True)


### PR DESCRIPTION
As I was attempting to clean code toward ruff rule PLW0603 (https://docs.astral.sh/ruff/rules/global-statement/) I noticed that some code is a bit... outdated to be refactored. Making some smaller PRs for the cleanup of PLW0603 assuming easier to review

This PR attempts to remove the global keyword from settings objects module. It was mainly used as a cache, so replaced it with functools.cache

As there are a couple of global statements and the settings class is a historical hairball, this is a small part 1 PR which removes the two variables only:
- POLICY_PLUGIN_MANAGER
- LOGGING_CLASS_PATH
