### PR TITLE
Add number of queries guard for ui structure

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/structure.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/structure.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from fastapi import Depends, HTTPException, status
 from sqlalchemy import select
+from sqlalchemy.orm import joinedload
 
 from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity
 from airflow.api_fastapi.common.db.common import SessionDep
@@ -31,6 +32,7 @@ from airflow.api_fastapi.core_api.services.ui.structure import (
     get_upstream_assets,
 )
 from airflow.api_fastapi.core_api.services.ui.task_group import task_group_to_dict
+from airflow.models.dag import DagModel
 from airflow.models.dag_version import DagVersion
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.utils.dag_edges import dag_edges
@@ -70,6 +72,7 @@ def structure_data(
         select(SerializedDagModel)
         .join(DagVersion)
         .where(SerializedDagModel.dag_id == dag_id, DagVersion.version_number == version_number)
+        .options(joinedload(SerializedDagModel.dag_model).joinedload(DagModel.task_outlet_asset_references)),
     )
     if serialized_dag is None:
         raise HTTPException(

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_structure.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_structure.py
@@ -33,6 +33,7 @@ from airflow.providers.standard.sensors.external_task import ExternalTaskSensor
 from airflow.sdk import Metadata, task
 from airflow.sdk.definitions.asset import Asset, AssetAlias, Dataset
 
+from tests_common.test_utils.asserts import assert_queries_count
 from tests_common.test_utils.db import clear_db_assets, clear_db_runs
 
 pytestmark = pytest.mark.db_test
@@ -207,7 +208,7 @@ def asset3_id(make_dags, asset3, session) -> str:
 
 class TestStructureDataEndpoint:
     @pytest.mark.parametrize(
-        ("params", "expected"),
+        ("params", "expected", "expected_queries_count"),
         [
             (
                 {"dag_id": DAG_ID},
@@ -264,6 +265,7 @@ class TestStructureDataEndpoint:
                         },
                     ],
                 },
+                3,
             ),
             (
                 {
@@ -271,6 +273,7 @@ class TestStructureDataEndpoint:
                     "root": "unknown_task",
                 },
                 {"edges": [], "nodes": []},
+                3,
             ),
             (
                 {
@@ -295,6 +298,7 @@ class TestStructureDataEndpoint:
                         },
                     ],
                 },
+                3,
             ),
             (
                 {"dag_id": DAG_ID_EXTERNAL_TRIGGER, "external_dependencies": True},
@@ -333,12 +337,14 @@ class TestStructureDataEndpoint:
                         },
                     ],
                 },
+                10,
             ),
         ],
     )
     @pytest.mark.usefixtures("make_dags")
-    def test_should_return_200(self, test_client, params, expected):
-        response = test_client.get("/structure/structure_data", params=params)
+    def test_should_return_200(self, test_client, params, expected, expected_queries_count):
+        with assert_queries_count(expected_queries_count):
+            response = test_client.get("/structure/structure_data", params=params)
         assert response.status_code == 200
         assert response.json() == expected
 
@@ -528,7 +534,8 @@ class TestStructureDataEndpoint:
             ],
         }
 
-        response = test_client.get("/structure/structure_data", params=params)
+        with assert_queries_count(10):
+            response = test_client.get("/structure/structure_data", params=params)
         assert response.status_code == 200
         assert response.json() == expected
 


### PR DESCRIPTION
Related: https://github.com/apache/airflow/issues/57561

N+1 queries problem found and solved.

Some structures request create a lot of db queries (10), that's caused by the `_DagDependenciesResolver` but that number of queries is fixed.