### PR TITLE
Enable pt006 rule and fix new generate errors

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_grid.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_grid.py
@@ -369,7 +369,7 @@ class TestGetGridDataEndpoint:
         assert response.json() == expected
 
     @pytest.mark.parametrize(
-        ("params, expected, expected_queries_count"),
+        ("params", "expected", "expected_queries_count"),
         [
             (
                 {

--- a/airflow-core/tests/unit/models/test_dag.py
+++ b/airflow-core/tests/unit/models/test_dag.py
@@ -1188,7 +1188,7 @@ class TestDag:
         )
         assert dr.creating_job_id == job_id
 
-    @pytest.mark.parametrize(["partition_key"], [[None], ["my-key"], [123]])
+    @pytest.mark.parametrize("partition_key", [None, "my-key", 123])
     def test_create_dagrun_partition_key(self, partition_key, dag_maker):
         with dag_maker("test_create_dagrun_partition_key"):
             ...

--- a/airflow-core/tests/unit/utils/test_cli_util.py
+++ b/airflow-core/tests/unit/utils/test_cli_util.py
@@ -292,7 +292,7 @@ def test_validate_dag_bundle_arg():
 
 
 @pytest.mark.parametrize(
-    ["dev_flag", "env_var", "expected"],
+    ("dev_flag", "env_var", "expected"),
     [
         # --dev flag tests
         (True, None, True),

--- a/providers/fab/tests/unit/fab/auth_manager/api_endpoints/test_role_and_permission_endpoint.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_endpoints/test_role_and_permission_endpoint.py
@@ -98,7 +98,7 @@ class TestGetRoleEndpoint(TestRoleEndpoint):
         assert response.status_code == 403
 
     @pytest.mark.parametrize(
-        "set_auth_role_public, expected_status_code",
+        ("set_auth_role_public", "expected_status_code"),
         (("Public", 403), ("Admin", 200)),
         indirect=["set_auth_role_public"],
     )
@@ -134,7 +134,7 @@ class TestGetRolesEndpoint(TestRoleEndpoint):
         assert response.status_code == 403
 
     @pytest.mark.parametrize(
-        "set_auth_role_public, expected_status_code",
+        ("set_auth_role_public", "expected_status_code"),
         (("Public", 403), ("Admin", 200)),
         indirect=["set_auth_role_public"],
     )
@@ -145,7 +145,7 @@ class TestGetRolesEndpoint(TestRoleEndpoint):
 
 class TestGetRolesEndpointPaginationandFilter(TestRoleEndpoint):
     @pytest.mark.parametrize(
-        "url, expected_roles",
+        ("url", "expected_roles"),
         [
             ("/fab/v1/roles?limit=1", ["Admin"]),
             ("/fab/v1/roles?limit=2", ["Admin", "Op"]),
@@ -196,7 +196,7 @@ class TestGetPermissionsEndpoint(TestRoleEndpoint):
         assert response.status_code == 403
 
     @pytest.mark.parametrize(
-        "set_auth_role_public, expected_status_code",
+        ("set_auth_role_public", "expected_status_code"),
         (("Public", 403), ("Admin", 200)),
         indirect=["set_auth_role_public"],
     )
@@ -217,7 +217,7 @@ class TestPostRole(TestRoleEndpoint):
         assert role is not None
 
     @pytest.mark.parametrize(
-        "payload, error_message",
+        ("payload", "error_message"),
         [
             (
                 {
@@ -328,7 +328,7 @@ class TestPostRole(TestRoleEndpoint):
         assert response.status_code == 403
 
     @pytest.mark.parametrize(
-        "set_auth_role_public, expected_status_code",
+        ("set_auth_role_public", "expected_status_code"),
         (("Public", 403), ("Admin", 200)),
         indirect=["set_auth_role_public"],
     )
@@ -373,7 +373,7 @@ class TestDeleteRole(TestRoleEndpoint):
         assert response.status_code == 403
 
     @pytest.mark.parametrize(
-        "set_auth_role_public, expected_status_code",
+        ("set_auth_role_public", "expected_status_code"),
         (("Public", 403), ("Admin", 204)),
         indirect=["set_auth_role_public"],
     )
@@ -385,7 +385,7 @@ class TestDeleteRole(TestRoleEndpoint):
 
 class TestPatchRole(TestRoleEndpoint):
     @pytest.mark.parametrize(
-        "payload, expected_name, expected_actions",
+        ("payload", "expected_name", "expected_actions"),
         [
             ({"name": "mytest"}, "mytest", []),
             (
@@ -429,7 +429,7 @@ class TestPatchRole(TestRoleEndpoint):
         assert len(self.app.appbuilder.sm.find_role("already_exists").permissions) == 0
 
     @pytest.mark.parametrize(
-        "update_mask, payload, expected_name, expected_actions",
+        ("update_mask", "payload", "expected_name", "expected_actions"),
         [
             (
                 "?update_mask=name",
@@ -477,7 +477,7 @@ class TestPatchRole(TestRoleEndpoint):
         assert response.json["detail"] == "'invalid_name' in update_mask is unknown"
 
     @pytest.mark.parametrize(
-        "payload, expected_error",
+        ("payload", "expected_error"),
         [
             (
                 {
@@ -559,7 +559,7 @@ class TestPatchRole(TestRoleEndpoint):
         assert response.status_code == 403
 
     @pytest.mark.parametrize(
-        "set_auth_role_public, expected_status_code",
+        ("set_auth_role_public", "expected_status_code"),
         (("Public", 403), ("Admin", 200)),
         indirect=["set_auth_role_public"],
     )

--- a/providers/fab/tests/unit/fab/auth_manager/api_endpoints/test_user_endpoint.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_endpoints/test_user_endpoint.py
@@ -264,7 +264,7 @@ class TestGetUsers(TestUserEndpoint):
 
 class TestGetUsersPagination(TestUserEndpoint):
     @pytest.mark.parametrize(
-        "url, expected_usernames",
+        ("url", "expected_usernames"),
         [
             ("/fab/v1/users?limit=1", ["test"]),
             ("/fab/v1/users?limit=2", ["test", "test_no_permissions"]),
@@ -494,7 +494,7 @@ class TestPostUser(TestUserEndpoint):
         assert response.status_code == 403, response.json
 
     @pytest.mark.parametrize(
-        "existing_user_fixture_name, error_detail_template",
+        ("existing_user_fixture_name", "error_detail_template"),
         [
             ("user_with_same_username", "Username `{username}` already exists. Use PATCH to update."),
             ("user_with_same_email", "The email `{email}` is already taken."),
@@ -521,7 +521,7 @@ class TestPostUser(TestUserEndpoint):
         assert response.json["detail"] == error_detail
 
     @pytest.mark.parametrize(
-        "payload_converter, error_message",
+        ("payload_converter", "error_message"),
         [
             pytest.param(
                 lambda p: {k: v for k, v in p.items() if k != "username"},
@@ -607,7 +607,7 @@ class TestPatchUser(TestUserEndpoint):
         assert data["last_name"] == "McTesterson"
 
     @pytest.mark.parametrize(
-        "payload, error_message",
+        ("payload", "error_message"),
         [
             ({"username": "another_user"}, "The username `another_user` already exists"),
             ({"email": "another_user@example.com"}, "The email `another_user@example.com` already exists"),
@@ -741,7 +741,7 @@ class TestPatchUser(TestUserEndpoint):
         assert response.status_code == 404, response.json
 
     @pytest.mark.parametrize(
-        "payload_converter, error_message",
+        ("payload_converter", "error_message"),
         [
             pytest.param(
                 lambda p: {k: v for k, v in p.items() if k != "username"},

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_login.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_login.py
@@ -54,7 +54,7 @@ class TestLogin:
         self.dummy_token = "DUMMY_TOKEN"
 
     @pytest.mark.parametrize(
-        "auth_type, method",
+        ("auth_type", "method"),
         [
             [AUTH_DB, "auth_user_db"],
             [AUTH_LDAP, "auth_user_ldap"],
@@ -79,7 +79,7 @@ class TestLogin:
         auth_manager.generate_jwt.assert_called_once_with(user=user, expiration_time_in_seconds=ANY)
 
     @pytest.mark.parametrize(
-        "auth_type, methods",
+        ("auth_type", "methods"),
         [
             [AUTH_DB, ["auth_user_db"]],
             [AUTH_LDAP, ["auth_user_ldap", "auth_user_db"]],

--- a/providers/fab/tests/unit/fab/auth_manager/cli_commands/test_db_command.py
+++ b/providers/fab/tests/unit/fab/auth_manager/cli_commands/test_db_command.py
@@ -59,7 +59,7 @@ try:
             mock_resetdb.assert_called_once_with(skip_init=True)
 
         @pytest.mark.parametrize(
-            "args, called_with",
+            ("args", "called_with"),
             [
                 (
                     [],
@@ -105,7 +105,7 @@ try:
             mock_upgradedb.assert_called_once_with(**called_with)
 
         @pytest.mark.parametrize(
-            "args, pattern",
+            ("args", "pattern"),
             [
                 pytest.param(
                     ["--to-revision", "abc", "--to-version", "1.3.0"],

--- a/providers/fab/tests/unit/fab/auth_manager/cli_commands/test_user_command.py
+++ b/providers/fab/tests/unit/fab/auth_manager/cli_commands/test_user_command.py
@@ -180,7 +180,7 @@ class TestCliUsers:
         assert 'User "test4" deleted' in stdout.getvalue()
 
     @pytest.mark.parametrize(
-        "args,raise_match",
+        ("args", "raise_match"),
         [
             (
                 [
@@ -414,7 +414,7 @@ class TestCliUsers:
         ), "User should have been removed from role 'Viewer'"
 
     @pytest.mark.parametrize(
-        "role, message",
+        ("role", "message"),
         [
             ["Viewer", 'User "test4" is already a member of role "Viewer"'],
             ["Foo", '"Foo" is not a valid role. Valid roles are'],
@@ -426,7 +426,7 @@ class TestCliUsers:
             user_command.add_role(args)
 
     @pytest.mark.parametrize(
-        "role, message",
+        ("role", "message"),
         [
             ["Admin", 'User "test4" is not a member of role "Admin"'],
             ["Foo", '"Foo" is not a valid role. Valid roles are'],
@@ -438,7 +438,7 @@ class TestCliUsers:
             user_command.remove_role(args)
 
     @pytest.mark.parametrize(
-        "user, message",
+        ("user", "message"),
         [
             [
                 {

--- a/providers/fab/tests/unit/fab/auth_manager/models/test_user_model.py
+++ b/providers/fab/tests/unit/fab/auth_manager/models/test_user_model.py
@@ -24,7 +24,7 @@ pytestmark = pytest.mark.db_test
 
 
 @pytest.mark.parametrize(
-    "user_id, expected_id",
+    ("user_id", "expected_id"),
     [(999, "999")],
 )
 def test_get_id_returns_str(user_id: int, expected_id: str) -> None:

--- a/providers/fab/tests/unit/fab/auth_manager/security_manager/test_override.py
+++ b/providers/fab/tests/unit/fab/auth_manager/security_manager/test_override.py
@@ -76,7 +76,7 @@ class TestFabAirflowSecurityManagerOverride:
         assert not sm.check_password("test_user", "test_password")
 
     @pytest.mark.parametrize(
-        "provider, resp, user_info",
+        ("provider", "resp", "user_info"),
         [
             ("github", {"login": "test"}, {"username": "github_test"}),
             ("githublocal", {"login": "test"}, {"username": "github_test"}),

--- a/providers/fab/tests/unit/fab/auth_manager/test_fab_auth_manager.py
+++ b/providers/fab/tests/unit/fab/auth_manager/test_fab_auth_manager.py
@@ -223,7 +223,7 @@ class TestFabAuthManager:
         assert auth_manager_with_appbuilder.is_logged_in() is False
 
     @pytest.mark.parametrize(
-        "api_name, method, user_permissions, expected_result",
+        ("api_name", "method", "user_permissions", "expected_result"),
         chain(
             *[
                 (
@@ -277,7 +277,7 @@ class TestFabAuthManager:
         assert result == expected_result
 
     @pytest.mark.parametrize(
-        "method, dag_access_entity, dag_details, user_permissions, expected_result",
+        ("method", "dag_access_entity", "dag_details", "user_permissions", "expected_result"),
         [
             # Scenario 1 #
             # With global permissions on Dags
@@ -509,7 +509,7 @@ class TestFabAuthManager:
         AIRFLOW_V_3_1_PLUS is not True, reason="HITL test will be skipped if Airflow version < 3.1.0"
     )
     @pytest.mark.parametrize(
-        "method, dag_access_entity, dag_details, user_permissions, expected_result",
+        ("method", "dag_access_entity", "dag_details", "user_permissions", "expected_result"),
         HITL_ENDPOINT_TESTS if AIRFLOW_V_3_1_PLUS else [],
     )
     @mock.patch.object(FabAuthManager, "get_authorized_dag_ids")
@@ -536,7 +536,7 @@ class TestFabAuthManager:
         assert result == expected_result
 
     @pytest.mark.parametrize(
-        "access_view, user_permissions, expected_result",
+        ("access_view", "user_permissions", "expected_result"),
         [
             # With permission (jobs)
             (
@@ -601,7 +601,7 @@ class TestFabAuthManager:
         assert result == expected_result
 
     @pytest.mark.parametrize(
-        "method, resource_name, user_permissions, expected_result",
+        ("method", "resource_name", "user_permissions", "expected_result"),
         [
             (
                 "GET",
@@ -643,7 +643,7 @@ class TestFabAuthManager:
         assert result == expected_result
 
     @pytest.mark.parametrize(
-        "menu_items, user_permissions, expected_result",
+        ("menu_items", "user_permissions", "expected_result"),
         [
             (
                 [MenuItem.ASSETS, MenuItem.DAGS],
@@ -686,7 +686,7 @@ class TestFabAuthManager:
         assert result == {"conn1", "conn2"}
 
     @pytest.mark.parametrize(
-        "method, user_permissions, expected_results",
+        ("method", "user_permissions", "expected_results"),
         [
             # Scenario 1
             # With global read permissions on Dags

--- a/providers/fab/tests/unit/fab/auth_manager/test_security.py
+++ b/providers/fab/tests/unit/fab/auth_manager/test_security.py
@@ -893,7 +893,7 @@ def test_access_control_is_set_on_init(
 
 
 @pytest.mark.parametrize(
-    "access_control_before, access_control_after",
+    ("access_control_before", "access_control_after"),
     [
         (READ_WRITE, READ_ONLY),
         # old access control format

--- a/providers/fab/tests/unit/fab/www/test_auth.py
+++ b/providers/fab/tests/unit/fab/www/test_auth.py
@@ -45,7 +45,7 @@ def app():
 
 
 @pytest.mark.parametrize(
-    "decorator_name, is_authorized_method_name",
+    ("decorator_name", "is_authorized_method_name"),
     [
         ("has_access_configuration", "is_authorized_configuration"),
         ("has_access_asset", "is_authorized_asset"),
@@ -131,7 +131,7 @@ def get_variable():
 
 
 @pytest.mark.parametrize(
-    "decorator_name, is_authorized_method_name, items",
+    ("decorator_name", "is_authorized_method_name", "items"),
     [
         (
             "has_access_connection",

--- a/providers/fab/tests/unit/fab/www/views/test_views_custom_user_views.py
+++ b/providers/fab/tests/unit/fab/www/views/test_views_custom_user_views.py
@@ -96,7 +96,7 @@ class TestSecurity:
             delete_user(app, "no_access")
             delete_user(app, "has_access")
 
-    @pytest.mark.parametrize("url, _, expected_text", PERMISSIONS_TESTS_PARAMS)
+    @pytest.mark.parametrize(("url", "_", "expected_text"), PERMISSIONS_TESTS_PARAMS)
     def test_user_model_view_without_access(self, url, expected_text, _, app, client):
         user_without_access = create_user(
             app,
@@ -115,7 +115,7 @@ class TestSecurity:
         assert response.status_code == 302
         assert response.location.startswith("/login/")
 
-    @pytest.mark.parametrize("url, permission, expected_text", PERMISSIONS_TESTS_PARAMS)
+    @pytest.mark.parametrize(("url", "permission", "expected_text"), PERMISSIONS_TESTS_PARAMS)
     def test_user_model_view_with_access(self, url, permission, expected_text, app, client):
         user_with_access = create_user(
             app,
@@ -225,7 +225,7 @@ class TestResetUserSessions:
         )
 
     @pytest.mark.parametrize(
-        "time_delta, user_sessions_deleted",
+        ("time_delta", "user_sessions_deleted"),
         [
             pytest.param(timedelta(days=-1), True, id="Both expired"),
             pytest.param(timedelta(hours=1), True, id="Both fresh"),

--- a/providers/snowflake/tests/unit/snowflake/utils/test_openlineage.py
+++ b/providers/snowflake/tests/unit/snowflake/utils/test_openlineage.py
@@ -50,7 +50,7 @@ from airflow.utils.state import TaskInstanceState
 
 
 @pytest.mark.parametrize(
-    "source,target",
+    ("source", "target"),
     [
         (
             "snowflake://user:pass@xy123456.us-east-1.aws/database/schema",
@@ -92,7 +92,7 @@ def test_snowflake_sqlite_account_urls(source, target):
 
 # Unit Tests using pytest.mark.parametrize
 @pytest.mark.parametrize(
-    "name, expected",
+    ("name", "expected"),
     [
         ("xy12345", "xy12345.us-west-1.aws"),  # No '-' or '_' in name
         ("xy12345.us-west-1.aws", "xy12345.us-west-1.aws"),  # Already complete locator

--- a/providers/standard/tests/unit/standard/operators/test_python.py
+++ b/providers/standard/tests/unit/standard/operators/test_python.py
@@ -645,10 +645,14 @@ class TestShortCircuitOperator(BasePythonTest):
     all_success_skipped_tasks: set[str] = set()
 
     @pytest.mark.parametrize(
-        argnames=(
-            "callable_return, test_ignore_downstream_trigger_rules, test_trigger_rule, expected_skipped_tasks, expected_task_states"
+        (
+            "callable_return",
+            "test_ignore_downstream_trigger_rules",
+            "test_trigger_rule",
+            "expected_skipped_tasks",
+            "expected_task_states",
         ),
-        argvalues=[
+        [
             # Skip downstream tasks, do not respect trigger rules, default trigger rule on all downstream
             # tasks
             (

--- a/providers/standard/tests/unit/standard/operators/test_trigger_dagrun.py
+++ b/providers/standard/tests/unit/standard/operators/test_trigger_dagrun.py
@@ -722,8 +722,8 @@ class TestDagRunOperatorAF2:
             task.execute_complete(context={}, event=trigger.serialize())
 
     @pytest.mark.parametrize(
-        argnames=("trigger_logical_date",),
-        argvalues=[
+        "trigger_logical_date",
+        [
             pytest.param(DEFAULT_DATE, id=f"logical_date={DEFAULT_DATE}"),
             pytest.param(None, id="logical_date=None"),
         ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -660,7 +660,6 @@ ignore = [
     "D212", # Conflicts with D213.  Both can not be enabled.
     "E731", # Do not assign a lambda expression, use a def
     "TC003", # Do not move imports from stdlib to TYPE_CHECKING block
-    "PT006", # Wrong type of names in @pytest.mark.parametrize
     "PT007", # Wrong type of values in @pytest.mark.parametrize
     "PT013", # silly rule prohibiting e.g. `from pytest import param`
     "PT019", # fixture without value is injected as parameter, use @pytest.mark.usefixtures instead

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -2376,7 +2376,7 @@ class TestEmailNotifications:
     FROM = "from@airflow"
 
     @pytest.mark.parametrize(
-        "emails, sent",
+        ("emails", "sent"),
         [
             pytest.param(
                 "test@example.com",
@@ -2434,7 +2434,7 @@ class TestEmailNotifications:
                     )
 
     @pytest.mark.parametrize(
-        "emails, sent",
+        ("emails", "sent"),
         [
             pytest.param(
                 "test@example.com",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
Issue: Enable Even More PyDocStyle Checks #40567
@ferruzzi @shahar1 

This PR is for enable PT006 rule:
PT006: all instances of @pytest.mark.parametrize names should be a tuple
https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/
These are the new 48 errors generated during PT006 modify PRs merge.
I also delete PT006 ignore in pyproject.toml. It should be the last one if we merge in time.

**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
