### PR TITLE
Expanding task sdk integration tests to test connection operations

### DIFF
--- a/task-sdk-tests/docker/docker-compose.yaml
+++ b/task-sdk-tests/docker/docker-compose.yaml
@@ -32,7 +32,8 @@ x-airflow-common:
     AIRFLOW__CORE__EXECUTION_API_SERVER_URL: 'http://airflow-apiserver:8080/execution/'
     AIRFLOW__API__BASE_URL: 'http://airflow-apiserver:8080/'
     AIRFLOW__API_AUTH__JWT_SECRET: 'test-secret-key-for-testing'
-  user: "${AIRFLOW_UID:-50000}:0"
+    AIRFLOW_VAR_TEST_VARIABLE_KEY: 'test_variable_value'
+    AIRFLOW_CONN_TEST_CONNECTION: 'postgresql://testuser:testpass@testhost:5432/testdb'
   volumes:
     - ${PWD}/dags:/opt/airflow/dags
     - ${PWD}/logs:/opt/airflow/logs

--- a/task-sdk-tests/docker/docker-compose.yaml
+++ b/task-sdk-tests/docker/docker-compose.yaml
@@ -34,6 +34,7 @@ x-airflow-common:
     AIRFLOW__API_AUTH__JWT_SECRET: 'test-secret-key-for-testing'
     AIRFLOW_VAR_TEST_VARIABLE_KEY: 'test_variable_value'
     AIRFLOW_CONN_TEST_CONNECTION: 'postgresql://testuser:testpass@testhost:5432/testdb'
+  user: "${AIRFLOW_UID:-50000}:0"
   volumes:
     - ${PWD}/dags:/opt/airflow/dags
     - ${PWD}/logs:/opt/airflow/logs

--- a/task-sdk-tests/tests/task_sdk_tests/test_connection_operations.py
+++ b/task-sdk-tests/tests/task_sdk_tests/test_connection_operations.py
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Integration tests for Connection operations.
+
+These tests validate the Execution API endpoints for Connection operations:
+- get(): Get connection details
+
+Prerequisites:
+- Connection "test_connection" is set via environment variable `AIRFLOW_CONN_TEST_CONNECTION`
+"""
+
+from __future__ import annotations
+
+from airflow.sdk.api.datamodels._generated import ConnectionResponse
+from task_sdk_tests import console
+
+
+def test_connection_get(sdk_client):
+    """
+    Test getting connection details.
+
+    Expected: ConnectionResponse with connection details
+    Endpoint: GET /execution/connections/{conn_id}
+    """
+    console.print("[yellow]Getting connection details...")
+
+    response = sdk_client.connections.get("test_connection")
+
+    console.print(" Connection Get Response ".center(72, "="))
+    console.print(f"[bright_blue]Response Type:[/] {type(response).__name__}")
+    console.print(f"[bright_blue]Connection ID:[/] {response.conn_id}")
+    console.print(f"[bright_blue]Connection Type:[/] {response.conn_type}")
+    console.print(f"[bright_blue]Host:[/] {response.host}")
+    console.print(f"[bright_blue]Schema:[/] {response.schema}")
+    console.print("=" * 72)
+
+    assert isinstance(response, ConnectionResponse)
+    assert response.conn_id == "test_connection"
+    assert response.conn_type == "postgres"
+    assert response.host == "testhost"
+    assert response.schema_ == "testdb"
+    console.print("[green]✅ Connection get test passed!")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Bootstrapping task sdk integration test for connections.

```shell script
(airflow) ➜  task-sdk-tests git:(expanding-task-sdk-integration-tests-variable) ✗ uv run pytest tests/task_sdk_tests/test_variable_operations.py
Installing apache-airflow-task-sdk==1.1.0 via pytest_sessionstart...
Installing from: /Users/amoghdesai/Documents/OSS/repos/airflow/task-sdk
Installing to current UV environment...
Current Python: /Users/amoghdesai/Documents/OSS/repos/airflow/.venv/bin/python3
Running command: uv pip install /Users/amoghdesai/Documents/OSS/repos/airflow/task-sdk
Using Python 3.13.3 environment at: /Users/amoghdesai/Documents/OSS/repos/airflow/.venv
Resolved 125 packages in 290ms
      Built apache-airflow-task-sdk @ file:///Users/amoghdesai/Documents/OSS/repos/airflow/task-sdk
Prepared 1 package in 219ms
Uninstalled 1 package in 0.90ms
Installed 1 package in 1ms
 ~ apache-airflow-task-sdk==1.2.0 (from file:///Users/amoghdesai/Documents/OSS/repos/airflow/task-sdk)
Task SDK installed successfully to UV environment via pytest_sessionstart!
Verifying task Task installation via pytest_sessionstart...
✅ Task SDK import successful via pytest_sessionstart
================================================================================================================ test session starts ================================================================================================================
platform darwin -- Python 3.13.3, pytest-8.4.1, pluggy-1.6.0 -- /Users/amoghdesai/Documents/OSS/repos/airflow/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /Users/amoghdesai/Documents/OSS/repos/airflow/task-sdk-tests
configfile: pyproject.toml
plugins: unordered-0.7.0, instafail-0.5.0, timeouts-1.2.1, asyncio-1.1.0, xdist-3.8.0, custom-exit-code-0.3.0, anyio-4.10.0, icdiff-0.9, rerunfailures-15.1, cov-6.2.1, kgb-7.2, mock-3.14.1, time-machine-2.17.0, requests-mock-1.12.1
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
setup timeout: 0.0s, execution timeout: 0.0s, teardown timeout: 0.0s
collected 2 items

tests/task_sdk_tests/test_variable_operations.py::test_variable_get PASSED
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
