### PR TITLE
Enable ruff PLW0603 rule

### DIFF
--- a/airflow-core/src/airflow/config_templates/airflow_local_settings.py
+++ b/airflow-core/src/airflow/config_templates/airflow_local_settings.py
@@ -129,7 +129,7 @@ def _default_conn_name_from(mod_path, hook_name):
     # Try to set the default conn name from a hook, but don't error if something goes wrong at runtime
     from importlib import import_module
 
-    global DEFAULT_REMOTE_CONN_ID
+    global DEFAULT_REMOTE_CONN_ID  # noqa: PLW0603
 
     try:
         mod = import_module(mod_path)

--- a/airflow-core/src/airflow/configuration.py
+++ b/airflow-core/src/airflow/configuration.py
@@ -659,7 +659,7 @@ def load_standard_airflow_configuration(airflow_config_parser: AirflowConfigPars
     :param airflow_config_parser: parser to which the configuration will be loaded
 
     """
-    global AIRFLOW_HOME  # to be cleaned in Airflow 4.0
+    global AIRFLOW_HOME  # noqa: PLW0603  # to be cleaned in Airflow 4.0
     log.info("Reading the config from %s", AIRFLOW_CONFIG)
     airflow_config_parser.read(AIRFLOW_CONFIG)
     if airflow_config_parser.has_option("core", "AIRFLOW_HOME"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -617,6 +617,7 @@ extend-select = [
     "PLW0245", # super call is missing parentheses
     "PLW0406", # Module {name} imports itself
     "PLW0602", # Using global for {name} but no assignment is done
+    "PLW0603", # Using the global statement to update {name} is discouraged
     "PLW0604", # global at module level is redundant
     "PLW0642", # Reassigned {} variable in {method_type} method
     "PLW0711", # Exception to catch is the result of a binary and operation


### PR DESCRIPTION
While implementing https://github.com/apache/airflow/pull/57294 I realized that a couple of more ruff PLW rules might be interesting, this PR enables PLW1641

See also https://docs.astral.sh/ruff/rules/#warning-plw

NOTE: This is a DRAFT to see and continously rebase which things of `global` statements are still open to clean