### PR TITLE
Remove adal dependency

### DIFF
--- a/providers/microsoft/azure/pyproject.toml
+++ b/providers/microsoft/azure/pyproject.toml
@@ -74,7 +74,6 @@ dependencies = [
     "azure-servicebus>=7.12.1",
     "azure-synapse-spark>=0.2.0",
     "azure-synapse-artifacts>=0.17.0",
-    "adal>=1.2.7",
     "azure-storage-file-datalake>=12.9.1",
     # azure-kusto-data 4.6.0 breaks main - see https://github.com/apache/airflow/issues/42575
     # azure-kusto-data 5.0.0 pins requests to a specific version which makes resolving dependencies harder


### PR DESCRIPTION
The `adal` library is not maintained  since 2021 nor needed.

From the library page:

> Note: This library is already replaced by MSAL Python, available here: https://pypi.org/project/msal/ .ADAL Python remains available here as a legacy. The ADAL for Python library makes it easy for python application to authenticate to Azure Active Directory (AAD) in order to access AAD protected web resources.

https://pypi.org/project/adal/#description

I seriously doubt we have any logic that requires this library. I couldn't trace why we added it to begin with (probably some pip resolution helper?)