### PR TITLE
Add tag provider step

### DIFF
--- a/dev/README_RELEASE_PROVIDERS.md
+++ b/dev/README_RELEASE_PROVIDERS.md
@@ -500,7 +500,7 @@ twine upload -r pypi ${AIRFLOW_REPO_ROOT}/dist/*
 
 ## Push the RC tags
 
-Before we pushed the date tag, now that the RC(s) are ready we can push the tags for them.
+Earlier, we pushed the date tag, now that the RC(s) are ready we can push the tags for them.
 
 ```shell script
 breeze release-management tag-providers

--- a/dev/README_RELEASE_PROVIDERS.md
+++ b/dev/README_RELEASE_PROVIDERS.md
@@ -37,6 +37,7 @@
   - [Build and sign the source and convenience packages](#build-and-sign-the-source-and-convenience-packages)
   - [Commit the source packages to Apache SVN repo](#commit-the-source-packages-to-apache-svn-repo)
   - [Publish the Regular distributions to PyPI (release candidates)](#publish-the-regular-distributions-to-pypi-release-candidates)
+  - [Push the RC tags](#push-the-rc-tags)
   - [Prepare documentation in Staging](#prepare-documentation-in-staging)
   - [Prepare issue in GitHub to keep status of testing](#prepare-issue-in-github-to-keep-status-of-testing)
   - [Prepare voting email for Providers release candidate](#prepare-voting-email-for-providers-release-candidate)

--- a/dev/README_RELEASE_PROVIDERS.md
+++ b/dev/README_RELEASE_PROVIDERS.md
@@ -497,6 +497,14 @@ twine upload -r pypi ${AIRFLOW_REPO_ROOT}/dist/*
 
 * Confirm that the packages are available under the links printed and look good.
 
+## Push the RC tags
+
+Before we pushed the date tag, now that the RC(s) are ready we can push the tags for them.
+
+```shell script
+breeze release-management tag-providers
+```
+
 ## Prepare documentation in Staging
 
 Documentation is an essential part of the product and should be made available to users.


### PR DESCRIPTION
The breeze release-management tag-providers appears in the release sequence (after vote) but not in the prepare sequence (before vote). This PR fix the problem