### PR TITLE
Properly highlight TaskGroup nodes when selected

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/Graph/Graph.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Graph/Graph.tsx
@@ -60,7 +60,7 @@ const nodeColor = (
 
 export const Graph = () => {
   const { colorMode = "light" } = useColorMode();
-  const { dagId = "", runId = "", taskId } = useParams();
+  const { dagId = "", groupId, runId = "", taskId } = useParams();
 
   const selectedVersion = useSelectedVersion();
 
@@ -130,7 +130,7 @@ export const Graph = () => {
       ...node,
       data: {
         ...node.data,
-        isSelected: node.id === taskId || node.id === `dag:${dagId}`,
+        isSelected: node.id === taskId || node.id === groupId || node.id === `dag:${dagId}`,
         taskInstance,
       },
     };
@@ -145,6 +145,8 @@ export const Graph = () => {
         isSelected:
           taskId === edge.source ||
           taskId === edge.target ||
+          groupId === edge.source ||
+          groupId === edge.target ||
           edge.source === `dag:${dagId}` ||
           edge.target === `dag:${dagId}`,
       },


### PR DESCRIPTION
 ## Problem
TaskGroup nodes in the Graph View do not display a blue border highlight when selected, unlike regular task nodes. When clicking on a TaskGroup, the URL updates correctly to include the group ID but the visual selection indicator is not applied.

## Solution
The Graph component was only checking the taskId URL parameter to set isSelected on nodes. TaskGroups use a separate groupId URL parameter when selected.

<img width="717" height="628" alt="Screenshot 2025-11-09 at 2 24 32 PM" src="https://github.com/user-attachments/assets/9c828b16-87ba-4fe8-bc89-9c25d621dcdf" />
<img width="761" height="681" alt="Screenshot 2025-11-09 at 2 24 43 PM" src="https://github.com/user-attachments/assets/d4138858-6546-4b22-be57-13f5b5566256" />
<img width="792" height="588" alt="Screenshot 2025-11-09 at 2 24 55 PM" src="https://github.com/user-attachments/assets/23ddc177-1b2d-41d3-b245-3c48aa817e01" />


### Related Issues
Closes #57900