### PR TITLE
Patch pools should have an optional description

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/pools.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/pools.py
@@ -39,7 +39,7 @@ class BasePool(BaseModel):
 
     pool: str = Field(serialization_alias="name")
     slots: int
-    description: str | None
+    description: str | None = Field(default=None)
     include_deferred: bool
 
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -11838,7 +11838,6 @@ components:
       required:
       - name
       - slots
-      - description
       - include_deferred
       - occupied_slots
       - running_slots

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -4651,7 +4651,7 @@ export const $PoolResponse = {
         }
     },
     type: 'object',
-    required: ['name', 'slots', 'description', 'include_deferred', 'occupied_slots', 'running_slots', 'queued_slots', 'scheduled_slots', 'open_slots', 'deferred_slots'],
+    required: ['name', 'slots', 'include_deferred', 'occupied_slots', 'running_slots', 'queued_slots', 'scheduled_slots', 'open_slots', 'deferred_slots'],
     title: 'PoolResponse',
     description: 'Pool serializer for responses.'
 } as const;

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -1211,7 +1211,7 @@ export type PoolPatchBody = {
 export type PoolResponse = {
     name: string;
     slots: number;
-    description: string | null;
+    description?: string | null;
     include_deferred: boolean;
     occupied_slots: number;
     running_slots: number;

--- a/airflow-core/src/airflow/ui/src/pages/Pools/PoolForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Pools/PoolForm.tsx
@@ -89,8 +89,9 @@ const PoolForm = ({ error, initialPool, isPending, manageMutate, setError }: Poo
             <Field.Label fontSize="md">{translate("pools.form.slots")}</Field.Label>
             <Input
               min={initialPool.slots}
-              onChange={(e) => {
-                const value = e.target.valueAsNumber;
+              onChange={(event) => {
+                const value = event.target.valueAsNumber;
+
                 field.onChange(isNaN(value) ? field.value : value);
               }}
               size="sm"

--- a/airflow-core/src/airflow/ui/src/pages/Pools/PoolForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Pools/PoolForm.tsx
@@ -87,7 +87,16 @@ const PoolForm = ({ error, initialPool, isPending, manageMutate, setError }: Poo
         render={({ field }) => (
           <Field.Root mt={4}>
             <Field.Label fontSize="md">{translate("pools.form.slots")}</Field.Label>
-            <Input {...field} min={initialPool.slots} size="sm" type="number" />
+            <Input
+              min={initialPool.slots}
+              onChange={(e) => {
+                const value = e.target.valueAsNumber;
+                field.onChange(isNaN(value) ? field.value : value);
+              }}
+              size="sm"
+              type="number"
+              value={field.value}
+            />
           </Field.Root>
         )}
       />
@@ -128,7 +137,7 @@ const PoolForm = ({ error, initialPool, isPending, manageMutate, setError }: Poo
           <Spacer />
           <Button
             colorPalette="brand"
-            disabled={!isValid || isPending}
+            disabled={!isValid || isPending || !isDirty}
             onClick={() => void handleSubmit(onSubmit)()}
           >
             <FiSave /> {translate("formActions.save")}

--- a/airflow-core/src/airflow/ui/src/queries/useEditPool.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useEditPool.ts
@@ -65,19 +65,18 @@ export const useEditPool = (
 
   const editPool = (editPoolRequestBody: PoolBody) => {
     const updateMask: Array<string> = [];
+    var parsedDescription = undefined;
 
     if (editPoolRequestBody.slots !== initialPool.slots) {
       updateMask.push("slots");
     }
     if (editPoolRequestBody.description !== initialPool.description) {
+      parsedDescription = editPoolRequestBody.description;
       updateMask.push("description");
     }
     if (editPoolRequestBody.include_deferred !== initialPool.include_deferred) {
       updateMask.push("include_deferred");
     }
-
-    const parsedDescription =
-      editPoolRequestBody.description === "" ? undefined : editPoolRequestBody.description;
 
     mutate({
       poolName: initialPool.name,

--- a/airflow-core/src/airflow/ui/src/queries/useEditPool.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useEditPool.ts
@@ -65,7 +65,7 @@ export const useEditPool = (
 
   const editPool = (editPoolRequestBody: PoolBody) => {
     const updateMask: Array<string> = [];
-    var parsedDescription = undefined;
+    let parsedDescription = undefined;
 
     if (editPoolRequestBody.slots !== initialPool.slots) {
       updateMask.push("slots");

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py
@@ -266,12 +266,6 @@ class TestPatchPool(TestPoolsEndpoint):
                         },
                         {
                             "input": {"pool": POOL1_NAME},
-                            "loc": ["description"],
-                            "msg": "Field required",
-                            "type": "missing",
-                        },
-                        {
-                            "input": {"pool": POOL1_NAME},
                             "loc": ["include_deferred"],
                             "msg": "Field required",
                             "type": "missing",


### PR DESCRIPTION
Issue - 

1. The edit pool was throwing required error when empty (though being an optional field)

<img width="1710" height="698" alt="image" src="https://github.com/user-attachments/assets/e00b1eea-34be-42c1-8739-478f33a019c8" />

2. The Submit button should only be active if there is some changes.

------------------------

Fix - 

https://github.com/user-attachments/assets/c58c20e3-97b6-446a-88eb-e735fae36b0e


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
