### PR TITLE
Enable PT006 rule to standard Provider test(decorator, hook) 8 files

### DIFF
--- a/providers/standard/tests/unit/standard/decorators/test_bash.py
+++ b/providers/standard/tests/unit/standard/decorators/test_bash.py
@@ -104,7 +104,7 @@ class TestBashDecorator:
             assert bash_task.operator._init_bash_command_not_set is True
 
     @pytest.mark.parametrize(
-        argnames=["command", "expected_command", "expected_return_val"],
+        argnames=("command", "expected_command", "expected_return_val"),
         argvalues=[
             pytest.param("echo hello world", "echo hello world", "hello world", id="not_templated"),
             pytest.param(
@@ -175,7 +175,7 @@ class TestBashDecorator:
         self.validate_bash_command_rtif(ti, excepted_command)
 
     @pytest.mark.parametrize(
-        argnames=["append_env", "user_defined_env", "expected_airflow_home"],
+        argnames=("append_env", "user_defined_env", "expected_airflow_home"),
         argvalues=[
             pytest.param(False, {"var": "value"}, "", id="no_append_env"),
             pytest.param(True, {"var": "value"}, "path/to/airflow/home", id="append_env"),
@@ -203,7 +203,7 @@ class TestBashDecorator:
         self.validate_bash_command_rtif(ti, "echo var=$var; echo AIRFLOW_HOME=$AIRFLOW_HOME;")
 
     @pytest.mark.parametrize(
-        argnames=["exit_code", "expected"],
+        argnames=("exit_code", "expected"),
         argvalues=[
             pytest.param(99, pytest.raises(AirflowSkipException), id="skip"),
             pytest.param(1, pytest.raises(AirflowException), id="non-zero"),
@@ -228,7 +228,7 @@ class TestBashDecorator:
             self.validate_bash_command_rtif(ti, f"exit {exit_code}")
 
     @pytest.mark.parametrize(
-        argnames=["skip_on_exit_code", "exit_code", "expected"],
+        argnames=("skip_on_exit_code", "exit_code", "expected"),
         argvalues=[
             pytest.param(None, 99, pytest.raises(AirflowSkipException), id="default_skip_exit_99"),
             pytest.param(None, 1, pytest.raises(AirflowException), id="default_skip_exit_1"),
@@ -272,12 +272,12 @@ class TestBashDecorator:
             self.validate_bash_command_rtif(ti, f"exit {exit_code}")
 
     @pytest.mark.parametrize(
-        argnames=[
+        argnames=(
             "user_defined_env",
             "append_env",
             "expected_razz",
             "expected_airflow_home",
-        ],
+        ),
         argvalues=[
             pytest.param(
                 {"razz": "matazz"}, True, "matazz", "path/to/airflow/home", id="user_defined_env_and_append"
@@ -448,7 +448,7 @@ class TestBashDecorator:
         self.validate_bash_command_rtif(ti, "echo")
 
     @pytest.mark.parametrize(
-        argnames=["return_val", "expected"],
+        argnames=("return_val", "expected"),
         argvalues=[
             pytest.param(None, pytest.raises(TypeError), id="return_none_typeerror"),
             pytest.param(1, pytest.raises(TypeError), id="return_int_typeerror"),

--- a/providers/standard/tests/unit/standard/decorators/test_branch_external_python.py
+++ b/providers/standard/tests/unit/standard/decorators/test_branch_external_python.py
@@ -43,7 +43,7 @@ class TestBranchExternalPythonDecoratedOperator:
     # possibilities. So we are increasing the timeout for this test to 3x of the default timeout
     @pytest.mark.execution_timeout(180)
     @pytest.mark.parametrize(
-        ["branch_task_name", "skipped_task_name"], [("task_1", "task_2"), ("task_2", "task_1")]
+        ("branch_task_name", "skipped_task_name"), [("task_1", "task_2"), ("task_2", "task_1")]
     )
     def test_branch_one(self, dag_maker, branch_task_name, skipped_task_name):
         @task

--- a/providers/standard/tests/unit/standard/decorators/test_branch_python.py
+++ b/providers/standard/tests/unit/standard/decorators/test_branch_python.py
@@ -40,7 +40,7 @@ class TestBranchPythonDecoratedOperator:
     # possibilities. So we are increasing the timeout for this test to 3x of the default timeout
     @pytest.mark.execution_timeout(180)
     @pytest.mark.parametrize(
-        ["branch_task_name", "skipped_task_name"], [("task_1", "task_2"), ("task_2", "task_1")]
+        ("branch_task_name", "skipped_task_name"), [("task_1", "task_2"), ("task_2", "task_1")]
     )
     def test_branch_one(self, dag_maker, branch_task_name, skipped_task_name):
         @task

--- a/providers/standard/tests/unit/standard/decorators/test_branch_virtualenv.py
+++ b/providers/standard/tests/unit/standard/decorators/test_branch_virtualenv.py
@@ -46,7 +46,7 @@ class TestBranchPythonVirtualenvDecoratedOperator:
     # possibilities. So we are increasing the timeout for this test to 3x of the default timeout
     @pytest.mark.execution_timeout(180)
     @pytest.mark.parametrize(
-        ["branch_task_name", "skipped_task_name"], [("task_1", "task_2"), ("task_2", "task_1")]
+        ("branch_task_name", "skipped_task_name"), [("task_1", "task_2"), ("task_2", "task_1")]
     )
     def test_branch_one(self, dag_maker, branch_task_name, tmp_path, skipped_task_name):
         requirements_file = tmp_path / "requirements.txt"

--- a/providers/standard/tests/unit/standard/decorators/test_python.py
+++ b/providers/standard/tests/unit/standard/decorators/test_python.py
@@ -585,7 +585,7 @@ class TestAirflowTaskDecorator(BasePythonTest):
         assert "add_2" in self.dag_non_serialized.task_ids
 
     @pytest.mark.parametrize(
-        argnames=["op_doc_attr", "op_doc_value", "expected_doc_md"],
+        argnames=("op_doc_attr", "op_doc_value", "expected_doc_md"),
         argvalues=[
             pytest.param("doc", "task docs.", None, id="set_doc"),
             pytest.param("doc_json", '{"task": "docs."}', None, id="set_doc_json"),

--- a/providers/standard/tests/unit/standard/decorators/test_python_virtualenv.py
+++ b/providers/standard/tests/unit/standard/decorators/test_python_virtualenv.py
@@ -203,7 +203,7 @@ class TestPythonVirtualenvDecorator:
         dag_maker.run_ti("f", dr)
 
     @pytest.mark.parametrize(
-        "serializer, extra_requirements",
+        ("serializer", "extra_requirements"),
         [
             pytest.param("pickle", [], id="pickle"),
             pytest.param("dill", ["dill"], marks=DILL_MARKER, id="dill"),
@@ -249,7 +249,7 @@ class TestPythonVirtualenvDecorator:
             dag_maker.run_ti("f", dr)
 
     @pytest.mark.parametrize(
-        "serializer, extra_requirements",
+        ("serializer", "extra_requirements"),
         [
             pytest.param("pickle", [], id="pickle"),
             pytest.param("dill", ["dill"], marks=DILL_MARKER, id="dill"),
@@ -276,7 +276,7 @@ class TestPythonVirtualenvDecorator:
         dag_maker.run_ti("f", dr)
 
     @pytest.mark.parametrize(
-        "serializer, extra_requirements",
+        ("serializer", "extra_requirements"),
         [
             pytest.param("pickle", [], id="pickle"),
             pytest.param("dill", ["dill"], marks=DILL_MARKER, id="dill"),

--- a/providers/standard/tests/unit/standard/decorators/test_short_circuit.py
+++ b/providers/standard/tests/unit/standard/decorators/test_short_circuit.py
@@ -90,7 +90,7 @@ def test_short_circuit_decorator(dag_maker):
 
 
 @pytest.mark.skipif(not AIRFLOW_V_3_0_1, reason="Test only runs on AF3.0.1")
-@pytest.mark.parametrize(["condition", "should_be_skipped"], [(True, False), (False, True)])
+@pytest.mark.parametrize(("condition", "should_be_skipped"), [(True, False), (False, True)])
 def test_short_circuit_decorator_af301(dag_maker, session, condition, should_be_skipped):
     with dag_maker(serialized=True, session=session):
 
@@ -121,7 +121,7 @@ def test_short_circuit_decorator_af301(dag_maker, session, condition, should_be_
 
 @pytest.mark.skipif(not AIRFLOW_V_3_0_1, reason="Test only runs on AF3.0.1")
 @pytest.mark.parametrize(
-    ["ignore_downstream_trigger_rules", "expected"], [(True, State.SKIPPED), (False, State.SUCCESS)]
+    ("ignore_downstream_trigger_rules", "expected"), [(True, State.SKIPPED), (False, State.SUCCESS)]
 )
 def test_short_circuit_decorator__ignore_downstream_trigger_rules(
     dag_maker, session, ignore_downstream_trigger_rules, expected

--- a/providers/standard/tests/unit/standard/hooks/test_subprocess.py
+++ b/providers/standard/tests/unit/standard/hooks/test_subprocess.py
@@ -34,7 +34,7 @@ OS_ENV_VAL = "this-is-from-os-environ"
 
 class TestSubprocessHook:
     @pytest.mark.parametrize(
-        "env,expected",
+        ("env", "expected"),
         [
             ({"ABC": "123", "AAA": "456"}, {"ABC": "123", "AAA": "456", OS_ENV_KEY: ""}),
             ({}, {OS_ENV_KEY: ""}),
@@ -66,7 +66,7 @@ class TestSubprocessHook:
             assert actual == expected
 
     @pytest.mark.parametrize(
-        "val,expected",
+        ("val", "expected"),
         [
             ("test-val", "test-val"),
             ("test-val\ntest-val\n", ""),


### PR DESCRIPTION
Issue: Enable Even More PyDocStyle Checks https://github.com/apache/airflow/issues/40567
@ferruzzi

This PR is for enable PT006 rule:
PT006: all instances of @pytest.mark.parametrize names should be a tuple
https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/

This is for  standard Provider test(decorator, hook).


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
