### PR TITLE
Refactor make_sure_configuration_loaded of conf to use provider hooks

### DIFF
--- a/airflow-core/src/airflow/configuration.py
+++ b/airflow-core/src/airflow/configuration.py
@@ -505,7 +505,7 @@ class AirflowConfigParser(ConfigParser):
             needs_reload = self._ensure_providers_config_unloaded()
         yield
         if needs_reload:
-            self._reload_providers()
+            self._reload_provider_configs()
 
     def _ensure_providers_config_loaded(self) -> None:
         """Ensure providers configurations are loaded."""

--- a/airflow-core/src/airflow/configuration.py
+++ b/airflow-core/src/airflow/configuration.py
@@ -498,20 +498,32 @@ class AirflowConfigParser(ConfigParser):
 
         :param with_providers: whether providers should be loaded
         """
-        reload_providers_when_leaving = False
-        if with_providers and not self._providers_configuration_loaded:
-            # make sure providers are initialized
+        needs_reload = False
+        if with_providers:
+            self._ensure_providers_config_loaded()
+        else:
+            needs_reload = self._ensure_providers_config_unloaded()
+        yield
+        if needs_reload:
+            self._reload_providers()
+
+    def _ensure_providers_config_loaded(self) -> None:
+        """Ensure providers configurations are loaded."""
+        if not self._providers_configuration_loaded:
             from airflow.providers_manager import ProvidersManager
 
-            # run internal method to initialize providers configuration in ordered to not trigger the
-            # initialize_providers_configuration cache (because we will be unloading it now
             ProvidersManager()._initialize_providers_configuration()
-        elif not with_providers and self._providers_configuration_loaded:
-            reload_providers_when_leaving = True
+
+    def _ensure_providers_config_unloaded(self) -> bool:
+        """Ensure providers configurations are unloaded temporarily to load core configs. Returns True if providers get unloaded."""
+        if self._providers_configuration_loaded:
             self.restore_core_default_configuration()
-        yield
-        if reload_providers_when_leaving:
-            self.load_providers_configuration()
+            return True
+        return False
+
+    def _reload_provider_configs(self) -> None:
+        """Reload providers configuration."""
+        self.load_providers_configuration()
 
     @staticmethod
     def _write_section_header(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Split provider-specific logic from make_sure_configuration_loaded into separate hook methods (ensure_providers_loaded, ensure_providers_unloaded, _reload_providers) that can be overridden in subclasses. This enables moving write() to the shared parser while keeping provider handling in core / sdk, but not in shared parser. I am handling this in: https://github.com/apache/airflow/pull/57744

## Changes

- Split provider loading/unloading logic into `ensure_providers_loaded()`, `ensure_providers_unloaded()`, and `_reload_providers()` hook methods
- Core overrides these hooks to handle provider management
- Shared parser provides no-op implementations

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
