### PR TITLE
KubernetesPodOperator: Rework of Kubernetes API retry behavior

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -27,7 +27,6 @@ from typing import TYPE_CHECKING, Any, Protocol
 
 import aiofiles
 import requests
-import tenacity
 from asgiref.sync import sync_to_async
 from kubernetes import client, config, utils, watch
 from kubernetes.client.models import V1Deployment
@@ -39,7 +38,7 @@ from airflow.exceptions import AirflowException, AirflowNotFoundException
 from airflow.models import Connection
 from airflow.providers.cncf.kubernetes.exceptions import KubernetesApiError, KubernetesApiPermissionError
 from airflow.providers.cncf.kubernetes.kube_client import _disable_verify_ssl, _enable_tcp_keepalive
-from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import should_retry_creation
+from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import generic_api_retry
 from airflow.providers.cncf.kubernetes.utils.container import (
     container_is_completed,
     container_is_running,
@@ -390,6 +389,7 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
         self.log.debug("Response: %s", response)
         return response
 
+    @generic_api_retry
     def get_custom_object(
         self, group: str, version: str, plural: str, name: str, namespace: str | None = None
     ):
@@ -412,6 +412,7 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
         )
         return response
 
+    @generic_api_retry
     def delete_custom_object(
         self, group: str, version: str, plural: str, name: str, namespace: str | None = None, **kwargs
     ):
@@ -540,12 +541,7 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
             name=name, namespace=namespace, pretty=True, **kwargs
         )
 
