### PR TITLE
Enable PT006 rule to google Provider test （hooks）

### DIFF
--- a/providers/google/tests/unit/google/cloud/hooks/test_alloy_db.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_alloy_db.py
@@ -88,7 +88,7 @@ class TestAlloyDbHook:
         )
 
     @pytest.mark.parametrize(
-        "given_timeout, expected_timeout",
+        ("given_timeout", "expected_timeout"),
         [
             (None, None),
             (0.0, None),
@@ -108,7 +108,7 @@ class TestAlloyDbHook:
         mock_operation.result.assert_called_once_with(timeout=expected_timeout)
 
     @pytest.mark.parametrize(
-        "given_timeout, expected_timeout",
+        ("given_timeout", "expected_timeout"),
         [
             (None, None),
             (0.0, None),
@@ -229,7 +229,7 @@ class TestAlloyDbHook:
         )
 
     @pytest.mark.parametrize(
-        "given_cluster, expected_cluster",
+        ("given_cluster", "expected_cluster"),
         [
             (TEST_CLUSTER, {**deepcopy(TEST_CLUSTER), **{"name": TEST_CLUSTER_NAME}}),
             (alloydb_v1.Cluster(), {"name": TEST_CLUSTER_NAME}),
@@ -390,7 +390,7 @@ class TestAlloyDbHook:
         )
 
     @pytest.mark.parametrize(
-        "given_user, expected_user",
+        ("given_user", "expected_user"),
         [
             (TEST_USER, {**deepcopy(TEST_USER), **{"name": TEST_USER_NAME}}),
             (alloydb_v1.User(), {"name": TEST_USER_NAME}),
@@ -549,7 +549,7 @@ class TestAlloyDbHook:
         )
 
     @pytest.mark.parametrize(
-        "given_backup, expected_backup",
+        ("given_backup", "expected_backup"),
         [
             (TEST_BACKUP, {**deepcopy(TEST_BACKUP), **{"name": TEST_BACKUP_NAME}}),
             (alloydb_v1.Backup(), {"name": TEST_BACKUP_NAME}),

--- a/providers/google/tests/unit/google/cloud/hooks/test_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_bigquery.py
@@ -659,7 +659,7 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
 
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.md5")
     @pytest.mark.parametrize(
-        "test_dag_id, expected_job_id",
+        ("test_dag_id", "expected_job_id"),
         [("test-dag-id-1.1", "airflow_test_dag_id_1_1_test_job_id_2020_01_23T00_00_00_hash")],
         ids=["test-dag-id-1.1"],
     )
@@ -710,7 +710,7 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
             self.hook.get_query_results(job_id=JOB_ID, location=LOCATION)
 
     @pytest.mark.parametrize(
-        "selected_fields, result",
+        ("selected_fields", "result"),
         [
             (None, [{"a": 1, "b": 2}, {"a": 3, "b": 4}]),
             ("a", [{"a": 1}, {"a": 3}]),
@@ -737,7 +737,7 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
             self.hook.split_tablename("dataset.table", None)
 
     @pytest.mark.parametrize(
-        "project_expected, dataset_expected, table_expected, table_input",
+        ("project_expected", "dataset_expected", "table_expected", "table_input"),
         [
             ("project", "dataset", "table", "dataset.table"),
             ("alternative", "dataset", "table", "alternative:dataset.table"),
@@ -754,7 +754,7 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
         assert table_expected == table
 
     @pytest.mark.parametrize(
-        "table_input, var_name, exception_message",
+        ("table_input", "var_name", "exception_message"),
         [
             ("alt1:alt2:alt3:dataset.table", None, "Use either : or . to specify project got {}"),
             (
@@ -1497,7 +1497,7 @@ class TestBigQueryAsyncHookMethods:
         assert isinstance(result, Job)
 
     @pytest.mark.parametrize(
-        "job_state, error_result, expected",
+        ("job_state", "error_result", "expected"),
         [
             ("DONE", None, {"status": "success", "message": "Job completed"}),
             ("DONE", {"message": "Timeout"}, {"status": "error", "message": "Timeout"}),
@@ -1688,7 +1688,7 @@ class TestBigQueryAsyncHookMethods:
         assert resp == response
 
     @pytest.mark.parametrize(
-        "records,pass_value,tolerance", [(["str"], "str", None), ([2], 2, None), ([0], 2, 1), ([4], 2, 1)]
+        ("records", "pass_value", "tolerance"), [(["str"], "str", None), ([2], 2, None), ([0], 2, 1), ([4], 2, 1)]
     )
     def test_value_check_success(self, records, pass_value, tolerance):
         """
@@ -1700,7 +1700,7 @@ class TestBigQueryAsyncHookMethods:
         assert response is None
 
     @pytest.mark.parametrize(
-        "records,pass_value,tolerance",
+        ("records", "pass_value", "tolerance"),
         [([], "", None), (["str"], "str1", None), ([2], 21, None), ([5], 2, 1), (["str"], 2, None)],
     )
     def test_value_check_fail(self, records, pass_value, tolerance):
@@ -1713,7 +1713,7 @@ class TestBigQueryAsyncHookMethods:
         assert isinstance(ex.value, AirflowException)
 
     @pytest.mark.parametrize(
-        "records,pass_value,tolerance, expected",
+        ("records", "pass_value", "tolerance", "expected"),
         [
             ([2.0], 2.0, None, [True]),
             ([2.0], 2.1, None, [False]),
@@ -1729,7 +1729,7 @@ class TestBigQueryAsyncHookMethods:
 
         assert BigQueryAsyncHook._get_numeric_matches(records, pass_value, tolerance) == expected
 
-    @pytest.mark.parametrize("test_input,expected", [(5.0, 5.0), (5, 5.0), ("5", 5), ("str", "str")])
+    @pytest.mark.parametrize(("test_input", "expected"), [(5.0, 5.0), (5, 5.0), ("5", 5), ("str", "str")])
     def test_convert_to_float_if_possible(self, test_input, expected):
         """
         Assert that type casting succeed for the possible value

--- a/providers/google/tests/unit/google/cloud/hooks/test_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_bigquery.py
@@ -1688,7 +1688,8 @@ class TestBigQueryAsyncHookMethods:
         assert resp == response
 
     @pytest.mark.parametrize(
-        ("records", "pass_value", "tolerance"), [(["str"], "str", None), ([2], 2, None), ([0], 2, 1), ([4], 2, 1)]
+        ("records", "pass_value", "tolerance"),
+        [(["str"], "str", None), ([2], 2, None), ([0], 2, 1), ([4], 2, 1)],
     )
     def test_value_check_success(self, records, pass_value, tolerance):
         """

--- a/providers/google/tests/unit/google/cloud/hooks/test_cloud_sql.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_cloud_sql.py
@@ -1147,7 +1147,7 @@ class TestCloudSqlDatabaseHook:
 
     @pytest.mark.parametrize("ssl_name", ["sslcert", "sslkey", "sslrootcert"])
     @pytest.mark.parametrize(
-        "cert_value, cert_path, extra_cert_path",
+        ("cert_value", "cert_path", "extra_cert_path"),
         [
             (None, None, "/connection/path/to/cert.pem"),
             (None, "/path/to/cert.pem", None),
@@ -1236,7 +1236,7 @@ class TestCloudSqlDatabaseHook:
         assert not mock_set_temporary_ssl_file.called
 
     @pytest.mark.parametrize(
-        "cert_name, cert_value",
+        ("cert_name", "cert_value"),
         [
             ["sslcert", SSL_CERT],
             ["sslkey", SSL_KEY],
@@ -1279,7 +1279,7 @@ class TestCloudSqlDatabaseHook:
         )
 
     @pytest.mark.parametrize(
-        "cert_name, cert_value",
+        ("cert_name", "cert_value"),
         [
             ["sslcert", SSL_CERT],
             ["sslkey", SSL_KEY],
@@ -1716,7 +1716,7 @@ def get_processor():
 
 class TestCloudSqlProxyRunner:
     @pytest.mark.parametrize(
-        ["version", "download_url"],
+        ("version", "download_url"),
         [
             (
                 "v1.23.0",

--- a/providers/google/tests/unit/google/cloud/hooks/test_cloud_storage_transfer_service.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_cloud_storage_transfer_service.py
@@ -489,7 +489,7 @@ class TestGCPTransferServiceHookWithPassedProjectId:
             )
 
     @pytest.mark.parametrize(
-        "statuses, expected_statuses",
+        ("statuses", "expected_statuses"),
         [
             ([GcpTransferOperationStatus.ABORTED], (GcpTransferOperationStatus.IN_PROGRESS,)),
             (
@@ -514,7 +514,7 @@ class TestGCPTransferServiceHookWithPassedProjectId:
             )
 
     @pytest.mark.parametrize(
-        "statuses, expected_statuses",
+        ("statuses", "expected_statuses"),
         [
             ([GcpTransferOperationStatus.ABORTED], GcpTransferOperationStatus.ABORTED),
             (

--- a/providers/google/tests/unit/google/cloud/hooks/test_cloud_storage_transfer_service_async.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_cloud_storage_transfer_service_async.py
@@ -151,7 +151,7 @@ class TestCloudDataTransferServiceAsyncHook:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "statuses, expected_statuses",
+        ("statuses", "expected_statuses"),
         [
             ([GcpTransferOperationStatus.ABORTED], (GcpTransferOperationStatus.IN_PROGRESS,)),
             (
@@ -186,7 +186,7 @@ class TestCloudDataTransferServiceAsyncHook:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "statuses, expected_statuses",
+        ("statuses", "expected_statuses"),
         [
             ([GcpTransferOperationStatus.ABORTED], GcpTransferOperationStatus.ABORTED),
             (

--- a/providers/google/tests/unit/google/cloud/hooks/test_compute_ssh.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_compute_ssh.py
@@ -112,7 +112,7 @@ class TestComputeEngineHookWithPassedProjectId:
 
     @pytest.mark.db_test
     @pytest.mark.parametrize(
-        "exception_type, error_message",
+        ("exception_type", "error_message"),
         [(SSHException, r"Error occurred when establishing SSH connection using Paramiko")],
     )
     @mock.patch("airflow.providers.google.cloud.hooks.compute_ssh.ComputeEngineHook")
@@ -216,7 +216,7 @@ class TestComputeEngineHookWithPassedProjectId:
 
     @pytest.mark.db_test
     @pytest.mark.parametrize(
-        "exception_type, error_message",
+        ("exception_type", "error_message"),
         [
             (
                 HttpError(resp=httplib2.Response({"status": 412}), content=b"Error content"),
@@ -415,7 +415,7 @@ class TestComputeEngineHookWithPassedProjectId:
 
     @pytest.mark.db_test
     @pytest.mark.parametrize(
-        "exception_type, error_message",
+        ("exception_type", "error_message"),
         [(SSHException, r"Error occurred when establishing SSH connection using Paramiko")],
     )
     @mock.patch("airflow.providers.google.cloud.hooks.compute_ssh.ComputeEngineHook")
@@ -522,7 +522,7 @@ class TestComputeEngineHookWithPassedProjectId:
         assert isinstance(hook.expire_time, int)
 
     @pytest.mark.parametrize(
-        "metadata, expected_metadata",
+        ("metadata", "expected_metadata"),
         [
             ({"items": []}, {"items": [{"key": "ssh-keys", "value": "user:pubkey\n"}]}),
             (

--- a/providers/google/tests/unit/google/cloud/hooks/test_dataflow.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_dataflow.py
@@ -206,7 +206,7 @@ class TestDataflowHook:
         assert mock_build.return_value == result
 
     @pytest.mark.parametrize(
-        "expected_result, job_name, append_job_name",
+        ("expected_result", "job_name", "append_job_name"),
         [
             (JOB_NAME, JOB_NAME, False),
             ("test-example", "test_example", False),
@@ -736,7 +736,7 @@ class TestDataflowJob:
         assert dataflow_job.get_jobs() == [job, job]
 
     @pytest.mark.parametrize(
-        "state, exception_regex",
+        ("state", "exception_regex"),
         [
             (DataflowJobStatus.JOB_STATE_FAILED, "unexpected terminal state: JOB_STATE_FAILED"),
             (DataflowJobStatus.JOB_STATE_CANCELLED, "unexpected terminal state: JOB_STATE_CANCELLED"),
@@ -878,7 +878,7 @@ class TestDataflowJob:
         assert result is False
 
     @pytest.mark.parametrize(
-        "job_type, job_state, wait_until_finished, expected_result",
+        ("job_type", "job_state", "wait_until_finished", "expected_result"),
         [
             # RUNNING
             (DataflowJobType.JOB_TYPE_BATCH, DataflowJobStatus.JOB_STATE_RUNNING, None, False),
@@ -915,7 +915,7 @@ class TestDataflowJob:
         assert result == expected_result
 
     @pytest.mark.parametrize(
-        "jobs, wait_until_finished, expected_result",
+        ("jobs", "wait_until_finished", "expected_result"),
         [
             # STREAMING
             (
@@ -987,7 +987,7 @@ class TestDataflowJob:
         assert result == expected_result
 
     @pytest.mark.parametrize(
-        "job_state, wait_until_finished, expected_result",
+        ("job_state", "wait_until_finished", "expected_result"),
         [
             # DONE
             (DataflowJobStatus.JOB_STATE_DONE, None, True),
@@ -1020,7 +1020,7 @@ class TestDataflowJob:
         assert result == expected_result
 
     @pytest.mark.parametrize(
-        "job_type, job_state, exception_regex",
+        ("job_type", "job_state", "exception_regex"),
         [
             (
                 DataflowJobType.JOB_TYPE_BATCH,
@@ -1090,7 +1090,7 @@ class TestDataflowJob:
             dataflow_job.job_reached_terminal_state(job)
 
     @pytest.mark.parametrize(
-        "job_type, expected_terminal_state, match",
+        ("job_type", "expected_terminal_state", "match"),
         [
             (
                 DataflowJobType.JOB_TYPE_BATCH,
@@ -1213,7 +1213,7 @@ class TestDataflowJob:
         )
 
     @pytest.mark.parametrize(
-        "drain_pipeline, job_type, requested_state",
+        ("drain_pipeline", "job_type", "requested_state"),
         [
             (False, "JOB_TYPE_BATCH", "JOB_STATE_CANCELLED"),
             (False, "JOB_TYPE_STREAMING", "JOB_STATE_CANCELLED"),

--- a/providers/google/tests/unit/google/cloud/hooks/test_datafusion.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_datafusion.py
@@ -519,7 +519,7 @@ class TestDataFusionHook:
         )
 
     @pytest.mark.parametrize(
-        "pipeline_type, expected_program_type",
+        ("pipeline_type", "expected_program_type"),
         [
             (DataFusionPipelineType.BATCH, "workflow"),
             (DataFusionPipelineType.STREAM, "spark"),
@@ -530,7 +530,7 @@ class TestDataFusionHook:
         assert DataFusionHook.cdap_program_type(pipeline_type) == expected_program_type
 
     @pytest.mark.parametrize(
-        "pipeline_type, expected_program_id",
+        ("pipeline_type", "expected_program_id"),
         [
             (DataFusionPipelineType.BATCH, "DataPipelineWorkflow"),
             (DataFusionPipelineType.STREAM, "DataStreamsSparkStreaming"),
@@ -556,7 +556,7 @@ class TestDataFusionHookAsynch:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "pipeline_type, constructed_url",
+        ("pipeline_type", "constructed_url"),
         [
             (DataFusionPipelineType.BATCH, CONSTRUCTED_PIPELINE_URL_GET),
             (DataFusionPipelineType.STREAM, CONSTRUCTED_PIPELINE_STREAM_URL_GET),
@@ -593,7 +593,7 @@ class TestDataFusionHookAsynch:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "pipeline_type, constructed_url",
+        ("pipeline_type", "constructed_url"),
         [
             (DataFusionPipelineType.BATCH, CONSTRUCTED_PIPELINE_URL_GET),
             (DataFusionPipelineType.STREAM, CONSTRUCTED_PIPELINE_STREAM_URL_GET),

--- a/providers/google/tests/unit/google/cloud/hooks/test_dataproc_metastore.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_dataproc_metastore.py
@@ -309,7 +309,7 @@ class TestDataprocMetastoreWithDefaultProjectIdHook:
         )
 
     @pytest.mark.parametrize(
-        "partitions_input, partitions",
+        ("partitions_input", "partitions"),
         [
             ([TEST_PARTITION_NAME], f"'{TEST_PARTITION_NAME}'"),
             ([TEST_SUBPARTITION_NAME], f"'{TEST_SUBPARTITION_NAME}'"),
@@ -576,7 +576,7 @@ class TestDataprocMetastoreWithoutDefaultProjectIdHook:
         )
 
     @pytest.mark.parametrize(
-        "partitions_input, partitions",
+        ("partitions_input", "partitions"),
         [
             ([TEST_PARTITION_NAME], f"'{TEST_PARTITION_NAME}'"),
             ([TEST_SUBPARTITION_NAME], f"'{TEST_SUBPARTITION_NAME}'"),

--- a/providers/google/tests/unit/google/cloud/hooks/test_gcs.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_gcs.py
@@ -96,7 +96,7 @@ class TestGCSHookHelperFunctions:
         assert gcs._parse_gcs_url("gs://bucket/") == ("bucket", "")
 
     @pytest.mark.parametrize(
-        "json_value, parsed_value",
+        ("json_value", "parsed_value"),
         [
             ("[1, 2, 3]", [1, 2, 3]),
             ('"string value"', "string value"),
@@ -960,7 +960,7 @@ class TestGCSHook:
         )
 
     @pytest.mark.parametrize(
-        "prefix, blob_names, returned_prefixes, call_args, result",
+        ("prefix", "blob_names", "returned_prefixes", "call_args", "result"),
         (
             (
                 "prefix",

--- a/providers/google/tests/unit/google/cloud/hooks/test_kubernetes_engine.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_kubernetes_engine.py
@@ -393,7 +393,7 @@ class TestGKEHook:
         assert operation_mock.call_count == 2
 
     @pytest.mark.parametrize(
-        "cluster_obj, expected_result",
+        ("cluster_obj", "expected_result"),
         [
             (CLUSTER_TEST_AUTOPROVISIONING, True),
             (CLUSTER_TEST_AUTOSCALED, True),
@@ -451,7 +451,7 @@ class TestGKEKubernetesHookDeployments:
         return self.credentials
 
     @pytest.mark.parametrize(
-        "api_client, expected_client",
+        ("api_client", "expected_client"),
         [
             (None, mock.MagicMock()),
             (mock_client := mock.MagicMock(), mock_client),  # type: ignore[name-defined]
@@ -629,7 +629,7 @@ class TestGKEKubernetesHookPod:
         return self.credentials
 
     @pytest.mark.parametrize(
-        "disable_tcp_keepalive, expected",
+        ("disable_tcp_keepalive", "expected"),
         (
             (True, False),
             (None, True),

--- a/providers/google/tests/unit/google/cloud/hooks/test_pubsub.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_pubsub.py
@@ -502,7 +502,7 @@ class TestPubSubHook:
         )
 
     @pytest.mark.parametrize(
-        "ack_ids, messages",
+        ("ack_ids", "messages"),
         [
             pytest.param(None, None, id="both-empty"),
             pytest.param([1, 2, 3], _generate_messages(3), id="both-provided"),
@@ -564,7 +564,7 @@ class TestPubSubHook:
         PubSubHook._validate_messages(messages)
 
     @pytest.mark.parametrize(
-        "messages, error_message",
+        ("messages", "error_message"),
         [
             ([("wrong type",)], "Wrong message type. Must be a dictionary."),
             ([{"wrong_key": b"test"}], "Wrong message. Dictionary must contain 'data' or 'attributes'."),

--- a/providers/google/tests/unit/google/cloud/hooks/test_secret_manager.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_secret_manager.py
@@ -108,7 +108,7 @@ class TestGoogleCloudSecretManagerHook:
         mock_client.assert_called_once()
 
     @pytest.mark.parametrize(
-        "input_secret, expected_secret",
+        ("input_secret", "expected_secret"),
         [
             (None, {"replication": {"automatic": {}}}),
             (mock_secret := MagicMock(), mock_secret),  # type: ignore[name-defined]
@@ -207,7 +207,7 @@ class TestGoogleCloudSecretManagerHook:
         )
 
     @pytest.mark.parametrize(
-        "secret_names, secret_id, secret_exists_expected",
+        ("secret_names", "secret_id", "secret_exists_expected"),
         [
             ([], SECRET_ID, False),
             (["secret/name"], SECRET_ID, False),

--- a/providers/google/tests/unit/google/cloud/hooks/test_spanner.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_spanner.py
@@ -437,7 +437,7 @@ class TestGcpSpannerHookDefaultProjectId:
         pass
 
     @pytest.mark.parametrize(
-        "returned_items, expected_counts",
+        ("returned_items", "expected_counts"),
         [
             pytest.param(
                 [

--- a/providers/google/tests/unit/google/cloud/hooks/test_vision.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_vision.py
@@ -239,7 +239,7 @@ class TestGcpVisionHook:
             update_mask=None,
         )
 
-    @pytest.mark.parametrize("location, product_set_id", LOCATION_PRODUCTSET_ID_TEST_PARAMS)
+    @pytest.mark.parametrize(("location", "product_set_id"), LOCATION_PRODUCTSET_ID_TEST_PARAMS)
     @mock.patch("airflow.providers.google.cloud.hooks.vision.CloudVisionHook.get_conn")
     def test_update_productset_no_explicit_name_and_missing_params_for_constructed_name(
         self, get_conn, location, product_set_id
@@ -265,7 +265,7 @@ class TestGcpVisionHook:
         assert ERR_UNABLE_TO_CREATE.format(label="ProductSet", id_label="productset_id") in str(err)
         update_product_set_method.assert_not_called()
 
-    @pytest.mark.parametrize("location, product_set_id", LOCATION_PRODUCTSET_ID_TEST_PARAMS)
+    @pytest.mark.parametrize(("location", "product_set_id"), LOCATION_PRODUCTSET_ID_TEST_PARAMS)
     @mock.patch("airflow.providers.google.cloud.hooks.vision.CloudVisionHook.get_conn")
     def test_update_productset_explicit_name_missing_params_for_constructed_name(
         self,
@@ -586,7 +586,7 @@ class TestGcpVisionHook:
             product=Product(name=product_name), metadata=(), retry=DEFAULT, timeout=None, update_mask=None
         )
 
-    @pytest.mark.parametrize("location, product_id", LOCATION_PRODUCT_ID_TEST_PARAMS)
+    @pytest.mark.parametrize(("location", "product_id"), LOCATION_PRODUCT_ID_TEST_PARAMS)
     @mock.patch("airflow.providers.google.cloud.hooks.vision.CloudVisionHook.get_conn")
     def test_update_product_no_explicit_name_and_missing_params_for_constructed_name(
         self, get_conn, location, product_id
@@ -612,7 +612,7 @@ class TestGcpVisionHook:
         assert ERR_UNABLE_TO_CREATE.format(label="Product", id_label="product_id") in str(err)
         update_product_method.assert_not_called()
 
-    @pytest.mark.parametrize("location, product_id", LOCATION_PRODUCT_ID_TEST_PARAMS)
+    @pytest.mark.parametrize(("location", "product_id"), LOCATION_PRODUCT_ID_TEST_PARAMS)
     @mock.patch("airflow.providers.google.cloud.hooks.vision.CloudVisionHook.get_conn")
     def test_update_product_explicit_name_missing_params_for_constructed_name(
         self, get_conn, location, product_id

--- a/providers/google/tests/unit/google/common/hooks/test_base_google.py
+++ b/providers/google/tests/unit/google/common/hooks/test_base_google.py
@@ -101,7 +101,7 @@ class TestQuotaRetry:
 
 class TestRefreshCredentialsRetry:
     @pytest.mark.parametrize(
-        "exc, retryable",
+        ("exc", "retryable"),
         [
             (RefreshError("Other error", "test body"), False),
             (RefreshError("Unable to acquire impersonated credentials", "test body"), True),
@@ -713,7 +713,7 @@ class TestGoogleBaseHook:
         assert http_authorized.timeout is not None
 
     @pytest.mark.parametrize(
-        "impersonation_chain, impersonation_chain_from_conn, target_principal, delegates",
+        ("impersonation_chain", "impersonation_chain_from_conn", "target_principal", "delegates"),
         [
             pytest.param("ACCOUNT_1", None, "ACCOUNT_1", None, id="string"),
             pytest.param(None, "ACCOUNT_1", "ACCOUNT_1", None, id="string_in_conn"),

--- a/providers/google/tests/unit/google/marketing_platform/hooks/test_search_ads.py
+++ b/providers/google/tests/unit/google/marketing_platform/hooks/test_search_ads.py
@@ -60,7 +60,7 @@ class TestGoogleSearchAdsReportingHook:
         "airflow.providers.google.marketing_platform.hooks.search_ads.GoogleSearchAdsReportingHook.customer_service"
     )
     @pytest.mark.parametrize(
-        "given_args, expected_args_extras",
+        ("given_args", "expected_args_extras"),
         [
             ({"page_token": None}, {}),
             ({"page_token": "next_page_token"}, {"pageToken": "next_page_token"}),
@@ -149,7 +149,7 @@ class TestGoogleSearchAdsReportingHook:
         "airflow.providers.google.marketing_platform.hooks.search_ads.GoogleSearchAdsReportingHook.fields_service"
     )
     @pytest.mark.parametrize(
-        "given_args, expected_args_extras",
+        ("given_args", "expected_args_extras"),
         [
             ({"page_token": None}, {}),
             ({"page_token": "next_page_token"}, {"pageToken": "next_page_token"}),


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
related: #40567

@ferruzzi 
This PR fixed `/cloud/hooks`, `common/hooks/` , `marketing_platform/hooks/` in google provider for enable PT006 rule:
https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
