### PR TITLE
Refactor imports to use FastAPI modules instead of Starlette

### DIFF
--- a/airflow-core/docs/howto/custom-view-plugin.rst
+++ b/airflow-core/docs/howto/custom-view-plugin.rst
@@ -118,7 +118,7 @@ Create an Airflow plugin that serves your React application:
 
     from pathlib import Path
     from fastapi import FastAPI
-    from starlette.staticfiles import StaticFiles
+    from fastapi.staticfiles import StaticFiles
     import mimetypes
 
     from airflow.plugins_manager import AirflowPlugin

--- a/airflow-core/src/airflow/api_fastapi/app.py
+++ b/airflow-core/src/airflow/api_fastapi/app.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, cast
 from urllib.parse import urlsplit
 
 from fastapi import FastAPI
-from starlette.routing import Mount
+from fastapi.routing import Mount
 
 from airflow.api_fastapi.common.dagbag import create_dag_bag
 from airflow.api_fastapi.core_api.app import (

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/routes/login.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/routes/login.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 from fastapi import Depends, Request, status
-from starlette.responses import RedirectResponse
+from fastapi.responses import RedirectResponse
 
 from airflow.api_fastapi.auth.managers.base_auth_manager import COOKIE_NAME_JWT_TOKEN
 from airflow.api_fastapi.auth.managers.simple.datamodels.login import LoginBody, LoginResponse

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
@@ -28,11 +28,10 @@ from json import JSONDecodeError
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TextIO
 
-from fastapi import FastAPI
-from starlette.requests import Request
-from starlette.responses import HTMLResponse
-from starlette.staticfiles import StaticFiles
-from starlette.templating import Jinja2Templates
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
 from termcolor import colored
 
 from airflow.api_fastapi.app import AUTH_MANAGER_FASTAPI_APP_PREFIX

--- a/airflow-core/src/airflow/api_fastapi/common/parameters.py
+++ b/airflow-core/src/airflow/api_fastapi/common/parameters.py
@@ -779,7 +779,7 @@ def _transform_dag_run_states(states: Iterable[str] | None) -> list[DagRunState 
         return [None if s in ("none", None) else DagRunState(s) for s in states]
     except ValueError:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=f"Invalid value for state. Valid values are {', '.join(DagRunState)}",
         )
 
@@ -805,7 +805,7 @@ def _transform_dag_run_types(types: list[str] | None) -> list[DagRunType | None]
         return [None if run_type in ("none", None) else DagRunType(run_type) for run_type in types]
     except ValueError:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=f"Invalid value for run type. Valid values are {', '.join(DagRunType)}",
         )
 
@@ -843,7 +843,7 @@ def _transform_ti_states(states: list[str] | None) -> list[TaskInstanceState | N
         return [None if s in ("no_status", "none", None) else TaskInstanceState(s) for s in states]
     except ValueError:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=f"Invalid value for state. Valid values are {', '.join(TaskInstanceState)}",
         )
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/app.py
@@ -22,13 +22,12 @@ import sys
 import warnings
 from pathlib import Path
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
-from starlette.requests import Request
-from starlette.responses import HTMLResponse, JSONResponse
-from starlette.staticfiles import StaticFiles
-from starlette.templating import Jinja2Templates
+from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
 
 from airflow.api_fastapi.auth.tokens import get_signing_key
 from airflow.exceptions import AirflowException

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dags.py
@@ -177,7 +177,7 @@ def get_dags(
         [
             status.HTTP_400_BAD_REQUEST,
             status.HTTP_404_NOT_FOUND,
-            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
         ]
     ),
     dependencies=[Depends(requires_access_dag(method="GET"))],
@@ -401,7 +401,7 @@ def unfavorite_dag(dag_id: str, session: SessionDep, user: GetUserDep):
         [
             status.HTTP_400_BAD_REQUEST,
             status.HTTP_404_NOT_FOUND,
-            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
         ]
     ),
     dependencies=[Depends(requires_access_dag(method="DELETE")), Depends(action_logging())],

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/dag_runs.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/dag_runs.py
@@ -48,7 +48,7 @@ log = logging.getLogger(__name__)
         status.HTTP_400_BAD_REQUEST: {"description": "DAG has import errors and cannot be triggered"},
         status.HTTP_404_NOT_FOUND: {"description": "DAG not found for the given dag_id"},
         status.HTTP_409_CONFLICT: {"description": "DAG Run already exists for the given dag_id"},
