### PR TITLE
Fix incorrect default docstring for GKEStartPodOperator and reverted changes accidently made in readme.md file

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/operators/kubernetes_engine.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/kubernetes_engine.py
@@ -617,7 +617,7 @@ class GKEStartPodOperator(GKEOperatorMixin, KubernetesPodOperator):
     :param on_finish_action: What to do when the pod reaches its final state, or the execution is interrupted.
         If "delete_pod", the pod will be deleted regardless its state; if "delete_succeeded_pod",
         only succeeded pod will be deleted. You can set to "keep_pod" to keep the pod.
-        Current default is `keep_pod`, but this will be changed in the next major release of this provider.
+        Current default is `delete_pod`, but this will be changed in the next major release of this provider.
     :param deferrable: Run operator in the deferrable mode.
     """
 


### PR DESCRIPTION
This PR updates the default docstring for the on_finish_action parameter in the GKE start function to correctly reflect its intended behavior. The previous wording was misleading/inaccurate, so this change improves clarity for users and developers reading the function documentation.

What is changed: 
Updated docstring to describe correct expected action/behavior

Why this change is needed:
The existing docstring could lead to confusion regarding the purpose and default behavior of on_finish_action

No functional code changes, only documentation clarity improvement