### PR TITLE
Enable PT006 rule to airflow-core tests (auth, common, always, integration)

### DIFF
--- a/airflow-core/tests/integration/cli/commands/test_celery_command.py
+++ b/airflow-core/tests/integration/cli/commands/test_celery_command.py
@@ -56,7 +56,7 @@ class TestWorkerServeLogs:
 
     @conf_vars({("core", "executor"): "CeleryExecutor"})
     @pytest.mark.parametrize(
-        "skip, expected",
+        ("skip", "expected"),
         [
             (True, ["bundle_cleanup_main"]),
             (False, ["serve_logs", "bundle_cleanup_main"]),

--- a/airflow-core/tests/integration/security/test_kerberos.py
+++ b/airflow-core/tests/integration/security/test_kerberos.py
@@ -53,7 +53,7 @@ class TestKerberosIntegration:
             assert renew_from_kt(principal=None, keytab=self.keytab) == 0
 
     @pytest.mark.parametrize(
-        "exit_on_fail, expected_context",
+        ("exit_on_fail", "expected_context"),
         [
             pytest.param(True, pytest.raises(SystemExit), id="exit-on-fail"),
             pytest.param(False, nullcontext(), id="return-code-of-fail"),

--- a/airflow-core/tests/unit/always/test_connection.py
+++ b/airflow-core/tests/unit/always/test_connection.py
@@ -423,7 +423,7 @@ class TestConnection:
                 assert actual_val == expected_val
 
     @pytest.mark.parametrize(
-        "uri,uri_parts",
+        ("uri", "uri_parts"),
         [
             (
                 "http://:password@host:80/database",
@@ -545,7 +545,7 @@ class TestConnection:
         assert connection.schema == uri_parts.schema
 
     @pytest.mark.parametrize(
-        "extra, expected",
+        ("extra", "expected"),
         [
             ('{"extra": null}', None),
             ('{"extra": {"yo": "hi"}}', '{"yo": "hi"}'),
@@ -557,7 +557,7 @@ class TestConnection:
         assert Connection.from_json(extra).extra == expected
 
     @pytest.mark.parametrize(
-        "val,expected",
+        ("val", "expected"),
         [
             ('{"conn_type": "abc-abc"}', "abc_abc"),
             ('{"conn_type": "abc_abc"}', "abc_abc"),
@@ -569,7 +569,7 @@ class TestConnection:
         assert Connection.from_json(val).conn_type == expected
 
     @pytest.mark.parametrize(
-        "val,expected",
+        ("val", "expected"),
         [
             ('{"port": 1}', 1),
             ('{"port": "1"}', 1),
@@ -581,7 +581,7 @@ class TestConnection:
         assert Connection.from_json(val).port == expected
 
     @pytest.mark.parametrize(
-        "val,expected",
+        ("val", "expected"),
         [
             ('pass :/!@#$%^&*(){}"', 'pass :/!@#$%^&*(){}"'),  # these are the same
             (None, None),
@@ -824,7 +824,7 @@ class TestConnection:
         assert Connection(uri="//abc").host == "abc"
 
     @pytest.mark.parametrize(
-        "conn, expected_json",
+        ("conn", "expected_json"),
         [
             pytest.param("get_connection1", "{}", id="empty"),
             pytest.param("get_connection2", '{"host": "apache.org"}', id="empty-extra"),

--- a/airflow-core/tests/unit/always/test_providers_manager.py
+++ b/airflow-core/tests/unit/always/test_providers_manager.py
@@ -362,7 +362,7 @@ class TestProviderManager:
 
 
 @pytest.mark.parametrize(
-    "value, expected_outputs,",
+    ("value", "expected_outputs"),
     [
         ("a", "a"),
         (1, 1),

--- a/airflow-core/tests/unit/always/test_secrets_backends.py
+++ b/airflow-core/tests/unit/always/test_secrets_backends.py
@@ -53,7 +53,7 @@ class TestBaseSecretsBackend:
         clear_db_variables()
 
     @pytest.mark.parametrize(
-        "kwargs, output",
+        ("kwargs", "output"),
         [
             ({"path_prefix": "PREFIX", "secret_id": "ID"}, "PREFIX/ID"),
             ({"path_prefix": "PREFIX", "secret_id": "ID", "sep": "-"}, "PREFIX-ID"),

--- a/airflow-core/tests/unit/always/test_secrets_local_filesystem.py
+++ b/airflow-core/tests/unit/always/test_secrets_local_filesystem.py
@@ -48,7 +48,7 @@ def mock_local_file(content):
 
 class TestFileParsers:
     @pytest.mark.parametrize(
-        "content, expected_message",
+        ("content", "expected_message"),
         [
             ("AA", 'Invalid line format. The line should contain at least one equal sign ("=")'),
             ("=", "Invalid line format. Key is empty."),
@@ -61,7 +61,7 @@ class TestFileParsers:
                 local_filesystem.load_variables("a.env")
 
     @pytest.mark.parametrize(
-        "content, expected_message",
+        ("content", "expected_message"),
         [
             ("[]", "The file should contain the object."),
             ("{AAAAA}", "Expecting property name enclosed in double quotes"),
@@ -74,7 +74,7 @@ class TestFileParsers:
                 local_filesystem.load_variables("a.json")
 
     @pytest.mark.parametrize(
-        "content, expected_message",
+        ("content", "expected_message"),
         [
             ("[]", "The file should contain the object."),
             ("key:\n  - item1\n  - item2\ninvalid_yaml: }", "did not find expected"),
@@ -89,7 +89,7 @@ class TestFileParsers:
 
 class TestLoadVariables:
     @pytest.mark.parametrize(
-        "file_content, expected_variables",
+        ("file_content", "expected_variables"),
         [
             ("", {}),
             ("KEY=AAA", {"KEY": "AAA"}),
@@ -105,7 +105,7 @@ class TestLoadVariables:
             assert expected_variables == variables
 
     @pytest.mark.parametrize(
-        "content, expected_message",
+        ("content", "expected_message"),
         [
             ("AA=A\nAA=B", "The \"a.env\" file contains multiple values for keys: ['AA']"),
         ],
@@ -116,7 +116,7 @@ class TestLoadVariables:
                 local_filesystem.load_variables("a.env")
 
     @pytest.mark.parametrize(
-        "file_content, expected_variables",
+        ("file_content", "expected_variables"),
         [
             ({}, {}),
             ({"KEY": "AAA"}, {"KEY": "AAA"}),
@@ -133,7 +133,7 @@ class TestLoadVariables:
             local_filesystem.load_variables("a.json")
 
     @pytest.mark.parametrize(
-        "file_content, expected_variables",
+        ("file_content", "expected_variables"),
         [
             ("KEY: AAA", {"KEY": "AAA"}),
             (
@@ -163,7 +163,7 @@ class TestLoadVariables:
 
 class TestLoadConnection:
     @pytest.mark.parametrize(
-        "file_content, expected_connection_uris",
+        ("file_content", "expected_connection_uris"),
         [
             ("CONN_ID=mysql://host_1/", {"CONN_ID": "mysql://host_1"}),
             (
@@ -190,7 +190,7 @@ class TestLoadConnection:
             assert expected_connection_uris == connection_uris_by_conn_id
 
     @pytest.mark.parametrize(
-        "content, expected_connection_uris",
+        ("content", "expected_connection_uris"),
         [
             (
                 "CONN_ID=mysql://host_1/?param1=val1&param2=val2",
@@ -208,7 +208,7 @@ class TestLoadConnection:
             assert expected_connection_uris == connection_uris_by_conn_id
 
     @pytest.mark.parametrize(
-        "content, expected_message",
+        ("content", "expected_message"),
         [
             ("AA", 'Invalid line format. The line should contain at least one equal sign ("=")'),
             ("=", "Invalid line format. Key is empty."),
@@ -221,7 +221,7 @@ class TestLoadConnection:
                 local_filesystem.load_connections_dict("a.env")
 
     @pytest.mark.parametrize(
-        "file_content, expected_connection_uris",
+        ("file_content", "expected_connection_uris"),
         [
             ({"CONN_ID": "mysql://host_1"}, {"CONN_ID": "mysql://host_1"}),
             ({"CONN_ID": ["mysql://host_1"]}, {"CONN_ID": "mysql://host_1"}),
@@ -239,7 +239,7 @@ class TestLoadConnection:
             assert expected_connection_uris == connection_uris_by_conn_id
 
     @pytest.mark.parametrize(
-        "file_content, expected_connection_uris",
+        ("file_content", "expected_connection_uris"),
         [
             ({"CONN_ID": None}, "Unexpected value type: <class 'NoneType'>."),
             ({"CONN_ID": 1}, "Unexpected value type: <class 'int'>."),
@@ -260,7 +260,7 @@ class TestLoadConnection:
             local_filesystem.load_connections_dict("a.json")
 
     @pytest.mark.parametrize(
-        "file_content, expected_attrs_dict",
+        ("file_content", "expected_attrs_dict"),
         [
             (
                 """CONN_A: 'mysql://host_a'""",
@@ -309,7 +309,7 @@ class TestLoadConnection:
                 assert actual_attrs == expected_attrs
 
     @pytest.mark.parametrize(
-        "file_content, expected_extras",
+        ("file_content", "expected_extras"),
         [
             (
                 """
@@ -371,7 +371,7 @@ class TestLoadConnection:
             assert expected_extras == connection_uris_by_conn_id
 
     @pytest.mark.parametrize(
-        "file_content, expected_message",
+        ("file_content", "expected_message"),
         [
             (
                 """conn_c:

--- a/airflow-core/tests/unit/api_fastapi/auth/managers/simple/test_simple_auth_manager.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/managers/simple/test_simple_auth_manager.py
@@ -41,7 +41,7 @@ class TestSimpleAuthManager:
             assert users == [{"role": "viewer", "username": "test1"}, {"role": "viewer", "username": "test2"}]
 
     @pytest.mark.parametrize(
-        "file_content,expected",
+        ("file_content", "expected"),
         [
             ("{}", {}),
             ("", {}),
@@ -84,7 +84,7 @@ class TestSimpleAuthManager:
                 assert len(user_passwords_from_file) == 2
 
     @pytest.mark.parametrize(
-        "file_content,expected",
+        ("file_content", "expected"),
         [
             ({"test1": "test1"}, {"test1": "test1"}),
             ({"test1": "test1", "test2": "test2"}, {"test1": "test1"}),
@@ -144,7 +144,7 @@ class TestSimpleAuthManager:
         ],
     )
     @pytest.mark.parametrize(
-        "role, method, result",
+        ("role", "method", "result"),
         [
             ("ADMIN", "GET", True),
             ("ADMIN", "DELETE", True),
@@ -160,7 +160,7 @@ class TestSimpleAuthManager:
         )
 
     @pytest.mark.parametrize(
-        "api, kwargs",
+        ("api", "kwargs"),
         [
             ("is_authorized_view", {"access_view": AccessView.CLUSTER_ACTIVITY}),
             (
@@ -173,7 +173,7 @@ class TestSimpleAuthManager:
         ],
     )
     @pytest.mark.parametrize(
-        "role, result",
+        ("role", "result"),
         [
             ("ADMIN", True),
             ("VIEWER", True),
@@ -200,7 +200,7 @@ class TestSimpleAuthManager:
         ],
     )
     @pytest.mark.parametrize(
-        "role, method, result",
+        ("role", "method", "result"),
         [
             ("ADMIN", "GET", True),
             ("OP", "DELETE", True),
@@ -219,7 +219,7 @@ class TestSimpleAuthManager:
         ["is_authorized_dag"],
     )
     @pytest.mark.parametrize(
-        "role, method, result",
+        ("role", "method", "result"),
         [
             ("ADMIN", "GET", True),
             ("OP", "DELETE", True),
@@ -245,7 +245,7 @@ class TestSimpleAuthManager:
         ],
     )
     @pytest.mark.parametrize(
-        "role, method, result",
+        ("role", "method", "result"),
         [
             ("ADMIN", "GET", True),
             ("VIEWER", "GET", True),

--- a/airflow-core/tests/unit/api_fastapi/auth/managers/test_base_auth_manager.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/managers/test_base_auth_manager.py
@@ -252,7 +252,7 @@ class TestBaseAuthManager:
         assert result == token
 
     @pytest.mark.parametrize(
-        "return_values, expected",
+        ("return_values", "expected"),
         [
             ([False, False], False),
             ([True, False], False),
@@ -274,7 +274,7 @@ class TestBaseAuthManager:
         assert result == expected
 
     @pytest.mark.parametrize(
-        "return_values, expected",
+        ("return_values", "expected"),
         [
             ([False, False], False),
             ([True, False], False),
@@ -294,7 +294,7 @@ class TestBaseAuthManager:
         assert result == expected
 
     @pytest.mark.parametrize(
-        "return_values, expected",
+        ("return_values", "expected"),
         [
             ([False, False], False),
             ([True, False], False),
@@ -314,7 +314,7 @@ class TestBaseAuthManager:
         assert result == expected
 
     @pytest.mark.parametrize(
-        "return_values, expected",
+        ("return_values", "expected"),
         [
             ([False, False], False),
             ([True, False], False),
@@ -336,7 +336,7 @@ class TestBaseAuthManager:
         assert result == expected
 
     @pytest.mark.parametrize(
-        "access_per_dag, access_per_team, rows, expected",
+        ("access_per_dag", "access_per_team", "rows", "expected"),
         [
             # Without teams
             # No access to any dag
@@ -392,7 +392,7 @@ class TestBaseAuthManager:
         assert result == expected
 
     @pytest.mark.parametrize(
-        "access_per_connection, access_per_team, rows, expected",
+        ("access_per_connection", "access_per_team", "rows", "expected"),
         [
             # Without teams
             # No access to any connection
@@ -449,7 +449,7 @@ class TestBaseAuthManager:
         assert result == expected
 
     @pytest.mark.parametrize(
-        "access_per_team, rows, expected",
+        ("access_per_team", "rows", "expected"),
         [
             # No access to any team
             (
@@ -484,7 +484,7 @@ class TestBaseAuthManager:
         assert result == expected
 
     @pytest.mark.parametrize(
-        "access_per_variable, access_per_team, rows, expected",
+        ("access_per_variable", "access_per_team", "rows", "expected"),
         [
             # Without teams
             # No access to any variable
@@ -541,7 +541,7 @@ class TestBaseAuthManager:
         assert result == expected
 
     @pytest.mark.parametrize(
-        "access_per_pool, access_per_team, rows, expected",
+        ("access_per_pool", "access_per_team", "rows", "expected"),
         [
             # Without teams
             # No access to any pool

--- a/airflow-core/tests/unit/api_fastapi/auth/test_tokens.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/test_tokens.py
@@ -196,7 +196,7 @@ async def test_jwt_wrong_subject(jwt_generator, jwt_validator):
 
 
 @pytest.mark.parametrize(
-    ["private_key", "algorithm"],
+    ("private_key", "algorithm"),
     [("rsa_private_key", "RS256"), ("ed25519_private_key", "EdDSA")],
     indirect=["private_key"],
 )

--- a/airflow-core/tests/unit/api_fastapi/common/test_exceptions.py
+++ b/airflow-core/tests/unit/api_fastapi/common/test_exceptions.py
@@ -124,7 +124,7 @@ class TestUniqueConstraintErrorHandler:
         clear_db_dags()
 
     @pytest.mark.parametrize(
-        "table, expected_exception",
+        ("table", "expected_exception"),
         generate_test_cases_parametrize(
             ["Pool", "Variable"],
             [
@@ -222,7 +222,7 @@ class TestUniqueConstraintErrorHandler:
         assert exeinfo_response_error.value.detail == expected_exception.detail
 
     @pytest.mark.parametrize(
-        "table, expected_exception",
+        ("table", "expected_exception"),
         generate_test_cases_parametrize(
             ["DagRun"],
             [


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
Issue: Enable Even More PyDocStyle Checks #40567
@ferruzzi

This PR is for enable PT006 rule:
PT006: all instances of @pytest.mark.parametrize names should be a tuple
https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/
There are a lot of file changes needed.
So, I separate to many PR, which contain about 5-10 file changes for easy review.
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
