### PR TITLE
Add number of queries guard for ui dependencies

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_dependencies.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_dependencies.py
@@ -26,6 +26,7 @@ from airflow.providers.standard.operators.trigger_dagrun import TriggerDagRunOpe
 from airflow.providers.standard.sensors.external_task import ExternalTaskSensor
 from airflow.sdk.definitions.asset import Asset
 
+from tests_common.test_utils.asserts import assert_queries_count
 from tests_common.test_utils.db import clear_db_dags, clear_db_serialized_dags
 
 pytestmark = pytest.mark.db_test
@@ -203,7 +204,8 @@ def expected_secondary_component_response(asset2_id):
 class TestGetDependencies:
     @pytest.mark.usefixtures("make_primary_connected_component")
     def test_should_response_200(self, test_client, expected_primary_component_response):
-        response = test_client.get("/dependencies")
+        with assert_queries_count(5):
+            response = test_client.get("/dependencies")
         assert response.status_code == 200
 
         assert response.json() == expected_primary_component_response
@@ -238,7 +240,8 @@ class TestGetDependencies:
     @pytest.mark.usefixtures("make_primary_connected_component", "make_secondary_connected_component")
     def test_with_node_id_filter(self, test_client, node_id, expected_response_fixture, request):
         expected_response = request.getfixturevalue(expected_response_fixture)
-        response = test_client.get("/dependencies", params={"node_id": node_id})
+        with assert_queries_count(5):
+            response = test_client.get("/dependencies", params={"node_id": node_id})
         assert response.status_code == 200
 
         assert response.json() == expected_response
@@ -255,7 +258,8 @@ class TestGetDependencies:
             (asset1_id, expected_primary_component_response),
             (asset2_id, expected_secondary_component_response),
         ):
-            response = test_client.get("/dependencies", params={"node_id": f"asset:{asset_id}"})
+            with assert_queries_count(5):
+                response = test_client.get("/dependencies", params={"node_id": f"asset:{asset_id}"})
             assert response.status_code == 200
 
             assert response.json() == expected_response


### PR DESCRIPTION
N+1 queries guard for dependencies endpoint.

No problem detected.

Related: https://github.com/apache/airflow/issues/57561