### PR TITLE
Fix Python 3.13 RuntimeWarning in test_reading_from_pipes

### DIFF
--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -231,6 +231,26 @@ class TestWatchedSubprocess:
     def disable_log_upload(self, spy_agency):
         spy_agency.spy_on(ActivitySubprocess._upload_logs, call_original=False)
 
+    @pytest.fixture(autouse=True)
+    def use_real_secrets_backends(self, monkeypatch):
+        """
+        Ensure that real secrets backend instances are used instead of mocks.
+
+        This prevents Python 3.13 RuntimeWarning when hasattr checks async methods
+        on mocked backends. The warning occurs because hasattr on AsyncMock creates
+        unawaited coroutines.
+
+        This fixture ensures test isolation when running in parallel with pytest-xdist,
+        regardless of what other tests patch.
+        """
+        from airflow.sdk.execution_time.secrets import ExecutionAPISecretsBackend
+        from airflow.secrets.environment_variables import EnvironmentVariablesBackend
+
+        monkeypatch.setattr(
+            "airflow.sdk.execution_time.supervisor.ensure_secrets_backend_loaded",
+            lambda: [EnvironmentVariablesBackend(), ExecutionAPISecretsBackend()],
+        )
+
     def test_reading_from_pipes(self, captured_logs, time_machine, client_with_ti_start):
         def subprocess_main():
             # This is run in the subprocess!


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

The test: `test_reading_from_pipes`  was failing intermittently in CI with a RuntimeWarning about unawaited coroutines when running in parallel with pytest-xdist. Example: https://github.com/apache/airflow/actions/runs/19189948589/job/54863177318

```python
======================================================================================== short test summary info =========================================================================================
FAILED task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestWatchedSubprocess::test_reading_from_pipes - assert [{'category': 'RuntimeWarning', 'event': "coroutine 'ExecutionAPISecretsBackend.aget_connection' was never awaited", '...lsite', 'filename': '/opt/airflow/task-sdk/tests/task_sdk/execution_time/test_supervisor.py', 'level': 'warning', ...}] == [{'logger': 'task.stdout', 'event': "I'm a short message", 'level': 'info', 'timestamp': '2024-11-07T12:34:56.078901Z'... 255, 'logger': 'py.warnings', 'timestamp': datetime.datetime(2024, 11, 7, 12, 34, 56, 78901, tzinfo=Timezone('UTC'))}]
  Extra items in the left sequence:
  {'category': 'RuntimeWarning', 'event': "coroutine 'ExecutionAPISecretsBackend.aget_connection' was never awaited", 'filename': '/usr/python/lib/python3.13/unittest/mock.py', 'level': 'warning', ...}
============================================================================== 1 failed, 1476 passed, 10 warnings in 58.80s ==============================================================================

```

Looks like the root cause is:
- Some tests patch ensure_secrets_backend_loaded() with MagicMock instances
- When `hasattr(mock, "aget_connection")` is called, Python 3.13's mock library
  creates an `AsyncMock` that generates an `unawaited` coroutine
- Python 3.13 is stricter about unawaited coroutines and emits RuntimeWarning
- With pytest-xdist parallel execution, mocks from other tests leak into
  test_reading_from_pipes when they run on the same worker


What made me doubt this is in `test_context_cache.py`:
```shell script
mock_backend = MagicMock(spec=["get_connection"]) # Attribute creation
mock_ensure_backends.return_value = [mock_backend]
```


- Warning originated from /usr/python/lib/python3.13/unittest/mock.py
- Only occurred intermittently, depending on test execution order

One thing to do would be to fix all tests that use `MagicMock(spec=[...])` to use spec_set or full class specs, but this would require changing multiple tests and there is a likelihood that such tests can be added in the future too. The fixture approach is more defensive and ensures this specific test is immune to contamination from any future tests.

I implemneted an autouse fixture that ensures real backend instances are used
(EnvironmentVariablesBackend and ExecutionAPISecretsBackend) instead
of relying on potentially mocked backends from other tests. This provides
test isolation for parallel execution.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
