### PR TITLE
Enable PT006 rule to airflow-core tests (ti_deps, serialization)

### DIFF
--- a/airflow-core/tests/unit/serialization/serializers/test_serializers.py
+++ b/airflow-core/tests/unit/serialization/serializers/test_serializers.py
@@ -115,7 +115,7 @@ class TestSerializers:
             assert input_obj.timestamp() == deserialized_obj.timestamp()
 
     @pytest.mark.parametrize(
-        "tz_input, expected_tz_name",
+        ("tz_input", "expected_tz_name"),
         [
             pytest.param("UTC", "UTC", id="utc"),
             pytest.param("Europe/Paris", "Europe/Paris", id="europe_paris"),
@@ -143,7 +143,7 @@ class TestSerializers:
             assert deserialize(serialize(deserialized_dt)) == deserialized_dt
 
     @pytest.mark.parametrize(
-        "expr, expected",
+        ("expr", "expected"),
         [("1", "1"), ("52e4", "520000"), ("2e0", "2"), ("12e-2", "0.12"), ("12.34", "12.34")],
     )
     def test_encode_decimal(self, expr, expected):
@@ -382,7 +382,7 @@ class TestSerializers:
         assert m.foo == d.foo
 
     @pytest.mark.parametrize(
-        "klass, version, data, msg",
+        ("klass", "version", "data", "msg"),
         [
             (
                 FooBarModel,
@@ -413,7 +413,7 @@ class TestSerializers:
 
     @pytest.mark.skipif(not PENDULUM3, reason="Test case for pendulum~=3")
     @pytest.mark.parametrize(
-        "ser_value, expected",
+        ("ser_value", "expected"),
         [
             pytest.param(
                 {
@@ -487,7 +487,7 @@ class TestSerializers:
 
     @pytest.mark.skipif(PENDULUM3, reason="Test case for pendulum~=2")
     @pytest.mark.parametrize(
-        "ser_value, expected",
+        ("ser_value", "expected"),
         [
             pytest.param(
                 {
@@ -577,7 +577,7 @@ class TestSerializers:
         assert zi.key == "Asia/Taipei"
 
     @pytest.mark.parametrize(
-        "klass, version, data, msg",
+        ("klass", "version", "data", "msg"),
         [
             (FixedTimezone, 1, 1.23, "is not of type int or str"),
             (FixedTimezone, 999, "UTC", "serialized 999 .* > 1"),
@@ -590,7 +590,7 @@ class TestSerializers:
             deserialize(klass, version, data)
 
     @pytest.mark.parametrize(
-        "tz_obj, expected",
+        ("tz_obj", "expected"),
         [
             (None, None),
             (CustomTZ(), "My/Custom"),
@@ -615,7 +615,7 @@ class TestSerializers:
         assert "Schema file schema.json does not exists" in str(ctx.value)
 
     @pytest.mark.parametrize(
-        "klass, version, data",
+        ("klass", "version", "data"),
         [(tuple, 1, [11, 12]), (set, 1, [11, 12]), (frozenset, 1, [11, 12])],
     )
     def test_builtin_deserialize(self, klass, version, data):
@@ -624,7 +624,7 @@ class TestSerializers:
         assert res == klass(data)
 
     @pytest.mark.parametrize(
-        "klass, version, data, msg",
+        ("klass", "version", "data", "msg"),
         [
             (tuple, 999, [11, 12], r"serialized version 999 is newer than class version 1"),
             (set, 2, [11, 12], r"serialized version 2 is newer than class version 1"),
@@ -636,7 +636,7 @@ class TestSerializers:
             builtin.deserialize(klass, version, data)
 
     @pytest.mark.parametrize(
-        "klass, version, data, msg",
+        ("klass", "version", "data", "msg"),
         [
             (str, 1, "11, 12", r"do not know how to deserialize builtins\.str"),
             (int, 1, 11, r"do not know how to deserialize builtins\.int"),
@@ -649,7 +649,7 @@ class TestSerializers:
             builtin.deserialize(klass, version, data)
 
     @pytest.mark.parametrize(
-        "func, msg",
+        ("func", "msg"),
         [
             (builtin.deserialize, r"do not know how to deserialize"),
             (builtin.stringify, r"do not know how to stringify"),
@@ -675,7 +675,7 @@ class TestSerializers:
             deserialize(bad)
 
     @pytest.mark.parametrize(
-        "value, expected",
+        ("value", "expected"),
         [
             (123, "dummy@version=1(123)"),
             ([1], "dummy@version=1([,1,])"),

--- a/airflow-core/tests/unit/serialization/test_dag_serialization.py
+++ b/airflow-core/tests/unit/serialization/test_dag_serialization.py
@@ -543,7 +543,7 @@ class TestStringifiedDAGs:
 
     @pytest.mark.db_test
     @pytest.mark.parametrize(
-        "timetable, serialized_timetable",
+        ("timetable", "serialized_timetable"),
         [
             (
                 cron_timetable("0 0 * * *"),
@@ -858,7 +858,7 @@ class TestStringifiedDAGs:
             )
 
     @pytest.mark.parametrize(
-        "dag_start_date, task_start_date, expected_task_start_date",
+        ("dag_start_date", "task_start_date", "expected_task_start_date"),
         [
             (
                 datetime(2019, 8, 1, tzinfo=timezone.utc),
@@ -914,7 +914,7 @@ class TestStringifiedDAGs:
             SerializedDAG.to_dict(dag)
 
     @pytest.mark.parametrize(
-        "dag_end_date, task_end_date, expected_task_end_date",
+        ("dag_end_date", "task_end_date", "expected_task_end_date"),
         [
             (
                 datetime(2019, 8, 1, tzinfo=timezone.utc),
@@ -955,7 +955,7 @@ class TestStringifiedDAGs:
         assert simple_task.end_date == expected_task_end_date
 
     @pytest.mark.parametrize(
-        "serialized_timetable, expected_timetable",
+        ("serialized_timetable", "expected_timetable"),
         [
             (
                 {"__type": "airflow.timetables.simple.NullTimetable", "__var": {}},
@@ -1004,7 +1004,7 @@ class TestStringifiedDAGs:
         assert dag.timetable == expected_timetable
 
     @pytest.mark.parametrize(
-        "serialized_timetable, expected_timetable_summary",
+        ("serialized_timetable", "expected_timetable_summary"),
         [
             (
                 {"__type": "airflow.timetables.simple.NullTimetable", "__var": {}},
@@ -1076,7 +1076,7 @@ class TestStringifiedDAGs:
             SerializedDAG.from_dict(serialized)
 
     @pytest.mark.parametrize(
-        "val, expected",
+        ("val", "expected"),
         [
             (
                 relativedelta(days=-1),
@@ -1106,7 +1106,7 @@ class TestStringifiedDAGs:
         assert val == round_tripped
 
     @pytest.mark.parametrize(
-        "val, expected_val",
+        ("val", "expected_val"),
         [
             (None, {}),
             ({"param_1": "value_1"}, {"param_1": "value_1"}),
@@ -1195,7 +1195,7 @@ class TestStringifiedDAGs:
         }
 
     @pytest.mark.parametrize(
-        "val, expected_val",
+        ("val", "expected_val"),
         [
             (None, {}),
             ({"param_1": "value_1"}, {"param_1": "value_1"}),
@@ -1351,7 +1351,7 @@ class TestStringifiedDAGs:
             return not self.__eq__(other)
 
     @pytest.mark.parametrize(
-        "templated_field, expected_field",
+        ("templated_field", "expected_field"),
         [
             (None, None),
             ([], []),
@@ -2181,7 +2181,7 @@ class TestStringifiedDAGs:
         assert ReadyToRescheduleDep in [type(d) for d in serialized_op.deps]
 
     @pytest.mark.parametrize(
-        "passed_success_callback, expected_value",
+        ("passed_success_callback", "expected_value"),
         [
             ({"on_success_callback": lambda x: print("hi")}, True),
             ({}, False),
@@ -2213,7 +2213,7 @@ class TestStringifiedDAGs:
         assert deserialized_dag.has_on_success_callback is expected_value
 
     @pytest.mark.parametrize(
-        "passed_failure_callback, expected_value",
+        ("passed_failure_callback", "expected_value"),
         [
             ({"on_failure_callback": lambda x: print("hi")}, True),
             ({}, False),
@@ -2245,7 +2245,7 @@ class TestStringifiedDAGs:
         assert deserialized_dag.has_on_failure_callback is expected_value
 
     @pytest.mark.parametrize(
-        "dag_arg, conf_arg, expected",
+        ("dag_arg", "conf_arg", "expected"),
         [
             (True, "True", True),
             (True, "False", True),
@@ -2278,7 +2278,7 @@ class TestStringifiedDAGs:
             assert deserialized_dag.disable_bundle_versioning is expected
 
     @pytest.mark.parametrize(
-        "object_to_serialized, expected_output",
+        ("object_to_serialized", "expected_output"),
         [
             (
                 ["task_1", "task_5", "task_2", "task_4"],
@@ -3735,7 +3735,7 @@ def dummy_callback():
 
 
 @pytest.mark.parametrize(
-    "callback_config,expected_flags,is_mapped",
+    ("callback_config", "expected_flags", "is_mapped"),
     [
         # Regular operator tests
         (
@@ -3904,7 +3904,7 @@ def test_task_callback_properties_exist():
 
 
 @pytest.mark.parametrize(
-    "old_callback_name,new_callback_name",
+    ("old_callback_name", "new_callback_name"),
     [
         ("on_execute_callback", "has_on_execute_callback"),
         ("on_failure_callback", "has_on_failure_callback"),
@@ -4180,7 +4180,7 @@ class TestMappedOperatorSerializationAndClientDefaults:
         assert deserialized_task.retries == 5  # Explicitly set value
 
     @pytest.mark.parametrize(
-        ["task_config", "dag_id", "task_id", "non_default_fields"],
+        ("task_config", "dag_id", "task_id", "non_default_fields"),
         [
             # Test case 1: Size optimization with non-default values
             pytest.param(
@@ -4273,7 +4273,7 @@ class TestMappedOperatorSerializationAndClientDefaults:
         assert expand_value["env"] == {"VAR1": "value1", "VAR2": "value2"}
 
     @pytest.mark.parametrize(
-        ["partial_kwargs_data", "expected_results"],
+        ("partial_kwargs_data", "expected_results"),
         [
             # Test case 1: Encoded format with client defaults
             pytest.param(
@@ -4351,7 +4351,7 @@ class TestMappedOperatorSerializationAndClientDefaults:
 
 
 @pytest.mark.parametrize(
-    ["callbacks", "expected_has_flags", "absent_keys"],
+    ("callbacks", "expected_has_flags", "absent_keys"),
     [
         pytest.param(
             {

--- a/airflow-core/tests/unit/serialization/test_serde.py
+++ b/airflow-core/tests/unit/serialization/test_serde.py
@@ -452,7 +452,7 @@ class TestSerDe:
         obj = deserialize(serialize(asset))
         assert asset.uri == obj.uri
 
-    @pytest.mark.parametrize("name, s", SERIALIZER_TESTS)
+    @pytest.mark.parametrize(("name", "s"), SERIALIZER_TESTS)
     def test_serializers_importable_and_str(self, name, s):
         """Test if all distributed serializers are lazy loading and can be imported"""
         if not isinstance(s, str):
@@ -478,7 +478,7 @@ class TestSerDe:
         s = deserialize(e, full=False)
 
     @pytest.mark.parametrize(
-        "obj, expected",
+        ("obj", "expected"),
         [
             (
                 Z(10),

--- a/airflow-core/tests/unit/serialization/test_serialized_objects.py
+++ b/airflow-core/tests/unit/serialization/test_serialized_objects.py
@@ -276,7 +276,7 @@ class MockLazySelectSequence(LazySelectSequence):
 
 
 @pytest.mark.parametrize(
-    "input, encoded_type, cmp_func",
+    ("input", "encoded_type", "cmp_func"),
     [
         ("test_str", None, equals),
         (1, None, equals),
@@ -614,7 +614,7 @@ def test_hash_property():
 
 
 @pytest.mark.parametrize(
-    "payload, expected_cls",
+    ("payload", "expected_cls"),
     [
         pytest.param(
             {

--- a/airflow-core/tests/unit/ti_deps/deps/test_mapped_task_upstream_dep.py
+++ b/airflow-core/tests/unit/ti_deps/deps/test_mapped_task_upstream_dep.py
@@ -45,7 +45,7 @@ UPSTREAM_FAILED = TaskInstanceState.UPSTREAM_FAILED
 
 
 @pytest.mark.parametrize(
-    ["task_state", "upstream_states", "expected_state", "expect_failed_dep"],
+    ("task_state", "upstream_states", "expected_state", "expect_failed_dep"),
     [
         # finished mapped dependencies with state != success result in failed dep and a modified state
         (None, [None, None], None, False),

--- a/airflow-core/tests/unit/ti_deps/deps/test_runnable_exec_date_dep.py
+++ b/airflow-core/tests/unit/ti_deps/deps/test_runnable_exec_date_dep.py
@@ -39,7 +39,7 @@ def clean_db(session):
 
 @time_machine.travel("2016-11-01")
 @pytest.mark.parametrize(
-    "logical_date, is_met",
+    ("logical_date", "is_met"),
     [
         (datetime(2016, 11, 3), False),
         (datetime(2016, 11, 1), True),

--- a/airflow-core/tests/unit/ti_deps/deps/test_task_concurrency.py
+++ b/airflow-core/tests/unit/ti_deps/deps/test_task_concurrency.py
@@ -35,7 +35,7 @@ class TestTaskConcurrencyDep:
         return BaseOperator(task_id="test_task", dag=DAG("test_dag", schedule=None), **kwargs)
 
     @pytest.mark.parametrize(
-        "kwargs, num_running_tis, is_task_concurrency_dep_met",
+        ("kwargs", "num_running_tis", "is_task_concurrency_dep_met"),
         [
             ({}, None, True),
             ({"max_active_tis_per_dag": 1}, 0, True),

--- a/airflow-core/tests/unit/ti_deps/deps/test_trigger_rule_dep.py
+++ b/airflow-core/tests/unit/ti_deps/deps/test_trigger_rule_dep.py
@@ -195,7 +195,7 @@ class TestTriggerRuleDep:
         assert dep_statuses[0].passed
         assert dep_statuses[0].reason == "The task had a always trigger rule set."
 
-    @pytest.mark.parametrize("flag_upstream_failed, expected_ti_state", [(True, SKIPPED), (False, None)])
+    @pytest.mark.parametrize(("flag_upstream_failed", "expected_ti_state"), [(True, SKIPPED), (False, None)])
     def test_one_success_tr_success(
         self, session, get_task_instance, flag_upstream_failed, expected_ti_state
     ):
@@ -219,7 +219,7 @@ class TestTriggerRuleDep:
         )
 
     @pytest.mark.parametrize(
-        "flag_upstream_failed, expected_ti_state", [(True, UPSTREAM_FAILED), (False, None)]
+        ("flag_upstream_failed", "expected_ti_state"), [(True, UPSTREAM_FAILED), (False, None)]
     )
     def test_one_success_tr_failure(
         self, session, get_task_instance, flag_upstream_failed, expected_ti_state
@@ -244,7 +244,7 @@ class TestTriggerRuleDep:
             expected_ti_state=expected_ti_state,
         )
 
-    @pytest.mark.parametrize("flag_upstream_failed, expected_ti_state", [(True, SKIPPED), (False, None)])
+    @pytest.mark.parametrize(("flag_upstream_failed", "expected_ti_state"), [(True, SKIPPED), (False, None)])
     def test_one_success_tr_failure_all_skipped(
         self, session, get_task_instance, flag_upstream_failed, expected_ti_state
     ):
@@ -268,7 +268,7 @@ class TestTriggerRuleDep:
             expected_ti_state=expected_ti_state,
         )
 
-    @pytest.mark.parametrize("flag_upstream_failed, expected_ti_state", [(True, SKIPPED), (False, None)])
+    @pytest.mark.parametrize(("flag_upstream_failed", "expected_ti_state"), [(True, SKIPPED), (False, None)])
     def test_one_failure_tr_failure(
         self, session, get_task_instance, flag_upstream_failed, expected_ti_state
     ):
@@ -356,7 +356,7 @@ class TestTriggerRuleDep:
         )
         _test_trigger_rule(ti=ti, session=session, flag_upstream_failed=flag_upstream_failed)
 
-    @pytest.mark.parametrize("flag_upstream_failed, expected_ti_state", [(True, SKIPPED), (False, None)])
+    @pytest.mark.parametrize(("flag_upstream_failed", "expected_ti_state"), [(True, SKIPPED), (False, None)])
     def test_one_done_tr_skip(self, session, get_task_instance, flag_upstream_failed, expected_ti_state):
         """
         One-done trigger rule skip
@@ -378,7 +378,7 @@ class TestTriggerRuleDep:
             expected_ti_state=expected_ti_state,
         )
 
-    @pytest.mark.parametrize("flag_upstream_failed, expected_ti_state", [(True, SKIPPED), (False, None)])
+    @pytest.mark.parametrize(("flag_upstream_failed", "expected_ti_state"), [(True, SKIPPED), (False, None)])
     def test_one_done_tr_upstream_failed(
         self, session, get_task_instance, flag_upstream_failed, expected_ti_state
     ):
@@ -420,7 +420,7 @@ class TestTriggerRuleDep:
         _test_trigger_rule(ti=ti, session=session, flag_upstream_failed=flag_upstream_failed)
 
     @pytest.mark.parametrize(
-        "flag_upstream_failed, expected_ti_state", [(True, UPSTREAM_FAILED), (False, None)]
+        ("flag_upstream_failed", "expected_ti_state"), [(True, UPSTREAM_FAILED), (False, None)]
     )
     def test_all_success_tr_failure(
         self, session, get_task_instance, flag_upstream_failed, expected_ti_state
@@ -446,7 +446,7 @@ class TestTriggerRuleDep:
             expected_ti_state=expected_ti_state,
         )
 
-    @pytest.mark.parametrize("flag_upstream_failed, expected_ti_state", [(True, SKIPPED), (False, None)])
+    @pytest.mark.parametrize(("flag_upstream_failed", "expected_ti_state"), [(True, SKIPPED), (False, None)])
     def test_all_success_tr_skip(self, session, get_task_instance, flag_upstream_failed, expected_ti_state):
         """
         All-success trigger rule fails when some upstream tasks are skipped.
@@ -502,7 +502,7 @@ class TestTriggerRuleDep:
                 ),
             )
 
-    @pytest.mark.parametrize("flag_upstream_failed, expected_ti_state", [(True, SKIPPED), (False, None)])
+    @pytest.mark.parametrize(("flag_upstream_failed", "expected_ti_state"), [(True, SKIPPED), (False, None)])
     def test_all_success_tr_skip_wait_for_past_depends_before_skipping_past_depends_met(
         self, session, get_task_instance, flag_upstream_failed, expected_ti_state
     ):
@@ -550,7 +550,7 @@ class TestTriggerRuleDep:
         _test_trigger_rule(ti=ti, session=session, flag_upstream_failed=flag_upstream_failed)
 
     @pytest.mark.parametrize(
-        "flag_upstream_failed, expected_ti_state", [(True, UPSTREAM_FAILED), (False, None)]
+        ("flag_upstream_failed", "expected_ti_state"), [(True, UPSTREAM_FAILED), (False, None)]
     )
     def test_none_failed_tr_failure(
         self, session, get_task_instance, flag_upstream_failed, expected_ti_state
@@ -577,7 +577,7 @@ class TestTriggerRuleDep:
         )
 
     @pytest.mark.parametrize(
-        "flag_upstream_failed, expected_ti_state", [(True, UPSTREAM_FAILED), (False, None)]
+        ("flag_upstream_failed", "expected_ti_state"), [(True, UPSTREAM_FAILED), (False, None)]
     )
     def test_none_failed_tr_failure_with_upstream_failure(
         self, session, get_task_instance, flag_upstream_failed, expected_ti_state
@@ -620,7 +620,7 @@ class TestTriggerRuleDep:
         )
         _test_trigger_rule(ti=ti, session=session, flag_upstream_failed=flag_upstream_failed)
 
-    @pytest.mark.parametrize("flag_upstream_failed, expected_ti_state", [(True, SKIPPED), (False, None)])
+    @pytest.mark.parametrize(("flag_upstream_failed", "expected_ti_state"), [(True, SKIPPED), (False, None)])
     def test_none_failed_min_one_success_tr_skipped(
         self, session, get_task_instance, flag_upstream_failed, expected_ti_state
     ):
@@ -645,7 +645,7 @@ class TestTriggerRuleDep:
         )
 
     @pytest.mark.parametrize(
-        "flag_upstream_failed, expected_ti_state", [(True, UPSTREAM_FAILED), (False, None)]
+        ("flag_upstream_failed", "expected_ti_state"), [(True, UPSTREAM_FAILED), (False, None)]
     )
     def test_none_failed_min_one_success_tr_failure(
         self, session, get_task_instance, flag_upstream_failed, expected_ti_state
@@ -672,7 +672,7 @@ class TestTriggerRuleDep:
         )
 
     @pytest.mark.parametrize(
-        "flag_upstream_failed, expected_ti_state", [(True, UPSTREAM_FAILED), (False, None)]
+        ("flag_upstream_failed", "expected_ti_state"), [(True, UPSTREAM_FAILED), (False, None)]
     )
     def test_none_failed_min_one_success_tr_upstream_failure(
         self, session, get_task_instance, flag_upstream_failed, expected_ti_state
@@ -715,7 +715,7 @@ class TestTriggerRuleDep:
         )
         _test_trigger_rule(ti=ti, session=session, flag_upstream_failed=flag_upstream_failed)
 
-    @pytest.mark.parametrize("flag_upstream_failed, expected_ti_state", [(True, SKIPPED), (False, None)])
+    @pytest.mark.parametrize(("flag_upstream_failed", "expected_ti_state"), [(True, SKIPPED), (False, None)])
     def test_all_failed_tr_failure(self, session, get_task_instance, flag_upstream_failed, expected_ti_state):
         """
         All-failed trigger rule failure
@@ -756,7 +756,7 @@ class TestTriggerRuleDep:
         _test_trigger_rule(ti=ti, session=session, flag_upstream_failed=flag_upstream_failed)
 
     @pytest.mark.parametrize(
-        "task_cfg, states, exp_reason, exp_state",
+        ("task_cfg", "states", "exp_reason", "exp_state"),
         [
             pytest.param(
                 dict(work=2, setup=0),
@@ -858,7 +858,7 @@ class TestTriggerRuleDep:
             expected_ti_state=exp_state if exp_state and flag_upstream_failed else None,
         )
 
-    @pytest.mark.parametrize("flag_upstream_failed, expected_ti_state", [(True, SKIPPED), (False, None)])
+    @pytest.mark.parametrize(("flag_upstream_failed", "expected_ti_state"), [(True, SKIPPED), (False, None)])
     def test_all_skipped_tr_failure(
         self, session, get_task_instance, flag_upstream_failed, expected_ti_state
     ):
@@ -883,7 +883,7 @@ class TestTriggerRuleDep:
             expected_ti_state=expected_ti_state,
         )
 
-    @pytest.mark.parametrize("flag_upstream_failed, expected_ti_state", [(True, SKIPPED), (False, None)])
+    @pytest.mark.parametrize(("flag_upstream_failed", "expected_ti_state"), [(True, SKIPPED), (False, None)])
     def test_all_skipped_tr_failure_upstream_failed(
         self, session, get_task_instance, flag_upstream_failed, expected_ti_state
     ):
@@ -966,7 +966,7 @@ class TestTriggerRuleDep:
         )
         _test_trigger_rule(ti=ti, session=session, flag_upstream_failed=flag_upstream_failed)
 
-    @pytest.mark.parametrize("flag_upstream_failed, expected_ti_state", [(True, SKIPPED), (False, None)])
+    @pytest.mark.parametrize(("flag_upstream_failed", "expected_ti_state"), [(True, SKIPPED), (False, None)])
     def test_none_skipped_tr_failure(
         self, session, get_task_instance, flag_upstream_failed, expected_ti_state
     ):
@@ -1037,7 +1037,7 @@ class TestTriggerRuleDep:
             expected_reason="No strategy to evaluate trigger rule 'Unknown Trigger Rule'.",
         )
 
-    @pytest.mark.parametrize("flag_upstream_failed, expected_ti_state", [(True, None), (False, None)])
+    @pytest.mark.parametrize(("flag_upstream_failed", "expected_ti_state"), [(True, None), (False, None)])
     def test_all_done_min_one_success_with_mixed_success_and_failure(
         self, session, get_task_instance, flag_upstream_failed, expected_ti_state
     ):
@@ -1064,7 +1064,7 @@ class TestTriggerRuleDep:
             expected_ti_state=expected_ti_state,
         )
 
-    @pytest.mark.parametrize("flag_upstream_failed, expected_ti_state", [(True, None), (False, None)])
+    @pytest.mark.parametrize(("flag_upstream_failed", "expected_ti_state"), [(True, None), (False, None)])
     def test_all_done_min_one_success_with_all_successful_upstreams(
         self, session, get_task_instance, flag_upstream_failed, expected_ti_state
     ):
@@ -1091,7 +1091,7 @@ class TestTriggerRuleDep:
             expected_ti_state=expected_ti_state,
         )
 
-    @pytest.mark.parametrize("flag_upstream_failed, expected_ti_state", [(True, SKIPPED), (False, None)])
+    @pytest.mark.parametrize(("flag_upstream_failed", "expected_ti_state"), [(True, SKIPPED), (False, None)])
     def test_all_done_min_one_success_with_success_and_skipped_upstream(
         self, session, get_task_instance, flag_upstream_failed, expected_ti_state
     ):
@@ -1121,7 +1121,7 @@ class TestTriggerRuleDep:
         )
 
     @pytest.mark.parametrize(
-        "flag_upstream_failed, expected_ti_state", [(True, UPSTREAM_FAILED), (False, None)]
+        ("flag_upstream_failed", "expected_ti_state"), [(True, UPSTREAM_FAILED), (False, None)]
     )
     def test_all_done_min_one_success_with_all_failed_upstreams(
         self, session, get_task_instance, flag_upstream_failed, expected_ti_state
@@ -1152,7 +1152,7 @@ class TestTriggerRuleDep:
         )
 
     @pytest.mark.parametrize(
-        "flag_upstream_failed, expected_ti_state", [(True, UPSTREAM_FAILED), (False, None)]
+        ("flag_upstream_failed", "expected_ti_state"), [(True, UPSTREAM_FAILED), (False, None)]
     )
     def test_all_done_min_one_success_with_upstream_failed_cascade(
         self, session, get_task_instance, flag_upstream_failed, expected_ti_state
@@ -1217,7 +1217,7 @@ class TestTriggerRuleDep:
         dr.update_state(session=session)
         assert dr.state == DagRunState.SUCCESS
 
-    @pytest.mark.parametrize("flag_upstream_failed, expected_ti_state", [(True, REMOVED), (False, None)])
+    @pytest.mark.parametrize(("flag_upstream_failed", "expected_ti_state"), [(True, REMOVED), (False, None)])
     def test_mapped_task_upstream_removed_with_all_success_trigger_rules(
         self,
         monkeypatch,
@@ -1451,7 +1451,7 @@ def test_mapped_task_check_before_expand(dag_maker, session, flag_upstream_faile
     )
 
 
-@pytest.mark.parametrize("flag_upstream_failed, expected_ti_state", [(True, SKIPPED), (False, None)])
+@pytest.mark.parametrize(("flag_upstream_failed", "expected_ti_state"), [(True, SKIPPED), (False, None)])
 @pytest.mark.need_serialized_dag
 def test_mapped_task_group_finished_upstream_before_expand(
     dag_maker, session, flag_upstream_failed, expected_ti_state
@@ -1541,7 +1541,7 @@ class TestTriggerRuleDepSetupConstraint:
         assert statuses[1].reason.startswith("Task's trigger rule 'all_success' requires all upstream tasks")
 
     @pytest.mark.parametrize(
-        "setup_state, expected", [(None, None), ("failed", "upstream_failed"), ("skipped", "skipped")]
+        ("setup_state", "expected"), [(None, None), ("failed", "upstream_failed"), ("skipped", "skipped")]
     )
     def test_setup_constraint_changes_state_appropriately(self, dag_maker, session, setup_state, expected):
         with dag_maker(session=session):
@@ -1590,7 +1590,7 @@ class TestTriggerRuleDepSetupConstraint:
         assert self.get_ti(dr, "t3").state == expected
 
     @pytest.mark.parametrize(
-        "setup_state, expected", [(None, None), ("failed", "upstream_failed"), ("skipped", "skipped")]
+        ("setup_state", "expected"), [(None, None), ("failed", "upstream_failed"), ("skipped", "skipped")]
     )
     def test_setup_constraint_will_fail_or_skip_fast(self, dag_maker, session, setup_state, expected):
         """
@@ -1653,7 +1653,7 @@ class TestTriggerRuleDepSetupConstraint:
 
 @pytest.mark.flaky(reruns=5)
 @pytest.mark.parametrize(
-    "map_index, flag_upstream_failed, expected_ti_state",
+    ("map_index", "flag_upstream_failed", "expected_ti_state"),
     [(2, True, None), (3, True, REMOVED), (4, True, REMOVED), (3, False, None)],
 )
 def test_setup_constraint_mapped_task_upstream_removed_and_success(
@@ -1682,7 +1682,13 @@ def test_setup_constraint_mapped_task_upstream_removed_and_success(
 
 
 @pytest.mark.parametrize(
-    "flag_upstream_failed, wait_for_past_depends_before_skipping, past_depends_met, expected_ti_state, expect_failure",
+    (
+        "flag_upstream_failed",
+        "wait_for_past_depends_before_skipping",
+        "past_depends_met",
+        "expected_ti_state",
+        "expect_failure",
+    ),
     [
         (False, True, True, None, False),
         (False, True, False, None, False),
@@ -1739,7 +1745,7 @@ def test_setup_constraint_wait_for_past_depends_before_skipping(
         )
 
 
-@pytest.mark.parametrize("flag_upstream_failed, expected_ti_state", [(True, SKIPPED), (False, None)])
+@pytest.mark.parametrize(("flag_upstream_failed", "expected_ti_state"), [(True, SKIPPED), (False, None)])
 @pytest.mark.need_serialized_dag
 def test_setup_mapped_task_group_finished_upstream_before_expand(
     dag_maker, session, flag_upstream_failed, expected_ti_state


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->

Issue: Enable Even More PyDocStyle Checks #40567
@ferruzzi

This PR is for enable PT006 rule:
PT006: all instances of @pytest.mark.parametrize names should be a tuple
https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/
There are a lot of file changes needed.
So, I separate to many PR, which contain about 5-10 file changes for easy review.

---

**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
