### PR TITLE
Increase waiter delay for ecs run tasks in system tests

### DIFF
--- a/providers/amazon/tests/system/amazon/aws/example_ecs.py
+++ b/providers/amazon/tests/system/amazon/aws/example_ecs.py
@@ -181,6 +181,8 @@ with DAG(
         # [END howto_awslogs_ecs]
     )
     # [END howto_operator_ecs_run_task]
+    # The default is 6 seconds between checks, which is very aggressive, setting to 60s to reduce throttling errors.
+    run_task.waiter_delay = 60
 
     # [START howto_operator_ecs_deregister_task_definition]
     deregister_task = EcsDeregisterTaskDefinitionOperator(

--- a/providers/amazon/tests/system/amazon/aws/example_ecs_fargate.py
+++ b/providers/amazon/tests/system/amazon/aws/example_ecs_fargate.py
@@ -140,6 +140,8 @@ with DAG(
 
     # EcsRunTaskOperator waits by default, setting as False to test the Sensor below.
     hello_world.wait_for_completion = False
+    # The default is 6 seconds between checks, which is very aggressive, setting to 60s to reduce throttling errors.
+    hello_world.waiter_delay = 60
 
     # [START howto_sensor_ecs_task_state]
     # By default, EcsTaskStateSensor waits until the task has started, but the


### PR DESCRIPTION
The default is 6s which is quite aggressive and causes throttling issues in the test harness. Tests don't need that kind of fidelity and can wait much longer between attempts to fire the trigger.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
