### PR TITLE
Fix import errors not cleared for files without DAGs

### DIFF
--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -292,7 +292,7 @@ def _update_import_errors(
 
     # Delete errors for files that were parsed but don't have errors in import_errors
     # (i.e., files that were successfully parsed without errors)
-    files_to_clear = files_parsed - set(import_errors.keys())
+    files_to_clear = files_parsed.difference(import_errors)
     if files_to_clear:
         session.execute(
             delete(ParseImportError).where(

--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -429,17 +429,8 @@ def update_dag_parsing_results_in_db(
             import_errors.update(serialize_errors)
     # Record import errors into the ORM - we don't retry on this one as it's not as critical that it works
     try:
-        if files_parsed is not None:
-            all_files_parsed = files_parsed
-        else:
-            # Fallback: infer from dags and import_errors
-            all_files_parsed = {
-                (bundle_name, dag.relative_fileloc) for dag in dags if dag.relative_fileloc is not None
-            }
-            all_files_parsed.update(import_errors.keys())
-
         _update_import_errors(
-            files_parsed=all_files_parsed,
+            files_parsed=files_parsed,
             bundle_name=bundle_name,
             import_errors=import_errors,
             session=session,

--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -285,21 +285,22 @@ def _update_import_errors(
 ):
     from airflow.listeners.listener import get_listener_manager
 
-    # We can remove anything from files parsed in this batch that doesn't have an error. We need to remove old
-    # errors (i.e. from files that are removed) separately
-
-    session.execute(
-        delete(ParseImportError).where(
-            tuple_(ParseImportError.bundle_name, ParseImportError.filename).in_(files_parsed)
-        )
-    )
-
-    # the below query has to match (bundle_name, filename) tuple in that order since the
-    # import_errors list is a dict with keys as (bundle_name, relative_fileloc)
+    # Check existing import errors BEFORE deleting, so we can determine if we should update or create
     existing_import_error_files = set(
         session.execute(select(ParseImportError.bundle_name, ParseImportError.filename))
     )
-    # Add the errors of the processed files
+
+    # Delete errors for files that were parsed but don't have errors in import_errors
+    # (i.e., files that were successfully parsed without errors)
+    files_to_clear = files_parsed - set(import_errors.keys())
+    if files_to_clear:
+        session.execute(
+            delete(ParseImportError).where(
+                tuple_(ParseImportError.bundle_name, ParseImportError.filename).in_(files_to_clear)
+            )
+        )
+
+    # Add or update the errors of the processed files
     for key, stacktrace in import_errors.items():
         bundle_name_, relative_fileloc = key
 
@@ -371,6 +372,7 @@ def update_dag_parsing_results_in_db(
     session: Session,
     *,
     warning_types: tuple[DagWarningType] = (DagWarningType.NONEXISTENT_POOL,),
+    files_parsed: set[tuple[str, str]] | None = None,
 ):
     """
     Update everything to do with DAG parsing in the DB.
@@ -388,6 +390,10 @@ def update_dag_parsing_results_in_db(
     then all warnings and errors related to this file will be removed.
 
     ``import_errors`` will be updated in place with an new errors
+
+    :param files_parsed: Set of (bundle_name, relative_fileloc) tuples for all files that were parsed.
+        If None, will be inferred from dags and import_errors. Passing this explicitly ensures that
+        import errors are cleared for files that were parsed but no longer contain DAGs.
     """
     # Retry 'DAG.bulk_write_to_db' & 'SerializedDagModel.bulk_sync_to_db' in case
     # of any Operational Errors
@@ -423,16 +429,17 @@ def update_dag_parsing_results_in_db(
             import_errors.update(serialize_errors)
     # Record import errors into the ORM - we don't retry on this one as it's not as critical that it works
     try:
-        # TODO: This won't clear errors for files that exist that no longer contain DAGs. Do we need to pass
-        # in the list of file parsed?
+        if files_parsed is not None:
+            all_files_parsed = files_parsed
+        else:
+            # Fallback: infer from dags and import_errors
+            all_files_parsed = {
+                (bundle_name, dag.relative_fileloc) for dag in dags if dag.relative_fileloc is not None
+            }
+            all_files_parsed.update(import_errors.keys())
 
-        good_dag_filelocs = {
-            (bundle_name, dag.relative_fileloc)
-            for dag in dags
-            if dag.relative_fileloc is not None and (bundle_name, dag.relative_fileloc) not in import_errors
-        }
         _update_import_errors(
-            files_parsed=good_dag_filelocs,
+            files_parsed=all_files_parsed,
             bundle_name=bundle_name,
             import_errors=import_errors,
             session=session,

--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -430,7 +430,7 @@ def update_dag_parsing_results_in_db(
     # Record import errors into the ORM - we don't retry on this one as it's not as critical that it works
     try:
         _update_import_errors(
-            files_parsed=files_parsed or {},
+            files_parsed=files_parsed if files_parsed else {},
             bundle_name=bundle_name,
             import_errors=import_errors,
             session=session,

--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -430,7 +430,7 @@ def update_dag_parsing_results_in_db(
     # Record import errors into the ORM - we don't retry on this one as it's not as critical that it works
     try:
         _update_import_errors(
-            files_parsed=files_parsed,
+            files_parsed=files_parsed or {},
             bundle_name=bundle_name,
             import_errors=import_errors,
             session=session,

--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -430,7 +430,7 @@ def update_dag_parsing_results_in_db(
     # Record import errors into the ORM - we don't retry on this one as it's not as critical that it works
     try:
         _update_import_errors(
-            files_parsed=files_parsed if files_parsed else {},
+            files_parsed=files_parsed if files_parsed is not None else set(),
             bundle_name=bundle_name,
             import_errors=import_errors,
             session=session,

--- a/airflow-core/src/airflow/dag_processing/dagbag.py
+++ b/airflow-core/src/airflow/dag_processing/dagbag.py
@@ -713,5 +713,5 @@ def sync_bag_to_db(
         None,  # file parsing duration is not well defined when parsing multiple files / multiple DAGs.
         dagbag.dag_warnings,
         session=session,
-        files_parsed=files_parsed if files_parsed else None,
+        files_parsed=files_parsed,
     )

--- a/airflow-core/src/airflow/dag_processing/dagbag.py
+++ b/airflow-core/src/airflow/dag_processing/dagbag.py
@@ -695,6 +695,16 @@ def sync_bag_to_db(
     from airflow.dag_processing.collection import update_dag_parsing_results_in_db
 
     import_errors = {(bundle_name, rel_path): error for rel_path, error in dagbag.import_errors.items()}
+
+    # Build the set of all files that were parsed and include files with import errors
+    # in case they are not in file_last_changed
+    files_parsed: set[tuple[str, str]] = set()
+    if dagbag.bundle_path:
+        for abs_filepath in dagbag.file_last_changed:
+            rel_fileloc = dagbag._get_relative_fileloc(abs_filepath)
+            files_parsed.add((bundle_name, rel_fileloc))
+    files_parsed.update(import_errors.keys())
+
     update_dag_parsing_results_in_db(
         bundle_name,
         bundle_version,
@@ -703,4 +713,5 @@ def sync_bag_to_db(
         None,  # file parsing duration is not well defined when parsing multiple files / multiple DAGs.
         dagbag.dag_warnings,
         session=session,
+        files_parsed=files_parsed if files_parsed else None,
     )

--- a/airflow-core/src/airflow/dag_processing/dagbag.py
+++ b/airflow-core/src/airflow/dag_processing/dagbag.py
@@ -698,12 +698,12 @@ def sync_bag_to_db(
 
     # Build the set of all files that were parsed and include files with import errors
     # in case they are not in file_last_changed
-    files_parsed: set[tuple[str, str]] = set()
+    files_parsed = set(import_errors)
     if dagbag.bundle_path:
-        for abs_filepath in dagbag.file_last_changed:
-            rel_fileloc = dagbag._get_relative_fileloc(abs_filepath)
-            files_parsed.add((bundle_name, rel_fileloc))
-    files_parsed.update(import_errors.keys())
+        files_parsed.update(
+            (bundle_name, dagbag._get_relative_fileloc(abs_filepath))
+            for abs_filepath in dagbag.file_last_changed
+        )
 
     update_dag_parsing_results_in_db(
         bundle_name,

--- a/airflow-core/tests/unit/dag_processing/test_collection.py
+++ b/airflow-core/tests/unit/dag_processing/test_collection.py
@@ -492,7 +492,9 @@ class TestUpdateDagParsingResults:
         mock_full_path.return_value = "abc.py"
 
         import_errors = {}
-        update_dag_parsing_results_in_db("testing", None, [dag], import_errors, None, set(), session)
+        update_dag_parsing_results_in_db(
+            "testing", None, [dag], import_errors, None, set(), session, files_parsed={("testing", "abc.py")}
+        )
         assert "SerializationError" in caplog.text
 
         # Should have been edited in place
@@ -656,6 +658,7 @@ class TestUpdateDagParsingResults:
             parse_duration=None,
             warnings=set(),
             session=session,
+            files_parsed={("testing", "abc.py")},
         )
 
         import_error = (
@@ -714,6 +717,7 @@ class TestUpdateDagParsingResults:
             parse_duration=None,
             warnings=set(),
             session=session,
+            files_parsed={(bundle_name, "abc.py")},
         )
         dag_model: DagModel = session.get(DagModel, (dag.dag_id,))
         assert dag_model.has_import_errors is False
@@ -758,6 +762,7 @@ class TestUpdateDagParsingResults:
             parse_duration=None,
             warnings=set(),
             session=session,
+            files_parsed={(bundle_name, "abc.py")},
         )
         dag_model = session.get(DagModel, (dag.dag_id,))
         assert dag_model.has_import_errors is True
@@ -778,9 +783,6 @@ class TestUpdateDagParsingResults:
     def test_clear_import_error_for_file_without_dags(self, testing_dag_bundle, session):
         """
         Test that import errors are cleared for files that were parsed but no longer contain DAGs.
-
-        This tests the fix for the issue where import errors persisted for files that were
-        successfully parsed but no longer contained any DAGs.
         """
         bundle_name = "testing"
         filename = "no_dags.py"


### PR DESCRIPTION
Previously, import errors persisted in the database for files that were successfully parsed but no longer contained any DAGs. This happened because we only tracked files that had DAGs, missing files that were parsed successfully but had their DAGs removed.

Now, when files are parsed, all parsed files are tracked (not just those with DAGs), ensuring import errors are properly cleared when a file is successfully parsed without errors, even if it no longer contains DAGs.

closes: #57621

