### PR TITLE
Breeze: Automatically set CHOKIDAR_USEPOLLING for WSL users in --dev-mode (#57846)

### DIFF
--- a/contributing-docs/03_contributors_quick_start.rst
+++ b/contributing-docs/03_contributors_quick_start.rst
@@ -613,20 +613,6 @@ Using Breeze
              alt="Accessing local airflow">
       </div>
 
-   **For WSL users:**
-
-    When running the React TypeScript UI with `breeze start-airflow --development`, you may need to enable polling for file change detection to make hot reloading work properly.
-    Set the following environment variable before starting the UI:
-
-    .. code-block:: bash
-       export CHOKIDAR_USEPOLLING=true
-   
-    Alternatively, you can modify the `dev` script in `ui/package.json` to include it:
-
-    .. code-block:: json
-       "dev": "CHOKIDAR_USEPOLLING=true vite --port 5173 --strictPort"
-  
-
 3. Setup a PostgreSQL database in your database management tool of choice
    (e.g. DBeaver, DataGrip) with host ``localhost``, port ``25433``,
    user ``postgres``,  password ``airflow``, and default schema ``airflow``

--- a/contributing-docs/03_contributors_quick_start.rst
+++ b/contributing-docs/03_contributors_quick_start.rst
@@ -613,6 +613,20 @@ Using Breeze
              alt="Accessing local airflow">
       </div>
 
+   **For WSL users:**
+
+    When running the React TypeScript UI with `breeze start-airflow --development`, you may need to enable polling for file change detection to make hot reloading work properly.
+    Set the following environment variable before starting the UI:
+
+    .. code-block:: bash
+       export CHOKIDAR_USEPOLLING=true
+   
+    Alternatively, you can modify the `dev` script in `ui/package.json` to include it:
+
+    .. code-block:: json
+       "dev": "CHOKIDAR_USEPOLLING=true vite --port 5173 --strictPort"
+  
+
 3. Setup a PostgreSQL database in your database management tool of choice
    (e.g. DBeaver, DataGrip) with host ``localhost``, port ``25433``,
    user ``postgres``,  password ``airflow``, and default schema ``airflow``

--- a/dev/breeze/src/airflow_breeze/commands/developer_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/developer_commands.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import os
+import platform
 import re
 import shlex
 import shutil
@@ -127,6 +128,18 @@ from airflow_breeze.utils.run_utils import (
 from airflow_breeze.utils.shared_options import get_dry_run, get_verbose, set_forced_answer
 
 CELERY_INTEGRATION = "celery"
+
+
+def is_wsl() -> bool:
+    """Detect if we are running inside WSL."""
+    if platform.system() != "Linux":
+        return False
+    try:
+        with open("/proc/version") as f:
+            version_info = f.read().lower()
+            return "microsoft" in version_info or "wsl" in version_info
+    except FileNotFoundError:
+        return False
 
 
 def _determine_constraint_branch_used(airflow_constraints_reference: str, use_airflow_version: str | None):
@@ -610,6 +623,13 @@ def start_airflow(
             "[warning]You cannot skip asset compilation in dev mode! Assets will be compiled!"
         )
         skip_assets_compilation = True
+
+    # Automatically enable file polling for hot reloading under WSL
+    if dev_mode and is_wsl():
+        os.environ["CHOKIDAR_USEPOLLING"] = "true"
+        get_console().print(
+            "[info]Detected WSL environment. Automatically enabled CHOKIDAR_USEPOLLING for hot reloading."
+        )
 
     if use_airflow_version is None and not skip_assets_compilation:
         # Now with the /ui project, lets only do a static build of /www and focus on the /ui

--- a/dev/breeze/src/airflow_breeze/commands/developer_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/developer_commands.py
@@ -132,7 +132,7 @@ CELERY_INTEGRATION = "celery"
 
 def is_wsl() -> bool:
     """Detect if we are running inside WSL."""
-    if platform.system().lower() != "Linux":
+    if platform.system().lower() != "linux":
         return False
     try:
         with open("/proc/version") as f:

--- a/dev/breeze/src/airflow_breeze/commands/developer_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/developer_commands.py
@@ -132,7 +132,7 @@ CELERY_INTEGRATION = "celery"
 
 def is_wsl() -> bool:
     """Detect if we are running inside WSL."""
-    if platform.system() != "Linux":
+    if platform.system().lower() != "Linux":
         return False
     try:
         with open("/proc/version") as f:


### PR DESCRIPTION


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---

### Description:

This PR enhances Breeze to automatically detect when it is running inside a WSL (Windows Subsystem for Linux) environment and set the environment variable
`CHOKIDAR_USEPOLLING=true` automatically when the `--dev-mode` flag is used with
`breeze start-airflow`.

Previously, WSL users needed to manually enable this variable to get proper hot reloading behavior when developing the React TypeScript UI.
Now Breeze automatically handles this by detecting WSL via `/proc/version` and `platform.system()`, ensuring hot reloading works without additional setup.

The update also removes the WSL note from the contributor quick start documentation, since it is no longer needed.

### Technical Details:

- Added a helper function `is_wsl()` in `developer_commands.py` to detect WSL (works for both WSL1 and WSL2).

- Modified `start_airflow()` to automatically set `CHOKIDAR_USEPOLLING=true` when `--dev-mode` is used in a WSL environment.

- Added an info message to notify users when automatic polling is enabled.

- Removed the previously documented manual WSL note from `03_contributors_quick_start.rst`.