### PR TITLE
Implement callback priority in trigger queue

### DIFF
--- a/airflow-core/src/airflow/models/trigger.py
+++ b/airflow-core/src/airflow/models/trigger.py
@@ -373,7 +373,9 @@ class Trigger(Base):
         # It prioritizes callbacks, then DAGs over event driven scheduling which is fair
         queries = [
             # Callback triggers
-            select(cls.id).where(cls.callback.has()).order_by(cls.created_date),
+            select(cls.id)
+            .join(Callback, isouter=False)
+            .order_by(Callback.priority_weight.desc(), cls.created_date),
             # Task Instance triggers
             select(cls.id)
             .prefix_with("STRAIGHT_JOIN", dialect="mysql")

--- a/airflow-core/tests/unit/models/test_trigger.py
+++ b/airflow-core/tests/unit/models/test_trigger.py
@@ -480,6 +480,23 @@ def test_get_sorted_triggers_different_priority_weights(session, create_task_ins
     """
     Tests that triggers are sorted by the priority_weight.
     """
+    callback_triggers = [
+        Trigger(classpath="airflow.triggers.testing.CallbackTrigger", kwargs={}),
+        Trigger(classpath="airflow.triggers.testing.CallbackTrigger", kwargs={}),
+        Trigger(classpath="airflow.triggers.testing.CallbackTrigger", kwargs={}),
+    ]
+    session.add_all(callback_triggers)
+    session.flush()
+
+    callbacks = [
+        TriggererCallback(callback_def=AsyncCallback("classpath.low"), priority_weight=1),
+        TriggererCallback(callback_def=AsyncCallback("classpath.mid"), priority_weight=5),
+        TriggererCallback(callback_def=AsyncCallback("classpath.high"), priority_weight=10),
+    ]
+    for callback, trigger in zip(callbacks, callback_triggers):
+        callback.trigger = trigger
+    session.add_all(callbacks)
+
     old_logical_date = datetime.datetime(
         2023, 5, 9, 12, 16, 14, 474415, tzinfo=pytz.timezone("Africa/Abidjan")
     )
@@ -517,11 +534,17 @@ def test_get_sorted_triggers_different_priority_weights(session, create_task_ins
     session.add(TI_new)
 
     session.commit()
-    assert session.query(Trigger).count() == 2
+    assert session.query(Trigger).count() == 5
 
     trigger_ids_query = Trigger.get_sorted_triggers(capacity=100, alive_triggerer_ids=[], session=session)
 
-    assert trigger_ids_query == [(trigger_new.id,), (trigger_old.id,)]
+    assert trigger_ids_query == [
+        (callback_triggers[2].id,),
+        (callback_triggers[1].id,),
+        (callback_triggers[0].id,),
+        (trigger_new.id,),
+        (trigger_old.id,),
+    ]
 
 
 class SensitiveKwargsTrigger(BaseTrigger):


### PR DESCRIPTION
This makes use of the priority_weight column in the Callback model. Currently, the user doesn't have the ability to set the priority but since the column exists, I figured we should support it on the execution side at least for now.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
