### PR TITLE
Fix broken canary, remove unneeded crypto key generation

### DIFF
--- a/airflow-core/tests/unit/always/test_connection.py
+++ b/airflow-core/tests/unit/always/test_connection.py
@@ -103,12 +103,10 @@ class UriTestCaseConfig:
 
 class TestConnection:
     def setup_method(self):
-        crypto._fernet = None
         self.patcher = mock.patch("airflow.models.connection.mask_secret", autospec=True)
         self.mask_secret = self.patcher.start()
 
     def teardown_method(self):
-        crypto._fernet = None
         self.patcher.stop()
 
     @conf_vars({("core", "fernet_key"): ""})

--- a/airflow-core/tests/unit/models/test_connection.py
+++ b/airflow-core/tests/unit/models/test_connection.py
@@ -23,14 +23,12 @@ from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
-from cryptography.fernet import Fernet
 
 from airflow.exceptions import AirflowException, AirflowNotFoundException
 from airflow.models import Connection
 from airflow.sdk.exceptions import AirflowRuntimeError, ErrorType
 from airflow.sdk.execution_time.comms import ErrorResponse
 
-from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import clear_db_connections
 
 if TYPE_CHECKING:
@@ -40,15 +38,6 @@ if TYPE_CHECKING:
 
 
 class TestConnection:
-    @pytest.fixture(autouse=True)
-    def clear_fernet_cache(self):
-        """Clear the fernet cache before each test to avoid encryption issues."""
-        from airflow.models.crypto import get_fernet
-
-        get_fernet.cache_clear()
-        yield
-        get_fernet.cache_clear()
-
     @pytest.mark.parametrize(
         (
             "uri",
@@ -216,7 +205,6 @@ class TestConnection:
             ),
         ],
     )
-    @conf_vars({("core", "fernet_key"): Fernet.generate_key().decode()})
     def test_get_uri(self, connection, expected_uri):
         assert connection.get_uri() == expected_uri
 


### PR DESCRIPTION
I am sorry that my PR https://github.com/apache/airflow/pull/57642 seem to generate some side effects. Just wanted to clean :-(

It seems also https://github.com/apache/airflow/pull/58034 did not fix it finally and some concurrency in xdist still made it broken as canary in https://github.com/apache/airflow/actions/runs/19189948589 still showing problems.

Relatized that all the fixture and setting of FERNET is not needed, testsruns happy without as normally the config.py generates a Fernet dynamically.

Also alongside, the PR https://github.com/apache/airflow/pull/57988 will (soon?) remove the leftovers of NullFernet and then we ensure it is always correctly crypted.