### PR TITLE
Use lazy imports for callback and deadline SDK definitions

### DIFF
--- a/airflow-core/docs/howto/deadline-alerts.rst
+++ b/airflow-core/docs/howto/deadline-alerts.rst
@@ -58,7 +58,7 @@ Below is an example Dag implementation. If the Dag has not finished 15 minutes a
 
     from datetime import datetime, timedelta
     from airflow import DAG
-    from airflow.sdk.definitions.deadline import AsyncCallback, DeadlineAlert, DeadlineReference
+    from airflow.sdk import AsyncCallback, DeadlineAlert, DeadlineReference
     from airflow.providers.slack.notifications.slack_webhook import SlackWebhookNotifier
     from airflow.providers.standard.operators.empty import EmptyOperator
 
@@ -84,6 +84,10 @@ The timeline for this example would look like this:
     |------|-----------|---------|-----------|--------|
         Scheduled    Queued    Started    Deadline
          00:00       00:03      00:05      00:18
+
+.. note::
+    The import path for :class:`~airflow.sdk.AsyncCallback` was changed in Airflow 3.2 from
+    `airflow.sdk.definitions.deadline` to `airflow.sdk`
 
 .. _built-in-deadline-references:
 
@@ -193,8 +197,7 @@ Using Callbacks
 
 When a deadline is exceeded, the callback's callable is executed with the specified kwargs. You can use an
 existing :doc:`Notifier </howto/notifications>` or create a custom callable.  A callback must be an
-:class:`~airflow.sdk.definitions.deadline.AsyncCallback`, with support coming soon for
-:class:`~airflow.sdk.definitions.deadline.SyncCallback`.
+:class:`~airflow.sdk.AsyncCallback`, with support coming soon for :class:`~airflow.sdk.SyncCallback`.
 
 Using Built-in Notifiers
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -260,7 +263,7 @@ A **custom asynchronous callback** might look like this:
 
     from airflow import DAG
     from airflow.providers.standard.operators.empty import EmptyOperator
