### PR TITLE
Remove global from lineage.hook

### DIFF
--- a/airflow-core/tests/unit/lineage/test_hook.py
+++ b/airflow-core/tests/unit/lineage/test_hook.py
@@ -872,8 +872,8 @@ class FakePlugin(plugins_manager.AirflowPlugin):
     ],
 )
 def test_get_hook_lineage_collector(has_readers, expected_class):
-    # reset global variable
-    hook._hook_lineage_collector = None
+    # reset cached instance
+    hook.get_hook_lineage_collector.cache_clear()
     plugins = [FakePlugin()] if has_readers else []
     with mock_plugin_manager(plugins=plugins):
         assert isinstance(get_hook_lineage_collector(), expected_class)

--- a/devel-common/src/tests_common/pytest_plugin.py
+++ b/devel-common/src/tests_common/pytest_plugin.py
@@ -1946,14 +1946,12 @@ def _mock_plugins(request: pytest.FixtureRequest):
 def hook_lineage_collector():
     from airflow.lineage import hook
 
-    hook.get_hook_lineage_collector.cache_clear()
     hlc = hook.HookLineageCollector()
     with mock.patch(
         "airflow.lineage.hook.get_hook_lineage_collector",
         return_value=hlc,
     ):
         yield hlc
-    hook.get_hook_lineage_collector.cache_clear()
 
 
 @pytest.fixture

--- a/devel-common/src/tests_common/pytest_plugin.py
+++ b/devel-common/src/tests_common/pytest_plugin.py
@@ -1947,7 +1947,12 @@ def hook_lineage_collector():
     from airflow.lineage import hook
 
     hook.get_hook_lineage_collector.cache_clear()
-    yield hook.get_hook_lineage_collector()
+    hlc = hook.HookLineageCollector()
+    with mock.patch(
+        "airflow.lineage.hook.get_hook_lineage_collector",
+        return_value=hlc,
+    ):
+        yield hlc
     hook.get_hook_lineage_collector.cache_clear()
 
 

--- a/devel-common/src/tests_common/pytest_plugin.py
+++ b/devel-common/src/tests_common/pytest_plugin.py
@@ -1944,14 +1944,17 @@ def _mock_plugins(request: pytest.FixtureRequest):
 
 @pytest.fixture
 def hook_lineage_collector():
-    from airflow.lineage import hook
+    from airflow.lineage.hook import HookLineageCollector
 
-    hlc = hook.HookLineageCollector()
+    hlc = HookLineageCollector()
     with mock.patch(
         "airflow.lineage.hook.get_hook_lineage_collector",
         return_value=hlc,
     ):
-        yield hlc
+        # Redirect calls to compat provider to support back-compat tests of 2.x as well
+        from airflow.providers.common.compat.lineage.hook import get_hook_lineage_collector
+
+        yield get_hook_lineage_collector()
 
 
 @pytest.fixture

--- a/devel-common/src/tests_common/pytest_plugin.py
+++ b/devel-common/src/tests_common/pytest_plugin.py
@@ -1946,10 +1946,9 @@ def _mock_plugins(request: pytest.FixtureRequest):
 def hook_lineage_collector():
     from airflow.lineage import hook
 
-    hook._hook_lineage_collector = None
-    hook._hook_lineage_collector = hook.HookLineageCollector()
+    hook.get_hook_lineage_collector.cache_clear()
     yield hook.get_hook_lineage_collector()
-    hook._hook_lineage_collector = None
+    hook.get_hook_lineage_collector.cache_clear()
 
 
 @pytest.fixture

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_s3.py
@@ -77,19 +77,6 @@ def s3_bucket(mocked_s3_res):
     return bucket
 
 
-@pytest.fixture
-def hook_lineage_collector():
-    from airflow.lineage import hook
-    from airflow.providers.common.compat.lineage.hook import get_hook_lineage_collector
-
-    hook._hook_lineage_collector = None
-    hook._hook_lineage_collector = hook.HookLineageCollector()
-
-    yield get_hook_lineage_collector()
-
-    hook._hook_lineage_collector = None
-
-
 class TestAwsS3Hook:
     @mock_aws
     def test_get_conn(self):

--- a/providers/openlineage/tests/unit/openlineage/extractors/test_manager.py
+++ b/providers/openlineage/tests/unit/openlineage/extractors/test_manager.py
@@ -48,6 +48,28 @@ if TYPE_CHECKING:
         AssetEventDagRunReference = TIRunContext = Any  # type: ignore[misc, assignment]
 
 
+@pytest.fixture
+def hook_lineage_collector():
+    from airflow.lineage import hook
+    from airflow.providers.common.compat.lineage.hook import get_hook_lineage_collector
+
+    hlc = hook.HookLineageCollector()
+    if AIRFLOW_V_3_0_PLUS:
+        from unittest import mock
+
+        with mock.patch(
+            "airflow.lineage.hook.get_hook_lineage_collector",
+            return_value=hlc,
+        ):
+            yield get_hook_lineage_collector()
+    else:
+        hook._hook_lineage_collector = hlc
+
+        yield get_hook_lineage_collector()
+
+        hook._hook_lineage_collector = None
+
+
 @pytest.mark.parametrize(
     ("uri", "dataset"),
     (

--- a/providers/openlineage/tests/unit/openlineage/extractors/test_manager.py
+++ b/providers/openlineage/tests/unit/openlineage/extractors/test_manager.py
@@ -48,21 +48,6 @@ if TYPE_CHECKING:
         AssetEventDagRunReference = TIRunContext = Any  # type: ignore[misc, assignment]
 
 
-@pytest.fixture
-def hook_lineage_collector():
-    from airflow.lineage import hook
-    from airflow.providers.common.compat.lineage.hook import (
-        get_hook_lineage_collector,
-    )
-
-    hook._hook_lineage_collector = None
-    hook._hook_lineage_collector = hook.HookLineageCollector()
-
-    yield get_hook_lineage_collector()
-
-    hook._hook_lineage_collector = None
-
-
 @pytest.mark.parametrize(
     ("uri", "dataset"),
     (


### PR DESCRIPTION
Another small increment to remove `global`statements for PR https://github.com/apache/airflow/pull/58116

Replace global variable with a cache()
Which even (after adusting pytests) also saves some lines of code :-D