### PR TITLE
Enable PT006 rule to airflow-core tests (route/ui, execution_api)

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_backfills.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_backfills.py
@@ -78,7 +78,7 @@ class TestBackfillEndpoint:
 
 class TestListBackfills(TestBackfillEndpoint):
     @pytest.mark.parametrize(
-        "test_params, response_params, total_entries",
+        ("test_params", "response_params", "total_entries"),
         [
             ({}, ["backfill1", "backfill2", "backfill3"], 3),
             ({"active": True}, ["backfill2", "backfill3"], 2),

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_calendar.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_calendar.py
@@ -65,7 +65,7 @@ class TestCalendar:
         clear_db_dags()
 
     @pytest.mark.parametrize(
-        "query_params, result",
+        ("query_params", "result"),
         [
             (
                 {},
@@ -111,7 +111,7 @@ class TestCalendar:
         assert body == result
 
     @pytest.mark.parametrize(
-        "query_params, result",
+        ("query_params", "result"),
         [
             (
                 {"granularity": "hourly"},

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_dags.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_dags.py
@@ -74,7 +74,7 @@ class TestGetDagRuns(TestPublicDagEndpoint):
         session.commit()
 
     @pytest.mark.parametrize(
-        "query_params, expected_ids,expected_total_dag_runs",
+        ("query_params", "expected_ids", "expected_total_dag_runs"),
         [
             # Filters
             ({}, [DAG1_ID, DAG2_ID], 11),
@@ -174,7 +174,7 @@ class TestGetDagRuns(TestPublicDagEndpoint):
         session.commit()
 
     @pytest.mark.parametrize(
-        "has_pending_actions, expected_total_entries, expected_pending_actions",
+        ("has_pending_actions", "expected_total_entries", "expected_pending_actions"),
         [
             # Without has_pending_actions param, should query all DAGs
             (None, 3, None),
@@ -326,7 +326,7 @@ class TestGetDagRuns(TestPublicDagEndpoint):
         assert response.status_code == 403
 
     @pytest.mark.parametrize(
-        "query_params, expected_dag_count",
+        ("query_params", "expected_dag_count"),
         [
             ({"has_asset_schedule": True}, 3),
             ({"has_asset_schedule": False}, 2),

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_dashboard.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_dashboard.py
@@ -238,7 +238,7 @@ def make_multiple_dags(dag_maker, session):
 
 class TestHistoricalMetricsDataEndpoint:
     @pytest.mark.parametrize(
-        "params, expected",
+        ("params", "expected"),
         [
             (
                 {"start_date": "2023-01-01T00:00", "end_date": "2023-08-02T00:00"},

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_dependencies.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_dependencies.py
@@ -221,7 +221,7 @@ class TestGetDependencies:
         assert response.status_code == 403
 
     @pytest.mark.parametrize(
-        "node_id, expected_response_fixture",
+        ("node_id", "expected_response_fixture"),
         [
             # Primary Component
             ("dag:downstream", "expected_primary_component_response"),

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_grid.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_grid.py
@@ -281,7 +281,7 @@ class TestGetGridDataEndpoint:
         ]
 
     @pytest.mark.parametrize(
-        "order_by,expected",
+        ("order_by", "expected"),
         [
             (
                 "logical_date",
@@ -319,7 +319,7 @@ class TestGetGridDataEndpoint:
         assert response.json() == expected
 
     @pytest.mark.parametrize(
-        "limit, expected",
+        ("limit", "expected"),
         [
             (
                 1,
@@ -337,7 +337,7 @@ class TestGetGridDataEndpoint:
         assert response.json() == expected
 
     @pytest.mark.parametrize(
-        "params, expected",
+        ("params", "expected"),
         [
             (
                 {
@@ -364,7 +364,7 @@ class TestGetGridDataEndpoint:
         assert response.json() == expected
 
     @pytest.mark.parametrize(
-        "params, expected",
+        ("params", "expected"),
         [
             (
                 {
@@ -532,7 +532,7 @@ class TestGetGridDataEndpoint:
         ]
 
     @pytest.mark.parametrize(
-        "endpoint,run_type,expected",
+        ("endpoint", "run_type", "expected"),
         [
             ("runs", "scheduled", [GRID_RUN_1]),
             ("runs", "manual", [GRID_RUN_2]),
@@ -547,7 +547,7 @@ class TestGetGridDataEndpoint:
         assert response.json() == expected
 
     @pytest.mark.parametrize(
-        "endpoint,triggering_user,expected",
+        ("endpoint", "triggering_user", "expected"),
         [
             ("runs", "user2", [GRID_RUN_2]),
             ("runs", "nonexistent", []),
@@ -567,7 +567,7 @@ class TestGetGridDataEndpoint:
         assert response.json() == [GRID_RUN_2]
 
     @pytest.mark.parametrize(
-        "endpoint,state,expected",
+        ("endpoint", "state", "expected"),
         [
             ("runs", "success", [GRID_RUN_1]),
             ("runs", "failed", [GRID_RUN_2]),

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_structure.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_structure.py
@@ -207,7 +207,7 @@ def asset3_id(make_dags, asset3, session) -> str:
 
 class TestStructureDataEndpoint:
     @pytest.mark.parametrize(
-        "params, expected",
+        ("params", "expected"),
         [
             (
                 {"dag_id": DAG_ID},
@@ -602,7 +602,7 @@ class TestStructureDataEndpoint:
         assert response.json() == expected
 
     @pytest.mark.parametrize(
-        "params, expected",
+        ("params", "expected"),
         [
             pytest.param(
                 {"dag_id": DAG_ID},

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_asset_events.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_asset_events.py
@@ -91,7 +91,7 @@ def test_asset_alias(session, test_asset_events, test_asset):
 
 class TestGetAssetEventByAsset:
     @pytest.mark.parametrize(
-        "uri, name",
+        ("uri", "name"),
         [
             (None, "test_get_asset_by_name"),
             ("s3://bucket/key", None),
@@ -159,7 +159,7 @@ class TestGetAssetEventByAsset:
         }
 
     @pytest.mark.parametrize(
-        "uri, name",
+        ("uri", "name"),
         [
             (None, "test_get_asset_by_name"),
             ("s3://bucket/key", None),
@@ -211,7 +211,7 @@ class TestGetAssetEventByAsset:
         }
 
     @pytest.mark.parametrize(
-        "uri, name",
+        ("uri", "name"),
         [
             (None, "test_get_asset_by_name"),
             ("s3://bucket/key", None),
@@ -263,7 +263,7 @@ class TestGetAssetEventByAsset:
         }
 
     @pytest.mark.parametrize(
-        "uri, name",
+        ("uri", "name"),
         [
             (None, "test_get_asset_by_name"),
             ("s3://bucket/key", None),
@@ -304,7 +304,7 @@ class TestGetAssetEventByAsset:
         }
 
     @pytest.mark.parametrize(
-        "uri, name",
+        ("uri", "name"),
         [
             (None, "test_get_asset_by_name"),
             ("s3://bucket/key", None),
@@ -372,7 +372,7 @@ class TestGetAssetEventByAsset:
         }
 
     @pytest.mark.parametrize(
-        "uri, name",
+        ("uri", "name"),
         [
             (None, "test_get_asset_by_name"),
             ("s3://bucket/key", None),
@@ -408,7 +408,7 @@ class TestGetAssetEventByAsset:
         }
 
     @pytest.mark.parametrize(
-        "uri, name",
+        ("uri", "name"),
         [
             (None, "test_get_asset_by_name"),
             ("s3://bucket/key", None),

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -137,7 +137,7 @@ class TestTIRunState:
         clear_db_dags()
 
     @pytest.mark.parametrize(
-        "max_tries, should_retry",
+        ("max_tries", "should_retry"),
         [
             pytest.param(0, False, id="max_retries=0"),
             pytest.param(3, True, id="should_retry"),
@@ -910,7 +910,7 @@ class TestTIUpdateState:
         ],
     )
     @pytest.mark.parametrize(
-        "outlet_events, expected_extra",
+        ("outlet_events", "expected_extra"),
         [
             pytest.param([], {}, id="default"),
             pytest.param(
@@ -969,7 +969,7 @@ class TestTIUpdateState:
         assert event[0].extra == expected_extra
 
     @pytest.mark.parametrize(
-        "outlet_events, expected_extra",
+        ("outlet_events", "expected_extra"),
         [
             pytest.param([], None, id="default"),
             pytest.param(
@@ -2033,7 +2033,7 @@ class TestGetCount:
         assert response.json() == 3
 
     @pytest.mark.parametrize(
-        ["map_index", "dynamic_task_args", "expected_count"],
+        ("map_index", "dynamic_task_args", "expected_count"),
         (
             pytest.param(None, [1, 2, 3], 4, id="use-default-map-index"),
             pytest.param(-1, [1, 2, 3], 1, id="map-index-(-1)"),
@@ -2077,13 +2077,7 @@ class TestGetCount:
         assert response.json() == expected_count
 
     @pytest.mark.parametrize(
-        [
-            "map_index",
-            "dynamic_task_args",
-            "task_ids",
-            "task_group_name",
-            "expected_count",
-        ],
+        ("map_index", "dynamic_task_args", "task_ids", "task_group_name", "expected_count"),
         (
             pytest.param(None, [1, 2, 3], None, None, 5, id="use-default-map-index-None"),
             pytest.param(-1, [1, 2, 3], ["task1"], None, 1, id="with-task-ids-and-map-index-(-1)"),
@@ -2341,7 +2335,7 @@ class TestGetTaskStates:
         }
 
     @pytest.mark.parametrize(
-        ["map_index", "dynamic_task_args", "states", "expected"],
+        ("map_index", "dynamic_task_args", "states", "expected"),
         (
             pytest.param(
                 None,
@@ -2397,14 +2391,7 @@ class TestGetTaskStates:
         assert response.json() == {"task_states": {dr.run_id: expected}}
 
     @pytest.mark.parametrize(
-        [
-            "map_index",
-            "dynamic_task_args",
-            "task_ids",
-            "task_group_name",
-            "states",
-            "expected",
-        ],
+        ("map_index", "dynamic_task_args", "task_ids", "task_group_name", "states", "expected"),
         (
             pytest.param(
                 None,

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_variables.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_variables.py
@@ -66,7 +66,7 @@ def access_denied(client):
 
 class TestGetVariable:
     @pytest.mark.parametrize(
-        "key, value",
+        ("key", "value"),
         [
             ("var1", "value"),
             ("var2/with_slash", "slash_value"),
@@ -131,7 +131,7 @@ class TestGetVariable:
 
 class TestPutVariable:
     @pytest.mark.parametrize(
-        "key, payload",
+        ("key", "payload"),
         [
             pytest.param("var_create", {"value": "{}", "description": "description"}, id="valid-payload"),
             pytest.param("var_create", {"value": "{}"}, id="missing-description"),
@@ -158,7 +158,7 @@ class TestPutVariable:
             assert var_from_db.description == payload["description"]
 
     @pytest.mark.parametrize(
-        "key, status_code, payload",
+        ("key", "status_code", "payload"),
         [
             pytest.param("", 404, {"value": "{}", "description": "description"}, id="missing-key"),
             pytest.param("var_create", 422, {"description": "description"}, id="missing-value"),
@@ -175,7 +175,7 @@ class TestPutVariable:
             assert response.json()["detail"][0]["msg"] == "Field required"
 
     @pytest.mark.parametrize(
-        "key, payload",
+        ("key", "payload"),
         [
             pytest.param("key", {"key": "key", "value": "{}", "description": "description"}, id="adding-key"),
             pytest.param(
@@ -243,7 +243,7 @@ class TestPutVariable:
 
 class TestDeleteVariable:
     @pytest.mark.parametrize(
-        "keys_to_create, key_to_delete",
+        ("keys_to_create", "key_to_delete"),
         [
             (["key1", "key2"], "key1"),
             (["key3/with_slash", "key4"], "key3/with_slash"),

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
@@ -133,7 +133,7 @@ class TestXComsGetEndpoint:
         assert any(msg.startswith("Checking read XCom access") for msg in caplog.messages)
 
     @pytest.mark.parametrize(
-        "offset, expected_status, expected_json",
+        ("offset", "expected_status", "expected_json"),
         [
             pytest.param(
                 -4,
@@ -275,7 +275,7 @@ class TestXComsGetEndpoint:
         assert response.json() == ["f", "o", "b"][key]
 
     @pytest.mark.parametrize(
-        "include_prior_dates, expected_xcoms",
+        ("include_prior_dates", "expected_xcoms"),
         [[True, ["earlier_value", "later_value"]], [False, ["later_value"]]],
     )
     def test_xcom_get_slice_accepts_include_prior_dates(
@@ -360,7 +360,7 @@ class TestXComsSetEndpoint:
         assert task_map is None, "Should not be mapped"
 
     @pytest.mark.parametrize(
-        "orig_value, ser_value, deser_value",
+        ("orig_value", "ser_value", "deser_value"),
         [
             pytest.param(1, 1, 1, id="int"),
             pytest.param(1.0, 1.0, 1.0, id="float"),

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2025_04_28/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2025_04_28/test_task_instances.py
@@ -51,7 +51,7 @@ class TestTIUpdateState:
         clear_db_runs()
 
     @pytest.mark.parametrize(
-        "mock_indexes, expected_response_indexes",
+        ("mock_indexes", "expected_response_indexes"),
         [
             pytest.param(
                 [("task_a", 5), ("task_b", 10)],

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2025_04_28/test_xcom.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2025_04_28/test_xcom.py
@@ -27,7 +27,7 @@ pytestmark = pytest.mark.db_test
 
 class TestXComsGetEndpoint:
     @pytest.mark.parametrize(
-        "offset, expected_status, expected_json",
+        ("offset", "expected_status", "expected_json"),
         [
             pytest.param(
                 -4,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
Issue: Enable Even More PyDocStyle Checks #40567
@ferruzzi

This PR is for enable PT006 rule:
PT006: all instances of @pytest.mark.parametrize names should be a tuple
https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/
There are a lot of file changes needed.
So, I separate to many PR, which contain about 5-10 file changes for easy review.

**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