-    from airflow.sdk.definitions.deadline import AsyncCallback, DeadlineAlert, DeadlineReference
+    from airflow.sdk import AsyncCallback, DeadlineAlert, DeadlineReference
 
     with DAG(
         dag_id="custom_deadline_alert",
@@ -341,7 +344,8 @@ implement an ``_evaluate_with()`` method.
     from airflow.models.deadline import ReferenceModels
     from sqlalchemy.orm import Session
 
-    from airflow.sdk.definitions.deadline import DeadlineReference, deadline_reference
+    from airflow.sdk import DeadlineReference
+    from airflow.sdk.definitions.deadline import deadline_reference
     from airflow.sdk.timezone import datetime
 
 
@@ -376,7 +380,7 @@ Once registered [see notes below], use your custom references in Dag definitions
 
     from datetime import timedelta
     from airflow import DAG
-    from airflow.sdk.definitions.deadline import AsyncCallback, DeadlineAlert, DeadlineReference
+    from airflow.sdk import AsyncCallback, DeadlineAlert, DeadlineReference
 
     with DAG(
         dag_id="custom_reference_example",

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -142,6 +142,7 @@ available
 avp
 Avro
 avro
+awaitable
 aws
 awsbatch
 awslogs

--- a/task-sdk/docs/api.rst
+++ b/task-sdk/docs/api.rst
@@ -102,7 +102,7 @@ Callbacks
 .. autoclass:: airflow.sdk.SyncCallback
 
 Deadline Alerts
----------
+---------------
 .. autoclass:: airflow.sdk.DeadlineAlert
 
 .. autoclass:: airflow.sdk.DeadlineReference

--- a/task-sdk/docs/api.rst
+++ b/task-sdk/docs/api.rst
@@ -95,6 +95,18 @@ Bases
 
 .. autoapiclass:: airflow.sdk.BaseHook
 
+Callbacks
+---------
+.. autoclass:: airflow.sdk.AsyncCallback
+
+.. autoclass:: airflow.sdk.SyncCallback
+
+Deadline Alerts
+---------
+.. autoclass:: airflow.sdk.DeadlineAlert
+
+.. autoclass:: airflow.sdk.DeadlineReference
+
 Connections & Variables
 -----------------------
 .. autoapiclass:: airflow.sdk.Connection

--- a/task-sdk/src/airflow/sdk/__init__.py
+++ b/task-sdk/src/airflow/sdk/__init__.py
@@ -26,6 +26,7 @@ __all__ = [
     "AssetAny",
     "AssetOrTimeSchedule",
     "AssetWatcher",
+    "AsyncCallback",
     "BaseAsyncOperator",
     "BaseHook",
     "BaseNotifier",
@@ -38,6 +39,8 @@ __all__ = [
     "CronTriggerTimetable",
     "DAG",
     "DagRunState",
+    "DeadlineAlert",
+    "DeadlineReference",
     "DeltaDataIntervalTimetable",
     "DeltaTriggerTimetable",
     "EdgeModifier",
@@ -49,6 +52,7 @@ __all__ = [
     "Param",
     "ParamsDict",
     "PokeReturnValue",
+    "SyncCallback",
     "TaskGroup",
     "TaskInstanceState",
     "Trace",
@@ -91,9 +95,11 @@ if TYPE_CHECKING:
     from airflow.sdk.definitions.asset import Asset, AssetAlias, AssetAll, AssetAny, AssetWatcher
     from airflow.sdk.definitions.asset.decorators import asset
     from airflow.sdk.definitions.asset.metadata import Metadata
+    from airflow.sdk.definitions.callback import AsyncCallback, SyncCallback
     from airflow.sdk.definitions.connection import Connection
     from airflow.sdk.definitions.context import Context, get_current_context, get_parsing_context
     from airflow.sdk.definitions.dag import DAG, dag
+    from airflow.sdk.definitions.deadline import DeadlineAlert, DeadlineReference
     from airflow.sdk.definitions.decorators import setup, task, teardown
     from airflow.sdk.definitions.decorators.task_group import task_group
     from airflow.sdk.definitions.edges import EdgeModifier, Label
@@ -126,6 +132,7 @@ __lazy_imports: dict[str, str] = {
     "AssetAny": ".definitions.asset",
     "AssetOrTimeSchedule": ".definitions.timetables.assets",
     "AssetWatcher": ".definitions.asset",
+    "AsyncCallback": ".definitions.callback",
     "BaseAsyncOperator": ".bases.operator",
     "BaseHook": ".bases.hook",
     "BaseNotifier": ".bases.notifier",
@@ -138,6 +145,8 @@ __lazy_imports: dict[str, str] = {
     "CronTriggerTimetable": ".definitions.timetables.trigger",
     "DAG": ".definitions.dag",
     "DagRunState": ".api.datamodels._generated",
+    "DeadlineAlert": ".definitions.deadline",
+    "DeadlineReference": ".definitions.deadline",
     "DeltaDataIntervalTimetable": ".definitions.timetables.interval",
     "DeltaTriggerTimetable": ".definitions.timetables.trigger",
     "EdgeModifier": ".definitions.edges",
@@ -150,6 +159,7 @@ __lazy_imports: dict[str, str] = {
     "ParamsDict": ".definitions.param",
     "PokeReturnValue": ".bases.sensor",
     "SecretCache": ".execution_time.cache",
+    "SyncCallback": ".definitions.callback",
     "TaskGroup": ".definitions.taskgroup",
     "TaskInstanceState": ".api.datamodels._generated",
     "Trace": ".observability.trace",

--- a/task-sdk/src/airflow/sdk/definitions/deadline.py
+++ b/task-sdk/src/airflow/sdk/definitions/deadline.py
@@ -111,28 +111,37 @@ class DeadlineReference:
     ------
 
     1. Example deadline references:
+
+    .. code-block:: python
+
        fixed = DeadlineReference.FIXED_DATETIME(datetime(2025, 5, 4))
        logical = DeadlineReference.DAGRUN_LOGICAL_DATE
        queued = DeadlineReference.DAGRUN_QUEUED_AT
 
     2. Using in a DAG:
+
+    .. code-block:: python
+
        DAG(
-           dag_id='dag_with_deadline',
+           dag_id="dag_with_deadline",
            deadline=DeadlineAlert(
                reference=DeadlineReference.DAGRUN_LOGICAL_DATE,
                interval=timedelta(hours=1),
                callback=hello_callback,
-           )
+           ),
        )
 
     3. Evaluating deadlines will ignore unexpected parameters:
+
+    .. code-block:: python
+
        # For deadlines requiring parameters:
-           deadline = DeadlineReference.DAGRUN_LOGICAL_DATE
-           deadline.evaluate_with(dag_id=dag.dag_id)
+       deadline = DeadlineReference.DAGRUN_LOGICAL_DATE
+       deadline.evaluate_with(dag_id=dag.dag_id)
 
        # For deadlines with no required parameters:
-           deadline = DeadlineReference.FIXED_DATETIME(datetime(2025, 5, 4))
-           deadline.evaluate_with()
+       deadline = DeadlineReference.FIXED_DATETIME(datetime(2025, 5, 4))
+       deadline.evaluate_with()
     """
 
     class TYPES:


### PR DESCRIPTION
Callback definitions in TaskSDK were moved to their own module in https://github.com/apache/airflow/pull/58177 causing existing Dags using `AsyncCallback` to fail. Using lazy imports ensure that Dag authors are shielded from these types of changes in the future.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
