### PR TITLE
Enable PT006 rule to openai Provider test(triggers)

### DIFF
--- a/providers/openai/tests/unit/openai/triggers/test_openai.py
+++ b/providers/openai/tests/unit/openai/triggers/test_openai.py
@@ -79,7 +79,7 @@ class TestOpenAIBatchTrigger:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "mock_batch_status, mock_status, mock_message",
+        ("mock_batch_status", "mock_status", "mock_message"),
         [
             (str(BatchStatus.COMPLETED), "success", "Batch batch_id has completed successfully."),
             (str(BatchStatus.CANCELLING), "cancelled", "Batch batch_id has been cancelled."),


### PR DESCRIPTION
Issue: Enable Even More PyDocStyle Checks https://github.com/apache/airflow/issues/40567
@ferruzzi

This PR is for enable PT006 rule:
PT006: all instances of @pytest.mark.parametrize names should be a tuple
https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/

This is for openai Provider.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