-    @tenacity.retry(
-        stop=tenacity.stop_after_attempt(3),
-        wait=tenacity.wait_random_exponential(),
-        reraise=True,
-        retry=tenacity.retry_if_exception(should_retry_creation),
-    )
+    @generic_api_retry
     def create_job(
         self,
         job: V1Job,
@@ -572,6 +568,7 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
             raise e
         return resp
 
+    @generic_api_retry
     def get_job(self, job_name: str, namespace: str) -> V1Job:
         """
         Get Job of specified name and namespace.
@@ -582,6 +579,7 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
         """
         return self.batch_v1_client.read_namespaced_job(name=job_name, namespace=namespace, pretty=True)
 
+    @generic_api_retry
     def get_job_status(self, job_name: str, namespace: str) -> V1Job:
         """
         Get job with status of specified name and namespace.
@@ -611,6 +609,7 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
             self.log.info("The job '%s' is incomplete. Sleeping for %i sec.", job_name, job_poll_interval)
             sleep(job_poll_interval)
 
+    @generic_api_retry
     def list_jobs_all_namespaces(self) -> V1JobList:
         """
         Get list of Jobs from all namespaces.
@@ -619,6 +618,7 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
         """
         return self.batch_v1_client.list_job_for_all_namespaces(pretty=True)
 
+    @generic_api_retry
     def list_jobs_from_namespace(self, namespace: str) -> V1JobList:
         """
         Get list of Jobs from dedicated namespace.
@@ -674,6 +674,7 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
             return bool(next((c for c in conditions if c.type == "Complete" and c.status), None))
         return False
 
+    @generic_api_retry
     def patch_namespaced_job(self, job_name: str, namespace: str, body: object) -> V1Job:
         """
         Update the specified Job.
@@ -879,6 +880,7 @@ class AsyncKubernetesHook(KubernetesHook):
             if kube_client is not None:
                 await kube_client.close()
 
+    @generic_api_retry
     async def get_pod(self, name: str, namespace: str) -> V1Pod:
         """
         Get pod's object.
@@ -899,6 +901,7 @@ class AsyncKubernetesHook(KubernetesHook):
                     raise KubernetesApiPermissionError("Permission denied (403) from Kubernetes API.") from e
                 raise KubernetesApiError from e
 
+    @generic_api_retry
     async def delete_pod(self, name: str, namespace: str):
         """
         Delete pod's object.
@@ -917,6 +920,7 @@ class AsyncKubernetesHook(KubernetesHook):
                 if str(e.status) != "404":
                     raise
 
+    @generic_api_retry
     async def read_logs(
         self, name: str, namespace: str, container_name: str | None = None, since_seconds: int | None = None
     ) -> list[str]:
@@ -949,6 +953,7 @@ class AsyncKubernetesHook(KubernetesHook):
             except HTTPError as e:
                 raise KubernetesApiError from e
 
+    @generic_api_retry
     async def get_pod_events(self, name: str, namespace: str) -> CoreV1EventList:
         """Get pod's events."""
         async with self.get_conn() as connection:
@@ -964,6 +969,7 @@ class AsyncKubernetesHook(KubernetesHook):
                     raise KubernetesApiPermissionError("Permission denied (403) from Kubernetes API.") from e
                 raise KubernetesApiError from e
 
+    @generic_api_retry
     async def get_job_status(self, name: str, namespace: str) -> V1Job:
         """
         Get job's status object.

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/kubernetes_helper_functions.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/kubernetes_helper_functions.py
@@ -94,6 +94,7 @@ def generic_api_retry(func):
         wait=WaitRetryAfterOrExponential(),
         retry=tenacity.retry_if_exception(_should_retry_api),
         reraise=True,
+        before_sleep=tenacity.before_sleep_log(log, logging.WARNING),
     )(func)
 
 

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/kubernetes_helper_functions.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/kubernetes_helper_functions.py
@@ -24,7 +24,8 @@ from typing import TYPE_CHECKING
 
 import pendulum
 import tenacity
-from kubernetes.client.rest import ApiException
+from kubernetes.client.rest import ApiException as SyncApiException
+from kubernetes_asyncio.client.exceptions import ApiException as AsyncApiException
 from slugify import slugify
 from urllib3.exceptions import HTTPError
 
@@ -61,7 +62,7 @@ TRANSIENT_STATUS_CODES = {409, 429, 500, 502, 503, 504}
 
 def _should_retry_api(exc: BaseException) -> bool:
     """Retry on selected ApiException status codes, plus plain HTTP/timeout errors."""
-    if isinstance(exc, ApiException):
+    if isinstance(exc, (SyncApiException, AsyncApiException)):
         return exc.status in TRANSIENT_STATUS_CODES
     return isinstance(exc, (HTTPError, KubernetesApiException))
 
@@ -71,7 +72,7 @@ class WaitRetryAfterOrExponential(tenacity.wait.wait_base):
 
     def __call__(self, retry_state):
         exc = retry_state.outcome.exception() if retry_state.outcome else None
-        if isinstance(exc, ApiException) and exc.status == 429:
+        if isinstance(exc, (SyncApiException, AsyncApiException)) and exc.status == 429:
             retry_after = (exc.headers or {}).get("Retry-After")
             if retry_after:
                 try:
@@ -207,18 +208,3 @@ def annotations_for_logging_task_metadata(annotation_set):
     else:
         annotations_for_logging = "<omitted>"
     return annotations_for_logging
-
-
-def should_retry_creation(exception: BaseException) -> bool:
-    """
-    Check if an Exception indicates a transient error and warrants retrying.
-
-    This function is needed for preventing 'No agent available' error. The error appears time to time
-    when users try to create a Resource or Job. This issue is inside kubernetes and in the current moment
-    has no solution. Like a temporary solution we decided to retry Job or Resource creation request each
-    time when this error appears.
-    More about this issue here: https://github.com/cert-manager/cert-manager/issues/6457
-    """
-    if isinstance(exception, ApiException):
-        return str(exception.status) == "500"
-    return False

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/kubernetes_helper_functions.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/kubernetes_helper_functions.py
@@ -60,14 +60,10 @@ TRANSIENT_STATUS_CODES = {409, 429, 500, 502, 503, 504}
 
 
 def _should_retry_api(exc: BaseException) -> bool:
-    # Retry on selected ApiException status codes, plus plain HTTP/timeout errors
+    """Retry on selected ApiException status codes, plus plain HTTP/timeout errors."""
     if isinstance(exc, ApiException):
         return exc.status in TRANSIENT_STATUS_CODES
-    if isinstance(exc, HTTPError):
-        return True
-    if isinstance(exc, KubernetesApiException):
-        return True
-    return False
+    return isinstance(exc, (HTTPError, KubernetesApiException))
 
 
 class WaitRetryAfterOrExponential(tenacity.wait.wait_base):

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/kubernetes_helper_functions.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/kubernetes_helper_functions.py
@@ -26,7 +26,7 @@ import pendulum
 import tenacity
 from kubernetes.client.rest import ApiException
 from slugify import slugify
-from urllib3.exceptions import HTTPError, TimeoutError
+from urllib3.exceptions import HTTPError
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
@@ -63,7 +63,7 @@ def _should_retry_api(exc: BaseException) -> bool:
     # Retry on selected ApiException status codes, plus plain HTTP/timeout errors
     if isinstance(exc, ApiException):
         return exc.status in TRANSIENT_STATUS_CODES
-    if isinstance(exc, (HTTPError, TimeoutError)):
+    if isinstance(exc, HTTPError):
         return True
     if isinstance(exc, KubernetesApiException):
         return True

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/resource.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/resource.py
@@ -23,13 +23,12 @@ from collections.abc import Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING
 
-import tenacity
 import yaml
 from kubernetes.utils import create_from_yaml
 
 from airflow.exceptions import AirflowException
 from airflow.providers.cncf.kubernetes.hooks.kubernetes import KubernetesHook
-from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import should_retry_creation
+from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import generic_api_retry
 from airflow.providers.cncf.kubernetes.utils.delete_from import delete_from_yaml
 from airflow.providers.cncf.kubernetes.utils.k8s_resource_iterator import k8s_resource_iterator
 from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_1_PLUS
@@ -132,12 +131,7 @@ class KubernetesCreateResourceOperator(KubernetesResourceBaseOperator):
         else:
             self.custom_object_client.create_cluster_custom_object(group, version, plural, body)
 
-    @tenacity.retry(
-        stop=tenacity.stop_after_attempt(3),
-        wait=tenacity.wait_random_exponential(),
-        reraise=True,
-        retry=tenacity.retry_if_exception(should_retry_creation),
-    )
+    @generic_api_retry
     def _create_objects(self, objects):
         self.log.info("Starting resource creation")
         if not self.custom_resource_definition:

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/conftest.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/conftest.py
@@ -25,6 +25,12 @@ import pytest
 DATA_FILE_DIRECTORY = Path(__file__).resolve().parent / "data_files"
 
 
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "no_wait_patch_disabled: disable autouse WaitRetryAfterOrExponential patch"
+    )
+
+
 @pytest.fixture(autouse=True)
 def no_retry_wait(request):
     # Skip patching if test has marker

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/conftest.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/conftest.py
@@ -26,7 +26,11 @@ DATA_FILE_DIRECTORY = Path(__file__).resolve().parent / "data_files"
 
 
 @pytest.fixture(autouse=True)
-def no_retry_wait():
+def no_retry_wait(request):
+    # Skip patching if test has marker
+    if request.node.get_closest_marker("no_wait_patch_disabled"):
+        yield
+        return
     patcher = mock.patch(
         "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.WaitRetryAfterOrExponential.__call__",
         return_value=0,

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/conftest.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/conftest.py
@@ -18,10 +18,22 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
 DATA_FILE_DIRECTORY = Path(__file__).resolve().parent / "data_files"
+
+
+@pytest.fixture(autouse=True)
+def no_retry_wait():
+    patcher = mock.patch(
+        "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.WaitRetryAfterOrExponential.__call__",
+        return_value=0,
+    )
+    patcher.start()
+    yield
+    patcher.stop()
 
 
 @pytest.fixture

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/hooks/test_kubernetes.py
@@ -677,8 +677,9 @@ class TestKubernetesHook:
 
     @patch(f"{HOOK_MODULE}.json.dumps")
     @patch(f"{HOOK_MODULE}.KubernetesHook.batch_v1_client")
-    def test_create_job_retries_three_times(self, mock_client, mock_json_dumps):
+    def test_create_job_retries_five_times(self, mock_client, mock_json_dumps):
         mock_client.create_namespaced_job.side_effect = [
+            ApiException(status=500),
             ApiException(status=500),
             ApiException(status=500),
             ApiException(status=500),
@@ -689,7 +690,7 @@ class TestKubernetesHook:
         with pytest.raises(ApiException):
             hook.create_job(job=mock.MagicMock())
 
-        assert mock_client.create_namespaced_job.call_count == 3
+        assert mock_client.create_namespaced_job.call_count == 5
 
     @pytest.mark.parametrize(
         ("given_namespace", "expected_namespace"),

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_resource.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_resource.py
@@ -277,8 +277,9 @@ class TestKubernetesXResourceOperator:
 
     @patch("kubernetes.config.load_kube_config")
     @patch("airflow.providers.cncf.kubernetes.operators.resource.create_from_yaml")
-    def test_create_objects_retries_three_times(self, mock_create_from_yaml, mock_load_kube_config, context):
+    def test_create_objects_retries_five_times(self, mock_create_from_yaml, mock_load_kube_config, context):
         mock_create_from_yaml.side_effect = [
+            ApiException(status=500),
             ApiException(status=500),
             ApiException(status=500),
             ApiException(status=500),
@@ -295,4 +296,4 @@ class TestKubernetesXResourceOperator:
         with pytest.raises(ApiException):
             op.execute(context)
 
-        assert mock_create_from_yaml.call_count == 3
+        assert mock_create_from_yaml.call_count == 5

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/test_kubernetes_helper_functions.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/test_kubernetes_helper_functions.py
@@ -40,6 +40,7 @@ class DummyRetryState:
 
 
 class TestWaitRetryAfterOrExponential:
+    @pytest.mark.no_wait_patch_disabled
     def test_call_with_retry_after_header(self):
         exc = ApiException(status=429)
         exc.headers = {"Retry-After": "15"}
@@ -47,6 +48,7 @@ class TestWaitRetryAfterOrExponential:
         wait = WaitRetryAfterOrExponential()(retry_state)
         assert wait == 15
 
+    @pytest.mark.no_wait_patch_disabled
     @pytest.mark.parametrize(("attempt_number", "expected_wait"), [(1, 1), (4, 8)])
     def test_call_without_retry_after_header(self, attempt_number, expected_wait):
         exc = ApiException(status=409)

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/test_kubernetes_helper_functions.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/test_kubernetes_helper_functions.py
@@ -21,10 +21,14 @@ import re
 from unittest import mock
 
 import pytest
-from kubernetes.client.rest import ApiException
+from kubernetes.client.rest import ApiException as SyncApiException
+from kubernetes_asyncio.client.exceptions import ApiException as AsyncApiException
+from urllib3.exceptions import HTTPError
 
 from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import (
+    KubernetesApiException,
     WaitRetryAfterOrExponential,
+    _should_retry_api,
     create_unique_id,
 )
 
@@ -33,25 +37,48 @@ pod_name_regex = r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])
 
 class DummyRetryState:
     def __init__(self, exception=None):
-        # self.attempt_number = 1
         self.outcome = mock.Mock() if exception is not None else None
         if self.outcome:
             self.outcome.exception = mock.Mock(return_value=exception)
 
 
+def test_should_retry_api():
+    exc = HTTPError()
+    assert _should_retry_api(exc)
+
+    exc = KubernetesApiException()
+    assert _should_retry_api(exc)
+
+    exc = SyncApiException(status=500)
+    assert _should_retry_api(exc)
+
+    exc = AsyncApiException(status=500)
+    assert _should_retry_api(exc)
+
+    exc = SyncApiException(status=404)
+    assert not _should_retry_api(exc)
+
+    exc = AsyncApiException(status=404)
+    assert not _should_retry_api(exc)
+
+
 class TestWaitRetryAfterOrExponential:
     @pytest.mark.no_wait_patch_disabled
-    def test_call_with_retry_after_header(self):
-        exc = ApiException(status=429)
+    @pytest.mark.parametrize(("exception"), [SyncApiException, AsyncApiException])
+    def test_call_with_retry_after_header(self, exception):
+        exc = exception(status=429)
         exc.headers = {"Retry-After": "15"}
         retry_state = DummyRetryState(exception=exc)
         wait = WaitRetryAfterOrExponential()(retry_state)
         assert wait == 15
 
     @pytest.mark.no_wait_patch_disabled
-    @pytest.mark.parametrize(("attempt_number", "expected_wait"), [(1, 1), (4, 8)])
-    def test_call_without_retry_after_header(self, attempt_number, expected_wait):
-        exc = ApiException(status=409)
+    @pytest.mark.parametrize(
+        ("attempt_number", "expected_wait", "exception"),
+        [(1, 1, SyncApiException), (4, 8, AsyncApiException)],
+    )
+    def test_call_without_retry_after_header(self, attempt_number, expected_wait, exception):
+        exc = exception(status=409)
         retry_state = DummyRetryState(exception=exc)
         retry_state.attempt_number = attempt_number
         wait = WaitRetryAfterOrExponential()(retry_state)

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_pod_manager.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_pod_manager.py
@@ -36,7 +36,6 @@ from airflow.providers.cncf.kubernetes.utils.pod_manager import (
     PodLogsConsumer,
     PodManager,
     PodPhase,
-    get_retry_after_seconds,
     parse_log_line,
 )
 from airflow.utils.timezone import utc
@@ -45,10 +44,6 @@ from unit.cncf.kubernetes.test_callbacks import MockKubernetesPodOperatorCallbac
 
 if TYPE_CHECKING:
     from pendulum import DateTime
-
-
-def wait_none(retry_state):
-    return 0
 
 
 def test_parse_log_line():
@@ -61,31 +56,6 @@ def test_parse_log_line():
     timestamp, line = parse_log_line(f"{real_timestamp} {log_message}")
     assert timestamp == pendulum.parse(real_timestamp)
     assert line == log_message
-
-
-class DummyRetryState:
-    def __init__(self, exception=None):
-        # self.attempt_number = 1
-        self.outcome = mock.Mock() if exception is not None else None
-        if self.outcome:
-            self.outcome.exception = mock.Mock(return_value=exception)
-
-
-def test_get_retry_after_seconds_with_retry_after_header():
-    exc = ApiException(status=429)
-    exc.headers = {"Retry-After": "15"}
-    retry_state = DummyRetryState(exception=exc)
-    wait = get_retry_after_seconds(retry_state)
-    assert wait == 15
-
-
-@pytest.mark.parametrize(("attempt_number", "expected_wait"), [(1, 1), (4, 8)])
-def test_get_retry_after_seconds_without_retry_after_header(attempt_number, expected_wait):
-    exc = ApiException(status=409)
-    retry_state = DummyRetryState(exception=exc)
-    retry_state.attempt_number = attempt_number
-    wait = get_retry_after_seconds(retry_state)
-    assert wait == expected_wait
 
 
 class TestPodManager:
@@ -103,8 +73,11 @@ class TestPodManager:
         assert isinstance(logs, PodLogsConsumer)
         assert logs.response == mock.sentinel.logs
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.get_retry_after_seconds", wait_none)
-    def test_read_pod_logs_retries_successfully(self):
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.WaitRetryAfterOrExponential.__call__",
+        return_value=0,
+    )
+    def test_read_pod_logs_retries_successfully(self, _mock_wait):
         mock.sentinel.metadata = mock.MagicMock()
         self.mock_kube_client.read_namespaced_pod_log.side_effect = [
             BaseHTTPError("Boom"),
@@ -149,8 +122,11 @@ class TestPodManager:
             self.pod_manager.fetch_container_logs(mock.MagicMock(), "container-name", follow=True)
             assert "[container-name] None" not in (record.message for record in caplog.records)
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.get_retry_after_seconds", wait_none)
-    def test_read_pod_logs_retries_fails(self):
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.WaitRetryAfterOrExponential.__call__",
+        return_value=0,
+    )
+    def test_read_pod_logs_retries_fails(self, mock_wait_call):
         mock.sentinel.metadata = mock.MagicMock()
         self.mock_kube_client.read_namespaced_pod_log.side_effect = [
             BaseHTTPError("Boom"),
@@ -242,8 +218,11 @@ class TestPodManager:
         events = self.pod_manager.read_pod_events(mock.sentinel)
         assert mock.sentinel.events == events
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.get_retry_after_seconds", wait_none)
-    def test_read_pod_events_retries_successfully(self):
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.WaitRetryAfterOrExponential.__call__",
+        return_value=0,
+    )
+    def test_read_pod_events_retries_successfully(self, mock_wait_call):
         mock.sentinel.metadata = mock.MagicMock()
         self.mock_kube_client.list_namespaced_event.side_effect = [
             BaseHTTPError("Boom"),
@@ -264,8 +243,11 @@ class TestPodManager:
             ]
         )
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.get_retry_after_seconds", wait_none)
-    def test_read_pod_events_retries_fails(self):
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.WaitRetryAfterOrExponential.__call__",
+        return_value=0,
+    )
+    def test_read_pod_events_retries_fails(self, mock_wait_call):
         mock.sentinel.metadata = mock.MagicMock()
         self.mock_kube_client.list_namespaced_event.side_effect = [
             BaseHTTPError("Boom"),
@@ -283,8 +265,11 @@ class TestPodManager:
         pod_info = self.pod_manager.read_pod(mock.sentinel)
         assert mock.sentinel.pod_info == pod_info
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.get_retry_after_seconds", wait_none)
-    def test_read_pod_retries_successfully(self):
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.WaitRetryAfterOrExponential.__call__",
+        return_value=0,
+    )
+    def test_read_pod_retries_successfully(self, mock_wait_call):
         mock.sentinel.metadata = mock.MagicMock()
         self.mock_kube_client.read_namespaced_pod.side_effect = [
             BaseHTTPError("Boom"),
@@ -316,8 +301,11 @@ class TestPodManager:
         self.mock_kube_client.read_namespaced_pod_log.return_value = mock_response
         self.pod_manager.fetch_container_logs(mock.sentinel, "base")
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.get_retry_after_seconds", wait_none)
-    def test_monitor_pod_logs_failures_non_fatal(self):
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.WaitRetryAfterOrExponential.__call__",
+        return_value=0,
+    )
+    def test_monitor_pod_logs_failures_non_fatal(self, mock_wait_call):
         mock.sentinel.metadata = mock.MagicMock()
         running_status = mock.MagicMock()
         running_status.configure_mock(**{"name": "base", "state.running": True})
@@ -340,8 +328,11 @@ class TestPodManager:
 
         self.pod_manager.fetch_container_logs(mock.sentinel, "base")
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.get_retry_after_seconds", wait_none)
-    def test_read_pod_retries_fails(self):
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.WaitRetryAfterOrExponential.__call__",
+        return_value=0,
+    )
+    def test_read_pod_retries_fails(self, mock_wait_call):
         mock.sentinel.metadata = mock.MagicMock()
         self.mock_kube_client.read_namespaced_pod.side_effect = [
             BaseHTTPError("Boom"),
@@ -386,9 +377,12 @@ class TestPodManager:
             ]
         )
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.get_retry_after_seconds", wait_none)
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.WaitRetryAfterOrExponential.__call__",
+        return_value=0,
+    )
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.container_is_running")
-    def test_fetch_container_logs_failures(self, mock_container_is_running):
+    def test_fetch_container_logs_failures(self, mock_container_is_running, mock_wait_call):
         MockWrapper.reset()
         mock_callbacks = MockWrapper.mock_callbacks
         last_timestamp_string = "2020-10-08T14:18:17.793417674Z"
@@ -440,9 +434,12 @@ class TestPodManager:
         assert "ERROR" not in caplog.text
 
     @pytest.mark.parametrize("status", [409, 429])
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.get_retry_after_seconds", wait_none)
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.WaitRetryAfterOrExponential.__call__",
+        return_value=0,
+    )
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.run_pod_async")
-    def test_start_pod_retries_on_409_or_429_error(self, mock_run_pod_async, status):
+    def test_start_pod_retries_on_409_or_429_error(self, mock_run_pod_async, mock__wait_call, status):
         mock_run_pod_async.side_effect = [
             ApiException(status=status),
             mock.MagicMock(),
@@ -450,16 +447,22 @@ class TestPodManager:
         self.pod_manager.create_pod(mock.sentinel)
         assert mock_run_pod_async.call_count == 2
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.get_retry_after_seconds", wait_none)
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.WaitRetryAfterOrExponential.__call__",
+        return_value=0,
+    )
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.run_pod_async")
-    def test_start_pod_fails_on_other_exception(self, mock_run_pod_async):
-        mock_run_pod_async.side_effect = [ApiException(status=504)]
+    def test_start_pod_fails_on_other_exception(self, mock_run_pod_async, mock_wait_call):
+        mock_run_pod_async.side_effect = [ApiException(status=401)]
         with pytest.raises(ApiException):
             self.pod_manager.create_pod(mock.sentinel)
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.get_retry_after_seconds", wait_none)
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.WaitRetryAfterOrExponential.__call__",
+        return_value=0,
+    )
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.run_pod_async")
-    def test_start_pod_retries_three_times(self, mock_run_pod_async):
+    def test_start_pod_retries_three_times(self, mock_run_pod_async, mock_wait_call):
         mock_run_pod_async.side_effect = [
             ApiException(status=409),
             ApiException(status=409),
@@ -679,10 +682,13 @@ class TestPodManager:
         assert ret == xcom_json
         assert mock_exec_xcom_kill.call_count == 1
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.get_retry_after_seconds", wait_none)
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.WaitRetryAfterOrExponential.__call__",
+        return_value=0,
+    )
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.kubernetes_stream")
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.extract_xcom_kill")
-    def test_extract_xcom_failure(self, mock_exec_xcom_kill, mock_kubernetes_stream):
+    def test_extract_xcom_failure(self, mock_exec_xcom_kill, mock_kubernetes_stream, mock_wait_call):
         """test when invalid json is retrieved from xcom sidecar container."""
         xcom_json = """{"a": "tru"""  # codespell:ignore tru
         mock_pod = MagicMock()
@@ -708,10 +714,13 @@ class TestPodManager:
         assert ret == xcom_result
         assert mock_exec_xcom_kill.call_count == 1
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.get_retry_after_seconds", wait_none)
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.WaitRetryAfterOrExponential.__call__",
+        return_value=0,
+    )
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.kubernetes_stream")
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.extract_xcom_kill")
-    def test_extract_xcom_none(self, mock_exec_xcom_kill, mock_kubernetes_stream):
+    def test_extract_xcom_none(self, mock_exec_xcom_kill, mock_kubernetes_stream, mock_wait_call):
         """test when None is retrieved from xcom sidecar container."""
         mock_pod = MagicMock()
         mock_client = MagicMock()
@@ -722,11 +731,14 @@ class TestPodManager:
             self.pod_manager.extract_xcom(pod=mock_pod)
         assert mock_exec_xcom_kill.call_count == 1
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.get_retry_after_seconds", wait_none)
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.WaitRetryAfterOrExponential.__call__",
+        return_value=0,
+    )
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.container_is_terminated")
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.container_is_running")
     def test_await_xcom_sidecar_container_timeout(
-        self, mock_container_is_running, mock_container_is_terminated
+        self, mock_container_is_running, mock_container_is_terminated, mock_wait_call
     ):
         mock_pod = MagicMock()
         mock_container_is_running.return_value = False
