### PR TITLE
UI Fix for backfill date picker

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/DateTimeInput.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DateTimeInput.tsx
@@ -47,7 +47,7 @@ export const DateTimeInput = forwardRef<HTMLInputElement, Props>(({ onChange, va
           target: {
             ...event.target,
             value: dayjs(event.target.value).isValid()
-              ? dayjs(event.target.value).tz(selectedTimezone, true).toISOString()
+              ? dayjs.tz(event.target.value, selectedTimezone).toISOString() // UI Timezone -> Utc -> yyyy-mm-ddThh:mm
               : "",
           },
         })


### PR DESCRIPTION
Fixes Backfill [date picker](https://github.com/apache/airflow/issues/57544) randomly changing the date when it is full and then modified.

Closes: #57544

# Problem
- Fill a date picker form, then modify the year.
- Any subsequent change will increase the other fields (days, or seconds)
![before](https://github.com/user-attachments/assets/36d231a5-77bf-4d3e-941c-c17526b93bd3)

# Solution
- Change the parsing process from 
Create day.js from date string
Convert with timezone to another day.js
- To
Create day.js using date string and a timezone
![after](https://github.com/user-attachments/assets/35bd3ea0-e20b-4964-8dbd-76c58b384655)

I think consecutive conversions causes an offset to be added, but this seems to fix it.
This keeps the same behavior as before (value as utc, display value as local time) 
