### PR TITLE
Enable PT006 rule to 13 files in providers (apache)

### DIFF
--- a/providers/apache/beam/tests/unit/apache/beam/hooks/test_beam.py
+++ b/providers/apache/beam/tests/unit/apache/beam/hooks/test_beam.py
@@ -173,7 +173,7 @@ class TestBeamHook:
         )
 
     @pytest.mark.parametrize(
-        "current_py_requirements, current_py_system_site_packages",
+        ("current_py_requirements", "current_py_system_site_packages"),
         [
             pytest.param("foo-bar", False, id="requirements without system site-packages"),
             pytest.param("foo-bar", True, id="requirements with system site-packages"),
@@ -437,7 +437,7 @@ class TestBeamRunner:
 
 class TestBeamOptionsToArgs:
     @pytest.mark.parametrize(
-        "options, expected_args",
+        ("options", "expected_args"),
         [
             ({"key": "val"}, ["--key=val"]),
             ({"key": None}, []),
@@ -592,7 +592,7 @@ class TestBeamAsyncHook:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "current_py_requirements, current_py_system_site_packages",
+        ("current_py_requirements", "current_py_system_site_packages"),
         [
             pytest.param("foo-bar", False, id="requirements without system site-packages"),
             pytest.param("foo-bar", True, id="requirements with system site-packages"),
@@ -667,7 +667,7 @@ class TestBeamAsyncHook:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "job_class, command_prefix",
+        ("job_class", "command_prefix"),
         [
             (JOB_CLASS, ["java", "-cp", JAR_FILE, JOB_CLASS]),
             (None, ["java", "-jar", JAR_FILE]),

--- a/providers/apache/beam/tests/unit/apache/beam/operators/test_beam.py
+++ b/providers/apache/beam/tests/unit/apache/beam/operators/test_beam.py
@@ -614,7 +614,7 @@ class TestBeamRunGoPipelineOperator:
         assert op.dataflow_config == {}
 
     @pytest.mark.parametrize(
-        "launcher_binary, go_file",
+        ("launcher_binary", "go_file"),
         [
             pytest.param("", "", id="both-empty"),
             pytest.param(None, None, id="both-not-set"),

--- a/providers/apache/drill/tests/unit/apache/drill/hooks/test_drill.py
+++ b/providers/apache/drill/tests/unit/apache/drill/hooks/test_drill.py
@@ -24,7 +24,7 @@ import pytest
 from airflow.providers.apache.drill.hooks.drill import DrillHook
 
 
-@pytest.mark.parametrize("host, expect_error", [("host_with?", True), ("good_host", False)])
+@pytest.mark.parametrize(("host", "expect_error"), [("host_with?", True), ("good_host", False)])
 def test_get_host(host, expect_error):
     with (
         patch("airflow.providers.apache.drill.hooks.drill.DrillHook.get_connection") as mock_get_connection,
@@ -67,7 +67,7 @@ class TestDrillHook:
         self.db_hook = TestDrillHook
 
     @pytest.mark.parametrize(
-        "host, port, conn_type, extra_dejson, expected_uri",
+        ("host", "port", "conn_type", "extra_dejson", "expected_uri"),
         [
             (
                 "host",

--- a/providers/apache/druid/tests/unit/apache/druid/hooks/test_druid.py
+++ b/providers/apache/druid/tests/unit/apache/druid/hooks/test_druid.py
@@ -359,7 +359,7 @@ class TestDruidHook:
         assert self.db_hook.get_auth() is None
 
     @pytest.mark.parametrize(
-        "verify_ssl_arg, ca_bundle_path, expected_return_value",
+        ("verify_ssl_arg", "ca_bundle_path", "expected_return_value"),
         [
             (False, None, False),
             (True, None, True),

--- a/providers/apache/hdfs/tests/unit/apache/hdfs/hooks/test_webhdfs.py
+++ b/providers/apache/hdfs/tests/unit/apache/hdfs/hooks/test_webhdfs.py
@@ -83,7 +83,7 @@ class TestWebHDFSHook:
             assert conn == mock_insecure_client.return_value
 
     @pytest.mark.parametrize(
-        "host, user, password",
+        ("host", "user", "password"),
         [
             pytest.param("host_1.com,host_2.com", "user", "without-password", id="without-password"),
             pytest.param("host_1.com,host_2.com", "user", "password", id="with-password"),

--- a/providers/apache/hdfs/tests/unit/apache/hdfs/log/test_hdfs_task_handler.py
+++ b/providers/apache/hdfs/tests/unit/apache/hdfs/log/test_hdfs_task_handler.py
@@ -171,7 +171,7 @@ class TestHdfsTaskHandler:
         assert logs == []
 
     @pytest.mark.parametrize(
-        "delete_local_copy, expected_existence_of_local_copy",
+        ("delete_local_copy", "expected_existence_of_local_copy"),
         [(True, False), (False, True)],
     )
     def test_close_with_delete_local_logs_conf(

--- a/providers/apache/hive/tests/unit/apache/hive/hooks/test_hive.py
+++ b/providers/apache/hive/tests/unit/apache/hive/hooks/test_hive.py
@@ -652,7 +652,7 @@ class TestHiveServer2Hook:
             )
 
     @pytest.mark.parametrize(
-        "host, port, schema, message",
+        ("host", "port", "schema", "message"),
         [
             ("localhost", "10000", "default", None),
             ("localhost:", "10000", "default", "The host used in beeline command"),
@@ -906,7 +906,7 @@ class TestHiveCli:
         assert not hook.high_availability
 
     @pytest.mark.parametrize(
-        "extra_dejson, correct_proxy_user, proxy_user",
+        ("extra_dejson", "correct_proxy_user", "proxy_user"),
         [
             ({"proxy_user": "a_user_proxy"}, "hive.server2.proxy.user=a_user_proxy", None),
         ],
@@ -938,7 +938,7 @@ class TestHiveCli:
             hook._prepare_cli_cmd()
 
     @pytest.mark.parametrize(
-        "extra_dejson, expected_keys",
+        ("extra_dejson", "expected_keys"),
         [
             (
                 {"high_availability": "true"},

--- a/providers/apache/impala/tests/unit/apache/impala/hooks/test_impala_sql.py
+++ b/providers/apache/impala/tests/unit/apache/impala/hooks/test_impala_sql.py
@@ -61,7 +61,7 @@ def get_cursor_descriptions(fields: list[str]) -> list[tuple[str]]:
 
 
 @pytest.mark.parametrize(
-    "host, login, password, port, schema, extra_dict, expected_query",
+    ("host", "login", "password", "port", "schema", "extra_dict", "expected_query"),
     [
         (
             "localhost",
@@ -125,7 +125,7 @@ def test_sqlalchemy_url_property(
 
 
 @pytest.mark.parametrize(
-    "sql, expected_rows",
+    ("sql", "expected_rows"),
     [
         ("SELECT * FROM users", [("Alice", 1), ("Bob", 2)]),
         ("SELECT 1", [(1,)]),

--- a/providers/apache/kafka/tests/unit/apache/kafka/operators/test_consume.py
+++ b/providers/apache/kafka/tests/unit/apache/kafka/operators/test_consume.py
@@ -126,7 +126,7 @@ class TestConsumeFromTopic:
         operator.execute(context={})
 
     @pytest.mark.parametrize(
-        ["max_messages", "expected_consumed_messages"],
+        ("max_messages", "expected_consumed_messages"),
         [
             [None, 1001],  # Consume all messages
             [100, 1000],  # max_messages < max_batch_size -> max_messages is set to default max_batch_size
@@ -183,7 +183,7 @@ class TestConsumeFromTopic:
         ConsumeFromTopicOperator(**operator_kwargs)
 
     @pytest.mark.parametrize(
-        "commit_cadence, enable_auto_commit, expected_warning",
+        ("commit_cadence", "enable_auto_commit", "expected_warning"),
         [
             # will not log warning if set 'enable.auto.commit' to false
             ("end_of_operator", "false", False),
@@ -242,7 +242,7 @@ class TestConsumeFromTopic:
                 mock_log.warning.assert_not_called()
 
     @pytest.mark.parametrize(
-        "commit_cadence, max_messages, expected_commit_calls",
+        ("commit_cadence", "max_messages", "expected_commit_calls"),
         [
             # end_of_operator: should call commit once at the end
             ("end_of_operator", 1500, 1),

--- a/providers/apache/kafka/tests/unit/apache/kafka/queues/test_kafka.py
+++ b/providers/apache/kafka/tests/unit/apache/kafka/queues/test_kafka.py
@@ -41,7 +41,7 @@ class TestKafkaMessageQueueProvider:
         assert isinstance(self.provider, BaseMessageQueueProvider)
 
     @pytest.mark.parametrize(
-        "queue_uri, expected_result",
+        ("queue_uri", "expected_result"),
         [
             pytest.param("kafka://localhost:9092/topic1", True, id="single_broker_single_topic"),
             pytest.param(
@@ -56,7 +56,7 @@ class TestKafkaMessageQueueProvider:
         assert self.provider.queue_matches(queue_uri) == expected_result
 
     @pytest.mark.parametrize(
-        "scheme, expected_result",
+        ("scheme", "expected_result"),
         [
             pytest.param("kafka", True, id="kafka_scheme"),
             pytest.param("redis+pubsub", False, id="redis_scheme"),
@@ -73,7 +73,7 @@ class TestKafkaMessageQueueProvider:
         assert self.provider.trigger_class() == AwaitMessageTrigger
 
     @pytest.mark.parametrize(
-        "queue_uri, extra_kwargs, expected_result",
+        ("queue_uri", "extra_kwargs", "expected_result"),
         [
             pytest.param(
                 "kafka://broker:9092/topic1,topic2",
@@ -95,7 +95,7 @@ class TestKafkaMessageQueueProvider:
         assert kwargs == expected_result
 
     @pytest.mark.parametrize(
-        "queue_uri, extra_kwargs, expected_error, error_match",
+        ("queue_uri", "extra_kwargs", "expected_error", "error_match"),
         [
             pytest.param(
                 "kafka://broker:9092/topic1",

--- a/providers/apache/livy/tests/unit/apache/livy/hooks/test_livy.py
+++ b/providers/apache/livy/tests/unit/apache/livy/hooks/test_livy.py
@@ -96,7 +96,7 @@ class TestLivyDbHook:
         )
 
     @pytest.mark.parametrize(
-        "conn_id, expected",
+        ("conn_id", "expected"),
         [
             pytest.param("default_port", "http://host", id="default-port"),
             pytest.param("default_protocol", "http://host", id="default-protocol"),

--- a/providers/apache/spark/tests/unit/apache/spark/hooks/test_spark_submit.py
+++ b/providers/apache/spark/tests/unit/apache/spark/hooks/test_spark_submit.py
@@ -1016,7 +1016,7 @@ class TestSparkSubmitHook:
         )
 
     @pytest.mark.parametrize(
-        "command, expected",
+        ("command", "expected"),
         [
             (
                 ("spark-submit", "foo", "--bar", "baz", "--password='secret'", "--foo", "bar"),

--- a/providers/apache/tinkerpop/tests/unit/apache/tinkerpop/hooks/test_gremlin.py
+++ b/providers/apache/tinkerpop/tests/unit/apache/tinkerpop/hooks/test_gremlin.py
@@ -36,7 +36,7 @@ def gremlin_hook():
 
 class TestGremlinHook:
     @pytest.mark.parametrize(
-        "host, port, expected_uri",
+        ("host", "port", "expected_uri"),
         [
             ("host", None, "ws://host:443/gremlin"),
             ("myhost", 1234, "ws://myhost:1234/gremlin"),
@@ -81,7 +81,7 @@ class TestGremlinHook:
             )
 
     @pytest.mark.parametrize(
-        "serializer, should_include",
+        ("serializer", "should_include"),
         [
             (None, False),
             ("dummy_serializer", True),
@@ -112,7 +112,7 @@ class TestGremlinHook:
                 assert "message_serializer" not in call_args
 
     @pytest.mark.parametrize(
-        "side_effect, expected_exception, expected_result",
+        ("side_effect", "expected_exception", "expected_result"),
         [
             (None, None, ["dummy_result"]),
             (Exception("Test error"), Exception, None),


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
Issue: Enable Even More PyDocStyle Checks https://github.com/apache/airflow/issues/40567
@ferruzzi

This PR is for enable PT006 rule:
all instances of @pytest.mark.parametrize names should be a tuple
https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/
There are a lot of file changes needed.
So, I separate to many PR, which contain about 13 file changes for easy review.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
