### PR TITLE
fix MyPy type errors in backfill.py

### DIFF
--- a/airflow-core/src/airflow/models/backfill.py
+++ b/airflow-core/src/airflow/models/backfill.py
@@ -551,7 +551,7 @@ def _create_backfill(
                 info=info,
                 backfill_id=br.id,
                 dag_run_conf=br.dag_run_conf,
-                reprocess_behavior=br.reprocess_behavior,
+                reprocess_behavior=ReprocessBehavior(br.reprocess_behavior),
                 backfill_sort_ordinal=backfill_sort_ordinal,
                 triggering_user_name=br.triggering_user_name,
                 run_on_latest_version=run_on_latest_version,


### PR DESCRIPTION
Sub task of https://github.com/apache/airflow/issues/56735.
Part of this issue

fixed errors:
<img width="589" height="90" alt="image" src="https://github.com/user-attachments/assets/fc697886-fd24-40c5-b0af-ae3036a20802" />


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
