### PR TITLE
Enable PT006 rule to task-sdk tests

### DIFF
--- a/task-sdk/tests/task_sdk/definitions/test_dag.py
+++ b/task-sdk/tests/task_sdk/definitions/test_dag.py
@@ -535,8 +535,8 @@ class TestDagDecorator:
         assert dag.dag_id == "noop_pipeline"
 
     @pytest.mark.parametrize(
-        argnames=("dag_doc_md", "expected_doc_md"),
-        argvalues=[
+        ("dag_doc_md", "expected_doc_md"),
+        [
             pytest.param("dag docs.", "dag docs.", id="use_dag_doc_md"),
             pytest.param(None, "Regular Dag documentation", id="use_dag_docstring"),
         ],

--- a/task-sdk/tests/task_sdk/definitions/test_dag.py
+++ b/task-sdk/tests/task_sdk/definitions/test_dag.py
@@ -36,7 +36,7 @@ DEFAULT_DATE = datetime(2016, 1, 1, tzinfo=timezone.utc)
 
 class TestDag:
     @pytest.mark.parametrize(
-        "dag_id, exc_type, exc_value",
+        ("dag_id", "exc_type", "exc_value"),
         [
             pytest.param(
                 123,
@@ -397,7 +397,7 @@ class TestDag:
 
 # Test some of the arg validation. This is not all the validations we perform, just some of them.
 @pytest.mark.parametrize(
-    ["attr", "value"],
+    ("attr", "value"),
     [
         pytest.param("max_consecutive_failed_dag_runs", "not_an_int", id="max_consecutive_failed_dag_runs"),
         pytest.param("dagrun_timeout", "not_an_int", id="dagrun_timeout"),
@@ -410,7 +410,7 @@ def test_invalid_type_for_args(attr: str, value: Any):
 
 
 @pytest.mark.parametrize(
-    "tags, should_pass",
+    ("tags", "should_pass"),
     [
         pytest.param([], True, id="empty tags"),
         pytest.param(["a normal tag"], True, id="one tag"),
@@ -428,7 +428,7 @@ def test__tags_length(tags: list[str], should_pass: bool):
 
 
 @pytest.mark.parametrize(
-    "input_tags, expected_result",
+    ("input_tags", "expected_result"),
     [
         pytest.param([], set(), id="empty tags"),
         pytest.param(
@@ -535,7 +535,7 @@ class TestDagDecorator:
         assert dag.dag_id == "noop_pipeline"
 
     @pytest.mark.parametrize(
-        argnames=["dag_doc_md", "expected_doc_md"],
+        argnames=("dag_doc_md", "expected_doc_md"),
         argvalues=[
             pytest.param("dag docs.", "dag docs.", id="use_dag_doc_md"),
             pytest.param(None, "Regular Dag documentation", id="use_dag_docstring"),

--- a/task-sdk/tests/task_sdk/definitions/test_deadline.py
+++ b/task-sdk/tests/task_sdk/definitions/test_deadline.py
@@ -62,7 +62,7 @@ TEST_DEADLINE_CALLBACK = AsyncCallback(TEST_CALLBACK_PATH, kwargs=TEST_CALLBACK_
 
 class TestDeadlineAlert:
     @pytest.mark.parametrize(
-        "test_alert, should_equal",
+        ("test_alert", "should_equal"),
         [
             pytest.param(
                 DeadlineAlert(
@@ -170,7 +170,7 @@ class TestDeadlineAlert:
 
 class TestCallback:
     @pytest.mark.parametrize(
-        "subclass, callable",
+        ("subclass", "callable"),
         [
             pytest.param(AsyncCallback, empty_async_callback_for_deadline_tests, id="async"),
             pytest.param(SyncCallback, empty_sync_callback_for_deadline_tests, id="sync"),
@@ -181,7 +181,7 @@ class TestCallback:
             subclass(callable, {"context": None})
 
     @pytest.mark.parametrize(
-        "callback_callable, expected_path",
+        ("callback_callable", "expected_path"),
         [
             pytest.param(
                 empty_sync_callback_for_deadline_tests,
@@ -207,7 +207,7 @@ class TestCallback:
             assert path == expected_path
 
     @pytest.mark.parametrize(
-        "callback_callable, error_type",
+        ("callback_callable", "error_type"),
         [
             pytest.param(42, ImportError, id="not_a_string"),
             pytest.param("", ImportError, id="empty_string"),
@@ -225,7 +225,7 @@ class TestCallback:
             Callback.get_callback_path(callback_callable)
 
     @pytest.mark.parametrize(
-        "callback1_args, callback2_args, should_equal",
+        ("callback1_args", "callback2_args", "should_equal"),
         [
             pytest.param(
                 (TEST_CALLBACK_PATH, TEST_CALLBACK_KWARGS),
@@ -254,7 +254,7 @@ class TestCallback:
         assert (callback1 == callback2) == should_equal
 
     @pytest.mark.parametrize(
-        "callback_class, args1, args2, should_be_same_hash",
+        ("callback_class", "args1", "args2", "should_be_same_hash"),
         [
             pytest.param(
                 AsyncCallback,
@@ -301,7 +301,7 @@ class TestCallback:
 
 class TestAsyncCallback:
     @pytest.mark.parametrize(
-        "callback_callable, kwargs, expected_path",
+        ("callback_callable", "kwargs", "expected_path"),
         [
             pytest.param(
                 empty_async_callback_for_deadline_tests,
@@ -334,7 +334,7 @@ class TestAsyncCallback:
 
 class TestSyncCallback:
     @pytest.mark.parametrize(
-        "callback_callable, executor",
+        ("callback_callable", "executor"),
         [
             pytest.param(empty_sync_callback_for_deadline_tests, "remote", id="with_executor"),
             pytest.param(empty_sync_callback_for_deadline_tests, None, id="without_executor"),

--- a/task-sdk/tests/task_sdk/definitions/test_macros.py
+++ b/task-sdk/tests/task_sdk/definitions/test_macros.py
@@ -27,7 +27,7 @@ from airflow.sdk.execution_time import macros
 
 
 @pytest.mark.parametrize(
-    "ds, days, expected",
+    ("ds", "days", "expected"),
     [
         ("2015-01-01", 5, "2015-01-06"),
         ("2015-01-02", 0, "2015-01-02"),
@@ -43,7 +43,7 @@ def test_ds_add(ds, days, expected):
 
 
 @pytest.mark.parametrize(
-    "ds, input_format, output_format, expected",
+    ("ds", "input_format", "output_format", "expected"),
     [
         ("2015-01-02", "%Y-%m-%d", "%m-%d-%y", "01-02-15"),
         ("2015-01-02", "%Y-%m-%d", "%Y-%m-%d", "2015-01-02"),
@@ -61,7 +61,7 @@ def test_ds_format(ds, input_format, output_format, expected):
 
 
 @pytest.mark.parametrize(
-    "input_value, expected",
+    ("input_value", "expected"),
     [
         ('{"field1":"value1", "field2":4, "field3":true}', {"field1": "value1", "field2": 4, "field3": True}),
         (
@@ -76,7 +76,7 @@ def test_json_loads(input_value, expected):
 
 
 @pytest.mark.parametrize(
-    "ds, input_format, output_format, locale, expected",
+    ("ds", "input_format", "output_format", "locale", "expected"),
     [
         ("2015-01-02", "%Y-%m-%d", "MM-dd-yy", None, "01-02-15"),
         ("2015-01-02", "%Y-%m-%d", "yyyy-MM-dd", None, "2015-01-02"),
@@ -96,7 +96,7 @@ def test_ds_format_locale(ds, input_format, output_format, locale, expected):
 
 
 @pytest.mark.parametrize(
-    "dt, since, expected",
+    ("dt", "since", "expected"),
     [
         (
             pendulum.datetime(2017, 1, 2),
@@ -128,7 +128,7 @@ def test_datetime_diff_for_humans(dt, since, expected):
 
 
 @pytest.mark.parametrize(
-    "input_value, expected",
+    ("input_value", "expected"),
     [
         ('{"field1":"value1", "field2":4, "field3":true}', {"field1": "value1", "field2": 4, "field3": True}),
         ("field1: value1\nfield2: value2", {"field1": "value1", "field2": "value2"}),

--- a/task-sdk/tests/task_sdk/definitions/test_mappedoperator.py
+++ b/task-sdk/tests/task_sdk/definitions/test_mappedoperator.py
@@ -536,7 +536,7 @@ def test_find_mapped_dependants_in_another_group():
 
 
 @pytest.mark.parametrize(
-    "partial_params, mapped_params, expected",
+    ("partial_params", "mapped_params", "expected"),
     [
         pytest.param(None, [{"a": 1}], [{"a": 1}], id="simple"),
         pytest.param({"b": 2}, [{"a": 1}], [{"a": 1, "b": 2}], id="merge"),

--- a/task-sdk/tests/task_sdk/definitions/test_mixins.py
+++ b/task-sdk/tests/task_sdk/definitions/test_mixins.py
@@ -68,7 +68,7 @@ def make_task(name, type_, setup_=False, teardown_=False):
 
 
 @pytest.mark.parametrize(
-    "setup_type, work_type, teardown_type", itertools.product(["classic", "taskflow"], repeat=3)
+    ("setup_type", "work_type", "teardown_type"), itertools.product(["classic", "taskflow"], repeat=3)
 )
 def test_as_teardown(setup_type, work_type, teardown_type):
     """
@@ -101,7 +101,7 @@ def test_as_teardown(setup_type, work_type, teardown_type):
 
 
 @pytest.mark.parametrize(
-    "setup_type, work_type, teardown_type", itertools.product(["classic", "taskflow"], repeat=3)
+    ("setup_type", "work_type", "teardown_type"), itertools.product(["classic", "taskflow"], repeat=3)
 )
 def test_as_teardown_oneline(setup_type, work_type, teardown_type):
     """

--- a/task-sdk/tests/task_sdk/definitions/test_module_loading.py
+++ b/task-sdk/tests/task_sdk/definitions/test_module_loading.py
@@ -23,7 +23,7 @@ from airflow.sdk.module_loading import is_valid_dotpath
 
 class TestModuleLoading:
     @pytest.mark.parametrize(
-        "path, expected",
+        ("path", "expected"),
         [
             pytest.param("valid_path", True, id="module_no_dots"),
             pytest.param("valid.dot.path", True, id="standard_dotpath"),

--- a/task-sdk/tests/task_sdk/definitions/test_param.py
+++ b/task-sdk/tests/task_sdk/definitions/test_param.py
@@ -237,7 +237,7 @@ class TestParam:
         assert restored_param.schema == param.schema
 
     @pytest.mark.parametrize(
-        "default, should_raise",
+        ("default", "should_raise"),
         [
             pytest.param({0, 1, 2}, True, id="default-non-JSON-serializable"),
             pytest.param(None, False, id="default-None"),  # Param init should not warn

--- a/task-sdk/tests/task_sdk/definitions/test_taskgroup.py
+++ b/task-sdk/tests/task_sdk/definitions/test_taskgroup.py
@@ -40,7 +40,7 @@ DEFAULT_DATE = timezone.datetime(2025, 1, 1)
 
 class TestTaskGroup:
     @pytest.mark.parametrize(
-        "group_id, exc_type, exc_value",
+        ("group_id", "exc_type", "exc_value"),
         [
             pytest.param(
                 123,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
Issue: Enable Even More PyDocStyle Checks #40567
@ferruzzi

This PR is for enable PT006 rule:
PT006: all instances of @pytest.mark.parametrize names should be a tuple
https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/
There are a lot of file changes needed.
So, I separate to many PR, which contain about 5-10 file changes for easy review.

**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
