### PR TITLE
Enable PT006 rule to 23 files in providers (amazon -> hooks, links, log, queues)

### DIFF
--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_athena_sql.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_athena_sql.py
@@ -102,7 +102,7 @@ class TestAthenaSQLHookConn:
         )
 
     @pytest.mark.parametrize(
-        "conn_params, conn_extra, expected_call_args",
+        ("conn_params", "conn_extra", "expected_call_args"),
         [
             (
                 {"schema": "athena_sql_schema1"},

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_base_aws.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_base_aws.py
@@ -167,7 +167,7 @@ class TestSessionFactory:
         assert isinstance(sf.conn, AwsConnectionWrapper)
 
     @pytest.mark.parametrize(
-        "region_name,conn_region_name",
+        ("region_name", "conn_region_name"),
         [
             ("eu-west-1", "cn-north-1"),
             ("eu-west-1", None),
@@ -185,7 +185,7 @@ class TestSessionFactory:
         assert sf.region_name == expected
 
     @pytest.mark.parametrize(
-        "botocore_config, conn_botocore_config",
+        ("botocore_config", "conn_botocore_config"),
         [
             (Config(s3={"us_east_1_regional_endpoint": "regional"}), None),
             (Config(s3={"us_east_1_regional_endpoint": "regional"}), Config(region_name="ap-southeast-1")),
@@ -283,7 +283,7 @@ class TestSessionFactory:
 
     @mock_aws
     @pytest.mark.parametrize(
-        "conn_id, conn_extra",
+        ("conn_id", "conn_extra"),
         config_for_credentials_test,
     )
     @pytest.mark.parametrize("region_name", ["ap-southeast-2", "sa-east-1"])
@@ -306,7 +306,7 @@ class TestSessionFactory:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "conn_id, conn_extra",
+        ("conn_id", "conn_extra"),
         config_for_credentials_test,
     )
     @pytest.mark.parametrize("region_name", ["ap-southeast-2", "sa-east-1"])
@@ -454,7 +454,9 @@ class TestAwsBaseHook:
         assert user_agent_tags["Caller"] == default_caller_name
 
     @pytest.mark.db_test
-    @pytest.mark.parametrize("env_var, expected_version", [({"AIRFLOW_CTX_DAG_ID": "banana"}, 5), [{}, None]])
+    @pytest.mark.parametrize(
+        ("env_var", "expected_version"), [({"AIRFLOW_CTX_DAG_ID": "banana"}, 5), [{}, None]]
+    )
     @mock.patch.object(AwsBaseHook, "_get_caller", return_value="Test")
     def test_user_agent_dag_run_key_is_hashed_correctly(
         self, _, env_var, expected_version, mock_supervisor_comms
@@ -805,7 +807,7 @@ class TestAwsBaseHook:
     @mock_aws
     @pytest.mark.parametrize("conn_type", ["client", "resource"])
     @pytest.mark.parametrize(
-        "connection_uri,region_name,env_region,expected_region_name",
+        ("connection_uri", "region_name", "env_region", "expected_region_name"),
         [
             ("aws://?region_name=eu-west-1", None, "", "eu-west-1"),
             ("aws://?region_name=eu-west-1", "cn-north-1", "", "cn-north-1"),
@@ -833,7 +835,7 @@ class TestAwsBaseHook:
     @mock_aws
     @pytest.mark.parametrize("conn_type", ["client", "resource"])
     @pytest.mark.parametrize(
-        "connection_uri,expected_partition",
+        ("connection_uri", "expected_partition"),
         [
             ("aws://?region_name=eu-west-1", "aws"),
             ("aws://?region_name=cn-north-1", "aws-cn"),
@@ -871,7 +873,7 @@ class TestAwsBaseHook:
             resource_hook._resolve_service_name(is_resource_type=False)
 
     @pytest.mark.parametrize(
-        "client_type,resource_type",
+        ("client_type", "resource_type"),
         [
             ("s3", "dynamodb"),
             (None, None),
@@ -922,7 +924,7 @@ class TestAwsBaseHook:
         assert hook.client_type == "ec2"
 
     @pytest.mark.parametrize(
-        "sts_service_endpoint_url, result_url",
+        ("sts_service_endpoint_url", "result_url"),
         [
             pytest.param(None, None, id="not-set"),
             pytest.param("https://sts.service:1234", "https://sts.service:1234", id="sts-service-endpoint"),

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_batch_client.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_batch_client.py
@@ -458,7 +458,7 @@ class TestBatchClientDelays:
         mock_sleep.assert_called_once_with(mock_uniform.return_value)
 
     @pytest.mark.parametrize(
-        "tries, lower, upper",
+        ("tries", "lower", "upper"),
         [
             (0, 0, 1),
             (1, 0, 2),

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_bedrock.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_bedrock.py
@@ -28,7 +28,7 @@ from airflow.providers.amazon.aws.hooks.bedrock import (
 
 class TestBedrockHooks:
     @pytest.mark.parametrize(
-        "test_hook, service_name",
+        ("test_hook", "service_name"),
         [
             pytest.param(BedrockHook(), "bedrock", id="bedrock"),
             pytest.param(BedrockRuntimeHook(), "bedrock-runtime", id="bedrock-runtime"),

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_comprehend.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_comprehend.py
@@ -26,7 +26,7 @@ from airflow.providers.amazon.aws.hooks.comprehend import ComprehendHook
 
 class TestComprehendHook:
     @pytest.mark.parametrize(
-        "test_hook, service_name",
+        ("test_hook", "service_name"),
         [pytest.param(ComprehendHook(), "comprehend", id="comprehend")],
     )
     def test_comprehend_hook(self, test_hook, service_name):

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_datasync.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_datasync.py
@@ -98,7 +98,7 @@ class TestDataSyncHookMocked:
         assert self.hook.wait_interval_seconds == 0
 
     @pytest.mark.parametrize(
-        "location_uri, expected_method",
+        ("location_uri", "expected_method"),
         [
             pytest.param("smb://spam/egg/", "create_location_smb", id="smb"),
             pytest.param("s3://foo/bar", "create_location_s3", id="s3"),

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_dynamodb.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_dynamodb.py
@@ -76,7 +76,7 @@ class TestDynamoDBHook:
         assert path.as_uri().endswith("/airflow/providers/amazon/aws/waiters/dynamodb.json")
 
     @pytest.mark.parametrize(
-        "response, status, error",
+        ("response", "status", "error"),
         [
             pytest.param(
                 {"ImportTableDescription": {"ImportStatus": "COMPLETED"}}, "COMPLETED", False, id="complete"
@@ -116,7 +116,7 @@ class TestDynamoDBHook:
             assert msg is None
 
     @pytest.mark.parametrize(
-        "effect, error",
+        ("effect", "error"),
         [
             pytest.param(
                 ClientError(

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_ecr.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_ecr.py
@@ -57,7 +57,7 @@ class TestEcrHook:
         assert result[0].password == f"{DEFAULT_ACCOUNT_ID}-auth-token"
 
     @pytest.mark.parametrize(
-        "accounts_id, expected_registry",
+        ("accounts_id", "expected_registry"),
         [
             pytest.param(DEFAULT_ACCOUNT_ID, DEFAULT_ACCOUNT_ID, id="moto-default-account"),
             pytest.param("111100002222", "111100002222", id="custom-account-id"),

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_eks.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_eks.py
@@ -738,7 +738,7 @@ class TestEksHooks:
     ]
 
     @pytest.mark.parametrize(
-        "launch_template, instance_types, disk_size, remote_access, expected_result",
+        ("launch_template", "instance_types", "disk_size", "remote_access", "expected_result"),
         test_cases,
     )
     def test_create_nodegroup_handles_launch_template_combinations(
@@ -1168,7 +1168,7 @@ class TestEksHooks:
     ]
 
     @pytest.mark.parametrize(
-        "selectors, expected_message, expected_result",
+        ("selectors", "expected_message", "expected_result"),
         selector_formatting_test_cases,
     )
     @mock_aws
@@ -1212,7 +1212,7 @@ class TestEksHook:
 
     @mock.patch("airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook.conn")
     @pytest.mark.parametrize(
-        "aws_conn_id, region_name, expected_region_args",
+        ("aws_conn_id", "region_name", "expected_region_args"),
         [
             ["test-id", "test-region", " --region-name test-region"],
             [None, "test-region", " --region-name test-region"],

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_kinesis_analytics.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_kinesis_analytics.py
@@ -23,7 +23,7 @@ from airflow.providers.amazon.aws.hooks.kinesis_analytics import KinesisAnalytic
 
 class TestKinesisAnalyticsV2Hook:
     @pytest.mark.parametrize(
-        "test_hook, service_name",
+        ("test_hook", "service_name"),
         [pytest.param(KinesisAnalyticsV2Hook(), "kinesisanalyticsv2", id="kinesisanalyticsv2")],
     )
     def test_kinesis_analytics_v2_hook(self, test_hook, service_name):

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_lambda_function.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_lambda_function.py
@@ -53,7 +53,7 @@ class TestLambdaHook:
         "airflow.providers.amazon.aws.hooks.lambda_function.LambdaHook.conn", new_callable=mock.PropertyMock
     )
     @pytest.mark.parametrize(
-        "payload, invoke_payload",
+        ("payload", "invoke_payload"),
         [(PAYLOAD, BYTES_PAYLOAD), (BYTES_PAYLOAD, BYTES_PAYLOAD)],
     )
     def test_invoke_lambda(self, mock_conn, payload, invoke_payload):
@@ -66,7 +66,7 @@ class TestLambdaHook:
         )
 
     @pytest.mark.parametrize(
-        "hook_params, boto3_params",
+        ("hook_params", "boto3_params"),
         [
             pytest.param(
                 {

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_logs.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_logs.py
@@ -29,7 +29,7 @@ from airflow.providers.amazon.aws.hooks.logs import AwsLogsHook
 @mock_aws
 class TestAwsLogsHook:
     @pytest.mark.parametrize(
-        "get_log_events_response, num_skip_events, expected_num_events, end_time",
+        ("get_log_events_response", "num_skip_events", "expected_num_events", "end_time"),
         [
             # 3 empty responses with different tokens
             (

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_quicksight.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_quicksight.py
@@ -95,13 +95,13 @@ class TestQuicksight:
         assert hook.conn is not None
 
     @pytest.mark.parametrize(
-        "response, expected_status",
+        ("response", "expected_status"),
         [
             pytest.param(MOCK_DESCRIBE_INGESTION_SUCCESS, "COMPLETED", id="completed"),
             pytest.param(MOCK_DESCRIBE_INGESTION_FAILURE, "Failed", id="failed"),
         ],
     )
-    @pytest.mark.parametrize("aws_account_id, expected_account_id", ACCOUNT_TEST_CASES)
+    @pytest.mark.parametrize(("aws_account_id", "expected_account_id"), ACCOUNT_TEST_CASES)
     def test_get_job_status(
         self, response, expected_status, aws_account_id, expected_account_id, mocked_account_id, mocked_client
     ):
@@ -124,7 +124,7 @@ class TestQuicksight:
         )
 
     @pytest.mark.parametrize(
-        "exception, error_match",
+        ("exception", "error_match"),
         [
             pytest.param(KeyError("Foo"), "Could not get status", id="key-error"),
             pytest.param(
@@ -152,7 +152,7 @@ class TestQuicksight:
             pytest.param(None, id="error-info-not-exists"),
         ],
     )
-    @pytest.mark.parametrize("aws_account_id, expected_account_id", ACCOUNT_TEST_CASES)
+    @pytest.mark.parametrize(("aws_account_id", "expected_account_id"), ACCOUNT_TEST_CASES)
     def test_get_error_info(
         self, error_info, aws_account_id, expected_account_id, mocked_client, mocked_account_id
     ):
@@ -171,7 +171,7 @@ class TestQuicksight:
 
     @mock.patch.object(QuickSightHook, "get_status", return_value="FAILED")
     @mock.patch.object(QuickSightHook, "get_error_info")
-    @pytest.mark.parametrize("aws_account_id, expected_account_id", ACCOUNT_TEST_CASES)
+    @pytest.mark.parametrize(("aws_account_id", "expected_account_id"), ACCOUNT_TEST_CASES)
     def test_wait_for_state_failure(
         self,
         mocked_get_error_info,
@@ -213,7 +213,7 @@ class TestQuicksight:
     @pytest.mark.parametrize(
         "wait_for_completion", [pytest.param(True, id="wait"), pytest.param(False, id="no-wait")]
     )
-    @pytest.mark.parametrize("aws_account_id, expected_account_id", ACCOUNT_TEST_CASES)
+    @pytest.mark.parametrize(("aws_account_id", "expected_account_id"), ACCOUNT_TEST_CASES)
     def test_create_ingestion(
         self, wait_for_completion, aws_account_id, expected_account_id, mocked_account_id, mocked_client
     ):

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_redshift_data.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_redshift_data.py
@@ -67,7 +67,7 @@ class TestRedshiftDataHook:
         mock_conn.describe_statement.assert_not_called()
 
     @pytest.mark.parametrize(
-        "cluster_identifier, workgroup_name, session_id",
+        ("cluster_identifier", "workgroup_name", "session_id"),
         [
             (None, None, None),
             ("some_cluster", "some_workgroup", None),
@@ -95,7 +95,7 @@ class TestRedshiftDataHook:
             )
 
     @pytest.mark.parametrize(
-        "cluster_identifier, workgroup_name, session_id",
+        ("cluster_identifier", "workgroup_name", "session_id"),
         [
             (None, None, None),
             ("some_cluster", "some_workgroup", None),
@@ -418,7 +418,7 @@ class TestRedshiftDataHook:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "describe_statement_response, expected_result",
+        ("describe_statement_response", "expected_result"),
         [
             ({"Status": "PICKED"}, True),
             ({"Status": "STARTED"}, True),
@@ -453,7 +453,7 @@ class TestRedshiftDataHook:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "describe_statement_response, expected_exception",
+        ("describe_statement_response", "expected_exception"),
         (
             (
                 {"Id": "uuid", "Status": "FAILED", "QueryString": "select 1", "Error": "Test error"},

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_redshift_sql.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_redshift_sql.py
@@ -167,7 +167,7 @@ class TestRedshiftSQLHookConn:
         )
 
     @pytest.mark.parametrize(
-        "conn_params, conn_extra, expected_call_args",
+        ("conn_params", "conn_extra", "expected_call_args"),
         [
             ({}, {}, {}),
             ({"login": "test"}, {}, {"user": "test"}),
@@ -186,7 +186,7 @@ class TestRedshiftSQLHookConn:
             mock_connect.assert_called_once_with(**expected_call_args)
 
     @pytest.mark.parametrize(
-        "connection_host, connection_extra, expected_cluster_identifier, expected_exception_msg",
+        ("connection_host", "connection_extra", "expected_cluster_identifier", "expected_exception_msg"),
         [
             # test without a connection host and without a cluster_identifier in connection extra
             (None, {"iam": True}, None, "Please set cluster_identifier or host in redshift connection."),
@@ -244,7 +244,7 @@ class TestRedshiftSQLHookConn:
 
     @mock.patch.dict("os.environ", AIRFLOW_CONN_AWS_DEFAULT=f"aws://?region_name={MOCK_REGION_NAME}")
     @pytest.mark.parametrize(
-        "connection_host, connection_extra, expected_identity",
+        ("connection_host", "connection_extra", "expected_identity"),
         [
             # test without a connection host but with a cluster_identifier in connection extra
             (

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_s3.py
@@ -114,7 +114,7 @@ class TestAwsS3Hook:
             S3Hook(transfer_config_args=transfer_config_args)
 
     @pytest.mark.parametrize(
-        "url, expected",
+        ("url", "expected"),
         [
             pytest.param(
                 "s3://test/this/is/not/a-real-key.txt", ("test", "this/is/not/a-real-key.txt"), id="s3 style"
@@ -758,7 +758,7 @@ class TestAwsS3Hook:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "mock_bucket_keys, mock_response_bucket_keys",
+        ("mock_bucket_keys", "mock_response_bucket_keys"),
         [
             (["test.txt"], ["test.txt"]),
             (["test_key"], ["test_key", "test_key2"]),
@@ -828,7 +828,7 @@ class TestAwsS3Hook:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "test_first_prefix, test_second_prefix, requester_pays",
+        ("test_first_prefix", "test_second_prefix", "requester_pays"),
         [
             ("async-prefix1/", "async-prefix2/", False),
             ("async-prefix1/", "async-prefix2/", True),
@@ -869,7 +869,7 @@ class TestAwsS3Hook:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "mock_prefix, mock_bucket",
+        ("mock_prefix", "mock_bucket"),
         [
             ("async-prefix1", "test_bucket"),
         ],
@@ -931,7 +931,7 @@ class TestAwsS3Hook:
     # @async_mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_s3_bucket_key")
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "contents, result",
+        ("contents", "result"),
         [
             (
                 [
@@ -985,7 +985,7 @@ class TestAwsS3Hook:
         assert response is result
 
     @pytest.mark.parametrize(
-        "key, pattern, expected",
+        ("key", "pattern", "expected"),
         [
             ("test.csv", r"[a-z]+\.csv", True),
             ("test.txt", r"test/[a-z]+\.csv", False),
@@ -1855,7 +1855,7 @@ class TestAwsS3Hook:
 
 
 @pytest.mark.parametrize(
-    "key_kind, has_conn, has_bucket, precedence, expected",
+    ("key_kind", "has_conn", "has_bucket", "precedence", "expected"),
     [
         ("full_key", "no_conn", "no_bucket", "unify", ["key_bucket", "key.txt"]),
         ("full_key", "no_conn", "no_bucket", "provide", ["key_bucket", "key.txt"]),
@@ -1926,7 +1926,7 @@ def test_unify_and_provide_bucket_name_combination(
 
 
 @pytest.mark.parametrize(
-    "key_kind, has_conn, has_bucket, expected",
+    ("key_kind", "has_conn", "has_bucket", "expected"),
     [
         ("full_key", "no_conn", "no_bucket", ["key_bucket", "key.txt"]),
         ("full_key", "no_conn", "with_bucket", ["kwargs_bucket", "s3://key_bucket/key.txt"]),

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_ssm.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_ssm.py
@@ -57,7 +57,7 @@ class TestSsmHook:
         assert self.hook.region_name == REGION
 
     @pytest.mark.parametrize(
-        "param_name, default_value, expected_result",
+        ("param_name", "default_value", "expected_result"),
         [
             pytest.param(EXISTING_PARAM_NAME, None, PARAM_VALUE, id="param_exists_no_default_provided"),
             pytest.param(EXISTING_PARAM_NAME, DEFAULT_VALUE, PARAM_VALUE, id="param_exists_with_default"),

--- a/providers/amazon/tests/unit/amazon/aws/links/test_base_aws.py
+++ b/providers/amazon/tests/unit/amazon/aws/links/test_base_aws.py
@@ -47,7 +47,7 @@ class SimpleBaseAwsLink(BaseAwsLink):
 
 class TestBaseAwsLink:
     @pytest.mark.parametrize(
-        "region_name, aws_partition,keywords,expected_value",
+        ("region_name", "aws_partition", "keywords", "expected_value"),
         [
             ("eu-central-1", "aws", {}, {"region_name": "eu-central-1", "aws_domain": "aws.amazon.com"}),
             ("cn-north-1", "aws-cn", {}, {"region_name": "cn-north-1", "aws_domain": "amazonaws.cn"}),

--- a/providers/amazon/tests/unit/amazon/aws/links/test_emr.py
+++ b/providers/amazon/tests/unit/amazon/aws/links/test_emr.py
@@ -68,7 +68,7 @@ class TestEmrClusterLink(BaseAwsLinksTestCase):
 
 
 @pytest.mark.parametrize(
-    "cluster_info, expected_uri",
+    ("cluster_info", "expected_uri"),
     [
         pytest.param({"Cluster": {}}, None, id="no-log-uri"),
         pytest.param({"Cluster": {"LogUri": "s3://myLogUri/"}}, "myLogUri/", id="has-log-uri"),
@@ -188,7 +188,7 @@ class TestEmrServerlessDashboardLink(BaseAwsLinksTestCase):
 
 
 @pytest.mark.parametrize(
-    "dashboard_info, expected_uri",
+    ("dashboard_info", "expected_uri"),
     [
         pytest.param(
             {"url": "https://example.com/?authToken=first-unique-value"},

--- a/providers/amazon/tests/unit/amazon/aws/links/test_step_function.py
+++ b/providers/amazon/tests/unit/amazon/aws/links/test_step_function.py
@@ -36,7 +36,7 @@ class TestStateMachineDetailsLink(BaseAwsLinksTestCase):
     link_class = StateMachineDetailsLink
 
     @pytest.mark.parametrize(
-        "state_machine_arn, expected_url",
+        ("state_machine_arn", "expected_url"),
         [
             pytest.param("", "", id="empty-arn"),
             pytest.param(None, "", id="arn-not-set"),
@@ -70,7 +70,7 @@ class TestStateMachineExecutionsDetailsLink(BaseAwsLinksTestCase):
     link_class = StateMachineExecutionsDetailsLink
 
     @pytest.mark.parametrize(
-        "execution_arn, expected_url",
+        ("execution_arn", "expected_url"),
         [
             pytest.param("", "", id="empty-arn"),
             pytest.param(None, "", id="arn-not-set"),

--- a/providers/amazon/tests/unit/amazon/aws/log/test_cloudwatch_task_handler.py
+++ b/providers/amazon/tests/unit/amazon/aws/log/test_cloudwatch_task_handler.py
@@ -337,7 +337,7 @@ class TestCloudwatchTaskHandler:
             ]
 
     @pytest.mark.parametrize(
-        "end_date, expected_end_time",
+        ("end_date", "expected_end_time"),
         [
             (None, None),
             (
@@ -357,7 +357,7 @@ class TestCloudwatchTaskHandler:
         )
 
     @pytest.mark.parametrize(
-        "conf_json_serialize, expected_serialized_output",
+        ("conf_json_serialize", "expected_serialized_output"),
         [
             pytest.param(
                 "airflow.providers.amazon.aws.log.cloudwatch_task_handler.json_serialize_legacy",

--- a/providers/amazon/tests/unit/amazon/aws/log/test_s3_task_handler.py
+++ b/providers/amazon/tests/unit/amazon/aws/log/test_s3_task_handler.py
@@ -341,7 +341,7 @@ class TestS3TaskHandler:
             boto3.resource("s3").Object("bucket", self.remote_log_key).get()
 
     @pytest.mark.parametrize(
-        "delete_local_copy, expected_existence_of_local_copy",
+        ("delete_local_copy", "expected_existence_of_local_copy"),
         [(True, False), (False, True)],
     )
     def test_close_with_delete_local_logs_conf(self, delete_local_copy, expected_existence_of_local_copy):

--- a/providers/amazon/tests/unit/amazon/aws/queues/test_sqs.py
+++ b/providers/amazon/tests/unit/amazon/aws/queues/test_sqs.py
@@ -42,7 +42,7 @@ def test_message_sqs_queue_matches():
 
 
 @pytest.mark.parametrize(
-    "scheme, expected_result",
+    ("scheme", "expected_result"),
     [
         pytest.param("sqs", True, id="sqs_scheme"),
         pytest.param("kafka", False, id="kafka_scheme"),


### PR DESCRIPTION


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Issue: Enable Even More PyDocStyle Checks https://github.com/apache/airflow/issues/40567
@ferruzzi

This PR is for enable PT006 rule:
all instances of @pytest.mark.parametrize names should be a tuple
https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/
There are a lot of file changes needed.
So, I separate to many PR, which contain about 23 file changes for easy review.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
