### PR TITLE
Missing SCC Role bindings for redis and api-server

### DIFF
--- a/chart/templates/rbac/security-context-constraint-rolebinding.yaml
+++ b/chart/templates/rbac/security-context-constraint-rolebinding.yaml
@@ -71,6 +71,9 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "scheduler.serviceAccountName" . }}
     namespace: "{{ .Release.Namespace }}"
+  - kind: ServiceAccount
+    name: {{ include "apiServer.serviceAccountName" . }}
+    namespace: "{{ .Release.Namespace }}"
   {{- if and .Values.statsd.enabled }}
   - kind: ServiceAccount
     name: {{ include "statsd.serviceAccountName" . }}
@@ -79,6 +82,11 @@ subjects:
   {{- if and .Values.flower.enabled (or (contains "CeleryExecutor" .Values.executor) (contains "CeleryKubernetesExecutor" .Values.executor)) }}
   - kind: ServiceAccount
     name: {{ include "flower.serviceAccountName" . }}
+    namespace: "{{ .Release.Namespace }}"
+  {{- end }}
+  {{- if .Values.redis.enabled }}
+  - kind: ServiceAccount
+    name: {{ include "redis.serviceAccountName" . }}
     namespace: "{{ .Release.Namespace }}"
   {{- end }}
   {{- if and (semverCompare ">=2.2.0" .Values.airflowVersion) }}

--- a/helm-tests/tests/helm_tests/security/test_scc_rolebinding.py
+++ b/helm-tests/tests/helm_tests/security/test_scc_rolebinding.py
@@ -55,13 +55,15 @@ class TestSCCActivation:
             assert jmespath.search("subjects[0].name", docs[0]) == "release-name-airflow-webserver"
             assert jmespath.search("subjects[1].name", docs[0]) == "release-name-airflow-worker"
             assert jmespath.search("subjects[2].name", docs[0]) == "release-name-airflow-scheduler"
-            assert jmespath.search("subjects[3].name", docs[0]) == "release-name-airflow-statsd"
-            assert jmespath.search("subjects[4].name", docs[0]) == "release-name-airflow-flower"
-            assert jmespath.search("subjects[5].name", docs[0]) == "release-name-airflow-triggerer"
-            assert jmespath.search("subjects[6].name", docs[0]) == "release-name-airflow-migrate-database-job"
-            assert jmespath.search("subjects[7].name", docs[0]) == "release-name-airflow-create-user-job"
-            assert jmespath.search("subjects[8].name", docs[0]) == "release-name-airflow-cleanup"
-            assert jmespath.search("subjects[9].name", docs[0]) == "release-name-airflow-dag-processor"
+            assert jmespath.search("subjects[3].name", docs[0]) == "release-name-airflow-api-server"
+            assert jmespath.search("subjects[4].name", docs[0]) == "release-name-airflow-statsd"
+            assert jmespath.search("subjects[5].name", docs[0]) == "release-name-airflow-flower"
+            assert jmespath.search("subjects[6].name", docs[0]) == "release-name-airflow-redis"
+            assert jmespath.search("subjects[7].name", docs[0]) == "release-name-airflow-triggerer"
+            assert jmespath.search("subjects[8].name", docs[0]) == "release-name-airflow-migrate-database-job"
+            assert jmespath.search("subjects[9].name", docs[0]) == "release-name-airflow-create-user-job"
+            assert jmespath.search("subjects[10].name", docs[0]) == "release-name-airflow-cleanup"
+            assert jmespath.search("subjects[11].name", docs[0]) == "release-name-airflow-dag-processor"
 
     @pytest.mark.parametrize(
         "rbac_enabled,scc_enabled,created,namespace,expected_name",
@@ -118,6 +120,8 @@ class TestSCCActivation:
             assert jmespath.search("subjects[0].name", docs[0]) == "release-name-airflow-webserver"
             assert jmespath.search("subjects[1].name", docs[0]) == "release-name-airflow-worker"
             assert jmespath.search("subjects[2].name", docs[0]) == "release-name-airflow-scheduler"
-            assert jmespath.search("subjects[3].name", docs[0]) == "release-name-airflow-triggerer"
-            assert jmespath.search("subjects[4].name", docs[0]) == "release-name-airflow-migrate-database-job"
-            assert len(docs[0]["subjects"]) == 5
+            assert jmespath.search("subjects[3].name", docs[0]) == "release-name-airflow-api-server"
+            assert jmespath.search("subjects[4].name", docs[0]) == "release-name-airflow-redis"
+            assert jmespath.search("subjects[5].name", docs[0]) == "release-name-airflow-triggerer"
+            assert jmespath.search("subjects[6].name", docs[0]) == "release-name-airflow-migrate-database-job"
+            assert len(docs[0]["subjects"]) == 7


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This PR fixes the `createSCCRoleBinding` not targeting all the necessary service accounts for a headache-free installation on Openshift, more specifically for redis and api-server services. 

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
