### PR TITLE
helm: ensure graceful redis shutdown

### DIFF
--- a/chart/templates/redis/redis-statefulset.yaml
+++ b/chart/templates/redis/redis-statefulset.yaml
@@ -94,7 +94,7 @@ spec:
           {{- end }}
           command: ["/bin/sh"]
           resources: {{- toYaml .Values.redis.resources | nindent 12 }}
-          args: ["-c", "redis-server --requirepass ${REDIS_PASSWORD}"]
+          args: ["-c", "exec redis-server --requirepass ${REDIS_PASSWORD}"]
           ports:
             - name: redis-db
               containerPort: {{ .Values.ports.redisDB }}


### PR DESCRIPTION
### What
This pull request modifies the **Helm chart's Redis configuration** to start the `redis-server` binary via `exec`, ensuring it runs as **PID 1** inside the container.

### Why
When a Kubernetes Pod is shutting down, it sends a **`SIGTERM`** signal to the container's main process (PID 1).

The previous configuration used the command: `/bin/sh -c "redis-server"`. In this setup:
1.  The `/bin/sh` shell is **PID 1**.
2.  The actual `redis-server` is a **child process**.

**Standard shells like `sh` do not automatically propagate signals (like `SIGTERM`)** to their child processes. When the shell receives `SIGTERM`, it ignores it and waits for its child to exit. Since the `redis-server` never receives the `SIGTERM`, it doesn't initiate a graceful save-and-exit sequence.

This leads to the pod hanging until the **`terminationGracePeriodSeconds`** timeout is reached (200 seconds by default), at which point Kubernetes sends a **`SIGKILL`** (forceful kill).

### Impact
* **Fixes Pod Hangs:** Eliminates unnecessary delays during Pod termination/scaling.
* **Prevents Data Loss Risk :** Allows Redis to perform a proper **`BGSAVE`** or persistence flush upon receiving `SIGTERM`, reducing the risk of data loss compared to an immediate `SIGKILL`.
 
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
