### PR TITLE
Enable PT006 rule to microsoft Provider test(log,sensors)

### DIFF
--- a/providers/microsoft/azure/tests/unit/microsoft/azure/log/test_wasb_task_handler.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/log/test_wasb_task_handler.py
@@ -197,7 +197,7 @@ class TestWasbTaskHandler:
         assert rec.exc_info is not None
 
     @pytest.mark.parametrize(
-        "delete_local_copy, expected_existence_of_local_copy",
+        ("delete_local_copy", "expected_existence_of_local_copy"),
         [(True, False), (False, True)],
     )
     @mock.patch.object(WasbRemoteLogIO, "write")

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/sensors/test_data_factory.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/sensors/test_data_factory.py
@@ -55,7 +55,7 @@ class TestAzureDataFactoryPipelineRunStatusSensor:
         assert self.sensor.poke_interval == self.config["poke_interval"]
 
     @pytest.mark.parametrize(
-        "pipeline_run_status, expected_status",
+        ("pipeline_run_status", "expected_status"),
         [
             (AzureDataFactoryPipelineRunStatus.SUCCEEDED, True),
             (AzureDataFactoryPipelineRunStatus.FAILED, "exception"),


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
@ferruzzi 

related: #40567 
This PR fixed microsoft Provider test in `/log`, `/sensors` for enable PT006 rule:
https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
