### PR TITLE
Fix group TI tab memory

### DIFF
--- a/airflow-core/src/airflow/ui/src/hooks/navigation/useNavigation.ts
+++ b/airflow-core/src/airflow/ui/src/hooks/navigation/useNavigation.ts
@@ -21,7 +21,7 @@ import { useLocation, useNavigate, useParams } from "react-router-dom";
 
 import type { GridRunsResponse } from "openapi/requests";
 import type { GridTask } from "src/layouts/Details/Grid/utils";
-import { getTaskInstanceAdditionalPath } from "src/utils/links";
+import { buildTaskInstanceUrl } from "src/utils/links";
 
 import type {
   NavigationDirection,
@@ -72,7 +72,6 @@ const buildPath = (params: {
 }): string => {
   const { dagId, mapIndex = "-1", mode, pathname, run, task } = params;
   const groupPath = task.isGroup ? "group/" : "";
-  const additionalPath = getTaskInstanceAdditionalPath(pathname);
 
   switch (mode) {
     case "run":
@@ -80,16 +79,15 @@ const buildPath = (params: {
     case "task":
       return `/dags/${dagId}/tasks/${groupPath}${task.id}`;
     case "TI":
-      if (task.is_mapped ?? false) {
-        if (mapIndex !== "-1") {
-          // For mapped tasks with specific map index, we need to construct the path manually
-          return `/dags/${dagId}/runs/${run.run_id}/tasks/${groupPath}${task.id}/mapped/${mapIndex}${additionalPath}`;
-        }
-
-        return `/dags/${dagId}/runs/${run.run_id}/tasks/${groupPath}${task.id}/mapped${additionalPath}`;
-      }
-
-      return `/dags/${dagId}/runs/${run.run_id}/tasks/${groupPath}${task.id}${additionalPath}`;
+      return buildTaskInstanceUrl({
+        currentPathname: pathname,
+        dagId,
+        isGroup: task.isGroup,
+        isMapped: task.is_mapped ?? false,
+        mapIndex,
+        runId: run.run_id,
+        taskId: task.id,
+      });
     default:
       return `/dags/${dagId}`;
   }

--- a/airflow-core/src/airflow/ui/src/utils/links.test.ts
+++ b/airflow-core/src/airflow/ui/src/utils/links.test.ts
@@ -232,7 +232,18 @@ describe("buildTaskInstanceUrl", () => {
       }),
     ).toBe("/dags/my_dag/runs/run_123/tasks/mapped_task/mapped");
 
-    // Complex: group + mapped + sub-routes
+    // Groups should never preserve tabs (only have "Task Instances" tab)
+    expect(
+      buildTaskInstanceUrl({
+        currentPathname: "/dags/old/runs/old/tasks/old_task/rendered_templates",
+        dagId: "new_dag",
+        isGroup: true,
+        runId: "new_run",
+        taskId: "new_group",
+      }),
+    ).toBe("/dags/new_dag/runs/new_run/tasks/group/new_group");
+
+    // Groups should never preserve tabs even for mapped groups
     expect(
       buildTaskInstanceUrl({
         currentPathname: "/dags/old/runs/old/tasks/group/old_group/events",
@@ -243,6 +254,6 @@ describe("buildTaskInstanceUrl", () => {
         runId: "new_run",
         taskId: "new_group",
       }),
-    ).toBe("/dags/new_dag/runs/new_run/tasks/group/new_group/mapped/3/events");
+    ).toBe("/dags/new_dag/runs/new_run/tasks/group/new_group/mapped/3");
   });
 });

--- a/airflow-core/src/airflow/ui/src/utils/links.ts
+++ b/airflow-core/src/airflow/ui/src/utils/links.ts
@@ -84,7 +84,8 @@ export const buildTaskInstanceUrl = (params: {
 }): string => {
   const { currentPathname, dagId, isGroup = false, isMapped = false, mapIndex, runId, taskId } = params;
   const groupPath = isGroup ? "group/" : "";
-  const additionalPath = getTaskInstanceAdditionalPath(currentPathname);
+  // Task groups only have "Task Instances" tab, so never preserve tabs for groups
+  const additionalPath = isGroup ? "" : getTaskInstanceAdditionalPath(currentPathname);
 
   let basePath = `/dags/${dagId}/runs/${runId}/tasks/${groupPath}${taskId}`;
 


### PR DESCRIPTION
## Related 

#55006

## What
Task Groups do not have tabs like `Rendered Templates` or `XCom`, so this change forces the URL to the group's main page(`Task Instances`), fixing 404 error.

Also refactors the `useNavigation` hook to use the shared `buildTaskInstanceUrl` from `links.ts` ,keeping it DRY
Both click and keyboard navigation are fixed now.

## Screenshots
**Before**


https://github.com/user-attachments/assets/055d625c-b530-480a-973a-c06124f58eab

**After**

https://github.com/user-attachments/assets/81fa379c-40b1-4513-b905-729ac75d1304

## Follow up PR

Implement persistent tab memory system across different navigation scenarios to improve UX when comparing tasks, runs, task instances(solving #57625)



<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
