### PR TITLE
SerDe: Add Pydantic schema support for ObjectStoragePath class

### DIFF
--- a/task-sdk/src/airflow/sdk/io/path.py
+++ b/task-sdk/src/airflow/sdk/io/path.py
@@ -428,8 +428,21 @@ class ObjectStoragePath(CloudPath):
         _source_type: Any,
         _handler: GetCoreSchemaHandler,
     ) -> core_schema.CoreSchema:
+        """
+        Generate the Pydantic core schema for ObjectStoragePath validation and serialization.
+
+        This method enables ObjectStoragePath to be used as a Pydantic field type with support for:
+        - Validation from serialized dict representation
+        - Validation from string paths
+        - Validation of existing ObjectStoragePath instances
+        - Serialization to dict format
+
+        :param _source_type: The source type being validated (unused)
+        :param _handler: Pydantic's schema handler (unused)
+        :return: A CoreSchema defining validation and serialization behavior
+        """
         def validate_from_typed_dict(value: dict) -> ObjectStoragePath:
-            result = cls.deserialize(value, version=cls.__version__)
+            result = cls.deserialize(value.copy(), version=cls.__version__)
             return result
 
         python_schema = core_schema.union_schema(
@@ -479,6 +492,15 @@ class ObjectStoragePath(CloudPath):
     def __get_pydantic_json_schema__(
         cls, _core_schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler
     ) -> JsonSchemaValue:
+        """
+        Generate the JSON schema representation for ObjectStoragePath.
+
+        This method customizes the JSON schema output to include the class name as the title.
+
+        :param _core_schema: The core schema to generate JSON schema from.
+        :param handler: The JSON schema handler.
+        :return: A JSON schema dictionary with the ObjectStoragePath title.
+        """
         json_schema = handler(_core_schema)
         json_schema = handler.resolve_ref_schema(json_schema)
         json_schema["title"] = cls.__qualname__

--- a/task-sdk/src/airflow/sdk/io/path.py
+++ b/task-sdk/src/airflow/sdk/io/path.py
@@ -441,6 +441,7 @@ class ObjectStoragePath(CloudPath):
         :param _handler: Pydantic's schema handler (unused)
         :return: A CoreSchema defining validation and serialization behavior
         """
+
         def validate_from_typed_dict(value: dict) -> ObjectStoragePath:
             result = cls.deserialize(value.copy(), version=cls.__version__)
             return result

--- a/task-sdk/tests/task_sdk/io/test_path.py
+++ b/task-sdk/tests/task_sdk/io/test_path.py
@@ -355,7 +355,7 @@ class TestBackwardsCompatibility:
             get_fs("file", storage_options={"foo": "bar"})
 
 
-class TestPydanticModel(BaseModel):
+class TPydanticModel(BaseModel):
     key: str
     path: ObjectStoragePath
     paths: list[ObjectStoragePath] | None
@@ -399,9 +399,7 @@ class TestPydanticSerDe:
         )
 
     def test_pydantic_model_serdes(self):
-        model = TestPydanticModel(
-            key="key1", path=ObjectStoragePath("s3://conn_id@bucket/test.txt"), paths=None
-        )
+        model = TPydanticModel(key="key1", path=ObjectStoragePath("s3://conn_id@bucket/test.txt"), paths=None)
         serialized = model.model_dump(mode="json")
         assert serialized == {
             "key": "key1",
@@ -409,7 +407,7 @@ class TestPydanticSerDe:
             "paths": None,
         }
         assert model.model_validate(serialized) == model
-        model = TestPydanticModel(
+        model = TPydanticModel(
             key="key1",
             path=ObjectStoragePath("s3://conn_id@bucket/test.txt"),
             paths=[
@@ -436,4 +434,4 @@ class TestPydanticSerDe:
         # model.model_validate(serialized) == model
 
     def test_pydantic_json_schema(self):
-        assert TestPydanticModel.model_json_schema()
+        assert TPydanticModel.model_json_schema()

--- a/task-sdk/tests/task_sdk/io/test_path.py
+++ b/task-sdk/tests/task_sdk/io/test_path.py
@@ -412,7 +412,7 @@ class TestPydanticSerDe:
             path=ObjectStoragePath("s3://conn_id@bucket/test.txt"),
             paths=[
                 ObjectStoragePath(
-                    "s3://bucket/test2.txt", aws_access_key="admin", aws_secret_access_key="passowrd"
+                    "s3://bucket/test2.txt", aws_access_key="admin", aws_secret_access_key="password"
                 ),
                 ObjectStoragePath("file:///tmp/test3.txt"),
             ],
@@ -425,7 +425,7 @@ class TestPydanticSerDe:
                 {
                     "path": "s3://bucket/test2.txt",
                     "conn_id": None,
-                    "kwargs": {"aws_access_key": "admin", "aws_secret_access_key": "passowrd"},
+                    "kwargs": {"aws_access_key": "admin", "aws_secret_access_key": "password"},
                 },
                 {"path": "file:///tmp/test3.txt", "conn_id": None, "kwargs": {}},
             ],


### PR DESCRIPTION
This pull request adds native Pydantic v2 support for the `ObjectStoragePath` class, enabling seamless validation, serialization, and deserialization with Pydantic models. It introduces custom schema methods and comprehensive tests to ensure robust integration.

**Pydantic integration for `ObjectStoragePath`:**

* Implemented `__get_pydantic_core_schema__` and `__get_pydantic_json_schema__` methods on `ObjectStoragePath` to provide custom validation, serialization, and JSON schema generation compatible with Pydantic v2. This allows `ObjectStoragePath` to be used as a Pydantic field with full type support.

**Testing enhancements:**

* Added `TestPydanticSerDe` test class to verify round-trip serialization and deserialization of `ObjectStoragePath` using Pydantic's `TypeAdapter`, including parameterized tests for various path and kwargs combinations.
* Introduced `TestPydanticModel`, a Pydantic model using `ObjectStoragePath` as a field, to test model-level serialization/deserialization and ensure compatibility with Pydantic features.

closes: #57726 