### PR TITLE
providers/trino: set split_statements=True by default and add unit tests

### DIFF
--- a/providers/trino/src/airflow/providers/trino/hooks/trino.py
+++ b/providers/trino/src/airflow/providers/trino/hooks/trino.py
@@ -309,16 +309,15 @@ class TrinoHook(DbApiHook):
         return_last: bool = True,
     ) -> tuple | list[tuple] | list[list[tuple] | tuple] | None:
         """
-        Overwrite common run. Default split_statements = True
-        :param sql: the sql statement to be executed (str) or a list of
-            sql statements to execute
-        :param autocommit: What to set the connection's autocommit setting to
-            before executing the query.
-        :param parameters: The parameters to render the SQL query with.
-        :param handler: The result handler which is called with the result of each statement.
-        :param split_statements: Whether to split a single SQL string into statements and run separately
-        :param return_last: Whether to return result for only last statement or for all after split
-        :return: if handler provided, returns query results (may be list of results depending on params)
+        Override common run to set split_statements=True by default.
+
+        :param sql: SQL statement or list of statements to execute.
+        :param autocommit: Set autocommit mode before query execution.
+        :param parameters: Parameters to render the SQL query with.
+        :param handler: Optional callable to process each statement result.
+        :param split_statements: Split single SQL string into statements if True.
+        :param return_last: Return only last statement result if True.
+        :return: Query result or list of results.
         """
         return super().run(sql, autocommit, parameters, handler, split_statements, return_last)
 

--- a/providers/trino/src/airflow/providers/trino/hooks/trino.py
+++ b/providers/trino/src/airflow/providers/trino/hooks/trino.py
@@ -21,7 +21,7 @@ import json
 import os
 from collections.abc import Iterable, Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, overload, Callable
 from urllib.parse import quote_plus, urlencode
 
 import trino
@@ -276,6 +276,51 @@ class TrinoHook(DbApiHook):
         else:
             df = pd.DataFrame(**kwargs)
         return df
+
+    @overload
+    def run(
+        self,
+        sql: str | Iterable[str],
+        autocommit: bool = ...,
+        parameters: Iterable | Mapping[str, Any] | None = ...,
+        handler: None = ...,
+        split_statements: bool = ...,
+        return_last: bool = ...,
+    ) -> None: ...
+
+    @overload
+    def run(
+        self,
+        sql: str | Iterable[str],
+        autocommit: bool = ...,
+        parameters: Iterable | Mapping[str, Any] | None = ...,
+        handler: Callable[[Any], T] = ...,
+        split_statements: bool = ...,
+        return_last: bool = ...,
+    ) -> tuple | list[tuple] | list[list[tuple] | tuple] | None: ...
+
+    def run(
+        self,
+        sql: str | Iterable[str],
+        autocommit: bool = False,
+        parameters: Iterable | Mapping[str, Any] | None = None,
+        handler: Callable[[Any], T] | None = None,
+        split_statements: bool = True,
+        return_last: bool = True,
+    ) -> tuple | list[tuple] | list[list[tuple] | tuple] | None:
+        """
+        Overwrite common run. Default split_statements = True
+        :param sql: the sql statement to be executed (str) or a list of
+            sql statements to execute
+        :param autocommit: What to set the connection's autocommit setting to
+            before executing the query.
+        :param parameters: The parameters to render the SQL query with.
+        :param handler: The result handler which is called with the result of each statement.
+        :param split_statements: Whether to split a single SQL string into statements and run separately
+        :param return_last: Whether to return result for only last statement or for all after split
+        :return: if handler provided, returns query results (may be list of results depending on params)
+        """
+        return super().run(sql, autocommit, parameters, handler, split_statements, return_last)
 
     def _get_polars_df(self, sql: str = "", parameters=None, **kwargs):
         try:

--- a/providers/trino/src/airflow/providers/trino/hooks/trino.py
+++ b/providers/trino/src/airflow/providers/trino/hooks/trino.py
@@ -19,9 +19,9 @@ from __future__ import annotations
 
 import json
 import os
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypeVar, overload, Callable
+from typing import TYPE_CHECKING, Any, TypeVar, overload
 from urllib.parse import quote_plus, urlencode
 
 import trino

