### PR TITLE
Use structured logs to ensure log message go to stdout

### DIFF
--- a/airflow-core/src/airflow/executors/executor_loader.py
+++ b/airflow-core/src/airflow/executors/executor_loader.py
@@ -18,10 +18,11 @@
 
 from __future__ import annotations
 
-import logging
 import os
 from collections import defaultdict
 from typing import TYPE_CHECKING
+
+import structlog
 
 from airflow.exceptions import AirflowConfigException, UnknownExecutorException
 from airflow.executors.executor_constants import (
@@ -35,7 +36,7 @@ from airflow.executors.executor_utils import ExecutorName
 from airflow.models.team import Team
 from airflow.utils.module_loading import import_string
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 if TYPE_CHECKING:
     from airflow.executors.base_executor import BaseExecutor

--- a/airflow-core/src/airflow/utils/serve_logs/core.py
+++ b/airflow-core/src/airflow/utils/serve_logs/core.py
@@ -18,15 +18,15 @@
 
 from __future__ import annotations
 
-import logging
 import socket
 import sys
 
+import structlog
 import uvicorn
 
 from airflow.configuration import conf
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 def serve_logs(port=None):


### PR DESCRIPTION
Migrate LocalExecutor, ExecutorLoader, and log server to use structured logging (structlog), as the stdlib root logger goes to stderr instead of stdout. And, we are moving everything over to structlog anyway, so this is more consistent too.