### PR TITLE
Enable PT006 rule to airflow-core tests (models)

### DIFF
--- a/airflow-core/tests/unit/models/test_mappedoperator.py
+++ b/airflow-core/tests/unit/models/test_mappedoperator.py
@@ -81,7 +81,7 @@ def test_task_mapping_with_dag_and_list_of_pandas_dataframe(mock_render_template
 
 
 @pytest.mark.parametrize(
-    ["num_existing_tis", "expected"],
+    ("num_existing_tis", "expected"),
     (
         pytest.param(0, [(0, None), (1, None), (2, None)], id="only-unmapped-ti-exists"),
         pytest.param(
@@ -235,7 +235,7 @@ def test_expand_mapped_task_instance_skipped_on_zero(dag_maker, session):
 
 
 @pytest.mark.parametrize(
-    ["num_existing_tis", "expected"],
+    ("num_existing_tis", "expected"),
     (
         pytest.param(0, [(0, None), (1, None), (2, None)], id="only-unmapped-ti-exists"),
         pytest.param(
@@ -400,7 +400,7 @@ def _create_named_map_index_renders_on_failure_taskflow(*, task_id, map_names, t
 
 
 @pytest.mark.parametrize(
-    "template, expected_rendered_names",
+    ("template", "expected_rendered_names"),
     [
         pytest.param(None, [None, None], id="unset"),
         pytest.param("", ["", ""], id="constant"),
@@ -1377,28 +1377,28 @@ class TestMappedSetupTeardown:
 
     @pytest.mark.parametrize(
         (
-            "email,"
-            "execution_timeout,"
-            "retry_delay,"
-            "max_retry_delay,"
-            "retry_exponential_backoff,"
-            "max_active_tis_per_dag,"
-            "max_active_tis_per_dagrun,"
-            "run_as_user,"
-            "resources,"
-            "has_on_execute_callback,"
-            "has_on_failure_callback,"
-            "has_on_retry_callback,"
-            "has_on_success_callback,"
-            "has_on_skipped_callback,"
-            "executor_config,"
-            "inlets,"
-            "outlets,"
-            "doc,"
-            "doc_md,"
-            "doc_json,"
-            "doc_yaml,"
-            "doc_rst"
+            "email",
+            "execution_timeout",
+            "retry_delay",
+            "max_retry_delay",
+            "retry_exponential_backoff",
+            "max_active_tis_per_dag",
+            "max_active_tis_per_dagrun",
+            "run_as_user",
+            "resources",
+            "has_on_execute_callback",
+            "has_on_failure_callback",
+            "has_on_retry_callback",
+            "has_on_success_callback",
+            "has_on_skipped_callback",
+            "executor_config",
+            "inlets",
+            "outlets",
+            "doc",
+            "doc_md",
+            "doc_json",
+            "doc_yaml",
+            "doc_rst",
         ),
         [
             pytest.param(

--- a/airflow-core/tests/unit/models/test_renderedtifields.py
+++ b/airflow-core/tests/unit/models/test_renderedtifields.py
@@ -104,7 +104,7 @@ class TestRenderedTaskInstanceFields:
         self.clean_db()
 
     @pytest.mark.parametrize(
-        ["templated_field", "expected_rendered_field"],
+        ("templated_field", "expected_rendered_field"),
         [
             pytest.param(None, None, id="None"),
             pytest.param([], [], id="list"),
@@ -231,7 +231,7 @@ class TestRenderedTaskInstanceFields:
         rtif.write()
 
     @pytest.mark.parametrize(
-        "rtif_num, num_to_keep, remaining_rtifs, expected_query_count",
+        ("rtif_num", "num_to_keep", "remaining_rtifs", "expected_query_count"),
         [
             (0, 1, 0, 1),
             (1, 1, 1, 1),
@@ -276,7 +276,7 @@ class TestRenderedTaskInstanceFields:
             assert remaining_rtifs == len(result)
 
     @pytest.mark.parametrize(
-        "num_runs, num_to_keep, remaining_rtifs, expected_query_count",
+        ("num_runs", "num_to_keep", "remaining_rtifs", "expected_query_count"),
         [
             (3, 1, 1, 1),
             (4, 2, 2, 1),

--- a/airflow-core/tests/unit/models/test_serialized_dag.py
+++ b/airflow-core/tests/unit/models/test_serialized_dag.py
@@ -475,7 +475,7 @@ class TestSerializedDagModel:
         db.clear_db_assets()
 
     @pytest.mark.parametrize(
-        "provide_interval, new_task, should_write",
+        ("provide_interval", "new_task", "should_write"),
         [
             (True, True, False),
             (True, False, False),

--- a/airflow-core/tests/unit/models/test_taskinstance.py
+++ b/airflow-core/tests/unit/models/test_taskinstance.py
@@ -891,7 +891,14 @@ class TestTaskInstance:
     # Numeric fields are in order:
     #   successes, skipped, failed, upstream_failed, removed, done
     @pytest.mark.parametrize(
-        "trigger_rule, upstream_setups, upstream_states, flag_upstream_failed, expect_state, expect_passed",
+        (
+            "trigger_rule",
+            "upstream_setups",
+            "upstream_states",
+            "flag_upstream_failed",
+            "expect_state",
+            "expect_passed",
+        ),
         [
             #
             # Tests for all_success
@@ -1165,7 +1172,7 @@ class TestTaskInstance:
     # Does not work for database isolation mode because there is local test monkeypatching of upstream_failed
     # That never gets propagated to internal_api
     @pytest.mark.parametrize(
-        "trigger_rule, upstream_states, flag_upstream_failed, expect_state, expect_completed",
+        ("trigger_rule", "upstream_states", "flag_upstream_failed", "expect_state", "expect_completed"),
         [
             #
             # Tests for all_success
@@ -1304,7 +1311,7 @@ class TestTaskInstance:
             assert ti.are_dependencies_met()
 
     @pytest.mark.parametrize(
-        "downstream_ti_state, expected_are_dependents_done",
+        ("downstream_ti_state", "expected_are_dependents_done"),
         [
             (State.SUCCESS, True),
             (State.SKIPPED, True),
@@ -2155,7 +2162,7 @@ class TestTaskInstance:
         pytest.param(datetime.timedelta(days=1), False, id="timedelta/no-catchup"),
     ]
 
-    @pytest.mark.parametrize("schedule, catchup", _prev_dates_param_list)
+    @pytest.mark.parametrize(("schedule", "catchup"), _prev_dates_param_list)
     def test_previous_ti(self, schedule, catchup, dag_maker) -> None:
         scenario = [State.SUCCESS, State.FAILED, State.SUCCESS]
 
@@ -2167,7 +2174,7 @@ class TestTaskInstance:
 
         assert ti_list[2].get_previous_ti().run_id != ti_list[0].run_id
 
-    @pytest.mark.parametrize("schedule, catchup", _prev_dates_param_list)
+    @pytest.mark.parametrize(("schedule", "catchup"), _prev_dates_param_list)
     def test_previous_ti_success(self, schedule, catchup, dag_maker) -> None:
         scenario = [State.FAILED, State.SUCCESS, State.FAILED, State.SUCCESS]
 
@@ -2264,7 +2271,7 @@ class TestTaskInstance:
         assert result == "Task: test_template_render -> test_template_render_task"
 
     @pytest.mark.parametrize(
-        "content, expected_output",
+        ("content", "expected_output"),
         [
             ('{{ conn.get("a_connection").host }}', "hostvalue"),
             ('{{ conn.get("a_connection", "unused_fallback").host }}', "hostvalue"),
@@ -2307,7 +2314,7 @@ class TestTaskInstance:
         assert result == expected_output
 
     @pytest.mark.parametrize(
-        "content, expected_output",
+        ("content", "expected_output"),
         [
             ("{{ var.value.a_variable }}", "a test value"),
             ('{{ var.value.get("a_variable") }}', "a test value"),
@@ -2340,7 +2347,7 @@ class TestTaskInstance:
             ti.task.render_template('{{ var.value.get("missing_variable") }}', context)
 
     @pytest.mark.parametrize(
-        "content, expected_output",
+        ("content", "expected_output"),
         [
             ("{{ var.value.a_variable }}", '{\n  "a": {\n    "test": "value"\n  }\n}'),
             ('{{ var.json.a_variable["a"]["test"] }}', "value"),
@@ -2943,7 +2950,7 @@ class TestTaskInstanceRecordTaskMapXComPush:
 
 class TestMappedTaskInstanceReceiveValue:
     @pytest.mark.parametrize(
-        "literal, expected_outputs",
+        ("literal", "expected_outputs"),
         [
             pytest.param([1, 2, 3], [1, 2, 3], id="list"),
             pytest.param({"a": 1, "b": 2}, [("a", 1), ("b", 2)], id="dict"),
@@ -2975,7 +2982,7 @@ class TestMappedTaskInstanceReceiveValue:
         assert outputs == expected_outputs
 
     @pytest.mark.parametrize(
-        "upstream_return, expected_outputs",
+        ("upstream_return", "expected_outputs"),
         [
             pytest.param([1, 2, 3], [1, 2, 3], id="list"),
             pytest.param({"a": 1, "b": 2}, [("a", 1), ("b", 2)], id="dict"),

--- a/airflow-core/tests/unit/models/test_trigger.py
+++ b/airflow-core/tests/unit/models/test_trigger.py
@@ -239,7 +239,7 @@ def test_submit_failure(session, create_task_instance):
 
 
 @pytest.mark.parametrize(
-    "event_cls, expected",
+    ("event_cls", "expected"),
     [
         (TaskSuccessEvent, "success"),
         (TaskFailedEvent, "failed"),

--- a/airflow-core/tests/unit/models/test_variable.py
+++ b/airflow-core/tests/unit/models/test_variable.py
@@ -335,7 +335,7 @@ class TestVariable:
 
 
 @pytest.mark.parametrize(
-    "variable_value, deserialize_json, expected_masked_values",
+    ("variable_value", "deserialize_json", "expected_masked_values"),
     [
         ("s3cr3t", False, ["s3cr3t"]),
         ('{"api_key": "s3cr3t"}', True, ["s3cr3t"]),

--- a/airflow-core/tests/unit/models/test_xcom.py
+++ b/airflow-core/tests/unit/models/test_xcom.py
@@ -461,7 +461,7 @@ class TestXComClear:
 
 class TestXComRoundTrip:
     @pytest.mark.parametrize(
-        "value, expected_value",
+        ("value", "expected_value"),
         [
             pytest.param(1, 1, id="int"),
             pytest.param(1.0, 1.0, id="float"),
@@ -490,7 +490,7 @@ class TestXComRoundTrip:
         assert deserialized_value == expected_value
 
     @pytest.mark.parametrize(
-        "value, expected_value",
+        ("value", "expected_value"),
         [
             pytest.param(1, 1, id="int"),
             pytest.param(1.0, 1.0, id="float"),

--- a/airflow-core/tests/unit/models/test_xcom_arg.py
+++ b/airflow-core/tests/unit/models/test_xcom_arg.py
@@ -181,7 +181,7 @@ class TestXComArgRuntime:
 
 
 @pytest.mark.parametrize(
-    "fillvalue, expected_results",
+    ("fillvalue", "expected_results"),
     [
         (NOTSET, {("a", 1), ("b", 2), ("c", 3)}),
         (None, {("a", 1), ("b", 2), ("c", 3), (None, 4)}),


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
Issue: Enable Even More PyDocStyle Checks #40567
@ferruzzi

This PR is for enable PT006 rule:
PT006: all instances of @pytest.mark.parametrize names should be a tuple
https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/
There are a lot of file changes needed.
So, I separate to many PR, which contain about 5-10 file changes for easy review.
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
