### PR TITLE
Fix the "Copy" button for the run config on DAG run details

### DIFF
--- a/airflow/www/static/js/components/RenderedJsonField.tsx
+++ b/airflow/www/static/js/components/RenderedJsonField.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import React from "react";
+import React, { useEffect } from "react";
 
 import ReactJson, { ReactJsonViewProps } from "react-json-view";
 
@@ -39,8 +39,16 @@ interface Props extends FlexProps {
 
 const RenderedJsonField = ({ content, jsonProps, ...rest }: Props) => {
   const [isJson, contentJson, contentFormatted] = jsonParse(content);
-  const { onCopy, hasCopied } = useClipboard(contentFormatted);
+  const { onCopy, hasCopied, setValue } = useClipboard(contentFormatted);
   const theme = useTheme();
+
+  // Current version of the "@chakra-ui/hooks v2.1.2" have a problem with multiple different run configs.
+  // The following code piece derived from this issue: https://github.com/chakra-ui/chakra-ui/issues/6759
+  useEffect(() => {
+    if (contentFormatted) {
+      setValue(contentFormatted);
+    }
+  }, [contentFormatted, setValue]);
 
   return isJson ? (
     <Flex {...rest} p={2}>


### PR DESCRIPTION
The copy button for the run config on the DAG run details page was not working properly. When you click it only copy the last config run.
After doing some research on this, I found out that there is a problem with the hook: useClipboard and I found an issue in their repository about a work around: https://github.com/chakra-ui/chakra-ui/issues/6759.

The possible solutions are like the following:
1. Upgrade the version (I did not test this, because I am not sure if it will be easy with all dependency tree)
2. Apply the workaround (I tested this, and it looks like it is working)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
