### PR TITLE
Use `Iterable` instead of list in API responses

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/assets.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from datetime import datetime
 
 from pydantic import AliasPath, ConfigDict, Field, JsonValue, NonNegativeInt, field_validator
@@ -107,7 +108,7 @@ class AssetAliasResponse(BaseModel):
 class AssetAliasCollectionResponse(BaseModel):
     """Asset alias collection response."""
 
-    asset_aliases: list[AssetAliasResponse]
+    asset_aliases: Iterable[AssetAliasResponse]
     total_entries: int
 
 
@@ -149,7 +150,7 @@ class AssetEventResponse(BaseModel):
 class AssetEventCollectionResponse(BaseModel):
     """Asset event collection response."""
 
-    asset_events: list[AssetEventResponse]
+    asset_events: Iterable[AssetEventResponse]
     total_entries: int
 
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/backfills.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/backfills.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from datetime import datetime
 
 from pydantic import AliasPath, Field, NonNegativeInt
@@ -57,7 +58,7 @@ class BackfillResponse(BaseModel):
 class BackfillCollectionResponse(BaseModel):
     """Backfill Collection serializer for responses."""
 
-    backfills: list[BackfillResponse]
+    backfills: Iterable[BackfillResponse]
     total_entries: int
 
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 from collections import abc
+from collections.abc import Iterable
 from typing import Annotated
 
 from pydantic import Field, field_validator
@@ -66,7 +67,7 @@ class ConnectionResponse(BaseModel):
 class ConnectionCollectionResponse(BaseModel):
     """Connection Collection serializer for responses."""
 
-    connections: list[ConnectionResponse]
+    connections: Iterable[ConnectionResponse]
     total_entries: int
 
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING
@@ -88,7 +89,7 @@ class DAGRunResponse(BaseModel):
 class DAGRunCollectionResponse(BaseModel):
     """DAG Run Collection serializer for responses."""
 
-    dag_runs: list[DAGRunResponse]
+    dag_runs: Iterable[DAGRunResponse]
     total_entries: int
 
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_versions.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_versions.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+from collections.abc import Iterable
 from datetime import datetime
 from uuid import UUID
 
@@ -41,5 +42,5 @@ class DagVersionResponse(BaseModel):
 class DAGVersionCollectionResponse(BaseModel):
     """DAG Version Collection serializer for responses."""
 
-    dag_versions: list[DagVersionResponse]
+    dag_versions: Iterable[DagVersionResponse]
     total_entries: int

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_warning.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_warning.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from datetime import datetime
 
 from pydantic import AliasPath, Field
@@ -38,5 +39,5 @@ class DAGWarningResponse(BaseModel):
 class DAGWarningCollectionResponse(BaseModel):
     """DAG warning collection serializer for responses."""
 
-    dag_warnings: list[DAGWarningResponse]
+    dag_warnings: Iterable[DAGWarningResponse]
     total_entries: int

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dags.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import inspect
 from collections import abc
+from collections.abc import Iterable
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
@@ -127,7 +128,7 @@ class DAGPatchBody(StrictBaseModel):
 class DAGCollectionResponse(BaseModel):
     """DAG Collection serializer for responses."""
 
-    dags: list[DAGResponse]
+    dags: Iterable[DAGResponse]
     total_entries: int
 
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/event_logs.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/event_logs.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from datetime import datetime
 
 from pydantic import AliasPath, Field
@@ -49,5 +50,5 @@ class EventLogResponse(BaseModel):
 class EventLogCollectionResponse(BaseModel):
     """Event Log Collection Response."""
 
-    event_logs: list[EventLogResponse]
+    event_logs: Iterable[EventLogResponse]
     total_entries: int

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/hitl.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/hitl.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from datetime import datetime
 from typing import Any
 
@@ -86,5 +86,5 @@ class HITLDetail(BaseHITLDetail):
 class HITLDetailCollection(BaseModel):
     """Schema for a collection of Human-in-the-loop details."""
 
