### PR TITLE
Enable PT006 rule to google Provider test (log,openlineage,common,utils)

### DIFF
--- a/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler.py
+++ b/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler.py
@@ -279,7 +279,7 @@ class TestGCSTaskHandler:
         )
 
     @pytest.mark.parametrize(
-        "delete_local_copy, expected_existence_of_local_copy",
+        ("delete_local_copy", "expected_existence_of_local_copy"),
         [(True, False), (False, True)],
     )
     @mock.patch(

--- a/providers/google/tests/unit/google/cloud/openlineage/test_utils.py
+++ b/providers/google/tests/unit/google/cloud/openlineage/test_utils.py
@@ -496,7 +496,7 @@ def test_get_identity_column_lineage_facet_no_input_datasets():
 
 
 @pytest.mark.parametrize(
-    "input_path, expected_output",
+    ("input_path", "expected_output"),
     [
         ("/path/to/file.txt", "path/to/file.txt"),  # Full file path
         ("file.txt", "file.txt"),  # File path in root directory
@@ -542,7 +542,7 @@ def test_is_openlineage_listener_not_found(mock_is_disabled, mock_get_listener):
 
 
 @pytest.mark.parametrize(
-    "job, expected",
+    ("job", "expected"),
     [
         ({"sparkJob": {}}, "sparkJob"),
         ({"pysparkJob": {}}, "pysparkJob"),
@@ -662,7 +662,7 @@ def test_inject_openlineage_properties_into_dataproc_job_all_injections(
 
 
 @pytest.mark.parametrize(
-    "batch, expected",
+    ("batch", "expected"),
     [
         ({"spark_batch": {}}, True),
         ({"pyspark_batch": {}}, True),
@@ -940,7 +940,7 @@ def test_inject_openlineage_properties_into_dataproc_batch_all_injections(
 
 
 @pytest.mark.parametrize(
-    "input_uris, expected_output",
+    ("input_uris", "expected_output"),
     [
         (["gs://bucket/blob"], {("gs://bucket", "/")}),
         (["gs://bucket/blob/*"], {("gs://bucket", "blob")}),

--- a/providers/google/tests/unit/google/cloud/utils/test_credentials_provider.py
+++ b/providers/google/tests/unit/google/cloud/utils/test_credentials_provider.py
@@ -523,7 +523,7 @@ class TestGetScopes:
         assert _get_scopes() == _DEFAULT_SCOPES
 
     @pytest.mark.parametrize(
-        "scopes_str, scopes",
+        ("scopes_str", "scopes"),
         [
             pytest.param("scope1", ["scope1"], id="single-scope"),
             pytest.param("scope1,scope2", ["scope1", "scope2"], id="multiple-scopes"),
@@ -538,7 +538,7 @@ class TestGetTargetPrincipalAndDelegates:
         assert _get_target_principal_and_delegates() == (None, None)
 
     @pytest.mark.parametrize(
-        "impersonation_chain, target_principal_and_delegates",
+        ("impersonation_chain", "target_principal_and_delegates"),
         [
             pytest.param(ACCOUNT_1_SAME_PROJECT, (ACCOUNT_1_SAME_PROJECT, None), id="string"),
             pytest.param([], (None, None), id="empty-list"),

--- a/providers/google/tests/unit/google/cloud/utils/test_dataform.py
+++ b/providers/google/tests/unit/google/cloud/utils/test_dataform.py
@@ -23,7 +23,7 @@ from airflow.providers.google.cloud.utils.dataform import DataformLocations, def
 
 
 @pytest.mark.parametrize(
-    "region, expected",
+    ("region", "expected"),
     [
         ("us-central1", DataformLocations.US),
         ("europe-west4", DataformLocations.EUROPE),

--- a/providers/google/tests/unit/google/cloud/utils/test_datafusion.py
+++ b/providers/google/tests/unit/google/cloud/utils/test_datafusion.py
@@ -23,7 +23,7 @@ from airflow.providers.google.cloud.utils.datafusion import DataFusionPipelineTy
 
 class TestDataFusionPipelineType:
     @pytest.mark.parametrize(
-        "str_value, expected_item",
+        ("str_value", "expected_item"),
         [
             ("batch", DataFusionPipelineType.BATCH),
             ("stream", DataFusionPipelineType.STREAM),

--- a/providers/google/tests/unit/google/cloud/utils/test_dataproc.py
+++ b/providers/google/tests/unit/google/cloud/utils/test_dataproc.py
@@ -23,7 +23,7 @@ from airflow.providers.google.cloud.utils.dataproc import DataprocOperationType
 
 class TestDataprocOperationType:
     @pytest.mark.parametrize(
-        "str_value, expected_item",
+        ("str_value", "expected_item"),
         [
             ("DIAGNOSE", DataprocOperationType.DIAGNOSE.value),
         ],

--- a/providers/google/tests/unit/google/common/test_deprecated.py
+++ b/providers/google/tests/unit/google/common/test_deprecated.py
@@ -134,7 +134,7 @@ class TestAirflowDeprecationAdapter:
             )
 
     @pytest.mark.parametrize(
-        "entity, expected_type",
+        ("entity", "expected_type"),
         [
             (AirflowDeprecationAdapter, "class"),
             (AirflowDeprecationAdapter.get_deprecated_msg, "function (or method)"),
@@ -144,7 +144,7 @@ class TestAirflowDeprecationAdapter:
         assert AirflowDeprecationAdapter.entity_type(entity) == expected_type
 
     @pytest.mark.parametrize(
-        "module_path, qualified_name, _str, expected_path",
+        ("module_path", "qualified_name", "_str", "expected_path"),
         [
             ("test-module", "test-qualified-name", "test-str", "test-module.test-qualified-name"),
             ("test-module", "", "test-str", "test-module"),
@@ -161,7 +161,7 @@ class TestAirflowDeprecationAdapter:
         assert AirflowDeprecationAdapter.entity_path(mock_entity) == expected_path
 
     @pytest.mark.parametrize(
-        "planned_removal_date, planned_removal_release, expected_message",
+        ("planned_removal_date", "planned_removal_release", "expected_message"),
         [
             ("August 22, 2024", None, "after August 22, 2024"),
             (None, "apache-airflow==1.2.3", "since version apache-airflow==1.2.3"),
@@ -181,7 +181,7 @@ class TestAirflowDeprecationAdapter:
         assert adapter.sunset_message() == expected_message
 
     @pytest.mark.parametrize(
-        "use_instead, expected_message",
+        ("use_instead", "expected_message"),
         [
             (None, "There is no replacement."),
             ("replacement", "Please use `replacement` instead."),
@@ -193,7 +193,7 @@ class TestAirflowDeprecationAdapter:
         assert adapter.replacement_message() == expected_message
 
     @pytest.mark.parametrize(
-        "reason, instructions",
+        ("reason", "instructions"),
         [
             ("Test reason", "Test instructions"),
             ("Test reason", None),


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
related: #40567

@ferruzzi 
This PR fixed 7 files in google provider for enable PT006 rule:
https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
