### PR TITLE
Update asset manager to be partition-aware

### DIFF
--- a/airflow-core/src/airflow/assets/manager.py
+++ b/airflow-core/src/airflow/assets/manager.py
@@ -306,7 +306,7 @@ class AssetManager(LoggingMixin):
             timetable = serdag.dag.timetable
             if TYPE_CHECKING:
                 assert isinstance(timetable, PartitionedAssetTimetable)
-            target_key = timetable.partition_mapper.map(partition_key)
+            target_key = timetable.partition_mapper.to_downstream(partition_key)
 
             apdr = cls._get_or_create_apdr(
                 target_key=target_key,

--- a/airflow-core/src/airflow/assets/manager.py
+++ b/airflow-core/src/airflow/assets/manager.py
@@ -311,6 +311,8 @@ class AssetManager(LoggingMixin):
             return partition_dags
 
         for target_dag in partition_dags:
+            if TYPE_CHECKING:
+                assert partition_key is not None
             from airflow.models.serialized_dag import SerializedDagModel
 
             serdag = SerializedDagModel.get(dag_id=target_dag.dag_id, session=session)

--- a/airflow-core/src/airflow/assets/manager.py
+++ b/airflow-core/src/airflow/assets/manager.py
@@ -343,12 +343,12 @@ class AssetManager(LoggingMixin):
             .order_by(AssetPartitionDagRun.id.desc())
             .limit(1)
         )
-        if latest_apdr and latest_apdr.target_dag_run_id is None:
+        if latest_apdr and latest_apdr.created_dag_run_id is None:
             apdr = latest_apdr
         else:
             apdr = AssetPartitionDagRun(
                 target_dag_id=target_dag.dag_id,
-                target_dag_run_id=None,
+                created_dag_run_id=None,
                 partition_key=partition_key,
             )
             session.add(apdr)

--- a/airflow-core/src/airflow/assets/manager.py
+++ b/airflow-core/src/airflow/assets/manager.py
@@ -270,8 +270,7 @@ class AssetManager(LoggingMixin):
             partition_key=partition_key,
             session=session,
         )
-        for d in partition_dags:
-            dags_to_queue.remove(d)  # don't double process
+        dags_to_queue = dags_to_queue.difference(partition_dags)  # don't double process
 
         if not dags_to_queue:
             return None

