### PR TITLE
rename names of data models related to roles for consistency across requests and responses

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/datamodels/roles.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/datamodels/roles.py
@@ -21,30 +21,30 @@ from pydantic import Field
 from airflow.api_fastapi.core_api.base import BaseModel, StrictBaseModel
 
 
-class ActionResponse(BaseModel):
+class Action(BaseModel):
     """Outgoing representation of an action (permission name)."""
 
     name: str
 
 
-class ResourceResponse(BaseModel):
+class Resource(BaseModel):
     """Outgoing representation of a resource."""
 
     name: str
 
 
-class ActionResourceResponse(BaseModel):
+class ActionResource(BaseModel):
     """Pairing of an action with a resource."""
 
-    action: ActionResponse
-    resource: ResourceResponse
+    action: Action
+    resource: Resource
 
 
 class RoleBody(StrictBaseModel):
     """Incoming payload for creating/updating a role."""
 
     name: str = Field(min_length=1)
-    permissions: list[ActionResourceResponse] = Field(
+    permissions: list[ActionResource] = Field(
         default_factory=list, alias="actions", validation_alias="actions"
     )
 
@@ -53,7 +53,7 @@ class RoleResponse(BaseModel):
     """Outgoing representation of a role and its permissions."""
 
     name: str
-    permissions: list[ActionResourceResponse] = Field(default_factory=list, serialization_alias="actions")
+    permissions: list[ActionResource] = Field(default_factory=list, serialization_alias="actions")
 
 
 class RoleCollectionResponse(BaseModel):

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/openapi/v2-fab-auth-manager-generated.yaml
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/openapi/v2-fab-auth-manager-generated.yaml
@@ -326,19 +326,7 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
 components:
   schemas:
-    ActionResourceResponse:
-      properties:
-        action:
-          $ref: '#/components/schemas/ActionResponse'
-        resource:
-          $ref: '#/components/schemas/ResourceResponse'
-      type: object
-      required:
-      - action
-      - resource
-      title: ActionResourceResponse
-      description: Pairing of an action with a resource.
-    ActionResponse:
+    Action:
       properties:
         name:
           type: string
@@ -346,8 +334,20 @@ components:
       type: object
       required:
       - name
-      title: ActionResponse
+      title: Action
       description: Outgoing representation of an action (permission name).
+    ActionResource:
+      properties:
+        action:
+          $ref: '#/components/schemas/Action'
+        resource:
+          $ref: '#/components/schemas/Resource'
+      type: object
+      required:
+      - action
+      - resource
+      title: ActionResource
+      description: Pairing of an action with a resource.
     HTTPExceptionResponse:
       properties:
         detail:
@@ -394,7 +394,7 @@ components:
       - access_token
       title: LoginResponse
       description: API Token serializer for responses.
-    ResourceResponse:
+    Resource:
       properties:
         name:
           type: string
@@ -402,7 +402,7 @@ components:
       type: object
       required:
       - name
-      title: ResourceResponse
+      title: Resource
       description: Outgoing representation of a resource.
     RoleBody:
       properties:
@@ -412,7 +412,7 @@ components:
           title: Name
         actions:
           items:
-            $ref: '#/components/schemas/ActionResourceResponse'
+            $ref: '#/components/schemas/ActionResource'
           type: array
           title: Actions
       additionalProperties: false
@@ -444,7 +444,7 @@ components:
           title: Name
         actions:
           items:
-            $ref: '#/components/schemas/ActionResourceResponse'
+            $ref: '#/components/schemas/ActionResource'
           type: array
           title: Actions
       type: object

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/datamodels/test_roles.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/datamodels/test_roles.py
@@ -22,9 +22,9 @@ import pytest
 from pydantic import ValidationError
 
 from airflow.providers.fab.auth_manager.api_fastapi.datamodels.roles import (
-    ActionResourceResponse,
-    ActionResponse,
-    ResourceResponse,
+    Action,
+    ActionResource,
+    Resource,
     RoleBody,
     RoleCollectionResponse,
     RoleResponse,
@@ -57,9 +57,9 @@ class TestRoleModels:
             RoleBody.model_validate({"name": "", "actions": []})
 
     def test_roleresponse_serializes_permissions_under_actions_alias(self):
-        ar = ActionResourceResponse(
-            action=ActionResponse(name="can_read"),
-            resource=ResourceResponse(name="DAG"),
+        ar = ActionResource(
+            action=Action(name="can_read"),
+            resource=Resource(name="DAG"),
         )
         rr = RoleResponse(name="viewer", permissions=[ar])
 
@@ -89,9 +89,9 @@ class TestRoleModels:
         assert first.action.name == "can_read"
 
     def test_rolecollection_response_dump_and_counts(self):
-        ar = ActionResourceResponse(
-            action=ActionResponse(name="can_read"),
-            resource=ResourceResponse(name="DAG"),
+        ar = ActionResource(
+            action=Action(name="can_read"),
+            resource=Resource(name="DAG"),
         )
         rc = RoleCollectionResponse(
             roles=[RoleResponse(name="viewer", permissions=[ar])],


### PR DESCRIPTION
# Why

https://github.com/apache/airflow/pull/57480#discussion_r2472978418

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
