### PR TITLE
[v3-1-test] Change old performance sub-project to pyproject.toml (#58…

### DIFF
--- a/performance/README.md
+++ b/performance/README.md
@@ -1,0 +1,45 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# Apache Airflow Performance Testing
+
+This package contains performance testing utilities and DAGs for Apache Airflow.
+
+## Overview
+
+The performance testing framework generates DAGs for performance testing purposes. The number of DAGs, tasks, and their structure can be controlled through environment variables.
+
+## Environment Variables
+
+- `PERF_DAGS_COUNT` - number of DAGs to generate
+- `PERF_TASKS_COUNT` - number of tasks in each DAG
+- `PERF_START_DATE` - if not provided current time - `PERF_START_AGO` applies
+- `PERF_START_AGO` - start time relative to current time used if PERF_START_DATE is not provided. Default `1h`
+- `SCHEDULE_INTERVAL_ENV` - Schedule interval. Default `@once`
+- `PERF_SHAPE` - shape of DAG. See `DagShape`. Default `NO_STRUCTURE`
+
+## Installation
+
+```bash
+pip install -e .
+```
+
+## License
+
+Apache License 2.0

--- a/performance/pyproject.toml
+++ b/performance/pyproject.toml
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+[build-system]
+requires = ["flit_core==3.12.0"]
+build-backend = "flit_core.buildapi"
+
+[project]
+name = "apache-airflow-performance"
+version = "0.1.0"
+requires-python = ">=3.10,!=3.13"
+description = "Performance testing utilities and DAGs for Apache Airflow"
+readme = { file = "README.md", content-type = "text/markdown" }
+license = "Apache-2.0"
+dependencies = [
+    "apache-airflow>=3.1.3",
+]
+authors = [
+    { name = "Apache Software Foundation", email = "dev@airflow.apache.org" },
+]
+classifiers = [
+    "Private :: Do Not Upload",
+]

--- a/performance/requirements.txt
+++ b/performance/requirements.txt
@@ -1,2 +1,0 @@
-apache-airflow==3.1.0
-openlineage-airflow==1.37.0


### PR DESCRIPTION
…372)

We keep on getting dependabot upgrades for this project and it's not really used (will be replaced by performance framework soon hopefully). In the meantime changing to pyproject.toml and removing `==` requirements should make dependabot more happy. (cherry picked from commit 79d54f3ca087fc42c4616724ba141eb1e2225045)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