--- a/airflow-core/src/airflow/assets/manager.py
+++ b/airflow-core/src/airflow/assets/manager.py
@@ -252,6 +252,7 @@ class AssetManager(LoggingMixin):
     @classmethod
     def _queue_dagruns(
         cls,
+        *,
         asset_id: int,
         dags_to_queue: set[DagModel],
         partition_key: str | None,
@@ -345,7 +346,7 @@ class AssetManager(LoggingMixin):
         target_key: str,
         target_dag: SerializedDagModel,
         session: Session,
-    ):
+    ) -> AssetPartitionDagRun:
         latest_apdr: AssetPartitionDagRun = session.scalar(
             select(AssetPartitionDagRun)
             .where(

--- a/airflow-core/src/airflow/assets/manager.py
+++ b/airflow-core/src/airflow/assets/manager.py
@@ -242,7 +242,7 @@ class AssetManager(LoggingMixin):
     def notify_asset_changed(asset: Asset):
         """Run applicable notification actions when an asset is changed."""
         try:
-            # todo: AIP-76 this will have to change. needs to know *what* happened to the asset (e.g. partition key)
+            # TODO: AIP-76 this will have to change. needs to know *what* happened to the asset (e.g. partition key)
             #  maybe we should just add the event to the signature
             #  or add a new hook `on_asset_event`
             get_listener_manager().hook.on_asset_changed(asset=asset)
@@ -296,7 +296,7 @@ class AssetManager(LoggingMixin):
         partition_key: str,
         session: Session,
     ) -> list[DagModel]:
-        # todo: AIP-76 there may be a better way to identify that timetable is partition-driven
+        # TODO: AIP-76 there may be a better way to identify that timetable is partition-driven
         partition_dags = [x for x in all_dags if x.timetable_summary == "Partitioned Asset"]
 
         for target_dag in partition_dags:

--- a/airflow-core/src/airflow/assets/manager.py
+++ b/airflow-core/src/airflow/assets/manager.py
@@ -166,6 +166,7 @@ class AssetManager(LoggingMixin):
         asset_event = AssetEvent(**event_kwargs)
         session.add(asset_event)
         session.flush()  # Ensure the event is written earlier than DDRQ entries below.
+
         dags_to_queue_from_asset = {
             ref.dag for ref in asset_model.scheduled_dags if not ref.dag.is_stale and not ref.dag.is_paused
         }
@@ -211,7 +212,7 @@ class AssetManager(LoggingMixin):
         dags_to_queue = (
             dags_to_queue_from_asset | dags_to_queue_from_asset_alias | dags_to_queue_from_asset_ref
         )
-        log.info("asset event added", asset_event=asset_event, dags_to_queue=dags_to_queue)
+        log.debug("asset event added", asset_event=asset_event, dags_to_queue=dags_to_queue)
         cls._queue_dagruns(
             asset_id=asset_model.id,
             dags_to_queue=dags_to_queue,

--- a/airflow-core/src/airflow/assets/manager.py
+++ b/airflow-core/src/airflow/assets/manager.py
@@ -314,6 +314,8 @@ class AssetManager(LoggingMixin):
             from airflow.models.serialized_dag import SerializedDagModel
 
             serdag = SerializedDagModel.get(dag_id=target_dag.dag_id, session=session)
+            if not serdag:
+                raise RuntimeError(f"Could not find serialized dag for dag_id={target_dag.dag_id}")
             timetable = serdag.dag.timetable
             if TYPE_CHECKING:
                 assert isinstance(timetable, PartitionedAssetTimetable)

--- a/airflow-core/src/airflow/assets/manager.py
+++ b/airflow-core/src/airflow/assets/manager.py
@@ -311,7 +311,6 @@ class AssetManager(LoggingMixin):
 
             apdr = cls._get_or_create_apdr(
                 target_key=target_key,
-                partition_key=partition_key,
                 target_dag=target_dag,
                 session=session,
             )
@@ -330,7 +329,6 @@ class AssetManager(LoggingMixin):
     def _get_or_create_apdr(
         cls,
         target_key: str,
-        partition_key: str,
         target_dag: SerializedDagModel,
         session: Session,
     ):
@@ -349,7 +347,7 @@ class AssetManager(LoggingMixin):
             apdr = AssetPartitionDagRun(
                 target_dag_id=target_dag.dag_id,
                 created_dag_run_id=None,
-                partition_key=partition_key,
+                partition_key=target_key,
             )
             session.add(apdr)
             session.flush()

--- a/airflow-core/src/airflow/example_dags/example_outlet_event_extra.py
+++ b/airflow-core/src/airflow/example_dags/example_outlet_event_extra.py
@@ -68,7 +68,7 @@ with DAG(
 
     def _asset_with_extra_from_classic_operator_post_execute(context, result):
         context["outlet_events"][asset].extra = {"hi": "bye"}
-        # todo: AIP-76 probably we want to make it so this could be
+        # TODO: AIP-76 probably we want to make it so this could be
         #  AssetEvent, list[AssetEvent], [], or None. And if [] or None,
         #  then no events would be emitted.
 

--- a/airflow-core/src/airflow/example_dags/example_outlet_event_extra.py
+++ b/airflow-core/src/airflow/example_dags/example_outlet_event_extra.py
@@ -68,6 +68,9 @@ with DAG(
 
     def _asset_with_extra_from_classic_operator_post_execute(context, result):
         context["outlet_events"][asset].extra = {"hi": "bye"}
+        # todo: AIP-76 probably we want to make it so this could be
+        #  AssetEvent, list[AssetEvent], [], or None. And if [] or None,
+        #  then no events would be emitted.
 
     BashOperator(
         task_id="asset_with_extra_from_classic_operator",

--- a/airflow-core/src/airflow/example_dags/example_outlet_event_extra.py
+++ b/airflow-core/src/airflow/example_dags/example_outlet_event_extra.py
@@ -70,7 +70,9 @@ with DAG(
         context["outlet_events"][asset].extra = {"hi": "bye"}
         # TODO: AIP-76 probably we want to make it so this could be
         #  AssetEvent, list[AssetEvent], [], or None. And if [] or None,
-        #  then no events would be emitted.
+        #  then no events would be emitted. The use case is, instead of unconditionally
+        #  emitting an event, we could optionally emit no events, or multiple events,
+        #  i.e. for different partitions.
 
     BashOperator(
         task_id="asset_with_extra_from_classic_operator",

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -1315,7 +1315,7 @@ class TaskInstance(Base, LoggingMixin):
     ) -> None:
         from airflow.sdk.definitions.asset import Asset, AssetAlias, AssetNameRef, AssetUniqueKey, AssetUriRef
 
-        # todo: AIP-76 should we provide an interface to override this?
+        # TODO: AIP-76 should we provide an interface to override this?
         partition_key = ti.dag_run.partition_key
         asset_keys = {
             AssetUniqueKey(o.name, o.uri)

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -1315,6 +1315,8 @@ class TaskInstance(Base, LoggingMixin):
     ) -> None:
         from airflow.sdk.definitions.asset import Asset, AssetAlias, AssetNameRef, AssetUniqueKey, AssetUriRef
 
+        # todo: AIP-76 should we provide an interface to override this?
+        partition_key = ti.dag_run.partition_key
         asset_keys = {
             AssetUniqueKey(o.name, o.uri)
             for o in task_outlets
@@ -1362,6 +1364,7 @@ class TaskInstance(Base, LoggingMixin):
                 task_instance=ti,
                 asset=am,
                 extra=asset_event_extras.get(key),
+                partition_key=partition_key,
                 session=session,
             )
 
@@ -1381,6 +1384,7 @@ class TaskInstance(Base, LoggingMixin):
                     task_instance=ti,
                     asset=am,
                     extra=asset_event_extras_by_name.get(nref.name),
+                    partition_key=partition_key,
                     session=session,
                 )
         if asset_uri_refs:
@@ -1399,6 +1403,7 @@ class TaskInstance(Base, LoggingMixin):
                     task_instance=ti,
                     asset=am,
                     extra=asset_event_extras_by_uri.get(uref.uri),
+                    partition_key=partition_key,
                     session=session,
                 )
 
@@ -1433,6 +1438,7 @@ class TaskInstance(Base, LoggingMixin):
                     asset=asset,
                     source_alias_names=event_aliase_names,
                     extra=asset_event_extra,
+                    partition_key=partition_key,
                     session=session,
                 )
                 if event is None:
@@ -1444,6 +1450,7 @@ class TaskInstance(Base, LoggingMixin):
                         asset=asset,
                         source_alias_names=event_aliase_names,
                         extra=asset_event_extra,
+                        partition_key=partition_key,
                         session=session,
                     )
 

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -1315,7 +1315,8 @@ class TaskInstance(Base, LoggingMixin):
     ) -> None:
         from airflow.sdk.definitions.asset import Asset, AssetAlias, AssetNameRef, AssetUniqueKey, AssetUriRef
 
-        # TODO: AIP-76 should we provide an interface to override this?
+        # TODO: AIP-76 should we provide an interface to override this, so that the task can
+        #  tell the truth if for some reason it touches a different partition?
         partition_key = ti.dag_run.partition_key
         asset_keys = {
             AssetUniqueKey(o.name, o.uri)

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -137,6 +137,7 @@ if TYPE_CHECKING:
     from airflow.serialization.json_schema import Validator
     from airflow.task.trigger_rule import TriggerRule
     from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
+    from airflow.timetables.simple import PartitionMapper
     from airflow.triggers.base import BaseEventTrigger
 
     try:
@@ -241,6 +242,18 @@ class _TimetableNotRegistered(ValueError):
     def __str__(self) -> str:
         return (
             f"Timetable class {self.type_string!r} is not registered or "
+            "you have a top level database access that disrupted the session. "
+            "Please check the airflow best practices documentation."
+        )
+
+
+class _PartitionMapperNotFound(ValueError):
+    def __init__(self, type_string: str) -> None:
+        self.type_string = type_string
+
+    def __str__(self) -> str:
+        return (
+            f"PartitionMapper class {self.type_string!r} could not be imported or "
             "you have a top level database access that disrupted the session. "
             "Please check the airflow best practices documentation."
         )
@@ -457,6 +470,45 @@ def decode_timetable(var: dict[str, Any]) -> Timetable:
     if timetable_class is None:
         raise _TimetableNotRegistered(importable_string)
     return timetable_class.deserialize(var[Encoding.VAR])
+
+
+def _load_partition_mapper(importable_string) -> PartitionMapper | None:
+    if importable_string.startswith("airflow.timetables."):
+        return import_string(importable_string)
+    else:
+        return None
+
+
+def encode_partition_mapper(var: PartitionMapper) -> dict[str, Any]:
+    """
+    Encode a PartitionMapper instance.
+
+    This delegates most of the serialization work to the type, so the behavior
+    can be completely controlled by a custom subclass.
+
+    :meta private:
+    """
+    partition_mapper_class = type(var)
+    importable_string = qualname(partition_mapper_class)
+    if _load_partition_mapper(importable_string) is None:
+        raise _PartitionMapperNotFound(importable_string)
+    return {Encoding.TYPE: importable_string, Encoding.VAR: var.serialize()}
+
+
+def decode_partition_mapper(var: dict[str, Any]) -> PartitionMapper:
+    """
+    Decode a previously serialized PartitionMapper.
+
+    Most of the deserialization logic is delegated to the actual type, which
+    we import from string.
+
+    :meta private:
+    """
+    importable_string = var[Encoding.TYPE]
+    partition_mapper_class = _load_partition_mapper(importable_string)
+    if partition_mapper_class is None:
+        raise _PartitionMapperNotFound(importable_string)
+    return partition_mapper_class.deserialize(var[Encoding.VAR])
 
 
 def encode_priority_weight_strategy(var: PriorityWeightStrategy) -> str:

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -475,8 +475,7 @@ def decode_timetable(var: dict[str, Any]) -> Timetable:
 def _load_partition_mapper(importable_string) -> PartitionMapper | None:
     if importable_string.startswith("airflow.timetables."):
         return import_string(importable_string)
-    else:
-        return None
+    return None
 
 
 def encode_partition_mapper(var: PartitionMapper) -> dict[str, Any]:

--- a/airflow-core/src/airflow/timetables/simple.py
+++ b/airflow-core/src/airflow/timetables/simple.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING, Any
 
@@ -220,7 +220,7 @@ class AssetTriggeredTimetable(_TrivialTimetable):
         return None
 
 
-class PartitionMapper:
+class PartitionMapper(ABC):
     """
     Base partition mapper class.
 

--- a/airflow-core/src/airflow/timetables/simple.py
+++ b/airflow-core/src/airflow/timetables/simple.py
@@ -271,7 +271,7 @@ class PartitionedAssetTimetable(AssetTriggeredTimetable):
         if not mapper_class_name:
             mapper_class = IdentityMapper
         else:
-            # todo: AIP-76 what is the right way to do this?
+            # TODO: AIP-76 what is the right way to do this?
             if mapper_class_name in globals():
                 mapper_class = globals()[mapper_class_name]
             else:

--- a/airflow-core/src/airflow/timetables/simple.py
+++ b/airflow-core/src/airflow/timetables/simple.py
@@ -232,6 +232,13 @@ class PartitionMapper:
     def to_upstream(self, key: str) -> Iterable[str]:
         """Yield the source keys that map to the given target partition key."""
 
+    def serialize(self) -> dict[str, Any]:
+        return {}
+
+    @classmethod
+    def deserialize(cls, data: dict[str, Any]) -> IdentityMapper:
+        return cls()
+
 
 class IdentityMapper(PartitionMapper):
     """Partition mapper that does not change the key."""

--- a/airflow-core/src/airflow/timetables/simple.py
+++ b/airflow-core/src/airflow/timetables/simple.py
@@ -227,18 +227,20 @@ class PartitionMapper:
     Maps keys from asset events to target dag run partitions.
     """
 
-    def map(self, key: str) -> str: ...
+    def to_downstream(self, key: str) -> str:
+        """Return the target key that the given source partition key maps to."""
 
-    def inverse_map(self, key: str) -> Iterable[str]: ...
+    def to_upstream(self, key: str) -> Iterable[str]:
+        """Yield the source keys that map to the given target partition key."""
 
 
 class IdentityMapper(PartitionMapper):
     """Partition mapper that does not change the key."""
 
-    def map(self, key: str) -> str:
+    def to_downstream(self, key: str) -> str:
         return key
 
-    def inverse_map(self, key: str) -> Iterable[str]:
+    def to_upstream(self, key: str) -> Iterable[str]:
         yield key
 
 

--- a/airflow-core/src/airflow/timetables/simple.py
+++ b/airflow-core/src/airflow/timetables/simple.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING, Any
 
 from airflow._shared.timezones import timezone
@@ -226,22 +226,24 @@ class PartitionMapper:
     Maps keys from asset events to target dag run partitions.
     """
 
-    def map(self, key): ...
+    def map(self, key: str) -> str: ...
 
-    def inverse_map(self, key): ...
+    def inverse_map(self, key: str) -> Iterable[str]: ...
 
 
 class IdentityMapper(PartitionMapper):
-    "Partition mapper that does not change the key."
+    """Partition mapper that does not change the key."""
 
-    def map(self, key):
+    def map(self, key: str) -> str:
         return key
 
-    def inverse_map(self, key):
-        return key
+    def inverse_map(self, key: str) -> Iterable[str]:
+        yield key
 
 
 class PartitionedAssetTimetable(AssetTriggeredTimetable):
+    """Asset-driven timetable that listens for partitioned assets."""
+
     @property
     def summary(self) -> str:
         return "Partitioned Asset"

--- a/airflow-core/src/airflow/timetables/simple.py
+++ b/airflow-core/src/airflow/timetables/simple.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+from abc import abstractmethod
 from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING, Any
 
@@ -226,9 +227,11 @@ class PartitionMapper:
     Maps keys from asset events to target dag run partitions.
     """
 
+    @abstractmethod
     def to_downstream(self, key: str) -> str:
         """Return the target key that the given source partition key maps to."""
 
+    @abstractmethod
     def to_upstream(self, key: str) -> Iterable[str]:
         """Yield the source keys that map to the given target partition key."""
 
@@ -236,7 +239,7 @@ class PartitionMapper:
         return {}
 
     @classmethod
-    def deserialize(cls, data: dict[str, Any]) -> IdentityMapper:
+    def deserialize(cls, data: dict[str, Any]) -> PartitionMapper:
         return cls()
 
 

--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -155,7 +155,7 @@ const TriggerDAGForm = ({ dagDisplayName, dagId, isPaused, onClose, open }: Trig
               </Stack>
               <Stack css={{ flexBasis: "70%" }}>
                 <Input {...field} size="sm" />
-                {/* todo: AIP-76 */}
+                {/* TODO: AIP-76 */}
                 {/* <Field.HelperText>{translate("components:triggerDag.runIdHelp")}</Field.HelperText> */}
               </Stack>
             </Field.Root>

--- a/airflow-core/tests/unit/models/test_taskinstance.py
+++ b/airflow-core/tests/unit/models/test_taskinstance.py
@@ -3238,52 +3238,6 @@ def test_find_relevant_relatives(dag_maker, session, normal_tasks, mapped_tasks,
     )
     assert result == expected
 
-@pytest.fixture
-def test_asset(session):
-    asset = AssetModel(
-        id=1,
-        name="test_get_asset_by_name",
-        uri="s3://bucket/key",
-        group="asset",
-        extra={"foo": "bar"},
-        created_at=DEFAULT_DATE,
-        updated_at=DEFAULT_DATE,
-    )
-    asset_active = AssetActive.for_asset(asset)
-    session.add_all([asset, asset_active])
-    session.commit()
-
-    yield asset
-
-    session.delete(asset)
-    session.delete(asset_active)
-    session.commit()
-
-
-@pytest.fixture
-def test_asset_events(session):
-    def make_timestamp(day):
-        return datetime(2021, 1, day, tzinfo=timezone.utc)
-
-    common = {
-        "asset_id": 1,
-        "extra": {"foo": "bar"},
-        "source_dag_id": "foo",
-        "source_task_id": "bar",
-        "source_run_id": "custom",
-        "source_map_index": -1,
-        "partition_key": None,
-    }
-
-    events = [AssetEvent(id=i, timestamp=make_timestamp(i), **common) for i in (1, 2, 3)]
-    session.add_all(events)
-    session.commit()
-    yield events
-
-    for event in events:
-        session.delete(event)
-    session.commit()
-
 
 def test_when_dag_run_has_partition_then_asset_does(dag_maker, session):
     asset = Asset(name="hello")

--- a/airflow-core/tests/unit/models/test_taskinstance.py
+++ b/airflow-core/tests/unit/models/test_taskinstance.py
@@ -162,14 +162,9 @@ def clean_db():
 
 class TestTaskInstance:
     def setup_method(self):
-        self.clean_db()
-
         # We don't want to store any code for (test) dags created in this file
         with patch.object(settings, "STORE_DAG_CODE", False):
             yield
-
-    def teardown_method(self):
-        self.clean_db()
 
     @pytest.mark.need_serialized_dag(False)
     def test_set_task_dates(self, dag_maker):
@@ -2852,28 +2847,6 @@ def test_refresh_from_task(pool_override, queue_by_policy, monkeypatch):
     ti.max_tries = expected_max_tries
     ti.refresh_from_task(task)
     assert ti.max_tries == expected_max_tries
-
-
-class TestRunRawTaskQueriesCount:
-    """
-    These tests are designed to detect changes in the number of queries executed
-    when calling _run_raw_task
-    """
-
-    @staticmethod
-    def _clean():
-        db.clear_db_runs()
-        db.clear_db_pools()
-        db.clear_db_dags()
-        db.clear_db_sla_miss()
-        db.clear_db_import_errors()
-        db.clear_db_assets()
-
-    def setup_method(self) -> None:
-        self._clean()
-
-    def teardown_method(self) -> None:
-        self._clean()
 
 
 class TestTaskInstanceRecordTaskMapXComPush:

--- a/devel-common/src/tests_common/test_utils/db.py
+++ b/devel-common/src/tests_common/test_utils/db.py
@@ -40,7 +40,6 @@ from airflow.models import (
     Trigger,
     Variable,
 )
-from airflow.models.asset import AssetPartitionDagRun, PartitionedAssetKeyLog
 from airflow.models.dag import DagOwnerAttributes
 from airflow.models.dagcode import DagCode
 from airflow.models.dagwarning import DagWarning
@@ -363,11 +362,19 @@ def clear_db_xcom():
 
 
 def clear_db_pakl():
+    if not AIRFLOW_V_3_2_PLUS:
+        return
+    from airflow.models.asset import PartitionedAssetKeyLog
+
     with create_session() as session:
         session.query(PartitionedAssetKeyLog).delete()
 
 
 def clear_db_apdr():
+    if not AIRFLOW_V_3_2_PLUS:
+        return
+    from airflow.models.asset import AssetPartitionDagRun
+
     with create_session() as session:
         session.query(AssetPartitionDagRun).delete()
 

--- a/devel-common/src/tests_common/test_utils/db.py
+++ b/devel-common/src/tests_common/test_utils/db.py
@@ -40,6 +40,7 @@ from airflow.models import (
     Trigger,
     Variable,
 )
+from airflow.models.asset import AssetPartitionDagRun, PartitionedAssetKeyLog
 from airflow.models.dag import DagOwnerAttributes
 from airflow.models.dagcode import DagCode
 from airflow.models.dagwarning import DagWarning
@@ -359,6 +360,16 @@ def clear_db_dag_warnings():
 def clear_db_xcom():
     with create_session() as session:
         session.query(XCom).delete()
+
+
+def clear_db_pakl():
+    with create_session() as session:
+        session.query(PartitionedAssetKeyLog).delete()
+
+
+def clear_db_apdr():
+    with create_session() as session:
+        session.query(AssetPartitionDagRun).delete()
 
 
 def clear_db_logs():


### PR DESCRIPTION
In this PR we make it so that when an asset is updated in a dag run that has a partition key, the asset event also gets the partition key, _and_ records are created in the appropriate tables as needed for scheduling dag runs that listen for the asset.

I have two outstanding questions:

One: [Right way to identify partitoned timetable](https://github.com/apache/airflow/pull/58289/files#r2530000995)



And two: [Right way to ser / deser partition mapper](https://github.com/apache/airflow/pull/58289/files#r2530001844)


