### PR TITLE
Fix Execution API migration version to be consistent with released 3.1.1

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py
@@ -33,8 +33,8 @@ from airflow.api_fastapi.execution_api.versions.v2025_11_05 import AddTriggering
 
 bundle = VersionBundle(
     HeadVersion(),
-    Version("2025-11-05", MakeDagRunConfNullable),
-    Version("2025-10-10", AddTriggeringUserNameField),
+    Version("2025-11-05", AddTriggeringUserNameField),
+    Version("2025-10-27", MakeDagRunConfNullable),
     Version("2025-09-23", AddDagVersionIdField),
     Version(
         "2025-08-10",


### PR DESCRIPTION
On [3.1.1], we have this:

```python
bundle = VersionBundle(
    HeadVersion(),
    Version("2025-10-27", MakeDagRunConfNullable),
    Version("2025-09-23", AddDagVersionIdField),
```

This fixes up MakeDagRunConfNullable to be the same as it was in the previous
release, and updates AddTriggeringUserNameField to be the new date.

This is already correct on main due to commit 24a0e261

[3.1.1]: https://github.com/apache/airflow/blob/3.1.1/airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py
