### PR TITLE
Add Helm chart to support StatefulSet workers without PVC

### DIFF
--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -456,10 +456,11 @@ spec:
         - name: logs
           persistentVolumeClaim:
             claimName: {{ template "airflow_logs_volume_claim" . }}
-  {{- else if not $persistence }}
+  {{- else }}
         - name: logs
           emptyDir: {{- toYaml (default (dict) .Values.logs.emptyDirConfig) | nindent 12 }}
-  {{- else }}
+  {{- end }}
+  {{- if .Values.logs.persistence.enabled }}
   volumeClaimTemplates:
     - apiVersion: v1
       kind: PersistentVolumeClaim


### PR DESCRIPTION
Decouple StatefulSet deployment from PVC creation in worker configuration. Previously, workers.persistence.enabled controlled both StatefulSet usage and PVC creation, making it impossible to use StatefulSet without volumes.

Changes:
- Modify volume template logic to use logs.persistence.enabled for PVC
- Allow StatefulSet workers with emptyDir when workers.persistence.enabled is true but logs.persistence.enabled is false
- Maintain backward compatibility: default behavior unchanged

This enables stable network identity for workers without persistent storage.