### PR TITLE
Enable PT006 rule to dev

### DIFF
--- a/dev/breeze/tests/test_cache.py
+++ b/dev/breeze/tests/test_cache.py
@@ -32,7 +32,7 @@ AIRFLOW_SOURCES = Path(__file__).parents[3].resolve()
 
 
 @pytest.mark.parametrize(
-    "parameter, value, result, exception",
+    ("parameter", "value", "result", "exception"),
     [
         ("backend", "mysql", (True, ["sqlite", "mysql", "postgres", "none"]), None),
         ("backend", "xxx", (False, ["sqlite", "mysql", "postgres", "none"]), None),

--- a/dev/breeze/tests/test_docker_command_utils.py
+++ b/dev/breeze/tests/test_docker_command_utils.py
@@ -222,7 +222,7 @@ def _fake_ctx_output(*names: str) -> str:
 
 
 @pytest.mark.parametrize(
-    "context_output, selected_context, console_output",
+    ("context_output", "selected_context", "console_output"),
     [
         (
             _fake_ctx_output("default"),

--- a/dev/breeze/tests/test_exclude_from_matrix.py
+++ b/dev/breeze/tests/test_exclude_from_matrix.py
@@ -22,7 +22,7 @@ from airflow_breeze.utils.exclude_from_matrix import excluded_combos, representa
 
 
 @pytest.mark.parametrize(
-    "list_1, list_2, expected_representative_list",
+    ("list_1", "list_2", "expected_representative_list"),
     [
         (["3.8", "3.9"], ["1", "2"], [("3.8", "1"), ("3.9", "2")]),
         (["3.8", "3.9"], ["1", "2", "3"], [("3.8", "1"), ("3.9", "2"), ("3.8", "3")]),

--- a/dev/breeze/tests/test_general_utils.py
+++ b/dev/breeze/tests/test_general_utils.py
@@ -22,7 +22,7 @@ from airflow_breeze.utils.packages import get_long_package_names
 
 
 @pytest.mark.parametrize(
-    "short_form_providers, expected",
+    ("short_form_providers", "expected"),
     [
         pytest.param(
             ("awesome", "foo.bar"),

--- a/dev/breeze/tests/test_packages.py
+++ b/dev/breeze/tests/test_packages.py
@@ -127,7 +127,7 @@ def test_get_suspended_provider_folders():
 
 
 @pytest.mark.parametrize(
-    "short_packages, filters, long_packages",
+    ("short_packages", "filters", "long_packages"),
     [
         (("amazon",), (), ("apache-airflow-providers-amazon",)),
         (("apache.hdfs",), (), ("apache-airflow-providers-apache-hdfs",)),
@@ -155,7 +155,7 @@ def test_find_matching_long_package_name_bad_filter():
 
 
 @pytest.mark.parametrize(
-    "provider_id, pip_package_name",
+    ("provider_id", "pip_package_name"),
     [
         ("asana", "apache-airflow-providers-asana"),
         ("apache.hdfs", "apache-airflow-providers-apache-hdfs"),
@@ -166,7 +166,7 @@ def test_get_pip_package_name(provider_id: str, pip_package_name: str):
 
 
 @pytest.mark.parametrize(
-    "provider_id, expected_package_name",
+    ("provider_id", "expected_package_name"),
     [
         ("asana", "apache_airflow_providers_asana"),
         ("apache.hdfs", "apache_airflow_providers_apache_hdfs"),
@@ -177,7 +177,7 @@ def test_get_dist_package_name_prefix(provider_id: str, expected_package_name: s
 
 
 @pytest.mark.parametrize(
-    "requirement_string, expected",
+    ("requirement_string", "expected"),
     [
         pytest.param("apache-airflow", ("apache-airflow", ""), id="no-version-specifier"),
         pytest.param(
@@ -217,7 +217,7 @@ def test_parse_pip_requirements_parse(requirement_string: str, expected: tuple[s
 
 
 @pytest.mark.parametrize(
-    "requirements, markdown, table",
+    ("requirements", "markdown", "table"),
     [
         (
             ["apache-airflow>2.5.0", "apache-airflow-providers-http"],
@@ -253,7 +253,7 @@ def test_validate_provider_info_with_schema():
 
 
 @pytest.mark.parametrize(
-    "provider_id, min_version",
+    ("provider_id", "min_version"),
     [
         ("amazon", "2.10.0"),
         ("fab", "3.0.2"),
@@ -348,7 +348,7 @@ def _check_dependencies_modified_properly(
 
 
 @pytest.mark.parametrize(
-    "provider_id, version_suffix, floored_version_suffix",
+    ("provider_id", "version_suffix", "floored_version_suffix"),
     [
         ("google", ".dev0", ".dev0"),
         ("google", ".dev1", ".dev0"),
@@ -402,7 +402,7 @@ AIRFLOWCTL_INIT_PY = AIRFLOW_ROOT_PATH / "airflow-ctl" / "src" / "airflowctl" / 
 
 
 @pytest.mark.parametrize(
-    "distributions,  init_file_path, version_suffix, floored_version_suffix",
+    ("distributions", "init_file_path", "version_suffix", "floored_version_suffix"),
     [
         (("airflow-core", "."), AIRFLOW_CORE_INIT_PY, ".dev0", ".dev0"),
         (("airflow-core", "."), AIRFLOW_CORE_INIT_PY, ".dev1+testversion34", ".dev0"),

--- a/dev/breeze/tests/test_provider_documentation.py
+++ b/dev/breeze/tests/test_provider_documentation.py
@@ -89,7 +89,7 @@ def test_find_insertion_index_insert_new_changelog():
 
 
 @pytest.mark.parametrize(
-    "version, provider_id, suffix, tag",
+    ("version", "provider_id", "suffix", "tag"),
     [
         ("1.0.1", "asana", "", "providers-asana/1.0.1"),
         ("1.0.1", "asana", "rc1", "providers-asana/1.0.1rc1"),
@@ -101,7 +101,7 @@ def test_get_version_tag(version: str, provider_id: str, suffix: str, tag: str):
 
 
 @pytest.mark.parametrize(
-    "folder_paths, from_commit, to_commit, git_command",
+    ("folder_paths", "from_commit", "to_commit", "git_command"),
     [
         (None, None, None, ["git", "log", "--pretty=format:%H %h %cd %s", "--date=short", "--", "."]),
         (
@@ -145,7 +145,7 @@ def test_get_git_log_command_wrong():
 
 
 @pytest.mark.parametrize(
-    "line, version, change",
+    ("line", "version", "change"),
     [
         (
             "LONG_HASH_123144 SHORT_HASH 2023-01-01 Description `with` no pr",
@@ -180,7 +180,7 @@ def test_get_change_from_line(line: str, version: str, change: Change):
 
 
 @pytest.mark.parametrize(
-    "input, output, markdown, changes_len",
+    ("input", "output", "markdown", "changes_len"),
     [
         (
             """
@@ -251,8 +251,17 @@ def generate_short_hash():
 
 
 @pytest.mark.parametrize(
-    "descriptions, with_breaking_changes, maybe_with_new_features,"
-    "breaking_count, feature_count, bugfix_count, other_count, misc_count, type_of_change",
+    (
+        "descriptions",
+        "with_breaking_changes",
+        "maybe_with_new_features",
+        "breaking_count",
+        "feature_count",
+        "bugfix_count",
+        "other_count",
+        "misc_count",
+        "type_of_change",
+    ),
     [
         (["Added feature x"], True, True, 0, 1, 0, 0, 0, [TypeOfChange.FEATURE]),
         (["Added feature x"], False, True, 0, 1, 0, 0, 0, [TypeOfChange.FEATURE]),
@@ -307,7 +316,7 @@ def test_classify_changes_automatically(
 
 
 @pytest.mark.parametrize(
-    "initial_version, bump_index, expected_version",
+    ("initial_version", "bump_index", "expected_version"),
     [
         ("4.2.1", VERSION_MAJOR_INDEX, "5.0.0"),
         ("3.5.9", VERSION_MINOR_INDEX, "3.6.0"),
@@ -322,7 +331,7 @@ def test_version_bump_for_provider_documentation(initial_version, bump_index, ex
 
 
 @pytest.mark.parametrize(
-    "changes, expected",
+    ("changes", "expected"),
     [
         pytest.param([TypeOfChange.SKIP], TypeOfChange.SKIP, id="only-skip"),
         pytest.param([TypeOfChange.DOCUMENTATION], TypeOfChange.DOCUMENTATION, id="only-doc"),
@@ -395,7 +404,7 @@ def test_get_most_impactful_change(changes, expected):
 
 
 @pytest.mark.parametrize(
-    "provider_id, changed_files, expected",
+    ("provider_id", "changed_files", "expected"),
     [
         pytest.param("slack", ["providers/slack/docs/slack.rst"], "documentation", id="only_docs"),
         pytest.param(

--- a/dev/breeze/tests/test_publish_docs_to_s3.py
+++ b/dev/breeze/tests/test_publish_docs_to_s3.py
@@ -87,7 +87,7 @@ class TestPublishDocsToS3:
             self.publish_docs_to_s3.get_all_eligible_docs
 
     @pytest.mark.parametrize(
-        "all_eligible_docs, doc_exists, overwrite, expected_source_dest_mapping",
+        ("all_eligible_docs", "doc_exists", "overwrite", "expected_source_dest_mapping"),
         [
             (
                 ["apache-airflow-providers-amazon", "apache-airflow-providers-google", "apache-airflow"],
@@ -194,7 +194,7 @@ class TestPublishDocsToS3:
         assert self.publish_docs_to_s3.source_dest_mapping == expected_source_dest_mapping
 
     @pytest.mark.parametrize(
-        "all_eligible_docs, doc_exists, overwrite, expected_source_dest_mapping",
+        ("all_eligible_docs", "doc_exists", "overwrite", "expected_source_dest_mapping"),
         [
             (
                 ["apache-airflow-providers-amazon", "apache-airflow-providers-google", "apache-airflow"],

--- a/dev/breeze/tests/test_pytest_args_for_test_types.py
+++ b/dev/breeze/tests/test_pytest_args_for_test_types.py
@@ -39,7 +39,7 @@ def _find_all_integration_folders() -> list[str]:
 
 
 @pytest.mark.parametrize(
-    "test_group, test_type, pytest_args",
+    ("test_group", "test_type", "pytest_args"),
     [
         # Those list needs to be updated every time we add a new directory to airflow-core/tests/ folder
         (
@@ -211,7 +211,7 @@ def test_pytest_args_for_missing_provider():
 
 
 @pytest.mark.parametrize(
-    "test_group, parallel_test_types, folders",
+    ("test_group", "parallel_test_types", "folders"),
     [
         (
             GroupOfTests.CORE,
@@ -344,7 +344,7 @@ def test_folders_for_parallel_test_types(
 
 
 @pytest.mark.parametrize(
-    "test_group, parallel_test_types",
+    ("test_group", "parallel_test_types"),
     [
         (
             GroupOfTests.CORE,

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -212,7 +212,7 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
 
 
 @pytest.mark.parametrize(
-    "files, expected_outputs,",
+    ("files", "expected_outputs"),
     [
         (
             pytest.param(
@@ -1181,7 +1181,7 @@ def test_expected_output_pull_request_main(
     reason="This test should not run if .git folder is missing (for example by default in breeze container)",
 )
 @pytest.mark.parametrize(
-    "files, commit_ref, expected_outputs",
+    ("files", "commit_ref", "expected_outputs"),
     [
         (
             pytest.param(
@@ -1246,7 +1246,7 @@ def test_excluded_providers():
 
 
 @pytest.mark.parametrize(
-    "files, expected_outputs",
+    ("files", "expected_outputs"),
     [
         (
             pytest.param(
@@ -1297,7 +1297,7 @@ def test_full_test_needed_when_scripts_changes(files: tuple[str, ...], expected_
 
 
 @pytest.mark.parametrize(
-    "files, pr_labels, default_branch, expected_outputs,",
+    ("files", "pr_labels", "default_branch", "expected_outputs"),
     [
         (
             pytest.param(
@@ -1592,7 +1592,7 @@ def test_expected_output_full_tests_needed(
 
 
 @pytest.mark.parametrize(
-    "files, expected_outputs,",
+    ("files", "expected_outputs"),
     [
         pytest.param(
             ("INTHEWILD.md",),
@@ -1710,7 +1710,7 @@ def test_expected_output_pull_request_v2_7(
 
 
 @pytest.mark.parametrize(
-    "files, pr_labels, default_branch, expected_outputs,",
+    ("files", "pr_labels", "default_branch", "expected_outputs"),
     [
         pytest.param(
             ("INTHEWILD.md",),
@@ -1797,7 +1797,7 @@ def test_expected_output_push(
 
 
 @pytest.mark.parametrize(
-    "files, expected_outputs,",
+    ("files", "expected_outputs"),
     [
         pytest.param(
             ("INTHEWILD.md",),
@@ -2066,7 +2066,7 @@ def test_files_provided_trigger_full_build_for_any_event_type(github_event):
 
 
 @pytest.mark.parametrize(
-    "files, expected_outputs, pr_labels, commit_ref",
+    ("files", "expected_outputs", "pr_labels", "commit_ref"),
     [
         pytest.param(
             ("airflow-core/src/airflow/models/dag.py",),
@@ -2114,7 +2114,7 @@ def test_upgrade_to_newer_dependencies(
 
 
 @pytest.mark.parametrize(
-    "files, expected_outputs,",
+    ("files", "expected_outputs"),
     [
         pytest.param(
             ("providers/google/docs/some_file.rst",),
@@ -2227,7 +2227,7 @@ def test_docs_filter(files: tuple[str, ...], expected_outputs: dict[str, str]):
 
 
 @pytest.mark.parametrize(
-    "files, expected_outputs,",
+    ("files", "expected_outputs"),
     [
         pytest.param(
             ("helm-tests/tests/helm_tests/random_helm_test.py",),
@@ -2252,7 +2252,7 @@ def test_helm_tests_trigger_ci_build(files: tuple[str, ...], expected_outputs: d
 
 
 @pytest.mark.parametrize(
-    "files, expected_outputs,",
+    ("files", "expected_outputs"),
     [
         pytest.param(
             ("providers/amazon/provider.yaml",),
@@ -2306,7 +2306,7 @@ def test_provider_yaml_or_pyproject_toml_changes_trigger_ci_build(
 
 
 @pytest.mark.parametrize(
-    "files, has_migrations",
+    ("files", "has_migrations"),
     [
         pytest.param(
             ("airflow-core/src/airflow/test.py",),
@@ -2333,7 +2333,7 @@ def test_has_migrations(files: tuple[str, ...], has_migrations: bool):
 
 
 @pytest.mark.parametrize(
-    "labels, expected_outputs,",
+    ("labels", "expected_outputs"),
     [
         pytest.param(
             (),
@@ -2367,7 +2367,7 @@ def test_provider_compatibility_checks(labels: tuple[str, ...], expected_outputs
 
 
 @pytest.mark.parametrize(
-    "files, expected_outputs, default_branch, pr_labels",
+    ("files", "expected_outputs", "default_branch", "pr_labels"),
     [
         pytest.param(
             ("README.md",),
@@ -2578,7 +2578,7 @@ def test_runner_type_schedule(mock_get):
 
 
 @pytest.mark.parametrize(
-    "integration, runner_type, expected_result",
+    ("integration", "runner_type", "expected_result"),
     [
         # Test integrations disabled for all CI environments
         pytest.param(

--- a/dev/breeze/tests/test_shell_params.py
+++ b/dev/breeze/tests/test_shell_params.py
@@ -29,7 +29,7 @@ console = Console(width=400, color_system="standard")
 
 
 @pytest.mark.parametrize(
-    "env_vars, kwargs, expected_vars",
+    ("env_vars", "kwargs", "expected_vars"),
     [
         pytest.param(
             {},

--- a/dev/breeze/tests/test_use_airflow_version.py
+++ b/dev/breeze/tests/test_use_airflow_version.py
@@ -24,7 +24,7 @@ from airflow_breeze.global_constants import GITHUB_REPO_BRANCH_PATTERN, PR_NUMBE
 
 
 @pytest.mark.parametrize(
-    "value, should_match_pr, should_match_repo",
+    ("value", "should_match_pr", "should_match_repo"),
     [
         pytest.param("57219", True, False, id="pr_number"),
         pytest.param("12345", True, False, id="another_pr_number"),

--- a/dev/breeze/tests/test_versions.py
+++ b/dev/breeze/tests/test_versions.py
@@ -22,7 +22,8 @@ from airflow_breeze.utils.versions import strip_leading_zeros_from_version
 
 
 @pytest.mark.parametrize(
-    "version,stripped_version", [("3.4.0", "3.4.0"), ("13.04.05", "13.4.5"), ("0003.00004.000005", "3.4.5")]
+    ("version", "stripped_version"),
+    [("3.4.0", "3.4.0"), ("13.04.05", "13.4.5"), ("0003.00004.000005", "3.4.5")],
 )
 def test_strip_leading_versions(version: str, stripped_version):
     assert stripped_version == strip_leading_zeros_from_version(version)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
Issue: Enable Even More PyDocStyle Checks https://github.com/apache/airflow/issues/40567
@ferruzzi

This PR is for enable PT006 rule:
PT011: all instances of @pytest.mark.parametrize names should be a tuple
https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/
There are a lot of file changes needed.
So, I separate to many PR, which contain about 12 file changes for easy review.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
