### PR TITLE
Remove unused TIDep.get_failure_reasons()

### DIFF
--- a/airflow-core/src/airflow/ti_deps/deps/base_ti_dep.py
+++ b/airflow-core/src/airflow/ti_deps/deps/base_ti_dep.py
@@ -120,33 +120,17 @@ class BaseTIDep:
         """
         Return whether a dependency is met for a given task instance.
 
-        A dependency is considered met if all the dependency statuses it reports are passing.
+        A dependency is considered met if all the dependency statuses it reports
+        are passing. This is only used in tests.
 
         :param ti: the task instance to see if this dependency is met for
         :param session: database session
         :param dep_context: The context this dependency is being checked under that stores
             state that can be used by this dependency.
+
+        :meta private:
         """
         return all(status.passed for status in self.get_dep_statuses(ti, session, dep_context))
-
-    @provide_session
-    def get_failure_reasons(
-        self,
-        ti: TaskInstance,
-        session: Session,
-        dep_context: DepContext | None = None,
-    ) -> Iterator[str]:
-        """
-        Return an iterable of strings that explain why this dependency wasn't met.
-
-        :param ti: the task instance to see if this dependency is met for
-        :param session: database session
-        :param dep_context: The context this dependency is being checked under that stores
-            state that can be used by this dependency.
-        """
-        for dep_status in self.get_dep_statuses(ti, session, dep_context):
-            if not dep_status.passed:
-                yield dep_status.reason
 
     def _failing_status(self, reason: str = "") -> TIDepStatus:
         return TIDepStatus(self.name, False, reason)


### PR DESCRIPTION
This method is no used anywhere anymore (`TI.get_failed_dep_statuses()` replaces it usages).

`TIDep.is_met()` is also not called anymore in Airflow, but still used in a lot of tests. Since it is still a useful wrapper, it decided to keep it with a note in the docstring clarifying its status.