### PR TITLE
include all __init__ params in template_fields for consistency with other operators

### DIFF
--- a/providers/smtp/src/airflow/providers/smtp/operators/smtp.py
+++ b/providers/smtp/src/airflow/providers/smtp/operators/smtp.py
@@ -47,7 +47,19 @@ class EmailOperator(BaseOperator):
     :param custom_headers: additional headers to add to the MIME message.
     """
 
-    template_fields: Sequence[str] = ("to", "from_email", "subject", "html_content", "files", "cc", "bcc")
+    template_fields: Sequence[str] = (
+        "to",
+        "subject",
+        "html_content",
+        "from_email",
+        "files",
+        "cc",
+        "bcc",
+        "mime_subtype",
+        "mime_charset",
+        "conn_id",
+        "custom_headers",
+    )
     template_fields_renderers = {"html_content": "html"}
     template_ext: Sequence[str] = (".html",)
     ui_color = "#e6faf9"

--- a/providers/smtp/tests/unit/smtp/operators/test_smtp.py
+++ b/providers/smtp/tests/unit/smtp/operators/test_smtp.py
@@ -79,5 +79,17 @@ class TestEmailOperator:
     def test_assert_templated_fields(self):
         """Test expected templated fields."""
         operator = EmailOperator(task_id="test_assert_templated_fields", **self.default_op_kwargs)
-        template_fields = ("to", "from_email", "subject", "html_content", "files", "cc", "bcc")
+        template_fields = (
+            "to",
+            "subject",
+            "html_content",
+            "from_email",
+            "files",
+            "cc",
+            "bcc",
+            "mime_subtype",
+            "mime_charset",
+            "conn_id",
+            "custom_headers",
+        )
         assert operator.template_fields == template_fields


### PR DESCRIPTION
- Added all __init__ parameters of EmailOperator to template_fields, enabling Jinja templating for every field.
- This change aligns the SMTP operator with other Airflow operators, allowing users to dynamically render all email-related parameters in DAGs.
- Improves flexibility for customizing email headers, recipients, subject, and content via templating.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
