### PR TITLE
Enable PT006 rule to google Provider test (triggers)

### DIFF
--- a/providers/google/tests/unit/google/cloud/transfers/test_bigquery_to_postgres.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_bigquery_to_postgres.py
@@ -127,7 +127,8 @@ class TestBigQueryToPostgresOperator:
         )
 
     @pytest.mark.parametrize(
-        "selected_fields, replace_index", [(None, None), (["col_1, col_2"], None), (None, ["col_1"])]
+        ("selected_fields", "replace_index"),
+        [(None, None), (["col_1, col_2"], None), (None, ["col_1"])],
     )
     def test_init_raises_exception_if_replace_is_true_and_missing_params(
         self, selected_fields, replace_index

--- a/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_gcs.py
@@ -677,8 +677,14 @@ class TestGoogleCloudStorageToCloudStorageOperator:
             operator.execute(None)
 
     @pytest.mark.parametrize(
-        "existing_objects, source_object, match_glob, exact_match, expected_source_objects, "
-        "expected_destination_objects",
+        (
+            "existing_objects",
+            "source_object",
+            "match_glob",
+            "exact_match",
+            "expected_source_objects",
+            "expected_destination_objects",
+        ),
         [
             (["source/foo.txt"], "source/foo.txt", None, True, ["source/foo.txt"], ["{prefix}/foo.txt"]),
             (["source/foo.txt"], "source/foo.txt", None, False, ["source/foo.txt"], ["{prefix}/foo.txt"]),

--- a/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_sftp.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_sftp.py
@@ -37,7 +37,7 @@ DESTINATION_SFTP = "destination_path"
 #       implement reverted changes from the first commit of PR #31261
 class TestGoogleCloudStorageToSFTPOperator:
     @pytest.mark.parametrize(
-        "source_object, target_object, keep_directory_structure",
+        ("source_object", "target_object", "keep_directory_structure"),
         [
             ("folder/test_object.txt", "folder/test_object.txt", True),
             ("folder/subfolder/test_object.txt", "folder/subfolder/test_object.txt", True),
@@ -79,7 +79,7 @@ class TestGoogleCloudStorageToSFTPOperator:
         gcs_hook_mock.return_value.delete.assert_not_called()
 
     @pytest.mark.parametrize(
-        "source_object, target_object, keep_directory_structure",
+        ("source_object", "target_object", "keep_directory_structure"),
         [
             ("folder/test_object.txt", "folder/test_object.txt", True),
             ("folder/subfolder/test_object.txt", "folder/subfolder/test_object.txt", True),
@@ -121,7 +121,14 @@ class TestGoogleCloudStorageToSFTPOperator:
         gcs_hook_mock.return_value.delete.assert_called_once_with(TEST_BUCKET, source_object)
 
     @pytest.mark.parametrize(
-        "source_object, prefix, delimiter, gcs_files_list, target_objects, keep_directory_structure",
+        (
+            "source_object",
+            "prefix",
+            "delimiter",
+            "gcs_files_list",
+            "target_objects",
+            "keep_directory_structure",
+        ),
         [
             (
                 "folder/test_object*.txt",
@@ -213,7 +220,14 @@ class TestGoogleCloudStorageToSFTPOperator:
         gcs_hook_mock.return_value.delete.assert_not_called()
 
     @pytest.mark.parametrize(
-        "source_object, prefix, delimiter, gcs_files_list, target_objects, keep_directory_structure",
+        (
+            "source_object",
+            "prefix",
+            "delimiter",
+            "gcs_files_list",
+            "target_objects",
+            "keep_directory_structure",
+        ),
         [
             (
                 "folder/test_object*.txt",
@@ -322,7 +336,13 @@ class TestGoogleCloudStorageToSFTPOperator:
             operator.execute(None)
 
     @pytest.mark.parametrize(
-        "source_object, destination_path, keep_directory_structure, expected_source, expected_destination",
+        (
+            "source_object",
+            "destination_path",
+            "keep_directory_structure",
+            "expected_source",
+            "expected_destination",
+        ),
         [
             (
                 "folder/test_object.txt",

--- a/providers/google/tests/unit/google/cloud/transfers/test_mssql_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_mssql_to_gcs.py
@@ -71,7 +71,7 @@ SCHEMA_JSON_BIT_FIELDS = [
 
 class TestMsSqlToGoogleCloudStorageOperator:
     @pytest.mark.parametrize(
-        "value, expected",
+        ("value", "expected"),
         [
             ("string", "string"),
             (32.9, 32.9),
@@ -165,7 +165,8 @@ class TestMsSqlToGoogleCloudStorageOperator:
     @mock.patch("airflow.providers.google.cloud.transfers.mssql_to_gcs.MsSqlHook")
     @mock.patch("airflow.providers.google.cloud.transfers.sql_to_gcs.GCSHook")
     @pytest.mark.parametrize(
-        "bit_fields,schema_json", [(None, SCHEMA_JSON), (["bit_fields", SCHEMA_JSON_BIT_FIELDS])]
+        ("bit_fields", "schema_json"),
+        [(None, SCHEMA_JSON), (["bit_fields", SCHEMA_JSON_BIT_FIELDS])],
     )
     def test_schema_file(self, gcs_hook_mock_class, mssql_hook_mock_class, bit_fields, schema_json):
         """Test writing schema files."""
@@ -196,7 +197,7 @@ class TestMsSqlToGoogleCloudStorageOperator:
         assert gcs_hook_mock.upload.call_count == 2
 
     @pytest.mark.parametrize(
-        "connection_port, default_port, expected_port",
+        ("connection_port", "default_port", "expected_port"),
         [(None, 4321, 4321), (1234, None, 1234), (1234, 4321, 1234)],
     )
     def test_execute_openlineage_events(self, connection_port, default_port, expected_port):

--- a/providers/google/tests/unit/google/cloud/transfers/test_mysql_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_mysql_to_gcs.py
@@ -99,7 +99,7 @@ class TestMySqlToGoogleCloudStorageOperator:
         assert op.field_delimiter == "|"
 
     @pytest.mark.parametrize(
-        "value, schema_type, expected",
+        ("value", "schema_type", "expected"),
         [
             ("string", None, "string"),
             (datetime.date(1970, 1, 2), None, "1970-01-02 00:00:00"),
@@ -369,7 +369,7 @@ class TestMySqlToGoogleCloudStorageOperator:
             op.execute(None)
 
     @pytest.mark.parametrize(
-        "connection_port, default_port, expected_port",
+        ("connection_port", "default_port", "expected_port"),
         [(None, 4321, 4321), (1234, None, 1234), (1234, 4321, 1234)],
     )
     def test_execute_openlineage_events(self, connection_port, default_port, expected_port):

--- a/providers/google/tests/unit/google/cloud/transfers/test_oracle_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_oracle_to_gcs.py
@@ -151,7 +151,7 @@ class TestOracleToGoogleCloudStorageOperator:
         assert gcs_hook_mock.upload.call_count == 2
 
     @pytest.mark.parametrize(
-        "input_service_name, input_sid, connection_port, default_port, expected_port",
+        ("input_service_name", "input_sid", "connection_port", "default_port", "expected_port"),
         [
             ("ServiceName", None, None, 1521, 1521),
             (None, "SID", None, 1521, 1521),

--- a/providers/google/tests/unit/google/cloud/transfers/test_postgres_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_postgres_to_gcs.py
@@ -107,7 +107,7 @@ class TestPostgresToGoogleCloudStorageOperator:
             assert b"".join(NDJSON_LINES) == file.read()
 
     @pytest.mark.parametrize(
-        "value, expected",
+        ("value", "expected"),
         [
             ("string", "string"),
             (32.9, 32.9),
@@ -225,7 +225,7 @@ class TestPostgresToGoogleCloudStorageOperator:
         assert gcs_hook_mock.upload.call_count == 2
 
     @pytest.mark.parametrize(
-        "connection_port, default_port, expected_port",
+        ("connection_port", "default_port", "expected_port"),
         [(None, 4321, 4321), (1234, None, 1234), (1234, 4321, 1234)],
     )
     def test_execute_openlineage_events(self, connection_port, default_port, expected_port):

--- a/providers/google/tests/unit/google/cloud/transfers/test_s3_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_s3_to_gcs.py
@@ -169,7 +169,7 @@ class TestS3ToGoogleCloudStorageOperator:
         )
 
     @pytest.mark.parametrize(
-        "source_objects, existing_objects, objects_expected",
+        ("source_objects", "existing_objects", "objects_expected"),
         [
             (MOCK_FILES, [], MOCK_FILES),
             (MOCK_FILES, [MOCK_FILE_1], [MOCK_FILE_2, MOCK_FILE_3]),
@@ -420,7 +420,7 @@ class TestS3ToGoogleCloudStorageOperatorDeferrable:
             operator.transfer_files_async(files=[], gcs_hook=mock.MagicMock(), s3_hook=mock.MagicMock())
 
     @pytest.mark.parametrize(
-        "file_names, chunks, expected_job_names",
+        ("file_names", "chunks", "expected_job_names"),
         [
             (MOCK_FILES, [MOCK_FILES], [TRANSFER_JOB_ID_0]),
             (

--- a/providers/google/tests/unit/google/cloud/transfers/test_sftp_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_sftp_to_gcs.py
@@ -333,7 +333,7 @@ class TestSFTPToGCSOperator:
         )
 
     @pytest.mark.parametrize(
-        "source_object, destination_path, expected_source, expected_destination",
+        ("source_object", "destination_path", "expected_source", "expected_destination"),
         [
             ("folder/test_object.txt", "dest/dir", "folder/test_object.txt", "dest"),
             ("folder/test_object.txt", "dest/dir/", "folder/test_object.txt", "dest/dir"),

--- a/providers/google/tests/unit/google/cloud/transfers/test_trino_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_trino_to_gcs.py
@@ -335,7 +335,7 @@ class TestTrinoToGCSOperator:
         assert mock_gcs_hook.return_value.upload.call_count == 2
 
     @pytest.mark.parametrize(
-        "connection_port, default_port, expected_port",
+        ("connection_port", "default_port", "expected_port"),
         [(None, 4321, 4321), (1234, None, 1234), (1234, 4321, 1234)],
     )
     def test_execute_openlineage_events(self, connection_port, default_port, expected_port):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
related: #40567

@ferruzzi 
This PR fixed 10 files in `/triggers` folder in google provider for enable PT006 rule:
https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
