### PR TITLE
Enable PT006 rule to hashicorp Provider test

### DIFF
--- a/providers/hashicorp/tests/unit/hashicorp/hooks/test_vault.py
+++ b/providers/hashicorp/tests/unit/hashicorp/hooks/test_vault.py
@@ -62,7 +62,7 @@ class TestVaultHook:
             VaultHook(**kwargs)
 
     @pytest.mark.parametrize(
-        "version, expected_version",
+        ("version", "expected_version"),
         [
             ("2", 2),
             (1, 1),
@@ -161,7 +161,7 @@ class TestVaultHook:
         assert test_hook.vault_client.kv_engine_version == 1
 
     @pytest.mark.parametrize(
-        "protocol, expected_url",
+        ("protocol", "expected_url"),
         [
             ("vaults", "https://localhost:8180"),
             ("http", "http://localhost:8180"),
@@ -195,7 +195,7 @@ class TestVaultHook:
         assert test_hook.vault_client.kv_engine_version == 2
 
     @pytest.mark.parametrize(
-        "use_tls, expected_url",
+        ("use_tls", "expected_url"),
         [
             (True, "https://localhost:8180"),
             (False, "http://localhost:8180"),
@@ -1282,7 +1282,7 @@ class TestVaultHook:
         )
 
     @pytest.mark.parametrize(
-        "method, expected_method",
+        ("method", "expected_method"),
         [
             (None, None),
             ("post", "post"),

--- a/providers/hashicorp/tests/unit/hashicorp/secrets/test_vault.py
+++ b/providers/hashicorp/tests/unit/hashicorp/secrets/test_vault.py
@@ -182,7 +182,7 @@ class TestVaultSecrets:
         assert returned_uri == "world"
 
     @pytest.mark.parametrize(
-        "mount_point, variables_path, variable_key, expected_args",
+        ("mount_point", "variables_path", "variable_key", "expected_args"),
         [
             ("airflow", "variables", "hello", {"mount_point": "airflow", "path": "variables/hello"}),
             (


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
related: #40567

This PR is for enable PT006 rule:
https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
