### PR TITLE
Enable PT006 rule to google Provider test (operators part2) 

### DIFF
--- a/providers/google/tests/unit/google/cloud/operators/test_datafusion.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_datafusion.py
@@ -414,7 +414,7 @@ class TestCloudDataFusionStartPipelineOperatorAsync:
             op.execute(context=mock.MagicMock())
 
     @pytest.mark.parametrize(
-        "pipeline_id, runtime_args, expected_run_id, expected_runtime_args, expected_output_suffix",
+        ("pipeline_id", "runtime_args", "expected_run_id", "expected_runtime_args", "expected_output_suffix"),
         [
             ("abc123", {"arg1": "val1"}, "abc123", {"arg1": "val1"}, "abc123"),
             (None, None, None, None, "unknown"),

--- a/providers/google/tests/unit/google/cloud/operators/test_dataprep.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_dataprep.py
@@ -90,7 +90,7 @@ class TestDataprepGetJobGroupOperator:
     @mock.patch("airflow.providers.google.cloud.operators.dataprep.GoogleDataprepHook")
     @mock.patch("airflow.providers.google.cloud.operators.dataprep.DataprepJobGroupLink")
     @pytest.mark.parametrize(
-        "provide_project_id, expected_call_count",
+        ("provide_project_id", "expected_call_count"),
         [
             (True, 1),
             (False, 0),
@@ -195,7 +195,7 @@ class TestDataprepCopyFlowOperatorTest:
     @mock.patch("airflow.providers.google.cloud.operators.dataprep.GoogleDataprepHook")
     @mock.patch("airflow.providers.google.cloud.operators.dataprep.DataprepFlowLink")
     @pytest.mark.parametrize(
-        "provide_project_id, expected_call_count",
+        ("provide_project_id", "expected_call_count"),
         [
             (True, 1),
             (False, 0),

--- a/providers/google/tests/unit/google/cloud/operators/test_functions.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_functions.py
@@ -70,7 +70,7 @@ def _prepare_test_bodies():
 
 
 class TestGcfFunctionDeploy:
-    @pytest.mark.parametrize("body, message", _prepare_test_bodies())
+    @pytest.mark.parametrize(("body", "message"), _prepare_test_bodies())
     @mock.patch("airflow.providers.google.cloud.operators.functions.CloudFunctionsHook")
     def test_missing_fields(self, mock_hook, body, message):
         op = CloudFunctionDeployFunctionOperator(
@@ -264,7 +264,7 @@ class TestGcfFunctionDeploy:
         mock_hook.reset_mock()
 
     @pytest.mark.parametrize(
-        "key, value, message",
+        ("key", "value", "message"),
         [
             ("name", "", "The body field 'name' of value '' does not match"),
             ("description", "", "The body field 'description' of value '' does not match"),
@@ -299,7 +299,7 @@ class TestGcfFunctionDeploy:
 
     @pytest.mark.db_test
     @pytest.mark.parametrize(
-        "source_code, message",
+        ("source_code", "message"),
         [
             (
                 {"sourceArchiveUrl": ""},
@@ -345,7 +345,7 @@ class TestGcfFunctionDeploy:
             op.execute(None)
 
     @pytest.mark.parametrize(
-        "source_code, message",
+        ("source_code", "message"),
         [
             (
                 {"sourceArchiveUrl": "", "zip_path": "/path/to/file"},
@@ -397,7 +397,7 @@ class TestGcfFunctionDeploy:
             )
 
     @pytest.mark.parametrize(
-        "source_code, project_id",
+        ("source_code", "project_id"),
         [
             ({"sourceArchiveUrl": "gs://url"}, "test_project_id"),
             ({"zip_path": "/path/to/file", "sourceUploadUrl": None}, "test_project_id"),
@@ -465,7 +465,7 @@ class TestGcfFunctionDeploy:
         mock_hook.reset_mock()
 
     @pytest.mark.parametrize(
-        "trigger, message",
+        ("trigger", "message"),
         [
             ({"eventTrigger": {}}, "The required body field 'trigger.eventTrigger.eventType' is missing"),
             (

--- a/providers/google/tests/unit/google/cloud/operators/test_kubernetes_engine.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_kubernetes_engine.py
@@ -104,7 +104,14 @@ GKE_OPERATORS_PATH = "airflow.providers.google.cloud.operators.kubernetes_engine
 
 class TestGKEClusterAuthDetails:
     @pytest.mark.parametrize(
-        ("use_dns_endpoint", "use_internal_ip", "endpoint", "private_endpoint", "dns_endpoint", "expected_cluster_url"),
+        (
+            "use_dns_endpoint",
+            "use_internal_ip",
+            "endpoint",
+            "private_endpoint",
+            "dns_endpoint",
+            "expected_cluster_url",
+        ),
         [
             (
                 False,

--- a/providers/google/tests/unit/google/cloud/operators/test_kubernetes_engine.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_kubernetes_engine.py
@@ -104,7 +104,7 @@ GKE_OPERATORS_PATH = "airflow.providers.google.cloud.operators.kubernetes_engine
 
 class TestGKEClusterAuthDetails:
     @pytest.mark.parametrize(
-        "use_dns_endpoint, use_internal_ip, endpoint, private_endpoint, dns_endpoint, expected_cluster_url",
+        ("use_dns_endpoint", "use_internal_ip", "endpoint", "private_endpoint", "dns_endpoint", "expected_cluster_url"),
         [
             (
                 False,
@@ -457,7 +457,7 @@ class TestGKECreateClusterOperator:
                 )
 
     @pytest.mark.parametrize(
-        "deprecated_field_name, deprecated_field_value",
+        ("deprecated_field_name", "deprecated_field_value"),
         [
             ("initial_node_count", 1),
             ("node_config", mock.MagicMock()),
@@ -687,7 +687,7 @@ class TestGKEStartPodOperator:
             )
 
     @pytest.mark.parametrize(
-        "kwargs, expected_attributes",
+        ("kwargs", "expected_attributes"),
         [
             (
                 {"on_finish_action": "delete_succeeded_pod"},

--- a/providers/google/tests/unit/google/cloud/operators/test_pubsub.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_pubsub.py
@@ -207,7 +207,7 @@ class TestPubSubSubscriptionCreateOperator:
         assert response == TEST_SUBSCRIPTION
 
     @pytest.mark.parametrize(
-        "project_id, subscription, subscription_project_id, expected_input, expected_output",
+        ("project_id", "subscription", "subscription_project_id", "expected_input", "expected_output"),
         [
             (
                 TEST_PROJECT,
@@ -353,7 +353,7 @@ class TestPubSubPublishOperator:
         )
 
     @pytest.mark.parametrize(
-        "project_id, expected_dataset",
+        ("project_id", "expected_dataset"),
         [
             # 1. project_id provided
             (TEST_PROJECT, f"topic:{TEST_PROJECT}:{TEST_TOPIC}"),

--- a/providers/google/tests/unit/google/cloud/operators/test_spanner.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_spanner.py
@@ -202,7 +202,7 @@ class TestCloudSpanner:
         assert result is None
 
     @pytest.mark.parametrize(
-        "project_id, instance_id, exp_msg",
+        ("project_id", "instance_id", "exp_msg"),
         [
             ("", INSTANCE_ID, "project_id"),
             (PROJECT_ID, "", "instance_id"),
@@ -264,7 +264,7 @@ class TestCloudSpanner:
         assert result
 
     @pytest.mark.parametrize(
-        "project_id, instance_id, exp_msg",
+        ("project_id", "instance_id", "exp_msg"),
         [
             ("", INSTANCE_ID, "project_id"),
             (PROJECT_ID, "", "instance_id"),
@@ -316,7 +316,7 @@ class TestCloudSpanner:
         assert result == [3]
 
     @pytest.mark.parametrize(
-        "project_id, instance_id, database_id, query, exp_msg",
+        ("project_id", "instance_id", "database_id", "query", "exp_msg"),
         [
             ("", INSTANCE_ID, DB_ID, INSERT_QUERY, "project_id"),
             (PROJECT_ID, "", DB_ID, INSERT_QUERY, "instance_id"),
@@ -384,7 +384,7 @@ class TestCloudSpanner:
         )
 
     @pytest.mark.parametrize(
-        "sql, expected_inputs, expected_outputs, expected_lineage",
+        ("sql", "expected_inputs", "expected_outputs", "expected_lineage"),
         [
             ("SELECT id, amount FROM public.orders", ["db1.public.orders"], [], {}),
             (
@@ -571,7 +571,7 @@ class TestCloudSpanner:
         assert result
 
     @pytest.mark.parametrize(
-        "project_id, instance_id, database_id, ddl_statements, exp_msg",
+        ("project_id", "instance_id", "database_id", "ddl_statements", "exp_msg"),
         [
             ("", INSTANCE_ID, DB_ID, DDL_STATEMENTS, "project_id"),
             (PROJECT_ID, "", DB_ID, DDL_STATEMENTS, "instance_id"),
@@ -641,7 +641,7 @@ class TestCloudSpanner:
         assert result
 
     @pytest.mark.parametrize(
-        "project_id, instance_id, database_id, ddl_statements, exp_msg",
+        ("project_id", "instance_id", "database_id", "ddl_statements", "exp_msg"),
         [
             ("", INSTANCE_ID, DB_ID, DDL_STATEMENTS, "project_id"),
             (PROJECT_ID, "", DB_ID, DDL_STATEMENTS, "instance_id"),
@@ -731,7 +731,7 @@ class TestCloudSpanner:
         assert result
 
     @pytest.mark.parametrize(
-        "project_id, instance_id, database_id, ddl_statements, exp_msg",
+        ("project_id", "instance_id", "database_id", "ddl_statements", "exp_msg"),
         [
             ("", INSTANCE_ID, DB_ID, DDL_STATEMENTS, "project_id"),
             (PROJECT_ID, "", DB_ID, DDL_STATEMENTS, "instance_id"),

--- a/providers/google/tests/unit/google/cloud/operators/test_text_to_speech.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_text_to_speech.py
@@ -74,7 +74,7 @@ class TestGcpTextToSpeech:
         )
 
     @pytest.mark.parametrize(
-        "missing_arg, input_data, voice, audio_config, target_bucket_name, target_filename",
+        ("missing_arg", "input_data", "voice", "audio_config", "target_bucket_name", "target_filename"),
         [
             ("input_data", "", VOICE, AUDIO_CONFIG, TARGET_BUCKET_NAME, TARGET_FILENAME),
             ("voice", INPUT, "", AUDIO_CONFIG, TARGET_BUCKET_NAME, TARGET_FILENAME),


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
related: #40567

@ferruzzi 
This PR fixed 7 files in `/cloud/operator` in google provider for enable PT006 rule:
https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
