### PR TITLE
Fix KuberetesPodTriggerer use correct parameter name to read pod logs.

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -939,7 +939,7 @@ class AsyncKubernetesHook(KubernetesHook):
                 logs = await v1_api.read_namespaced_pod_log(
                     name=name,
                     namespace=namespace,
-                    container_name=container_name,
+                    container=container_name,
                     follow=False,
                     timestamps=True,
                     since_seconds=since_seconds,

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/hooks/test_kubernetes.py
@@ -1072,7 +1072,7 @@ class TestAsyncKubernetesHook:
         lib_method.assert_called_with(
             name=POD_NAME,
             namespace=NAMESPACE,
-            container_name=CONTAINER_NAME,
+            container=CONTAINER_NAME,
             follow=False,
             timestamps=True,
             since_seconds=10,

--- a/providers/google/tests/unit/google/cloud/hooks/test_kubernetes_engine.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_kubernetes_engine.py
@@ -539,7 +539,7 @@ class TestGKEKubernetesAsyncHook:
             namespace=POD_NAMESPACE,
             follow=False,
             timestamps=True,
-            container_name=None,
+            container=None,
             since_seconds=None,
         )
         assert "Test string #1" in logs


### PR DESCRIPTION
# Overview

`read_namespaced_pod_log` expects the container name in the `container` parameter, not `container_name`. The incorrect argument prevented `KubernetesPodTrigger` from fetching logs, causing the trigger to emit an error while the task kept running on the worker.

# Change Summary

* Use correct `container` argument when calling `read_namespaced_pod_log`.
* Update unit tests to assert the proper call signature.