### PR TITLE
Fix loading providers hooks fields w/o FAB provider installed

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/services/ui/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/ui/connections.py
@@ -17,8 +17,6 @@
 
 from __future__ import annotations
 
-import contextlib
-import importlib
 import logging
 from collections.abc import MutableMapping
 from functools import cache
@@ -132,68 +130,46 @@ class HookMetaService:
             """Mock for wtforms.validators.any_of."""
             return HookMetaService.MockEnum(allowed_values)
 
-        with contextlib.ExitStack() as stack:
+        # Before importing ProvidersManager, we need to mock all FAB and WTForms
+        # dependencies to avoid ImportErrors when FAB is not installed.
+        import sys
+        from importlib.util import find_spec
+        from unittest.mock import MagicMock
+
+        for mod_name in [
+            "wtforms",
+            "wtforms.csrf",
+            "wtforms.fields",
+            "wtforms.fields.simple",
+            "wtforms.validators",
+            "flask_babel",
+            "flask_appbuilder",
+            "flask_appbuilder.fieldwidgets",
+        ]:
             try:
-                importlib.import_module("wtforms")
-                stack.enter_context(mock.patch("wtforms.StringField", HookMetaService.MockStringField))
-                stack.enter_context(mock.patch("wtforms.fields.StringField", HookMetaService.MockStringField))
-                stack.enter_context(
-                    mock.patch("wtforms.fields.simple.StringField", HookMetaService.MockStringField)
-                )
-
-                stack.enter_context(mock.patch("wtforms.IntegerField", HookMetaService.MockIntegerField))
-                stack.enter_context(
-                    mock.patch("wtforms.fields.IntegerField", HookMetaService.MockIntegerField)
-                )
-                stack.enter_context(mock.patch("wtforms.PasswordField", HookMetaService.MockPasswordField))
-                stack.enter_context(mock.patch("wtforms.BooleanField", HookMetaService.MockBooleanField))
-                stack.enter_context(
-                    mock.patch("wtforms.fields.BooleanField", HookMetaService.MockBooleanField)
-                )
-                stack.enter_context(
-                    mock.patch("wtforms.fields.simple.BooleanField", HookMetaService.MockBooleanField)
-                )
-                stack.enter_context(mock.patch("wtforms.validators.Optional", HookMetaService.MockOptional))
-                stack.enter_context(mock.patch("wtforms.validators.any_of", mock_any_of))
-            except ImportError:
-                pass
-
-            try:
-                importlib.import_module("flask_babel")
-                stack.enter_context(mock.patch("flask_babel.lazy_gettext", mock_lazy_gettext))
-            except ImportError:
-                pass
-
-            try:
-                importlib.import_module("flask_appbuilder")
-                stack.enter_context(
-                    mock.patch(
-                        "flask_appbuilder.fieldwidgets.BS3TextFieldWidget", HookMetaService.MockAnyWidget
-                    )
-                )
-                stack.enter_context(
-                    mock.patch(
-                        "flask_appbuilder.fieldwidgets.BS3TextAreaFieldWidget", HookMetaService.MockAnyWidget
-                    )
-                )
-                stack.enter_context(
-                    mock.patch(
-                        "flask_appbuilder.fieldwidgets.BS3PasswordFieldWidget", HookMetaService.MockAnyWidget
-                    )
-                )
-            except ImportError:
-                pass
-
+                if not find_spec(mod_name):
+                    raise ModuleNotFoundError
+            except ModuleNotFoundError:
+                sys.modules[mod_name] = MagicMock()
+        with (
+            mock.patch("wtforms.StringField", HookMetaService.MockStringField),
+            mock.patch("wtforms.fields.StringField", HookMetaService.MockStringField),
+            mock.patch("wtforms.fields.simple.StringField", HookMetaService.MockStringField),
+            mock.patch("wtforms.IntegerField", HookMetaService.MockIntegerField),
+            mock.patch("wtforms.fields.IntegerField", HookMetaService.MockIntegerField),
+            mock.patch("wtforms.PasswordField", HookMetaService.MockPasswordField),
+            mock.patch("wtforms.BooleanField", HookMetaService.MockBooleanField),
+            mock.patch("wtforms.fields.BooleanField", HookMetaService.MockBooleanField),
+            mock.patch("wtforms.fields.simple.BooleanField", HookMetaService.MockBooleanField),
+            mock.patch("flask_babel.lazy_gettext", mock_lazy_gettext),
+            mock.patch("flask_appbuilder.fieldwidgets.BS3TextFieldWidget", HookMetaService.MockAnyWidget),
+            mock.patch("flask_appbuilder.fieldwidgets.BS3TextAreaFieldWidget", HookMetaService.MockAnyWidget),
+            mock.patch("flask_appbuilder.fieldwidgets.BS3PasswordFieldWidget", HookMetaService.MockAnyWidget),
+            mock.patch("wtforms.validators.Optional", HookMetaService.MockOptional),
+            mock.patch("wtforms.validators.any_of", mock_any_of),
+        ):
             pm = ProvidersManager()
-            pm._cleanup()  # Remove any cached hooks with non mocked FAB
-            pm._init_airflow_core_hooks()  # Initialize core hooks
             return pm.hooks, pm.connection_form_widgets, pm.field_behaviours  # Will init providers hooks
-
-        return (
-            {},
-            {},
-            {},
-        )  # Make mypy happy, should never been reached https://github.com/python/mypy/issues/7726
 
     @staticmethod
     def _make_standard_fields(field_behaviour: dict | None) -> StandardHookFields | None:


### PR DESCRIPTION
closes: #55841
related: #57555 #49446

Sorry that I was not actively enough paying attention that the contributed mocking of provider forms w/o Fab was not working. I _thought_ it was fixed by #49446 and did not test explicitly myself. Raising awareness in the bug #55841 now made me a follow-up fix.

This PR reverts mostly the changes made by #49446 as the original code was "almost" working, just did not consider that mocking the WTForms and FAB classes only works if the modules are really installed. The mock is now extended to mock the modules to tell the system they are available before mocking. If installed just mocks will be applied to load fields, if WTForms, FAB and flask_babel are not installed the system is patched to assume they are existing.

How to test the fix:
Best Option: Patch the single file into an installation and check if it is working
Alternative:
- Start based on this branch via `breeze start-airflow --python 3.12 --load-example-dags --backend postgres --executor LocalExecutor --answer y` and then log on to the UI. To to admin -> connections and see all is working. No surprise FAB is installed per default. Then log out and stop API server in the tmux panel. Then remove the FAB provider and tooling via `uv pip uninstall WTForms apache-airflow-providers-fab flask_appbuilder flask_babel` in the panel where API server is stopped. Restart API Server and logon the UI again. Double check that on Admin->Providers the FAB provider is non existing. Then check Admin->Connections and Add a connection if fields are populated, e.g. from Airbyte