### PR TITLE
Update Release instruction to include Task SDK version update

### DIFF
--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -361,7 +361,7 @@ uv tool install -e ./dev/breeze
 
 - Set the Airflow version in `airflow-core/src/airflow/__init__.py` (without the RC tag).
 - Set the Task SDK version in `task-sdk/src/airflow/sdk/__init__.py` (without the RC tag)
-- Update the Task SDK version `>=` part in `airflow-core/pyproject.toml` to `>=` TASK_SDK_VERSION without RC
+- Update the Task SDK version `>=` part in `airflow-core/pyproject.toml` to `==` TASK_SDK_VERSION without RC
 - Run `git commit` without a message to update versions in `docs`.
 - Add supported Airflow version to `./scripts/ci/prek/supported_versions.py` and let prek do the job again.
 - Replace the versions in `README.md` about installation and verify that installation instructions work fine.

--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -350,7 +350,17 @@ uv tool install -e ./dev/breeze
     git reset --hard origin/v${VERSION_BRANCH}-test
     ```
 
-- Set your version in `airflow/__init__.py` (without the RC tag).
+- Create a new branch from v${VERSION_BRANCH}-test
+
+    ```shell script
+    git checkout -b ${SYNC_BRANCH}
+    ```
+
+    We sync this new branch to the stable branch so that people would continue to backport PRs to the test branch
+    while the RC is being voted. The new branch must be in sync with where you cut it off from the test branch.
+
+- Set the Airflow version in `airflow-core/src/airflow/__init__.py` (without the RC tag).
+- Update the Task SDK version `>=` part in `airflow-core/pyproject.toml` to `>=` TASK_SDK_VERSION without RC
 - Run `git commit` without a message to update versions in `docs`.
 - Add supported Airflow version to `./scripts/ci/prek/supported_versions.py` and let prek do the job again.
 - Replace the versions in `README.md` about installation and verify that installation instructions work fine.

--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -360,6 +360,7 @@ uv tool install -e ./dev/breeze
     while the RC is being voted. The new branch must be in sync with where you cut it off from the test branch.
 
 - Set the Airflow version in `airflow-core/src/airflow/__init__.py` (without the RC tag).
+- Set the Task SDK version in `task-sdk/src/airflow/sdk/__init__.py` (without the RC tag)
 - Update the Task SDK version `>=` part in `airflow-core/pyproject.toml` to `>=` TASK_SDK_VERSION without RC
 - Run `git commit` without a message to update versions in `docs`.
 - Add supported Airflow version to `./scripts/ci/prek/supported_versions.py` and let prek do the job again.


### PR DESCRIPTION
This PR updates the release branch to include task-sdk version update when doing a new release. Also updates how we sync test branch for a new release

