### PR TITLE
Revert "Remove global from serialization (#57703)"

### DIFF
--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -31,7 +31,7 @@ import re
 import sys
 import weakref
 from collections.abc import Collection, Iterable, Iterator, Mapping, Sequence
-from functools import cache, cached_property, lru_cache
+from functools import cached_property, lru_cache
 from inspect import signature
 from textwrap import dedent
 from typing import (
@@ -140,6 +140,7 @@ if TYPE_CHECKING:
     from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
     from airflow.triggers.base import BaseEventTrigger
 
+    HAS_KUBERNETES: bool
     try:
         from kubernetes.client import models as k8s  # noqa: TC004
 
@@ -3854,7 +3855,6 @@ class SerializedAssetWatcher(AssetWatcher):
     trigger: dict
 
 
-@cache
 def _has_kubernetes(attempt_import: bool = False) -> bool:
     """
     Check if kubernetes libraries are available.
@@ -3863,11 +3863,17 @@ def _has_kubernetes(attempt_import: bool = False) -> bool:
         False, only check if already in sys.modules (avoids expensive import).
     :return: True if kubernetes libraries are available, False otherwise.
     """
+    global HAS_KUBERNETES
+    if "HAS_KUBERNETES" in globals():
+        return HAS_KUBERNETES
+
     # Check if kubernetes is already imported before triggering expensive import
     if "kubernetes.client" not in sys.modules and not attempt_import:
+        HAS_KUBERNETES = False
         return False
 
     # Loading kube modules is expensive, so delay it until the last moment
+
     try:
         from kubernetes.client import models as k8s
 
@@ -3875,9 +3881,10 @@ def _has_kubernetes(attempt_import: bool = False) -> bool:
 
         globals()["k8s"] = k8s
         globals()["PodGenerator"] = PodGenerator
-        return True
+        HAS_KUBERNETES = True
     except ImportError:
-        return False
+        HAS_KUBERNETES = False
+    return HAS_KUBERNETES
 
 
 AssetT = TypeVar("AssetT", bound=BaseAsset, covariant=True)

--- a/airflow-core/tests/unit/serialization/test_serialized_objects.py
+++ b/airflow-core/tests/unit/serialization/test_serialized_objects.py
@@ -737,7 +737,6 @@ class TestKubernetesImportAvoidance:
             pytest.skip("Kubernetes already imported, cannot test import avoidance")
 
         # Call _has_kubernetes() - should check sys.modules and return False without importing
-        _has_kubernetes.cache_clear()
         result = _has_kubernetes()
 
         assert result is False
@@ -748,7 +747,6 @@ class TestKubernetesImportAvoidance:
         pytest.importorskip("kubernetes")
 
         # Now k8s is imported, should return True
-        _has_kubernetes.cache_clear()
         result = _has_kubernetes()
 
         assert result is True


### PR DESCRIPTION
This reverts commit 3ba3c78404066c4262e15fe7162d25ea2158c121.

Attempting to stabilise main with JSONDecodeErrors.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
