### PR TITLE
Enable PT006 rule to task-sdk tests

### DIFF
--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -62,7 +62,7 @@ if TYPE_CHECKING:
 
 class TestClient:
     @pytest.mark.parametrize(
-        ["path", "json_response"],
+        ("path", "json_response"),
         [
             (
                 "/task-instances/1/run",
@@ -249,7 +249,7 @@ class TestClient:
         assert response.request.headers["Authorization"] == "Bearer abc"
 
     @pytest.mark.parametrize(
-        ["status_code", "description"],
+        ("status_code", "description"),
         [
             (399, "status code < 400"),
             (301, "3xx redirect status code"),

--- a/task-sdk/tests/task_sdk/bases/test_operator.py
+++ b/task-sdk/tests/task_sdk/bases/test_operator.py
@@ -711,7 +711,7 @@ class TestBaseOperator:
         task.render_template_fields({})
         assert task.arg2 == "foo_barbarbar"
 
-    @pytest.mark.parametrize(("content",), [(object(),), (uuid.uuid4(),)])
+    @pytest.mark.parametrize("content", [object(), uuid.uuid4()])
     def test_render_template_fields_no_change(self, content):
         """Tests if non-templatable types remain unchanged."""
         task = BaseOperator(task_id="op1")

--- a/task-sdk/tests/task_sdk/bases/test_sensor.py
+++ b/task-sdk/tests/task_sdk/bases/test_sensor.py
@@ -666,7 +666,7 @@ class TestPokeModeOnly:
 
 class TestAsyncSensor:
     @pytest.mark.parametrize(
-        "soft_fail, expected_exception",
+        ("soft_fail", "expected_exception"),
         [
             (True, AirflowSkipException),
             (False, AirflowException),

--- a/task-sdk/tests/task_sdk/definitions/_internal/test_decorators.py
+++ b/task-sdk/tests/task_sdk/definitions/_internal/test_decorators.py
@@ -25,7 +25,7 @@ from airflow.sdk.definitions._internal.decorators import remove_task_decorator
 
 class TestExternalPythonDecorator:
     @pytest.mark.parametrize(
-        "decorators, expected_decorators",
+        ("decorators", "expected_decorators"),
         [
             (["@task.external_python"], []),
             (["@task.external_python()"], []),

--- a/task-sdk/tests/task_sdk/definitions/_internal/test_templater.py
+++ b/task-sdk/tests/task_sdk/definitions/_internal/test_templater.py
@@ -110,7 +110,7 @@ def test_private_access(env):
 
 
 @pytest.mark.parametrize(
-    ["name", "expected"],
+    ("name", "expected"),
     (
         ("ds", "2012-07-24"),
         ("ds_nodash", "20120724"),

--- a/task-sdk/tests/task_sdk/definitions/test_asset.py
+++ b/task-sdk/tests/task_sdk/definitions/test_asset.py
@@ -46,7 +46,7 @@ ASSET_MODULE_PATH = "airflow.sdk.definitions.asset"
 
 
 @pytest.mark.parametrize(
-    "sql_conn_value, name, should_raise",
+    ("sql_conn_value", "name", "should_raise"),
     [
         pytest.param("mysql://localhost/db", "", True, id="mysql-empty"),
         pytest.param("mysql://localhost/db", "\n\t", True, id="mysql-whitespace"),
@@ -72,7 +72,7 @@ def test_invalid_names(sql_conn_value, name, should_raise, monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "sql_conn_value, uri, should_raise",
+    ("sql_conn_value", "uri", "should_raise"),
     [
         pytest.param("mysql://localhost/db", "", True, id="mysql-empty"),
         pytest.param("mysql://localhost/db", "\n\t", True, id="mysql-whitespace"),
@@ -128,7 +128,7 @@ def test_both_name_and_uri():
 
 
 @pytest.mark.parametrize(
-    "uri, normalized",
+    ("uri", "normalized"),
     [
         pytest.param("foobar", "foobar", id="scheme-less"),
         pytest.param("foo:bar", "foo:bar", id="scheme-less-colon"),
@@ -319,14 +319,14 @@ test_cases = [
 ]
 
 
-@pytest.mark.parametrize("expression, expected", test_cases)
+@pytest.mark.parametrize(("expression", "expected"), test_cases)
 def test_evaluate_assets_expression(expression, expected):
     expr = expression()
     assert assets_equal(expr, expected)
 
 
 @pytest.mark.parametrize(
-    "expression, error",
+    ("expression", "error"),
     [
         pytest.param(
             lambda: asset1 & 1,  # type: ignore[operator]
@@ -433,7 +433,7 @@ class TestAssetUniqueKey:
         )
 
     @pytest.mark.parametrize(
-        "name, uri, expected_asset_unique_key",
+        ("name", "uri", "expected_asset_unique_key"),
         [
             ("test", None, AssetUniqueKey(name="test", uri="test")),
             (None, "test://test/", AssetUniqueKey(name="test://test/", uri="test://test/")),
@@ -452,21 +452,21 @@ class TestAssetAlias:
 
 
 class TestAssetSubclasses:
-    @pytest.mark.parametrize("subcls, group", ((Model, "model"), (Dataset, "dataset")))
+    @pytest.mark.parametrize(("subcls", "group"), ((Model, "model"), (Dataset, "dataset")))
     def test_only_name(self, subcls, group):
         obj = subcls(name="foobar")
         assert obj.name == "foobar"
         assert obj.uri == "foobar"
         assert obj.group == group
 
-    @pytest.mark.parametrize("subcls, group", ((Model, "model"), (Dataset, "dataset")))
+    @pytest.mark.parametrize(("subcls", "group"), ((Model, "model"), (Dataset, "dataset")))
     def test_only_uri(self, subcls, group):
         obj = subcls(uri="s3://bucket/key/path")
         assert obj.name == "s3://bucket/key/path"
         assert obj.uri == "s3://bucket/key/path"
         assert obj.group == group
 
-    @pytest.mark.parametrize("subcls, group", ((Model, "model"), (Dataset, "dataset")))
+    @pytest.mark.parametrize(("subcls", "group"), ((Model, "model"), (Dataset, "dataset")))
     def test_both_name_and_uri(self, subcls, group):
         obj = subcls("foobar", "s3://bucket/key/path")
         assert obj.name == "foobar"
@@ -474,7 +474,7 @@ class TestAssetSubclasses:
         assert obj.group == group
 
     @pytest.mark.parametrize("arg", ["foobar", "s3://bucket/key/path"])
-    @pytest.mark.parametrize("subcls, group", ((Model, "model"), (Dataset, "dataset")))
+    @pytest.mark.parametrize(("subcls", "group"), ((Model, "model"), (Dataset, "dataset")))
     def test_only_posarg(self, subcls, group, arg):
         obj = subcls(arg)
         assert obj.name == arg

--- a/task-sdk/tests/task_sdk/definitions/test_asset_decorators.py
+++ b/task-sdk/tests/task_sdk/definitions/test_asset_decorators.py
@@ -179,7 +179,7 @@ class TestAssetDecorator:
         assert err.value.args[0] == "@task decorator with 'outlets' argument is not supported in @asset"
 
     @pytest.mark.parametrize(
-        "provided_uri, expected_uri",
+        ("provided_uri", "expected_uri"),
         [
             pytest.param(None, "custom", id="default-uri"),
             pytest.param("s3://bucket/object", "s3://bucket/object", id="custom-uri"),


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
Issue: Enable Even More PyDocStyle Checks #40567
@ferruzzi

This PR is for enable PT006 rule:
PT006: all instances of @pytest.mark.parametrize names should be a tuple
https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/
There are a lot of file changes needed.
So, I separate to many PR, which contain about 5-10 file changes for easy review.
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
