### PR TITLE
Enable PT006 rule to 10 files in helm-tests

### DIFF
--- a/helm-tests/tests/helm_tests/airflow_aux/test_airflow_common.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_airflow_common.py
@@ -29,7 +29,7 @@ class TestAirflowCommon:
     """
 
     @pytest.mark.parametrize(
-        "logs_values, expected_mount",
+        ("logs_values", "expected_mount"),
         [
             (
                 {"persistence": {"enabled": True, "subPath": "test/logs"}},
@@ -74,7 +74,7 @@ class TestAirflowCommon:
             assert expected_mount in jmespath.search("spec.template.spec.containers[0].volumeMounts", doc)
 
     @pytest.mark.parametrize(
-        "dag_values, expected_mount",
+        ("dag_values", "expected_mount"),
         [
             (
                 {"gitSync": {"enabled": True}},
@@ -297,7 +297,7 @@ class TestAirflowCommon:
             assert jmespath.search("topologySpreadConstraints[0].topologyKey", podSpec) == "foo"
 
     @pytest.mark.parametrize(
-        "expected_image,tag,digest",
+        ("expected_image", "tag", "digest"),
         [
             ("apache/airflow:user-tag", "user-tag", None),
             ("apache/airflow@user-digest", None, "user-digest"),
@@ -328,7 +328,7 @@ class TestAirflowCommon:
             assert expected_image == jmespath.search("spec.template.spec.initContainers[0].image", doc)
 
     @pytest.mark.parametrize(
-        "expected_image,tag,digest",
+        ("expected_image", "tag", "digest"),
         [
             ("apache/airflow:user-tag", "user-tag", None),
             ("apache/airflow@user-digest", None, "user-digest"),

--- a/helm-tests/tests/helm_tests/airflow_aux/test_annotations.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_annotations.py
@@ -38,7 +38,7 @@ class TestServiceAccountAnnotations:
     """Tests Service Account Annotations."""
 
     @pytest.mark.parametrize(
-        "values,show_only,expected_annotations",
+        ("values", "show_only", "expected_annotations"),
         [
             (
                 {
@@ -350,7 +350,7 @@ class TestServiceAccountAnnotations:
 
 
 @pytest.mark.parametrize(
-    "values,show_only,expected_annotations",
+    ("values", "show_only", "expected_annotations"),
     [
         (
             {

--- a/helm-tests/tests/helm_tests/airflow_aux/test_cleanup_pods.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_cleanup_pods.py
@@ -50,7 +50,7 @@ class TestCleanupDeployment:
     ]
 
     @pytest.mark.parametrize(
-        "release_name,schedule_value,schedule_result",
+        ("release_name", "schedule_value", "schedule_result"),
         cron_tests,
         ids=[x[0] for x in cron_tests],
     )

--- a/helm-tests/tests/helm_tests/airflow_aux/test_configmap.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_configmap.py
@@ -48,7 +48,7 @@ class TestConfigmap:
         assert annotations.get("key-two") == "value-two"
 
     @pytest.mark.parametrize(
-        "af_version, secret_key, secret_key_name, expected",
+        ("af_version", "secret_key", "secret_key_name", "expected"),
         [
             ("3.0.0", None, None, False),
             ("2.2.0", None, None, True),
@@ -98,7 +98,7 @@ class TestConfigmap:
         assert jmespath.search('data."krb5.conf"', docs[0]) == "krb5\ncontent"
 
     @pytest.mark.parametrize(
-        "executor, af_version, should_be_created",
+        ("executor", "af_version", "should_be_created"),
         [
             ("KubernetesExecutor", "1.10.11", False),
             ("KubernetesExecutor", "1.10.12", True),
@@ -166,7 +166,7 @@ metadata:
         assert expected in cfg.splitlines()
 
     @pytest.mark.parametrize(
-        "dag_values, expected_default_dag_folder",
+        ("dag_values", "expected_default_dag_folder"),
         [
             (
                 {"gitSync": {"enabled": True}},
@@ -203,7 +203,7 @@ metadata:
         assert expected_folder_config in cfg.splitlines()
 
     @pytest.mark.parametrize(
-        "airflow_version, enabled",
+        ("airflow_version", "enabled"),
         [
             ("2.10.4", False),
             ("3.0.0", True),
@@ -220,7 +220,7 @@ metadata:
         assert expected_line in cfg.splitlines()
 
     @pytest.mark.parametrize(
-        "airflow_version, enabled",
+        ("airflow_version", "enabled"),
         [
             ("2.10.4", False),
             ("2.10.4", True),
@@ -242,7 +242,7 @@ metadata:
         assert expected_line in cfg.splitlines()
 
     @pytest.mark.parametrize(
-        "airflow_version, base_url, execution_api_server_url, expected_execution_url",
+        ("airflow_version", "base_url", "execution_api_server_url", "expected_execution_url"),
         [
             (
                 "3.0.0",

--- a/helm-tests/tests/helm_tests/airflow_aux/test_create_user_job.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_create_user_job.py
@@ -343,7 +343,7 @@ class TestCreateUserJob:
         assert "ttlSecondsAfterFinished" not in spec
 
     @pytest.mark.parametrize(
-        "airflow_version, expected_arg",
+        ("airflow_version", "expected_arg"),
         [
             ("1.10.14", "airflow create_user"),
             ("2.0.2", "airflow users create"),

--- a/helm-tests/tests/helm_tests/airflow_aux/test_extra_env_env_from.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_extra_env_env_from.py
@@ -103,7 +103,7 @@ class TestExtraEnvEnvFrom:
         cls.k8s_objects = render_chart(RELEASE_NAME, values=values)
         cls.k8s_objects_by_key = prepare_k8s_lookup_dict(cls.k8s_objects)
 
-    @pytest.mark.parametrize("k8s_obj_key, env_paths", PARAMS)
+    @pytest.mark.parametrize(("k8s_obj_key", "env_paths"), PARAMS)
     def test_extra_env(self, k8s_obj_key, env_paths):
         expected_env_as_str = textwrap.dedent(
             f"""
