### PR TITLE
Fix Execution API connection lookups with slashes

### DIFF
--- a/airflow-core/docs/howto/connection.rst
+++ b/airflow-core/docs/howto/connection.rst
@@ -31,6 +31,14 @@ Connections may be defined in the following ways:
   - in the :ref:`Airflow metadata database <connections-in-database>`
     (using the :ref:`CLI <connection/cli>` or :ref:`web UI <creating_connection_ui>`)
 
+.. important::
+
+   Airflow 3 tasks read connections through the Task Execution API. Every connection must therefore
+   include a ``conn_type`` (even when the definition lives in a JSON secret or environment variable);
+   otherwise the Execution API cannot serialize the record and Task SDK calls such as
+   ``BaseHook.get_connection`` will fail with ``CONNECTION_NOT_FOUND``. Always set ``conn_type`` to one of
+   the values documented for your provider when creating connections outside of the UI/CLI.
+
 .. _environment_variables_connections:
 
 Storing connections in environment variables

--- a/airflow-core/newsfragments/57864.bugfix.rst
+++ b/airflow-core/newsfragments/57864.bugfix.rst
@@ -1,3 +1,1 @@
-Fix Task SDK connection lookups when ``conn_id`` contains ``/`` by percent-encoding the path segment and
-raise a descriptive 422 (and document the requirement) when an Execution API connection or secret omits
-``conn_type`` so tasks don't fail with a confusing 404. (#57864)
+Fix Task SDK connection lookups when ``conn_id`` contains ``/`` by percent-encoding the path segment and raise a descriptive 422 (and document the requirement) when an Execution API connection or secret omits ``conn_type`` so tasks don't fail with a confusing 404. (#57864)

--- a/airflow-core/newsfragments/57864.bugfix.rst
+++ b/airflow-core/newsfragments/57864.bugfix.rst
@@ -1,0 +1,3 @@
+Fix Task SDK connection lookups when ``conn_id`` contains ``/`` by percent-encoding the path segment and
+raise a descriptive 422 (and document the requirement) when an Execution API connection or secret omits
+``conn_type`` so tasks don't fail with a confusing 404. (#57864)

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -24,6 +24,7 @@ import uuid
 from functools import cache
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, TypeVar
+from urllib.parse import quote
 
 import certifi
 import httpx
@@ -369,7 +370,8 @@ class ConnectionOperations:
     def get(self, conn_id: str) -> ConnectionResponse | ErrorResponse:
         """Get a connection from the API server."""
         try:
-            resp = self.client.get(f"connections/{conn_id}")
+            encoded_conn_id = quote(conn_id, safe="")
+            resp = self.client.get(f"connections/{encoded_conn_id}")
         except ServerResponseError as e:
             if e.response.status_code == HTTPStatus.NOT_FOUND:
                 log.debug(


### PR DESCRIPTION
## Summary
  - Fix Execution API connection lookups by accepting `/{connection_id:path}`, decoding the path segment, and returning a 422 with `reason=missing_conn_type` when a secret/env var omits `conn_type`;
  updated docs to explain the requirement.
  - Percent-encode connection IDs on the Task SDK client side so IDs containing `/` resolve correctly, keeping server/client behavior in sync.
  - Added regression tests for both sides plus a newsfragment; happy to take feedback if a different routing/validation strategy is preferred (this version leans on URI encode/decode).

  closes: #57864

  ## Testing
  - `pytest airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_connections.py`
  - `pytest task-sdk/tests/task_sdk/api/test_client.py::TestConnectionOperations`
  - `prek --all-files` (minus Breeze-only hooks on this machine)