### PR TITLE
Update path for `breeze testing task-sdk-integration-tests ...`

### DIFF
--- a/contributing-docs/testing/task_sdk_integration_tests.rst
+++ b/contributing-docs/testing/task_sdk_integration_tests.rst
@@ -82,7 +82,7 @@ reproducibility:
    breeze testing task-sdk-integration-tests
 
    # Run specific test files
-   breeze testing task-sdk-integration-tests task_sdk_tests/test_task_sdk_health.py
+   breeze testing task-sdk-integration-tests tests/task_sdk_tests/test_task_sdk_health.py
 
    # Run with custom Docker image
    DOCKER_IMAGE=my-custom-airflow-image:latest breeze testing task-sdk-integration-tests


### PR DESCRIPTION
## Description

Updating the docs to properly reflect the path that should be passed when running specific Task SDK integration tests.

Per the previous docs, a command like (`breeze testing task-sdk-integration-tests task_sdk_tests/test_variable_operations.py`) this should execute tests in the `test_variable_operations.py` file. However, running this command resulted in the exception: `ERROR: file or directory not found: task_sdk_tests/test_variable_operations.py`.

Adding `tests/` in front of `task_sdk_tests/...` solved this issue. The updated command looks something like this:

```
breeze testing task-sdk-integration-tests tests/task_sdk_tests/test_variable_operations.py
```

The appropriate changes in the documentation were made to reflect this.
