### PR TITLE
Enable PT006 rule to standard Provider test(sensor, trigger) 5 files

### DIFF
--- a/providers/standard/tests/unit/standard/sensors/test_date_time.py
+++ b/providers/standard/tests/unit/standard/sensors/test_date_time.py
@@ -38,7 +38,7 @@ class TestDateTimeSensor:
         cls.dag = DAG("test_dag", schedule=None, default_args=args)
 
     @pytest.mark.parametrize(
-        "task_id, target_time, expected",
+        ("task_id", "target_time", "expected"),
         [
             (
                 "valid_datetime",
@@ -75,7 +75,7 @@ class TestDateTimeSensor:
             )
 
     @pytest.mark.parametrize(
-        "task_id, target_time, expected",
+        ("task_id", "target_time", "expected"),
         [
             (
                 "poke_datetime",
@@ -95,7 +95,7 @@ class TestDateTimeSensor:
         assert op.poke(None) == expected
 
     @pytest.mark.parametrize(
-        "native, target_time, expected_type",
+        ("native", "target_time", "expected_type"),
         [
             (False, "2025-01-01T00:00:00+00:00", pendulum.DateTime),
             (True, "{{ data_interval_end }}", pendulum.DateTime),

--- a/providers/standard/tests/unit/standard/sensors/test_external_task_sensor.py
+++ b/providers/standard/tests/unit/standard/sensors/test_external_task_sensor.py
@@ -859,7 +859,7 @@ exit 0
             )
 
     @pytest.mark.parametrize(
-        "kwargs, expected_message",
+        ("kwargs", "expected_message"),
         (
             (
                 {
@@ -884,7 +884,7 @@ exit 0
         ),
     )
     @pytest.mark.parametrize(
-        "soft_fail, expected_exception",
+        ("soft_fail", "expected_exception"),
         (
             (
                 False,
@@ -932,7 +932,7 @@ exit 0
                 op.execute(context={})
 
     @pytest.mark.parametrize(
-        "response_get_current, response_exists, kwargs, expected_message",
+        ("response_get_current", "response_exists", "kwargs", "expected_message"),
         (
             (None, None, {}, f"The external DAG {TEST_DAG_ID} does not exist."),
             (
@@ -957,7 +957,7 @@ exit 0
         ),
     )
     @pytest.mark.parametrize(
-        "soft_fail, expected_exception",
+        ("soft_fail", "expected_exception"),
         (
             (
                 False,
@@ -1520,7 +1520,7 @@ class TestExternalTaskAsyncSensor:
 
 @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Needs Flask app context fixture for AF 2")
 @pytest.mark.parametrize(
-    argnames=["external_dag_id", "external_task_id", "expected_external_dag_id", "expected_external_task_id"],
+    argnames=("external_dag_id", "external_task_id", "expected_external_dag_id", "expected_external_task_id"),
     argvalues=[
         ("dag_test", "task_test", "dag_test", "task_test"),
         ("dag_{{ ds }}", "task_{{ ds }}", f"dag_{DEFAULT_DATE.date()}", f"task_{DEFAULT_DATE.date()}"),

--- a/providers/standard/tests/unit/standard/sensors/test_time.py
+++ b/providers/standard/tests/unit/standard/sensors/test_time.py
@@ -40,7 +40,7 @@ DEFAULT_DATE_WITH_TZ = datetime(2015, 1, 1, tzinfo=DEFAULT_TIMEZONE)
 
 class TestTimeSensor:
     @pytest.mark.parametrize(
-        "tzinfo, start_date, target_time ,expected",
+        ("tzinfo", "start_date", "target_time", "expected"),
         [
             (timezone.utc, DEFAULT_DATE_WO_TZ, time(10, 0), True),
             (timezone.utc, DEFAULT_DATE_WITH_TZ, time(16, 0), True),
@@ -63,7 +63,7 @@ class TestTimeSensor:
             assert op.target_datetime.tzinfo == timezone.utc
 
     @pytest.mark.parametrize(
-        "current_datetime, server_timezone",
+        ("current_datetime", "server_timezone"),
         [
             ("2025-01-26 22:00:00", "UTC"),
             ("2025-01-27 07:00:00", "Asia/Seoul"),  # UTC+09:00

--- a/providers/standard/tests/unit/standard/triggers/test_external_task.py
+++ b/providers/standard/tests/unit/standard/triggers/test_external_task.py
@@ -224,7 +224,7 @@ class TestWorkflowTrigger:
         assert mock_sleep.await_count == 1
 
     @pytest.mark.parametrize(
-        "task_ids, task_group_id, states, logical_dates, mock_ti_count, mock_task_states, mock_dag_count, expected",
+        ("task_ids", "task_group_id", "states", "logical_dates", "mock_ti_count", "mock_task_states", "mock_dag_count", "expected"),
         [
             (
                 ["task_id_one", "task_id_two"],

--- a/providers/standard/tests/unit/standard/triggers/test_temporal.py
+++ b/providers/standard/tests/unit/standard/triggers/test_temporal.py
@@ -75,7 +75,7 @@ def test_timedelta_trigger_serialization():
 
 
 @pytest.mark.parametrize(
-    "tz, end_from_trigger",
+    ("tz", "end_from_trigger"),
     [
         (pendulum.timezone("UTC"), True),
         (pendulum.timezone("UTC"), False),  # only really need to test one


### PR DESCRIPTION
Issue: Enable Even More PyDocStyle Checks https://github.com/apache/airflow/issues/40567
@ferruzzi

This PR is for enable PT006 rule:
PT006: all instances of @pytest.mark.parametrize names should be a tuple
https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/

This is for standard Provider test(sensor, trigger)
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
