### PR TITLE
Add `LIST` permission to admin role in Keycloak auth manager

### DIFF
--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/cli/commands.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/cli/commands.py
@@ -179,7 +179,8 @@ def _create_read_only_permission(client: KeycloakAdmin, client_uuid: str):
 
 def _create_admin_permission(client: KeycloakAdmin, client_uuid: str):
     all_scopes = client.get_client_authz_scopes(client_uuid)
-    scopes = [scope["id"] for scope in all_scopes if scope["name"] in get_args(ExtendedResourceMethod)]
+    scope_names = get_args(ExtendedResourceMethod) + ("LIST",)
+    scopes = [scope["id"] for scope in all_scopes if scope["name"] in scope_names]
     payload = {
         "name": "Admin",
         "type": "scope",

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
@@ -112,6 +112,7 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
 
     def refresh_user(self, *, user: KeycloakAuthManagerUser) -> KeycloakAuthManagerUser | None:
         if self._token_expired(user.access_token):
+            log.debug("Refreshing the token")
             client = self.get_keycloak_client()
             tokens = client.refresh_token(user.refresh_token)
             user.refresh_token = tokens["refresh_token"]

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/cli/test_commands.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/cli/test_commands.py
@@ -277,7 +277,13 @@ class TestCommands:
 
     def test_create_permissions_admin(self):
         client = Mock()
-        scopes = [{"id": "1", "name": "GET"}, {"id": "2", "name": "MENU"}, {"id": "3", "name": "PUT"}]
+        scopes = [
+            {"id": "1", "name": "GET"},
+            {"id": "2", "name": "MENU"},
+            {"id": "3", "name": "PUT"},
+            {"id": "4", "name": "LIST"},
+            {"id": "5", "name": "DUMMY"},
+        ]
 
         client.get_client_authz_scopes.return_value = scopes
 
@@ -291,7 +297,7 @@ class TestCommands:
                 "type": "scope",
                 "logic": "POSITIVE",
                 "decisionStrategy": "UNANIMOUS",
-                "scopes": ["1", "2", "3"],
+                "scopes": ["1", "2", "3", "4"],
             },
         )
 


### PR DESCRIPTION
While working on #56614 I found out the `Admin` role in Keycloak auth manager was missing `LIST` permissions.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
