### PR TITLE
Add learnings from Airflow 3 migration

### DIFF
--- a/airflow-core/docs/installation/upgrading_to_airflow3.rst
+++ b/airflow-core/docs/installation/upgrading_to_airflow3.rst
@@ -231,6 +231,9 @@ them to FastAPI apps or ensure you install the FAB provider which provides a bac
 Ideally, you should convert your plugins to the Airflow 3 Plugin interface i.e External Views (``external_views``), Fast API apps (``fastapi_apps``)
 and FastAPI middlewares (``fastapi_root_middlewares``).
 
+If you use the Airflow Helm Chart to deploy Airflow, please check your defined values against configuration options available in Airflow 3.
+All configuration options below ``webserver`` need to be changed to ``apiServer``. Consider that many parameters have been renamed or removed.
+
 Step 7: Changes to your startup scripts
 ---------------------------------------
 
@@ -247,6 +250,15 @@ The Dag processor must now be started independently, even for local or developme
     airflow dag-processor
 
 You should now be able to start up your Airflow 3 instance.
+
+Step 8: Things to check
+-----------------------
+
+Please consider checking the following things after upgrading your Airflow instance:
+
+- If you configured Single-Sign-On (SSO) using OAuth, OIDC, or LDAP, make sure that the authentication is working as expected.
+  If you use a custom ``webserver_config.py`` you need to replace ``from airflow.www.security import AirflowSecurityManager``
+  with ``from airflow.providers.fab.auth_manager.security_manager.override import FabAirflowSecurityManagerOverride``.
 
 .. _breaking-changes:
 


### PR DESCRIPTION
As discussed during Dev Call today (2025-11-06) I also wanted to contribute the (current and not final) feedback from our migration. Thanks to @wolfdn as well as for highlighting.

Not sure if there are other/better placed to put these things in, it is not perfectly fitting - feedback welcome.

Especially for all users using helm to deploy the config check is not directly working, don't know if we shoudl add a full mapping of config values to transfer?

Also added the Step 8 only with one bullet point, maybe we can take this and extend this with some common pitfalls as a kind of Q&A section?