### PR TITLE
add `task_pending_timeout` to `CeleryExecutor`

### DIFF
--- a/providers/celery/provider.yaml
+++ b/providers/celery/provider.yaml
@@ -321,6 +321,18 @@ config:
         type: integer
         example: ~
         default: "3"
+      task_pending_timeout:
+        description: |
+          Timeout in seconds for tasks in Celery's PENDING state (queued to Celery broker
+          but not yet picked up by a worker). When exceeded, tasks are marked as failed and
+          removed from the executor. This prevents executor slot leaks when tasks are sent
+          to queues for which no worker are available.
+
+          Set to 0 to disable (default)
+        version_added: ~
+        type: integer
+        example: "300"
+        default: "0"
       extra_celery_config:
         description: |
           Extra celery configs to include in the celery worker.

--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
@@ -446,7 +446,7 @@ class CeleryExecutor(BaseExecutor):
 
         This to guard against task leak scenario:
          1. Celery executor sends task to a specific celery queue
-         2. Celery worker is unavailable for the given queue. Celery task is in PENDING state.
+         2. No Celery workers are consuming from the given queue. Celery task will remain in PENDING state.
          3. DagRun timeout kicks in, setting DagRun and associated TaskInstance(s) to failed but not deleting
             the task from self.running
          4. The executor's self.running continuously fills up until hitting self.parallelism

--- a/providers/celery/tests/unit/celery/executors/test_celery_executor.py
+++ b/providers/celery/tests/unit/celery/executors/test_celery_executor.py
@@ -466,6 +466,7 @@ def test_celery_extra_celery_config_loaded_from_string():
 class TestCeleryExecutorPendingTimeout:
     """Unit tests for CeleryExecutor pending timeout functionality via update_task_state."""
 
+    @pytest.mark.backend("mysql", "postgres")
     def test_update_task_state_pending_timeout_disabled_no_timeout(self):
         """
         Test update_task_state with pending_task_timeout DISABLED (0).
@@ -506,6 +507,7 @@ class TestCeleryExecutorPendingTimeout:
             # Task should NOT be in event_buffer (not failed)
             assert key not in executor.event_buffer
 
+    @pytest.mark.backend("mysql", "postgres")
     def test_update_task_state_pending_timeout_exceeded_fails_task(self):
         """
         Test update_task_state with pending_task_timeout ENABLED.
@@ -565,6 +567,7 @@ class TestCeleryExecutorPendingTimeout:
             assert key not in executor.running
             assert key not in executor.tasks
 
+    @pytest.mark.backend("mysql", "postgres")
     def test_update_task_state_pending_to_started_cleans_timestamp(self):
         """
         Test update_task_state when task transitions from PENDING to STARTED.
@@ -599,6 +602,7 @@ class TestCeleryExecutorPendingTimeout:
             # Timestamp should be cleaned up
             assert key not in executor.task_pending_since
 
+    @pytest.mark.backend("mysql", "postgres")
     def test_update_task_state_non_pending_states_no_timestamp(self):
         """
         Test update_task_state with non-PENDING states (SUCCESS, FAILURE, STARTED).


### PR DESCRIPTION
Executor parallelism limit reached due to task leak in CeleryExecutor. Addition of `celery.task_pending_timeout` to fix this.

Scenario as follows:
1. our deployment sees celery executor route a given task to team specific celery queue, with team dedicated worker to consume it
2. in my company we have the scheduler along with dags deployed in many different dcs and it happens that a specific team + their dedicated workers are not setup in a given dc, yet their dags are present.
    - due to multi dc nature of my company, we try to keep dc discrepancies to a minimum and thus all dags are deployed in all dcs
3. thus we're in a situation where we can have dags that sends tasks to team specific celery queue for which workers do not exist to consume said tasks
4. these tasks are not evicted from `celery_executor.running` in memory state during scheduler lifetime. They remain indefinitely in `celery_state.PENDING` (task instance state `RUNNING`) til' scheduler is restarted. Thus slowly leaking tasks until executor.parallelism limit reached
    - note that heartbeat nor dagrun timeout removes associated tasks from celery_executor.running

The idea is to add a `celery.task_pending_timeout` configuration such that a task in `celery_state.PENDING` will time out one it reaches the configured `celery.task_pending_timeout`. This way freeing up the executor slot it was holding.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
