### PR TITLE
Add working_directory parameter

### DIFF
--- a/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/hooks/winrm.py
+++ b/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/hooks/winrm.py
@@ -226,6 +226,7 @@ class WinRMHook(BaseHook):
         ps_path: str | None = None,
         output_encoding: str = "utf-8",
         return_output: bool = True,
+        working_directory: str | None = None,
     ) -> tuple[int, list[bytes], list[bytes]]:
         """
         Run a command.
@@ -235,12 +236,13 @@ class WinRMHook(BaseHook):
             If specified, it will execute the command as powershell script.
         :param output_encoding: the encoding used to decode stout and stderr.
         :param return_output: Whether to accumulate and return the stdout or not.
+        :param working_directory: specify working directory.
         :return: returns a tuple containing return_code, stdout and stderr in order.
         """
         winrm_client = self.get_conn()
         self.log.info("Establishing WinRM connection to host: %s", self.remote_host)
         try:
-            shell_id = winrm_client.open_shell()
+            shell_id = winrm_client.open_shell(working_directory=working_directory)
         except Exception as error:
             error_msg = f"Error connecting to host: {self.remote_host}, error: {error}"
             self.log.error(error_msg)

--- a/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/operators/winrm.py
+++ b/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/operators/winrm.py
@@ -50,10 +50,14 @@ class WinRMOperator(BaseOperator):
     :param output_encoding: the encoding used to decode stout and stderr
     :param timeout: timeout for executing the command.
     :param expected_return_code: expected return code value(s) of command.
+    :param working_directory: specify working directory.
     """
 
-    template_fields: Sequence[str] = ("command",)
-    template_fields_renderers = {"command": "powershell"}
+    template_fields: Sequence[str] = (
+        "command",
+        "working_directory",
+    )
+    template_fields_renderers = {"command": "powershell", "working_directory": "powershell"}
 
     def __init__(
         self,
@@ -66,6 +70,7 @@ class WinRMOperator(BaseOperator):
         output_encoding: str = "utf-8",
         timeout: int = 10,
         expected_return_code: int | list[int] | range = 0,
+        working_directory: str | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -77,6 +82,7 @@ class WinRMOperator(BaseOperator):
         self.output_encoding = output_encoding
         self.timeout = timeout
         self.expected_return_code = expected_return_code
+        self.working_directory = working_directory
 
     def execute(self, context: Context) -> list | str:
         if self.ssh_conn_id and not self.winrm_hook:
@@ -97,6 +103,7 @@ class WinRMOperator(BaseOperator):
             ps_path=self.ps_path,
             output_encoding=self.output_encoding,
             return_output=self.do_xcom_push,
+            working_directory=self.working_directory,
         )
 
         success = False

--- a/providers/microsoft/winrm/tests/unit/microsoft/winrm/hooks/test_winrm.py
+++ b/providers/microsoft/winrm/tests/unit/microsoft/winrm/hooks/test_winrm.py
@@ -23,7 +23,11 @@ import pytest
 
 from airflow.exceptions import AirflowException
 from airflow.providers.microsoft.winrm.hooks.winrm import WinRMHook
-from airflow.sdk import Connection
+
+try:
+    from airflow.sdk import Connection
+except ImportError:
+    from airflow.models import Connection
 
 
 class TestWinRMHook:

--- a/providers/microsoft/winrm/tests/unit/microsoft/winrm/hooks/test_winrm.py
+++ b/providers/microsoft/winrm/tests/unit/microsoft/winrm/hooks/test_winrm.py
@@ -22,12 +22,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from airflow.exceptions import AirflowException
+from airflow.models import Connection
 from airflow.providers.microsoft.winrm.hooks.winrm import WinRMHook
-
-try:
-    from airflow.sdk import Connection
-except ImportError:
-    from airflow.models import Connection
 
 
 class TestWinRMHook:

--- a/providers/microsoft/winrm/tests/unit/microsoft/winrm/hooks/test_winrm.py
+++ b/providers/microsoft/winrm/tests/unit/microsoft/winrm/hooks/test_winrm.py
@@ -22,8 +22,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from airflow.exceptions import AirflowException
-from airflow.models import Connection
 from airflow.providers.microsoft.winrm.hooks.winrm import WinRMHook
+from airflow.sdk import Connection
 
 
 class TestWinRMHook:
@@ -42,6 +42,8 @@ class TestWinRMHook:
     @patch(
         "airflow.providers.microsoft.winrm.hooks.winrm.WinRMHook.get_connection",
         return_value=Connection(
+            conn_id="",
+            conn_type="",
             login="username",
             password="password",
             host="remote_host",
@@ -113,6 +115,8 @@ class TestWinRMHook:
     @patch(
         "airflow.providers.microsoft.winrm.hooks.winrm.WinRMHook.get_connection",
         return_value=Connection(
+            conn_id="",
+            conn_type="",
             login="username",
             password="password",
             host="remote_host",
@@ -154,6 +158,8 @@ class TestWinRMHook:
     @patch(
         "airflow.providers.microsoft.winrm.hooks.winrm.WinRMHook.get_connection",
         return_value=Connection(
+            conn_id="",
+            conn_type="",
             login="username",
             password="password",
             host="remote_host",
@@ -177,16 +183,20 @@ class TestWinRMHook:
                   }""",
         ),
     )