@@ -972,9 +984,12 @@ class TestAsyncPodManager:
                     unexpected_call = mock.call("[%s] %s", container_name, not_expected)
                     assert unexpected_call not in mock_log_info.mock_calls
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.get_retry_after_seconds", wait_none)
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.WaitRetryAfterOrExponential.__call__",
+        return_value=0,
+    )
     @pytest.mark.asyncio
-    async def test_fetch_container_logs_before_current_sec_error_handling(self):
+    async def test_fetch_container_logs_before_current_sec_error_handling(self, mock_wait_call):
         pod = mock.MagicMock()
         container_name = "base"
         since_time = pendulum.now().subtract(minutes=1)

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_pod_manager.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_pod_manager.py
@@ -46,17 +46,6 @@ if TYPE_CHECKING:
     from pendulum import DateTime
 
 
-@pytest.fixture(autouse=True)
-def no_retry_wait():
-    patcher = mock.patch(
-        "airflow.providers.cncf.kubernetes.kubernetes_helper_functions.WaitRetryAfterOrExponential.__call__",
-        return_value=0,
-    )
-    patcher.start()
-    yield
-    patcher.stop()
-
-
 def test_parse_log_line():
     log_message = "This should return no timestamp"
     timestamp, line = parse_log_line(log_message)


### PR DESCRIPTION
# Overview

We are encountering "Too Many Requests" (HTTP 429) errors from the Kubernetes API when scaling up nodes in our Kubernetes cluster. We introduced already the retry handling in the PodManager with this PR: https://github.com/apache/airflow/pull/58033
but we found also the issue that the PodManager access the KuberentesHook api client direct and so the idea is to add the retry on the Hook level and catch only the spezific funtions on the PodManager with direct access to the API Client with retry handling. 

This PR also changes the handling of the retries so that only retry worth statuscodes and errors are retried.

We are encountering frequent HTTP 429 “Too Many Requests” responses from the Kubernetes API during node scale-up operations. A prior change (see PR https://github.com/apache/airflow/pull/58033) introduced retry handling in the PodManager. But some PodManager methods bypassed that logic by using the KubernetesHook API client directly. This change moves the primary retry mechanism into the KubernetesHook and adds targeted retries only for PodManager methods that invoke the API client directly.

Retry behavior is refined to act only on retry-worthy status codes and errors.

We welcome your feedback on this change!

# Details of change:

* Retry logic centralized at the KubernetesHook level.
* PodManager now retries only for methods that directly invoke the Kubernetes API client.
* Retries limited to transient, retry-worthy status codes and network errors.



