### PR TITLE
Add HTTP URL authentication support to GitHook

### DIFF
--- a/providers/git/src/airflow/providers/git/hooks/git.py
+++ b/providers/git/src/airflow/providers/git/hooks/git.py
@@ -91,6 +91,11 @@ class GitHook(BaseHook):
             return
         if self.auth_token and self.repo_url.startswith("https://"):
             self.repo_url = self.repo_url.replace("https://", f"https://{self.user_name}:{self.auth_token}@")
+        elif self.auth_token and self.repo_url.startswith("http://"):
+            self.repo_url = self.repo_url.replace("http://", f"http://{self.user_name}:{self.auth_token}@")
+        elif self.repo_url.startswith("http://"):
+            # if no auth token, use the repo url as is
+            self.repo_url = self.repo_url
         elif not self.repo_url.startswith("git@") or not self.repo_url.startswith("https://"):
             self.repo_url = os.path.expanduser(self.repo_url)
 

--- a/providers/git/tests/unit/git/hooks/test_git.py
+++ b/providers/git/tests/unit/git/hooks/test_git.py
@@ -38,10 +38,13 @@ def bundle_temp_dir(tmp_path):
 GIT_DEFAULT_BRANCH = "main"
 
 AIRFLOW_HTTPS_URL = "https://github.com/apache/airflow.git"
+AIRFLOW_HTTP_URL = "http://github.com/apache/airflow.git"
 AIRFLOW_GIT = "git@github.com:apache/airflow.git"
 ACCESS_TOKEN = "my_access_token"
 CONN_DEFAULT = "git_default"
 CONN_HTTPS = "my_git_conn"
+CONN_HTTP = "my_git_conn_http"
+CONN_HTTP_NO_AUTH = "my_git_conn_http_no_auth"
 CONN_ONLY_PATH = "my_git_conn_only_path"
 CONN_ONLY_INLINE_KEY = "my_git_conn_only_inline_key"
 CONN_BOTH_PATH_INLINE = "my_git_conn_both_path_inline"
@@ -87,6 +90,21 @@ class TestGitHook:
         )
         create_connection_without_db(
             Connection(
+                conn_id=CONN_HTTP,
+                host=AIRFLOW_HTTP_URL,
+                password=ACCESS_TOKEN,
+                conn_type="git",
+            )
+        )
+        create_connection_without_db(
+            Connection(
+                conn_id=CONN_HTTP_NO_AUTH,
+                host=AIRFLOW_HTTP_URL,
+                conn_type="git",
+            )
+        )
+        create_connection_without_db(
+            Connection(
                 conn_id=CONN_ONLY_PATH,
                 host="path/to/repo",
                 conn_type="git",
@@ -112,6 +130,18 @@ class TestGitHook:
                 CONN_HTTPS,
                 {"repo_url": "https://github.com/apache/zzzairflow"},
                 f"https://user:{ACCESS_TOKEN}@github.com/apache/zzzairflow",
+            ),
+            (CONN_HTTP, {}, f"http://user:{ACCESS_TOKEN}@github.com/apache/airflow.git"),
+            (
+                CONN_HTTP,
+                {"repo_url": "http://github.com/apache/zzzairflow"},
+                f"http://user:{ACCESS_TOKEN}@github.com/apache/zzzairflow",
+            ),
+            (CONN_HTTP_NO_AUTH, {}, AIRFLOW_HTTP_URL),
+            (
+                CONN_HTTP_NO_AUTH,
+                {"repo_url": "http://github.com/apache/zzzairflow"},
+                "http://github.com/apache/zzzairflow",
             ),
             (CONN_ONLY_PATH, {}, "path/to/repo"),
         ],


### PR DESCRIPTION
GitHook now supports authentication tokens with HTTP URLs, matching the existing HTTPS support. This enables authentication with internal git repositories that use HTTP instead of HTTPS.

HTTP URLs without authentication tokens are preserved as-is.

