### PR TITLE
Remove the limitation for sagemaker for Python 3.13

### DIFF
--- a/providers/amazon/pyproject.toml
+++ b/providers/amazon/pyproject.toml
@@ -80,8 +80,8 @@ dependencies = [
     "sagemaker-studio>=1.0.9",
     # Sagemaker studio in Python 3.13 requires version >=1.1.0 and Pydynamodb >=0.7.5
     # Because of sqlean pinning (https://github.com/passren/PyDynamoDB/issues/72)
-    "pydynamodb>=0.7.5; python_version >= \"3.13\"",
-    "sqlean.py>=3.47.0; python_version >= \"3.13\"",
+    "pydynamodb>=0.7.5; python_version >= '3.13'",
+    "sqlean.py>=3.47.0; python_version >= '3.13'",
     "marshmallow>=3",
 ]
 

--- a/providers/amazon/pyproject.toml
+++ b/providers/amazon/pyproject.toml
@@ -77,10 +77,11 @@ dependencies = [
     "asgiref>=2.3.0",
     "PyAthena>=3.10.0",
     "jmespath>=0.7.0",
-    "sagemaker-studio>=1.0.9; python_version < \"3.13\"",
-    # The sagemaker studio 1.1.0+ uses pydynamodb that pins sqlean in version 3.45.1 that is not
-    # Supporting Python 3.13 https://github.com/passren/PyDynamoDB/issues/72
-    "sagemaker-studio>=1.0.9,<1.1.0; python_version >= \"3.13\"",
+    "sagemaker-studio>=1.0.9",
+    # Sagemaker studio in Python 3.13 requires version >=1.1.0 and Pydynamodb >=0.7.5
+    # Because of sqlean pinning (https://github.com/passren/PyDynamoDB/issues/72)
+    "pydynamodb>=0.7.5; python_version >= \"3.13\"",
+    "sqlean.py>=3.47.0; python_version >= \"3.13\"",
     "marshmallow>=3",
 ]
 


### PR DESCRIPTION
After https://github.com/passren/PyDynamoDB/issues/72 was raised, PydynamoDB 0.7.5 has been released with Python 3.13 and we can force it for Python 3.13 to be used so that `pip` will not even try to compile earlier versions of sqlean.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
