### PR TITLE
Fix nit in release docs for python client

### DIFF
--- a/dev/README_RELEASE_PYTHON_CLIENT.md
+++ b/dev/README_RELEASE_PYTHON_CLIENT.md
@@ -360,7 +360,7 @@ cd "${AIRFLOW_REPO_ROOT}"
 
 ```shell
 git fetch apache --tags
-git checkout providers/${VERSION_RC}
+git checkout python-client/${VERSION_RC}
 ```
 
 4) Build the distribution and source tarball:


### PR DESCRIPTION
While checking release for python client 3.1.3rc2 found one copy&paste error.