### PR TITLE
Enable PT006 rule to airflow-core tests (route/public)

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_event_logs.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_event_logs.py
@@ -109,7 +109,7 @@ class TestEventLogsEndpoint:
 
 class TestGetEventLog(TestEventLogsEndpoint):
     @pytest.mark.parametrize(
-        "event_log_key, expected_status_code, expected_body",
+        ("event_log_key", "expected_status_code", "expected_body"),
         [
             (
                 EVENT_NORMAL,
@@ -199,7 +199,7 @@ class TestGetEventLog(TestEventLogsEndpoint):
 
 class TestGetEventLogs(TestEventLogsEndpoint):
     @pytest.mark.parametrize(
-        "query_params, expected_status_code, expected_total_entries, expected_events",
+        ("query_params", "expected_status_code", "expected_total_entries", "expected_events"),
         [
             (
                 {},

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_extra_links.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_extra_links.py
@@ -115,7 +115,7 @@ class TestGetExtraLinks:
         return dag
 
     @pytest.mark.parametrize(
-        "url, expected_status_code, expected_response",
+        ("url", "expected_status_code", "expected_response"),
         [
             pytest.param(
                 "/dags/INVALID/dagRuns/TEST_DAG_RUN_ID/taskInstances/TEST_SINGLE_LINK/links",

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_hitl.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_hitl.py
@@ -539,7 +539,7 @@ class TestGetHITLDetailsEndpoint:
 
     @pytest.mark.usefixtures("sample_hitl_details")
     @pytest.mark.parametrize(
-        "params, expected_ti_count",
+        ("params", "expected_ti_count"),
         [
             # ti related filter
             ({"dag_id_pattern": "hitl_dag"}, 5),
@@ -637,7 +637,7 @@ class TestGetHITLDetailsEndpoint:
     @pytest.mark.usefixtures("sample_hitl_details")
     @pytest.mark.parametrize("asc_desc_mark", ["", "-"], ids=["asc", "desc"])
     @pytest.mark.parametrize(
-        "key, get_key_lambda",
+        ("key", "get_key_lambda"),
         [
             # ti key
             ("ti_id", lambda x: x["task_instance"]["id"]),

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_import_error.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_import_error.py
@@ -144,7 +144,7 @@ def set_mock_auth_manager__batch_is_authorized_dag(
 
 class TestGetImportError:
     @pytest.mark.parametrize(
-        "prepared_import_error_idx, expected_status_code, expected_body",
+        ("prepared_import_error_idx", "expected_status_code", "expected_body"),
         [
             (
                 0,
@@ -242,7 +242,7 @@ class TestGetImportError:
 
 class TestGetImportErrors:
     @pytest.mark.parametrize(
-        "query_params, expected_status_code, expected_total_entries, expected_filenames",
+        ("query_params", "expected_status_code", "expected_total_entries", "expected_filenames"),
         [
             (
                 {},
@@ -346,7 +346,7 @@ class TestGetImportErrors:
         assert response.status_code == 403
 
     @pytest.mark.parametrize(
-        "team, batch_is_authorized_dag_return_value, expected_stack_trace",
+        ("team", "batch_is_authorized_dag_return_value", "expected_stack_trace"),
         [
             pytest.param(
                 "test_team",

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_job.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_job.py
@@ -128,7 +128,7 @@ class TestJobEndpoint:
 
 class TestGetJobs(TestJobEndpoint):
     @pytest.mark.parametrize(
-        "testcase, query_params, expected_status_code, expected_total_entries",
+        ("testcase", "query_params", "expected_status_code", "expected_total_entries"),
         [
             # original testcases refactor from tests/cli/commands/test_jobs_command.py
             (TESTCASE_ONE_SCHEDULER, {}, 200, 1),

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_log.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_log.py
@@ -180,7 +180,7 @@ class TestTaskInstancesLog:
         assert response.status_code == 200
 
     @pytest.mark.parametrize(
-        "request_url, expected_filename, extra_query_string, try_number",
+        ("request_url", "expected_filename", "extra_query_string", "try_number"),
         [
             (
                 f"/dags/{DAG_ID}/dagRuns/{RUN_ID}/taskInstances/{TASK_ID}/logs/1",
@@ -236,7 +236,7 @@ class TestTaskInstancesLog:
             assert "timestamp" in log
 
     @pytest.mark.parametrize(
-        "request_url, expected_filename, extra_query_string, try_number",
+        ("request_url", "expected_filename", "extra_query_string", "try_number"),
         [
             (
                 f"/dags/{DAG_ID}/dagRuns/{RUN_ID}/taskInstances/{TASK_ID}/logs/1",
@@ -414,7 +414,7 @@ class TestTaskInstancesLog:
         assert response.json()["detail"] == "TaskInstance not found"
 
     @pytest.mark.parametrize(
-        "supports_external_link, task_id, expected_status, expected_response, mock_external_url",
+        ("supports_external_link", "task_id", "expected_status", "expected_response", "mock_external_url"),
         [
             (
                 True,

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_plugins.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_plugins.py
@@ -29,7 +29,7 @@ pytestmark = pytest.mark.db_test
 @skip_if_force_lowest_dependencies_marker
 class TestGetPlugins:
     @pytest.mark.parametrize(
-        "query_params, expected_total_entries, expected_names",
+        ("query_params", "expected_total_entries", "expected_names"),
         [
             # Filters
             (

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py
@@ -166,7 +166,7 @@ class TestGetPool(TestPoolsEndpoint):
 
 class TestGetPools(TestPoolsEndpoint):
     @pytest.mark.parametrize(
-        "query_params, expected_total_entries, expected_ids",
+        ("query_params", "expected_total_entries", "expected_ids"),
         [
             # Filters
             ({}, 4, [Pool.DEFAULT_POOL_NAME, POOL1_NAME, POOL2_NAME, POOL3_NAME]),
@@ -219,7 +219,7 @@ class TestGetPools(TestPoolsEndpoint):
 
 class TestPatchPool(TestPoolsEndpoint):
     @pytest.mark.parametrize(
-        "pool_name, query_params, body, expected_status_code, expected_response",
+        ("pool_name", "query_params", "body", "expected_status_code", "expected_response"),
         [
             # Error
             (
@@ -398,7 +398,7 @@ class TestPatchPool(TestPoolsEndpoint):
 
 class TestPostPool(TestPoolsEndpoint):
     @pytest.mark.parametrize(
-        "body, expected_status_code, expected_response",
+        ("body", "expected_status_code", "expected_response"),
         [
             (
                 {"name": "my_pool", "slots": 11},
@@ -453,7 +453,13 @@ class TestPostPool(TestPoolsEndpoint):
         assert response.status_code == 403
 
     @pytest.mark.parametrize(
-        "body,first_expected_status_code, first_expected_response, second_expected_status_code, second_expected_response",
+        (
+            "body",
+            "first_expected_status_code",
+            "first_expected_response",
+            "second_expected_status_code",
+            "second_expected_response",
+        ),
         [
             (
                 {"name": "my_pool", "slots": 11},
@@ -506,7 +512,7 @@ class TestPostPool(TestPoolsEndpoint):
 class TestBulkPools(TestPoolsEndpoint):
     @pytest.mark.enable_redact
     @pytest.mark.parametrize(
-        "actions, expected_results",
+        ("actions", "expected_results"),
         [
             pytest.param(
                 {

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_providers.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_providers.py
@@ -50,7 +50,7 @@ MOCK_PROVIDERS = {
 
 class TestGetProviders:
     @pytest.mark.parametrize(
-        "query_params, expected_total_entries, expected_package_name",
+        ("query_params", "expected_total_entries", "expected_package_name"),
         [
             # Filters
             ({}, 2, ["apache-airflow-providers-amazon", "apache-airflow-providers-apache-cassandra"]),

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -251,7 +251,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
         assert response.status_code == 403
 
     @pytest.mark.parametrize(
-        "run_id, expected_version_number",
+        ("run_id", "expected_version_number"),
         [
             ("run1", 1),
             ("run2", 2),
@@ -784,7 +784,7 @@ class TestGetMappedTaskInstances:
         assert list(range(4, 14)) == [ti["map_index"] for ti in body["task_instances"]]
 
     @pytest.mark.parametrize(
-        "params , expected_map_indexes",
+        ("params", "expected_map_indexes"),
         [
             ({"order_by": "map_index", "limit": 100}, list(range(100))),
             ({"order_by": "-map_index", "limit": 100}, list(range(109, 9, -1))),
@@ -818,7 +818,7 @@ class TestGetMappedTaskInstances:
         assert expected_map_indexes == [ti["map_index"] for ti in body["task_instances"]]
 
     @pytest.mark.parametrize(
-        "params, expected_map_indexes",
+        ("params", "expected_map_indexes"),
         [
             ({"order_by": "rendered_map_index", "limit": 108}, [0] + list(range(1, 108))),  # Asc
             ({"order_by": "-rendered_map_index", "limit": 100}, [0] + list(range(11, 110)[::-1])),  # Desc
@@ -887,7 +887,7 @@ class TestGetMappedTaskInstances:
         assert body["task_instances"] == []
 
     @pytest.mark.parametrize(
-        "query_params, expected_total_entries, expected_task_instance_count",
+        ("query_params", "expected_total_entries", "expected_task_instance_count"),
         [
             ({"state": "success"}, 3, 3),
             ({"state": "running"}, 0, 0),
@@ -939,7 +939,7 @@ class TestGetMappedTaskInstances:
 
 class TestGetTaskInstances(TestTaskInstanceEndpoint):
     @pytest.mark.parametrize(
-        "task_instances, update_extras, url, params, expected_ti, expected_queries_number",
+        ("task_instances", "update_extras", "url", "params", "expected_ti", "expected_queries_number"),
         [
             pytest.param(
                 [
@@ -1462,7 +1462,7 @@ class TestGetTaskInstances(TestTaskInstanceEndpoint):
         assert count == len(response.json()["task_instances"])
 
     @pytest.mark.parametrize(
-        "order_by_field, base_date",
+        ("order_by_field", "base_date"),
         [
             ("start_date", DEFAULT_DATETIME_1 + timedelta(days=20)),
             ("logical_date", DEFAULT_DATETIME_2),
@@ -1573,7 +1573,7 @@ class TestGetTaskDependencies(TestTaskInstanceEndpoint):
         assert response.json() == {"dependencies": []}
 
     @pytest.mark.parametrize(
-        "state, dependencies",
+        ("state", "dependencies"),
         [
             (
                 State.SCHEDULED,
@@ -1659,7 +1659,7 @@ class TestGetTaskDependencies(TestTaskInstanceEndpoint):
 
 class TestGetTaskInstancesBatch(TestTaskInstanceEndpoint):
     @pytest.mark.parametrize(
-        "task_instances, update_extras, payload, expected_ti_count",
+        ("task_instances", "update_extras", "payload", "expected_ti_count"),
         [
             pytest.param(
                 [
@@ -1798,7 +1798,7 @@ class TestGetTaskInstancesBatch(TestTaskInstanceEndpoint):
         assert start_dates_asc == list(reversed(start_dates_desc))
 
     @pytest.mark.parametrize(
-        "task_instances, payload, expected_ti_count",
+        ("task_instances", "payload", "expected_ti_count"),
         [
             pytest.param(
                 [
@@ -1836,7 +1836,7 @@ class TestGetTaskInstancesBatch(TestTaskInstanceEndpoint):
         assert expected_ti_count == len(body["task_instances"])
 
     @pytest.mark.parametrize(
-        "payload, expected_ti, total_ti",
+        ("payload", "expected_ti", "total_ti"),
         [
             pytest.param(
                 {"dag_ids": ["example_python_operator", "example_skip_dag"]},
@@ -1899,7 +1899,7 @@ class TestGetTaskInstancesBatch(TestTaskInstanceEndpoint):
         assert "Input should be '~'" in str(response.json()["detail"])
 
     @pytest.mark.parametrize(
-        "payload, expected",
+        ("payload", "expected"),
         [
             ({"end_date_lte": "2020-11-10T12:42:39.442973"}, "Input should have timezone info"),
             ({"end_date_gte": "2020-11-10T12:42:39.442973"}, "Input should have timezone info"),
@@ -2308,7 +2308,7 @@ class TestGetTaskInstanceTry(TestTaskInstanceEndpoint):
         }
 
     @pytest.mark.parametrize(
-        "run_id, expected_version_number",
+        ("run_id", "expected_version_number"),
         [
             ("run1", 1),
             ("run2", 2),
@@ -2365,7 +2365,7 @@ class TestGetTaskInstanceTry(TestTaskInstanceEndpoint):
         }
 
     @pytest.mark.parametrize(
-        "run_id, expected_version_number",
+        ("run_id", "expected_version_number"),
         [
             ("run1", 1),
             ("run2", 2),
@@ -2444,7 +2444,7 @@ class TestGetTaskInstanceTry(TestTaskInstanceEndpoint):
 
 class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
     @pytest.mark.parametrize(
-        "main_dag, task_instances, request_dag, payload, expected_ti",
+        ("main_dag", "task_instances", "request_dag", "payload", "expected_ti"),
         [
             pytest.param(
                 "example_python_operator",
@@ -2758,7 +2758,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         )
 
     @pytest.mark.parametrize(
-        "flag, expected",
+        ("flag", "expected"),
         [
             ("include_past", 2),  # T0 ~ T1
             ("include_future", 2),  # T1 ~ T2
@@ -2838,7 +2838,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         assert response.status_code == 403
 
     @pytest.mark.parametrize(
-        "main_dag, task_instances, request_dag, payload, expected_ti",
+        ("main_dag", "task_instances", "request_dag", "payload", "expected_ti"),
         [
             pytest.param(
                 "example_python_operator",
@@ -3009,7 +3009,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         assert failed_dag_runs == 0
 
     @pytest.mark.parametrize(
-        "target_logical_date, response_logical_date",
+        ("target_logical_date", "response_logical_date"),
         [
             pytest.param(DEFAULT_DATETIME_1, "2020-01-01T00:00:00Z", id="date"),
             pytest.param(None, None, id="null"),
@@ -3292,7 +3292,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         assert f"Dag Run id TEST_DAG_RUN_ID_100 not found in dag {dag_id}" in response.text
 
     @pytest.mark.parametrize(
-        "payload, expected",
+        ("payload", "expected"),
         [
             (
                 {"end_date": "2020-11-10T12:42:39.442973"},
@@ -3385,7 +3385,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         assert "The Dag with ID: `non-existent-dag` was not found" in response.text
 
     @pytest.mark.parametrize(
-        "dry_run, audit_log_count",
+        ("dry_run", "audit_log_count"),
         [
             (True, 0),
             (False, 1),
@@ -3743,7 +3743,7 @@ class TestGetTaskInstanceTries(TestTaskInstanceEndpoint):
         }
 
     @pytest.mark.parametrize(
-        "run_id, expected_version_number",
+        ("run_id", "expected_version_number"),
         [
             ("run1", 1),
             ("run2", 2),
@@ -3801,7 +3801,7 @@ class TestGetTaskInstanceTries(TestTaskInstanceEndpoint):
         }
 
     @pytest.mark.parametrize(
-        "run_id, expected_version_number",
+        ("run_id", "expected_version_number"),
         [
             ("run1", 1),
             ("run2", 2),
@@ -3872,7 +3872,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
         get_listener_manager().clear()
 
     @pytest.mark.parametrize(
-        "state, listener_state",
+        ("state", "listener_state"),
         [
             ("success", [TaskInstanceState.SUCCESS]),
             ("failed", [TaskInstanceState.FAILED]),
@@ -4070,7 +4070,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
         assert response.status_code == 403
 
     @pytest.mark.parametrize(
-        "error, code, payload",
+        ("error", "code", "payload"),
         [
             [
                 [
@@ -4142,7 +4142,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
         assert response.status_code == 404
 
     @pytest.mark.parametrize(
-        "payload, expected",
+        ("payload", "expected"),
         [
             (
                 {
@@ -4178,7 +4178,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
         }
 
     @pytest.mark.parametrize(
-        "new_state,expected_status_code,expected_json,set_ti_state_call_count",
+        ("new_state", "expected_status_code", "expected_json", "set_ti_state_call_count"),
         [
             (
                 "failed",
@@ -4278,7 +4278,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
         assert mock_set_ti_state.call_count == set_ti_state_call_count
 
     @pytest.mark.parametrize(
-        "new_note_value,ti_note_data",
+        ("new_note_value", "ti_note_data"),
         [
             (
                 "My super cool TaskInstance note.",
@@ -4766,7 +4766,7 @@ class TestPatchTaskInstanceDryRun(TestTaskInstanceEndpoint):
             _check_task_instance_note(session, task_after["id"], None)
 
     @pytest.mark.parametrize(
-        "error, code, payload",
+        ("error", "code", "payload"),
         [
             [
                 [
@@ -4838,7 +4838,7 @@ class TestPatchTaskInstanceDryRun(TestTaskInstanceEndpoint):
         assert response.status_code == 404
 
     @pytest.mark.parametrize(
-        "payload, expected",
+        ("payload", "expected"),
         [
             (
                 {
@@ -4874,7 +4874,7 @@ class TestPatchTaskInstanceDryRun(TestTaskInstanceEndpoint):
         }
 
     @pytest.mark.parametrize(
-        "new_state,expected_status_code,expected_json,set_ti_state_call_count",
+        ("new_state", "expected_status_code", "expected_json", "set_ti_state_call_count"),
         [
             (
                 "failed",
@@ -5006,7 +5006,7 @@ class TestDeleteTaskInstance(TestTaskInstanceEndpoint):
         assert response.status_code == 403
 
     @pytest.mark.parametrize(
-        "test_url, setup_needed, expected_error",
+        ("test_url", "setup_needed", "expected_error"),
         [
             (
                 f"/dags/non_existent_dag/dagRuns/{RUN_ID}/taskInstances/{TASK_ID}",
@@ -5035,7 +5035,7 @@ class TestDeleteTaskInstance(TestTaskInstanceEndpoint):
         assert response.json()["detail"] == expected_error
 
     @pytest.mark.parametrize(
-        "task_instances, map_index, expected_status_code, expected_remaining",
+        ("task_instances", "map_index", "expected_status_code", "expected_remaining"),
         [
             pytest.param(
                 [{"task_id": TASK_ID, "state": State.SUCCESS}],
@@ -5135,7 +5135,7 @@ class TestBulkTaskInstances(TestTaskInstanceEndpoint):
     ENDPOINT_URL = f"/dags/{DAG_ID}/dagRuns/{RUN_ID}/taskInstances"
 
     @pytest.mark.parametrize(
-        "default_ti, actions, expected_results",
+        ("default_ti", "actions", "expected_results"),
         [
             pytest.param(
                 [{"task_id": TASK_ID, "state": State.SUCCESS}],

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py
@@ -141,7 +141,7 @@ class TestDeleteVariable(TestVariableEndpoint):
 class TestGetVariable(TestVariableEndpoint):
     @pytest.mark.enable_redact
     @pytest.mark.parametrize(
-        "key, expected_response",
+        ("key", "expected_response"),
         [
             (
                 TEST_VARIABLE_KEY,
@@ -214,7 +214,7 @@ class TestGetVariable(TestVariableEndpoint):
 class TestGetVariables(TestVariableEndpoint):
     @pytest.mark.enable_redact
     @pytest.mark.parametrize(
-        "query_params, expected_total_entries, expected_keys",
+        ("query_params", "expected_total_entries", "expected_keys"),
         [
             # Filters
             (
@@ -328,7 +328,7 @@ class TestGetVariables(TestVariableEndpoint):
 class TestPatchVariable(TestVariableEndpoint):
     @pytest.mark.enable_redact
     @pytest.mark.parametrize(
-        "key, body, params, expected_response",
+        ("key", "body", "params", "expected_response"),
         [
             (
                 TEST_VARIABLE_KEY,
@@ -450,7 +450,7 @@ class TestPatchVariable(TestVariableEndpoint):
 class TestPostVariable(TestVariableEndpoint):
     @pytest.mark.enable_redact
     @pytest.mark.parametrize(
-        "body, expected_response",
+        ("body", "expected_response"),
         [
             (
                 {
@@ -593,7 +593,7 @@ class TestPostVariable(TestVariableEndpoint):
 class TestBulkVariables(TestVariableEndpoint):
     @pytest.mark.enable_redact
     @pytest.mark.parametrize(
-        "actions, expected_results",
+        ("actions", "expected_results"),
         [
             pytest.param(
                 {
@@ -1184,7 +1184,7 @@ class TestBulkVariables(TestVariableEndpoint):
         check_last_log(session, dag_id=None, event="bulk_variables", logical_date=None)
 
     @pytest.mark.parametrize(
-        "entity_key, entity_value, entity_description",
+        ("entity_key", "entity_value", "entity_description"),
         [
             (
                 "my_dict_var_param",

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_xcom.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_xcom.py
@@ -162,7 +162,7 @@ class TestGetXComEntry(TestXComEndpoint):
         assert response.json()["detail"] == f"XCom entry with key: `{TEST_XCOM_KEY_2}` not found"
 
     @pytest.mark.parametrize(
-        "params, expected_value",
+        ("params", "expected_value"),
         [
             pytest.param(
                 {"deserialize": True},
@@ -196,7 +196,7 @@ class TestGetXComEntry(TestXComEndpoint):
         assert response.json()["value"] == expected_value
 
     @pytest.mark.parametrize(
-        "xcom_value, expected_return",
+        ("xcom_value", "expected_return"),
         [
             pytest.param(42, 42, id="jsonable"),
             pytest.param(AssetAlias("x"), "AssetAlias(name='x', group='asset')", id="nonjsonable"),
@@ -368,7 +368,7 @@ class TestGetXComEntries(TestXComEndpoint):
         }
 
     @pytest.mark.parametrize(
-        "key, expected_entries",
+        ("key", "expected_entries"),
         [
             (
                 TEST_XCOM_KEY,
@@ -482,7 +482,7 @@ class TestGetXComEntries(TestXComEndpoint):
 
 class TestPaginationGetXComEntries(TestXComEndpoint):
     @pytest.mark.parametrize(
-        "query_params, expected_xcom_ids",
+        ("query_params", "expected_xcom_ids"),
         [
             (
                 {"limit": "1"},
@@ -544,7 +544,7 @@ class TestPaginationGetXComEntries(TestXComEndpoint):
 
 class TestCreateXComEntry(TestXComEndpoint):
     @pytest.mark.parametrize(
-        "dag_id, task_id, dag_run_id, request_body, expected_status, expected_detail",
+        ("dag_id", "task_id", "dag_run_id", "request_body", "expected_status", "expected_detail"),
         [
             # Test case: Valid input, should succeed with 201 CREATED
             pytest.param(
@@ -649,7 +649,7 @@ class TestCreateXComEntry(TestXComEndpoint):
 
 class TestPatchXComEntry(TestXComEndpoint):
     @pytest.mark.parametrize(
-        "key, patch_body, expected_status, expected_detail",
+        ("key", "patch_body", "expected_status", "expected_detail"),
         [
             # Test case: Valid update, should return 200 OK
             pytest.param(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
Issue: Enable Even More PyDocStyle Checks #40567
@ferruzzi

This PR is for enable PT006 rule:
PT006: all instances of @pytest.mark.parametrize names should be a tuple
https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/
There are a lot of file changes needed.
So, I separate to many PR, which contain about 5-10 file changes for easy review.
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
