### PR TITLE
docs: remove outdated Bazel circular dependency warning from installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,11 +167,6 @@ While it is possible to install Airflow with tools like [Poetry](https://python-
 `pip` - especially when it comes to constraint vs. requirements management.
 Installing via `Poetry` or `pip-tools` is not currently supported.
 
-There are known issues with ``bazel`` that might lead to circular dependencies when using it to install
-Airflow. Please switch to ``pip`` if you encounter such problems. ``Bazel`` community works on fixing
-the problem in `this PR <https://github.com/bazelbuild/rules_python/pull/1166>`_ so it might be that
-newer versions of ``bazel`` will handle it.
-
 If you wish to install Airflow using those tools, you should use the constraint files and convert
 them to the appropriate format and workflow that your tool requires.
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

**[DOCS] Remove outdated Bazel circular dependency warning**

This PR removes an outdated note in the "Installing from PyPI" section that warned users about possible circular dependency issues when installing Airflow with Bazel.

The referenced issue in the Bazel ecosystem has already been resolved and merged in  
**bazelbuild/rules_python#1166**.  
Because the problem no longer exists, the warning is misleading and unnecessarily discourages users from using Bazel-based tooling.  
This update ensures the documentation remains accurate, up-to-date, and aligned with the current state of Bazel’s Python rules.

### What was changed
- Deleted the paragraph that stated Bazel may lead to circular dependencies during Airflow installation.
- Verified that the surrounding text flows naturally after the removal.
- No functional changes; documentation only.

### Why this change is needed
- The Bazel circular dependency issue has been resolved upstream.
- Retaining the warning provides inaccurate guidance to users.
- Helps maintain documentation correctness and reduce confusion.

### Related references
- Upstream fix: bazelbuild/rules_python#1166  
- No Airflow issue associated (documentation cleanup).

<!-- Please keep an empty line above the dashes. -->
---
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
