### PR TITLE
Docs: Clarify that masking in Connection 'extra' JSON is keyword-dependent

### DIFF
--- a/airflow-core/docs/security/secrets/mask-sensitive-values.rst
+++ b/airflow-core/docs/security/secrets/mask-sensitive-values.rst
@@ -40,7 +40,7 @@ Sensitive field names
 When masking is enabled, Airflow will always mask the password field of every Connection that is accessed by a
 task.
 
-It will also mask the value of an Airflow Variable , rendered template dictionaries, XCom dictionaries or the field of a Connection's extra JSON blob if the
+It will also mask the value of an Airflow Variable, rendered template dictionaries, XCom dictionaries or the field of a Connection's extra JSON blob if the
 Variable name or field name contains any of the known-sensitive keywords.
 
 **Default Sensitive Keywords:**

--- a/airflow-core/docs/security/secrets/mask-sensitive-values.rst
+++ b/airflow-core/docs/security/secrets/mask-sensitive-values.rst
@@ -92,7 +92,7 @@ your Dag file or operator's ``execute`` function using the ``mask_secret`` funct
 
     @task
     def my_func():
-        from airflow.sdk.execution_time.secrets_masker import mask_secret
+        from airflow.sdk.log import mask_secret
 
         mask_secret("custom_value")
 
@@ -105,7 +105,7 @@ or
 
     class MyOperator(BaseOperator):
         def execute(self, context):
-            from airflow.sdk.execution_time.secrets_masker import mask_secret
+            from airflow.sdk.log import mask_secret
 
             mask_secret("custom_value")
 

--- a/airflow-core/docs/security/secrets/mask-sensitive-values.rst
+++ b/airflow-core/docs/security/secrets/mask-sensitive-values.rst
@@ -40,15 +40,47 @@ Sensitive field names
 When masking is enabled, Airflow will always mask the password field of every Connection that is accessed by a
 task.
 
-It will also mask the value of a Variable, rendered template dictionaries, XCom dictionaries or the
-field of a Connection's extra JSON blob if the name is in the list of known-sensitive fields (i.e. 'access_token',
-'api_key', 'apikey', 'authorization', 'passphrase', 'passwd', 'password', 'private_key', 'secret' or 'token').
-This list can also be extended:
+It will also mask the value of an Airflow Variable or a field of a Connection's extra JSON blob if the
+Variable name or field name contains any of the known-sensitive keywords.
+
+**Default Sensitive Keywords:**
+
+``access_token``, ``api_key``, ``apikey``, ``authorization``, ``passphrase``, ``passwd``, ``password``,
+``private_key``, ``secret``, ``token``, ``keyfile_dict``, ``service_account``.
+
+This list can also be extended using the environment variable ``AIRFLOW__CORE__SENSITIVE_VAR_CONN_NAMES``:
 
 .. code-block:: ini
 
     [core]
     sensitive_var_conn_names = comma,separated,sensitive,names
+
+**Examples of Masking Behavior:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 25 20 35
+
+   * - Source
+     - Key / Variable Name
+     - Matching Keyword
+     - Masking Scope
+   * - Connection Extra
+     - google_keyfile_dict
+     - keyfile_dict
+     - Everywhere (Logs, Rendered Templates, UI)
+   * - Connection Extra
+     - hello
+     - None
+     - Not Masked
+   * - Variable
+     - service_account
+     - service_account
+     - Everywhere (Logs, Rendered Templates, UI)
+   * - Variable
+     - test_keyfile_dict
+     - keyfile_dict
+     - Variables UI Only
 
 Adding your own masks
 """""""""""""""""""""

--- a/airflow-core/docs/security/secrets/mask-sensitive-values.rst
+++ b/airflow-core/docs/security/secrets/mask-sensitive-values.rst
@@ -40,7 +40,7 @@ Sensitive field names
 When masking is enabled, Airflow will always mask the password field of every Connection that is accessed by a
 task.
 
-It will also mask the value of an Airflow Variable or a field of a Connection's extra JSON blob if the
+It will also mask the value of an Airflow Variable , rendered template dictionaries, XCom dictionaries or the field of a Connection's extra JSON blob if the
 Variable name or field name contains any of the known-sensitive keywords.
 
 **Default Sensitive Keywords:**
@@ -92,7 +92,7 @@ your Dag file or operator's ``execute`` function using the ``mask_secret`` funct
 
     @task
     def my_func():
-        from airflow.sdk.log import mask_secret
+        from airflow.sdk.execution_time.secrets_masker import mask_secret
 
         mask_secret("custom_value")
 
@@ -105,7 +105,7 @@ or
 
     class MyOperator(BaseOperator):
         def execute(self, context):
-            from airflow.sdk.log import mask_secret
+            from airflow.sdk.execution_time.secrets_masker import mask_secret
 
             mask_secret("custom_value")
 


### PR DESCRIPTION
## Description
This PR updates the **Masking Sensitive Data** documentation to clarify that keys in a Connection's `extra` JSON field are not masked automatically unless they contain specific sensitive keywords.

**Reason for Change:**
Currently, the documentation states: *"Airflow will by default mask Connection passwords and keys from a Connection’s extra (JSON) field..."*
This implies that **all** keys in the `extra` field are masked by default, which is misleading. In reality, masking is triggered only if the key name contains a substring from the default sensitive keyword list (e.g., `password`, `secret`, `token`).

**Changes in this PR:**
1.  **Updated Default Masking Text:** Explicitly states that masking depends on the key name containing a sensitive keyword.
2.  **Added Keyword List:** Explicitly lists the default keywords (`access_token`, `api_key`, `passphrase`, etc.) so users know exactly what triggers the masking.
3.  **Added Examples Table:** Added a table demonstrating the masking behavior across different scopes (Logs, UI, Rendered Templates) to differentiate between Connection `extra` JSON behavior and Variable behavior.

closes: #58514