### PR TITLE
Make `conf.validate` pluggable on config parser

### DIFF
--- a/airflow-core/src/airflow/configuration.py
+++ b/airflow-core/src/airflow/configuration.py
@@ -779,7 +779,7 @@ class AirflowConfigParser(ConfigParser):
             validator()
         self.is_validated = True
 
-    def _validate_deprecated_values(self):
+    def _validate_deprecated_values(self) -> None:
         """Validate and upgrade deprecated default values."""
         for section, replacement in self.deprecated_values.items():
             for name, info in replacement.items():

--- a/airflow-core/src/airflow/configuration.py
+++ b/airflow-core/src/airflow/configuration.py
@@ -773,7 +773,7 @@ class AirflowConfigParser(ConfigParser):
             self._upgrade_postgres_metastore_conn,
         ]
 
-    def validate(self):
+    def validate(self) -> None:
         """Run all registered validators."""
         for validator in self._validators:
             validator()

--- a/airflow-core/src/airflow/configuration.py
+++ b/airflow-core/src/airflow/configuration.py
@@ -32,7 +32,7 @@ import subprocess
 import sys
 import warnings
 from base64 import b64encode
-from collections.abc import Generator, Iterable
+from collections.abc import Callable, Generator, Iterable
 from configparser import ConfigParser, NoOptionError, NoSectionError
 from contextlib import contextmanager
 from copy import deepcopy
@@ -758,10 +758,29 @@ class AirflowConfigParser(ConfigParser):
         self._default_values = create_default_config_parser(self.configuration_description)
         self._providers_configuration_loaded = False
 
-    def validate(self):
-        self._validate_sqlite3_version()
-        self._validate_enums()
+    @property
+    def _validators(self) -> list[Callable[[], None]]:
+        """
+        Return list of validators defined on a config parser class.
 
+        Subclasses can override this to customize the validators that are run during validation on the
+        config parser instance.
+        """
+        return [
+            self._validate_sqlite3_version,
+            self._validate_enums,
+            self._validate_deprecated_values,
+            self._upgrade_postgres_metastore_conn,
+        ]
+
+    def validate(self):
+        """Run all registered validators."""
+        for validator in self._validators:
+            validator()
+        self.is_validated = True
+
+    def _validate_deprecated_values(self):
+        """Validate and upgrade deprecated default values."""
         for section, replacement in self.deprecated_values.items():
             for name, info in replacement.items():
                 old, new = info
@@ -776,9 +795,6 @@ class AirflowConfigParser(ConfigParser):
                         current_value=current_value,
                         new_value=new_value,
                     )
-
-        self._upgrade_postgres_metastore_conn()
-        self.is_validated = True
 
     def _upgrade_postgres_metastore_conn(self):
         """

--- a/airflow-core/tests/unit/core/test_configuration.py
+++ b/airflow-core/tests/unit/core/test_configuration.py
@@ -1105,6 +1105,33 @@ key7 =
             for key, value in expected_backend_kwargs.items():
                 assert getattr(secrets_backend, key) == value
 
+    def test_default_validators(self):
+        """Test that _validators property returns default validators."""
+        test_conf = AirflowConfigParser(default_config="")
+        validators = test_conf._validators
+
+        assert len(validators) == 4
+
+    def test_validate_sets_is_validated_flag(self):
+        """Test that validate() sets is_validated to True."""
+        test_conf = AirflowConfigParser(default_config="")
+        assert test_conf.is_validated is False
+        test_conf.validate()
+        assert test_conf.is_validated is True
+
+    def test_validators_can_be_overridden_in_subclass(self):
+        """Test that subclasses can override _validators to customize validation."""
+
+        class CustomConfigParser(AirflowConfigParser):
+            @property
+            def _validators(self):
+                return [self._validate_enums]
+
+        test_conf = CustomConfigParser(default_config="")
+        validators = test_conf._validators
+        assert len(validators) == 1
+        assert validators[0].__name__ == "_validate_enums"
+
 
 @mock.patch.dict(
     "os.environ",

--- a/airflow-core/tests/unit/core/test_configuration.py
+++ b/airflow-core/tests/unit/core/test_configuration.py
@@ -1105,20 +1105,6 @@ key7 =
             for key, value in expected_backend_kwargs.items():
                 assert getattr(secrets_backend, key) == value
 
-    def test_default_validators(self):
-        """Test that _validators property returns default validators."""
-        test_conf = AirflowConfigParser(default_config="")
-        validators = test_conf._validators
-
-        assert len(validators) == 4
-        expected_validators = [
-            "_validate_sqlite3_version",
-            "_validate_enums",
-            "_validate_deprecated_values",
-            "_upgrade_postgres_metastore_conn",
-        ]
-        assert [v.__name__ for v in validators] == expected_validators
-
     def test_validate_sets_is_validated_flag(self):
         """Test that validate() sets is_validated to True."""
         test_conf = AirflowConfigParser(default_config="")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Through this PR I intend to refactor `AirflowConfigParser.validate()` to use a pluggable validator pattern, enabling subclasses to customize which validators run during configuration validation.


### Why am I doing this?

This prepares for moving the configuration parser to a shared library (as work has been started on https://github.com/apache/airflow/pull/57744). The shared parser will be used by both airflow-core and task-sdk, but each distribution could need different validators, example:

- Core needs: SQLite version checks, Postgres connection upgrades, enum validation, deprecated value handling
- SDK needs: None of the above (no database validators, no Core-specific enums at all)

Without this refactoring, SDK would inherit all Core validators, if those move to shared. If they stay in core, then there would be unnecessary duplication of code which can potentially become a maintenance burden.

### How this change helps:

- Subclasses can customize validation by overriding `_validators`
- Each validator is a separate method, easier to test and maintain
- Backward compatible: Same validators run, just organized differently

Future Benefits:
- Easier migration to shared: When moving to shared parser, SDK can override `_validators` to exclude core specific validators
- No code duplication: Validators of core stay in core, SDK inherits empty list from shared and can override as needed

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
