### PR TITLE
Enable PT006 rule to 19 files in providers (cncf,common)

### DIFF
--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/decorators/test_kubernetes_cmd.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/decorators/test_kubernetes_cmd.py
@@ -81,7 +81,7 @@ class TestKubernetesCmdDecorator(TestKubernetesDecoratorsBase):
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "func_return, exception",
+        ("func_return", "exception"),
         [
             pytest.param("string", TypeError, id="iterable_str"),
             pytest.param(True, TypeError, id="bool"),
@@ -236,7 +236,7 @@ class TestKubernetesCmdDecorator(TestKubernetesDecoratorsBase):
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        argnames=["command", "op_arg", "expected_command"],
+        argnames=("command", "op_arg", "expected_command"),
         argvalues=[
             pytest.param(
                 ["echo", "hello"],

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/decorators/test_kubernetes_commons.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/decorators/test_kubernetes_commons.py
@@ -134,7 +134,7 @@ def parametrize_kubernetes_decorators_commons(cls):
         if not name.startswith("test_") or not callable(method):
             continue
         new_method = pytest.mark.parametrize(
-            "task_decorator,decorator_name",
+            ("task_decorator", "decorator_name"),
             [
                 (task.kubernetes, "kubernetes"),
                 (task.kubernetes_cmd, "kubernetes_cmd"),

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -261,7 +261,7 @@ class TestKubernetesExecutor:
         AirflowKubernetesScheduler is None, reason="kubernetes python package is not installed"
     )
     @pytest.mark.parametrize(
-        "response, task_publish_max_retries, should_requeue, task_expected_state",
+        ("response", "task_publish_max_retries", "should_requeue", "task_expected_state"),
         [
             pytest.param(
                 HTTPResponse(body='{"message": "any message"}', status=400),
@@ -840,7 +840,7 @@ class TestKubernetesExecutor:
             executor.end()
 
     @pytest.mark.parametrize(
-        "multi_namespace_mode_namespace_list, watchers_keys",
+        ("multi_namespace_mode_namespace_list", "watchers_keys"),
         [
             pytest.param(["A", "B", "C"], ["A", "B", "C"]),
             pytest.param(None, ["ALL_NAMESPACES"]),
@@ -1363,7 +1363,7 @@ class TestKubernetesExecutor:
         assert executor.running == set()
 
     @pytest.mark.parametrize(
-        "raw_multi_namespace_mode, raw_value_namespace_list, expected_value_in_kube_config",
+        ("raw_multi_namespace_mode", "raw_value_namespace_list", "expected_value_in_kube_config"),
         [
             pytest.param("true", "A,B,C", ["A", "B", "C"]),
             pytest.param("true", "", None),
@@ -1540,7 +1540,7 @@ class TestKubernetesJobWatcher:
         )
 
     @pytest.mark.parametrize(
-        "raw_object, is_watcher_queue_called",
+        ("raw_object", "is_watcher_queue_called"),
         [
             pytest.param(
                 {
@@ -1853,7 +1853,7 @@ class TestKubernetesJobWatcher:
             mock_underscore_run.assert_called_once_with(mock.ANY, "0", mock.ANY, mock.ANY)
 
     @pytest.mark.parametrize(
-        "state_reasons, expected_result",
+        ("state_reasons", "expected_result"),
         [
             pytest.param("e1,e2,e3", ["e1", "e2", "e3"]),
             pytest.param("e1, e2,e3", ["e1", "e2", "e3"]),

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/hooks/test_kubernetes.py
@@ -142,7 +142,7 @@ class TestKubernetesHook:
         clear_test_connections()
 
     @pytest.mark.parametrize(
-        "in_cluster_param, conn_id, in_cluster_called",
+        ("in_cluster_param", "conn_id", "in_cluster_called"),
         (
             (True, None, True),
             (None, None, False),
@@ -219,7 +219,7 @@ class TestKubernetesHook:
         assert isinstance(api_conn, kubernetes.client.api_client.ApiClient)
 
     @pytest.mark.parametrize(
-        "disable_verify_ssl, conn_id, disable_called",
+        ("disable_verify_ssl", "conn_id", "disable_called"),
         (
             (True, None, True),
             (None, None, False),
@@ -251,7 +251,7 @@ class TestKubernetesHook:
         assert isinstance(api_conn, kubernetes.client.api_client.ApiClient)
 
     @pytest.mark.parametrize(
-        "disable_tcp_keepalive, conn_id, expected",
+        ("disable_tcp_keepalive", "conn_id", "expected"),
         (
             (True, None, False),
             (None, None, True),
@@ -283,7 +283,7 @@ class TestKubernetesHook:
         assert isinstance(api_conn, kubernetes.client.api_client.ApiClient)
 
     @pytest.mark.parametrize(
-        "config_path_param, conn_id, call_path",
+        ("config_path_param", "conn_id", "call_path"),
         (
             (None, None, KUBE_CONFIG_PATH),
             ("/my/path/override", None, "/my/path/override"),
@@ -309,7 +309,7 @@ class TestKubernetesHook:
         assert isinstance(api_conn, kubernetes.client.api_client.ApiClient)
 
     @pytest.mark.parametrize(
-        "conn_id, has_config",
+        ("conn_id", "has_config"),
         (
             (None, False),
             ("kube_config", True),
@@ -341,7 +341,7 @@ class TestKubernetesHook:
         assert isinstance(api_conn, kubernetes.client.api_client.ApiClient)
 
     @pytest.mark.parametrize(
-        "context_param, conn_id, expected_context",
+        ("context_param", "conn_id", "expected_context"),
         (
             ("param-context", None, "param-context"),
             (None, None, None),
@@ -372,7 +372,7 @@ class TestKubernetesHook:
         assert isinstance(api_conn, kubernetes.client.api_client.ApiClient)
 
     @pytest.mark.parametrize(
-        "conn_id, expected",
+        ("conn_id", "expected"),
         (
             pytest.param(None, None, id="no-conn-id"),
             pytest.param("with_namespace", "mock_namespace", id="conn-with-namespace"),
@@ -390,7 +390,7 @@ class TestKubernetesHook:
             )
 
     @pytest.mark.parametrize(
-        "conn_id, expected",
+        ("conn_id", "expected"),
         (
             pytest.param("sidecar_container_image", "private.repo.com/alpine:3.16", id="sidecar-with-image"),
             pytest.param("sidecar_container_image_empty", None, id="sidecar-without-image"),
@@ -401,7 +401,7 @@ class TestKubernetesHook:
         assert hook.get_xcom_sidecar_container_image() == expected
 
     @pytest.mark.parametrize(
-        "conn_id, expected",
+        ("conn_id", "expected"),
         (
             pytest.param(
                 "sidecar_container_resources",
@@ -491,7 +491,7 @@ class TestKubernetesHook:
         assert job_actual == job_expected
 
     @pytest.mark.parametrize(
-        "conditions, expected_result",
+        ("conditions", "expected_result"),
         [
             (None, False),
             ([], False),
@@ -538,7 +538,7 @@ class TestKubernetesHook:
         assert not job_failed
 
     @pytest.mark.parametrize(
-        "condition_type, status, expected_result",
+        ("condition_type", "status", "expected_result"),
         [
             ("Complete", False, False),
             ("Complete", True, True),
@@ -573,7 +573,7 @@ class TestKubernetesHook:
         assert not job_successful
 
     @pytest.mark.parametrize(
-        "condition_type, status, expected_result",
+        ("condition_type", "status", "expected_result"),
         [
             ("Complete", False, False),
             ("Complete", True, True),
@@ -692,14 +692,14 @@ class TestKubernetesHook:
         assert mock_client.create_namespaced_job.call_count == 3
 
     @pytest.mark.parametrize(
-        "given_namespace, expected_namespace",
+        ("given_namespace", "expected_namespace"),
         [
             (None, "default-namespace"),
             ("given-namespace", "given-namespace"),
         ],
     )
     @pytest.mark.parametrize(
-        "given_client, expected_client",
+        ("given_client", "expected_client"),
         [
             (None, mock.MagicMock()),
             (mock_client := mock.MagicMock(), mock_client),  # type: ignore[name-defined]

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/log_handlers/test_log_handlers.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/log_handlers/test_log_handlers.py
@@ -100,7 +100,7 @@ class TestFileTaskLogHandler:
             mock_k8s_get_task_log.assert_not_called()
 
     @pytest.mark.parametrize(
-        "pod_override, namespace_to_call",
+        ("pod_override", "namespace_to_call"),
         [
             pytest.param(k8s.V1Pod(metadata=k8s.V1ObjectMeta(namespace="namespace-A")), "namespace-A"),
             pytest.param(k8s.V1Pod(metadata=k8s.V1ObjectMeta(namespace="namespace-B")), "namespace-B"),

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_job.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_job.py
@@ -275,7 +275,7 @@ class TestKubernetesJobOperator:
             ),
         )
 
-    @pytest.mark.parametrize(("randomize_name",), ([True], [False]))
+    @pytest.mark.parametrize("randomize_name", (True, False))
     def test_full_job_spec(self, randomize_name, job_spec, clean_dags_dagruns_and_dagbundles):
         job_spec_name_base = job_spec.metadata.name
 
@@ -299,7 +299,7 @@ class TestKubernetesJobOperator:
         )
         assert job.metadata.labels == {"foo": "bar"}
 
-    @pytest.mark.parametrize(("randomize_name",), ([True], [False]))
+    @pytest.mark.parametrize("randomize_name", (True, False))
     def test_full_job_spec_kwargs(self, randomize_name, job_spec, clean_dags_dagruns_and_dagbundles):
         # kwargs take precedence, however
         image = "some.custom.image:andtag"
@@ -376,7 +376,7 @@ class TestKubernetesJobOperator:
 
         return tpl_file
 
-    @pytest.mark.parametrize(("randomize_name",), ([True], [False]))
+    @pytest.mark.parametrize("randomize_name", (True, False))
     def test_job_template_file(self, randomize_name, job_template_file, clean_dags_dagruns_and_dagbundles):
         k = KubernetesJobOperator(
             task_id="task",
@@ -426,7 +426,7 @@ class TestKubernetesJobOperator:
 
         assert job.spec.template.spec.affinity.to_dict() == affinity
 
-    @pytest.mark.parametrize(("randomize_name",), ([True], [False]))
+    @pytest.mark.parametrize("randomize_name", (True, False))
     def test_job_template_file_kwargs_override(
         self, randomize_name, job_template_file, clean_dags_dagruns_and_dagbundles
     ):
@@ -1002,7 +1002,7 @@ class TestKubernetesDeleteJobOperator:
         mock_delete_namespaced_job.assert_called_once_with(name=JOB_NAME, namespace=JOB_NAMESPACE)
 
     @pytest.mark.parametrize(
-        "on_status, success, fail, deleted",
+        ("on_status", "success", "fail", "deleted"),
         [
             (None, True, True, True),
             (None, True, False, True),

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -297,7 +297,7 @@ class TestKubernetesPodOperator:
         )
 
     @pytest.mark.parametrize(
-        "input,render_template_as_native_obj,raises_error",
+        ("input", "render_template_as_native_obj", "raises_error"),
         [
             pytest.param([k8s.V1EnvVar(name="{{ bar }}", value="{{ foo }}")], False, False, id="current"),
             pytest.param({"{{ bar }}": "{{ foo }}"}, False, False, id="backcompat"),
@@ -399,7 +399,7 @@ class TestKubernetesPodOperator:
         ]
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize(("in_cluster",), ([True], [False]))
+    @pytest.mark.parametrize("in_cluster", (True, False))
     @patch(HOOK_CLASS)
     def test_labels(self, hook_mock, in_cluster):
         hook_mock.return_value.is_in_cluster = in_cluster
@@ -721,7 +721,7 @@ class TestKubernetesPodOperator:
             assert result == mock_pod_request_obj
 
     @pytest.mark.parametrize(
-        "pod_phase, pod_reason, should_reuse",
+        ("pod_phase", "pod_reason", "should_reuse"),
         [
             ("Running", "", True),
             ("Running", "Evicted", False),
@@ -867,7 +867,7 @@ class TestKubernetesPodOperator:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "task_kwargs, base_container_fail, expect_to_delete_pod",
+        ("task_kwargs", "base_container_fail", "expect_to_delete_pod"),
         [
             ({"on_finish_action": "delete_pod"}, True, True),
             ({"on_finish_action": "delete_pod"}, False, True),
@@ -946,7 +946,7 @@ class TestKubernetesPodOperator:
             delete_pod_mock.assert_not_called()
 
     @pytest.mark.parametrize(
-        "task_kwargs, should_be_deleted",
+        ("task_kwargs", "should_be_deleted"),
         [
             pytest.param({}, True, id="default"),  # default values
             pytest.param({"on_finish_action": "delete_pod"}, True, id="delete-pod"),
@@ -1038,7 +1038,7 @@ class TestKubernetesPodOperator:
             ),
         )
 
-    @pytest.mark.parametrize(("randomize_name",), ([True], [False]))
+    @pytest.mark.parametrize("randomize_name", (True, False))
     def test_full_pod_spec(self, randomize_name, pod_spec):
         pod_spec_name_base = pod_spec.metadata.name
 
@@ -1071,7 +1071,7 @@ class TestKubernetesPodOperator:
             "run_id": "test",
         }
 
-    @pytest.mark.parametrize(("randomize_name",), ([True], [False]))
+    @pytest.mark.parametrize("randomize_name", (True, False))
     def test_full_pod_spec_kwargs(self, randomize_name, pod_spec):
         # kwargs take precedence, however
         image = "some.custom.image:andtag"
@@ -1152,7 +1152,7 @@ class TestKubernetesPodOperator:
 
         return tpl_file
 
-    @pytest.mark.parametrize(("randomize_name",), ([True], [False]))
+    @pytest.mark.parametrize("randomize_name", (True, False))
     def test_pod_template_file(self, randomize_name, pod_template_file):
         k = KubernetesPodOperator(
             task_id="task",
@@ -1215,7 +1215,7 @@ class TestKubernetesPodOperator:
 
         assert pod.spec.affinity.to_dict() == affinity
 
-    @pytest.mark.parametrize(("randomize_name",), ([True], [False]))
+    @pytest.mark.parametrize("randomize_name", (True, False))
     def test_pod_template_file_kwargs_override(self, randomize_name, pod_template_file):
         # kwargs take precedence, however
         image = "some.custom.image:andtag"
@@ -1251,7 +1251,7 @@ class TestKubernetesPodOperator:
             "run_id": "test",
         }
 
-    @pytest.mark.parametrize(("randomize_name",), ([True], [False]))
+    @pytest.mark.parametrize("randomize_name", (True, False))
     def test_pod_template_dict(self, randomize_name):
         templated_pod = k8s.V1Pod(
             metadata=k8s.V1ObjectMeta(
@@ -1561,7 +1561,7 @@ class TestKubernetesPodOperator:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "task_kwargs, should_fail, should_be_deleted",
+        ("task_kwargs", "should_fail", "should_be_deleted"),
         [
             ({}, False, True),
             ({}, True, True),
@@ -1675,7 +1675,7 @@ class TestKubernetesPodOperator:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "kwargs, actual_exit_code, expected_exc",
+        ("kwargs", "actual_exit_code", "expected_exc"),
         [
             ({}, 0, None),
             ({}, 100, AirflowException),
@@ -2069,7 +2069,7 @@ class TestKubernetesPodOperator:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "side_effect, exception_type, expect_exc",
+        ("side_effect", "exception_type", "expect_exc"),
         [
             ([ApiException(401), mock.DEFAULT], ApiException, True),  # works after one 401
             ([ApiException(401)] * 3 + [mock.DEFAULT], ApiException, True),  # works after 3 retries
@@ -2359,7 +2359,7 @@ class TestKubernetesPodOperatorAsync:
         mocked_log.error.assert_called_once_with(log_message, status, message)
 
     @pytest.mark.parametrize(
-        "kwargs, actual_exit_code, expected_exc, pod_status, event_status",
+        ("kwargs", "actual_exit_code", "expected_exc", "pod_status", "event_status"),
         [
             ({}, 0, None, "Succeeded", "success"),
             ({}, 100, AirflowException, "Failed", "error"),
@@ -2586,7 +2586,7 @@ class TestKubernetesPodOperatorAsync:
         post_complete_action.assert_not_called()
 
     @pytest.mark.parametrize(
-        "log_pod_spec_on_failure,expect_match",
+        ("log_pod_spec_on_failure", "expect_match"),
         [
             (True, r"Pod task-.* returned a failure.\nremote_pod:.*"),
             (False, r"Pod task-.* returned a failure.(?!\nremote_pod:)"),

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_spark_kubernetes.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_spark_kubernetes.py
@@ -344,7 +344,7 @@ class TestSparkKubernetesOperatorCreateApplication:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "task_name, application_file_path",
+        ("task_name", "application_file_path"),
         [
             ("default_yaml", "spark/application_test.yaml"),
             ("default_json", "spark/application_test.json"),
@@ -385,7 +385,7 @@ class TestSparkKubernetesOperatorCreateApplication:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "task_name, application_file_path",
+        ("task_name", "application_file_path"),
         [
             ("default_yaml", "spark/application_test.yaml"),
             ("default_json", "spark/application_test.json"),
@@ -431,7 +431,7 @@ class TestSparkKubernetesOperatorCreateApplication:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "task_name, application_file_path",
+        ("task_name", "application_file_path"),
         [
             ("task_id_yml", "spark/application_test_with_no_name_from_config.yaml"),
             ("task_id_json", "spark/application_test_with_no_name_from_config.json"),

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/test_kubernetes_helper_functions.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/test_kubernetes_helper_functions.py
@@ -28,7 +28,7 @@ pod_name_regex = r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])
 
 class TestCreateUniqueId:
     @pytest.mark.parametrize(
-        "val, expected",
+        ("val", "expected"),
         [
             ("task-id", "task-id"),  # no problem
             ("task_id", "task-id"),  # underscores
@@ -45,7 +45,7 @@ class TestCreateUniqueId:
         assert re.match(pod_name_regex, actual)
 
     @pytest.mark.parametrize(
-        "val, expected",
+        ("val", "expected"),
         [
             ("dag-id", "dag-id"),  # no problem
             ("dag_id", "dag-id"),  # underscores
@@ -62,7 +62,7 @@ class TestCreateUniqueId:
         assert re.match(pod_name_regex, actual)
 
     @pytest.mark.parametrize(
-        "dag_id, task_id, expected",
+        ("dag_id", "task_id", "expected"),
         [
             ("dag-id", "task-id", "dag-id-task-id"),  # no problem
             ("dag_id", "task_id", "dag-id-task-id"),  # underscores

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/test_pod_generator.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/test_pod_generator.py
@@ -168,7 +168,7 @@ class TestPodGenerator:
         )
 
     @pytest.mark.parametrize(
-        "content_json, expected",
+        ("content_json", "expected"),
         [
             pytest.param(
                 '{"token":"mock","ti":{"id":"4d828a62-a417-4936-a7a6-2b3fabacecab","task_id":"mock","dag_id":"mock","run_id":"mock","try_number":1,"map_index":-1,"pool_slots":1,"queue":"default","priority_weight":1},"dag_rel_path":"mock.py","bundle_info":{"name":"n/a","version":"no matter"},"log_path":"mock.log","kind":"ExecuteTask"}',
@@ -349,14 +349,14 @@ class TestPodGenerator:
         assert result_dict == expected_dict
 
     @pytest.mark.parametrize(
-        "config_image, expected_image",
+        ("config_image", "expected_image"),
         [
             pytest.param("my_image:my_tag", "my_image:my_tag", id="image_in_cfg"),
             pytest.param(None, "busybox", id="no_image_in_cfg"),
         ],
     )
     @pytest.mark.parametrize(
-        "pod_override_object_namespace, expected_namespace",
+        ("pod_override_object_namespace", "expected_namespace"),
         [
             ("new_namespace", "new_namespace"),  # pod_override_object namespace should be used
             (None, "test_namespace"),  # if it is not provided, we use default one
@@ -704,7 +704,7 @@ class TestPodGenerator:
         assert re.match(r"^[a-z0-9]{8}$", actual_suffix)
 
     @pytest.mark.parametrize(
-        "pod_id, expected_starts_with",
+        ("pod_id", "expected_starts_with"),
         (
             (
                 "somewhat-long-pod-name-maybe-longer-than-previously-supported-with-hyphen-",
@@ -743,7 +743,7 @@ class TestPodGenerator:
         PodGenerator(pod=k8s.V1Pod())
 
     @pytest.mark.parametrize(
-        "extra, extra_expected",
+        ("extra", "extra_expected"),
         [
             pytest.param(dict(), {}, id="base"),
             pytest.param(dict(airflow_worker=2), {"airflow-worker": "2"}, id="worker"),

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/triggers/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/triggers/test_pod.py
@@ -254,7 +254,7 @@ class TestKubernetesPodTrigger:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "logging_interval, exp_event",
+        ("logging_interval", "exp_event"),
         [
             pytest.param(
                 0,
@@ -313,7 +313,7 @@ class TestKubernetesPodTrigger:
         assert mock_fetch_container_logs_before_current_sec.call_count == 2
 
     @pytest.mark.parametrize(
-        "container_state, expected_state",
+        ("container_state", "expected_state"),
         [
             (
                 {"running": k8s.V1ContainerStateRunning(), "terminated": None, "waiting": None},
@@ -460,7 +460,7 @@ class TestKubernetesPodTrigger:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "exc_count, call_count",
+        ("exc_count", "call_count"),
         [
             pytest.param(0, 1, id="no exception"),
             pytest.param(2, 3, id="2 exc, 1 success"),

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_container.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_container.py
@@ -29,7 +29,7 @@ from airflow.providers.cncf.kubernetes.utils.container import (
 
 
 @pytest.mark.parametrize(
-    "container_state, expected_is_terminated",
+    ("container_state", "expected_is_terminated"),
     [("waiting", False), ("running", False), ("terminated", True)],
 )
 def test_container_is_terminated_with_waiting_state(container_state, expected_is_terminated):
@@ -98,7 +98,7 @@ def params_for_test_container_is_running():
     return pod_mock_list
 
 
-@pytest.mark.parametrize("remote_pod, result", params_for_test_container_is_running())
+@pytest.mark.parametrize(("remote_pod", "result"), params_for_test_container_is_running())
 def test_container_is_running(remote_pod, result):
     """The `container_is_running` function is designed to handle an assortment of bad objects
     returned from `read_pod`.  E.g. a None object, an object `e` such that `e.status` is None,
@@ -163,7 +163,7 @@ def params_for_test_container_is_succeeded():
     return pod_mock_list
 
 
-@pytest.mark.parametrize("remote_pod, result", params_for_test_container_is_succeeded())
+@pytest.mark.parametrize(("remote_pod", "result"), params_for_test_container_is_succeeded())
 def test_container_is_succeeded(remote_pod, result):
     """The `container_is_succeeded` function is designed to handle an assortment of bad objects
     returned from `read_pod`.  E.g. a None object, an object `e` such that `e.status` is None,

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_pod_manager.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_pod_manager.py
@@ -614,7 +614,9 @@ class TestPodManager:
         args, kwargs = self.mock_kube_client.read_namespaced_pod_log.call_args_list[0]
         assert kwargs["since_seconds"] == 5
 
-    @pytest.mark.parametrize("follow, is_running_calls, exp_running", [(True, 3, False), (False, 3, False)])
+    @pytest.mark.parametrize(
+        ("follow", "is_running_calls", "exp_running"), [(True, 3, False), (False, 3, False)]
+    )
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.container_is_running")
     def test_fetch_container_running_follow(
         self, container_running_mock, follow, is_running_calls, exp_running
@@ -878,7 +880,7 @@ class TestAsyncPodManager:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "log_lines, now, expected_log_messages, not_expected_log_messages",
+        ("log_lines", "now", "expected_log_messages", "not_expected_log_messages"),
         [
             # Case 1: No logs
             ([], pendulum.now(), [], []),
@@ -967,7 +969,7 @@ class TestAsyncPodManager:
 
 class TestPodLogsConsumer:
     @pytest.mark.parametrize(
-        "chunks, expected_logs",
+        ("chunks", "expected_logs"),
         [
             ([b"message"], [b"message"]),
             ([b"message1\nmessage2"], [b"message1\n", b"message2"]),
@@ -999,7 +1001,13 @@ class TestPodLogsConsumer:
             assert list(consumer) == []
 
     @pytest.mark.parametrize(
-        "container_run, termination_time, now_time, post_termination_timeout, expected_logs_available",
+        (
+            "container_run",
+            "termination_time",
+            "now_time",
+            "post_termination_timeout",
+            "expected_logs_available",
+        ),
         [
             (
                 False,
@@ -1072,7 +1080,13 @@ class TestPodLogsConsumer:
             assert consumer.logs_available() == expected_logs_available
 
     @pytest.mark.parametrize(
-        "read_pod_cache_timeout, mock_read_pod_at_0, mock_read_pod_at_1, mock_read_pods, expected_read_pods",
+        (
+            "read_pod_cache_timeout",
+            "mock_read_pod_at_0",
+            "mock_read_pod_at_1",
+            "mock_read_pods",
+            "expected_read_pods",
+        ),
         [
             (
                 120,

--- a/providers/common/compat/tests/unit/common/compat/test__compat_utils.py
+++ b/providers/common/compat/tests/unit/common/compat/test__compat_utils.py
@@ -26,7 +26,7 @@ class TestCreateModuleGetattr:
     """Unit tests for the create_module_getattr utility function."""
 
     @pytest.mark.parametrize(
-        ["name", "import_map", "is_module"],
+        ("name", "import_map", "is_module"),
         [
             ("BaseHook", {"BaseHook": "airflow.hooks.base"}, False),
             ("timezone", {}, True),  # Will be tested with module_map
@@ -51,7 +51,7 @@ class TestCreateModuleGetattr:
             assert isinstance(result, type) or callable(result)
 
     @pytest.mark.parametrize(
-        ["name", "paths", "should_succeed"],
+        ("name", "paths", "should_succeed"),
         [
             ("BaseHook", ("airflow.sdk", "airflow.hooks.base"), True),
             ("NonExistent", ("fake.module1", "fake.module2"), False),
@@ -106,7 +106,7 @@ class TestCreateModuleGetattr:
         assert exc_info.value.__cause__ is not None
 
     @pytest.mark.parametrize(
-        "error_scenario,map_config,expected_match",
+        ("error_scenario", "map_config", "expected_match"),
         [
             (
                 "import_error",
@@ -191,7 +191,7 @@ class TestCreateModuleGetattr:
             getattr_fn("Fake")
 
     @pytest.mark.parametrize(
-        "map_type,config",
+        ("map_type", "config"),
         [
             ("import_map", {"BaseHook": "airflow.hooks.base"}),
             ("module_map", {"timezone": "airflow.utils.timezone"}),

--- a/providers/common/io/tests/unit/common/io/xcom/test_backend.py
+++ b/providers/common/io/tests/unit/common/io/xcom/test_backend.py
@@ -429,7 +429,7 @@ class TestXComObjectStorageBackend:
         assert value == {"key": "superlargevalue" * 100}
 
     @pytest.mark.parametrize(
-        "value, expected_value",
+        ("value", "expected_value"),
         [
             pytest.param(
                 "file://airflow/xcoms/non_existing_file.json",

--- a/providers/common/sql/tests/unit/common/sql/hooks/test_sql.py
+++ b/providers/common/sql/tests/unit/common/sql/hooks/test_sql.py
@@ -69,8 +69,16 @@ index = 0
 
 @pytest.mark.db_test
 @pytest.mark.parametrize(
-    "return_last, split_statements, sql, cursor_calls,"
-    "cursor_descriptions, cursor_results, hook_descriptions, hook_results, ",
+    (
+        "return_last",
+        "split_statements",
+        "sql",
+        "cursor_calls",
+        "cursor_descriptions",
+        "cursor_results",
+        "hook_descriptions",
+        "hook_results",
+    ),
     [
         pytest.param(
             True,
@@ -309,7 +317,7 @@ class TestDbApiHook:
 
     @pytest.mark.db_test
     @pytest.mark.parametrize(
-        "df_type, expected_type",
+        ("df_type", "expected_type"),
         [
             ("test_default_df_type", pd.DataFrame),
             ("pandas", pd.DataFrame),

--- a/providers/common/sql/tests/unit/common/sql/hooks/test_sqlparse.py
+++ b/providers/common/sql/tests/unit/common/sql/hooks/test_sqlparse.py
@@ -22,7 +22,7 @@ from airflow.providers.common.sql.hooks.sql import DbApiHook
 
 
 @pytest.mark.parametrize(
-    "line,parsed_statements",
+    ("line", "parsed_statements"),
     [
         ("SELECT * FROM table", ["SELECT * FROM table"]),
         ("SELECT * FROM table;", ["SELECT * FROM table;"]),

--- a/providers/common/sql/tests/unit/common/sql/operators/test_sql.py
+++ b/providers/common/sql/tests/unit/common/sql/operators/test_sql.py
@@ -522,7 +522,7 @@ class TestTableCheckOperator:
         return operator
 
     @pytest.mark.parametrize(
-        ["conn_id"],
+        "conn_id",
         [
             pytest.param("postgres_default", marks=[pytest.mark.backend("postgres")]),
             pytest.param("mysql_default", marks=[pytest.mark.backend("mysql")]),
@@ -559,7 +559,7 @@ class TestTableCheckOperator:
             hook.run(["DROP TABLE employees"])
 
     @pytest.mark.parametrize(
-        ["conn_id"],
+        "conn_id",
         [
             pytest.param("postgres_default", marks=[pytest.mark.backend("postgres")]),
             pytest.param("mysql_default", marks=[pytest.mark.backend("mysql")]),

--- a/providers/common/sql/tests/unit/common/sql/operators/test_sql_execute.py
+++ b/providers/common/sql/tests/unit/common/sql/operators/test_sql_execute.py
@@ -51,7 +51,7 @@ class Row2(NamedTuple):
 
 
 @pytest.mark.parametrize(
-    "sql, return_last, split_statement, hook_results, hook_descriptions, expected_results",
+    ("sql", "return_last", "split_statement", "hook_results", "hook_descriptions", "expected_results"),
     [
         pytest.param(
             "select * from dummy",
@@ -166,7 +166,7 @@ def test_exec_success(sql, return_last, split_statement, hook_results, hook_desc
 
 
 @pytest.mark.parametrize(
-    "sql, return_last, split_statement, hook_results, hook_descriptions, expected_results",
+    ("sql", "return_last", "split_statement", "hook_results", "hook_descriptions", "expected_results"),
     [
         pytest.param(
             "select * from dummy",
@@ -288,7 +288,7 @@ def test_exec_success_with_process_output(
 
 
 @pytest.mark.parametrize(
-    "connection_port, default_port, expected_port",
+    ("connection_port", "default_port", "expected_port"),
     [(None, 4321, 4321), (1234, None, 1234), (1234, 4321, 1234)],
 )
 def test_execute_openlineage_events(connection_port, default_port, expected_port):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
Issue: Enable Even More PyDocStyle Checks https://github.com/apache/airflow/issues/40567
@ferruzzi

This PR is for enable PT006 rule:
all instances of @pytest.mark.parametrize names should be a tuple
https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/
There are a lot of file changes needed.
So, I separate to many PR, which contain about 19 file changes for easy review.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
