### PR TITLE
fix: task root in parentRunFacet is not always the same as in dag run

### DIFF
--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
@@ -43,7 +43,6 @@ from airflow.providers.openlineage.utils.utils import (
     get_dag_documentation,
     get_dag_parent_run_facet,
     get_job_name,
-    get_root_information_from_dagrun_conf,
     get_task_documentation,
     get_task_parent_run_facet,
     get_user_provided_run_facets,
@@ -229,7 +228,7 @@ class OpenLineageListener:
                     **get_task_parent_run_facet(
                         parent_run_id=parent_run_id,
                         parent_job_name=dag.dag_id,
-                        **get_root_information_from_dagrun_conf(getattr(dagrun, "conf", {})),
+                        dr_conf=getattr(dagrun, "conf", {}),
                     ),
                     **get_airflow_mapped_task_facet(task_instance),
                     **get_airflow_run_facet(dagrun, dag, task_instance, task, task_uuid),
@@ -360,7 +359,7 @@ class OpenLineageListener:
                     **get_task_parent_run_facet(
                         parent_run_id=parent_run_id,
                         parent_job_name=dag.dag_id,
-                        **get_root_information_from_dagrun_conf(getattr(dagrun, "conf", {})),
+                        dr_conf=getattr(dagrun, "conf", {}),
                     ),
                     **get_airflow_run_facet(dagrun, dag, task_instance, task, task_uuid),
                     **get_airflow_debug_facet(),
@@ -502,7 +501,7 @@ class OpenLineageListener:
                     **get_task_parent_run_facet(
                         parent_run_id=parent_run_id,
                         parent_job_name=dag.dag_id,
-                        **get_root_information_from_dagrun_conf(getattr(dagrun, "conf", {})),
+                        dr_conf=getattr(dagrun, "conf", {}),
                     ),
                     **get_airflow_run_facet(dagrun, dag, task_instance, task, task_uuid),
                     **get_airflow_debug_facet(),
@@ -557,7 +556,7 @@ class OpenLineageListener:
                     **get_task_parent_run_facet(
                         parent_run_id=parent_run_id,
                         parent_job_name=ti.dag_id,
-                        **get_root_information_from_dagrun_conf(getattr(dagrun, "conf", {})),
+                        dr_conf=getattr(dagrun, "conf", {}),
                     ),
                     **get_airflow_debug_facet(),
                 },

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
@@ -1467,7 +1467,9 @@ class TestOpenLineageListenerAirflow3:
 
         listener.on_task_instance_failed(previous_state=None, task_instance=task_instance, error=err)
         mock_get_task_parent_run_facet.assert_called_once_with(
-            parent_run_id="2020-01-01T01:01:01+00:00.dag_id.0", parent_job_name=task_instance.dag_id
+            parent_run_id="2020-01-01T01:01:01+00:00.dag_id.0",
+            parent_job_name=task_instance.dag_id,
+            dr_conf={},
         )
         expected_args = dict(
             end_time="2023-01-03T13:01:01+00:00",
@@ -1643,7 +1645,9 @@ class TestOpenLineageListenerAirflow3:
         calls = listener.adapter.complete_task.call_args_list
         assert len(calls) == 1
         mock_get_task_parent_run_facet.assert_called_once_with(
-            parent_run_id="2020-01-01T01:01:01+00:00.dag_id.0", parent_job_name=task_instance.dag_id
+            parent_run_id="2020-01-01T01:01:01+00:00.dag_id.0",
+            parent_job_name=task_instance.dag_id,
+            dr_conf={},
         )
         expected_args = dict(
             end_time="2023-01-03T13:01:01+00:00",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

When working on #57809 I missed support for one case. When only parent information is present in DagRun conf, it's used in DagRun parent run facet as parent and root. Currently, it's not propagated to task root - so in that case task's root is always DagRun, as before.

This PR fixes that, now the root in DagRun's parentRunFacet should always be the same as root in Task's parentRunFacet.

This is the test case that checks that specific scenario:
<img width="743" height="526" alt="image" src="https://github.com/user-attachments/assets/83c6f1dd-dad1-4db2-bc3e-81f872573631" />


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
