### PR TITLE
Update pyproject.toml files with pytest>=9.0.0 TOML syntax

### DIFF
--- a/airflow-ctl-tests/pyproject.toml
+++ b/airflow-ctl-tests/pyproject.toml
@@ -41,7 +41,14 @@ dependencies = [
 ]
 
 [tool.pytest]
-addopts = "-rasl --verbosity=2 -p no:flaky -p no:nose -p no:legacypath"
+addopts = [
+    "-rasl",
+    "--verbosity=2",
+    "-p", "no:flaky",
+    "-p", "no:nose",
+    "-p", "no:legacypath",
+]
+
 norecursedirs = [
     ".eggs",
 ]

--- a/airflow-ctl-tests/pyproject.toml
+++ b/airflow-ctl-tests/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "apache-airflow-devel-common",
 ]
 
-[tool.pytest.ini_options]
+[tool.pytest]
 addopts = "-rasl --verbosity=2 -p no:flaky -p no:nose -p no:legacypath"
 norecursedirs = [
     ".eggs",

--- a/airflow-ctl/pyproject.toml
+++ b/airflow-ctl/pyproject.toml
@@ -196,7 +196,7 @@ testpaths = [
 ]
 asyncio_default_fixture_loop_scope = "function"
 
-pythonpath = "tests"
+pythonpath = ["tests"]
 
 # Keep temporary directories (created by `tmp_path`) for 2 recent runs only failed tests.
 tmp_path_retention_count = "2"

--- a/airflow-ctl/pyproject.toml
+++ b/airflow-ctl/pyproject.toml
@@ -163,7 +163,7 @@ input = "../airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-ge
 output = "src/airflowctl/api/datamodels/generated.py"
 
 ## pytest settings ##
-[tool.pytest.ini_options]
+[tool.pytest]
 addopts = [
     "--tb=short",
     "-rasl",

--- a/airflow-e2e-tests/pyproject.toml
+++ b/airflow-e2e-tests/pyproject.toml
@@ -42,7 +42,14 @@ dependencies = [
 ]
 
 [tool.pytest]
-addopts = "-rasl --verbosity=2 -p no:flaky -p no:nose -p no:legacypath"
+addopts = [
+    "-rasl",
+    "--verbosity=2",
+    "-p", "no:flaky",
+    "-p", "no:nose",
+    "-p", "no:legacypath",
+]
+
 norecursedirs = [
     ".eggs",
 ]

--- a/airflow-e2e-tests/pyproject.toml
+++ b/airflow-e2e-tests/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "boto3>=1.37.2",
 ]
 
-[tool.pytest.ini_options]
+[tool.pytest]
 addopts = "-rasl --verbosity=2 -p no:flaky -p no:nose -p no:legacypath"
 norecursedirs = [
     ".eggs",

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -104,7 +104,12 @@ include = [
 
 [tool.pytest]
 # make sure that pytest.ini is not read from pyproject.toml in paraent directories
-addopts = "--color=yes --cov-config=pyproject.toml --cov=airflow_client"
+addopts = [
+    "--color=yes",
+    "--cov-config=pyproject.toml",
+    "--cov=airflow_client",
+]
+
 norecursedirs = [
 ]
 log_level = "INFO"

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -102,7 +102,7 @@ include = [
     "/airflow_client",
 ]
 
-[tool.pytest.ini_options]
+[tool.pytest]
 # make sure that pytest.ini is not read from pyproject.toml in paraent directories
 addopts = "--color=yes --cov-config=pyproject.toml --cov=airflow_client"
 norecursedirs = [

--- a/dev/breeze/pyproject.toml
+++ b/dev/breeze/pyproject.toml
@@ -90,7 +90,14 @@ line-length = 110
 target-version = ['py310', 'py311', 'py312']
 
 [tool.pytest]
-addopts = "-rasl --verbosity=2 -p no:flaky -p no:nose -p no:legacypath"
+addopts = [
+    "-rasl",
+    "--verbosity=2",
+    "-p", "no:flaky",
+    "-p", "no:nose",
+    "-p", "no:legacypath",
+]
+
 norecursedirs = [
     ".eggs",
 ]

--- a/dev/breeze/pyproject.toml
+++ b/dev/breeze/pyproject.toml
@@ -89,7 +89,7 @@ name = "airflow_breeze"
 line-length = 110
 target-version = ['py310', 'py311', 'py312']
 
-[tool.pytest.ini_options]
+[tool.pytest]
 addopts = "-rasl --verbosity=2 -p no:flaky -p no:nose -p no:legacypath"
 norecursedirs = [
     ".eggs",

--- a/docker-tests/pyproject.toml
+++ b/docker-tests/pyproject.toml
@@ -40,7 +40,13 @@ dependencies = [
 ]
 
 [tool.pytest]
-addopts = "-rasl --verbosity=2 -p no:flaky -p no:nose -p no:legacypath"
+addopts = [
+    "-rasl",
+    "--verbosity=2",
+    "-p", "no:flaky",
+    "-p", "no:nose",
+    "-p", "no:legacypath",
+]
 norecursedirs = [
     ".eggs",
 ]

--- a/docker-tests/pyproject.toml
+++ b/docker-tests/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "apache-airflow-devel-common",
 ]
 
-[tool.pytest.ini_options]
+[tool.pytest]
 addopts = "-rasl --verbosity=2 -p no:flaky -p no:nose -p no:legacypath"
 norecursedirs = [
     ".eggs",

--- a/helm-tests/pyproject.toml
+++ b/helm-tests/pyproject.toml
@@ -40,7 +40,13 @@ dependencies = [
 ]
 
 [tool.pytest]
-addopts = "-rasl --verbosity=2 -p no:flaky -p no:nose -p no:legacypath"
+addopts = [
+    "-rasl",
+    "--verbosity=2",
+    "-p", "no:flaky",
+    "-p", "no:nose",
+    "-p", "no:legacypath",
+]
 norecursedirs = [
     ".eggs",
 ]

--- a/helm-tests/pyproject.toml
+++ b/helm-tests/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "apache-airflow-providers-cncf-kubernetes",
 ]
 
-[tool.pytest.ini_options]
+[tool.pytest]
 addopts = "-rasl --verbosity=2 -p no:flaky -p no:nose -p no:legacypath"
 norecursedirs = [
     ".eggs",

--- a/kubernetes-tests/pyproject.toml
+++ b/kubernetes-tests/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "requests>=2.32.0,<3",
 ]
 
-[tool.pytest.ini_options]
+[tool.pytest]
 addopts = "-rasl --verbosity=2 -p no:flaky -p no:nose -p no:legacypath"
 norecursedirs = [
     ".eggs",

--- a/kubernetes-tests/pyproject.toml
+++ b/kubernetes-tests/pyproject.toml
@@ -44,7 +44,13 @@ dependencies = [
 ]
 
 [tool.pytest]
-addopts = "-rasl --verbosity=2 -p no:flaky -p no:nose -p no:legacypath"
+addopts = [
+    "-rasl",
+    "--verbosity=2",
+    "-p", "no:flaky",
+    "-p", "no:nose",
+    "-p", "no:legacypath",
+]
 norecursedirs = [
     ".eggs",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -906,7 +906,7 @@ mark-parentheses = false
 fixture-parentheses = false
 
 ## pytest settings ##
-[tool.pytest.ini_options]
+[tool.pytest]
 addopts = [
     "--tb=short",
     "-rasl",

--- a/task-sdk-integration-tests/pyproject.toml
+++ b/task-sdk-integration-tests/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "apache-airflow-devel-common",
 ]
 
-[tool.pytest.ini_options]
+[tool.pytest]
 addopts = "-rasl --verbosity=2 -p no:flaky -p no:nose -p no:legacypath"
 norecursedirs = [
     ".eggs",

--- a/task-sdk-integration-tests/pyproject.toml
+++ b/task-sdk-integration-tests/pyproject.toml
@@ -41,7 +41,13 @@ dependencies = [
 ]
 
 [tool.pytest]
-addopts = "-rasl --verbosity=2 -p no:flaky -p no:nose -p no:legacypath"
+addopts = [
+    "-rasl",
+    "--verbosity=2",
+    "-p", "no:flaky",
+    "-p", "no:nose",
+    "-p", "no:legacypath",
+]
 norecursedirs = [
     ".eggs",
 ]

--- a/task-sdk/pyproject.toml
+++ b/task-sdk/pyproject.toml
@@ -236,7 +236,7 @@ testpaths = [
 ]
 asyncio_default_fixture_loop_scope = "function"
 
-pythonpath = "tests"
+pythonpath = ["tests"]
 
 # Keep temporary directories (created by `tmp_path`) for 2 recent runs only failed tests.
 tmp_path_retention_count = "2"

--- a/task-sdk/pyproject.toml
+++ b/task-sdk/pyproject.toml
@@ -205,7 +205,7 @@ url = 'http://0.0.0.0:8080/execution/openapi.json'
 output = 'src/airflow/sdk/api/datamodels/_generated.py'
 
 ## pytest settings ##
-[tool.pytest.ini_options]
+[tool.pytest]
 addopts = [
     "--tb=short",
     "-rasl",


### PR DESCRIPTION
## Why
Since we upgraded pytest to >=9.0.0, we don't need to use `tool.pytset.ini_options`

## What
Replace `tool.pytest.ini_options` with `tool.pytest` and fix the syntax accordingly

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
