### PR TITLE
Create test_cloud_storage_transfer.py

### DIFF
--- a/airflow-core/tests/unit/always/test_project_structure.py
+++ b/airflow-core/tests/unit/always/test_project_structure.py
@@ -143,7 +143,6 @@ class TestProjectStructure:
             "providers/google/tests/unit/google/cloud/links/test_cloud_functions.py",
             "providers/google/tests/unit/google/cloud/links/test_cloud_memorystore.py",
             "providers/google/tests/unit/google/cloud/links/test_cloud_sql.py",
-            "providers/google/tests/unit/google/cloud/links/test_cloud_storage_transfer.py",
             "providers/google/tests/unit/google/cloud/links/test_cloud_tasks.py",
             "providers/google/tests/unit/google/cloud/links/test_compute.py",
             "providers/google/tests/unit/google/cloud/links/test_data_loss_prevention.py",

--- a/providers/google/tests/unit/google/cloud/links/test_cloud_storage_transfer.py
+++ b/providers/google/tests/unit/google/cloud/links/test_cloud_storage_transfer.py
@@ -113,8 +113,9 @@ class TestCloudStorageTransferListLink:
 
         # Create a mock operator with project_id
         class MockOperator:
-            def __init__(self, project_id):
+            def __init__(self, project_id, task_id=None):
                 self.project_id = project_id
