### PR TITLE
feat: use get async conn from common compact

### DIFF
--- a/providers/slack/src/airflow/providers/slack/hooks/slack.py
+++ b/providers/slack/src/airflow/providers/slack/hooks/slack.py
@@ -39,8 +39,9 @@ from slack_sdk.web.async_client import AsyncWebClient
 from typing_extensions import NotRequired
 
 from airflow.exceptions import AirflowException, AirflowNotFoundException
+from airflow.providers.common.compat.connection import get_async_connection
 from airflow.providers.common.compat.sdk import BaseHook
-from airflow.providers.slack.utils import ConnectionExtraConfig, get_async_connection
+from airflow.providers.slack.utils import ConnectionExtraConfig
 from airflow.utils.helpers import exactly_one
 
 if TYPE_CHECKING:

--- a/providers/slack/src/airflow/providers/slack/hooks/slack_webhook.py
+++ b/providers/slack/src/airflow/providers/slack/hooks/slack_webhook.py
@@ -27,8 +27,9 @@ from slack_sdk import WebhookClient
 from slack_sdk.webhook.async_client import AsyncWebhookClient
 
 from airflow.exceptions import AirflowException, AirflowNotFoundException
+from airflow.providers.common.compat.connection import get_async_connection
 from airflow.providers.common.compat.sdk import BaseHook
-from airflow.providers.slack.utils import ConnectionExtraConfig, get_async_connection
+from airflow.providers.slack.utils import ConnectionExtraConfig
 
 if TYPE_CHECKING:
     from slack_sdk.http_retry import RetryHandler

--- a/providers/slack/src/airflow/providers/slack/utils/__init__.py
+++ b/providers/slack/src/airflow/providers/slack/utils/__init__.py
@@ -20,9 +20,6 @@ import warnings
 from collections.abc import Sequence
 from typing import Any
 
-from asgiref.sync import sync_to_async
-
-from airflow.providers.common.compat.sdk import BaseHook, Connection
 from airflow.utils.types import NOTSET
 
 
@@ -123,15 +120,3 @@ def parse_filename(
         if fallback:
             return fallback, None
         raise ex from None
-
-
-async def get_async_connection(conn_id: str) -> Connection:
-    """
-    Get an asynchronous Airflow connection that is backwards compatible.
-
-    :param conn_id: The provided connection ID.
-    :returns: Connection
-    """
-    if hasattr(BaseHook, "aget_connection"):
-        return await BaseHook.aget_connection(conn_id=conn_id)
-    return await sync_to_async(BaseHook.get_connection)(conn_id=conn_id)

--- a/providers/slack/tests/unit/slack/utils/test_utils.py
+++ b/providers/slack/tests/unit/slack/utils/test_utils.py
@@ -16,12 +16,9 @@
 # under the License.
 from __future__ import annotations
 
-from unittest import mock
-
 import pytest
 
-from airflow.models.connection import Connection
-from airflow.providers.slack.utils import ConnectionExtraConfig, get_async_connection, parse_filename
+from airflow.providers.slack.utils import ConnectionExtraConfig, parse_filename
 
 
 class TestConnectionExtra:
@@ -147,41 +144,3 @@ class TestParseFilename:
     def test_wrong_fallback(self, filename):
         with pytest.raises(ValueError, match="Invalid fallback value"):
             assert parse_filename(filename, self.SUPPORTED_FORMAT, "mp4")
-
-
-class MockAgetBaseHook:
-    def __init__(*args, **kargs):
-        pass
-
-    async def aget_connection(self, conn_id: str):
-        return Connection(
-            conn_id="test_conn",
-            conn_type="slack",
-            password="secret_token_aget",
-        )
-
-
-class MockBaseHook:
-    def __init__(*args, **kargs):
-        pass
-
-    def get_connection(self, conn_id: str):
-        return Connection(
-            conn_id="test_conn_sync",
-            conn_type="slack",
-            password="secret_token",
-        )
-
-
-class TestGetAsyncConnection:
-    @mock.patch("airflow.providers.slack.utils.BaseHook", new_callable=MockAgetBaseHook)
-    @pytest.mark.asyncio
-    async def test_get_async_connection_with_aget(self, mock_hook):
-        conn = await get_async_connection("test_conn")
-        assert conn.password == "secret_token_aget"
-
-    @mock.patch("airflow.providers.slack.utils.BaseHook", new_callable=MockBaseHook)
-    @pytest.mark.asyncio
-    async def test_get_async_connection_with_get_connection(self, mock_hook):
-        conn = await get_async_connection("test_conn")
-        assert conn.password == "secret_token"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This logic is now available in the `airflow.providers.common.compat` provider. See #57143. Let's use it from there.

related: #55237


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
