### PR TITLE
feat(openlineage): Add parentRunFacet for DAG events

### DIFF
--- a/providers/openlineage/docs/guides/user.rst
+++ b/providers/openlineage/docs/guides/user.rst
@@ -478,6 +478,56 @@ You can enable this automation by setting ``spark_inject_transport_info`` option
   AIRFLOW__OPENLINEAGE__SPARK_INJECT_TRANSPORT_INFO=true
 
 
+Passing parent information to Airflow DAG
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To enable full OpenLineage lineage tracking across dependent DAGs, you can pass parent and root job information
+through the DAG's ``dag_run.conf``. When a DAG run configuration includes an ``openlineage`` section with valid metadata,
+this information is automatically parsed and converted into DAG run's ``parentRunFacet``, from which the root information
+is also propagated to all tasks. If no DAG run ``openlineage`` configuration is provided, the DAG run will not contain
+``parentRunFacet`` and root of all tasks will default to Dag run.
+
+The ``openlineage`` dict in conf should contain the following keys:
+
+
+*(all three values must be included to create a parent reference)*
+
+- **parentRunId** — the unique run ID (uuid) of the direct parent job
+- **parentJobName** — the name of the parent job
+- **parentJobNamespace** — the namespace of the parent job
+
+*(all three values must be included to create a root reference, otherwise parent will be used as root)*
+
+- **rootParentRunId** — the run ID (uuid) of the top-level (root) job
+- **rootParentJobName** — the name of the top-level (root) job
+- **rootParentJobNamespace** — the namespace of the top-level (root) job
+
+.. note::
+
+  We highly recommend providing all six OpenLineage identifiers (parent and root) to ensure complete lineage tracking. If the root information is missing, the parent set will be used as the root; if any of the three parent fields are missing, no parent facet will be created. Partial or mixed configurations are not supported - either all three parent or all three root values must be provided together.
+
+
+Example:
+
+.. code-block:: shell
+
+    curl -X POST "http://<AIRFLOW_HOST>/api/v2/dags/my_dag_name/dagRuns" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "logical_date": "2019-08-24T14:15:22Z",
+      "conf": {
+        "openlineage": {
+          "parentRunId": "3bb703d1-09c1-4a42-8da5-35a0b3216072",
+          "parentJobNamespace": "prod_biz",
+          "parentJobName": "get_files",
+          "rootParentRunId": "9d3b14f7-de91-40b6-aeef-e887e2c7673e",
+          "rootParentJobNamespace": "prod_analytics",
+          "rootParentJobName": "generate_report_sales_e2e"
+        }
+      }
+    }'
+
+
 Troubleshooting
 ===============
 

--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/macros.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/macros.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING
 
 from airflow.providers.openlineage import conf
 from airflow.providers.openlineage.plugins.adapter import OpenLineageAdapter
-from airflow.providers.openlineage.utils.utils import get_job_name
+from airflow.providers.openlineage.utils.utils import get_job_name, get_root_information_from_dagrun_conf
 from airflow.providers.openlineage.version_compat import AIRFLOW_V_3_0_PLUS
 
 if TYPE_CHECKING:
