### PR TITLE
Synchronize description of official vs. convenience packages in sourc…

### DIFF
--- a/airflow-core/docs/installation/installing-from-sources.rst
+++ b/airflow-core/docs/installation/installing-from-sources.rst
@@ -28,19 +28,17 @@ Released packages
     You can choose different version of Airflow by selecting a different version from the drop-down at
     the top-left of the page.
 
-The ``source``, ``sdist`` and ``whl`` packages released are the "official" sources of installation that you
-can use if you want to verify the origin of the packages and want to verify checksums and signatures of
-the packages. The packages are available via the
-`Official Apache Software Foundation Downloads <https://dlcdn.apache.org/>`_
+The Source packages are official packages of the Apache Software Foundation - and the ones that you can
+use is you want to build the packages yourself from the source code and be sure that the provenance of
+the packages is verified and matches the source code from the repository and you can verify the
+checksums and signatures of the packages.
 
-As of version 2.8 Airflow follows PEP 517/518 and uses ``pyproject.toml`` file to define build dependencies
-and build process and it requires relatively modern versions of packaging tools to get Airflow built from
-local sources or ``sdist`` packages, as PEP 517 compliant build hooks are used to determine dynamic build
-dependencies. In case of ``pip``, it means that at least version 22.1.0 is needed (released at the beginning of
-2022) to build or install Airflow from sources. This does not affect the ability of installing Airflow from
-released wheel packages.
+The ``sdist`` and ``whl`` packages released are the convenience packages - of installation also installed from
+the same sources and you can still verify the origin of the packages and want to verify checksums and
+signatures of the packages. The packages are available via the Official Apache Software Foundations Downloads
+`Official Apache Software Foundations Downloads <https://dlcdn.apache.org/>`_
 
-The |version| downloads of Airflow® are available at:
+The ``|version|`` downloads of Airflow® are available at:
 
 .. jinja:: official_download_page
 

--- a/airflow-ctl/docs/installation/installing-from-sources.rst
+++ b/airflow-ctl/docs/installation/installing-from-sources.rst
@@ -28,12 +28,17 @@ Released packages
     You can choose different version of Airflow by selecting a different version from the drop-down at
     the top-left of the page.
 
-The ``source``, ``sdist`` and ``whl`` packages released are the "official" sources of installation that you
-can use if you want to verify the origin of the packages and want to verify checksums and signatures of
-the packages. The packages are available via the
+The Source packages are official packages of the Apache Software Foundation - and the ones that you can
+use is you want to build the packages yourself from the source code and be sure that the provenance of
+the packages is verified and matches the source code from the repository and you can verify the
+checksums and signatures of the packages.
+
+The ``sdist`` and ``whl`` packages released are the convenience packages - of installation also installed from
+the same sources and you can still verify the origin of the packages and want to verify checksums and
+signatures of the packages. The packages are available via the Official Apache Software Foundations Downloads
 `Official Apache Software Foundations Downloads <https://dlcdn.apache.org/>`_
 
-The {{ airflowctl_version }} downloads of Airflow Ctl are available at:
+The ``|version|`` downloads of Airflow Ctl are available at:
 
 .. jinja:: official_download_page
 

--- a/dev/breeze/doc/09_release_management_tasks.rst
+++ b/dev/breeze/doc/09_release_management_tasks.rst
@@ -428,7 +428,7 @@ Installing providers
 """"""""""""""""""""
 
 In some cases we want to just see if the providers generated can be installed with Airflow without
-verifying them. This happens automatically on CI for sdist packages but you can also run it manually if you
+verifying them. This happens automatically on CI for ``sdist`` packages but you can also run it manually if you
 just prepared providers and they are present in ``dist`` folder.
 
 .. code-block:: bash


### PR DESCRIPTION
…e installs

I noticed one more inconsistency between source packages vs. whl and sdist distribution source installation between providers, airflow-ctl and airflow-core.

This PR generally synchronizes the description and usage of "|version|" placeholder.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
