### PR TITLE
fix mypy errors in delete_dag.py

### DIFF
--- a/airflow-core/src/airflow/api/common/delete_dag.py
+++ b/airflow-core/src/airflow/api/common/delete_dag.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from sqlalchemy import delete, select
 
@@ -34,6 +34,7 @@ from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import TaskInstanceState
 
 if TYPE_CHECKING:
+    from sqlalchemy.engine import CursorResult, Result
     from sqlalchemy.orm import Session
 
 log = logging.getLogger(__name__)
@@ -70,13 +71,14 @@ def delete_dag(dag_id: str, keep_records_in_log: bool = True, session: Session =
         model for model in get_sqla_model_classes() if model.__name__ not in ["TaskInstance", "DagRun"]
     ]
 
-    count = 0
+    count: int = 0
     for model in models_for_deletion:
         if hasattr(model, "dag_id") and (not keep_records_in_log or model.__name__ != "Log"):
-            result = session.execute(
+            result: Result = session.execute(
                 delete(model).where(model.dag_id == dag_id).execution_options(synchronize_session="fetch")
             )
-            count += result.rowcount or 0
+            cursor_result = cast("CursorResult", result)
+            count += cursor_result.rowcount
 
     # Delete entries in Import Errors table for a deleted DAG
     # This handles the case when the dag_id is changed in the file


### PR DESCRIPTION
related: #56735



<!-- Please keep an empty line above the dashes. -->
---

Fixing mypy issues after SQLA 2 migration in delete_dag.py.

SQLA docs recommend type casting `Result` to `CursorResult` whenever `rowcount` is required and the execute statement is known to be returning `rowcount`. Ref: https://docs.sqlalchemy.org/en/20/changelog/changelog_20.html#change-2.0.44-typing