### PR TITLE
Enable PT006 rule to keycloak Provider test

### DIFF
--- a/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
@@ -130,7 +130,7 @@ class TestKeycloakAuthManager:
         assert result.refresh_token == "new_refresh_token"
 
     @pytest.mark.parametrize(
-        "function, method, details, permission, attributes",
+        ("function", "method", "details", "permission", "attributes"),
         [
             [
                 "is_authorized_configuration",
@@ -198,7 +198,7 @@ class TestKeycloakAuthManager:
         ],
     )
     @pytest.mark.parametrize(
-        "status_code, expected",
+        ("status_code", "expected"),
         [
             [200, True],
             [403, False],
@@ -278,7 +278,7 @@ class TestKeycloakAuthManager:
         assert "Request not recognized by Keycloak. invalid_scope. Invalid scopes: GET" in str(e.value)
 
     @pytest.mark.parametrize(
-        "method, access_entity, details, permission, attributes",
+        ("method", "access_entity", "details", "permission", "attributes"),
         [
             [
                 "GET",
@@ -311,7 +311,7 @@ class TestKeycloakAuthManager:
         ],
     )
     @pytest.mark.parametrize(
-        "status_code, expected",
+        ("status_code", "expected"),
         [
             [200, True],
             [403, False],
@@ -344,7 +344,7 @@ class TestKeycloakAuthManager:
         assert result == expected
 
     @pytest.mark.parametrize(
-        "status_code, expected",
+        ("status_code", "expected"),
         [
             [200, True],
             [403, False],
@@ -372,7 +372,7 @@ class TestKeycloakAuthManager:
         assert result == expected
 
     @pytest.mark.parametrize(
-        "status_code, expected",
+        ("status_code", "expected"),
         [
             [200, True],
             [403, False],
@@ -398,7 +398,7 @@ class TestKeycloakAuthManager:
         assert result == expected
 
     @pytest.mark.parametrize(
-        "status_code, response, expected",
+        ("status_code", "response", "expected"),
         [
             [
                 200,
@@ -455,7 +455,7 @@ class TestKeycloakAuthManager:
         assert len(auth_manager.get_cli_commands()) == 1
 
     @pytest.mark.parametrize(
-        "expiration, expected",
+        ("expiration", "expected"),
         [
             (-30, True),
             (30, False),


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
related: #40567 
This PR fixed keycloak Provider test for enable PT006 rule:
https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/
There are a lot of file changes needed.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
