### PR TITLE
Enable PT006 rule to google Provider test (sensors,secret) 

### DIFF
--- a/providers/google/tests/unit/google/cloud/secrets/test_secret_manager.py
+++ b/providers/google/tests/unit/google/cloud/secrets/test_secret_manager.py
@@ -58,7 +58,7 @@ class TestCloudSecretManagerBackend:
         assert backend._is_valid_prefix_and_sep()
 
     @pytest.mark.parametrize(
-        "prefix, sep",
+        ("prefix", "sep"),
         [
             pytest.param("not:valid", ":", id="colon separator"),
             pytest.param("not/valid", "/", id="backslash separator"),
@@ -71,7 +71,7 @@ class TestCloudSecretManagerBackend:
             CloudSecretManagerBackend(connections_prefix=prefix, sep=sep)
 
     @pytest.mark.parametrize(
-        "prefix, sep, is_valid",
+        ("prefix", "sep", "is_valid"),
         [
             pytest.param("valid1", "-", True, id="valid: dash separator"),
             pytest.param("isValid", "_", True, id="valid: underscore separator"),

--- a/providers/google/tests/unit/google/cloud/sensors/test_bigtable.py
+++ b/providers/google/tests/unit/google/cloud/sensors/test_bigtable.py
@@ -36,7 +36,7 @@ IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
 class BigtableWaitForTableReplicationTest:
     @pytest.mark.parametrize(
-        "missing_attribute, project_id, instance_id, table_id",
+        ("missing_attribute", "project_id", "instance_id", "table_id"),
         [
             ("instance_id", PROJECT_ID, "", TABLE_ID),
             ("table_id", PROJECT_ID, INSTANCE_ID, ""),

--- a/providers/google/tests/unit/google/cloud/sensors/test_cloud_storage_transfer_service.py
+++ b/providers/google/tests/unit/google/cloud/sensors/test_cloud_storage_transfer_service.py
@@ -180,7 +180,7 @@ class TestGcpStorageTransferOperationWaitForJobStatusSensor:
         )
 
     @pytest.mark.parametrize(
-        "expected_status, received_status",
+        ("expected_status", "received_status"),
         [
             (GcpTransferOperationStatus.SUCCESS, {GcpTransferOperationStatus.SUCCESS}),
             ({GcpTransferOperationStatus.SUCCESS}, {GcpTransferOperationStatus.SUCCESS}),

--- a/providers/google/tests/unit/google/cloud/sensors/test_dataflow.py
+++ b/providers/google/tests/unit/google/cloud/sensors/test_dataflow.py
@@ -46,7 +46,7 @@ TEST_IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
 class TestDataflowJobStatusSensor:
     @pytest.mark.parametrize(
-        "expected_status, current_status, sensor_return",
+        ("expected_status", "current_status", "sensor_return"),
         [
             (DataflowJobStatus.JOB_STATE_DONE, DataflowJobStatus.JOB_STATE_DONE, True),
             (DataflowJobStatus.JOB_STATE_DONE, DataflowJobStatus.JOB_STATE_RUNNING, False),
@@ -171,7 +171,7 @@ class TestDataflowJobStatusSensor:
 
 class TestDataflowJobMetricsSensor:
     @pytest.mark.parametrize(
-        "job_current_state, fail_on_terminal_state",
+        ("job_current_state", "fail_on_terminal_state"),
         [
             (DataflowJobStatus.JOB_STATE_RUNNING, True),
             (DataflowJobStatus.JOB_STATE_RUNNING, False),
@@ -349,7 +349,7 @@ class TestDataflowJobMetricsSensor:
 
 class TestDataflowJobMessagesSensor:
     @pytest.mark.parametrize(
-        "job_current_state, fail_on_terminal_state",
+        ("job_current_state", "fail_on_terminal_state"),
         [
             (DataflowJobStatus.JOB_STATE_RUNNING, True),
             (DataflowJobStatus.JOB_STATE_RUNNING, False),
@@ -525,7 +525,7 @@ class TestDataflowJobMessagesSensor:
 
 class TestDataflowJobAutoScalingEventsSensor:
     @pytest.mark.parametrize(
-        "job_current_state, fail_on_terminal_state",
+        ("job_current_state", "fail_on_terminal_state"),
         [
             (DataflowJobStatus.JOB_STATE_RUNNING, True),
             (DataflowJobStatus.JOB_STATE_RUNNING, False),

--- a/providers/google/tests/unit/google/cloud/sensors/test_dataform.py
+++ b/providers/google/tests/unit/google/cloud/sensors/test_dataform.py
@@ -38,7 +38,7 @@ TEST_IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
 class TestDataformWorkflowInvocationActionStateSensor:
     @pytest.mark.parametrize(
-        "expected_status, current_status, sensor_return",
+        ("expected_status", "current_status", "sensor_return"),
         [
             (WorkflowInvocationAction.State.SUCCEEDED, WorkflowInvocationAction.State.SUCCEEDED, True),
             (WorkflowInvocationAction.State.SUCCEEDED, WorkflowInvocationAction.State.RUNNING, False),

--- a/providers/google/tests/unit/google/cloud/sensors/test_datafusion.py
+++ b/providers/google/tests/unit/google/cloud/sensors/test_datafusion.py
@@ -38,7 +38,7 @@ FAILURE_STATUSES = {"FAILED"}
 
 class TestCloudDataFusionPipelineStateSensor:
     @pytest.mark.parametrize(
-        "expected_status, current_status, sensor_return",
+        ("expected_status", "current_status", "sensor_return"),
         [
             (PipelineStates.COMPLETED, PipelineStates.COMPLETED, True),
             (PipelineStates.COMPLETED, PipelineStates.RUNNING, False),

--- a/providers/google/tests/unit/google/cloud/sensors/test_dataproc_metastore.py
+++ b/providers/google/tests/unit/google/cloud/sensors/test_dataproc_metastore.py
@@ -53,7 +53,7 @@ TEST_URI = "test-uri"
 
 class TestMetastoreHivePartitionSensor:
     @pytest.mark.parametrize(
-        "requested_partitions, result_files_with_rows, expected_result",
+        ("requested_partitions", "result_files_with_rows", "expected_result"),
         [
             (None, [(RESULT_FILE_NAME_1, [])], False),
             ([None], [(RESULT_FILE_NAME_1, [])], False),
@@ -145,7 +145,7 @@ class TestMetastoreHivePartitionSensor:
             sensor.poke(context={})
 
     @pytest.mark.parametrize(
-        "requested_partitions, result_files_with_rows, expected_result",
+        ("requested_partitions", "result_files_with_rows", "expected_result"),
         [
             ([PARTITION_1, PARTITION_1], [(RESULT_FILE_NAME_1, [ROW_1])], True),
         ],


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
related: #40567

@ferruzzi 
This PR fixed 7 files in `/sensors` and  `/secret` in google provider for enable PT006 rule:
https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
