### PR TITLE
Enable PT006 rule to 23 files in providers (all remaining files related to amazon)

### DIFF
--- a/providers/amazon/tests/unit/amazon/aws/auth_manager/avp/test_facade.py
+++ b/providers/amazon/tests/unit/amazon/aws/auth_manager/avp/test_facade.py
@@ -61,7 +61,7 @@ class TestAwsAuthManagerAmazonVerifiedPermissionsFacade:
         assert hasattr(facade, "avp_policy_store_id")
 
     @pytest.mark.parametrize(
-        "entity_id, context, user, expected_entities, expected_context, avp_response, expected",
+        ("entity_id", "context", "user", "expected_entities", "expected_context", "avp_response", "expected"),
         [
             # User with groups with no permissions
             (
@@ -196,7 +196,7 @@ class TestAwsAuthManagerAmazonVerifiedPermissionsFacade:
             facade.is_authorized(method="GET", entity_type=AvpEntities.VARIABLE, user=test_user)
 
     @pytest.mark.parametrize(
-        "user, avp_response, expected",
+        ("user", "avp_response", "expected"),
         [
             (
                 test_user,

--- a/providers/amazon/tests/unit/amazon/aws/auth_manager/test_aws_auth_manager.py
+++ b/providers/amazon/tests/unit/amazon/aws/auth_manager/test_aws_auth_manager.py
@@ -97,7 +97,7 @@ class TestAwsAuthManager:
         assert hasattr(auth_manager, "avp_facade")
 
     @pytest.mark.parametrize(
-        "details, user, expected_user, expected_entity_id",
+        ("details", "user", "expected_user", "expected_entity_id"),
         [
             (None, mock, ANY, None),
             (ConfigurationDetails(section="test"), mock, mock, "test"),
@@ -128,7 +128,7 @@ class TestAwsAuthManager:
         assert result
 
     @pytest.mark.parametrize(
-        "details, user, expected_user, expected_entity_id",
+        ("details", "user", "expected_user", "expected_entity_id"),
         [
             (None, mock, ANY, None),
             (ConnectionDetails(conn_id="conn_id"), mock, mock, "conn_id"),
@@ -159,7 +159,7 @@ class TestAwsAuthManager:
         assert result
 
     @pytest.mark.parametrize(
-        "access_entity, details, user, expected_user, expected_entity_id, expected_context",
+        ("access_entity", "details", "user", "expected_user", "expected_entity_id", "expected_context"),
         [
             (None, None, mock, ANY, None, None),
             (None, DagDetails(id="dag_1"), mock, mock, "dag_1", None),
@@ -207,7 +207,7 @@ class TestAwsAuthManager:
         assert result
 
     @pytest.mark.parametrize(
-        "details, user, expected_user, expected_entity_id",
+        ("details", "user", "expected_user", "expected_entity_id"),
         [
             (None, mock, ANY, None),
             (BackfillDetails(id=1), mock, mock, 1),
@@ -235,7 +235,7 @@ class TestAwsAuthManager:
         assert result
 
     @pytest.mark.parametrize(
-        "details, user, expected_user, expected_entity_id",
+        ("details", "user", "expected_user", "expected_entity_id"),
         [
             (None, mock, ANY, None),
             (AssetDetails(id="1"), mock, mock, "1"),
@@ -263,7 +263,7 @@ class TestAwsAuthManager:
         assert result
 
     @pytest.mark.parametrize(
-        "details, user, expected_user, expected_entity_id",
+        ("details", "user", "expected_user", "expected_entity_id"),
         [
             (None, mock, ANY, None),
             (AssetAliasDetails(id="1"), mock, mock, "1"),
@@ -294,7 +294,7 @@ class TestAwsAuthManager:
         assert result
 
     @pytest.mark.parametrize(
-        "details, user, expected_user, expected_entity_id",
+        ("details", "user", "expected_user", "expected_entity_id"),
         [
             (None, mock, ANY, None),
             (PoolDetails(name="pool1"), mock, mock, "pool1"),
@@ -322,7 +322,7 @@ class TestAwsAuthManager:
         assert result
 
     @pytest.mark.parametrize(
-        "details, user, expected_user, expected_entity_id",
+        ("details", "user", "expected_user", "expected_entity_id"),
         [
             (None, mock, ANY, None),
             (VariableDetails(key="var1"), mock, mock, "var1"),
@@ -350,7 +350,7 @@ class TestAwsAuthManager:
         assert result
 
     @pytest.mark.parametrize(
-        "access_view, user, expected_user",
+        ("access_view", "user", "expected_user"),
         [
             (AccessView.CLUSTER_ACTIVITY, mock, ANY),
             (AccessView.PLUGINS, mock, mock),
@@ -613,7 +613,7 @@ class TestAwsAuthManager:
         assert result
 
     @pytest.mark.parametrize(
-        "get_authorized_method, avp_entity, entities_parameter",
+        ("get_authorized_method", "avp_entity", "entities_parameter"),
         [
             ("filter_authorized_connections", AvpEntities.CONNECTION.value, "conn_ids"),
             ("filter_authorized_dag_ids", AvpEntities.DAG.value, "dag_ids"),
@@ -622,7 +622,7 @@ class TestAwsAuthManager:
         ],
     )
     @pytest.mark.parametrize(
-        "method, user, expected_result",
+        ("method", "user", "expected_result"),
         [
             ("GET", AwsAuthManagerUser(user_id="test_user_id1", groups=[]), {"entity_1"}),
             ("PUT", AwsAuthManagerUser(user_id="test_user_id1", groups=[]), set()),

--- a/providers/amazon/tests/unit/amazon/aws/executors/batch/test_batch_executor.py
+++ b/providers/amazon/tests/unit/amazon/aws/executors/batch/test_batch_executor.py
@@ -787,7 +787,7 @@ class TestBatchExecutorConfig:
         assert submit_kwargs["tags"] == templated_tags
 
     @pytest.mark.parametrize(
-        "submit_job_kwargs, exec_config, expected_result",
+        ("submit_job_kwargs", "exec_config", "expected_result"),
         [
             # No input submit_job_kwargs or executor overrides
             (

--- a/providers/amazon/tests/unit/amazon/aws/executors/batch/test_utils.py
+++ b/providers/amazon/tests/unit/amazon/aws/executors/batch/test_utils.py
@@ -85,7 +85,7 @@ class TestBatchJob:
     """Tests for the BatchJob class."""
 
     @pytest.mark.parametrize(
-        "batch_status, expected_airflow_state",
+        ("batch_status", "expected_airflow_state"),
         [
             ("SUBMITTED", State.QUEUED),
             ("PENDING", State.QUEUED),

--- a/providers/amazon/tests/unit/amazon/aws/executors/ecs/test_ecs_executor.py
+++ b/providers/amazon/tests/unit/amazon/aws/executors/ecs/test_ecs_executor.py
@@ -1158,7 +1158,7 @@ class TestAwsEcsExecutor:
         self.sync_call_count += 1
 
     @pytest.mark.parametrize(
-        "desired_status, last_status, exit_code, expected_status",
+        ("desired_status", "last_status", "exit_code", "expected_status"),
         [
             ("RUNNING", "QUEUED", 0, State.QUEUED),
             ("STOPPED", "RUNNING", 0, State.RUNNING),
@@ -1667,7 +1667,7 @@ class TestEcsExecutorConfig:
             assert task_kwargs["launchType"] == "FARGATE"
 
     @pytest.mark.parametrize(
-        "run_task_kwargs, exec_config, expected_result",
+        ("run_task_kwargs", "exec_config", "expected_result"),
         [
             # No input run_task_kwargs or executor overrides
             (

--- a/providers/amazon/tests/unit/amazon/aws/executors/utils/test_exponential_backoff_retry.py
+++ b/providers/amazon/tests/unit/amazon/aws/executors/utils/test_exponential_backoff_retry.py
@@ -39,7 +39,7 @@ class TestExponentialBackoffRetry:
         mock_callable_function.assert_called_once()
 
     @pytest.mark.parametrize(
-        "attempt_number, utcnow_value, expected_calls",
+        ("attempt_number", "utcnow_value", "expected_calls"),
         [
             (
                 0,
@@ -192,7 +192,7 @@ class TestExponentialBackoffRetry:
         assert mock_callable_function.call_count == 3
 
     @pytest.mark.parametrize(
-        "attempt_number, utcnow_value, expected_calls",
+        ("attempt_number", "utcnow_value", "expected_calls"),
         [
             (
                 0,

--- a/providers/amazon/tests/unit/amazon/aws/secrets/test_secrets_manager.py
+++ b/providers/amazon/tests/unit/amazon/aws/secrets/test_secrets_manager.py
@@ -151,7 +151,7 @@ class TestSecretsManagerBackend:
         new_callable=mock.PropertyMock,
     )
     @pytest.mark.parametrize(
-        "connection_id, connections_lookup_pattern, num_client_calls",
+        ("connection_id", "connections_lookup_pattern", "num_client_calls"),
         [
             ("test", "test", 1),
             ("test", ".*", 1),
@@ -178,7 +178,7 @@ class TestSecretsManagerBackend:
         new_callable=mock.PropertyMock,
     )
     @pytest.mark.parametrize(
-        "variable_key, variables_lookup_pattern, num_client_calls",
+        ("variable_key", "variables_lookup_pattern", "num_client_calls"),
         [
             ("test", "test", 1),
             ("test", ".*", 1),
@@ -205,7 +205,7 @@ class TestSecretsManagerBackend:
         new_callable=mock.PropertyMock,
     )
     @pytest.mark.parametrize(
-        "config_key, config_lookup_pattern, num_client_calls",
+        ("config_key", "config_lookup_pattern", "num_client_calls"),
         [
             ("test", "test", 1),
             ("test", ".*", 1),

--- a/providers/amazon/tests/unit/amazon/aws/secrets/test_systems_manager.py
+++ b/providers/amazon/tests/unit/amazon/aws/secrets/test_systems_manager.py
@@ -236,7 +236,7 @@ class TestSsmSecrets:
         new_callable=mock.PropertyMock,
     )
     @pytest.mark.parametrize(
-        "connection_id, connections_lookup_pattern, num_client_calls",
+        ("connection_id", "connections_lookup_pattern", "num_client_calls"),
         [
             ("test", "test", 1),
             ("test", ".*", 1),
@@ -267,7 +267,7 @@ class TestSsmSecrets:
         new_callable=mock.PropertyMock,
     )
     @pytest.mark.parametrize(
-        "variable_key, variables_lookup_pattern, num_client_calls",
+        ("variable_key", "variables_lookup_pattern", "num_client_calls"),
         [
             ("test", "test", 1),
             ("test", ".*", 1),
@@ -298,7 +298,7 @@ class TestSsmSecrets:
         new_callable=mock.PropertyMock,
     )
     @pytest.mark.parametrize(
-        "config_key, config_lookup_pattern, num_client_calls",
+        ("config_key", "config_lookup_pattern", "num_client_calls"),
         [
             ("test", "test", 1),
             ("test", ".*", 1),

--- a/providers/amazon/tests/unit/amazon/aws/sensors/test_batch.py
+++ b/providers/amazon/tests/unit/amazon/aws/sensors/test_batch.py
@@ -181,7 +181,7 @@ class TestBatchComputeEnvironmentSensor:
         assert "AWS Batch compute environment failed" in str(ctx.value)
 
     @pytest.mark.parametrize(
-        "compute_env, error_message",
+        ("compute_env", "error_message"),
         (
             (
                 [{"status": "unknown_status"}],

--- a/providers/amazon/tests/unit/amazon/aws/sensors/test_comprehend.py
+++ b/providers/amazon/tests/unit/amazon/aws/sensors/test_comprehend.py
@@ -137,7 +137,7 @@ class TestComprehendCreateDocumentClassifierCompletedSensor:
         assert op.hook._config.read_timeout == 42
 
     @pytest.mark.parametrize(
-        "state, message, output",
+        ("state", "message", "output"),
         [
             pytest.param("TRAINED", "", "s3://test-output", id="training succeeded"),
             pytest.param(

--- a/providers/amazon/tests/unit/amazon/aws/sensors/test_ecs.py
+++ b/providers/amazon/tests/unit/amazon/aws/sensors/test_ecs.py
@@ -109,7 +109,7 @@ class TestEcsBaseSensor(EcsBaseTestCase):
 
 class TestEcsClusterStateSensor(EcsBaseTestCase):
     @pytest.mark.parametrize(
-        "return_state, expected", [("ACTIVE", True), ("PROVISIONING", False), ("DEPROVISIONING", False)]
+        ("return_state", "expected"), [("ACTIVE", True), ("PROVISIONING", False), ("DEPROVISIONING", False)]
     )
     def test_default_values_poke(self, return_state, expected):
         task = self.create_rendered_task(EcsClusterStateSensor, cluster_name=TEST_CLUSTER_NAME)
@@ -128,7 +128,7 @@ class TestEcsClusterStateSensor(EcsBaseTestCase):
             m.assert_called_once_with(cluster_name=TEST_CLUSTER_NAME)
 
     @pytest.mark.parametrize(
-        "target_state, return_state, expected",
+        ("target_state", "return_state", "expected"),
         [
             (EcsClusterStates.ACTIVE, "ACTIVE", True),
             (EcsClusterStates.ACTIVE, "DEPROVISIONING", False),
@@ -146,7 +146,7 @@ class TestEcsClusterStateSensor(EcsBaseTestCase):
             m.assert_called_once_with(cluster_name=TEST_CLUSTER_NAME)
 
     @pytest.mark.parametrize(
-        "failure_states, return_state",
+        ("failure_states", "return_state"),
         [
             ({EcsClusterStates.ACTIVE}, "ACTIVE"),
             ({EcsClusterStates.PROVISIONING, EcsClusterStates.DEPROVISIONING}, "DEPROVISIONING"),
@@ -169,7 +169,7 @@ class TestEcsClusterStateSensor(EcsBaseTestCase):
 
 class TestEcsTaskDefinitionStateSensor(EcsBaseTestCase):
     @pytest.mark.parametrize(
-        "return_state, expected", [("ACTIVE", True), ("INACTIVE", False), ("DELETE_IN_PROGRESS", False)]
+        ("return_state", "expected"), [("ACTIVE", True), ("INACTIVE", False), ("DELETE_IN_PROGRESS", False)]
     )
     def test_default_values_poke(self, return_state, expected):
         task = self.create_rendered_task(
@@ -181,7 +181,7 @@ class TestEcsTaskDefinitionStateSensor(EcsBaseTestCase):
             m.assert_called_once_with(task_definition=TEST_TASK_DEFINITION_ARN)
 
     @pytest.mark.parametrize(
-        "target_state, return_state, expected",
+        ("target_state", "return_state", "expected"),
         [
             (EcsTaskDefinitionStates.INACTIVE, "ACTIVE", False),
             (EcsTaskDefinitionStates.INACTIVE, "INACTIVE", True),
@@ -201,7 +201,7 @@ class TestEcsTaskDefinitionStateSensor(EcsBaseTestCase):
 
 class TestEcsTaskStateSensor(EcsBaseTestCase):
     @pytest.mark.parametrize(
-        "return_state, expected",
+        ("return_state", "expected"),
         [
             ("PROVISIONING", False),
             ("PENDING", False),
@@ -230,7 +230,7 @@ class TestEcsTaskStateSensor(EcsBaseTestCase):
             m.assert_called_once_with(cluster=TEST_CLUSTER_NAME, task=TEST_TASK_ARN)
 
     @pytest.mark.parametrize(
-        "target_state, return_state, expected",
+        ("target_state", "return_state", "expected"),
         [
             (EcsTaskStates.RUNNING, "RUNNING", True),
             (EcsTaskStates.DEACTIVATING, "DEACTIVATING", True),
@@ -248,7 +248,7 @@ class TestEcsTaskStateSensor(EcsBaseTestCase):
             m.assert_called_once_with(cluster=TEST_CLUSTER_NAME, task=TEST_TASK_ARN)
 
     @pytest.mark.parametrize(
-        "failure_states, return_state",
+        ("failure_states", "return_state"),
         [
             ({EcsTaskStates.RUNNING}, "RUNNING"),
             ({EcsTaskStates.RUNNING, EcsTaskStates.DEACTIVATING}, "DEACTIVATING"),

--- a/providers/amazon/tests/unit/amazon/aws/sensors/test_emr_serverless_application.py
+++ b/providers/amazon/tests/unit/amazon/aws/sensors/test_emr_serverless_application.py
@@ -46,7 +46,7 @@ class TestEmrServerlessApplicationSensor:
 
 class TestPokeReturnValue(TestEmrServerlessApplicationSensor):
     @pytest.mark.parametrize(
-        "state, expected_result",
+        ("state", "expected_result"),
         [
             ("CREATING", False),
             ("STARTING", False),

--- a/providers/amazon/tests/unit/amazon/aws/sensors/test_emr_serverless_job.py
+++ b/providers/amazon/tests/unit/amazon/aws/sensors/test_emr_serverless_job.py
@@ -49,7 +49,7 @@ class TestEmrServerlessJobSensor:
 
 class TestPokeReturnValue(TestEmrServerlessJobSensor):
     @pytest.mark.parametrize(
-        "state, expected_result",
+        ("state", "expected_result"),
         [
             ("PENDING", False),
             ("RUNNING", False),

--- a/providers/amazon/tests/unit/amazon/aws/sensors/test_lambda_function.py
+++ b/providers/amazon/tests/unit/amazon/aws/sensors/test_lambda_function.py
@@ -46,7 +46,7 @@ class TestLambdaFunctionStateSensor:
         assert op.botocore_config == {"baz": "qux"}
 
     @pytest.mark.parametrize(
-        "get_function_output, expect_failure, expected",
+        ("get_function_output", "expect_failure", "expected"),
         [
             pytest.param(
                 {"Configuration": {"State": "Active"}},

--- a/providers/amazon/tests/unit/amazon/aws/sensors/test_opensearch_serverless.py
+++ b/providers/amazon/tests/unit/amazon/aws/sensors/test_opensearch_serverless.py
@@ -58,7 +58,7 @@ class TestOpenSearchServerlessCollectionActiveSensor:
         assert op.hook._config.read_timeout == 42
 
     @pytest.mark.parametrize(
-        "collection_name, collection_id, expected_pass",
+        ("collection_name", "collection_id", "expected_pass"),
         [
             pytest.param("name", "id", False, id="both_provided_fails"),
             pytest.param("name", None, True, id="only_name_provided_passes"),

--- a/providers/amazon/tests/unit/amazon/aws/sensors/test_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/sensors/test_s3.py
@@ -95,7 +95,7 @@ class TestS3KeySensor:
             op.poke(None)
 
     @pytest.mark.parametrize(
-        "key, bucket, parsed_key, parsed_bucket",
+        ("key", "bucket", "parsed_key", "parsed_bucket"),
         [
             pytest.param("s3://bucket/key", None, "key", "bucket", id="key as s3url"),
             pytest.param("key", "bucket", "key", "bucket", id="separate bucket and key"),
@@ -294,7 +294,7 @@ class TestS3KeySensor:
         assert op.poke(None) is True
 
     @pytest.mark.parametrize(
-        "key, pattern, expected",
+        ("key", "pattern", "expected"),
         [
             ("test.csv", r"[a-z]+\.csv", True),
             ("test.txt", r"test/[a-z]+\.csv", False),
@@ -343,7 +343,7 @@ class TestS3KeySensor:
             op.execute_complete(context={}, event={"status": "error", "message": message})
 
     @pytest.mark.parametrize(
-        "metadata_keys, expected",
+        ("metadata_keys", "expected"),
         [
             (["Size", "Key"], True),
             (["Content"], False),
@@ -522,7 +522,7 @@ class TestS3KeysUnchangedSensor:
             self.sensor.is_keys_unchanged({"a"})
 
     @pytest.mark.parametrize(
-        "current_objects, expected_returns, inactivity_periods",
+        ("current_objects", "expected_returns", "inactivity_periods"),
         [
             pytest.param(
                 ({"a"}, {"a", "b"}, {"a", "b", "c"}),

--- a/providers/amazon/tests/unit/amazon/aws/system/utils/test_helpers.py
+++ b/providers/amazon/tests/unit/amazon/aws/system/utils/test_helpers.py
@@ -71,7 +71,7 @@ class TestAmazonSystemTestHelpers:
     ]
 
     @pytest.mark.parametrize(
-        "env_value, ssm_value, default_value, expected_result", FETCH_VARIABLE_TEST_CASES
+        ("env_value", "ssm_value", "default_value", "expected_result"), FETCH_VARIABLE_TEST_CASES
     )
     @patch.object(os, "getenv")
     def test_fetch_variable_success(
@@ -113,7 +113,7 @@ class TestAmazonSystemTestHelpers:
         ("12Ab", False),
     ]
 
-    @pytest.mark.parametrize("env_id, is_valid", ENV_ID_TEST_CASES)
+    @pytest.mark.parametrize(("env_id", "is_valid"), ENV_ID_TEST_CASES)
     def test_validate_env_id_success(self, env_id, is_valid):
         if is_valid:
             captured_output = StringIO()

--- a/providers/amazon/tests/unit/amazon/aws/transfers/test_redshift_to_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/transfers/test_redshift_to_s3.py
@@ -40,7 +40,9 @@ from tests_common.test_utils.asserts import assert_equal_ignore_multiple_spaces
 
 
 class TestRedshiftToS3Transfer:
-    @pytest.mark.parametrize("table_as_file_name, expected_s3_key", [[True, "key/table_"], [False, "key"]])
+    @pytest.mark.parametrize(
+        ("table_as_file_name", "expected_s3_key"), [[True, "key/table_"], [False, "key"]]
+    )
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
     @mock.patch("airflow.models.connection.Connection")
     @mock.patch("boto3.session.Session")
@@ -99,7 +101,9 @@ class TestRedshiftToS3Transfer:
         assert secret_key in unload_query
         assert_equal_ignore_multiple_spaces(mock_run.call_args.args[0], unload_query)
 
-    @pytest.mark.parametrize("table_as_file_name, expected_s3_key", [[True, "key/table_"], [False, "key"]])
+    @pytest.mark.parametrize(
+        ("table_as_file_name", "expected_s3_key"), [[True, "key/table_"], [False, "key"]]
+    )
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
     @mock.patch("airflow.models.connection.Connection")
     @mock.patch("boto3.session.Session")
@@ -161,7 +165,7 @@ class TestRedshiftToS3Transfer:
         assert_equal_ignore_multiple_spaces(mock_run.call_args.args[0], unload_query)
 
     @pytest.mark.parametrize(
-        "table, table_as_file_name, expected_s3_key",
+        ("table", "table_as_file_name", "expected_s3_key"),
         [
             ["table", True, "key/table_"],
             ["table", False, "key"],
@@ -227,7 +231,7 @@ class TestRedshiftToS3Transfer:
         assert_equal_ignore_multiple_spaces(mock_run.call_args.args[0], unload_query)
 
     @pytest.mark.parametrize(
-        "table_as_file_name, expected_s3_key, select_query, expected_query",
+        ("table_as_file_name", "expected_s3_key", "select_query", "expected_query"),
         [
             [
                 True,
@@ -433,7 +437,9 @@ class TestRedshiftToS3Transfer:
         ):
             op.execute(None)
 
-    @pytest.mark.parametrize("table_as_file_name, expected_s3_key", [[True, "key/table_"], [False, "key"]])
+    @pytest.mark.parametrize(
+        ("table_as_file_name", "expected_s3_key"), [[True, "key/table_"], [False, "key"]]
+    )
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
     @mock.patch("airflow.models.connection.Connection")
     @mock.patch("boto3.session.Session")
@@ -508,7 +514,9 @@ class TestRedshiftToS3Transfer:
         with pytest.raises(AirflowException):
             redshift_operator.execute(None)
 
-    @pytest.mark.parametrize("table_as_file_name, expected_s3_key", [[True, "key/table_"], [False, "key"]])
+    @pytest.mark.parametrize(
+        ("table_as_file_name", "expected_s3_key"), [[True, "key/table_"], [False, "key"]]
+    )
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
     @mock.patch("airflow.models.connection.Connection")
     @mock.patch("boto3.session.Session")

--- a/providers/amazon/tests/unit/amazon/aws/transfers/test_sql_to_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/transfers/test_sql_to_s3.py
@@ -32,7 +32,7 @@ from airflow.providers.amazon.aws.transfers.sql_to_s3 import SqlToS3Operator
 
 class TestSqlToS3Operator:
     @pytest.mark.parametrize(
-        "file_format, dtype_backend, df_kwargs, expected_key_suffix",
+        ("file_format", "dtype_backend", "df_kwargs", "expected_key_suffix"),
         [
             ("csv", "numpy_nullable", {"index": False, "header": False}, ".csv"),
             ("csv", "pyarrow", {"index": False, "header": False}, ".csv"),
@@ -366,7 +366,7 @@ class TestSqlToS3Operator:
         assert hook.log_sql == op.sql_hook_params["log_sql"]
 
     @pytest.mark.parametrize(
-        "df_type_param,expected_df_type",
+        ("df_type_param", "expected_df_type"),
         [
             pytest.param("polars", "polars", id="with-polars"),
             pytest.param("pandas", "pandas", id="with-pandas"),
@@ -410,7 +410,7 @@ class TestSqlToS3Operator:
         )
 
     @pytest.mark.parametrize(
-        "df_type,input_df_creator",
+        ("df_type", "input_df_creator"),
         [
             pytest.param(
                 "pandas",
@@ -450,7 +450,7 @@ class TestSqlToS3Operator:
             assert group_name in ["A", "B"]
 
     @pytest.mark.parametrize(
-        "kwargs,expected_warning,expected_error,expected_read_kwargs",
+        ("kwargs", "expected_warning", "expected_error", "expected_read_kwargs"),
         [
             pytest.param(
                 {"read_pd_kwargs": {"dtype_backend": "pyarrow"}},
@@ -517,7 +517,7 @@ class TestSqlToS3Operator:
                 assert op.read_kwargs == expected_read_kwargs
 
     @pytest.mark.parametrize(
-        "df_type,should_call_fix_dtypes",
+        ("df_type", "should_call_fix_dtypes"),
         [
             pytest.param("pandas", True, id="pandas-calls-fix-dtypes"),
             pytest.param("polars", False, id="polars-skips-fix-dtypes"),
@@ -557,7 +557,7 @@ class TestSqlToS3Operator:
             mock_fix_dtypes.assert_not_called()
 
     @pytest.mark.parametrize(
-        "kwargs,expected_warning,expected_read_kwargs,expected_df_kwargs",
+        ("kwargs", "expected_warning", "expected_read_kwargs", "expected_df_kwargs"),
         [
             pytest.param(
                 {
@@ -615,7 +615,7 @@ class TestSqlToS3Operator:
         assert op.df_kwargs == expected_df_kwargs
 
     @pytest.mark.parametrize(
-        "fmt, df_kwargs, expected_key",
+        ("fmt", "df_kwargs", "expected_key"),
         [
             ("csv", {"compression": "gzip", "index": False}, "data.csv.gz"),
             ("csv", {"index": False}, "data.csv"),
@@ -652,7 +652,7 @@ class TestSqlToS3Operator:
         assert uploaded_key == expected_key
 
     @pytest.mark.parametrize(
-        "file_format, df_kwargs, expected_suffix",
+        ("file_format", "df_kwargs", "expected_suffix"),
         [
             ("csv", {"compression": "gzip", "index": False}, ".csv.gz"),
             ("csv", {"index": False}, ".csv"),

--- a/providers/amazon/tests/unit/amazon/aws/triggers/test_opensearch_serverless.py
+++ b/providers/amazon/tests/unit/amazon/aws/triggers/test_opensearch_serverless.py
@@ -48,7 +48,7 @@ class TestOpenSearchServerlessCollectionActiveTrigger:
     COLLECTION_ID = "test_collection_id"
 
     @pytest.mark.parametrize(
-        "collection_name, collection_id, expected_pass",
+        ("collection_name", "collection_id", "expected_pass"),
         [
             pytest.param(COLLECTION_NAME, COLLECTION_ID, False, id="both_provided_fails"),
             pytest.param(COLLECTION_NAME, None, True, id="only_name_provided_passes"),

--- a/providers/amazon/tests/unit/amazon/aws/triggers/test_redshift_data.py
+++ b/providers/amazon/tests/unit/amazon/aws/triggers/test_redshift_data.py
@@ -61,7 +61,7 @@ class TestRedshiftDataTrigger:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "return_value, response",
+        ("return_value", "response"),
         [
             (
                 True,
@@ -101,7 +101,7 @@ class TestRedshiftDataTrigger:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "raised_exception, expected_response",
+        ("raised_exception", "expected_response"),
         [
             (
                 RedshiftDataQueryFailedError("Failed"),

--- a/providers/amazon/tests/unit/amazon/aws/utils/test_connection_wrapper.py
+++ b/providers/amazon/tests/unit/amazon/aws/utils/test_connection_wrapper.py
@@ -193,7 +193,7 @@ class TestAwsConnectionWrapper:
         assert wrap_conn.session_kwargs != session_kwargs
 
     @pytest.mark.parametrize(
-        "region_name,conn_region_name",
+        ("region_name", "conn_region_name"),
         [
             ("mock-region-name", None),
             ("mock-region-name", "mock-connection-region-name"),
@@ -220,7 +220,7 @@ class TestAwsConnectionWrapper:
 
     @mock.patch("airflow.providers.amazon.aws.utils.connection_wrapper.Config")
     @pytest.mark.parametrize(
-        "botocore_config, botocore_config_kwargs",
+        ("botocore_config", "botocore_config_kwargs"),
         [
             (Config(s3={"us_east_1_regional_endpoint": "regional"}), None),
             (Config(region_name="ap-southeast-1"), {"user_agent": "Airflow Amazon Provider"}),
@@ -247,7 +247,9 @@ class TestAwsConnectionWrapper:
                 botocore_config_kwargs["signature_version"] = UNSIGNED
             assert mock.call(**botocore_config_kwargs) in mock_botocore_config.mock_calls
 
-    @pytest.mark.parametrize("aws_account_id, aws_iam_role", [(None, None), ("111111111111", "another-role")])
+    @pytest.mark.parametrize(
+        ("aws_account_id", "aws_iam_role"), [(None, None), ("111111111111", "another-role")]
+    )
     def test_get_role_arn(self, aws_account_id, aws_iam_role):
         mock_conn = mock_connection_factory(
             extra={
@@ -414,7 +416,7 @@ class TestAwsConnectionWrapper:
         assert wrap_conn.get_service_endpoint_url("ec2") is None
 
     @pytest.mark.parametrize(
-        "global_endpoint_url, sts_service_endpoint_url, expected_endpoint_url",
+        ("global_endpoint_url", "sts_service_endpoint_url", "expected_endpoint_url"),
         [
             pytest.param(None, None, None, id="not-set"),
             pytest.param("https://global.service", None, None, id="global-only"),

--- a/providers/amazon/tests/unit/amazon/aws/utils/test_eks_get_token.py
+++ b/providers/amazon/tests/unit/amazon/aws/utils/test_eks_get_token.py
@@ -29,7 +29,7 @@ from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 class TestGetEksToken:
     @time_machine.travel("1995-02-14", tick=False)
     @pytest.mark.parametrize(
-        "args, expected_region_name",
+        ("args", "expected_region_name"),
         [
             [
                 [

--- a/providers/amazon/tests/unit/amazon/aws/utils/test_waiter.py
+++ b/providers/amazon/tests/unit/amazon/aws/utils/test_waiter.py
@@ -54,7 +54,7 @@ def assert_expected_waiter_type(waiter: mock.MagicMock, expected: str):
 
 class TestWaiter:
     @pytest.mark.parametrize(
-        "get_state_responses, fails, expected_exception, expected_num_calls",
+        ("get_state_responses", "fails", "expected_exception", "expected_num_calls"),
         [
             ([generate_response("Created")], False, None, 1),
             ([generate_response("Failed")], True, AirflowException, 1),


### PR DESCRIPTION

Issue: Enable Even More PyDocStyle Checks https://github.com/apache/airflow/issues/40567
@ferruzzi

This PR is for enable PT006 rule:
all instances of @pytest.mark.parametrize names should be a tuple
https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/
There are a lot of file changes needed.
So, I separate to many PR, which contain about 23 file changes for easy review.
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
