### PR TITLE
Remove deprecation warning in common test utils

### DIFF
--- a/devel-common/src/tests_common/pytest_plugin.py
+++ b/devel-common/src/tests_common/pytest_plugin.py
@@ -1825,8 +1825,8 @@ def refuse_to_run_test_from_wrongly_named_files(request: pytest.FixtureRequest):
 
 
 @pytest.fixture(autouse=True, scope="session")
-@pytest.mark.usefixture("_ensure_configured_logging")
-def initialize_providers_manager():
+def initialize_providers_manager(request: pytest.FixtureRequest):
+    request.getfixturevalue("_ensure_configured_logging")
     if importlib.util.find_spec("airflow") is None:
         # If airflow is not installed, we should not initialize providers manager
         return

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_appflow.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_appflow.py
@@ -56,7 +56,6 @@ DUMP_COMMON_ARGS = {
 AppflowBaseOperator.UPDATE_PROPAGATION_TIME = 0  # avoid wait
 
 
-@pytest.mark.db_test
 @pytest.fixture
 def ctx(create_task_instance, session):
     ti = create_task_instance(


### PR DESCRIPTION
> pytest.PytestRemovedIn9Warning: Marks applied to fixtures have no effect
> https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function

Example run https://github.com/apache/airflow/actions/runs/19237936579/job/54993801664?pr=58147

The linked document says 

> > Deprecated since version 7.4.
>
> Applying a mark to a fixture function never had any effect, but it is a common user error.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
