### PR TITLE
Remove unnecessary list in aws_template_fields

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/utils/mixins.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/utils/mixins.py
@@ -158,4 +158,4 @@ def aws_template_fields(*template_fields: str) -> tuple[str, ...]:
             f"{', '.join(map(repr, template_fields))}."
         )
         raise TypeError(msg)
-    return tuple(sorted(list({"aws_conn_id", "region_name", "verify"} | set(template_fields))))
+    return tuple(sorted({"aws_conn_id", "region_name", "verify"} | set(template_fields)))


### PR DESCRIPTION
This PR removes a redundant list() call in the aws_template_fields utility function under the Amazon provider.

The sorted() function already returns a list, so the extra list() conversion was unnecessary.
This change simplifies the code without altering any functionality.