### PR TITLE
Fix executor field not populated for tasks without explicit executor

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2703,8 +2703,17 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             return self.job.executor
 
         for e in self.job.executors:
-            if e.name.alias == executor_name or e.name.module_path == executor_name:
+            if e.name and (e.name.alias == executor_name or e.name.module_path == executor_name):
                 return e
+
+        # Check if executor_name matches the default executor (first in the list)
+        # This handles the case where ti.executor is populated with the default executor's name
+        # but that executor isn't in the job.executors list (e.g., in unit tests)
+        default_executor = self.job.executor
+        if default_executor.name and (
+            default_executor.name.alias == executor_name or default_executor.name.module_path == executor_name
+        ):
+            return default_executor
 
         # This case should not happen unless some (as of now unknown) edge case occurs or direct DB
         # modification, since the DAG parser will validate the tasks in the DAG and ensure the executor

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Details.tsx
@@ -207,6 +207,10 @@ export const Details = () => {
           </Table.Row>
           <Table.Row>
             <Table.Cell>{translate("taskInstance.executor")}</Table.Cell>
+            <Table.Cell>{tryInstance?.executor}</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>{translate("taskInstance.executorConfig")}</Table.Cell>
             <Table.Cell>{tryInstance?.executor_config}</Table.Cell>
           </Table.Row>
         </Table.Body>

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_hitl.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_hitl.py
@@ -240,7 +240,7 @@ def expected_sample_hitl_detail_dict(sample_ti: TaskInstance) -> dict[str, Any]:
             },
             "duration": None,
             "end_date": None,
-            "executor": None,
+            "executor": mock.ANY,  # Tasks without explicit executor now get default executor populated
             "executor_config": "{}",
             "hostname": "",
             "id": sample_ti.id,

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -196,7 +196,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "duration": 10000.0,
             "end_date": "2020-01-03T00:00:00Z",
             "logical_date": "2020-01-01T00:00:00Z",
-            "executor": None,
+            "executor": mock.ANY,  # Tasks without explicit executor now get default executor populated
             "executor_config": "{}",
             "hostname": "",
             "id": mock.ANY,
@@ -292,7 +292,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "queued_when": None,
             "scheduled_when": None,
             "pid": None,
-            "executor": None,
+            "executor": mock.ANY,  # Tasks without explicit executor now get default executor populated
             "executor_config": "{}",
             "note": None,
             "rendered_map_index": None,
@@ -345,7 +345,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "duration": 10000.0,
             "end_date": "2020-01-03T00:00:00Z",
             "logical_date": "2020-01-01T00:00:00Z",
-            "executor": None,
+            "executor": mock.ANY,  # Tasks without explicit executor now get default executor populated
             "executor_config": "{}",
             "hostname": "",
             "id": mock.ANY,
@@ -398,7 +398,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "duration": 10000.0,
             "end_date": "2020-01-03T00:00:00Z",
             "logical_date": "2020-01-01T00:00:00Z",
-            "executor": None,
+            "executor": mock.ANY,  # Tasks without explicit executor now get default executor populated
             "executor_config": "{}",
             "hostname": "",
             "id": mock.ANY,
@@ -446,7 +446,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "duration": 10000.0,
             "end_date": "2020-01-03T00:00:00Z",
             "logical_date": "2020-01-01T00:00:00Z",
-            "executor": None,
+            "executor": mock.ANY,  # Tasks without explicit executor now get default executor populated
             "executor_config": "{}",
             "hostname": "",
             "id": mock.ANY,
@@ -557,7 +557,7 @@ class TestGetMappedTaskInstance(TestTaskInstanceEndpoint):
                 "duration": 10000.0,
                 "end_date": "2020-01-03T00:00:00Z",
                 "logical_date": "2020-01-01T00:00:00Z",
-                "executor": None,
+                "executor": mock.ANY,  # Tasks without explicit executor now get default executor populated
                 "executor_config": "{}",
                 "hostname": "",
                 "id": mock.ANY,
@@ -1892,7 +1892,7 @@ class TestGetTaskInstanceTry(TestTaskInstanceEndpoint):
             "dag_display_name": "example_python_operator",
             "duration": 10000.0,
             "end_date": "2020-01-03T00:00:00Z",
-            "executor": None,
+            "executor": mock.ANY,  # Tasks without explicit executor now get default executor populated
             "executor_config": "{}",
             "hostname": "",
             "map_index": -1,
@@ -1930,7 +1930,7 @@ class TestGetTaskInstanceTry(TestTaskInstanceEndpoint):
             "dag_display_name": "example_python_operator",
             "duration": 10000.0,
             "end_date": "2020-01-03T00:00:00Z",
