### PR TITLE
Fix Liveness / Readiness / Startup probe path for Airflow 3.x #58129

### DIFF
--- a/airflow-core/docs/howto/docker-compose/docker-compose.yaml
+++ b/airflow-core/docs/howto/docker-compose/docker-compose.yaml
@@ -123,7 +123,7 @@ services:
     ports:
       - "8080:8080"
     healthcheck:
-      test: ["CMD", "curl", "--fail", "http://localhost:8080/api/v2/version"]
+      test: ["CMD", "curl", "--fail", "http://localhost:8080/api/v2/monitor/health"]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/airflow-core/docs/howto/run-with-self-signed-certificate.rst
+++ b/airflow-core/docs/howto/run-with-self-signed-certificate.rst
@@ -69,7 +69,7 @@ Alter the API Server health check to trust the certificate:
       - "8080:8080"
     healthcheck:
       # Add --cacert to trust certificate
-      test: ["CMD", "curl", "--fail", "--cacert", "${AIRFLOW_PROJ_DIR:-.}/config/cert.pem", "https://localhost:8080/api/v2/version"]
+      test: ["CMD", "curl", "--fail", "--cacert", "${AIRFLOW_PROJ_DIR:-.}/config/cert.pem", "https://localhost:8080/api/v2/monitor/health"]
 
 Running Airflow
 ===============

--- a/airflow-e2e-tests/tests/airflow_e2e_tests/conftest.py
+++ b/airflow-e2e-tests/tests/airflow_e2e_tests/conftest.py
@@ -104,7 +104,7 @@ def spin_up_airflow_environment(tmp_path_factory):
 
         compose_instance.start()
 
-        compose_instance.wait_for(f"http://{DOCKER_COMPOSE_HOST_PORT}/api/v2/version")
+        compose_instance.wait_for(f"http://{DOCKER_COMPOSE_HOST_PORT}/api/v2/monitor/health")
         compose_instance.exec_in_container(
             command=["airflow", "dags", "reserialize"], service_name="airflow-dag-processor"
         )

--- a/chart/templates/api-server/api-server-deployment.yaml
+++ b/chart/templates/api-server/api-server-deployment.yaml
@@ -188,7 +188,7 @@ spec:
               containerPort: {{ .Values.ports.apiServer }}
           livenessProbe:
             httpGet:
-              path: /api/v2/version
+              path: /api/v2/monitor/health
               port: {{ .Values.ports.apiServer }}
               scheme: {{ .Values.apiServer.livenessProbe.scheme | default "http" }}
             initialDelaySeconds: {{ .Values.apiServer.livenessProbe.initialDelaySeconds }}
@@ -197,7 +197,7 @@ spec:
             periodSeconds: {{ .Values.apiServer.livenessProbe.periodSeconds }}
           readinessProbe:
             httpGet:
-              path: /api/v2/version
+              path: /api/v2/monitor/health
               port: {{ .Values.ports.apiServer }}
               scheme: {{ .Values.apiServer.readinessProbe.scheme | default "http" }}
             initialDelaySeconds: {{ .Values.apiServer.readinessProbe.initialDelaySeconds }}
@@ -206,7 +206,7 @@ spec:
             periodSeconds: {{ .Values.apiServer.readinessProbe.periodSeconds }}
           startupProbe:
             httpGet:
-              path: /api/v2/version
+              path: /api/v2/monitor/health
               port: {{ .Values.ports.apiServer }}
               scheme: {{ .Values.apiServer.startupProbe.scheme | default "http" }}
             initialDelaySeconds: {{ .Values.apiServer.startupProbe.initialDelaySeconds }}

--- a/helm-tests/tests/helm_tests/airflow_core/test_api_server.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_api_server.py
@@ -72,6 +72,15 @@ class TestAPIServerDeployment:
             "spec.template.spec.containers[0].startupProbe.httpGet.scheme", docs[0]
         )
 
+    def test_should_use_monitor_health_for_http_probes(self):
+        docs = render_chart(show_only=["templates/api-server/api-server-deployment.yaml"])
+
+        for probe in ("livenessProbe", "readinessProbe", "startupProbe"):
+            assert (
+                jmespath.search(f"spec.template.spec.containers[0].{probe}.httpGet.path", docs[0])
+                == "/api/v2/monitor/health"
+            )
+
     def test_should_add_extra_containers(self):
         docs = render_chart(
             values={

--- a/task-sdk-integration-tests/docker/docker-compose.yaml
+++ b/task-sdk-integration-tests/docker/docker-compose.yaml
@@ -88,7 +88,7 @@ services:
     ports:
       - "8080:8080"
     healthcheck:
-      test: ["CMD", "curl", "--fail", "http://localhost:8080/api/v2/version"]
+      test: ["CMD", "curl", "--fail", "http://localhost:8080/api/v2/monitor/health"]
       interval: 30s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.
 -->
## Description
- Update every api-server and scheduler health and probe check for docker-compose and helm chart to use `/api/v2/monitor/health` introduced in [Airflow 3.x](https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/logging-monitoring/check-health.html#checking-airflow-health-status)

## Testing
-  Updated helm chart templates, docker-compose, related tests, and docs I could find.

closes: #58129

_Maintainers please let me know if I missed anything._
