### PR TITLE
Add number of queries guard for ui backfill

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/backfills.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/backfills.py
@@ -20,6 +20,7 @@ from typing import Annotated
 
 from fastapi import Depends, status
 from sqlalchemy import select
+from sqlalchemy.orm import joinedload
 
 from airflow.api_fastapi.common.db.common import SessionDep, paginated_select
 from airflow.api_fastapi.common.parameters import (
@@ -64,7 +65,7 @@ def list_backfills_ui(
     ],
 ) -> BackfillCollectionResponse:
     select_stmt, total_entries = paginated_select(
-        statement=select(Backfill),
+        statement=select(Backfill).options(joinedload(Backfill.dag_model)),
         filters=[dag_id, active],
         order_by=order_by,
         offset=offset,

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_backfills.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_backfills.py
@@ -25,6 +25,7 @@ from airflow.models import DagModel
 from airflow.models.backfill import Backfill
 from airflow.utils.session import provide_session
 
+from tests_common.test_utils.asserts import assert_queries_count
 from tests_common.test_utils.db import (
     clear_db_backfills,
     clear_db_dag_bundles,
@@ -152,7 +153,8 @@ class TestListBackfills(TestBackfillEndpoint):
         expected_response = []
         for backfill in response_params:
             expected_response.append(backfill_responses[backfill])
-        response = test_client.get("/backfills", params=test_params)
+        with assert_queries_count(2):
+            response = test_client.get("/backfills", params=test_params)
         assert response.status_code == 200
         assert response.json() == {
             "backfills": expected_response,


### PR DESCRIPTION
Fix N+1 queries problem and add safe guard, 

Part of https://github.com/apache/airflow/issues/57561