### PR TITLE
Fix atomicity issue in SerializedDagModel.write_dag preventing orphaned DagVersions

### DIFF
--- a/airflow-core/src/airflow/models/dag_version.py
+++ b/airflow-core/src/airflow/models/dag_version.py
@@ -137,7 +137,6 @@ class DagVersion(Base):
         )
         log.debug("Writing DagVersion %s to the DB", dag_version)
         session.add(dag_version)
-        session.commit()
         log.debug("DagVersion %s written to the DB", dag_version)
         return dag_version
 

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -3795,7 +3795,7 @@ class TestSchedulerJob:
         SerializedDagModel.write_dag(
             LazyDeserializedDAG.from_dag(dag), bundle_name="testing", session=session
         )
-
+        session.commit()
         dag_version_2 = DagVersion.get_latest_version(dr.dag_id, session=session)
         assert dag_version_2 != dag_version_1
 


### PR DESCRIPTION
When writing serialized DAGs to the database, if DagCode.write_code failed or serializedDag writing failed, after DagVersion was created, the DagVersion would remain committed even though the SerializedDagModel write failed. This left orphaned DagVersion records in the database that could cause inconsistencies in DAG versioning.

The fix ensures all operations (DagVersion, SerializedDagModel, and DagCode) are created within the same transaction, so if any operation fails, everything rolls back together maintaining database consistency.


