### PR TITLE
Re-Enable Back-Compat tests for Edge3

### DIFF
--- a/dev/breeze/src/airflow_breeze/global_constants.py
+++ b/dev/breeze/src/airflow_breeze/global_constants.py
@@ -844,8 +844,8 @@ PROVIDERS_COMPATIBILITY_TESTS_MATRIX: list[dict[str, str | list[str]]] = [
     },
     {
         "python-version": "3.10",
-        "airflow-version": "3.1.0",
-        "remove-providers": "edge3",  # Need to remove edge3 from tests until we have 3.1.1 used here.
+        "airflow-version": "3.1.2",
+        "remove-providers": "",
         "run-unit-tests": "true",
     },
 ]


### PR DESCRIPTION
I noticed that after we had 3.1.2 released the backcompat test for providers still was using 3.1.0.

After upgrading we also can re-eable back-compat tests for Edge3 provider. Yeah!