### PR TITLE
Enable PT006 rule to google Provider test (operators part1)

### DIFF
--- a/providers/google/tests/unit/google/cloud/operators/test_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_bigquery.py
@@ -238,7 +238,7 @@ class TestBigQueryCreateTableOperator:
         )
 
     @pytest.mark.parametrize(
-        "if_exists, is_conflict, expected_error, log_msg",
+        ("if_exists", "is_conflict", "expected_error", "log_msg"),
         [
             ("ignore", False, None, None),
             ("log", False, None, None),
@@ -370,7 +370,7 @@ class TestBigQueryCreateEmptyDatasetOperator:
         )
 
     @pytest.mark.parametrize(
-        "if_exists, is_conflict, expected_error, log_msg",
+        ("if_exists", "is_conflict", "expected_error", "log_msg"),
         [
             ("ignore", False, None, None),
             ("log", False, None, None),
@@ -896,7 +896,7 @@ class TestBigQueryGetDatasetTablesOperator:
 
 
 @pytest.mark.parametrize(
-    "operator_class, kwargs",
+    ("operator_class", "kwargs"),
     [
         (BigQueryCheckOperator, dict(sql="Select * from test_table")),
         (BigQueryValueCheckOperator, dict(sql="Select * from test_table", pass_value=95)),
@@ -2480,7 +2480,7 @@ class TestBigQueryValueCheckOperator:
         assert str(exc.value) == f"BigQuery job {real_job_id} failed: True"
 
     @pytest.mark.parametrize(
-        "kwargs, expected",
+        ("kwargs", "expected"),
         [
             ({"sql": "SELECT COUNT(*) from Any"}, "missing keyword argument 'pass_value'"),
             ({"pass_value": "Any"}, "missing keyword argument 'sql'"),
@@ -2591,7 +2591,7 @@ class TestBigQueryValueCheckOperator:
 @pytest.mark.db_test
 class TestBigQueryColumnCheckOperator:
     @pytest.mark.parametrize(
-        "check_type, check_value, check_result",
+        ("check_type", "check_value", "check_result"),
         [
             ("equal_to", 0, 0),
             ("greater_than", 0, 1),
@@ -2625,7 +2625,7 @@ class TestBigQueryColumnCheckOperator:
         ti.task.execute(MagicMock())
 
     @pytest.mark.parametrize(
-        "check_type, check_value, check_result",
+        ("check_type", "check_value", "check_result"),
         [
             ("equal_to", 0, 1),
             ("greater_than", 0, -1),
@@ -2658,7 +2658,7 @@ class TestBigQueryColumnCheckOperator:
             ti.task.execute(MagicMock())
 
     @pytest.mark.parametrize(
-        "check_type, check_value, check_result",
+        ("check_type", "check_value", "check_result"),
         [
             ("equal_to", 0, 0),
             ("greater_than", 0, 1),

--- a/providers/google/tests/unit/google/cloud/operators/test_bigtable.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_bigtable.py
@@ -57,7 +57,7 @@ EMPTY_COLUMN_FAMILIES: dict = {}
 
 class TestBigtableInstanceCreate:
     @pytest.mark.parametrize(
-        "missing_attribute, project_id, instance_id, main_cluster_id, main_cluster_zone",
+        ("missing_attribute", "project_id", "instance_id", "main_cluster_id", "main_cluster_zone"),
         [
             ("instance_id", PROJECT_ID, "", CLUSTER_ID, CLUSTER_ZONE),
             ("main_cluster_id", PROJECT_ID, INSTANCE_ID, "", CLUSTER_ZONE),
@@ -283,7 +283,7 @@ class TestBigtableInstanceUpdate:
         )
 
     @pytest.mark.parametrize(
-        "missing_attribute, project_id, instance_id",
+        ("missing_attribute", "project_id", "instance_id"),
         [("instance_id", PROJECT_ID, "")],
     )
     @mock.patch("airflow.providers.google.cloud.operators.bigtable.BigtableHook")
@@ -385,7 +385,7 @@ class TestBigtableInstanceUpdate:
 
 class TestBigtableClusterUpdate:
     @pytest.mark.parametrize(
-        "missing_attribute, project_id, instance_id, cluster_id, nodes",
+        ("missing_attribute", "project_id", "instance_id", "cluster_id", "nodes"),
         [
             ("instance_id", PROJECT_ID, "", CLUSTER_ID, NODES),
             ("cluster_id", PROJECT_ID, INSTANCE_ID, "", NODES),
@@ -572,7 +572,7 @@ class TestBigtableInstanceDelete:
         )
 
     @pytest.mark.parametrize(
-        "missing_attribute, project_id, instance_id",
+        ("missing_attribute", "project_id", "instance_id"),
         [("instance_id", PROJECT_ID, "")],
     )
     @mock.patch("airflow.providers.google.cloud.operators.bigtable.BigtableHook")
@@ -670,7 +670,7 @@ class TestBigtableTableDelete:
         )
 
     @pytest.mark.parametrize(
-        "missing_attribute, project_id, instance_id, table_id",
+        ("missing_attribute", "project_id", "instance_id", "table_id"),
         [
             ("instance_id", PROJECT_ID, "", TABLE_ID),
             ("table_id", PROJECT_ID, INSTANCE_ID, ""),
@@ -810,7 +810,7 @@ class TestBigtableTableCreate:
         )
 
     @pytest.mark.parametrize(
-        "missing_attribute, project_id, instance_id, table_id",
+        ("missing_attribute", "project_id", "instance_id", "table_id"),
         [
             ("instance_id", PROJECT_ID, "", TABLE_ID),
             ("table_id", PROJECT_ID, INSTANCE_ID, ""),

--- a/providers/google/tests/unit/google/cloud/operators/test_cloud_build.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_cloud_build.py
@@ -138,7 +138,7 @@ class TestCloudBuildOperator:
             CloudBuildCreateBuildOperator(task_id="id")
 
     @pytest.mark.parametrize(
-        "file_type, file_content",
+        ("file_type", "file_content"),
         [
             (
                 ".json",
@@ -333,7 +333,7 @@ class TestBuildProcessor:
             BuildProcessor(build={"source": {}}).process_body()
 
     @pytest.mark.parametrize(
-        "url, expected_dict",
+        ("url", "expected_dict"),
         [
             (
                 "https://source.cloud.google.com/airflow-project/airflow-repo",
@@ -372,7 +372,7 @@ class TestBuildProcessor:
             BuildProcessor(build=body).process_body()
 
     @pytest.mark.parametrize(
-        "url, expected_dict",
+        ("url", "expected_dict"),
         [
             (
                 "gs://bucket-name/airflow-object.tar.gz",
@@ -502,7 +502,7 @@ def test_async_create_build_with_missing_build_should_throw_exception(mock_hook)
 
 
 @pytest.mark.parametrize(
-    "file_type, file_content",
+    ("file_type", "file_content"),
     [
         (
             ".json",

--- a/providers/google/tests/unit/google/cloud/operators/test_cloud_logging_sink.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_cloud_logging_sink.py
@@ -512,7 +512,7 @@ class TestCloudLoggingListSinksOperator:
 
 
 class TestCloudLoggingUpdateSinksOperator:
-    @pytest.mark.parametrize("sink_config, update_mask", update_test_cases, ids=update_test_ids)
+    @pytest.mark.parametrize(("sink_config", "update_mask"), update_test_cases, ids=update_test_ids)
     def test_template_fields(self, sink_config, update_mask):
         operator = CloudLoggingUpdateSinkOperator(
             task_id=TASK_ID,
@@ -536,7 +536,7 @@ class TestCloudLoggingUpdateSinksOperator:
         assert "Required parameters are missing" in str(excinfo.value)
 
     @mock.patch(CLOUD_LOGGING_HOOK_PATH)
-    @pytest.mark.parametrize("sink_config, update_mask", update_test_cases, ids=update_test_ids)
+    @pytest.mark.parametrize(("sink_config", "update_mask"), update_test_cases, ids=update_test_ids)
     def test_update_sink_success(self, hook_mock, sink_config, update_mask):
         hook_instance = hook_mock.return_value
 
@@ -559,7 +559,7 @@ class TestCloudLoggingUpdateSinksOperator:
         assert result == LogSink.to_dict(sink_)
 
     @mock.patch(CLOUD_LOGGING_HOOK_PATH)
-    @pytest.mark.parametrize("sink_config, update_mask", update_test_cases, ids=update_test_ids)
+    @pytest.mark.parametrize(("sink_config", "update_mask"), update_test_cases, ids=update_test_ids)
     def test_update_sink_raises_not_found(self, hook_mock, sink_config, update_mask):
         hook_instance = hook_mock.return_value
 
@@ -580,7 +580,7 @@ class TestCloudLoggingUpdateSinksOperator:
         hook_instance.update_sink.assert_not_called()
 
     @mock.patch(CLOUD_LOGGING_HOOK_PATH)
-    @pytest.mark.parametrize("sink_config, update_mask", update_test_cases, ids=update_test_ids)
+    @pytest.mark.parametrize(("sink_config", "update_mask"), update_test_cases, ids=update_test_ids)
     def test_update_sink_raises_generic_error(self, hook_mock, sink_config, update_mask):
         hook_instance = hook_mock.return_value
         hook_instance.get_sink.side_effect = GoogleAPICallError("something went wrong")
@@ -664,7 +664,7 @@ class TestCloudLoggingUpdateSinksOperator:
             operator.execute(context)
 
     @mock.patch(CLOUD_LOGGING_HOOK_PATH)
-    @pytest.mark.parametrize("sink_config, update_mask", update_test_cases, ids=update_test_ids)
+    @pytest.mark.parametrize(("sink_config", "update_mask"), update_test_cases, ids=update_test_ids)
     def test_template_rendering(self, hook_mock, sink_config, update_mask):
         with DAG(
             dag_id="test_render_native",
@@ -718,7 +718,7 @@ class TestCloudLoggingUpdateSinksOperator:
         )
 
     @mock.patch(CLOUD_LOGGING_HOOK_PATH)
-    @pytest.mark.parametrize("sink_config, update_mask", update_test_cases, ids=update_test_ids)
+    @pytest.mark.parametrize(("sink_config", "update_mask"), update_test_cases, ids=update_test_ids)
     def test_template_rendering_with_proto(self, hook_mock, sink_config, update_mask):
         sink_obj = LogSink(**sink_config)
         mask_obj = FieldMask(paths=update_mask["paths"])

--- a/providers/google/tests/unit/google/cloud/operators/test_cloud_sql.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_cloud_sql.py
@@ -745,7 +745,7 @@ class TestCloudSqlQueryValidation:
         get_connection.side_effect = [gcp_connection, cloudsql_connection, cloudsql_connection2]
 
     @pytest.mark.parametrize(
-        "project_id, location, instance_name, database_type, use_proxy, use_ssl, sql, message",
+        ("project_id", "location", "instance_name", "database_type", "use_proxy", "use_ssl", "sql", "message"),
         [
             (
                 "project_id",
@@ -841,7 +841,7 @@ class TestCloudSqlQueryValidation:
         assert "The UNIX socket path length cannot exceed" in str(err)
 
     @pytest.mark.parametrize(
-        "connection_port, default_port, expected_port",
+        ("connection_port", "default_port", "expected_port"),
         [(None, 4321, 4321), (1234, None, 1234), (1234, 4321, 1234)],
     )
     def test_execute_openlineage_events(self, connection_port, default_port, expected_port):

--- a/providers/google/tests/unit/google/cloud/operators/test_cloud_sql.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_cloud_sql.py
@@ -745,7 +745,16 @@ class TestCloudSqlQueryValidation:
         get_connection.side_effect = [gcp_connection, cloudsql_connection, cloudsql_connection2]
 
     @pytest.mark.parametrize(
-        ("project_id", "location", "instance_name", "database_type", "use_proxy", "use_ssl", "sql", "message"),
+        (
+            "project_id",
+            "location",
+            "instance_name",
+            "database_type",
+            "use_proxy",
+            "use_ssl",
+            "sql",
+            "message",
+        ),
         [
             (
                 "project_id",

--- a/providers/google/tests/unit/google/cloud/operators/test_cloud_storage_transfer_service.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_cloud_storage_transfer_service.py
@@ -387,7 +387,7 @@ class TestGcpStorageTransferJobCreateOperator:
     # fields
     @pytest.mark.db_test
     @pytest.mark.parametrize(
-        "body, excepted",
+        ("body", "excepted"),
         [(VALID_TRANSFER_JOB_JINJA, VALID_TRANSFER_JOB_JINJA_RENDERED)],
     )
     @mock.patch(
@@ -1024,7 +1024,7 @@ class TestS3ToGoogleCloudStorageTransferOperator:
             )
 
     @pytest.mark.parametrize(
-        "wait, job_name",
+        ("wait", "job_name"),
         [
             (True, "transferJobs/123"),
             (False, "transferJobs/456"),
@@ -1079,7 +1079,7 @@ class TestS3ToGoogleCloudStorageTransferOperator:
         assert run_facet.wait == wait
 
     @pytest.mark.parametrize(
-        "object_conditions, delete_source",
+        ("object_conditions", "delete_source"),
         [
             ({"includePrefixes": ["2025/"]}, True),
             (None, False),


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
related: #40567

@ferruzzi 
This PR fixed 6 files in `/cloud/operator` in google provider for enable PT006 rule:
https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
