### PR TITLE
Migrate FAB GET /roles/{name} to FastAPI

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/openapi/v2-fab-auth-manager-generated.yaml
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/openapi/v2-fab-auth-manager-generated.yaml
@@ -263,6 +263,54 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - FabAuthManager
+      summary: Get Role
+      description: Get an existing role.
+      operationId: get_role
+      security:
+      - OAuth2PasswordBearer: []
+      - HTTPBearer: []
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          minLength: 1
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RoleResponse'
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Unauthorized
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Forbidden
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Not Found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
 components:
   schemas:
     ActionResourceResponse:

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/routes/roles.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/routes/roles.py
@@ -100,3 +100,16 @@ def delete_role(name: str = Path(..., min_length=1)) -> None:
     """Delete an existing role."""
     with get_application_builder():
         return FABAuthManagerRoles.delete_role(name=name)
+
+
+@roles_router.get(
+    "/roles/{name}",
+    responses=create_openapi_http_exception_doc(
+        [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND]
+    ),
+    dependencies=[Depends(requires_fab_custom_view("GET", permissions.RESOURCE_ROLE))],
+)
+def get_role(name: str = Path(..., min_length=1)) -> RoleResponse:
+    """Get an existing role."""
+    with get_application_builder():
+        return FABAuthManagerRoles.get_role(name=name)

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/services/roles.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/services/roles.py
@@ -108,3 +108,15 @@ class FABAuthManagerRoles:
                 detail=f"Role with name {name!r} does not exist.",
             )
         security_manager.delete_role(existing)
+
+    @classmethod
+    def get_role(cls, name: str) -> RoleResponse:
+        security_manager = get_fab_auth_manager().security_manager
+
+        existing = security_manager.find_role(name=name)
+        if not existing:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Role with name {name!r} does not exist.",
+            )
+        return RoleResponse.model_validate(existing)

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_roles.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_roles.py
@@ -229,3 +229,26 @@ class TestRolesService:
         with pytest.raises(HTTPException) as ex:
             FABAuthManagerRoles.delete_role(name="roleA")
         assert ex.value.status_code == 404
+
+    # GET /roles/{name}
+
+    def test_get_role_success(self, get_fab_auth_manager, fab_auth_manager, security_manager):
+        security_manager.find_role.return_value = _make_role_obj("roleA", [("can_read", "DAG")])
+        fab_auth_manager.security_manager = security_manager
+        get_fab_auth_manager.return_value = fab_auth_manager
+
+        out = FABAuthManagerRoles.get_role(name="roleA")
+
+        assert out.name == "roleA"
+        assert out.permissions
+        assert out.permissions[0].action.name == "can_read"
+        assert out.permissions[0].resource.name == "DAG"
+
+    def test_get_role_not_found(self, get_fab_auth_manager, fab_auth_manager, security_manager):
+        security_manager.find_role.return_value = None
+        fab_auth_manager.security_manager = security_manager
+        get_fab_auth_manager.return_value = fab_auth_manager
+
+        with pytest.raises(HTTPException) as ex:
+            FABAuthManagerRoles.get_role(name="roleA")
+        assert ex.value.status_code == 404


### PR DESCRIPTION
Align FAB provider with Airflow 3’s FastAPI-first direction and continue removing remaining Connexion/Flask surface.
This PR is a follow-up for issue Replace connexion with fast-api for FAB provider (https://github.com/apache/airflow/issues/56730) by migrating a single endpoint GET /auth/fab/v1/roles/{name}.

# How
New FastAPI endpoint

Implemented GET /auth/fab/v1/roles/{name} on the FAB router with 200 OK on success
Path parameter

name: str — required, validated with min_length=1.
# Service logic

Added get_role(name: str) method to FABAuthManagerRoles service class.
Uses FAB security manager’s find_role().
Raises HTTPException(status_code=404) if the role does not exist.
# Tests
Added route tests for
GET /roles/{name} 
- success (200)
- unauthorized (403)
- not found (404)