### PR TITLE
Add test setup and example asset operation tests to task SDK integration tests

### DIFF
--- a/task-sdk-tests/dags/test_asset_dag.py
+++ b/task-sdk-tests/dags/test_asset_dag.py
@@ -43,17 +43,3 @@ with DAG(
         return "asset_produced"
 
     produce_asset()
-
-
-with DAG(
-    dag_id="asset_consumer_dag",
-    description="DAG that is triggered by asset updates",
-    schedule=[test_asset],
-    catchup=False,
-) as consumer_dag:
-
-    @task
-    def consume_asset():
-        """Task that consumes the asset."""
-        print("Consuming test asset")
-        return "asset_consumed"

--- a/task-sdk-tests/dags/test_asset_dag.py
+++ b/task-sdk-tests/dags/test_asset_dag.py
@@ -1,0 +1,59 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Test DAG for asset operations.
+
+This file contains:
+- asset_producer_dag: A DAG that produces an asset
+- asset_consumer_dag: A DAG that is triggered by the asset
+"""
+
+from __future__ import annotations
+
+from airflow.sdk import DAG, Asset, task
+
+test_asset = Asset(uri="test://asset1", name="test_asset")
+
+with DAG(
+    dag_id="asset_producer_dag",
+    description="DAG that produces an asset for testing",
+    schedule=None,
+    catchup=False,
+) as producer_dag:
+
+    @task(outlets=[test_asset])
+    def produce_asset():
+        """Task that produces the test asset."""
+        print("Producing test asset")
+        return "asset_produced"
+
+    produce_asset()
+
+
+with DAG(
+    dag_id="asset_consumer_dag",
+    description="DAG that is triggered by asset updates",
+    schedule=[test_asset],
+    catchup=False,
+) as consumer_dag:
+
+    @task
+    def consume_asset():
+        """Task that consumes the asset."""
+        print("Consuming test asset")
+        return "asset_consumed"

--- a/task-sdk-tests/tests/task_sdk_tests/conftest.py
+++ b/task-sdk-tests/tests/task_sdk_tests/conftest.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -182,6 +183,220 @@ def pytest_sessionstart(session):
         raise
 
 
+def setup_dag_and_get_client(
+    *,
+    dag_id: str,
+    headers: dict[str, str],
+    auth_token: str | None = None,
+    task_id_filter: str | Callable[[dict], bool] | None = None,
+    wait_for_task_state: str | None = None,
+    wait_for_dag_state: str | None = None,
+    wait_timeout: int = 60,
+    additional_metadata: dict | None = None,
+) -> dict:
+    """
+    Utility to set up a DAG run and create an SDK client.
+
+    This function handles the common pattern of:
+    1. Getting DAG status
+    2. Unpausing DAG (if needed)
+    3. Triggering a DAG run
+    4. Waiting for task instances or DAG run state
+    5. Acquiring the task instance ID for the triggered DAG run
+    6. Generating JWT token for that task instance
+    7. Creating a task SDK client with that JWT token
+
+    Args:
+        dag_id: The DAG ID to set up
+        headers: Headers for API requests (must include Authorization)
+        auth_token: Auth token string (extracted from headers if not provided)
+        task_id_filter: Task ID to filter for, or callable that takes TI dict and returns bool.
+                       If None, uses first available task instance.
+        wait_for_task_state: If provided, wait for task instance to reach this state.
+                             Mutually exclusive with wait_for_dag_state.
+        wait_for_dag_state: If provided, wait for DAG run to reach this state.
+                            Mutually exclusive with wait_for_task_state.
+        wait_timeout: Maximum number of attempts to wait (each attempt is ~2 seconds)
+        additional_metadata: Additional metadata to include in return dict
+
+    Returns:
+        A dict which contains:
+        - dag_info: dict with dag_id, dag_run_id, logical_date
+        - task_instance_id: UUID string of task instance
+        - sdk_client: Authenticated SDK client
+        - core_api_headers: Headers for Core API requests
+        - auth_token: Auth token string
+        - Any additional metadata from additional_metadata
+
+    Raises:
+        TimeoutError: If waiting for the DAG run or task instance times out
+        RuntimeError: If task instance is not found or DAG run fails
+    """
+    import time
+
+    import requests
+
+    from airflow.sdk.api.client import Client
+    from airflow.sdk.timezone import utcnow
+    from task_sdk_tests.jwt_plugin import generate_jwt_token
+
+    if wait_for_task_state and wait_for_dag_state:
+        raise ValueError("Cannot specify both wait_for_task_state and wait_for_dag_state")
+
+    # Step 1: Get DAG status
+    console.print(f"[yellow]Checking {dag_id} status...")
+    dag_response = requests.get(f"http://localhost:8080/api/v2/dags/{dag_id}", headers=headers)
+    dag_response.raise_for_status()
+    dag_data = dag_response.json()
+
+    # Step 2: Unpause DAG if needed
+    if dag_data.get("is_paused", True):
+        console.print(f"[yellow]Unpausing {dag_id}...")
+        unpause_response = requests.patch(
+            f"http://localhost:8080/api/v2/dags/{dag_id}", json={"is_paused": False}, headers=headers
+        )
+        unpause_response.raise_for_status()
+        console.print(f"[green]✅ {dag_id} unpaused")
+
+    # Step 3: Trigger DAG run
+    logical_date = utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")[:-3] + "Z"
+    payload = {"conf": {}, "logical_date": logical_date}
+
+    console.print(f"[yellow]Triggering {dag_id}...")
+    trigger_response = requests.post(
+        f"http://localhost:8080/api/v2/dags/{dag_id}/dagRuns", json=payload, headers=headers, timeout=30
+    )
+    trigger_response.raise_for_status()
+    dag_run_data = trigger_response.json()
+    dag_run_id = dag_run_data["dag_run_id"]
+
+    console.print(f"[green]✅ {dag_id} triggered: {dag_run_id}")
+
+    # Step 4: Wait for condition
+    if wait_for_dag_state:
+        # Wait for DAG run to reach specific state
+        console.print(f"[yellow]Waiting for {dag_id} to reach state '{wait_for_dag_state}'...")
+        final_state = None
+        for attempt in range(wait_timeout):
+            try:
+                dr_response = requests.get(
+                    f"http://localhost:8080/api/v2/dags/{dag_id}/dagRuns/{dag_run_id}", headers=headers
+                )
+                dr_response.raise_for_status()
+                dr_data = dr_response.json()
+                state = dr_data.get("state")
+
+                if state == wait_for_dag_state:
+                    console.print(f"[green]✅ {dag_id} reached state '{wait_for_dag_state}'!")
+                    final_state = state
+                    break
+                if state in ["failed", "skipped"]:
+                    raise RuntimeError(f"{dag_id} ended in state: {state}")
+                console.print(
+                    f"[blue]Waiting for {dag_id} to reach '{wait_for_dag_state}' "
+                    f"(attempt {attempt + 1}/{wait_timeout}, current state: {state})"
+                )
+
+            except Exception as e:
+                console.print(f"[yellow]DAG run check failed: {e}")
+
+            time.sleep(2)
+
+        if final_state != wait_for_dag_state:
+            raise TimeoutError(f"{dag_id} did not reach state '{wait_for_dag_state}' within timeout period")
+
+    # Step 5: Get task instance ID
+    console.print(f"[yellow]Getting task instance ID from {dag_id}...")
+    ti_url = f"http://localhost:8080/api/v2/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances"
+    ti_response = requests.get(ti_url, headers=headers, timeout=10)
+    ti_response.raise_for_status()
+
+    task_instances = ti_response.json().get("task_instances", [])
+
+    # Filter task instances
+    if wait_for_task_state:
+        # Wait for specific task to reach specific state
+        console.print(f"[yellow]Waiting for task instance to reach state '{wait_for_task_state}'...")
+        ti_id = None
+
+        for attempt in range(wait_timeout):
+            try:
+                ti_response = requests.get(ti_url, headers=headers, timeout=10)
+                ti_response.raise_for_status()
+                task_instances = ti_response.json().get("task_instances", [])
+
+                # Filter task instances
+                for ti in task_instances:
+                    if callable(task_id_filter):
+                        matches_filter = task_id_filter(ti)
+                    elif task_id_filter:
+                        matches_filter = ti.get("task_id") == task_id_filter
+                    else:
+                        matches_filter = True
+
+                    if matches_filter and ti.get("state") == wait_for_task_state:
+                        ti_id = ti.get("id")
+                        if ti_id:
+                            console.print(f"[green]✅ Found task in '{wait_for_task_state}' state")
+                            console.print(f"[green]    Task ID: {ti.get('task_id')}")
+                            console.print(f"[green]    Instance ID: {ti_id}")
+                            break
+
+                if ti_id:
+                    break
+                console.print(f"[blue]Waiting for task instance (attempt {attempt + 1}/{wait_timeout})")
+
+            except Exception as e:
+                console.print(f"[yellow]Task check failed: {e}")
+
+            time.sleep(2)
+
+        if not ti_id:
+            raise TimeoutError(
+                f"Task instance did not reach '{wait_for_task_state}' state within timeout period"
+            )
+    else:
+        ti_id = None
+        for ti in task_instances:
+            if callable(task_id_filter):
+                matches_filter = task_id_filter(ti)
+            elif task_id_filter:
+                matches_filter = ti.get("task_id") == task_id_filter
+            else:
+                matches_filter = True
+
+            if matches_filter:
+                ti_id = ti.get("id")
+                break
+
+        if not ti_id:
+            raise RuntimeError(f"Could not find task instance ID from {dag_id}")
+
+        console.print(f"[green]✅ Found task instance ID: {ti_id}")
+
+    # Step 6: Generate JWT token and create SDK client
+    jwt_token = generate_jwt_token(ti_id)
+    sdk_client = Client(base_url=f"http://{TASK_SDK_HOST_PORT}/execution", token=jwt_token)
+
+    # Extract auth token from headers if not provided
+    if auth_token is None:
+        auth_token = headers.get("Authorization", "").replace("Bearer ", "")
+
+    # Build return dict
+    result = {
+        "auth_token": auth_token,
+        "dag_info": {"dag_id": dag_id, "dag_run_id": dag_run_id, "logical_date": logical_date},
+        "task_instance_id": ti_id,
+        "sdk_client": sdk_client,
+        "core_api_headers": headers,
+    }
+
+    if additional_metadata:
+        result.update(additional_metadata)
+
+    return result
+
+
 @pytest.fixture(scope="session")
 def airflow_ready(docker_compose_setup):
     """Shared fixture that waits for Airflow to be ready and provides auth token to communicate with Airflow."""
@@ -209,92 +424,17 @@ def airflow_ready(docker_compose_setup):
 @pytest.fixture(scope="session")
 def airflow_test_setup(docker_compose_setup, airflow_ready):
     """Fixed session-scoped fixture that matches UI behavior."""
-    import time
-
-    import requests
-
-    from airflow.sdk.api.client import Client
-    from airflow.sdk.timezone import utcnow
-    from task_sdk_tests.jwt_plugin import generate_jwt_token
-
-    auth_token = airflow_ready["auth_token"]
     headers = airflow_ready["headers"]
+    auth_token = airflow_ready["auth_token"]
 
-    # For regular test setup, we need a running dag, this part checks and triggers test_dag
-    console.print("[yellow]Checking DAG status...")
-    dag_response = requests.get("http://localhost:8080/api/v2/dags/test_dag", headers=headers)
-    dag_response.raise_for_status()
-    dag_data = dag_response.json()
-
-    if dag_data.get("is_paused", True):
-        console.print("[yellow]Unpausing DAG...")
-        unpause_response = requests.patch(
-            "http://localhost:8080/api/v2/dags/test_dag", json={"is_paused": False}, headers=headers
-        )
-        unpause_response.raise_for_status()
-        console.print("[green] DAG unpaused")
-    logical_date = utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")[:-3] + "Z"
-    payload = {"conf": {}, "logical_date": logical_date}
-
-    trigger_response = requests.post(
-        "http://localhost:8080/api/v2/dags/test_dag/dagRuns", json=payload, headers=headers, timeout=30
+    return setup_dag_and_get_client(
+        dag_id="test_dag",
+        headers=headers,
+        auth_token=auth_token,
+        task_id_filter="long_running_task",
+        wait_for_task_state="running",
+        wait_timeout=30,
     )
-
-    console.print(f"[blue]Trigger DAG Run response status: {trigger_response.status_code}")
-    console.print(f"[blue]Trigger DAG Run response: {trigger_response.text}")
-
-    trigger_response.raise_for_status()
-    dag_run_data = trigger_response.json()
-    dag_run_id = dag_run_data["dag_run_id"]
-
-    console.print(f"[green]DAG triggered: {dag_run_id}")
-
-    # Get task instance for testing - wait for long_running_task to be RUNNING
-    console.print("[yellow]Waiting for long_running_task to be RUNNING...")
-    ti_id = None
-
-    for attempt in range(30):
-        try:
-            ti_url = f"http://localhost:8080/api/v2/dags/test_dag/dagRuns/{dag_run_id}/taskInstances"
-            ti_response = requests.get(ti_url, headers=headers, timeout=10)
-            ti_response.raise_for_status()
-
-            task_instances = ti_response.json().get("task_instances", [])
-
-            # Look specifically for long_running_task that is in RUNNING state
-            for ti in task_instances:
-                if ti.get("task_id") == "long_running_task" and ti.get("state") == "running":
-                    ti_id = ti.get("id")
-                    if ti_id:
-                        console.print(f"[green]✅ Found running task: '{ti.get('task_id')}'")
-                        console.print(f"[green]    State: {ti.get('state')}")
-                        console.print(f"[green]    Instance ID: {ti_id}")
-                        break
-
-            if ti_id:
-                break
-            console.print(f"[blue]Waiting for long_running_task to start (attempt {attempt + 1}/30)")
-
-        except Exception as e:
-            console.print(f"[yellow]Task check failed: {e}")
-
-        time.sleep(2)
-
-    if not ti_id:
-        console.print("[red] long_running_task never reached RUNNING state. Final debug info:")
-        raise TimeoutError("long_running_task did not reach RUNNING state within timeout period")
-
-    # Create SDK client and return it
-    jwt_token = generate_jwt_token(ti_id)
-    sdk_client = Client(base_url=f"http://{TASK_SDK_HOST_PORT}/execution", token=jwt_token)
-
-    return {
-        "auth_token": auth_token,
-        "dag_info": {"dag_id": "test_dag", "dag_run_id": dag_run_id, "logical_date": logical_date},
-        "task_instance_id": ti_id,
-        "sdk_client": sdk_client,
-        "core_api_headers": headers,
-    }
 
 
 @pytest.fixture(scope="session")
@@ -344,100 +484,18 @@ def sdk_client_for_assets(asset_test_setup):
 @pytest.fixture(scope="session")
 def asset_test_setup(docker_compose_setup, airflow_ready):
     """Setup assets for testing by triggering asset_producer_dag."""
-    import time
-
-    import requests
-
-    from airflow.sdk.api.client import Client
-    from airflow.sdk.timezone import utcnow
-    from task_sdk_tests.jwt_plugin import generate_jwt_token
-
     headers = airflow_ready["headers"]
+    auth_token = airflow_ready["auth_token"]
 
-    # For asset test setup, we need to trigger asset_producer_dag to create test asset
-    console.print("[yellow]Checking asset_producer_dag status...")
-    dag_response = requests.get("http://localhost:8080/api/v2/dags/asset_producer_dag", headers=headers)
-    dag_response.raise_for_status()
-    dag_data = dag_response.json()
-
-    if dag_data.get("is_paused", True):
-        console.print("[yellow]Unpausing asset_producer_dag...")
-        unpause_response = requests.patch(
-            "http://localhost:8080/api/v2/dags/asset_producer_dag", json={"is_paused": False}, headers=headers
-        )
-        unpause_response.raise_for_status()
-        console.print("[green]asset_producer_dag unpaused")
-
-    logical_date = utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")[:-3] + "Z"
-    payload = {"conf": {}, "logical_date": logical_date}
-
-    console.print("[yellow]Triggering asset_producer_dag...")
-    trigger_response = requests.post(
-        "http://localhost:8080/api/v2/dags/asset_producer_dag/dagRuns",
-        json=payload,
+    return setup_dag_and_get_client(
+        dag_id="asset_producer_dag",
         headers=headers,
-        timeout=30,
+        auth_token=auth_token,
+        task_id_filter="produce_asset",
+        wait_for_dag_state="success",
+        wait_timeout=60,
+        additional_metadata={
+            "name": "test_asset",
+            "uri": "test://asset1/",
+        },
     )
-
-    trigger_response.raise_for_status()
-    dag_run_data = trigger_response.json()
-    dag_run_id = dag_run_data["dag_run_id"]
-
-    console.print(f"[green]asset_producer_dag triggered: {dag_run_id}")
-
-    console.print("[yellow]Waiting for asset_producer_dag to complete...")
-    final_state = None
-    for attempt in range(60):
-        try:
-            dr_response = requests.get(
-                f"http://localhost:8080/api/v2/dags/asset_producer_dag/dagRuns/{dag_run_id}", headers=headers
-            )
-            dr_response.raise_for_status()
-            dr_data = dr_response.json()
-            state = dr_data.get("state")
-
-            if state == "success":
-                console.print("[green]asset_producer_dag completed successfully!")
-                final_state = state
-                break
-            if state in ["failed", "skipped"]:
-                raise RuntimeError(f"asset_producer_dag ended in state: {state}")
-            console.print(
-                f"[blue]Waiting for asset_producer_dag to complete (attempt {attempt + 1}/60, state: {state})"
-            )
-
-        except Exception as e:
-            console.print(f"[yellow]DAG run check failed: {e}")
-
-        time.sleep(2)
-
-    if final_state != "success":
-        raise TimeoutError("asset_producer_dag did not complete successfully within timeout period")
-
-    # Get task instance for testing - wait for long_running_task to be RUNNING
-    console.print("[yellow]Getting task instance ID from asset_producer_dag...")
-    ti_url = f"http://localhost:8080/api/v2/dags/asset_producer_dag/dagRuns/{dag_run_id}/taskInstances"
-    ti_response = requests.get(ti_url, headers=headers, timeout=10)
-    ti_response.raise_for_status()
-
-    task_instances = ti_response.json().get("task_instances", [])
-    ti_id = None
-    for ti in task_instances:
-        if ti.get("task_id") == "produce_asset":
-            ti_id = ti.get("id")
-            break
-
-    if not ti_id:
-        raise RuntimeError("Could not find task instance ID from asset_producer_dag")
-
-    console.print(f"[green]Found task instance ID: {ti_id}")
-
-    jwt_token = generate_jwt_token(ti_id)
-    sdk_client = Client(base_url=f"http://{TASK_SDK_HOST_PORT}/execution", token=jwt_token)
-
-    return {
-        "name": "test_asset",
-        "uri": "test://asset1/",
-        "dag_run_id": dag_run_id,
-        "sdk_client": sdk_client,
-    }

--- a/task-sdk-tests/tests/task_sdk_tests/test_asset_operations.py
+++ b/task-sdk-tests/tests/task_sdk_tests/test_asset_operations.py
@@ -1,0 +1,65 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Integration tests for Asset operations.
+
+These tests validate the Execution API endpoints for Asset operations:
+- get(): Get asset by name
+"""
+
+from __future__ import annotations
+
+from airflow.sdk.api.datamodels._generated import AssetResponse
+from airflow.sdk.execution_time.comms import ErrorResponse
+from task_sdk_tests import console
+
+
+def test_asset_get_by_name(sdk_client_for_assets, asset_test_setup):
+    """Test getting asset by name."""
+    console.print("[yellow]Getting asset by name...")
+
+    response = sdk_client_for_assets.assets.get(name=asset_test_setup["name"])
+
+    console.print(" Asset Get By Name Response ".center(72, "="))
+    console.print(f"[bright_blue]Response Type:[/] {type(response).__name__}")
+    console.print(f"[bright_blue]Name:[/] {response.name}")
+    console.print(f"[bright_blue]URI:[/] {response.uri}")
+    console.print(f"[bright_blue]Group:[/] {response.group}")
+    console.print("=" * 72)
+
+    assert isinstance(response, AssetResponse)
+    assert response.name == asset_test_setup["name"]
+    assert response.uri == asset_test_setup["uri"]
+    console.print("[green]Asset get by name test passed!")
+
+
+def test_asset_get_by_name_not_found(sdk_client_for_assets):
+    """Test getting non-existent asset by name."""
+    console.print("[yellow]Getting non-existent asset by name...")
+
+    response = sdk_client_for_assets.assets.get(name="non_existent_asset_name")
+
+    console.print(" Asset Get (Not Found) Response ".center(72, "="))
+    console.print(f"[bright_blue]Response Type:[/] {type(response).__name__}")
+    console.print(f"[bright_blue]Error Type:[/] {response.error}")
+    console.print(f"[bright_blue]Detail:[/] {response.detail}")
+    console.print("=" * 72)
+
+    assert isinstance(response, ErrorResponse)
+    assert str(response.error).endswith("ASSET_NOT_FOUND")
+    console.print("[green]Asset get by name (not found) test passed!")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Adding tests for asset operations by virtue of doing the following:

1. Adding similar test setup for asset dag trigger etc as the normal dag operations added in #56139
2. Adding an example test dag for assets that will be triggered manually through the tests to test for creation of assets, this dag will be useful for testing asset events (coming next)
3. Covers the `get` call for now, both positive and negative cases, will add stubs for the rest in a follow up


Ran all tests and it works like I'd like:
```
(airflow) ➜  task-sdk-tests git:(extend-integration-tests-asset-operations) ✗ uv run pytest -s
      Built apache-airflow @ file:///Users/amoghdesai/Documents/OSS/repos/airflow
Uninstalled 1 package in 1ms
Installed 1 package in 1ms
================================================= test session starts =================================================
platform darwin -- Python 3.13.3, pytest-8.4.1, pluggy-1.6.0 -- /Users/amoghdesai/Documents/OSS/repos/airflow/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /Users/amoghdesai/Documents/OSS/repos/airflow/task-sdk-tests
configfile: pyproject.toml
plugins: unordered-0.7.0, instafail-0.5.0, timeouts-1.2.1, asyncio-1.1.0, xdist-3.8.0, custom-exit-code-0.3.0, anyio-4.10.0, icdiff-0.9, rerunfailures-15.1, cov-6.2.1, kgb-7.2, mock-3.14.1, time-machine-2.17.0, requests-mock-1.12.1
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
setup timeout: 0.0s, execution timeout: 0.0s, teardown timeout: 0.0s
collected 18 items                                                                                                    

tests/task_sdk_tests/test_asset_event_operations.py::test_asset_event_get SKIPPED (TODO: Implement Asset Event
operations tests)
tests/task_sdk_tests/test_asset_operations.py::test_asset_get_by_name Starting docker-compose for session...
WARN[0000] The "AIRFLOW_UID" variable is not set. Defaulting to a blank string. 
WARN[0000] The "AIRFLOW_UID" variable is not set. Defaulting to a blank string. 
[+] Running 6/6
 ✔ Network airflow-task-sdk-test0_default                    Created                                              0.0s 
 ✔ Container airflow-task-sdk-test0-postgres-1               Hea...                                              28.1s 
 ✔ Container airflow-task-sdk-test0-airflow-init-1           Exited                                              28.1s 
 ✔ Container airflow-task-sdk-test0-airflow-dag-processor-1  Healthy                                             28.0s 
 ✔ Container airflow-task-sdk-test0-airflow-apiserver-1      Healthy                                             43.0s 
 ✔ Container airflow-task-sdk-test0-airflow-scheduler-1      Healthy                                             59.5s 
Docker compose started successfully!

✅ Got auth token
Checking asset_producer_dag status...
Unpausing asset_producer_dag...
✅ asset_producer_dag unpaused
Triggering asset_producer_dag...
✅ asset_producer_dag triggered: manual__2025-11-07T07:36:18.945797+00:00
Waiting for asset_producer_dag to complete...
Waiting for asset_producer_dag to complete (attempt 1/60, state: queued)
Waiting for asset_producer_dag to complete (attempt 2/60, state: running)
✅ asset_producer_dag completed successfully!
Getting task instance ID from asset_producer_dag...
✅ Found task instance ID: 019a5d3e-a98b-7eba-b1e1-11cbdfd8829f
Getting asset by name...
====================== Asset Get By Name Response ======================
Response Type: AssetResponse
Name: test_asset
URI: test://asset1/
Group: asset
========================================================================
✅ Asset get by name test passed!
PASSED
tests/task_sdk_tests/test_asset_operations.py::test_asset_get_by_name_not_found Getting non-existent asset by name...
[2025-11-07T07:36:23.293231Z] {client.py:606} ERROR - Asset not found params={'name': 'non_existent_asset_name'} detail={'detail': {'reason': 'not_found', 'message': 'Asset with name non_existent_asset_name not found'}} status_code=404
==================== Asset Get (Not Found) Response ====================
Response Type: ErrorResponse
Error Type: ErrorType.ASSET_NOT_FOUND
Detail: {'name': 'non_existent_asset_name'}
========================================================================
✅ Asset get by name (not found) test passed!
PASSED
tests/task_sdk_tests/test_connection_operations.py::test_connection_get Checking DAG status...
Unpausing DAG...
✅ DAG unpaused
Trigger DAG Run response status: 200
Trigger DAG Run response: 
{"dag_run_id":"manual__2025-11-07T07:36:23.314944+00:00","dag_id":"test_dag","logical_date":"2025-11-07T07:36:23.311200Z","queued_at":"2025-11-07T07:36:23.320298Z","start_date":null,"end_date":null,"duration":null,"data_interval_start":"2025-11-07T07:36:23.311200Z","data_interval_end":"2025-11-07T07:36:23.311200Z","run_after":"2025-11-07T07:36:23.311200Z","last_scheduling_decision":null,"run_type"
:"manual","state":"queued","triggered_by":"rest_api","triggering_user_name":"Anonymous","conf":{},"note":null,"dag_versions":[{"id":"019a5d3e-0bb1-7065-ba4a-2280d4827f70","version_number":1,"dag_id":"test_dag","bundle_name":"dags-folder","bundle_version":null,"created_at":"2025-11-07T07:35:38.673050Z","dag_display_name":"test_dag","bundle_url":null}],"bundle_version":null,"dag_display_name":"test_
dag"}
✅ DAG triggered: manual__2025-11-07T07:36:23.314944+00:00
Waiting for long_running_task to be RUNNING...
Waiting for long_running_task to start (attempt 1/30)
Waiting for long_running_task to start (attempt 2/30)
Waiting for long_running_task to start (attempt 3/30)
Waiting for long_running_task to start (attempt 4/30)
✅ Found running task: 'long_running_task'
    State: running
    Instance ID: 019a5d3e-ba20-7b5e-b0a3-dcfc614a5001
Getting connection details...
======================= Connection Get Response ========================
Response Type: ConnectionResponse
Connection ID: test_connection
Connection Type: postgres
Host: testhost
Schema: <bound method BaseModel.schema of <class 'airflow.sdk.api.datamodels._generated.ConnectionResponse'>>
========================================================================
✅ Connection get test passed!
PASSED
tests/task_sdk_tests/test_hitl_operations.py::test_hitl_add_response SKIPPED (TODO: Implement HITL operations
tests)
tests/task_sdk_tests/test_hitl_operations.py::test_hitl_update_response SKIPPED (TODO: Implement HITL
operations tests)
tests/task_sdk_tests/test_hitl_operations.py::test_hitl_get_detail_response SKIPPED (TODO: Implement HITL
operations tests)
tests/task_sdk_tests/test_task_instance_operations.py::test_ti_get_previous_successful_dagrun Getting previous successful DAG run...
===================== Previous Successful DAG Run ======================
Response Type: PrevSuccessfulDagRunResponse
Data Interval Start: None
Data Interval End: None
Start Date: None
End Date: None
========================================================================
✅ Previous DAG run test passed!
PASSED
tests/task_sdk_tests/test_task_instance_operations.py::test_ti_validate_inlets_and_outlets Validating inlets and outlets...
======================= Validate Inlets/Outlets ========================
Response Type: InactiveAssetsResponse
Inactive Assets Count: 0
Inactive Assets: []
========================================================================
✅ Validate inlets/outlets test passed!
PASSED
tests/task_sdk_tests/test_task_instance_operations.py::test_ti_get_count Getting task instance count...
========================= Task Instance Count ==========================
DAG ID: test_dag
Count: 3
========================================================================
✅ Task instance count test passed!
PASSED
tests/task_sdk_tests/test_task_instance_operations.py::test_ti_get_task_states Getting task states...
============================= Task States ==============================
Response Type: TaskStatesResponse
DAG ID: test_dag
Run ID: manual__2025-11-07T07:36:23.314944+00:00
Task States: {'manual__2025-11-07T07:36:23.314944+00:00': {'get_task_instance_id': 'success', 'long_running_task': 'running', 'return_tuple_task': 'success'}}
========================================================================
✅ Task states test passed!
PASSED
tests/task_sdk_tests/test_task_instance_operations.py::test_ti_set_rtif Setting Rendered Task Instance Fields...
============================ RTIF Response =============================
Response Type: OKResponse
Status: True
Task Instance ID: 019a5d3e-ba20-7b5e-b0a3-dcfc614a5001
Fields Set: ['rendered_field_1', 'rendered_field_2']
========================================================================
✅ RTIF test passed!
PASSED
tests/task_sdk_tests/test_task_instance_operations.py::test_ti_heartbeat Getting task instance details for heartbeat...
========================== Worker Information ==========================
Worker Hostname: 6ae0460ef102
Worker PID: 47
========================================================================
Sending heartbeat with worker's PID/hostname...
========================== Heartbeat Response ==========================
Status: Success (204 No Content)
Task Instance ID: 019a5d3e-ba20-7b5e-b0a3-dcfc614a5001
Used PID: 47
Used Hostname: 6ae0460ef102
========================================================================
✅ Heartbeat test passed!
PASSED
tests/task_sdk_tests/test_task_instance_operations.py::test_ti_state_transitions Testing state transition: RUNNING → FAILED...
======================= State: FAILED (Terminal) =======================
Transition: RUNNING → FAILED
Status: Success (204 No Content)
Final State: FAILED
Task Instance ID: 019a5d3e-ba20-7b5e-b0a3-dcfc614a5001
========================================================================
✅ Successfully transitioned to FAILED terminal state!
PASSED
tests/task_sdk_tests/test_task_sdk_health.py::test_task_sdk_health Making health check request...
======================== Health Check Response =========================
Status Code: 200
Response: {'ok': ['airflow.api_fastapi.auth.tokens.JWTValidator'], 'failing': {}}
========================================================================
✅ Task SDK health check passed!
PASSED
tests/task_sdk_tests/test_xcom_operations.py::test_get_xcom Getting existing XCom from return_tuple_task...
========================== XCom Get Response ===========================
Response Type: XComResponse
Key: return_value
Value Type: dict
Value: {'__data__': [1, 'test_value'], '__version__': 1, '__classname__': 'builtins.tuple'}
========================================================================
✅ XCom get test passed!
PASSED
tests/task_sdk_tests/test_xcom_operations.py::test_set_xcom Setting XCom value...
========================== XCom Set Response ===========================
Response Type: OKResponse
Status: True
========================================================================
Getting XCom value...
========================== XCom Get Response ===========================
Response Type: XComResponse
Key: test_xcom_key
Value: {'test': 'data', 'number': 42}
========================================================================
✅ XCom set and get test passed!
PASSED
tests/task_sdk_tests/test_xcom_operations.py::test_xcom_delete Deleting XCom value...
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
