### PR TITLE
Enable PT006 rule to 12 files in helm-tests (airflow-core,apiserver,webserver)

### DIFF
--- a/helm-tests/tests/chart_utils/log_groomer.py
+++ b/helm-tests/tests/chart_utils/log_groomer.py
@@ -166,7 +166,7 @@ class LogGroomerTestBase:
         assert jmespath.search("spec.template.spec.containers[1].command", docs[0]) == ["release-name"]
         assert jmespath.search("spec.template.spec.containers[1].args", docs[0]) == ["Helm"]
 
-    @pytest.mark.parametrize("retention_days, retention_result", [(None, None), (30, "30")])
+    @pytest.mark.parametrize(("retention_days", "retention_result"), [(None, None), (30, "30")])
     def test_log_groomer_retention_days_overrides(self, retention_days, retention_result):
         if self.obj_name == "dag-processor":
             values = {
@@ -191,7 +191,7 @@ class LogGroomerTestBase:
         else:
             assert len(jmespath.search("spec.template.spec.containers[1].env", docs[0])) == 2
 
-    @pytest.mark.parametrize("frequency_minutes, frequency_result", [(None, None), (20, "20")])
+    @pytest.mark.parametrize(("frequency_minutes", "frequency_result"), [(None, None), (20, "20")])
     def test_log_groomer_frequency_minutes_overrides(self, frequency_minutes, frequency_result):
         if self.obj_name == "dag-processor":
             values = {

--- a/helm-tests/tests/chart_utils/log_groomer.py
+++ b/helm-tests/tests/chart_utils/log_groomer.py
@@ -166,7 +166,7 @@ class LogGroomerTestBase:
         assert jmespath.search("spec.template.spec.containers[1].command", docs[0]) == ["release-name"]
         assert jmespath.search("spec.template.spec.containers[1].args", docs[0]) == ["Helm"]
 
-    @pytest.mark.parametrize(("retention_days", "retention_result"), [(None, None), (30, "30")])
+    @pytest.mark.parametrize("retention_days, retention_result", [(None, None), (30, "30")])
     def test_log_groomer_retention_days_overrides(self, retention_days, retention_result):
         if self.obj_name == "dag-processor":
             values = {
@@ -191,7 +191,7 @@ class LogGroomerTestBase:
         else:
             assert len(jmespath.search("spec.template.spec.containers[1].env", docs[0])) == 2
 
-    @pytest.mark.parametrize(("frequency_minutes", "frequency_result"), [(None, None), (20, "20")])
+    @pytest.mark.parametrize("frequency_minutes, frequency_result", [(None, None), (20, "20")])
     def test_log_groomer_frequency_minutes_overrides(self, frequency_minutes, frequency_result):
         if self.obj_name == "dag-processor":
             values = {

--- a/helm-tests/tests/helm_tests/airflow_core/test_api_server.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_api_server.py
@@ -34,7 +34,7 @@ class TestAPIServerDeployment:
     """Tests api-server deployment."""
 
     @pytest.mark.parametrize(
-        "revision_history_limit, global_revision_history_limit",
+        ("revision_history_limit", "global_revision_history_limit"),
         [(8, 10), (10, 8), (8, None), (None, 10), (None, None)],
     )
     def test_revision_history_limit(self, revision_history_limit, global_revision_history_limit):
@@ -384,7 +384,7 @@ class TestAPIServerDeployment:
         )
 
     @pytest.mark.parametrize(
-        "log_persistence_values, expected_claim_name",
+        ("log_persistence_values", "expected_claim_name"),
         [
             ({"enabled": False}, None),
             ({"enabled": True}, "release-name-logs"),
@@ -636,7 +636,7 @@ class TestAPIServerService:
         assert jmespath.search("spec.loadBalancerSourceRanges", docs[0]) == ["10.123.0.0/16"]
 
     @pytest.mark.parametrize(
-        "ports, expected_ports",
+        ("ports", "expected_ports"),
         [
             ([{"port": 8888}], [{"port": 8888}]),  # name is optional with a single port
             (
@@ -679,7 +679,7 @@ class TestAPIServerService:
         assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
 
     @pytest.mark.parametrize(
-        "ports, expected_ports",
+        ("ports", "expected_ports"),
         [
             (
                 [{"nodePort": "31000", "port": "8080"}],
@@ -733,7 +733,7 @@ class TestAPIServerNetworkPolicy:
         assert jmespath.search("spec.ingress[0].ports", docs[0]) == [{"port": 8080}]
 
     @pytest.mark.parametrize(
-        "ports, expected_ports",
+        ("ports", "expected_ports"),
         [
             ([{"port": "sidecar"}], [{"port": "sidecar"}]),
             (

--- a/helm-tests/tests/helm_tests/airflow_core/test_dag_processor.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_dag_processor.py
@@ -26,7 +26,7 @@ class TestDagProcessor:
     """Tests DAG processor."""
 
     @pytest.mark.parametrize(
-        "airflow_version, num_docs",
+        ("airflow_version", "num_docs"),
         [
             ("2.2.0", 0),
             ("2.3.0", 1),
@@ -45,7 +45,7 @@ class TestDagProcessor:
         assert len(docs) == num_docs
 
     @pytest.mark.parametrize(
-        "airflow_version, num_docs",
+        ("airflow_version", "num_docs"),
         [
             ("2.10.4", 0),
             ("3.0.0", 1),
@@ -61,7 +61,7 @@ class TestDagProcessor:
         assert len(docs) == num_docs
 
     @pytest.mark.parametrize(
-        "airflow_version, enabled",
+        ("airflow_version", "enabled"),
         [
             ("2.10.4", False),
             ("2.10.4", True),
@@ -480,7 +480,7 @@ class TestDagProcessor:
         ]
 
     @pytest.mark.parametrize(
-        "airflow_version, probe_command",
+        ("airflow_version", "probe_command"),
         [
             ("2.4.9", "airflow jobs check --hostname $(hostname)"),
             ("2.5.0", "airflow jobs check --local"),
@@ -498,7 +498,7 @@ class TestDagProcessor:
         )
 
     @pytest.mark.parametrize(
-        "log_values, expected_volume",
+        ("log_values", "expected_volume"),
         [
             ({"persistence": {"enabled": False}}, {"emptyDir": {}}),
             (
@@ -570,7 +570,7 @@ class TestDagProcessor:
         assert jmespath.search("spec.template.spec.containers[0].resources", docs[0]) == {}
 
     @pytest.mark.parametrize(
-        "strategy, expected_strategy",
+        ("strategy", "expected_strategy"),
         [
             (None, None),
             (
@@ -604,7 +604,7 @@ class TestDagProcessor:
         ]
 
     @pytest.mark.parametrize(
-        "revision_history_limit, global_revision_history_limit",
+        ("revision_history_limit", "global_revision_history_limit"),
         [(8, 10), (10, 8), (8, None), (None, 10), (None, None)],
     )
     def test_revision_history_limit(self, revision_history_limit, global_revision_history_limit):
@@ -733,7 +733,7 @@ class TestDagProcessor:
         assert jmespath.search("metadata.annotations", docs[0])["test_annotation"] == "test_annotation_value"
 
     @pytest.mark.parametrize(
-        "webserver_config, should_add_volume",
+        ("webserver_config", "should_add_volume"),
         [
             ("CSRF_ENABLED = True", True),
             (None, False),

--- a/helm-tests/tests/helm_tests/airflow_core/test_env.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_env.py
@@ -22,7 +22,7 @@ from chart_utils.helm_template_generator import render_chart
 
 
 @pytest.mark.parametrize(
-    ["airflow_version", "template_yaml"],
+    ("airflow_version", "template_yaml"),
     [
         ("2.10.0", "templates/webserver/webserver-deployment.yaml"),
         ("3.0.0", "templates/api-server/api-server-deployment.yaml"),
@@ -44,7 +44,7 @@ def test_should_add_airflow_home(airflow_version, template_yaml):
 
 
 @pytest.mark.parametrize(
-    ["airflow_version", "template_yaml"],
+    ("airflow_version", "template_yaml"),
     [
         ("2.10.0", "templates/webserver/webserver-deployment.yaml"),
         ("3.0.0", "templates/api-server/api-server-deployment.yaml"),

--- a/helm-tests/tests/helm_tests/airflow_core/test_scheduler.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_scheduler.py
@@ -26,7 +26,7 @@ class TestScheduler:
     """Tests scheduler."""
 
     @pytest.mark.parametrize(
-        "executor, persistence, kind",
+        ("executor", "persistence", "kind"),
         [
             ("CeleryExecutor", False, "Deployment"),
             ("CeleryExecutor", True, "Deployment"),
@@ -230,7 +230,7 @@ class TestScheduler:
         assert jmespath.search("spec.template.metadata.labels", docs[0])["test_label"] == "test_label_value"
 
     @pytest.mark.parametrize(
-        "revision_history_limit, global_revision_history_limit",
+        ("revision_history_limit", "global_revision_history_limit"),
         [(8, 10), (10, 8), (8, None), (None, 10), (None, None)],
     )
     def test_revision_history_limit(self, revision_history_limit, global_revision_history_limit):
@@ -461,7 +461,7 @@ class TestScheduler:
         ]
 
     @pytest.mark.parametrize(
-        "airflow_version, probe_command",
+        ("airflow_version", "probe_command"),
         [
             ("1.9.0", "from airflow.jobs.scheduler_job import SchedulerJob"),
             ("2.1.0", "airflow jobs check --job-type SchedulerJob --hostname $(hostname)"),
@@ -479,7 +479,7 @@ class TestScheduler:
         )
 
     @pytest.mark.parametrize(
-        "airflow_version, probe_command",
+        ("airflow_version", "probe_command"),
         [
             ("1.9.0", "from airflow.jobs.scheduler_job import SchedulerJob"),
             ("2.1.0", "airflow jobs check --job-type SchedulerJob --hostname $(hostname)"),
@@ -497,7 +497,7 @@ class TestScheduler:
         )
 
     @pytest.mark.parametrize(
-        "log_values, expected_volume",
+        ("log_values", "expected_volume"),
         [
             ({"persistence": {"enabled": False}}, {"emptyDir": {}}),
             (
@@ -638,7 +638,7 @@ class TestScheduler:
         assert volume_mount in jmespath.search("spec.template.spec.initContainers[0].volumeMounts", docs[0])
 
     @pytest.mark.parametrize(
-        "executor, persistence, update_strategy, expected_update_strategy",
+        ("executor", "persistence", "update_strategy", "expected_update_strategy"),
         [
             ("CeleryExecutor", False, {"rollingUpdate": {"partition": 0}}, None),
             ("CeleryExecutor", True, {"rollingUpdate": {"partition": 0}}, None),
@@ -678,7 +678,7 @@ class TestScheduler:
         assert expected_update_strategy == jmespath.search("spec.updateStrategy", docs[0])
 
     @pytest.mark.parametrize(
-        "executor, persistence, strategy, expected_strategy",
+        ("executor", "persistence", "strategy", "expected_strategy"),
         [
             ("LocalExecutor", False, None, None),
             ("LocalExecutor", False, {"type": "Recreate"}, {"type": "Recreate"}),
@@ -758,7 +758,7 @@ class TestScheduler:
         ]
 
     @pytest.mark.parametrize(
-        "airflow_version, dag_processor, executor, skip_dags_mount",
+        ("airflow_version", "dag_processor", "executor", "skip_dags_mount"),
         [
             # standalone dag_processor is optional on 2.10, so we can skip dags for non-local if its on
             ("2.10.4", True, "LocalExecutor", False),
@@ -912,7 +912,7 @@ class TestScheduler:
         }
 
     @pytest.mark.parametrize(
-        "scheduler_values, expected",
+        ("scheduler_values", "expected"),
         [
             ({}, 10),
             ({"scheduler": {"terminationGracePeriodSeconds": 1200}}, 1200),
@@ -955,7 +955,7 @@ class TestSchedulerService:
     """Tests scheduler service."""
 
     @pytest.mark.parametrize(
-        "executor, creates_service",
+        ("executor", "creates_service"),
         [
             ("LocalExecutor", True),
             ("CeleryExecutor", False),
@@ -996,7 +996,7 @@ class TestSchedulerService:
         assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
 
     @pytest.mark.parametrize(
-        "executor, expected_label",
+        ("executor", "expected_label"),
         [
             ("LocalExecutor", "LocalExecutor"),
             ("CeleryExecutor", "CeleryExecutor"),
@@ -1036,7 +1036,7 @@ class TestSchedulerServiceAccount:
         assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
 
     @pytest.mark.parametrize(
-        "executor, default_automount_service_account",
+        ("executor", "default_automount_service_account"),
         [
             ("LocalExecutor", None),
             ("CeleryExecutor", True),
@@ -1059,7 +1059,7 @@ class TestSchedulerServiceAccount:
         assert jmespath.search("automountServiceAccountToken", docs[0]) is default_automount_service_account
 
     @pytest.mark.parametrize(
-        "executor, automount_service_account, should_automount_service_account",
+        ("executor", "automount_service_account", "should_automount_service_account"),
         [
             ("LocalExecutor", True, None),
             ("CeleryExecutor", False, False),

--- a/helm-tests/tests/helm_tests/airflow_core/test_triggerer.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_triggerer.py
@@ -26,7 +26,7 @@ class TestTriggerer:
     """Tests triggerer."""
 
     @pytest.mark.parametrize(
-        "airflow_version, num_docs",
+        ("airflow_version", "num_docs"),
         [
             ("2.1.0", 0),
             ("2.2.0", 1),
@@ -55,7 +55,7 @@ class TestTriggerer:
         assert len(docs) == 0
 
     @pytest.mark.parametrize(
-        "revision_history_limit, global_revision_history_limit",
+        ("revision_history_limit", "global_revision_history_limit"),
         [(8, 10), (10, 8), (8, None), (None, 10), (None, None)],
     )
     def test_revision_history_limit(self, revision_history_limit, global_revision_history_limit):
@@ -438,7 +438,7 @@ class TestTriggerer:
         ]
 
     @pytest.mark.parametrize(
-        "airflow_version, probe_command",
+        ("airflow_version", "probe_command"),
         [
             ("2.4.9", "airflow jobs check --job-type TriggererJob --hostname $(hostname)"),
             ("2.5.0", "airflow jobs check --job-type TriggererJob --local"),
@@ -455,7 +455,7 @@ class TestTriggerer:
         )
 
     @pytest.mark.parametrize(
-        "log_values, expected_volume",
+        ("log_values", "expected_volume"),
         [
             ({"persistence": {"enabled": False}}, {"emptyDir": {}}),
             (
@@ -525,7 +525,7 @@ class TestTriggerer:
         assert jmespath.search("spec.template.spec.containers[0].resources", docs[0]) == {}
 
     @pytest.mark.parametrize(
-        "persistence, update_strategy, expected_update_strategy",
+        ("persistence", "update_strategy", "expected_update_strategy"),
         [
             (False, None, None),
             (True, {"rollingUpdate": {"partition": 0}}, {"rollingUpdate": {"partition": 0}}),
@@ -548,7 +548,7 @@ class TestTriggerer:
         assert expected_update_strategy == jmespath.search("spec.updateStrategy", docs[0])
 
     @pytest.mark.parametrize(
-        "persistence, strategy, expected_strategy",
+        ("persistence", "strategy", "expected_strategy"),
         [
             (True, None, None),
             (
@@ -797,7 +797,7 @@ class TestTriggererKedaAutoScaler:
         assert jmespath.search("spec.scaleTargetRef.envSourceContainerName", docs[0]) == "triggerer"
 
     @pytest.mark.parametrize(
-        "query, expected_query",
+        ("query", "expected_query"),
         [
             # default query
             (

--- a/helm-tests/tests/helm_tests/airflow_core/test_worker.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_worker.py
@@ -26,7 +26,7 @@ class TestWorker:
     """Tests worker."""
 
     @pytest.mark.parametrize(
-        "executor, persistence, kind",
+        ("executor", "persistence", "kind"),
         [
             ("CeleryExecutor", False, "Deployment"),
             ("CeleryExecutor", True, "StatefulSet"),
@@ -47,7 +47,7 @@ class TestWorker:
         assert kind == jmespath.search("kind", docs[0])
 
     @pytest.mark.parametrize(
-        "revision_history_limit, global_revision_history_limit",
+        ("revision_history_limit", "global_revision_history_limit"),
         [(8, 10), (10, 8), (8, None), (None, 10), (None, None)],
     )
     def test_revision_history_limit(self, revision_history_limit, global_revision_history_limit):
@@ -272,7 +272,7 @@ class TestWorker:
         assert jmespath.search("spec.template.spec.hostAliases[0].hostnames[0]", docs[0]) == "test.hostname"
 
     @pytest.mark.parametrize(
-        "persistence, update_strategy, expected_update_strategy",
+        ("persistence", "update_strategy", "expected_update_strategy"),
         [
             (False, None, None),
             (True, {"rollingUpdate": {"partition": 0}}, {"rollingUpdate": {"partition": 0}}),
@@ -294,7 +294,7 @@ class TestWorker:
         assert expected_update_strategy == jmespath.search("spec.updateStrategy", docs[0])
 
     @pytest.mark.parametrize(
-        "persistence, strategy, expected_strategy",
+        ("persistence", "strategy", "expected_strategy"),
         [
             (True, None, None),
             (
@@ -447,7 +447,7 @@ class TestWorker:
         )
 
     @pytest.mark.parametrize(
-        "base_scheduler_name, worker_scheduler_name, expected",
+        ("base_scheduler_name", "worker_scheduler_name", "expected"),
         [
             ("default-scheduler", "most-allocated", "most-allocated"),
             ("default-scheduler", None, "default-scheduler"),
@@ -491,7 +491,7 @@ class TestWorker:
         assert jmespath.search("spec.template.spec.runtimeClassName", docs[0]) == "nvidia"
 
     @pytest.mark.parametrize(
-        "airflow_version, default_cmd",
+        ("airflow_version", "default_cmd"),
         [
             ("2.7.0", "airflow.providers.celery.executors.celery_executor.app"),
             ("2.6.3", "airflow.executors.celery_executor.app"),
@@ -565,7 +565,7 @@ class TestWorker:
         assert jmespath.search("spec.template.spec.initContainers[1].restartPolicy", docs[0]) == "Always"
 
     @pytest.mark.parametrize(
-        "log_values, expected_volume",
+        ("log_values", "expected_volume"),
         [
             ({"persistence": {"enabled": False}}, {"emptyDir": {}}),
             (
@@ -675,7 +675,7 @@ class TestWorker:
         } in jmespath.search("spec.template.spec.containers[2].volumeMounts", docs[0])
 
     @pytest.mark.parametrize(
-        "airflow_version, init_container_enabled, expected_init_containers",
+        ("airflow_version", "init_container_enabled", "expected_init_containers"),
         [
             ("1.9.0", True, 2),
             ("1.9.0", False, 2),
@@ -711,7 +711,7 @@ class TestWorker:
             assert initContainers[1]["args"] == ["kerberos", "-o"]
 
     @pytest.mark.parametrize(
-        "airflow_version, expected_arg",
+        ("airflow_version", "expected_arg"),
         [
             ("1.9.0", "airflow worker"),
             ("1.10.14", "airflow worker"),
@@ -799,7 +799,7 @@ class TestWorker:
         assert jmespath.search("metadata.annotations", docs[0])["test_annotation"] == "test_annotation_value"
 
     @pytest.mark.parametrize(
-        "globalScope, localScope, precedence",
+        ("globalScope", "localScope", "precedence"),
         [
             ({}, {}, "false"),
             ({}, {"safeToEvict": True}, "true"),
@@ -986,7 +986,7 @@ class TestWorker:
         )
 
     @pytest.mark.parametrize(
-        "globalScope, localScope, precedence",
+        ("globalScope", "localScope", "precedence"),
         [
             ({"scope": "global"}, {"podAnnotations": {}}, "global"),
             ({}, {"podAnnotations": {"scope": "local"}}, "local"),
@@ -1054,7 +1054,7 @@ class TestWorkerKedaAutoScaler:
         assert "replicas" not in jmespath.search("spec", docs[0])
 
     @pytest.mark.parametrize(
-        "query, executor, expected_query",
+        ("query", "executor", "expected_query"),
         [
             # default query with CeleryExecutor
             (
@@ -1164,7 +1164,7 @@ class TestWorkerHPAAutoScaler:
         assert "replicas" not in jmespath.search("spec", docs[0])
 
     @pytest.mark.parametrize(
-        "metrics, executor, expected_metrics",
+        ("metrics", "executor", "expected_metrics"),
         [
             # default metrics
             (
@@ -1275,7 +1275,7 @@ class TestWorkerServiceAccount:
         ],
     )
     @pytest.mark.parametrize(
-        "workers_values, obj",
+        ("workers_values", "obj"),
         [
             ({"serviceAccount": {"create": True}}, "worker"),
             (
@@ -1310,7 +1310,7 @@ class TestWorkerServiceAccount:
         ],
     )
     @pytest.mark.parametrize(
-        "workers_values, obj",
+        ("workers_values", "obj"),
         [
             ({"serviceAccount": {"create": True}}, "worker"),
             (
@@ -1388,7 +1388,7 @@ class TestWorkerServiceAccount:
         assert jmespath.search("automountServiceAccountToken", docs[0]) is True
 
     @pytest.mark.parametrize(
-        "workers_values, obj",
+        ("workers_values", "obj"),
         [
             (
                 {"useWorkerDedicatedServiceAccounts": True, "celery": {"serviceAccount": {"create": True}}},
@@ -1415,7 +1415,7 @@ class TestWorkerServiceAccount:
         assert jmespath.search("automountServiceAccountToken", docs[0]) is True
 
     @pytest.mark.parametrize(
-        "workers_values, obj",
+        ("workers_values", "obj"),
         [
             ({"serviceAccount": {"create": True, "automountServiceAccountToken": False}}, "worker"),
             (

--- a/helm-tests/tests/helm_tests/apiserver/test_ingress_apiserver.py
+++ b/helm-tests/tests/helm_tests/apiserver/test_ingress_apiserver.py
@@ -146,7 +146,7 @@ class TestIngressAPIServer:
         assert not jmespath.search("spec.rules[*].host", docs[0])
 
     @pytest.mark.parametrize(
-        "global_value, api_server_value, expected",
+        ("global_value", "api_server_value", "expected"),
         [
             (None, None, False),
             (None, False, False),

--- a/helm-tests/tests/helm_tests/webserver/test_hpa_webserver.py
+++ b/helm-tests/tests/helm_tests/webserver/test_hpa_webserver.py
@@ -48,7 +48,7 @@ class TestWebserverHPA:
         assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
 
     @pytest.mark.parametrize(
-        "min_replicas, max_replicas",
+        ("min_replicas", "max_replicas"),
         [
             (None, None),
             (2, 8),
@@ -95,7 +95,7 @@ class TestWebserverHPA:
         assert jmespath.search("spec.behavior", docs[0]) == expected_behavior
 
     @pytest.mark.parametrize(
-        "metrics, expected_metrics",
+        ("metrics", "expected_metrics"),
         [
             # default metrics
             (

--- a/helm-tests/tests/helm_tests/webserver/test_ingress_flower.py
+++ b/helm-tests/tests/helm_tests/webserver/test_ingress_flower.py
@@ -142,7 +142,7 @@ class TestIngressFlower:
         assert not jmespath.search("spec.rules[*].host", docs[0])
 
     @pytest.mark.parametrize(
-        "global_value, flower_value, expected",
+        ("global_value", "flower_value", "expected"),
         [
             (None, None, False),
             (None, False, False),

--- a/helm-tests/tests/helm_tests/webserver/test_ingress_web.py
+++ b/helm-tests/tests/helm_tests/webserver/test_ingress_web.py
@@ -146,7 +146,7 @@ class TestIngressWeb:
         assert not jmespath.search("spec.rules[*].host", docs[0])
 
     @pytest.mark.parametrize(
-        "global_value, web_value, expected",
+        ("global_value", "web_value", "expected"),
         [
             (None, None, False),
             (None, False, False),

--- a/helm-tests/tests/helm_tests/webserver/test_webserver.py
+++ b/helm-tests/tests/helm_tests/webserver/test_webserver.py
@@ -120,7 +120,7 @@ class TestWebserverDeployment:
         )
 
     @pytest.mark.parametrize(
-        "revision_history_limit, global_revision_history_limit",
+        ("revision_history_limit", "global_revision_history_limit"),
         [(8, 10), (10, 8), (8, None), (None, 10), (None, None)],
     )
     def test_revision_history_limit(self, revision_history_limit, global_revision_history_limit):
@@ -354,7 +354,7 @@ class TestWebserverDeployment:
         )
 
     @pytest.mark.parametrize(
-        "airflow_version, expected_arg",
+        ("airflow_version", "expected_arg"),
         [
             ("2.0.0", ["airflow", "db", "check-migrations", "--migration-wait-timeout=60"]),
             ("2.1.0", ["airflow", "db", "check-migrations", "--migration-wait-timeout=60"]),
@@ -578,7 +578,7 @@ class TestWebserverDeployment:
         )
 
     @pytest.mark.parametrize(
-        "log_persistence_values, expected_claim_name",
+        ("log_persistence_values", "expected_claim_name"),
         [
             ({"enabled": False}, None),
             ({"enabled": True}, "release-name-logs"),
@@ -607,7 +607,7 @@ class TestWebserverDeployment:
             ]
 
     @pytest.mark.parametrize(
-        "af_version, pod_template_file_expected",
+        ("af_version", "pod_template_file_expected"),
         [
             ("1.10.10", False),
             ("1.10.12", True),
@@ -741,7 +741,7 @@ class TestWebserverDeployment:
         assert jmespath.search("spec.template.spec.initContainers[0].resources", docs[0]) == {}
 
     @pytest.mark.parametrize(
-        "airflow_version, expected_strategy",
+        ("airflow_version", "expected_strategy"),
         [
             ("2.0.2", {"type": "RollingUpdate", "rollingUpdate": {"maxSurge": 1, "maxUnavailable": 0}}),
             ("1.10.14", {"type": "Recreate"}),
@@ -826,7 +826,7 @@ class TestWebserverDeployment:
         assert jmespath.search("spec.template.spec.containers[0].args", docs[0]) == ["Helm"]
 
     @pytest.mark.parametrize(
-        "airflow_version, dag_values",
+        ("airflow_version", "dag_values"),
         [
             ("1.10.15", {"gitSync": {"enabled": False}}),
             ("1.10.15", {"persistence": {"enabled": False}}),
@@ -851,7 +851,7 @@ class TestWebserverDeployment:
         assert len(jmespath.search("spec.template.spec.containers", docs[0])) == 1
 
     @pytest.mark.parametrize(
-        "airflow_version, dag_values, expected_read_only",
+        ("airflow_version", "dag_values", "expected_read_only"),
         [
             ("1.10.15", {"gitSync": {"enabled": True}}, True),
             ("1.10.15", {"persistence": {"enabled": True}}, False),
@@ -883,7 +883,7 @@ class TestWebserverDeployment:
         ]
 
     @pytest.mark.parametrize(
-        "dags_values, expected_claim_name",
+        ("dags_values", "expected_claim_name"),
         [
             ({"persistence": {"enabled": True}}, "release-name-dags"),
             ({"persistence": {"enabled": True, "existingClaim": "test-claim"}}, "test-claim"),
@@ -947,7 +947,7 @@ class TestWebserverDeployment:
         assert jmespath.search("metadata.annotations", docs[0])["test_annotation"] == "test_annotation_value"
 
     @pytest.mark.parametrize(
-        "webserver_values, expected",
+        ("webserver_values", "expected"),
         [
             ({"airflowVersion": "2.10.5"}, 30),
             ({"airflowVersion": "2.10.5", "webserver": {"terminationGracePeriodSeconds": 1200}}, 1200),
@@ -1004,7 +1004,7 @@ class TestWebserverService:
         assert jmespath.search("spec.loadBalancerSourceRanges", docs[0]) == ["10.123.0.0/16"]
 
     @pytest.mark.parametrize(
-        "ports, expected_ports",
+        ("ports", "expected_ports"),
         [
             ([{"port": 8888}], [{"port": 8888}]),  # name is optional with a single port
             (
@@ -1049,7 +1049,7 @@ class TestWebserverService:
         assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
 
     @pytest.mark.parametrize(
-        "ports, expected_ports",
+        ("ports", "expected_ports"),
         [
             (
                 [{"nodePort": "31000", "port": "8080"}],
@@ -1145,7 +1145,7 @@ class TestWebserverNetworkPolicy:
         assert jmespath.search("spec.ingress[0].ports", docs[0]) == [{"port": 8080}]
 
     @pytest.mark.parametrize(
-        "ports, expected_ports",
+        ("ports", "expected_ports"),
         [
             ([{"port": "sidecar"}], [{"port": "sidecar"}]),
             (


### PR DESCRIPTION
Issue: Enable Even More PyDocStyle Checks https://github.com/apache/airflow/issues/40567
@ferruzzi

This PR is for enable PT006 rule:
PT011: all instances of @pytest.mark.parametrize names should be a tuple
https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/
There are a lot of file changes needed.
So, I separate to many PR, which contain about 12 file changes for easy review.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