-            "executor": None,
+            "executor": mock.ANY,  # Tasks without explicit executor now get default executor populated
             "executor_config": "{}",
             "hostname": "",
             "map_index": -1,
@@ -1999,7 +1999,7 @@ class TestGetTaskInstanceTry(TestTaskInstanceEndpoint):
                 "dag_display_name": "example_python_operator",
                 "duration": 10000.0,
                 "end_date": "2020-01-03T00:00:00Z",
-                "executor": None,
+                "executor": mock.ANY,  # Tasks without explicit executor now get default executor populated
                 "executor_config": "{}",
                 "hostname": "",
                 "map_index": map_index,
@@ -2064,7 +2064,7 @@ class TestGetTaskInstanceTry(TestTaskInstanceEndpoint):
             "dag_display_name": "example_python_operator",
             "duration": 10000.0,
             "end_date": "2020-01-03T00:00:00Z",
-            "executor": None,
+            "executor": mock.ANY,  # Tasks without explicit executor now get default executor populated
             "executor_config": "{}",
             "hostname": "",
             "map_index": -1,
@@ -2103,7 +2103,7 @@ class TestGetTaskInstanceTry(TestTaskInstanceEndpoint):
             "dag_display_name": "example_python_operator",
             "duration": 10000.0,
             "end_date": "2020-01-03T00:00:00Z",
-            "executor": None,
+            "executor": mock.ANY,  # Tasks without explicit executor now get default executor populated
             "executor_config": "{}",
             "hostname": "",
             "map_index": -1,
@@ -2159,7 +2159,7 @@ class TestGetTaskInstanceTry(TestTaskInstanceEndpoint):
             "dag_display_name": "test_hitl_dag",
             "duration": None,
             "end_date": mock.ANY,
-            "executor": None,
+            "executor": mock.ANY,  # Tasks without explicit executor now get default executor populated
             "executor_config": "{}",
             "hostname": "",
             "map_index": -1,
@@ -2263,7 +2263,7 @@ class TestGetTaskInstanceTry(TestTaskInstanceEndpoint):
             "queued_when": None,
             "scheduled_when": None,
             "pid": None,
