### PR TITLE
Bump min version of openlineage libraries to 1.40.0

### DIFF
--- a/providers/dbt/cloud/tests/unit/dbt/cloud/utils/test_openlineage.py
+++ b/providers/dbt/cloud/tests/unit/dbt/cloud/utils/test_openlineage.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-from openlineage.common import __version__
+from openlineage.client.constants import __version__
 from packaging.version import parse
 
 from airflow.exceptions import AirflowOptionalProviderFeatureException

--- a/providers/openlineage/pyproject.toml
+++ b/providers/openlineage/pyproject.toml
@@ -62,8 +62,8 @@ dependencies = [
     "apache-airflow-providers-common-sql>=1.20.0",
     "apache-airflow-providers-common-compat>=1.8.0",
     "attrs>=22.2",
-    "openlineage-integration-common>=1.38.0",
-    "openlineage-python>=1.38.0",
+    "openlineage-integration-common>=1.40.0",
+    "openlineage-python>=1.40.0",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

`openlineage-client` seems to have released 1.40.0 yesterday where the `__version__` flag was moved from the original version to `openlineage.client.constants`.

Due to this CI fails with error:
```shell script
__________________________________________________________ ERROR collecting providers/dbt/cloud/tests/unit/dbt/cloud/utils/test_openlineage.py ___________________________________________________________
ImportError while importing test module '/opt/airflow/providers/dbt/cloud/tests/unit/dbt/cloud/utils/test_openlineage.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/python/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
providers/dbt/cloud/tests/unit/dbt/cloud/utils/test_openlineage.py:24: in <module>
    from openlineage.common import __version__
E   ImportError: cannot import name '__version__' from 'openlineage.common' (/usr/python/lib/python3.10/site-packages/openlineage/common/__init__.py)
```

Bumping min OL version to be 1.40.0 and updating the import statement as I do not see any risk in doing that. But if we want to / think this option isn't great I can work it around with:

```python
Python 3.13.3 (main, Apr  8 2025, 13:54:08) [Clang 17.0.0 (clang-1700.0.13.3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from importlib import metadata
>>> metadata.version("openlineage-python")
'1.40.0'
```

I am OK with both approaches


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