-    def test_run_without_stdout(self, mock_get_connection, mock_protocol):
+    def test_run_without_stdout_and_working_dir(self, mock_get_connection, mock_protocol):
         winrm_hook = WinRMHook(ssh_conn_id="conn_id")
-
+        working_dir = "c:\\test"
         mock_protocol.return_value.run_command = MagicMock(return_value="command_id")
         mock_protocol.return_value.get_command_output_raw = MagicMock(
             return_value=(b"stdout", b"stderr", 0, True)
         )
+        mock_protocol.return_value.open_shell = MagicMock()
 
-        return_code, stdout_buffer, stderr_buffer = winrm_hook.run("dir", return_output=False)
+        return_code, stdout_buffer, stderr_buffer = winrm_hook.run(
+            "dir", return_output=False, working_directory=working_dir
+        )
 
+        mock_protocol.return_value.open_shell.assert_called_once_with(working_directory=working_dir)
         assert return_code == 0
         assert not stdout_buffer
         assert stderr_buffer == [b"stderr"]

--- a/providers/microsoft/winrm/tests/unit/microsoft/winrm/hooks/test_winrm.py
+++ b/providers/microsoft/winrm/tests/unit/microsoft/winrm/hooks/test_winrm.py
@@ -22,8 +22,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from airflow.exceptions import AirflowException
-from airflow.models import Connection
 from airflow.providers.microsoft.winrm.hooks.winrm import WinRMHook
+
+try:
+    from airflow.sdk import Connection  # type: ignore
+except ImportError:
+    from airflow.models import Connection  # type: ignore
 
 
 class TestWinRMHook:

--- a/providers/microsoft/winrm/tests/unit/microsoft/winrm/operators/test_winrm.py
+++ b/providers/microsoft/winrm/tests/unit/microsoft/winrm/operators/test_winrm.py
@@ -44,8 +44,11 @@ class TestWinRMOperator:
     def test_default_returning_0_command(self, mock_hook):
         stdout = [b"O", b"K"]
         command = "not_empty"
+        working_dir = "c:\\temp"
         mock_hook.run.return_value = (0, stdout, [])
-        op = WinRMOperator(task_id="test_task_id", winrm_hook=mock_hook, command=command)
+        op = WinRMOperator(
+            task_id="test_task_id", winrm_hook=mock_hook, command=command, working_directory=working_dir
+        )
         execute_result = op.execute(None)
         assert execute_result == b64encode(b"".join(stdout)).decode("utf-8")
         mock_hook.run.assert_called_once_with(
@@ -53,6 +56,7 @@ class TestWinRMOperator:
             ps_path=None,
             output_encoding="utf-8",
             return_output=True,
+            working_directory=working_dir,
         )
 
     @mock.patch("airflow.providers.microsoft.winrm.operators.winrm.WinRMHook")
@@ -94,6 +98,7 @@ class TestWinRMOperator:
                 ps_path=None,
                 output_encoding="utf-8",
                 return_output=True,
+                working_directory=None,
             )
         else:
             exception_msg = f"Error running cmd: {command}, return code: {real_return_code}, error: KO"


### PR DESCRIPTION
Add working_directory parameter to winrm operator (for case when command needs to be started from a specific directory)



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
