### PR TITLE
Fix DAG hash calculation to be deterministic across database versions to fix CI

### DIFF
--- a/airflow-core/src/airflow/models/serialized_dag.py
+++ b/airflow-core/src/airflow/models/serialized_dag.py
@@ -366,6 +366,11 @@ class SerializedDagModel(Base):
                         [cls._sort_serialized_dag_dict(i) for i in serialized_dag],
                         key=lambda x: x["__var"]["task_id"],
                     )
+                if all("task_id" in i for i in serialized_dag):
+                    return sorted(
+                        [cls._sort_serialized_dag_dict(i) for i in serialized_dag],
+                        key=lambda x: x["task_id"],
+                    )
             elif all(isinstance(item, str) for item in serialized_dag):
                 return sorted(serialized_dag)
             return [cls._sort_serialized_dag_dict(i) for i in serialized_dag]

--- a/airflow-core/src/airflow/models/serialized_dag.py
+++ b/airflow-core/src/airflow/models/serialized_dag.py
@@ -368,7 +368,7 @@ class SerializedDagModel(Base):
                     )
                 if all("task_id" in i for i in serialized_dag):
                     return sorted(
-                        [cls._sort_serialized_dag_dict(i) for i in serialized_dag],
+                        (cls._sort_serialized_dag_dict(i) for i in serialized_dag),
                         key=lambda x: x["task_id"],
                     )
             elif all(isinstance(item, str) for item in serialized_dag):

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -2486,7 +2486,9 @@ class SerializedDAG(BaseSerialization):
         try:
             serialized_dag = cls.serialize_to_json(dag, cls._decorated_fields)
             serialized_dag["_processor_dags_folder"] = DAGS_FOLDER
-            serialized_dag["tasks"] = [cls.serialize(task) for _, task in dag.task_dict.items()]
+            serialized_dag["tasks"] = [
+                cls.serialize(task) for _, task in sorted(dag.task_dict.items(), key=lambda x: x[0])
+            ]
 
             dag_deps = [
                 dep


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
The test `test_example_dag_hashes_are_always_consistent` was failing in Postgres 17 CI while passing in Postgres 13 in [https://github.com/apache/airflow/actions/runs/19315183483](https://github.com/apache/airflow/actions/runs/19315183483). The issue was that DAG hashes were non-deterministic due to task serialization order depending on dictionary iteration order, which could vary between environments or database versions.

## Fix
- Sort tasks by `task_id` during serialization in `serialize_dag()` to ensure deterministic ordering regardless of dictionary iteration order

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
