### PR TITLE
Fix test_remote_logging_s3 when contents not found

### DIFF
--- a/airflow-e2e-tests/tests/airflow_e2e_tests/remote_log_tests/test_remote_logging.py
+++ b/airflow-e2e-tests/tests/airflow_e2e_tests/remote_log_tests/test_remote_logging.py
@@ -74,10 +74,11 @@ class TestRemoteLogging:
             print(f"Expected at least {self.task_count} log files, found {len(contents)}. Retrying...")
             time.sleep(self.retry_interval_in_seconds)
 
-        if len(response["Contents"]) < self.task_count:
+        if len(contents) < self.task_count:
             pytest.fail(
                 f"Expected at least {self.task_count} log files in S3 bucket {bucket_name}, "
-                f"but found {len(response['Contents'])} objects: {[obj.get('Key') for obj in response.get('Contents', [])]}"
+                f"but found {len(contents)} objects: {[obj.get('Key') for obj in contents]}. \n"
+                f"List Objects Response: {response}"
             )
 
         task_logs = self.airflow_client.get_task_logs(


### PR DESCRIPTION
related:
- #57744
- https://github.com/apache/airflow/actions/runs/19498816027/job/55821436375?pr=57744

## Why

- The test crash when there isn't `Contents` field in `response = s3_client.list_objects_v2(Bucket=bucket_name)` response.


## What

- Get `contents` variable from retry instead of from `response["Contents"]`.
- Add logging for raw API response from `list_objects_v2` as well.
