### PR TITLE
Prepare edge3 provider ad-hoc release rc2 (October 2025)

### DIFF
--- a/providers/edge3/docs/changelog.rst
+++ b/providers/edge3/docs/changelog.rst
@@ -53,6 +53,9 @@ Misc
    appropriate section above if needed. Do not delete the lines(!):
    * ``Extract prek hooks for Edge provider (#57104)``
    * ``Prepare edge3 provider ad-hoc release (October 2025) (#57280)``
+   * ``Enable ruff PLW1508 rule (#57653)``
+   * ``Fix code formatting via ruff preview (#57641)``
+   * ``Prepare edge3 provider ad-hoc release rc2 (October 2025) (#57538)``
 
 1.4.0
 .....


### PR DESCRIPTION
we had more changes merged to main so need to regenerated commits before cut release

```
Summary of prepared documentation:

Success: 1

edge3


Successfully prepared documentation for packages!
```
