### PR TITLE
Make sure regenerating provider dependencies happens only once

### DIFF
--- a/dev/breeze/src/airflow_breeze/global_constants.py
+++ b/dev/breeze/src/airflow_breeze/global_constants.py
@@ -26,6 +26,7 @@ import subprocess
 from collections.abc import Generator
 from enum import Enum
 from pathlib import Path
+from threading import Lock
 
 from airflow_breeze.utils.functools_cache import clearable_cache
 from airflow_breeze.utils.host_info_utils import Architecture
@@ -655,10 +656,6 @@ AIRFLOW_GENERATED_PROVIDER_DEPENDENCIES_HASH_PATH = (
     AIRFLOW_ROOT_PATH / "generated" / "provider_dependencies.json.sha256sum"
 )
 
-UPDATE_PROVIDER_DEPENDENCIES_SCRIPT = (
-    AIRFLOW_ROOT_PATH / "scripts" / "ci" / "prek" / "update_providers_dependencies.py"
-)
-
 ALL_PYPROJECT_TOML_FILES = []
 
 
@@ -682,6 +679,33 @@ def get_all_provider_pyproject_toml_provider_yaml_files() -> Generator[Path, Non
                 break
 
 
+_regenerate_provider_deps_lock = Lock()
+_has_regeneration_of_providers_run = False
+
+UPDATE_PROVIDER_DEPENDENCIES_SCRIPT = (
+    AIRFLOW_ROOT_PATH / "scripts" / "ci" / "prek" / "update_providers_dependencies.py"
+)
+
+
+def regenerate_provider_dependencies_once() -> None:
+    """Run provider dependencies regeneration once per interpreter execution.
+
+    This function is safe to call multiple times from different modules; the
+    underlying command will only run once. If the underlying command fails the
+    CalledProcessError is propagated to the caller.
+    """
+    global _has_regeneration_of_providers_run
+    with _regenerate_provider_deps_lock:
+        if _has_regeneration_of_providers_run:
+            return
+        # Run the regeneration command from the repository root to ensure correct
+        # relative paths if the script expects to be run from AIRFLOW_ROOT_PATH.
+        subprocess.check_call(
+            ["uv", "run", UPDATE_PROVIDER_DEPENDENCIES_SCRIPT.as_posix()], cwd=AIRFLOW_ROOT_PATH
+        )
+        _has_regeneration_of_providers_run = True
+
+
 def _calculate_provider_deps_hash():
     import hashlib
 
@@ -697,7 +721,7 @@ def _run_provider_dependencies_generation(calculated_hash=None) -> dict:
     AIRFLOW_GENERATED_PROVIDER_DEPENDENCIES_HASH_PATH.write_text(calculated_hash)
     # We use regular print there as rich console might not be initialized yet here
     print("Regenerating provider dependencies file")
-    subprocess.check_call(["uv", "run", UPDATE_PROVIDER_DEPENDENCIES_SCRIPT.as_posix()])
+    regenerate_provider_dependencies_once()
     return json.loads(AIRFLOW_GENERATED_PROVIDER_DEPENDENCIES_PATH.read_text())
 
 
@@ -725,6 +749,7 @@ def generate_provider_dependencies_if_needed():
 
 
 DEVEL_DEPS_PATH = AIRFLOW_ROOT_PATH / "generated" / "devel_deps.txt"
+
 
 # Initialize files for rebuild check
 FILES_FOR_REBUILD_CHECK = [

--- a/dev/breeze/src/airflow_breeze/utils/md5_build_check.py
+++ b/dev/breeze/src/airflow_breeze/utils/md5_build_check.py
@@ -22,14 +22,13 @@ from __future__ import annotations
 
 import hashlib
 import os
-import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from airflow_breeze.global_constants import (
     ALL_PYPROJECT_TOML_FILES,
     FILES_FOR_REBUILD_CHECK,
-    UPDATE_PROVIDER_DEPENDENCIES_SCRIPT,
+    regenerate_provider_dependencies_once,
 )
 from airflow_breeze.utils.console import get_console
 from airflow_breeze.utils.path_utils import AIRFLOW_ROOT_PATH
@@ -113,7 +112,8 @@ def calculate_md5_checksum_for_files(
                 get_console().print(
                     [os.fspath(file.relative_to(AIRFLOW_ROOT_PATH)) for file in modified_pyproject_toml_files]
                 )
-            subprocess.check_call(["uv", "run", UPDATE_PROVIDER_DEPENDENCIES_SCRIPT.as_posix()])
+            # Delegate to the shared helper that ensures regeneration runs only once
+            regenerate_provider_dependencies_once()
     for file in FILES_FOR_REBUILD_CHECK:
         is_modified = check_md5_sum_for_file(file, md5sum_cache_dir, update)
         if is_modified:


### PR DESCRIPTION
This has to be done in global_constants module, because regeneration can happen just during importing and if we try to do it in a separate package circular dependencies might happen.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
