### PR TITLE
Support for "reconnecting" Supervisor Comms from task process when `dag.test()` is used

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -1504,7 +1504,6 @@ class InProcessTestSupervisor(ActivitySubprocess):
         return None
 
     def _handle_socket_comms(self):
-
         while self._open_sockets:
             self._service_subprocess(1.0)
 
@@ -1588,7 +1587,7 @@ class InProcessTestSupervisor(ActivitySubprocess):
                 state=TaskInstanceState.RUNNING,
             )
 
-            # Create a socketpair pre-emptively, in case the task process runs VirtualEnv operator or run as
+            # Create a socketpair preemptively, in case the task process runs VirtualEnv operator or run as
             # user.
             with supervisor._setup_subprocess_socket():
                 context = ti.get_template_context()

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -1587,7 +1587,7 @@ class InProcessTestSupervisor(ActivitySubprocess):
                 state=TaskInstanceState.RUNNING,
             )
 
-            # Create a socketpair pre-emptively, in case the task process runs VirtualEnv operator or run_as_user
+            # Create a socketpair preemptively, in case the task process runs VirtualEnv operator or run_as_user
             with supervisor._setup_subprocess_socket():
                 context = ti.get_template_context()
                 log = structlog.get_logger(logger_name="task")

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -1499,8 +1499,8 @@ class InProcessTestSupervisor(ActivitySubprocess):
     def _check_subprocess_exit(
         self, raise_on_timeout: bool = False, expect_signal: None | int = None
     ) -> int | None:
-        # In process has no subprocess, so we don't need to poll anything. This is called from
-        # _service_subprocess, so we need to override it
+        # InProcessSupervisor has no subprocess, so we don't need to poll anything. This is called from
+        # _handle_socket_comms, so we need to override it
         return None
 
     def _handle_socket_comms(self):
@@ -1587,8 +1587,7 @@ class InProcessTestSupervisor(ActivitySubprocess):
                 state=TaskInstanceState.RUNNING,
             )
 
-            # Create a socketpair preemptively, in case the task process runs VirtualEnv operator or run as
-            # user.
+            # Create a socketpair pre-emptively, in case the task process runs VirtualEnv operator or run_as_user
             with supervisor._setup_subprocess_socket():
                 context = ti.get_template_context()
                 log = structlog.get_logger(logger_name="task")

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -27,6 +27,7 @@ import os
 import selectors
 import signal
 import sys
+import threading
 import time
 import weakref
 from collections import deque
@@ -1495,6 +1496,45 @@ class InProcessTestSupervisor(ActivitySubprocess):
             # Bypass the tenacity retries!
             return super().request.__wrapped__(self, *args, **kwargs)  # type: ignore[attr-defined]
 
+    def _check_subprocess_exit(
+        self, raise_on_timeout: bool = False, expect_signal: None | int = None
+    ) -> int | None:
+        # In process has no subprocess, so we don't need to poll anything. This is called from
+        # _service_subprocess, so we need to override it
+        return None
+
+    def _handle_socket_comms(self):
+
+        while self._open_sockets:
+            self._service_subprocess(1.0)
+
+    @contextlib.contextmanager
+    def _setup_subprocess_socket(self):
+        thread = threading.Thread(target=self._handle_socket_comms, daemon=True)
+
+        requests, child_sock = socketpair()
+
+        self._open_sockets[requests] = "requests"
+        self.stdin = requests
+
+        self.selector.register(
+            requests,
+            selectors.EVENT_READ,
+            length_prefixed_frame_reader(self.handle_requests(log), on_close=self._on_socket_closed),
+        )
+        os.set_inheritable(child_sock.fileno(), True)
+        os.environ["__AIRFLOW_SUPERVISOR_FD"] = str(child_sock.fileno())
+
+        try:
+            thread.start()
+            yield child_sock
+        finally:
+            requests.close()
+            child_sock.close()
+            self._on_socket_closed(requests)
+            thread.join(0)
+            os.environ.pop("__AIRFLOW_SUPERVISOR_FD", None)
+
     @classmethod
     def start(  # type: ignore[override]
         cls,
@@ -1547,16 +1587,20 @@ class InProcessTestSupervisor(ActivitySubprocess):
                 start_date=start_date,
                 state=TaskInstanceState.RUNNING,
             )
-            context = ti.get_template_context()
-            log = structlog.get_logger(logger_name="task")
 
-            state, msg, error = run(ti, context, log)
-            finalize(ti, state, context, log, error)
+            # Create a socketpair pre-emptively, in case the task process runs VirtualEnv operator or run as
+            # user.
+            with supervisor._setup_subprocess_socket():
+                context = ti.get_template_context()
+                log = structlog.get_logger(logger_name="task")
 
-            # In the normal subprocess model, the task runner calls this before exiting.
-            # Since we're running in-process, we manually notify the API server that
-            # the task has finished—unless the terminal state was already sent explicitly.
-            supervisor.update_task_state_if_needed()
+                state, msg, error = run(ti, context, log)
+                finalize(ti, state, context, log, error)
+
+                # In the normal subprocess model, the task runner calls this before exiting.
+                # Since we're running in-process, we manually notify the API server that
+                # the task has finished—unless the terminal state was already sent explicitly.
+                supervisor.update_task_state_if_needed()
 
         return TaskRunResult(ti=ti, state=state, msg=msg, error=error)
 

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1491,11 +1491,15 @@ def reinit_supervisor_comms() -> None:
     run_as_user, or from inside the python code in a virtualenv (et al.) operator to re-connect so those tasks
     can continue to access variables etc.
     """
+    import socket
+
     if "SUPERVISOR_COMMS" not in globals():
         global SUPERVISOR_COMMS
         log = structlog.get_logger(logger_name="task")
 
-        SUPERVISOR_COMMS = CommsDecoder[ToTask, ToSupervisor](log=log)
+        fd = int(os.environ.get("__AIRFLOW_SUPERVISOR_FD", "0"))
+
+        SUPERVISOR_COMMS = CommsDecoder[ToTask, ToSupervisor](log=log, socket=socket.socket(fileno=fd))
 
     logs = SUPERVISOR_COMMS.send(ResendLoggingFD())
     if isinstance(logs, SentFDs):


### PR DESCRIPTION
This is a follow up to #57212, which worked fine "at run time" but did not
work in many of our own unit tests, which rely on `dag.test` or `ti.run`.

The way this is implemented is that when we use the InProcessTestSupervisor we
pre-emptively create a socket pair. We have to create it even it its not being
used, as we can't know.

And since this is all in one process we create a thread to handle the socket
comms. Since this is only ever for tests performance or hitting the GIL
doesn't matter.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
