### PR TITLE
Enable PT006 rule to 6 files in providers (edge3,git)

### DIFF
--- a/providers/edge3/tests/unit/edge3/cli/test_worker.py
+++ b/providers/edge3/tests/unit/edge3/cli/test_worker.py
@@ -164,7 +164,7 @@ class TestEdgeWorker:
 
     @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Test requires Airflow 3+")
     @pytest.mark.parametrize(
-        "configs, expected_url",
+        ("configs", "expected_url"),
         [
             (
                 {("edge", "api_url"): "https://api-host/edge_worker/v1/rpcapi"},
@@ -217,7 +217,7 @@ class TestEdgeWorker:
         assert mock_supervise.call_args.kwargs["server"] == "http://mock-url"
 
     @pytest.mark.parametrize(
-        "reserve_result, fetch_result, expected_calls",
+        ("reserve_result", "fetch_result", "expected_calls"),
         [
             pytest.param(None, False, (0, 0), id="no_job"),
             pytest.param(
@@ -357,7 +357,7 @@ class TestEdgeWorker:
         )
 
     @pytest.mark.parametrize(
-        "drain, maintenance_mode, jobs, expected_state",
+        ("drain", "maintenance_mode", "jobs", "expected_state"),
         [
             pytest.param(False, False, False, EdgeWorkerState.IDLE, id="idle"),
             pytest.param(False, False, True, EdgeWorkerState.RUNNING, id="running_jobs"),

--- a/providers/edge3/tests/unit/edge3/executors/test_edge_executor.py
+++ b/providers/edge3/tests/unit/edge3/executors/test_edge_executor.py
@@ -67,7 +67,7 @@ class TestEdgeExecutor:
 
     @pytest.mark.skipif(AIRFLOW_V_3_0_PLUS, reason="_process_tasks is not used in Airflow 3.0+")
     @pytest.mark.parametrize(
-        "pool_slots, expected_concurrency",
+        ("pool_slots", "expected_concurrency"),
         [
             pytest.param(1, 1, id="default_pool_size"),
             pytest.param(5, 5, id="increased_pool_size"),

--- a/providers/edge3/tests/unit/edge3/plugins/test_edge_executor_plugin.py
+++ b/providers/edge3/tests/unit/edge3/plugins/test_edge_executor_plugin.py
@@ -102,7 +102,7 @@ def test_plugin_is_airflow_plugin(plugin):
 
 @pytest.mark.skipif(AIRFLOW_V_3_0_PLUS, reason="Plugin endpoint is not used in Airflow 3.0+")
 @pytest.mark.parametrize(
-    "initial_comment, expected_comment",
+    ("initial_comment", "expected_comment"),
     [
         pytest.param(
             "comment", "[2020-01-01 00:00] - user updated maintenance mode\nComment: comment", id="no user"

--- a/providers/edge3/tests/unit/edge3/worker_api/routes/test_worker.py
+++ b/providers/edge3/tests/unit/edge3/worker_api/routes/test_worker.py
@@ -96,7 +96,7 @@ class TestWorkerApiRoutes:
             assert worker[0].queues is None
 
     @pytest.mark.parametrize(
-        "worker_state, body_state, expected_state",
+        ("worker_state", "body_state", "expected_state"),
         [
             pytest.param(
                 EdgeWorkerState.MAINTENANCE_REQUEST,
@@ -197,7 +197,7 @@ class TestWorkerApiRoutes:
         assert return_queues == ["default", "default2"]
 
     @pytest.mark.parametrize(
-        "add_queues, remove_queues, expected_queues",
+        ("add_queues", "remove_queues", "expected_queues"),
         [
             pytest.param(None, None, ["init"], id="no-changes"),
             pytest.param(

--- a/providers/git/tests/unit/git/bundles/test_git.py
+++ b/providers/git/tests/unit/git/bundles/test_git.py
@@ -427,7 +427,7 @@ class TestGitDagBundle:
         assert mock_gitRepo.return_value.remotes.origin.fetch.call_count == 2
 
     @pytest.mark.parametrize(
-        "repo_url, extra_conn_kwargs, expected_url",
+        ("repo_url", "extra_conn_kwargs", "expected_url"),
         [
             ("git@github.com:apache/airflow.git", None, "https://github.com/apache/airflow/tree/0f0f0f"),
             ("git@github.com:apache/airflow", None, "https://github.com/apache/airflow/tree/0f0f0f"),
@@ -497,7 +497,7 @@ class TestGitDagBundle:
         bundle.initialize.assert_not_called()
 
     @pytest.mark.parametrize(
-        "repo_url, extra_conn_kwargs, expected_url",
+        ("repo_url", "extra_conn_kwargs", "expected_url"),
         [
             (
                 "git@github.com:apache/airflow.git",
@@ -587,7 +587,7 @@ class TestGitDagBundle:
 
     @pytest.mark.skipif(not AIRFLOW_V_3_1_PLUS, reason="Airflow 3.0 does not support view_url_template")
     @pytest.mark.parametrize(
-        "repo_url, extra_conn_kwargs, expected_url",
+        ("repo_url", "extra_conn_kwargs", "expected_url"),
         [
             (
                 "git@github.com:apache/airflow.git",
@@ -717,7 +717,7 @@ class TestGitDagBundle:
 
     @patch.dict(os.environ, {"AIRFLOW_CONN_MY_TEST_GIT": '{"host": "something", "conn_type": "git"}'})
     @pytest.mark.parametrize(
-        "conn_id, expected_hook_type",
+        ("conn_id", "expected_hook_type"),
         [("my_test_git", GitHook), ("something-else", type(None))],
     )
     def test_repo_url_access_missing_connection_doesnt_error(
@@ -742,7 +742,7 @@ class TestGitDagBundle:
             assert mock_lock.call_count == 2  # both initialize and refresh
 
     @pytest.mark.parametrize(
-        "conn_json, repo_url, expected",
+        ("conn_json", "repo_url", "expected"),
         [
             (
                 {"host": "git@github.com:apache/airflow.git"},

--- a/providers/git/tests/unit/git/hooks/test_git.py
+++ b/providers/git/tests/unit/git/hooks/test_git.py
@@ -104,7 +104,7 @@ class TestGitHook:
         )
 
     @pytest.mark.parametrize(
-        "conn_id, hook_kwargs, expected_repo_url",
+        ("conn_id", "hook_kwargs", "expected_repo_url"),
         [
             (CONN_DEFAULT, {}, AIRFLOW_GIT),
             (CONN_HTTPS, {}, f"https://user:{ACCESS_TOKEN}@github.com/apache/airflow.git"),


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
Issue: Enable Even More PyDocStyle Checks https://github.com/apache/airflow/issues/40567
@ferruzzi

This PR is for enable PT006 rule:
all instances of @pytest.mark.parametrize names should be a tuple
https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/
There are a lot of file changes needed.
So, I separate to many PR, which contain about 6 file changes for easy review.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
