### PR TITLE
Decrease the batch inference size for example_bedrock_batch_inference

### DIFF
--- a/providers/amazon/tests/system/amazon/aws/example_bedrock_batch_inference.py
+++ b/providers/amazon/tests/system/amazon/aws/example_bedrock_batch_inference.py
@@ -71,7 +71,7 @@ CLAUDE_MODEL_ID = "anthropic.claude-3-5-sonnet-20241022-v2:0"
 ANTHROPIC_VERSION = "bedrock-2023-05-31"
 
 # Batch inferences currently require a minimum of 100 prompts per batch.
-MIN_NUM_PROMPTS = 300
+MIN_NUM_PROMPTS = 100
 PROMPT_TEMPLATE = "Even numbers are red. Odd numbers are blue. What color is {n}?"
 
 
@@ -97,6 +97,9 @@ def generate_prompts(_env_id: str, _bucket: str, _key: str):
 
         # Convert each prompt to serialized json, append a newline, and write that line to the temp file.
         tmp_file.writelines(json.dumps(prompt) + "\n" for prompt in prompts)
+
+        # Flush the buffer to ensure all data is written to disk before upload
+        tmp_file.flush()
 
         # Upload the file to S3.
         S3Hook().conn.upload_file(tmp_file.name, _bucket, _key)


### PR DESCRIPTION
The system tests just needs to run the minimum batch size to test functionality. The shorter batch should decrease test runtime and resource usage.

Also fix a bug that caused the prompts list to be an unreliable size, there was a missing flush on the temp file.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
