### PR TITLE
Fix bug on the state and run_type filter for Dag Runs page

### DIFF
--- a/airflow-core/src/airflow/ui/src/constants/filterConfigs.tsx
+++ b/airflow-core/src/airflow/ui/src/constants/filterConfigs.tsx
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+/* eslint-disable max-lines */
 import { Flex } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 import { FiBarChart, FiUser } from "react-icons/fi";

--- a/airflow-core/src/airflow/ui/src/constants/filterConfigs.tsx
+++ b/airflow-core/src/airflow/ui/src/constants/filterConfigs.tsx
@@ -16,8 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-/* eslint-disable max-lines */
 import { Flex } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 import { FiBarChart, FiUser } from "react-icons/fi";

--- a/airflow-core/src/airflow/ui/src/constants/filterConfigs.tsx
+++ b/airflow-core/src/airflow/ui/src/constants/filterConfigs.tsx
@@ -208,7 +208,7 @@ export const useFilterConfigs = () => {
             </Flex>
           ),
         value: option.value === "all" ? (
-          "" 
+          ""
         ) : (
           option.value
         ),
@@ -231,7 +231,7 @@ export const useFilterConfigs = () => {
             <StateBadge state={option.value as DagRunState}>{translate(option.label)}</StateBadge>
           ),
         value: option.value === "all" ? (
-          "" 
+          ""
         ) : (
           option.value
         ),

--- a/airflow-core/src/airflow/ui/src/constants/filterConfigs.tsx
+++ b/airflow-core/src/airflow/ui/src/constants/filterConfigs.tsx
@@ -200,7 +200,9 @@ export const useFilterConfigs = () => {
       label: translate("common:dagRun.runType"),
       options: dagRunTypeOptions.items.map((option) => ({
         label:
-          option.value === "all" ? (translate(option.label)) : (
+          option.value === "all" ? (
+            translate(option.label)
+          ) : (
             <Flex alignItems="center" gap={1}>
               <RunTypeIcon runType={option.value as DagRunType} />
               {translate(option.label)}

--- a/airflow-core/src/airflow/ui/src/constants/filterConfigs.tsx
+++ b/airflow-core/src/airflow/ui/src/constants/filterConfigs.tsx
@@ -208,11 +208,7 @@ export const useFilterConfigs = () => {
               {translate(option.label)}
             </Flex>
           ),
-        value: option.value === "all" ? (
-          ""
-        ) : (
-          option.value
-        ),
+        value: option.value === "all" ? "" : option.value,
       })),
       type: FilterTypes.SELECT,
     },
@@ -231,11 +227,7 @@ export const useFilterConfigs = () => {
           ) : (
             <StateBadge state={option.value as DagRunState}>{translate(option.label)}</StateBadge>
           ),
-        value: option.value === "all" ? (
-          ""
-        ) : (
-          option.value
-        ),
+        value: option.value === "all" ? "" : option.value,
       })),
       type: FilterTypes.SELECT,
     },

--- a/airflow-core/src/airflow/ui/src/constants/filterConfigs.tsx
+++ b/airflow-core/src/airflow/ui/src/constants/filterConfigs.tsx
@@ -199,19 +199,13 @@ export const useFilterConfigs = () => {
       label: translate("common:dagRun.runType"),
       options: dagRunTypeOptions.items.map((option) => ({
         label:
-          option.value === "all" ? (
-            translate(option.label)
-          ) : (
+          option.value === "all" ? (translate(option.label)) : (
             <Flex alignItems="center" gap={1}>
               <RunTypeIcon runType={option.value as DagRunType} />
               {translate(option.label)}
             </Flex>
           ),
-        value: option.value === "all" ? (
-          ""
-        ) : (
-          option.value
-        ),
+        value: option.value === "all" ? ("") : (option.value),
       })),
       type: FilterTypes.SELECT,
     },
@@ -230,11 +224,7 @@ export const useFilterConfigs = () => {
           ) : (
             <StateBadge state={option.value as DagRunState}>{translate(option.label)}</StateBadge>
           ),
-        value: option.value === "all" ? (
-          ""
-        ) : (
-          option.value
-        ),
+        value: option.value === "all" ? ("") : (option.value),
       })),
       type: FilterTypes.SELECT,
     },

--- a/airflow-core/src/airflow/ui/src/constants/filterConfigs.tsx
+++ b/airflow-core/src/airflow/ui/src/constants/filterConfigs.tsx
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 /* eslint-disable max-lines */
 import { Flex } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";

--- a/airflow-core/src/airflow/ui/src/constants/filterConfigs.tsx
+++ b/airflow-core/src/airflow/ui/src/constants/filterConfigs.tsx
@@ -207,7 +207,11 @@ export const useFilterConfigs = () => {
               {translate(option.label)}
             </Flex>
           ),
-        value: option.value,
+        value: option.value === "all" ? (
+          "" 
+        ) : (
+          option.value
+        ),
       })),
       type: FilterTypes.SELECT,
     },
@@ -226,7 +230,11 @@ export const useFilterConfigs = () => {
           ) : (
             <StateBadge state={option.value as DagRunState}>{translate(option.label)}</StateBadge>
           ),
-        value: option.value,
+        value: option.value === "all" ? (
+          "" 
+        ) : (
+          option.value
+        ),
       })),
       type: FilterTypes.SELECT,
     },

--- a/airflow-core/src/airflow/ui/src/constants/filterConfigs.tsx
+++ b/airflow-core/src/airflow/ui/src/constants/filterConfigs.tsx
@@ -205,7 +205,11 @@ export const useFilterConfigs = () => {
               {translate(option.label)}
             </Flex>
           ),
-        value: option.value === "all" ? ("") : (option.value),
+        value: option.value === "all" ? (
+          ""
+        ) : (
+          option.value
+        ),
       })),
       type: FilterTypes.SELECT,
     },
@@ -224,7 +228,11 @@ export const useFilterConfigs = () => {
           ) : (
             <StateBadge state={option.value as DagRunState}>{translate(option.label)}</StateBadge>
           ),
-        value: option.value === "all" ? ("") : (option.value),
+        value: option.value === "all" ? (
+          ""
+        ) : (
+          option.value
+        ),
       })),
       type: FilterTypes.SELECT,
     },


### PR DESCRIPTION
## WHY

related: #53043 
While working on the Task Instances counterpart( #56920 just for ref ), I encountered a similar issue with the “All” option.
On the Dag Runs page, selecting All for State and/or Run Type currently sends values that the backend interprets as real filters, which leads to an error. The "All" option should clear the filter, instead of sends values as filters option

picture:
<img width="474" height="43" alt="error param dag-run" src="https://github.com/user-attachments/assets/572e0af4-5545-4f39-9531-2972da0d4c74" />
<img width="1146" height="269" alt="image" src="https://github.com/user-attachments/assets/1ac7fe4e-4719-44ef-b602-2f4f16563127" />
<img width="455" height="30" alt="error run type" src="https://github.com/user-attachments/assets/8ba59f46-2c7e-4b20-949e-8bb8adea4d6b" />

<img width="962" height="290" alt="error run type all option" src="https://github.com/user-attachments/assets/55de1eff-13ed-45dc-ae4f-ee14e9903eb9" />


## HOW

The filter logic now clears the value for the filter itself rather than passing it as a filter value , without affecting other active filters.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