@@ -121,7 +121,7 @@ class TestExtraEnvEnvFrom:
             env = jmespath.search(f"{path}.env", k8s_object)
             assert expected_env_as_str in yaml.dump(env)
 
-    @pytest.mark.parametrize("k8s_obj_key, env_from_paths", PARAMS)
+    @pytest.mark.parametrize(("k8s_obj_key", "env_from_paths"), PARAMS)
     def test_extra_env_from(self, k8s_obj_key, env_from_paths):
         expected_env_from_as_str = textwrap.dedent(
             f"""

--- a/helm-tests/tests/helm_tests/airflow_aux/test_job_launcher_role.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_job_launcher_role.py
@@ -25,7 +25,7 @@ class TestJobLauncher:
     """Tests job launcher RBAC."""
 
     @pytest.mark.parametrize(
-        "executor, rbac, allow, expected_accounts",
+        ("executor", "rbac", "allow", "expected_accounts"),
         [
             ("CeleryKubernetesExecutor", True, True, ["scheduler", "worker"]),
             ("KubernetesExecutor", True, True, ["scheduler", "worker"]),
@@ -51,7 +51,7 @@ class TestJobLauncher:
             assert docs == []
 
     @pytest.mark.parametrize(
-        "multiNamespaceMode, namespace, expectedRole, expectedRoleBinding",
+        ("multiNamespaceMode", "namespace", "expectedRole", "expectedRoleBinding"),
         [
             (
                 True,
@@ -93,7 +93,7 @@ class TestJobLauncher:
             assert actualRoleRefKind == "Role"
 
     @pytest.mark.parametrize(
-        "multiNamespaceMode, namespace, expectedRole",
+        ("multiNamespaceMode", "namespace", "expectedRole"),
         [
             (True, "namespace", "namespace-release-name-job-launcher-role"),
             (True, "other-ns", "other-ns-release-name-job-launcher-role"),

--- a/helm-tests/tests/helm_tests/airflow_aux/test_migrate_database_job.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_migrate_database_job.py
@@ -31,7 +31,7 @@ class TestMigrateDatabaseJob:
         assert jmespath.search("spec.template.spec.securityContext.runAsUser", docs[0]) == 50000
 
     @pytest.mark.parametrize(
-        "migrate_database_job_enabled,created",
+        ("migrate_database_job_enabled", "created"),
         [
             (False, False),
             (True, True),
@@ -160,7 +160,7 @@ class TestMigrateDatabaseJob:
         )
 
     @pytest.mark.parametrize(
-        "use_default_image,expected_image",
+        ("use_default_image", "expected_image"),
         [
             (True, "apache/airflow:2.1.0"),
             (False, "apache/airflow:user-image"),
@@ -352,7 +352,7 @@ class TestMigrateDatabaseJob:
         assert "ttlSecondsAfterFinished" not in spec
 
     @pytest.mark.parametrize(
-        "airflow_version, expected_arg",
+        ("airflow_version", "expected_arg"),
         [
             ("1.10.14", "airflow upgradedb"),
             ("2.0.2", "airflow db upgrade"),

--- a/helm-tests/tests/helm_tests/airflow_aux/test_pod_launcher_role.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_pod_launcher_role.py
@@ -25,7 +25,7 @@ class TestPodLauncher:
     """Tests pod launcher."""
 
     @pytest.mark.parametrize(
-        "executor, rbac, allow, expected_accounts",
+        ("executor", "rbac", "allow", "expected_accounts"),
         [
             ("CeleryKubernetesExecutor", True, True, ["scheduler", "worker"]),
             ("KubernetesExecutor", True, True, ["scheduler", "worker"]),
@@ -51,7 +51,7 @@ class TestPodLauncher:
             assert docs == []
 
     @pytest.mark.parametrize(
-        "multiNamespaceMode, namespace, expectedRole, expectedRoleBinding",
+        ("multiNamespaceMode", "namespace", "expectedRole", "expectedRoleBinding"),
         [
             (
                 True,
@@ -93,7 +93,7 @@ class TestPodLauncher:
             assert actualRoleRefKind == "Role"
 
     @pytest.mark.parametrize(
-        "multiNamespaceMode, namespace, expectedRole",
+        ("multiNamespaceMode", "namespace", "expectedRole"),
         [
             (True, "namespace", "namespace-release-name-pod-launcher-role"),
             (True, "other-ns", "other-ns-release-name-pod-launcher-role"),

--- a/helm-tests/tests/helm_tests/airflow_aux/test_pod_template_file.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_pod_template_file.py
@@ -137,7 +137,7 @@ class TestPodTemplateFile:
         assert jmespath.search("spec.initContainers", docs[0]) is None
 
     @pytest.mark.parametrize(
-        "dag_values, expected_read_only",
+        ("dag_values", "expected_read_only"),
         [
             ({"gitSync": {"enabled": True}}, True),
             ({"persistence": {"enabled": True}}, False),
@@ -255,7 +255,7 @@ class TestPodTemplateFile:
         } in jmespath.search("spec.initContainers[0].volumeMounts", docs[0])
 
     @pytest.mark.parametrize(
-        "tag,expected_prefix",
+        ("tag", "expected_prefix"),
         [
             ("v3.6.7", "GIT_SYNC_"),
             ("v4.4.2", "GITSYNC_"),
@@ -306,7 +306,7 @@ class TestPodTemplateFile:
         )
 
     @pytest.mark.parametrize(
-        "dags_gitsync_values, expected",
+        ("dags_gitsync_values", "expected"),
         [
             ({"enabled": True}, {"emptyDir": {}}),
             ({"enabled": True, "emptyDirConfig": {"sizeLimit": "10Gi"}}, {"emptyDir": {"sizeLimit": "10Gi"}}),
@@ -321,7 +321,7 @@ class TestPodTemplateFile:
         assert {"name": "dags", **expected} in jmespath.search("spec.volumes", docs[0])
 
     @pytest.mark.parametrize(
-        "log_values, expected",
+        ("log_values", "expected"),
         [
             ({"persistence": {"enabled": False}}, {"emptyDir": {}}),
             (
@@ -582,7 +582,7 @@ class TestPodTemplateFile:
         )
 
     @pytest.mark.parametrize(
-        "base_scheduler_name, worker_scheduler_name, expected",
+        ("base_scheduler_name", "worker_scheduler_name", "expected"),
         [
             ("default-scheduler", "most-allocated", "most-allocated"),
             ("default-scheduler", None, "default-scheduler"),
@@ -998,7 +998,7 @@ class TestPodTemplateFile:
         } in jmespath.search("spec.containers[1].volumeMounts", docs[0])
 
     @pytest.mark.parametrize(
-        "airflow_version, init_container_enabled, expected_init_containers",
+        ("airflow_version", "init_container_enabled", "expected_init_containers"),
         [
             ("1.9.0", True, 0),
             ("1.9.0", False, 0),
@@ -1035,7 +1035,7 @@ class TestPodTemplateFile:
             assert initContainers[0]["args"] == ["kerberos", "-o"]
 
     @pytest.mark.parametrize(
-        "cmd, expected",
+        ("cmd", "expected"),
         [
             (["test", "command", "to", "run"], ["test", "command", "to", "run"]),
             (["cmd", "{{ .Release.Name }}"], ["cmd", "release-name"]),
@@ -1071,7 +1071,7 @@ class TestPodTemplateFile:
         assert jmespath.search("spec.containers[0].command", docs[0]) is None
 
     @pytest.mark.parametrize(
-        "airflow_version, workers_values, kerberos_init_container, expected_config_name",
+        ("airflow_version", "workers_values", "kerberos_init_container", "expected_config_name"),
         [
             (None, {"kerberosSidecar": {"enabled": True}}, False, "api-server-config"),
             (None, {"kerberosInitContainer": {"enabled": True}}, True, "api-server-config"),


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
Issue: Enable Even More PyDocStyle Checks https://github.com/apache/airflow/issues/40567
@ferruzzi

This PR is for enable PT006 rule:
PT011: all instances of @pytest.mark.parametrize names should be a tuple
https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/
There are a lot of file changes needed.
So, I separate to many PR, which contain about 10 file changes for easy review.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