@@ -102,7 +102,7 @@ def lineage_root_parent_id(task_instance: TaskInstance):
     """
     return "/".join(
         (
-            lineage_job_namespace(),
+            lineage_root_job_namespace(task_instance),
             lineage_root_job_name(task_instance),
             lineage_root_run_id(task_instance),
         )
@@ -110,10 +110,16 @@ def lineage_root_parent_id(task_instance: TaskInstance):
 
 
 def lineage_root_job_name(task_instance: TaskInstance):
+    root_parent_job_name = _get_ol_root_id("root_parent_job_name", task_instance)
+    if root_parent_job_name:
+        return root_parent_job_name
     return task_instance.dag_id
 
 
 def lineage_root_run_id(task_instance: TaskInstance):
+    root_parent_run_id = _get_ol_root_id("root_parent_run_id", task_instance)
+    if root_parent_run_id:
+        return root_parent_run_id
     return OpenLineageAdapter.build_dag_run_id(
         dag_id=task_instance.dag_id,
         logical_date=_get_logical_date(task_instance),
@@ -121,32 +127,44 @@ def lineage_root_run_id(task_instance: TaskInstance):
     )
 
 
+def lineage_root_job_namespace(task_instance: TaskInstance):
+    root_parent_job_namespace = _get_ol_root_id("root_parent_job_namespace", task_instance)
+    if root_parent_job_namespace:
+        return root_parent_job_namespace
+    return conf.namespace()
+
+
+def _get_ol_root_id(id_key: str, task_instance: TaskInstance) -> str | None:
+    dr_conf = _get_dag_run_conf(task_instance=task_instance)
+    ol_root_info = get_root_information_from_dagrun_conf(dr_conf=dr_conf)
+    if ol_root_info and ol_root_info.get(id_key):
+        return ol_root_info[id_key]
+    return None
+
+
+def _get_dagrun_from_ti(task_instance: TaskInstance):
+    context = task_instance.get_template_context()
+    if getattr(task_instance, "dag_run", None):
+        return task_instance.dag_run
+    return context["dag_run"]
+
+
+def _get_dag_run_conf(task_instance: TaskInstance) -> dict:
+    dr = _get_dagrun_from_ti(task_instance=task_instance)
+    return dr.conf or {}
+
+
 def _get_dag_run_clear_number(task_instance: TaskInstance):
-    # todo: remove when min airflow version >= 3.0
-    if AIRFLOW_V_3_0_PLUS:
-        context = task_instance.get_template_context()
-        if hasattr(task_instance, "dag_run"):
-            dag_run = task_instance.dag_run
-        else:
-            dag_run = context["dag_run"]
-        return dag_run.clear_number
-    return task_instance.dag_run.clear_number
+    dr = _get_dagrun_from_ti(task_instance=task_instance)
+    return dr.clear_number
 
 
 def _get_logical_date(task_instance):
-    # todo: remove when min airflow version >= 3.0
     if AIRFLOW_V_3_0_PLUS:
-        context = task_instance.get_template_context()
-        if hasattr(task_instance, "dag_run"):
-            dag_run = task_instance.dag_run
-        else:
-            dag_run = context["dag_run"]
-        if hasattr(dag_run, "logical_date") and dag_run.logical_date:
-            date = dag_run.logical_date
-        else:
-            date = dag_run.run_after
-    elif hasattr(task_instance, "logical_date"):
-        date = task_instance.logical_date
-    else:
-        date = task_instance.execution_date
-    return date
+        dr = _get_dagrun_from_ti(task_instance=task_instance)
+        if getattr(dr, "logical_date", None):
+            return dr.logical_date
+        return dr.run_after
+    if getattr(task_instance, "logical_date", None):
+        return task_instance.logical_date
+    return task_instance.execution_date

--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/openlineage.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/openlineage.py
@@ -28,6 +28,7 @@ if not conf.is_disabled():
         lineage_job_namespace,
         lineage_parent_id,
         lineage_root_job_name,
+        lineage_root_job_namespace,
         lineage_root_parent_id,
         lineage_root_run_id,
         lineage_run_id,
@@ -51,6 +52,7 @@ class OpenLineageProviderPlugin(AirflowPlugin):
             lineage_parent_id,
             lineage_root_run_id,
             lineage_root_job_name,
+            lineage_root_job_namespace,
             lineage_root_parent_id,
         ]
         listeners = [get_openlineage_listener()]

--- a/providers/openlineage/tests/system/openlineage/example_openlineage_trigger_dag.py
+++ b/providers/openlineage/tests/system/openlineage/example_openlineage_trigger_dag.py
@@ -20,6 +20,7 @@ Simple DAG that triggers another simple DAG.
 It checks:
     - task's trigger_dag_id
     - DAGRun START and COMPLETE events, for the triggered DAG
+    - propagation of OL parent and root info from DAGRun conf
 """
 
 from __future__ import annotations
