### PR TITLE
Bug-fix tag filter with special characters

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagTags.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagTags.tsx
@@ -35,7 +35,7 @@ export const DagTags = ({ hideIcon = false, tags }: Props) => (
     icon={hideIcon ? undefined : <FiTag data-testid="dag-tag" />}
     interactive
     items={tags.map(({ name }) => (
-      <RouterLink key={name} to={`/dags?${SearchParamsKeys.TAGS}=${name}`}>
+      <RouterLink key={name} to={`/dags?${SearchParamsKeys.TAGS}=${encodeURIComponent(name)}`}>
         {name}
       </RouterLink>
     ))}


### PR DESCRIPTION
## Problem
`&` in a tag name is breaking by not capturing the full string but rather the first portion just before the `&`. This may affect other special characters.

## Solution
Added encodeURIComponent() to properly URL-encode tag names when constructing filter links in DagTags.tsx. This ensures special characters like `&` are percent-encoded and treated as part of the tag value rather than URL syntax.

Full unfiltered Dags:
<img width="1134" height="739" alt="Screenshot 2025-11-13 at 10 20 32 AM" src="https://github.com/user-attachments/assets/034e3ec2-0591-4b44-a817-0bc8fabb1f41" />

Filtered by tag with `&`
<img width="1029" height="447" alt="Screenshot 2025-11-13 at 10 20 41 AM" src="https://github.com/user-attachments/assets/bb649a4d-44a5-4fd0-be97-cbd114020686" />


## Related Issue: 
Fixes #58260