### PR TITLE
Fix: Make Airbyte connection fields properly labeled in Airflow 3

### DIFF
--- a/providers/airbyte/src/airflow/providers/airbyte/hooks/airbyte.py
+++ b/providers/airbyte/src/airflow/providers/airbyte/hooks/airbyte.py
@@ -103,7 +103,12 @@ class AirbyteHook(BaseHook):
                 "extra",
                 "port",
             ],
-            "relabeling": {"login": "Client ID", "password": "Client Secret", "schema": "Token URL"},
+            "relabeling": {
+                "host": "Server URL",
+                "login": "Client ID",
+                "password": "Client Secret",
+                "schema": "Token URL",
+            },
             "placeholders": {},
         }
 

--- a/providers/airbyte/tests/unit/airbyte/hooks/test_airbyte.py
+++ b/providers/airbyte/tests/unit/airbyte/hooks/test_airbyte.py
@@ -224,3 +224,18 @@ class TestAirbyteHook:
         # Check if the session is created correctly
         assert hook.airbyte_api is not None
         assert hook.airbyte_api.sdk_configuration.client.proxies == self._mock_proxy["proxies"]
+
+    def test_get_ui_field_behaviour(self):
+        """
+        Test the UI field behavior configuration for Airbyte connections.
+        """
+        assert AirbyteHook.get_ui_field_behaviour() == {
+            "hidden_fields": ["extra", "port"],
+            "relabeling": {
+                "host": "Server URL",
+                "login": "Client ID",
+                "password": "Client Secret",
+                "schema": "Token URL",
+            },
+            "placeholders": {},
+        }


### PR DESCRIPTION
This PR picks up the work from @Zeglow in PR #55869, which had become stale.

- Add proper relabeling for Airbyte-specific field meanings
- Ensure 'login' displays as 'Client ID' and 'password' as 'Client Secret'
- Similar pattern to other provider fixes

Closes https://github.com/apache/airflow/issues/55841

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