@@ -47,7 +48,17 @@ with DAG(
         trigger_dag_id="openlineage_trigger_dag_child__notrigger",
         trigger_run_id=f"openlineage_trigger_dag_triggering_child_{datetime.now().isoformat()}",
         wait_for_completion=True,
-        conf={"some_config": "value1"},
+        conf={
+            "some_config": "value1",
+            "openlineage": {
+                "parentRunId": "3bb703d1-09c1-4a42-8da5-35a0b3216072",
+                "parentJobNamespace": "prod_biz",
+                "parentJobName": "get_files",
+                "rootParentRunId": "9d3b14f7-de91-40b6-aeef-e887e2c7673e",
+                "rootParentJobNamespace": "prod_analytics",
+                "rootParentJobName": "generate_report_sales_e2e",
+            },
+        },
         poke_interval=10,
     )
 

--- a/providers/openlineage/tests/system/openlineage/expected_events/openlineage_trigger_dag.json
+++ b/providers/openlineage/tests/system/openlineage/expected_events/openlineage_trigger_dag.json
@@ -21,7 +21,15 @@
                     },
                     "dagRun": {
                         "conf": {
-                            "some_config": "value1"
+                            "some_config": "value1",
+                            "openlineage": {
+                                "parentRunId": "3bb703d1-09c1-4a42-8da5-35a0b3216072",
+                                "parentJobNamespace": "prod_biz",
+                                "parentJobName": "get_files",
+                                "rootParentRunId": "9d3b14f7-de91-40b6-aeef-e887e2c7673e",
+                                "rootParentJobNamespace": "prod_analytics",
+                                "rootParentJobName": "generate_report_sales_e2e"
+                            }
                         },
                         "dag_id": "openlineage_trigger_dag_child__notrigger",
                         "data_interval_end": "{{ is_datetime(result) }}",
@@ -33,6 +41,26 @@
                     },
                     "_producer": "{{ regex_match(result, \"^https:\\/\\/github.com/apache/airflow/tree/providers-openlineage\\/[\\d]+\\.[\\d]+\\.[\\d]+.*$\") }}",
                     "_schemaURL": "{{ regex_match(result, \"^https:\\/\\/openlineage.io\\/spec\\/[\\d-]+\\/OpenLineage.json\\#\\/\\$defs\\/RunFacet\") }}"
+                },
+                "parent": {
+                  "job": {
+                    "namespace": "prod_biz",
+                    "name": "get_files"
+                  },
+                  "run": {
+                    "runId": "3bb703d1-09c1-4a42-8da5-35a0b3216072"
+                  },
+                  "root": {
+                    "job": {
+                      "name": "generate_report_sales_e2e",
+                      "namespace": "prod_analytics"
+                    },
+                    "run": {
+                      "runId": "9d3b14f7-de91-40b6-aeef-e887e2c7673e"
+                    }
+                  },
+                  "_producer": "{{ regex_match(result, \"^https:\\/\\/github.com/apache/airflow/tree/providers-openlineage\\/[\\d]+\\.[\\d]+\\.[\\d]+.*$\") }}",
+                  "_schemaURL": "{{ regex_match(result, \"^https:\\/\\/openlineage.io\\/spec\\/facets\\/[\\d-]+\\/ParentRunFacet.json\\#\\/\\$defs\\/ParentRunFacet$\") }}"
                 },
                 "nominalTime": {
                     "nominalEndTime": "{{ is_datetime(result) }}",
@@ -153,7 +181,15 @@
                     },
                     "dagRun": {
                         "conf": {
-                            "some_config": "value1"
+                            "some_config": "value1",
+                            "openlineage": {
+                                "parentRunId": "3bb703d1-09c1-4a42-8da5-35a0b3216072",
+                                "parentJobNamespace": "prod_biz",
+                                "parentJobName": "get_files",
+                                "rootParentRunId": "9d3b14f7-de91-40b6-aeef-e887e2c7673e",
+                                "rootParentJobNamespace": "prod_analytics",
+                                "rootParentJobName": "generate_report_sales_e2e"
+                            }
                         },
                         "dag_id": "openlineage_trigger_dag_child__notrigger",
                         "data_interval_end": "{{ is_datetime(result) }}",
@@ -166,6 +202,26 @@
                     },
                     "_producer": "{{ regex_match(result, \"^https:\\/\\/github.com/apache/airflow/tree/providers-openlineage\\/[\\d]+\\.[\\d]+\\.[\\d]+.*$\") }}",
                     "_schemaURL": "{{ regex_match(result, \"^https:\\/\\/openlineage.io\\/spec\\/[\\d-]+\\/OpenLineage.json\\#\\/\\$defs\\/RunFacet\") }}"