+                self.task_id = task_id
                 self.extra_links_params = {"project_id": project_id}
 
         ti = create_task_instance_of_operator(
@@ -163,9 +164,10 @@ class TestCloudStorageTransferJobLink:
 
         # Create a mock operator with required parameters
         class MockOperator:
-            def __init__(self, project_id, transfer_job):
+            def __init__(self, project_id, transfer_job, task_id=None):
                 self.project_id = project_id
                 self.transfer_job = transfer_job
+                self.task_id = task_id
                 self.extra_links_params = {
                     "project_id": project_id,
                     "transfer_job": transfer_job,
@@ -260,8 +262,9 @@ class TestCloudStorageTransferDetailsLink:
 
         # Create a mock operator
         class MockOperator:
-            def __init__(self, project_id):
+            def __init__(self, project_id, task_id=None):
                 self.project_id = project_id
+                self.task_id = task_id
                 self.extra_links_params = {"project_id": project_id}
 
         ti = create_task_instance_of_operator(
@@ -302,8 +305,9 @@ class TestCloudStorageTransferDetailsLink:
         link = CloudStorageTransferDetailsLink()
 
         class MockOperator:
-            def __init__(self, project_id):
+            def __init__(self, project_id, task_id=None):
                 self.project_id = project_id
+                self.task_id = task_id
                 self.extra_links_params = {"project_id": project_id}
 
         ti = create_task_instance_of_operator(
@@ -344,8 +348,9 @@ class TestCloudStorageTransferDetailsLink:
         link = CloudStorageTransferDetailsLink()
 
         class MockOperator:
-            def __init__(self, project_id):
+            def __init__(self, project_id, task_id=None):
                 self.project_id = project_id
+                self.task_id = task_id
                 self.extra_links_params = {"project_id": project_id}
 
         ti = create_task_instance_of_operator(

--- a/providers/google/tests/unit/google/cloud/links/test_cloud_storage_transfer.py
+++ b/providers/google/tests/unit/google/cloud/links/test_cloud_storage_transfer.py
@@ -1,0 +1,379 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+
+from airflow.providers.google.cloud.links.cloud_storage_transfer import (
+    CloudStorageTransferDetailsLink,
+    CloudStorageTransferJobLink,
+    CloudStorageTransferLinkHelper,
+    CloudStorageTransferListLink,
+)
+
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+
+if AIRFLOW_V_3_0_PLUS:
+    from airflow.sdk.execution_time.comms import XComResult
+
+TEST_PROJECT_ID = "test-project-id"
+TEST_TRANSFER_JOB = "test-transfer-job"
+TEST_TRANSFER_OPERATION = "test-transfer-operation"
+TEST_OPERATION_NAME = f"transferOperations/{TEST_TRANSFER_OPERATION}"
+
+CLOUD_STORAGE_TRANSFER_BASE_LINK = "https://console.cloud.google.com/transfer"
+EXPECTED_CLOUD_STORAGE_TRANSFER_LIST_LINK = (
+    CLOUD_STORAGE_TRANSFER_BASE_LINK + f"/jobs?project={TEST_PROJECT_ID}"
+)
+EXPECTED_CLOUD_STORAGE_TRANSFER_JOB_LINK = (
+    CLOUD_STORAGE_TRANSFER_BASE_LINK
+    + f"/jobs/transferJobs%2F{TEST_TRANSFER_JOB}/runs?project={TEST_PROJECT_ID}"
+)
+EXPECTED_CLOUD_STORAGE_TRANSFER_OPERATION_LINK = (
+    CLOUD_STORAGE_TRANSFER_BASE_LINK
+    + f"/jobs/transferJobs%2F{TEST_TRANSFER_JOB}/runs/transferOperations%2F{TEST_TRANSFER_OPERATION}"
+    + f"?project={TEST_PROJECT_ID}"
+)
+
+
+class TestCloudStorageTransferLinkHelper:
+    def test_extract_parts_with_valid_operation_name(self):
+        """Test extract_parts with a valid operation name."""
+        operation_name = f"transferOperations/{TEST_TRANSFER_OPERATION}-{TEST_TRANSFER_JOB}"
+        transfer_operation, transfer_job = CloudStorageTransferLinkHelper.extract_parts(operation_name)
+
+        assert transfer_operation == TEST_TRANSFER_OPERATION
+        assert transfer_job == TEST_TRANSFER_JOB
+
+    def test_extract_parts_with_none_operation_name(self):
+        """Test extract_parts with None operation name."""
+        transfer_operation, transfer_job = CloudStorageTransferLinkHelper.extract_parts(None)
+
+        assert transfer_operation == ""
+        assert transfer_job == ""
+
+    def test_extract_parts_with_empty_operation_name(self):
+        """Test extract_parts with empty operation name."""
+        transfer_operation, transfer_job = CloudStorageTransferLinkHelper.extract_parts("")
+
+        assert transfer_operation == ""
+        assert transfer_job == ""
+
+    def test_extract_parts_with_malformed_operation_name(self):
+        """Test extract_parts with malformed operation name."""
+        operation_name = "invalid-format"
+        transfer_operation, transfer_job = CloudStorageTransferLinkHelper.extract_parts(operation_name)
+
+        # Should handle gracefully but may raise IndexError for malformed input
+        # The actual behavior depends on the split operations
+        try:
+            # If it doesn't raise an exception, check what we get
+            assert transfer_operation is not None
+            assert transfer_job is not None
+        except IndexError:
+            # This is expected behavior for malformed input
+            pass
+
+
+class TestCloudStorageTransferListLink:
+    def test_name_and_key(self):
+        """Test that name and key are set correctly."""
+        link = CloudStorageTransferListLink()
+
+        assert link.name == "Cloud Storage Transfer"
+        assert link.key == "cloud_storage_transfer"
+
+    def test_format_str(self):
+        """Test that format_str is set correctly."""
+        link = CloudStorageTransferListLink()
+
+        expected_format = CLOUD_STORAGE_TRANSFER_BASE_LINK + "/jobs?project={project_id}"
+        assert link.format_str == expected_format
+
+    @pytest.mark.db_test
+    def test_get_link(self, create_task_instance_of_operator, session, mock_supervisor_comms):
+        """Test get_link method for CloudStorageTransferListLink."""
+        expected_url = EXPECTED_CLOUD_STORAGE_TRANSFER_LIST_LINK
+        link = CloudStorageTransferListLink()
+
+        # Create a mock operator with project_id
+        class MockOperator:
+            def __init__(self, project_id):
+                self.project_id = project_id
+                self.extra_links_params = {"project_id": project_id}
+
+        ti = create_task_instance_of_operator(
+            MockOperator,
+            dag_id="test_link_dag",
+            task_id="test_link_task",
+            project_id=TEST_PROJECT_ID,
+        )
+        session.add(ti)
+        session.commit()
+
+        link.persist(context={"ti": ti, "task": ti.task})
+
+        if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
+            mock_supervisor_comms.send.return_value = XComResult(
+                key="key",
+                value={"project_id": TEST_PROJECT_ID},
+            )
+
+        actual_url = link.get_link(operator=ti.task, ti_key=ti.key)
+        assert actual_url == expected_url
+
+
+class TestCloudStorageTransferJobLink:
+    def test_name_and_key(self):
+        """Test that name and key are set correctly."""
+        link = CloudStorageTransferJobLink()
+
+        assert link.name == "Cloud Storage Transfer Job"
+        assert link.key == "cloud_storage_transfer_job"
+
+    def test_format_str(self):
+        """Test that format_str is set correctly."""
+        link = CloudStorageTransferJobLink()
+
+        expected_format = (
+            CLOUD_STORAGE_TRANSFER_BASE_LINK + "/jobs/transferJobs%2F{transfer_job}/runs?project={project_id}"
+        )
+        assert link.format_str == expected_format
+
+    @pytest.mark.db_test
+    def test_get_link(self, create_task_instance_of_operator, session, mock_supervisor_comms):
+        """Test get_link method for CloudStorageTransferJobLink."""
+        expected_url = EXPECTED_CLOUD_STORAGE_TRANSFER_JOB_LINK
+        link = CloudStorageTransferJobLink()
+
+        # Create a mock operator with required parameters
+        class MockOperator:
+            def __init__(self, project_id, transfer_job):
+                self.project_id = project_id
+                self.transfer_job = transfer_job
+                self.extra_links_params = {
+                    "project_id": project_id,
+                    "transfer_job": transfer_job,
+                }
+
+        ti = create_task_instance_of_operator(
+            MockOperator,
+            dag_id="test_link_dag",
+            task_id="test_link_task",
+            project_id=TEST_PROJECT_ID,
+            transfer_job=TEST_TRANSFER_JOB,
+        )
+        session.add(ti)
+        session.commit()
+
+        link.persist(context={"ti": ti, "task": ti.task})
+
+        if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
+            mock_supervisor_comms.send.return_value = XComResult(
+                key="key",
+                value={
+                    "project_id": TEST_PROJECT_ID,
+                    "transfer_job": TEST_TRANSFER_JOB,
+                },
+            )
+
+        actual_url = link.get_link(operator=ti.task, ti_key=ti.key)
+        assert actual_url == expected_url
+
+
+class TestCloudStorageTransferDetailsLink:
+    def test_name_and_key(self):
+        """Test that name and key are set correctly."""
+        link = CloudStorageTransferDetailsLink()
+
+        assert link.name == "Cloud Storage Transfer Details"
+        assert link.key == "cloud_storage_transfer_details"
+
+    def test_format_str(self):
+        """Test that format_str is set correctly."""
+        link = CloudStorageTransferDetailsLink()
+
+        expected_format = (
+            CLOUD_STORAGE_TRANSFER_BASE_LINK
+            + "/jobs/transferJobs%2F{transfer_job}/runs/transferOperations%2F{transfer_operation}"
+            + "?project={project_id}"
+        )
+        assert link.format_str == expected_format
+
+    def test_extract_parts_with_valid_operation_name(self):
+        """Test extract_parts with a valid operation name."""
+        operation_name = f"transferOperations/{TEST_TRANSFER_OPERATION}-{TEST_TRANSFER_JOB}"
+        transfer_operation, transfer_job = CloudStorageTransferDetailsLink.extract_parts(operation_name)
+
+        assert transfer_operation == TEST_TRANSFER_OPERATION
+        assert transfer_job == TEST_TRANSFER_JOB
+
+    def test_extract_parts_with_none_operation_name(self):
+        """Test extract_parts with None operation name."""
+        transfer_operation, transfer_job = CloudStorageTransferDetailsLink.extract_parts(None)
+
+        assert transfer_operation == ""
+        assert transfer_job == ""
+
+    def test_extract_parts_with_empty_operation_name(self):
+        """Test extract_parts with empty operation name."""
+        transfer_operation, transfer_job = CloudStorageTransferDetailsLink.extract_parts("")
+
+        assert transfer_operation == ""
+        assert transfer_job == ""
+
+    def test_extract_parts_with_malformed_operation_name(self):
+        """Test extract_parts with malformed operation name."""
+        operation_name = "invalid-format"
+        transfer_operation, transfer_job = CloudStorageTransferDetailsLink.extract_parts(operation_name)
+
+        # Should handle gracefully but may raise IndexError for malformed input
+        # The actual behavior depends on the split operations
+        try:
+            # If it doesn't raise an exception, check what we get
+            assert transfer_operation is not None
+            assert transfer_job is not None
+        except IndexError:
+            # This is expected behavior for malformed input
+            pass
+
+    @pytest.mark.db_test
+    def test_get_link(self, create_task_instance_of_operator, session, mock_supervisor_comms):
+        """Test get_link method for CloudStorageTransferDetailsLink."""
+        expected_url = EXPECTED_CLOUD_STORAGE_TRANSFER_OPERATION_LINK
+        link = CloudStorageTransferDetailsLink()
+
+        # Create a mock operator
+        class MockOperator:
+            def __init__(self, project_id):
+                self.project_id = project_id
+                self.extra_links_params = {"project_id": project_id}
+
+        ti = create_task_instance_of_operator(
+            MockOperator,
+            dag_id="test_link_dag",
+            task_id="test_link_task",
+            project_id=TEST_PROJECT_ID,
+        )
+        session.add(ti)
+        session.commit()
+
+        # Test persist method with operation_name
+        operation_name = f"transferOperations/{TEST_TRANSFER_OPERATION}-{TEST_TRANSFER_JOB}"
+        link.persist(
+            context={"ti": ti, "task": ti.task},
+            project_id=TEST_PROJECT_ID,
+            operation_name=operation_name,
+        )
+
+        if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
+            mock_supervisor_comms.send.return_value = XComResult(
+                key="key",
+                value={
+                    "project_id": TEST_PROJECT_ID,
+                    "transfer_job": TEST_TRANSFER_JOB,
+                    "transfer_operation": TEST_TRANSFER_OPERATION,
+                },
+            )
+
+        actual_url = link.get_link(operator=ti.task, ti_key=ti.key)
+        assert actual_url == expected_url
+
+    @pytest.mark.db_test
+    def test_persist_with_none_operation_name(
+        self, create_task_instance_of_operator, session, mock_supervisor_comms
+    ):
+        """Test persist method with None operation_name."""
+        link = CloudStorageTransferDetailsLink()
+
+        class MockOperator:
+            def __init__(self, project_id):
+                self.project_id = project_id
+                self.extra_links_params = {"project_id": project_id}
+
+        ti = create_task_instance_of_operator(
+            MockOperator,
+            dag_id="test_link_dag",
+            task_id="test_link_task",
+            project_id=TEST_PROJECT_ID,
+        )
+        session.add(ti)
+        session.commit()
+
+        # Test persist method with None operation_name
+        link.persist(
+            context={"ti": ti, "task": ti.task},
+            project_id=TEST_PROJECT_ID,
+            operation_name=None,
+        )
+
+        if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
+            mock_supervisor_comms.send.return_value = XComResult(
+                key="key",
+                value={
+                    "project_id": TEST_PROJECT_ID,
+                    "transfer_job": "",
+                    "transfer_operation": "",
+                },
+            )
+
+        actual_url = link.get_link(operator=ti.task, ti_key=ti.key)
+        # Should return empty string when transfer_job and transfer_operation are empty
+        assert actual_url == ""
+
+    @pytest.mark.db_test
+    def test_persist_with_empty_operation_name(
+        self, create_task_instance_of_operator, session, mock_supervisor_comms
+    ):
+        """Test persist method with empty operation_name."""
+        link = CloudStorageTransferDetailsLink()
+
+        class MockOperator:
+            def __init__(self, project_id):
+                self.project_id = project_id
+                self.extra_links_params = {"project_id": project_id}
+
+        ti = create_task_instance_of_operator(
+            MockOperator,
+            dag_id="test_link_dag",
+            task_id="test_link_task",
+            project_id=TEST_PROJECT_ID,
+        )
+        session.add(ti)
+        session.commit()
+
+        # Test persist method with empty operation_name
+        link.persist(
+            context={"ti": ti, "task": ti.task},
+            project_id=TEST_PROJECT_ID,
+            operation_name="",
+        )
+
+        if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
+            mock_supervisor_comms.send.return_value = XComResult(
+                key="key",
+                value={
+                    "project_id": TEST_PROJECT_ID,
+                    "transfer_job": "",
+                    "transfer_operation": "",
+                },
+            )
+
+        actual_url = link.get_link(operator=ti.task, ti_key=ti.key)
+        # Should return empty string when transfer_job and transfer_operation are empty
+        assert actual_url == ""


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
 Add missing test for google/cloud/links/test_cloud_storage_transfer.py
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
