### PR TITLE
Add missing release note for DAG.test() behavior change

### DIFF
--- a/airflow-core/newsfragments/34490.doc.rst
+++ b/airflow-core/newsfragments/34490.doc.rst
@@ -1,0 +1,1 @@
+Added missing release note for an unintended behavior change in ``DAG.test()`` related to exception handling. The behavior was modified without a documented changelog entry, and has now been acknowledged for clarity and traceability. (`#34490 <https://github.com/apache/airflow/issues/34490>`_)


### PR DESCRIPTION
This PR adds a missing release note about the behavior change in `DAG.test()`.

Related issue: #34490