+                },
+                "parent": {
+                  "job": {
+                    "namespace": "prod_biz",
+                    "name": "get_files"
+                  },
+                  "run": {
+                    "runId": "3bb703d1-09c1-4a42-8da5-35a0b3216072"
+                  },
+                  "root": {
+                    "job": {
+                      "name": "generate_report_sales_e2e",
+                      "namespace": "prod_analytics"
+                    },
+                    "run": {
+                      "runId": "9d3b14f7-de91-40b6-aeef-e887e2c7673e"
+                    }
+                  },
+                  "_producer": "{{ regex_match(result, \"^https:\\/\\/github.com/apache/airflow/tree/providers-openlineage\\/[\\d]+\\.[\\d]+\\.[\\d]+.*$\") }}",
+                  "_schemaURL": "{{ regex_match(result, \"^https:\\/\\/openlineage.io\\/spec\\/facets\\/[\\d-]+\\/ParentRunFacet.json\\#\\/\\$defs\\/ParentRunFacet$\") }}"
                 },
                 "nominalTime": {
                     "nominalEndTime": "{{ is_datetime(result) }}",
@@ -241,10 +297,90 @@
         "eventType": "START",
         "run": {
             "facets": {
+                "parent": {
+                  "job": {
+                    "namespace": "{{ result is string }}",
+                    "name": "openlineage_trigger_dag_child__notrigger"
+                  },
+                  "run": {
+                    "runId": "{{ is_uuid(result) }}"
+                  },
+                  "root": {
+                    "job": {
+                      "name": "generate_report_sales_e2e",
+                      "namespace": "prod_analytics"
+                    },
+                    "run": {
+                      "runId": "9d3b14f7-de91-40b6-aeef-e887e2c7673e"
+                    }
+                  },
+                  "_producer": "{{ regex_match(result, \"^https:\\/\\/github.com/apache/airflow/tree/providers-openlineage\\/[\\d]+\\.[\\d]+\\.[\\d]+.*$\") }}",
+                  "_schemaURL": "{{ regex_match(result, \"^https:\\/\\/openlineage.io\\/spec\\/facets\\/[\\d-]+\\/ParentRunFacet.json\\#\\/\\$defs\\/ParentRunFacet$\") }}"
+                }
+            }
+        },
+        "job": {
+            "name": "openlineage_trigger_dag_child__notrigger.do_nothing_task"
+        }
+    },
+    {
+        "eventType": "COMPLETE",
+        "run": {
+            "facets": {
+                "parent": {
+                  "job": {
+                    "namespace": "{{ result is string }}",
+                    "name": "openlineage_trigger_dag_child__notrigger"
+                  },
+                  "run": {
+                    "runId": "{{ is_uuid(result) }}"
+                  },
+                  "root": {
+                    "job": {
+                      "name": "generate_report_sales_e2e",
+                      "namespace": "prod_analytics"
+                    },
+                    "run": {
+                      "runId": "9d3b14f7-de91-40b6-aeef-e887e2c7673e"
+                    }
+                  },
+                  "_producer": "{{ regex_match(result, \"^https:\\/\\/github.com/apache/airflow/tree/providers-openlineage\\/[\\d]+\\.[\\d]+\\.[\\d]+.*$\") }}",
+                  "_schemaURL": "{{ regex_match(result, \"^https:\\/\\/openlineage.io\\/spec\\/facets\\/[\\d-]+\\/ParentRunFacet.json\\#\\/\\$defs\\/ParentRunFacet$\") }}"
+                }
+            }
+        },
+        "job": {
+            "name": "openlineage_trigger_dag_child__notrigger.do_nothing_task"
+        }
+    },
+    {
+        "eventType": "START",
+        "run": {
+            "facets": {
                 "airflow": {
                     "task": {
                         "trigger_dag_id": "openlineage_trigger_dag_child__notrigger"
                     }
+                },
+                "parent": {
+                  "job": {
+                    "namespace": "{{ result is string }}",
+                    "name": "openlineage_trigger_dag"
+                  },
+                  "run": {
+                    "runId": "{{ is_uuid(result) }}"
+                  },
+                  "root": {
+                    "job": {
+                      "name": "openlineage_trigger_dag",
+                      "namespace": "{{ result is string }}"
+                    },
+                    "run": {
+                      "runId": "{{ is_uuid(result) }}"
+                    }
+                  },
+                  "_producer": "{{ regex_match(result, \"^https:\\/\\/github.com/apache/airflow/tree/providers-openlineage\\/[\\d]+\\.[\\d]+\\.[\\d]+.*$\") }}",
+                  "_schemaURL": "{{ regex_match(result, \"^https:\\/\\/openlineage.io\\/spec\\/facets\\/[\\d-]+\\/ParentRunFacet.json\\#\\/\\$defs\\/ParentRunFacet$\") }}"
                 }
             }
         },
@@ -260,6 +396,26 @@
                     "task": {
                         "trigger_dag_id": "openlineage_trigger_dag_child__notrigger"
                     }
+                },
+                "parent": {
+                  "job": {
+                    "namespace": "{{ result is string }}",
+                    "name": "openlineage_trigger_dag"
+                  },
+                  "run": {
+                    "runId": "{{ is_uuid(result) }}"
+                  },
+                  "root": {
+                    "job": {
+                      "name": "openlineage_trigger_dag",
+                      "namespace": "{{ result is string }}"
+                    },
+                    "run": {
+                      "runId": "{{ is_uuid(result) }}"
+                    }
+                  },
+                  "_producer": "{{ regex_match(result, \"^https:\\/\\/github.com/apache/airflow/tree/providers-openlineage\\/[\\d]+\\.[\\d]+\\.[\\d]+.*$\") }}",
+                  "_schemaURL": "{{ regex_match(result, \"^https:\\/\\/openlineage.io\\/spec\\/facets\\/[\\d-]+\\/ParentRunFacet.json\\#\\/\\$defs\\/ParentRunFacet$\") }}"
                 }
             }
         },


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Currently OpenLineage provider only supports simple parent-child references, with two gaps:
1. DagRun is always considered a root job for all the tasks
2. DagRun has no parent or root jobs

This PR adds a possibility to provide a DagRun with openlineage parent and root job/run identifiers so that the parentRunFacet can be created for DagRun OpenLineage event. This is done by using `DagRun.conf`, the only possibility I found to pass a complex data structure to a DagRun for both Airflow 2 and 3, that can be retrieved by using TaskInstance (available for listeners) and also possible to pass through both API call and TriggerDagRunOperator (will be instrumented in separate PR to automatically inject OL metadata into conf of triggered DagRun).

Additionaly, if DagRun has a root job/run, it's propagated to all the tasks as root job/run, so that it's reflecting the real situation.

This PR is only adding support for this feature in OpenLineage provider, so that it looks for _openlineage data in dagrun conf and creates parentRunFacet from it. Other operators like `TriggerDagRunOperator` will be instrumented in separate PRs so that this data is injected automatically for people using OpenLineage, improving lineage quality.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