-        status.HTTP_422_UNPROCESSABLE_ENTITY: {"description": "Invalid payload"},
+        status.HTTP_422_UNPROCESSABLE_CONTENT: {"description": "Invalid payload"},
     },
 )
 def trigger_dag_run(
@@ -100,7 +100,7 @@ def trigger_dag_run(
     responses={
         status.HTTP_400_BAD_REQUEST: {"description": "DAG has import errors and cannot be triggered"},
         status.HTTP_404_NOT_FOUND: {"description": "DAG not found for the given dag_id"},
-        status.HTTP_422_UNPROCESSABLE_ENTITY: {"description": "Invalid payload"},
+        status.HTTP_422_UNPROCESSABLE_CONTENT: {"description": "Invalid payload"},
     },
 )
 def clear_dag_run(

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -95,7 +95,7 @@ log = structlog.get_logger(__name__)
     responses={
         status.HTTP_404_NOT_FOUND: {"description": "Task Instance not found"},
         status.HTTP_409_CONFLICT: {"description": "The TI is already in the requested state"},
-        status.HTTP_422_UNPROCESSABLE_ENTITY: {"description": "Invalid payload for the state transition"},
+        status.HTTP_422_UNPROCESSABLE_CONTENT: {"description": "Invalid payload for the state transition"},
     },
     response_model_exclude_unset=True,
 )
@@ -336,7 +336,7 @@ def _get_upstream_map_indexes(
     responses={
         status.HTTP_404_NOT_FOUND: {"description": "Task Instance not found"},
         status.HTTP_409_CONFLICT: {"description": "The TI is already in the requested state"},
-        status.HTTP_422_UNPROCESSABLE_ENTITY: {"description": "Invalid payload for the state transition"},
+        status.HTTP_422_UNPROCESSABLE_CONTENT: {"description": "Invalid payload for the state transition"},
     },
 )
 def ti_update_state(
@@ -580,7 +580,7 @@ def _create_ti_state_update_query_and_update_state(
     status_code=status.HTTP_204_NO_CONTENT,
     responses={
         status.HTTP_404_NOT_FOUND: {"description": "Task Instance not found"},
-        status.HTTP_422_UNPROCESSABLE_ENTITY: {"description": "Invalid payload for the state transition"},
+        status.HTTP_422_UNPROCESSABLE_CONTENT: {"description": "Invalid payload for the state transition"},
     },
 )
 def ti_skip_downstream(
@@ -627,7 +627,7 @@ def ti_skip_downstream(
         status.HTTP_409_CONFLICT: {
             "description": "The TI attempting to heartbeat should be terminated for the given reason"
         },
-        status.HTTP_422_UNPROCESSABLE_ENTITY: {"description": "Invalid payload for the state transition"},
+        status.HTTP_422_UNPROCESSABLE_CONTENT: {"description": "Invalid payload for the state transition"},
     },
 )
 def ti_heartbeat(
@@ -702,7 +702,7 @@ def ti_heartbeat(
     # TODO: Do we need to use create_openapi_http_exception_doc here?
     responses={
         status.HTTP_404_NOT_FOUND: {"description": "Task Instance not found"},
-        status.HTTP_422_UNPROCESSABLE_ENTITY: {
+        status.HTTP_422_UNPROCESSABLE_CONTENT: {
             "description": "Invalid payload for the setting rendered task instance fields"
         },
     },
@@ -734,7 +734,7 @@ def ti_put_rtif(
     status_code=status.HTTP_204_NO_CONTENT,
     responses={
         status.HTTP_404_NOT_FOUND: {"description": "Task Instance not found"},
-        status.HTTP_422_UNPROCESSABLE_ENTITY: {"description": "Invalid rendered_map_index value"},
+        status.HTTP_422_UNPROCESSABLE_CONTENT: {"description": "Invalid rendered_map_index value"},
     },
 )
 def ti_patch_rendered_map_index(
@@ -749,7 +749,7 @@ def ti_patch_rendered_map_index(
     if not rendered_map_index:
         log.error("rendered_map_index cannot be empty")
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail="rendered_map_index cannot be empty",
         )
 

--- a/providers/amazon/src/airflow/providers/amazon/aws/auth_manager/routes/login.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/auth_manager/routes/login.py
@@ -21,9 +21,8 @@ import logging
 from typing import Any
 
 import anyio
-from fastapi import HTTPException, Request
-from starlette import status
-from starlette.responses import RedirectResponse
+from fastapi import HTTPException, Request, status
+from fastapi.responses import RedirectResponse
 
 from airflow.api_fastapi.app import (
     AUTH_MANAGER_FASTAPI_APP_PREFIX,

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/routes/login.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/routes/login.py
@@ -16,9 +16,8 @@
 # under the License.
 from __future__ import annotations
 
-from starlette import status
-from starlette.requests import Request  # noqa: TC002
-from starlette.responses import RedirectResponse
+from fastapi import Request, status
+from fastapi.responses import RedirectResponse
 
 from airflow.api_fastapi.app import get_auth_manager
 from airflow.api_fastapi.auth.managers.base_auth_manager import COOKIE_NAME_JWT_TOKEN

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/services/login.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/services/login.py
@@ -18,9 +18,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
 
+from fastapi import HTTPException, status
 from flask_appbuilder.const import AUTH_LDAP
-from starlette import status
-from starlette.exceptions import HTTPException
 
 from airflow.api_fastapi.app import get_auth_manager
 from airflow.configuration import conf

--- a/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
@@ -26,10 +26,10 @@ from urllib.parse import urljoin
 import packaging.version
 from connexion import FlaskApi
 from fastapi import FastAPI
+from fastapi.middleware.wsgi import WSGIMiddleware
 from flask import Blueprint, current_app, g
 from sqlalchemy import select
 from sqlalchemy.orm import Session, joinedload
-from starlette.middleware.wsgi import WSGIMiddleware
 
 from airflow import __version__ as airflow_version
 from airflow.api_fastapi.app import AUTH_MANAGER_FASTAPI_APP_PREFIX

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_login.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_login.py
@@ -20,8 +20,8 @@ from __future__ import annotations
 from unittest.mock import ANY, MagicMock, patch
 
 import pytest
+from fastapi import HTTPException
 from flask_appbuilder.const import AUTH_DB, AUTH_LDAP
-from starlette.exceptions import HTTPException
 
 from airflow.providers.fab.auth_manager.api_fastapi.services.login import FABAuthManagerLogin
 

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/routes/login.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/routes/login.py
@@ -21,7 +21,7 @@ import logging
 from typing import Annotated
 
 from fastapi import Depends, Request
-from starlette.responses import HTMLResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, RedirectResponse
 
 from airflow.api_fastapi.app import get_auth_manager
 from airflow.api_fastapi.auth.managers.base_auth_manager import COOKIE_NAME_JWT_TOKEN

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/routes/token.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/routes/token.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import logging
 
-from starlette import status
+from fastapi import status
 
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/services/token.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/services/token.py
@@ -17,9 +17,8 @@
 
 from __future__ import annotations
 
-from fastapi import HTTPException
+from fastapi import HTTPException, status
 from keycloak import KeycloakAuthenticationError
-from starlette import status
 
 from airflow.api_fastapi.app import get_auth_manager
 from airflow.configuration import conf


### PR DESCRIPTION
# Why
- related: https://github.com/apache/airflow/pull/57199#discussion_r2463178216
# Note
After this change, the remaining from `starlette` imports are limited to the following
<img width="617" height="435" alt="image" src="https://github.com/user-attachments/assets/13f52578-6433-45f7-93ed-88611bd1cafd" />


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
