### PR TITLE
Enable PT006 rule to airflow-core tests (cli)

### DIFF
--- a/airflow-core/tests/unit/cli/commands/test_api_server_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_api_server_command.py
@@ -134,7 +134,7 @@ class TestCliApiServer(_CommonCLIUvicornTestClass):
             mock_environ.__setitem__.assert_has_calls(expected_setitem_calls)
 
     @pytest.mark.parametrize(
-        "cli_args, expected_additional_kwargs",
+        ("cli_args", "expected_additional_kwargs"),
         [
             pytest.param(
                 [
@@ -303,7 +303,7 @@ class TestCliApiServer(_CommonCLIUvicornTestClass):
             mock_open.assert_not_called()
 
     @pytest.mark.parametrize(
-        "ssl_arguments, error_pattern",
+        ("ssl_arguments", "error_pattern"),
         [
             (["--ssl-cert", "_.crt", "--ssl-key", "_.key"], "does not exist _.crt"),
             (["--ssl-cert", "_.crt"], "Need both.*certificate.*key"),

--- a/airflow-core/tests/unit/cli/commands/test_backfill_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_backfill_command.py
@@ -64,7 +64,7 @@ class TestCliBackfill:
 
     @mock.patch("airflow.cli.commands.backfill_command._create_backfill")
     @pytest.mark.parametrize(
-        "repro, expected_repro",
+        ("repro", "expected_repro"),
         [
             (None, None),
             ("none", ReprocessBehavior.NONE),

--- a/airflow-core/tests/unit/cli/commands/test_config_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_config_command.py
@@ -276,7 +276,7 @@ class TestConfigLint:
             assert normalized_message in normalized_output
 
     @pytest.mark.parametrize(
-        "section, option, suggestion",
+        ("section", "option", "suggestion"),
         [
             (
                 "core",
@@ -436,7 +436,7 @@ class TestConfigLint:
             assert expected_message in normalized_output
 
     @pytest.mark.parametrize(
-        "env_var, config_change, expected_message",
+        ("env_var", "config_change", "expected_message"),
         [
             (
                 "AIRFLOW__CORE__CHECK_SLAS",

--- a/airflow-core/tests/unit/cli/commands/test_connection_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_connection_command.py
@@ -223,7 +223,7 @@ class TestCliExportConnections:
         assert output_filepath.read_text() == expected_connections
 
     @pytest.mark.parametrize(
-        "serialization_format, expected",
+        ("serialization_format", "expected"),
         [
             (
                 "uri",
@@ -370,7 +370,7 @@ class TestCliAddConnections:
 
     @skip_if_force_lowest_dependencies_marker
     @pytest.mark.parametrize(
-        "cmd, expected_output, expected_conn",
+        ("cmd", "expected_output", "expected_conn"),
         [
             pytest.param(
                 [

--- a/airflow-core/tests/unit/cli/commands/test_db_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_db_command.py
@@ -89,7 +89,7 @@ class TestCliDb:
         assert called == {"to_revision": None, "from_revision": None, "show_sql_only": True}
 
     @pytest.mark.parametrize(
-        "args, match",
+        ("args", "match"),
         [
             (
                 {
@@ -166,7 +166,7 @@ class TestCliDb:
         mock_wait_for_migrations.assert_called_once_with(timeout=60)
 
     @pytest.mark.parametrize(
-        "args, called_with",
+        ("args", "called_with"),
         [
             (
                 [],
@@ -253,7 +253,7 @@ class TestCliDb:
         mock_upgradedb.assert_called_once_with(**called_with)
 
     @pytest.mark.parametrize(
-        "args, pattern",
+        ("args", "pattern"),
         [
             pytest.param(
                 ["--to-revision", "abc", "--to-version", "2.10.0"],
@@ -473,7 +473,7 @@ class TestCliDb:
         assert called == {"to_revision": "22ed7efa9da2", "from_revision": None, "show_sql_only": True}
 
     @pytest.mark.parametrize(
-        "args, match",
+        ("args", "match"),
         [
             (
                 {
@@ -594,7 +594,7 @@ class TestCliDb:
             db_command.run_db_downgrade_command(Args(), fake_command, heads)
 
     @pytest.mark.parametrize(
-        "args, match",
+        ("args", "match"),
         [
             (["-y", "--to-revision", "abc", "--to-version", "2.2.0"], "Cannot supply both"),
             (["-y", "--to-revision", "abc1", "--from-revision", "abc2"], "only .* with `--show-sql-only`"),
@@ -615,7 +615,7 @@ class TestCliDb:
             db_command.downgrade(self.parser.parse_args(["db", "downgrade", *args]))
 
     @pytest.mark.parametrize(
-        "args, expected",
+        ("args", "expected"),
         [
             (["-y", "--to-revision", "abc1"], dict(to_revision="abc1")),
             (
@@ -640,7 +640,7 @@ class TestCliDb:
         mock_dg.assert_called_with(**{**defaults, **expected})
 
     @pytest.mark.parametrize(
-        "resp, raise_",
+        ("resp", "raise_"),
         [
             ("y", False),
             ("Y", False),
@@ -728,7 +728,7 @@ class TestCLIDBClean:
             batch_size=None,
         )
 
-    @pytest.mark.parametrize("confirm_arg, expected", [(["-y"], False), ([], True)])
+    @pytest.mark.parametrize(("confirm_arg", "expected"), [(["-y"], False), ([], True)])
     @patch("airflow.cli.commands.db_command.run_cleanup")
     def test_confirm(self, run_cleanup_mock, confirm_arg, expected):
         """
@@ -755,7 +755,7 @@ class TestCLIDBClean:
             batch_size=None,
         )
 
-    @pytest.mark.parametrize("extra_arg, expected", [(["--skip-archive"], True), ([], False)])
+    @pytest.mark.parametrize(("extra_arg", "expected"), [(["--skip-archive"], True), ([], False)])
     @patch("airflow.cli.commands.db_command.run_cleanup")
     def test_skip_archive(self, run_cleanup_mock, extra_arg, expected):
         """
@@ -782,7 +782,7 @@ class TestCLIDBClean:
             batch_size=None,
         )
 
-    @pytest.mark.parametrize("dry_run_arg, expected", [(["--dry-run"], True), ([], False)])
+    @pytest.mark.parametrize(("dry_run_arg", "expected"), [(["--dry-run"], True), ([], False)])
     @patch("airflow.cli.commands.db_command.run_cleanup")
     def test_dry_run(self, run_cleanup_mock, dry_run_arg, expected):
         """
@@ -810,7 +810,7 @@ class TestCLIDBClean:
         )
 
     @pytest.mark.parametrize(
-        "extra_args, expected", [(["--tables", "hello, goodbye"], ["hello", "goodbye"]), ([], None)]
+        ("extra_args", "expected"), [(["--tables", "hello, goodbye"], ["hello", "goodbye"]), ([], None)]
     )
     @patch("airflow.cli.commands.db_command.run_cleanup")
     def test_tables(self, run_cleanup_mock, extra_args, expected):
@@ -838,7 +838,7 @@ class TestCLIDBClean:
             batch_size=None,
         )
 
-    @pytest.mark.parametrize("extra_args, expected", [(["--verbose"], True), ([], False)])
+    @pytest.mark.parametrize(("extra_args", "expected"), [(["--verbose"], True), ([], False)])
     @patch("airflow.cli.commands.db_command.run_cleanup")
     def test_verbose(self, run_cleanup_mock, extra_args, expected):
         """
@@ -865,7 +865,7 @@ class TestCLIDBClean:
             batch_size=None,
         )
 
-    @pytest.mark.parametrize("extra_args, expected", [(["--batch-size", "1234"], 1234), ([], None)])
+    @pytest.mark.parametrize(("extra_args", "expected"), [(["--batch-size", "1234"], 1234), ([], None)])
     @patch("airflow.cli.commands.db_command.run_cleanup")
     def test_batch_size(self, run_cleanup_mock, extra_args, expected):
         """
@@ -910,7 +910,7 @@ class TestCLIDBClean:
         )
 
     @pytest.mark.parametrize(
-        "extra_args, expected", [(["--tables", "hello, goodbye"], ["hello", "goodbye"]), ([], None)]
+        ("extra_args", "expected"), [(["--tables", "hello, goodbye"], ["hello", "goodbye"]), ([], None)]
     )
     @patch("airflow.cli.commands.db_command.export_archived_records")
     @patch("airflow.cli.commands.db_command.os.path.isdir", return_value=True)
@@ -935,7 +935,7 @@ class TestCLIDBClean:
             needs_confirm=True,
         )
 
-    @pytest.mark.parametrize("extra_args, expected", [(["--drop-archives"], True), ([], False)])
+    @pytest.mark.parametrize(("extra_args", "expected"), [(["--drop-archives"], True), ([], False)])
     @patch("airflow.cli.commands.db_command.export_archived_records")
     @patch("airflow.cli.commands.db_command.os.path.isdir", return_value=True)
     def test_drop_archives_in_export_archived_records_command(
@@ -960,7 +960,7 @@ class TestCLIDBClean:
         )
 
     @pytest.mark.parametrize(
-        "extra_args, expected", [(["--tables", "hello, goodbye"], ["hello", "goodbye"]), ([], None)]
+        ("extra_args", "expected"), [(["--tables", "hello, goodbye"], ["hello", "goodbye"]), ([], None)]
     )
     @patch("airflow.cli.commands.db_command.drop_archived_tables")
     def test_tables_in_drop_archived_records_command(self, mock_drop_archived_records, extra_args, expected):
@@ -974,7 +974,7 @@ class TestCLIDBClean:
         db_command.drop_archived(args)
         mock_drop_archived_records.assert_called_once_with(table_names=expected, needs_confirm=True)
 
-    @pytest.mark.parametrize("extra_args, expected", [(["-y"], False), ([], True)])
+    @pytest.mark.parametrize(("extra_args", "expected"), [(["-y"], False), ([], True)])
     @patch("airflow.cli.commands.db_command.drop_archived_tables")
     def test_confirm_in_drop_archived_records_command(self, mock_drop_archived_records, extra_args, expected):
         args = self.parser.parse_args(
@@ -1005,7 +1005,7 @@ def test_get_version_revision():
 
 
 @pytest.mark.parametrize(
-    "raw,expected",
+    ("raw", "expected"),
     [
         ("pa!sw0rd#", '"pa!sw0rd#"'),
         ('he"llo', '"he\\"llo"'),

--- a/airflow-core/tests/unit/cli/commands/test_info_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_info_command.py
@@ -50,7 +50,7 @@ class TestPiiAnonymizer:
         assert self.instance.process_path(home_path) == "${HOME}/airflow/config"
 
     @pytest.mark.parametrize(
-        "before, after",
+        ("before", "after"),
         [
             (
                 "postgresql+psycopg2://postgres:airflow@postgres/airflow",

--- a/airflow-core/tests/unit/cli/commands/test_scheduler_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_scheduler_command.py
@@ -39,7 +39,7 @@ class TestSchedulerCommand:
         cls.parser = cli_parser.get_parser()
 
     @pytest.mark.parametrize(
-        "executor, expect_serve_logs",
+        ("executor", "expect_serve_logs"),
         [
             ("CeleryExecutor", False),
             ("LocalExecutor", True),

--- a/airflow-core/tests/unit/cli/commands/test_variable_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_variable_command.py
@@ -479,7 +479,7 @@ NEW_VAR=fresh_value"""
         assert Variable.get("NEW_VAR") == "fresh_value"
 
     @pytest.mark.parametrize(
-        "format,invalid_content,error_pattern",
+        ("format", "invalid_content", "error_pattern"),
         [
             ("json", '{"invalid": "json", missing_quotes: true}', "Failed to load the secret file"),
             ("yaml", "invalid:\n  - yaml\n  content: {missing", "Failed to load the secret file"),

--- a/airflow-core/tests/unit/cli/test_cli_parser.py
+++ b/airflow-core/tests/unit/cli/test_cli_parser.py
@@ -388,7 +388,7 @@ class TestCli:
         assert (f"airflow command error: argument GROUP_OR_COMMAND: invalid choice: '{command}'") in stderr
 
     @pytest.mark.parametrize(
-        "executor,expected_args",
+        ("executor", "expected_args"),
         [
             ("CeleryExecutor", ["celery"]),
             ("KubernetesExecutor", ["kubernetes"]),


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
Issue: Enable Even More PyDocStyle Checks #40567
@ferruzzi

This PR is for enable PT006 rule:
PT006: all instances of @pytest.mark.parametrize names should be a tuple
https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/
There are a lot of file changes needed.
So, I separate to many PR, which contain about 5-10 file changes for easy review.
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