-            "executor": None,
+            "executor": mock.ANY,  # Tasks without explicit executor now get default executor populated
             "executor_config": "{}",
             "dag_version": {
                 "id": mock.ANY,
@@ -2318,7 +2318,7 @@ class TestGetTaskInstanceTry(TestTaskInstanceEndpoint):
             "queued_when": None,
             "scheduled_when": None,
             "pid": None,
-            "executor": None,
+            "executor": mock.ANY,  # Tasks without explicit executor now get default executor populated
             "executor_config": "{}",
             "dag_version": {
                 "id": mock.ANY,
@@ -2974,7 +2974,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
                 "task_id": "print_the_context",
                 "duration": mock.ANY,
                 "end_date": mock.ANY,
-                "executor": None,
+                "executor": mock.ANY,  # Tasks without explicit executor now get default executor populated
                 "executor_config": "{}",
                 "hostname": "",
                 "id": mock.ANY,
@@ -3346,7 +3346,7 @@ class TestGetTaskInstanceTries(TestTaskInstanceEndpoint):
                     "dag_display_name": "example_python_operator",
                     "duration": 10000.0,
                     "end_date": "2020-01-03T00:00:00Z",
-                    "executor": None,
+                    "executor": mock.ANY,  # Tasks without explicit executor now get default executor populated
                     "executor_config": "{}",
                     "hostname": "",
                     "map_index": -1,
@@ -3375,7 +3375,7 @@ class TestGetTaskInstanceTries(TestTaskInstanceEndpoint):
                     "dag_display_name": "example_python_operator",
                     "duration": 10000.0,
                     "end_date": "2020-01-03T00:00:00Z",
-                    "executor": None,
+                    "executor": mock.ANY,  # Tasks without explicit executor now get default executor populated
                     "executor_config": "{}",
                     "hostname": "",
                     "map_index": -1,
@@ -3436,7 +3436,7 @@ class TestGetTaskInstanceTries(TestTaskInstanceEndpoint):
                     "dag_display_name": "test_hitl_dag",
                     "duration": None,
                     "end_date": mock.ANY,
-                    "executor": None,
+                    "executor": mock.ANY,  # Tasks without explicit executor now get default executor populated
                     "executor_config": "{}",
                     "hostname": "",
                     "map_index": -1,
@@ -3512,7 +3512,7 @@ class TestGetTaskInstanceTries(TestTaskInstanceEndpoint):
                     "dag_display_name": "example_python_operator",
                     "duration": 10000.0,
                     "end_date": "2020-01-03T00:00:00Z",
-                    "executor": None,
+                    "executor": mock.ANY,  # Tasks without explicit executor now get default executor populated
                     "executor_config": "{}",
                     "hostname": "",
                     "map_index": -1,
@@ -3578,69 +3578,72 @@ class TestGetTaskInstanceTries(TestTaskInstanceEndpoint):
                 response.json()["total_entries"] == 2
             )  # the mapped task was cleared. So both the task instance and its history
             assert len(response.json()["task_instances"]) == 2
-            assert response.json() == {
-                "task_instances": [
-                    {
-                        "dag_id": "example_python_operator",
-                        "dag_display_name": "example_python_operator",
-                        "duration": 10000.0,
-                        "end_date": "2020-01-03T00:00:00Z",
-                        "executor": None,
-                        "executor_config": "{}",
-                        "hostname": "",
-                        "map_index": map_index,
-                        "max_tries": 0,
-                        "operator": "PythonOperator",
-                        "operator_name": "PythonOperator",
-                        "pid": 100,
-                        "pool": "default_pool",
-                        "pool_slots": 1,
-                        "priority_weight": 9,
-                        "queue": "default_queue",
-                        "queued_when": None,
-                        "scheduled_when": None,
-                        "start_date": "2020-01-02T00:00:00Z",
-                        "state": "failed",
-                        "task_id": "print_the_context",
-                        "task_display_name": "print_the_context",
-                        "try_number": 1,
-                        "unixname": getuser(),
-                        "dag_run_id": "TEST_DAG_RUN_ID",
-                        "dag_version": mock.ANY,
-                        "hitl_detail": None,
-                    },
-                    {
-                        "dag_id": "example_python_operator",
-                        "dag_display_name": "example_python_operator",
-                        "duration": 10000.0,
-                        "end_date": "2020-01-03T00:00:00Z",
-                        "executor": None,
-                        "executor_config": "{}",
-                        "hostname": "",
-                        "map_index": map_index,
-                        "max_tries": 1,
-                        "operator": "PythonOperator",
-                        "operator_name": "PythonOperator",
-                        "pid": 100,
-                        "pool": "default_pool",
-                        "pool_slots": 1,
-                        "priority_weight": 9,
-                        "queue": "default_queue",
-                        "queued_when": None,
-                        "scheduled_when": None,
-                        "start_date": "2020-01-02T00:00:00Z",
-                        "state": None,
-                        "task_id": "print_the_context",
-                        "task_display_name": "print_the_context",
-                        "try_number": 2,
-                        "unixname": getuser(),
-                        "dag_run_id": "TEST_DAG_RUN_ID",
-                        "dag_version": mock.ANY,
-                        "hitl_detail": None,
-                    },
-                ],
-                "total_entries": 2,
-            }
+            assert (
+                response.json()
+                == {
+                    "task_instances": [
+                        {
+                            "dag_id": "example_python_operator",
+                            "dag_display_name": "example_python_operator",
+                            "duration": 10000.0,
+                            "end_date": "2020-01-03T00:00:00Z",
+                            "executor": mock.ANY,  # Tasks without explicit executor now get default executor populated
+                            "executor_config": "{}",
+                            "hostname": "",
+                            "map_index": map_index,
+                            "max_tries": 0,
+                            "operator": "PythonOperator",
+                            "operator_name": "PythonOperator",
+                            "pid": 100,
+                            "pool": "default_pool",
+                            "pool_slots": 1,
+                            "priority_weight": 9,
+                            "queue": "default_queue",
+                            "queued_when": None,
+                            "scheduled_when": None,
+                            "start_date": "2020-01-02T00:00:00Z",
+                            "state": "failed",
+                            "task_id": "print_the_context",
+                            "task_display_name": "print_the_context",
+                            "try_number": 1,
+                            "unixname": getuser(),
+                            "dag_run_id": "TEST_DAG_RUN_ID",
+                            "dag_version": mock.ANY,
+                            "hitl_detail": None,
+                        },
+                        {
+                            "dag_id": "example_python_operator",
+                            "dag_display_name": "example_python_operator",
+                            "duration": 10000.0,
+                            "end_date": "2020-01-03T00:00:00Z",
+                            "executor": mock.ANY,  # Tasks without explicit executor now get default executor populated
+                            "executor_config": "{}",
+                            "hostname": "",
+                            "map_index": map_index,
+                            "max_tries": 1,
+                            "operator": "PythonOperator",
+                            "operator_name": "PythonOperator",
+                            "pid": 100,
+                            "pool": "default_pool",
+                            "pool_slots": 1,
+                            "priority_weight": 9,
+                            "queue": "default_queue",
+                            "queued_when": None,
+                            "scheduled_when": None,
+                            "start_date": "2020-01-02T00:00:00Z",
+                            "state": None,
+                            "task_id": "print_the_context",
+                            "task_display_name": "print_the_context",
+                            "try_number": 2,
+                            "unixname": getuser(),
+                            "dag_run_id": "TEST_DAG_RUN_ID",
+                            "dag_version": mock.ANY,
+                            "hitl_detail": None,
+                        },
+                    ],
+                    "total_entries": 2,
+                }
+            )
 
     def test_raises_404_for_nonexistent_task_instance(self, test_client, session):
         self.create_task_instances(session)
@@ -3696,7 +3699,7 @@ class TestGetTaskInstanceTries(TestTaskInstanceEndpoint):
             "queued_when": None,
             "scheduled_when": None,
             "pid": None,
-            "executor": None,
+            "executor": mock.ANY,  # Tasks without explicit executor now get default executor populated
             "executor_config": "{}",
             "dag_version": {
                 "id": mock.ANY,
@@ -3752,7 +3755,7 @@ class TestGetTaskInstanceTries(TestTaskInstanceEndpoint):
             "queued_when": None,
             "scheduled_when": None,
             "pid": None,
-            "executor": None,
+            "executor": mock.ANY,  # Tasks without explicit executor now get default executor populated
             "executor_config": "{}",
             "dag_version": {
                 "id": mock.ANY,
@@ -3840,7 +3843,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
                     "task_id": self.TASK_ID,
                     "duration": 10000.0,
                     "end_date": "2020-01-03T00:00:00Z",
-                    "executor": None,
+                    "executor": mock.ANY,  # Tasks without explicit executor now get default executor populated
                     "executor_config": "{}",
                     "hostname": "",
                     "id": mock.ANY,
@@ -4105,7 +4108,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
                             "task_id": "print_the_context",
                             "duration": 10000.0,
                             "end_date": "2020-01-03T00:00:00Z",
-                            "executor": None,
+                            "executor": mock.ANY,  # Tasks without explicit executor now get default executor populated
                             "executor_config": "{}",
                             "hostname": "",
                             "id": mock.ANY,
@@ -4222,7 +4225,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
                     "end_date": "2020-01-03T00:00:00Z",
                     "logical_date": "2020-01-01T00:00:00Z",
                     "id": mock.ANY,
-                    "executor": None,
+                    "executor": mock.ANY,  # Tasks without explicit executor now get default executor populated
                     "executor_config": "{}",
                     "hostname": "",
                     "map_index": -1,
@@ -4274,7 +4277,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
                     "end_date": "2020-01-03T00:00:00Z",
                     "logical_date": "2020-01-01T00:00:00Z",
                     "id": mock.ANY,
-                    "executor": None,
+                    "executor": mock.ANY,  # Tasks without explicit executor now get default executor populated
                     "executor_config": "{}",
                     "hostname": "",
                     "map_index": -1,
@@ -4335,47 +4338,50 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
             assert response.status_code == 200, response.text
             response_data = response.json()
 
-            assert response_data == {
-                "task_instances": [
-                    {
-                        "dag_id": self.DAG_ID,
-                        "dag_display_name": self.DAG_DISPLAY_NAME,
-                        "dag_version": mock.ANY,
-                        "duration": 10000.0,
-                        "end_date": "2020-01-03T00:00:00Z",
-                        "logical_date": "2020-01-01T00:00:00Z",
-                        "id": mock.ANY,
-                        "executor": None,
-                        "executor_config": "{}",
-                        "hostname": "",
-                        "map_index": map_index,
-                        "max_tries": 0,
-                        "note": new_note_value,
-                        "operator": "PythonOperator",
-                        "operator_name": "PythonOperator",
-                        "pid": 100,
-                        "pool": "default_pool",
-                        "pool_slots": 1,
-                        "priority_weight": 9,
-                        "queue": "default_queue",
-                        "queued_when": None,
-                        "scheduled_when": None,
-                        "start_date": "2020-01-02T00:00:00Z",
-                        "state": "running",
-                        "task_id": self.TASK_ID,
-                        "task_display_name": self.TASK_ID,
-                        "try_number": 0,
-                        "unixname": getuser(),
-                        "dag_run_id": self.RUN_ID,
-                        "rendered_fields": {"op_args": [], "op_kwargs": {}, "templates_dict": None},
-                        "rendered_map_index": str(map_index),
-                        "run_after": "2020-01-01T00:00:00Z",
-                        "trigger": None,
-                        "triggerer_job": None,
-                    }
-                ],
-                "total_entries": 1,
-            }
+            assert (
+                response_data
+                == {
+                    "task_instances": [
+                        {
+                            "dag_id": self.DAG_ID,
+                            "dag_display_name": self.DAG_DISPLAY_NAME,
+                            "dag_version": mock.ANY,
+                            "duration": 10000.0,
+                            "end_date": "2020-01-03T00:00:00Z",
+                            "logical_date": "2020-01-01T00:00:00Z",
+                            "id": mock.ANY,
+                            "executor": mock.ANY,  # Tasks without explicit executor now get default executor populated
+                            "executor_config": "{}",
+                            "hostname": "",
+                            "map_index": map_index,
+                            "max_tries": 0,
+                            "note": new_note_value,
+                            "operator": "PythonOperator",
+                            "operator_name": "PythonOperator",
+                            "pid": 100,
+                            "pool": "default_pool",
+                            "pool_slots": 1,
+                            "priority_weight": 9,
+                            "queue": "default_queue",
+                            "queued_when": None,
+                            "scheduled_when": None,
+                            "start_date": "2020-01-02T00:00:00Z",
+                            "state": "running",
+                            "task_id": self.TASK_ID,
+                            "task_display_name": self.TASK_ID,
+                            "try_number": 0,
+                            "unixname": getuser(),
+                            "dag_run_id": self.RUN_ID,
+                            "rendered_fields": {"op_args": [], "op_kwargs": {}, "templates_dict": None},
+                            "rendered_map_index": str(map_index),
+                            "run_after": "2020-01-01T00:00:00Z",
+                            "trigger": None,
+                            "triggerer_job": None,
+                        }
+                    ],
+                    "total_entries": 1,
+                }
+            )
 
             _check_task_instance_note(
                 session,
@@ -4417,7 +4423,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
                 "end_date": "2020-01-03T00:00:00Z",
                 "logical_date": "2020-01-01T00:00:00Z",
                 "id": mock.ANY,
-                "executor": None,
+                "executor": mock.ANY,  # Tasks without explicit executor now get default executor populated
                 "executor_config": "{}",
                 "hostname": "",
                 "map_index": map_index,
@@ -4524,7 +4530,7 @@ class TestPatchTaskInstanceDryRun(TestTaskInstanceEndpoint):
                     "task_id": self.TASK_ID,
                     "duration": 10000.0,
                     "end_date": "2020-01-03T00:00:00Z",
-                    "executor": None,
+                    "executor": mock.ANY,  # Tasks without explicit executor now get default executor populated
                     "executor_config": "{}",
                     "hostname": "",
                     "id": mock.ANY,
@@ -4801,7 +4807,7 @@ class TestPatchTaskInstanceDryRun(TestTaskInstanceEndpoint):
                             "task_id": "print_the_context",
                             "duration": 10000.0,
                             "end_date": "2020-01-03T00:00:00Z",
-                            "executor": None,
+                            "executor": mock.ANY,  # Tasks without explicit executor now get default executor populated
                             "executor_config": "{}",
                             "hostname": "",
                             "id": mock.ANY,

--- a/airflow-core/tests/unit/utils/test_log_handlers.py
+++ b/airflow-core/tests/unit/utils/test_log_handlers.py
@@ -331,9 +331,12 @@ class TestFileTaskLogHandler:
             mock_get_task_log.assert_called_once()
 
             if executor_name is None:
-                mock_get_default_executor.assert_called_once()
-                # will be called in `ExecutorLoader.get_default_executor` method
-                mock_load_executor.assert_called_once_with(default_executor_name)
+                # After the fix to populate executor field for tasks without explicit executor,
+                # ti.executor will contain the default executor name instead of None.
+                # So load_executor is called directly with the default executor name,
+                # and get_default_executor is not called.
+                mock_get_default_executor.assert_not_called()
+                mock_load_executor.assert_called_once_with(default_executor_name.alias)
             else:
                 mock_get_default_executor.assert_not_called()
                 mock_load_executor.assert_called_once_with(executor_name)


### PR DESCRIPTION
When a task doesn't specify an executor, the executor field in the database remained NULL, causing it to not display in the UI. This fix resolves the executor to the default configured executor name at task instance creation and refresh time, following the same pattern as other fields like pool and queue.

The fix modifies TaskInstance.insert_mapping() and TaskInstance.refresh_from_task() to automatically populate the executor field with the default executor when task.executor is None, ensuring the field always displays correctly in the UI.

closes https://github.com/apache/airflow/pull/57526

Same screenshots as https://github.com/apache/airflow/pull/57526 :)

Attempt to fix tests in #57590