-    hitl_details: list[HITLDetail]
+    hitl_details: Iterable[HITLDetail]
     total_entries: int

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/import_error.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/import_error.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+from collections.abc import Iterable
 from datetime import datetime
 
 from pydantic import Field
@@ -36,5 +37,5 @@ class ImportErrorResponse(BaseModel):
 class ImportErrorCollectionResponse(BaseModel):
     """Import Error Collection Response."""
 
-    import_errors: list[ImportErrorResponse]
+    import_errors: Iterable[ImportErrorResponse]
     total_entries: int

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/job.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/job.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+from collections.abc import Iterable
 from datetime import datetime
 
 from pydantic import AliasPath, Field
@@ -44,5 +45,5 @@ class JobResponse(BaseModel):
 class JobCollectionResponse(BaseModel):
     """Job Collection Response."""
 
-    jobs: list[JobResponse]
+    jobs: Iterable[JobResponse]
     total_entries: int

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/pools.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/pools.py
@@ -17,7 +17,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from typing import Annotated
 
 from pydantic import BeforeValidator, Field
@@ -57,7 +57,7 @@ class PoolResponse(BasePool):
 class PoolCollectionResponse(BaseModel):
     """Pool Collection serializer for responses."""
 
-    pools: list[PoolResponse]
+    pools: Iterable[PoolResponse]
     total_entries: int
 
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/task_instances.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+from collections.abc import Iterable
 from datetime import datetime
 from typing import Annotated, Any
 
@@ -83,7 +84,7 @@ class TaskInstanceResponse(BaseModel):
 class TaskInstanceCollectionResponse(BaseModel):
     """Task Instance Collection serializer for responses."""
 
-    task_instances: list[TaskInstanceResponse]
+    task_instances: Iterable[TaskInstanceResponse]
     total_entries: int
 
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/variables.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/variables.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterable
 
 from pydantic import Field, JsonValue, model_validator
 
@@ -61,7 +62,7 @@ class VariableBody(StrictBaseModel):
 class VariableCollectionResponse(BaseModel):
     """Variable Collection serializer for responses."""
 
-    variables: list[VariableResponse]
+    variables: Iterable[VariableResponse]
     total_entries: int
 
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/xcom.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/xcom.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+from collections.abc import Iterable
 from datetime import datetime
 from typing import Any
 
@@ -77,7 +78,7 @@ class XComResponseString(XComResponse):
 class XComCollectionResponse(BaseModel):
     """XCom Collection serializer for responses."""
 
-    xcom_entries: list[XComResponse]
+    xcom_entries: Iterable[XComResponse]
     total_entries: int
 
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
@@ -246,7 +246,7 @@ def get_asset_aliases(
     )
 
     return AssetAliasCollectionResponse(
-        asset_aliases=list(session.scalars(asset_aliases_select)),
+        asset_aliases=session.scalars(asset_aliases_select),
         total_entries=total_entries,
     )
 