--- a/providers/trino/tests/unit/trino/hooks/test_trino.py
+++ b/providers/trino/tests/unit/trino/hooks/test_trino.py
@@ -401,6 +401,38 @@ class TestTrinoHook:
         self.db_hook.run(sql, autocommit, parameters, list)
         mock_run.assert_called_once_with(sql, autocommit, parameters, handler)
 
+    @patch("airflow.hooks.dbapi.DbApiHook.run")
+    def test_run_defaults_no_handler(self, super_run):
+        super_run.return_value = None
+        sql = "SELECT 1"
+        result = self.db_hook.run(sql)
+        assert result is None
+        super_run.assert_called_once_with(sql, False, None, None, True, True)
+
+    @patch("airflow.hooks.dbapi.DbApiHook.run")
+    def test_run_with_handler_and_params(self, super_run):
+        super_run.return_value = [("ok",)]
+        sql = "SELECT 1"
+        autocommit = True
+        parameters = ("hello", "world")
+        handler = list
+        res = self.db_hook.run(
+            sql,
+            autocommit = autocommit,
+            parameters = parameters,
+            handler = handler,
+            split_statements = False,
+            return_last = False,
+        )
+        assert res == [("ok",)]
+        super_run.assert_called_once_with(sql, True, parameters, handler, False, False)
+
+    @patch("airflow.hooks.dbapi.DbApiHook.run")
+    def test_run_multistatement_defaults_to_split(self, super_run):
+        sql = "SELECT 1; SELECT 2"
+        self.db_hook.run(sql)
+        super_run.assert_called_once_with(sql, False, None, None, True, True)
+
     def test_connection_success(self):
         status, msg = self.db_hook.test_connection()
         assert status is True

--- a/providers/trino/tests/unit/trino/hooks/test_trino.py
+++ b/providers/trino/tests/unit/trino/hooks/test_trino.py
@@ -418,11 +418,11 @@ class TestTrinoHook:
         handler = list
         res = self.db_hook.run(
             sql,
-            autocommit = autocommit,
-            parameters = parameters,
-            handler = handler,
-            split_statements = False,
-            return_last = False,
+            autocommit=autocommit,
+            parameters=parameters,
+            handler=handler,
+            split_statements=False,
+            return_last=False,
         )
         assert res == [("ok",)]
         super_run.assert_called_once_with(sql, True, parameters, handler, False, False)

--- a/providers/trino/tests/unit/trino/hooks/test_trino.py
+++ b/providers/trino/tests/unit/trino/hooks/test_trino.py
@@ -401,7 +401,7 @@ class TestTrinoHook:
         self.db_hook.run(sql, autocommit, parameters, list)
         mock_run.assert_called_once_with(sql, autocommit, parameters, handler)
 
-    @patch("airflow.hooks.dbapi.DbApiHook.run")
+    @patch("airflow.providers.common.sql.hooks.sql.DbApiHook.run")
     def test_run_defaults_no_handler(self, super_run):
         super_run.return_value = None
         sql = "SELECT 1"
@@ -409,7 +409,7 @@ class TestTrinoHook:
         assert result is None
         super_run.assert_called_once_with(sql, False, None, None, True, True)
 
-    @patch("airflow.hooks.dbapi.DbApiHook.run")
+    @patch("airflow.providers.common.sql.hooks.sql.DbApiHook.run")
     def test_run_with_handler_and_params(self, super_run):
         super_run.return_value = [("ok",)]
         sql = "SELECT 1"
@@ -427,7 +427,7 @@ class TestTrinoHook:
         assert res == [("ok",)]
         super_run.assert_called_once_with(sql, True, parameters, handler, False, False)
 
-    @patch("airflow.hooks.dbapi.DbApiHook.run")
+    @patch("airflow.providers.common.sql.hooks.sql.DbApiHook.run")
     def test_run_multistatement_defaults_to_split(self, super_run):
         sql = "SELECT 1; SELECT 2"
         self.db_hook.run(sql)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
### Summary

- Sets `split_statements=True` and `return_last=True` by default in `TrinoHook.run()`.
- Adds unit tests verifying correct delegation to `DbApiHook.run()` with proper defaults.

### Tests

- Added `test_run_defaults_no_handler`, `test_run_with_handler_and_params`, and `test_run_multistatement_defaults_to_split` in `tests/providers/trino/hooks/test_trino.py`.
- Verified all tests pass locally.

closes #47167
