### PR TITLE
Enable PT006 rule to standard Provider test(operator) 6 files

### DIFF
--- a/providers/standard/tests/unit/standard/operators/test_bash.py
+++ b/providers/standard/tests/unit/standard/operators/test_bash.py
@@ -63,7 +63,7 @@ class TestBashOperator:
 
     @pytest.mark.db_test
     @pytest.mark.parametrize(
-        "append_env,user_defined_env,expected_airflow_home",
+        ("append_env", "user_defined_env", "expected_airflow_home"),
         [
             (False, None, "MY_PATH_TO_AIRFLOW_HOME"),
             (True, {"AIRFLOW_HOME": "OVERRIDDEN_AIRFLOW_HOME"}, "OVERRIDDEN_AIRFLOW_HOME"),
@@ -122,7 +122,7 @@ class TestBashOperator:
         assert expected == tmp_file.read_text()
 
     @pytest.mark.parametrize(
-        "val,expected",
+        ("val", "expected"),
         [
             ("test-val", "test-val"),
             ("test-val\ntest-val\n", ""),
@@ -194,7 +194,7 @@ class TestBashOperator:
         assert (test_cwd_path / "outputs.txt").read_text().splitlines()[0] == "xxxx"
 
     @pytest.mark.parametrize(
-        "extra_kwargs,actual_exit_code,expected_exc",
+        ("extra_kwargs", "actual_exit_code", "expected_exc"),
         [
             ({}, 0, None),
             ({}, 100, AirflowException),

--- a/providers/standard/tests/unit/standard/operators/test_datetime.py
+++ b/providers/standard/tests/unit/standard/operators/test_datetime.py
@@ -121,7 +121,7 @@ class TestBranchDateTimeOperator:
             )
 
     @pytest.mark.parametrize(
-        "target_lower,target_upper",
+        ("target_lower", "target_upper"),
         targets,
     )
     @time_machine.travel("2020-07-07 10:54:05")
@@ -147,7 +147,7 @@ class TestBranchDateTimeOperator:
             )
 
     @pytest.mark.parametrize(
-        "target_lower,target_upper",
+        ("target_lower", "target_upper"),
         targets,
     )
     @pytest.mark.parametrize(
@@ -282,7 +282,7 @@ class TestBranchDateTimeOperator:
             )
 
     @pytest.mark.parametrize(
-        "target_lower,target_upper",
+        ("target_lower", "target_upper"),
         targets,
     )
     @time_machine.travel("2020-12-01 09:00:00")

--- a/providers/standard/tests/unit/standard/operators/test_hitl.py
+++ b/providers/standard/tests/unit/standard/operators/test_hitl.py
@@ -163,7 +163,7 @@ class TestHITLOperator:
         hitl_op.validate_defaults()
 
     @pytest.mark.parametrize(
-        "extra_kwargs, expected_error_msg",
+        ("extra_kwargs", "expected_error_msg"),
         [
             ({"defaults": ["0"]}, r'defaults ".*" should be a subset of options ".*"'),
             (
@@ -242,7 +242,7 @@ class TestHITLOperator:
         }
 
     @pytest.mark.parametrize(
-        "input_params, expected_params",
+        ("input_params", "expected_params"),
         [
             (ParamsDict({"input": 1}), {"input": 1}),
             ({"input": Param(5, type="integer", minimum=3)}, {"input": 5}),
@@ -290,7 +290,7 @@ class TestHITLOperator:
         }
 
     @pytest.mark.parametrize(
-        "event, expected_exception",
+        ("event", "expected_exception"),
         [
             ({"error": "unknown", "error_type": "unknown"}, HITLTriggerEventError),
             ({"error": "this is timeotu", "error_type": "timeout"}, HITLTimeoutError),
@@ -350,7 +350,7 @@ class TestHITLOperator:
             )
 
     @pytest.mark.parametrize(
-        "options, params_input, expected_parsed_query",
+        ("options", "params_input", "expected_parsed_query"),
         [
             (None, None, {"map_index": ["-1"]}),
             ("1", None, {"_options": ["['1']"], "map_index": ["-1"]}),
@@ -414,7 +414,7 @@ class TestHITLOperator:
             assert parse_qs(parse_result.query) == expected_parsed_query
 
     @pytest.mark.parametrize(
-        "options, params_input, expected_err_msg",
+        ("options", "params_input", "expected_err_msg"),
         [
             ([100, "2", 30000], None, "options {.*} are not valid options"),
             (

--- a/providers/standard/tests/unit/standard/operators/test_python.py
+++ b/providers/standard/tests/unit/standard/operators/test_python.py
@@ -338,7 +338,7 @@ class TestPythonOperator(BasePythonTest):
         self.run_as_task(func, op_kwargs={"custom": 1})
 
     @pytest.mark.parametrize(
-        "show_return_value_in_logs, should_shown",
+        ("show_return_value_in_logs", "should_shown"),
         [
             pytest.param(NOTSET, True, id="default"),
             pytest.param(True, True, id="show"),
@@ -580,7 +580,7 @@ class TestBranchOperator(BasePythonTest):
             )
 
     @pytest.mark.parametrize(
-        "choice,expected_states",
+        ("choice", "expected_states"),
         [
             ("task1", [State.SUCCESS, State.SUCCESS, State.SUCCESS]),
             ("join", [State.SUCCESS, State.SKIPPED, State.SUCCESS]),
@@ -1073,7 +1073,7 @@ class BaseTestPythonVirtualenvOperator(BasePythonTest):
         assert set(context) == declared_keys
 
     @pytest.mark.parametrize(
-        "kwargs, actual_exit_code, expected_state",
+        ("kwargs", "actual_exit_code", "expected_state"),
         [
             ({}, 0, TaskInstanceState.SUCCESS),
             ({}, 100, TaskInstanceState.FAILED),
@@ -1237,7 +1237,7 @@ class TestPythonVirtualenvOperator(BaseTestPythonVirtualenvOperator):
         self.run_as_task(f)
 
     @pytest.mark.parametrize(
-        "serializer, extra_requirements",
+        ("serializer", "extra_requirements"),
         [
             pytest.param("pickle", [], id="pickle"),
             pytest.param("dill", ["dill"], marks=DILL_MARKER, id="dill"),
@@ -1289,7 +1289,7 @@ class TestPythonVirtualenvOperator(BaseTestPythonVirtualenvOperator):
         self.run_as_task(f, requirements=["funcsigs==0.4"], do_not_use_caching=True)
 
     @pytest.mark.parametrize(
-        "serializer, extra_requirements",
+        ("serializer", "extra_requirements"),
         [
             pytest.param("pickle", [], id="pickle"),
             pytest.param("dill", ["dill"], marks=DILL_MARKER, id="dill"),
@@ -1309,7 +1309,7 @@ class TestPythonVirtualenvOperator(BaseTestPythonVirtualenvOperator):
         )
 
     @pytest.mark.parametrize(
-        "serializer, extra_requirements",
+        ("serializer", "extra_requirements"),
         [
             pytest.param("pickle", [], id="pickle"),
             pytest.param("dill", ["dill"], marks=DILL_MARKER, id="dill"),
@@ -1380,7 +1380,7 @@ class TestPythonVirtualenvOperator(BaseTestPythonVirtualenvOperator):
         )
 
     @pytest.mark.parametrize(
-        "serializer, extra_requirements",
+        ("serializer", "extra_requirements"),
         [
             pytest.param("pickle", [], id="pickle"),
             pytest.param("dill", ["dill"], marks=DILL_MARKER, id="dill"),
@@ -1599,7 +1599,7 @@ class TestPythonVirtualenvOperator(BaseTestPythonVirtualenvOperator):
         self.run_as_task(f, serializer=serializer, system_site_packages=False, requirements=None)
 
     @pytest.mark.parametrize(
-        "requirements, system_site, want_airflow, want_pendulum",
+        ("requirements", "system_site", "want_airflow", "want_pendulum"),
         [
             # nothing → just base keys
             ([], False, False, False),
@@ -2239,7 +2239,7 @@ class TestCurrentContextRuntime:
 @pytest.mark.need_serialized_dag(False)
 class TestShortCircuitWithTeardown:
     @pytest.mark.parametrize(
-        "ignore_downstream_trigger_rules, with_teardown, should_skip, expected",
+        ("ignore_downstream_trigger_rules", "with_teardown", "should_skip", "expected"),
         [
             (False, True, True, ["op2"]),
             (False, True, False, []),
@@ -2377,7 +2377,7 @@ class TestShortCircuitWithTeardown:
 
 
 @pytest.mark.parametrize(
-    "text_input, expected_tuple",
+    ("text_input", "expected_tuple"),
     [
         pytest.param("   2.7.18.final.0  ", (2, 7, 18, "final", 0), id="py27"),
         pytest.param("3.10.13.final.0\n", (3, 10, 13, "final", 0), id="py310"),

--- a/providers/standard/tests/unit/standard/operators/test_trigger_dagrun.py
+++ b/providers/standard/tests/unit/standard/operators/test_trigger_dagrun.py
@@ -478,7 +478,7 @@ class TestDagRunOperatorAF2:
             assert len(dagruns) == 2
 
     @pytest.mark.parametrize(
-        "trigger_run_id, trigger_logical_date",
+        ("trigger_run_id", "trigger_logical_date"),
         [
             (None, DEFAULT_DATE),
             ("dummy_run_id", None),
@@ -528,7 +528,7 @@ class TestDagRunOperatorAF2:
         assert dr.get_task_instance("test_task").state == TaskInstanceState.SKIPPED
 
     @pytest.mark.parametrize(
-        "trigger_run_id, trigger_logical_date, expected_dagruns_count",
+        ("trigger_run_id", "trigger_logical_date", "expected_dagruns_count"),
         [
             (None, DEFAULT_DATE, 1),
             (None, None, 2),
@@ -722,7 +722,7 @@ class TestDagRunOperatorAF2:
             task.execute_complete(context={}, event=trigger.serialize())
 
     @pytest.mark.parametrize(
-        argnames=["trigger_logical_date"],
+        argnames=("trigger_logical_date",),
         argvalues=[
             pytest.param(DEFAULT_DATE, id=f"logical_date={DEFAULT_DATE}"),
             pytest.param(None, id="logical_date=None"),

--- a/providers/standard/tests/unit/standard/operators/test_weekday.py
+++ b/providers/standard/tests/unit/standard/operators/test_weekday.py
@@ -288,7 +288,7 @@ class TestBranchDayOfWeekOperator:
                 )
 
     @pytest.mark.parametrize(
-        "_,week_day,fail_msg",
+        ("_", "week_day", "fail_msg"),
         [
             ("string", "Thsday", "Thsday"),
             ("list", ["Monday", "Thsday"], "Thsday"),


### PR DESCRIPTION
Issue: Enable Even More PyDocStyle Checks https://github.com/apache/airflow/issues/40567
@ferruzzi

This PR is for enable PT006 rule:
PT006: all instances of @pytest.mark.parametrize names should be a tuple
https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/

This is for standard Provider test(operator).

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
