### PR TITLE
Enable PT006 rule to jenkins Provider test 

### DIFF
--- a/providers/jenkins/tests/unit/jenkins/operators/test_jenkins_job_trigger.py
+++ b/providers/jenkins/tests/unit/jenkins/operators/test_jenkins_job_trigger.py
@@ -186,7 +186,7 @@ class TestJenkinsOperator:
                 operator.execute(None)
 
     @pytest.mark.parametrize(
-        "state, allowed_jenkins_states",
+        ("state", "allowed_jenkins_states"),
         [
             (
                 "SUCCESS",
@@ -253,7 +253,7 @@ class TestJenkinsOperator:
                 pytest.fail(f"Job failed with state={state} while allowed states={allowed_jenkins_states}")
 
     @pytest.mark.parametrize(
-        "state, allowed_jenkins_states",
+        ("state", "allowed_jenkins_states"),
         [
             (
                 "FAILURE",

--- a/providers/jenkins/tests/unit/jenkins/sensors/test_jenkins.py
+++ b/providers/jenkins/tests/unit/jenkins/sensors/test_jenkins.py
@@ -28,7 +28,7 @@ from airflow.providers.jenkins.sensors.jenkins import JenkinsBuildSensor
 
 class TestJenkinsBuildSensor:
     @pytest.mark.parametrize(
-        "build_number, build_state, result",
+        ("build_number", "build_state", "result"),
         [
             (
                 None,
@@ -70,7 +70,7 @@ class TestJenkinsBuildSensor:
             jenkins_mock.get_build_info.assert_called_once_with("a_job_on_jenkins", target_build_number)
 
     @pytest.mark.parametrize(
-        "build_number, build_state, result",
+        ("build_number", "build_state", "result"),
         [
             (
                 1,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
related: #40567 
This PR fixed jenkins Provider test for enable PT006 rule:
https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/
There are a lot of file changes needed.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