@@ -337,7 +337,7 @@ def get_asset_events(
     assets_events = session.scalars(assets_event_select)
 
     return AssetEventCollectionResponse(
-        asset_events=list(assets_events),
+        asset_events=assets_events,
         total_entries=total_entries,
     )
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/connections.py
@@ -138,7 +138,7 @@ def get_connections(
     connections = session.scalars(connection_select)
 
     return ConnectionCollectionResponse(
-        connections=list(connections),
+        connections=connections,
         total_entries=total_entries,
     )
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -408,7 +408,7 @@ def get_dag_runs(
     dag_runs = session.scalars(dag_run_select)
 
     return DAGRunCollectionResponse(
-        dag_runs=list(dag_runs),
+        dag_runs=dag_runs,
         total_entries=total_entries,
     )
 
@@ -635,6 +635,6 @@ def get_list_dag_runs_batch(
     dag_runs = session.scalars(dag_runs_select)
 
     return DAGRunCollectionResponse(
-        dag_runs=list(dag_runs),
+        dag_runs=dag_runs,
         total_entries=total_entries,
     )

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_versions.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_versions.py
@@ -125,6 +125,6 @@ def get_dag_versions(
     dag_versions = session.scalars(dag_versions_select)
 
     return DAGVersionCollectionResponse(
-        dag_versions=list(dag_versions),
+        dag_versions=dag_versions,
         total_entries=total_entries,
     )

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_warning.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_warning.py
@@ -76,6 +76,6 @@ def list_dag_warnings(
     dag_warnings = session.scalars(dag_warnings_select)
 
     return DAGWarningCollectionResponse(
-        dag_warnings=list(dag_warnings),
+        dag_warnings=dag_warnings,
         total_entries=total_entries,
     )

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dags.py
@@ -166,7 +166,7 @@ def get_dags(
     dags = session.scalars(dags_select)
 
     return DAGCollectionResponse(
-        dags=list(dags),
+        dags=dags,
         total_entries=total_entries,
     )
 
@@ -342,7 +342,7 @@ def patch_dags(
     )
 
     return DAGCollectionResponse(
-        dags=list(dags),
+        dags=dags,
         total_entries=total_entries,
     )
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/event_logs.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/event_logs.py
@@ -159,6 +159,6 @@ def get_event_logs(
     event_logs = session.scalars(event_logs_select)
 
     return EventLogCollectionResponse(
-        event_logs=list(event_logs),
+        event_logs=event_logs,
         total_entries=total_entries,
     )

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/hitl.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/hitl.py
@@ -292,6 +292,6 @@ def get_hitl_details(
     hitl_details = session.scalars(hitl_detail_select)
 
     return HITLDetailCollection(
-        hitl_details=list(hitl_details),
+        hitl_details=hitl_details,
         total_entries=total_entries,
     )

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/import_error.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/import_error.py
@@ -147,7 +147,7 @@ def get_import_errors(
         # Early return if the user has access to all DAGs
         import_errors = session.scalars(import_errors_select).all()
         return ImportErrorCollectionResponse(
-            import_errors=list(import_errors),
+            import_errors=import_errors,
             total_entries=total_entries,
         )
 
@@ -205,6 +205,6 @@ def get_import_errors(
         import_errors.append(import_error)
 
     return ImportErrorCollectionResponse(
-        import_errors=list(import_errors),
+        import_errors=import_errors,
         total_entries=total_entries,
     )

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/job.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/job.py
@@ -130,6 +130,6 @@ def get_jobs(
         jobs = [job for job in jobs if job.is_alive()]
 
     return JobCollectionResponse(
-        jobs=list(jobs),
+        jobs=jobs,
         total_entries=total_entries,
     )

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/pools.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/pools.py
@@ -118,7 +118,7 @@ def get_pools(
         session=session,
     )
 
-    pools = list(session.scalars(pools_select))
+    pools = session.scalars(pools_select)
 
     return PoolCollectionResponse(
         pools=pools,

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
@@ -242,10 +242,10 @@ def get_mapped_task_instances(
         limit=limit,
         session=session,
     )
-    task_instances = list(session.scalars(task_instance_select).all())
+    task_instances = session.scalars(task_instance_select)
 
     return TaskInstanceCollectionResponse(
-        task_instances=list(task_instances),
+        task_instances=task_instances,
         total_entries=total_entries,
     )
 
@@ -525,7 +525,7 @@ def get_task_instances(
 
     task_instances = session.scalars(task_instance_select)
     return TaskInstanceCollectionResponse(
-        task_instances=list(task_instances),
+        task_instances=task_instances,
         total_entries=total_entries,
     )
 
@@ -641,7 +641,7 @@ def get_task_instances_batch(
     task_instances = session.scalars(task_instance_select)
 
     return TaskInstanceCollectionResponse(
-        task_instances=list(task_instances),
+        task_instances=task_instances,
         total_entries=total_entries,
     )
 


### PR DESCRIPTION
Following-up on the [comment](https://apache-airflow.slack.com/archives/C06K9Q5G2UA/p1762320172286769) from @uranusjr. With the recent work on resolving mypy static errors with SQLA2,  `list` and `all` have been used a lot although it is not strictly needed. A better solution is to update the model to accept `Iterable` instead of `list`.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
