### PR TITLE
Add additional clarifying docs for TaskGroup params

### DIFF
--- a/airflow-core/docs/core-concepts/dags.rst
+++ b/airflow-core/docs/core-concepts/dags.rst
@@ -551,9 +551,8 @@ A TaskGroup can be used to organize tasks into hierarchical groups in Graph view
 
 Tasks in TaskGroups live on the same original Dag, and honor all the Dag settings and pool configurations.
 
-.. note::
-   For a complete list of parameters available for ``TaskGroup`` and the ``@task_group`` decorator,
-   see the `TaskGroup API Reference <https://airflow.apache.org/docs/task-sdk/stable/api.html#airflow.sdk.TaskGroup>`_.
+.. seealso::
+   API reference for :class:`~airflow.sdk.TaskGroup` and :class:`~airflow.sdk.task_group`
 
 .. image:: /img/ui-light/task_group.gif
 

--- a/airflow-core/docs/core-concepts/dags.rst
+++ b/airflow-core/docs/core-concepts/dags.rst
@@ -551,6 +551,10 @@ A TaskGroup can be used to organize tasks into hierarchical groups in Graph view
 
 Tasks in TaskGroups live on the same original Dag, and honor all the Dag settings and pool configurations.
 
+.. note::
+   For a complete list of parameters available for ``TaskGroup`` and the ``@task_group`` decorator,
+   see the `TaskGroup API Reference <https://airflow.apache.org/docs/task-sdk/stable/api.html#airflow.sdk.TaskGroup>`_.
+
 .. image:: /img/ui-light/task_group.gif
 
 Dependency relationships can be applied across all tasks in a TaskGroup with the ``>>`` and ``<<`` operators. For example, the following code puts ``task1`` and ``task2`` in TaskGroup ``group1`` and then puts both tasks upstream of ``task3``:

--- a/airflow-core/docs/public-airflow-interface.rst
+++ b/airflow-core/docs/public-airflow-interface.rst
@@ -126,6 +126,11 @@ API Server, etc.), providing a version-agnostic, stable interface for writing an
 * ``get_current_context``
 * ``get_parsing_context``
 
+.. note::
+   For detailed parameter documentation for all airflow.sdk classes, decorators, and functions
+   (including ``TaskGroup``, ``DAG``, ``@task_group``, etc.), see the
+   `Task SDK API Reference <https://airflow.apache.org/docs/task-sdk/stable/api.html>`_.
+
 **Migration from Airflow 2.x:**
 
 For detailed migration instructions from Airflow 2.x to 3.x, including import changes and other breaking changes,

--- a/airflow-core/docs/public-airflow-interface.rst
+++ b/airflow-core/docs/public-airflow-interface.rst
@@ -126,10 +126,8 @@ API Server, etc.), providing a version-agnostic, stable interface for writing an
 * ``get_current_context``
 * ``get_parsing_context``
 
-.. note::
-   For detailed parameter documentation for all airflow.sdk classes, decorators, and functions
-   (including ``TaskGroup``, ``DAG``, ``@task_group``, etc.), see the
-   `Task SDK API Reference <https://airflow.apache.org/docs/task-sdk/stable/api.html>`_.
+.. seealso::
+   API reference for :class:`~airflow.sdk.TaskGroup`, :class:`~airflow.sdk.DAG`, and :class:`~airflow.sdk.task_group`
 
 **Migration from Airflow 2.x:**
 


### PR DESCRIPTION
## Problem:
TaskGroup parameter documentation exists in the Task SDK API Reference but is not easily discoverable from the main Airflow documentation

## Solution:
Add cross-references from the main documentation to the Task SDK API Reference:
  - In public-airflow-interface.rst
  - In core-concepts/dags.rst

## Related Issues:
  - Closes #58446