### PR TITLE
Chart: Enhance Celery Worker Sets support for multi-queue configurations

### DIFF
--- a/chart/newsfragments/58547.significant.rst
+++ b/chart/newsfragments/58547.significant.rst
@@ -1,0 +1,8 @@
+Support for Multiple Celery Worker Sets in the Helm Chart
+
+Helm chart behavior related to Celery worker configuration has changed.
+Multiple worker sets can now be configured, which affects how worker sets are rendered and scaled.
+Users upgrading the chart should review their Helm values if they relied on the previous
+single worker behavior.
+
+See `Helm PR #58547 <https://github.com/apache/airflow/pull/58547>`_ for details.

--- a/chart/newsfragments/58547.significant.rst
+++ b/chart/newsfragments/58547.significant.rst
@@ -1,8 +1,24 @@
 Support for Multiple Celery Worker Sets in the Helm Chart
 
-Helm chart behavior related to Celery worker configuration has changed.
-Multiple worker sets can now be configured, which affects how worker sets are rendered and scaled.
-Users upgrading the chart should review their Helm values if they relied on the previous
-single worker behavior.
+Description
+This PR enhances the Airflow Helm chart to support advanced Celery worker topologies, enabling more flexible resource allocation and precise autoscaling configurations.
+
+Why is this needed?
+1. Flexible Worker Topologies
+As Airflow adoption grows, platform teams often need to route tasks exclusively to specialized worker sets (e.g., GPU-optimized, Memory-optimized) without maintaining a generic "default" worker.
+
+Enhancement: The new workers.enableDefault flag allows users to configure a deployment consisting only of specialized worker sets defined in workers.celery.sets. This provides greater flexibility for teams to design their worker architecture exactly as needed.
+2. Multi-Queue Autoscaling Support
+Complex workflows often require a single worker set to handle tasks from multiple specific queues (e.g., queue: "high-priority,vip").
+
+Enhancement: This PR updates the KEDA ScaledObject generation to support comma-separated queue lists. By using the SQL IN (...) clause, we ensure that KEDA scales worker sets based on the precise aggregate workload of all their assigned queues.
+3. Granular Configuration Overrides
+Different worker sets may require different operational strategies within the same cluster.
+
+Enhancement: This change improves the configuration merge logic, allowing individual worker sets to override global settings. For example, a user can now enable KEDA globally but explicitly disable it for a specific worker set that requires a static number of replicas.
+Changes
+New Feature: Added workers.enableDefault (default: true) to values.yaml.
+Enhancement: Updated worker-kedaautoscaler.yaml to use SQL IN clause for queue filtering, supporting multi-queue configurations (e.g., queue: "a,b" -> AND queue IN ('a','b')).
+Refactor: Standardized template rendering to ensure consistent behavior between the default worker and workers.celery.sets.
 
 See `Helm PR #58547 <https://github.com/apache/airflow/pull/58547>`_ for details.

--- a/chart/newsfragments/58547.significant.rst
+++ b/chart/newsfragments/58547.significant.rst
@@ -19,6 +19,6 @@ Enhancement: This change improves the configuration merge logic, allowing indivi
 Changes
 New Feature: Added ``workers.enableDefault`` (default: true) to values.yaml.
 Enhancement: Updated worker-kedaautoscaler.yaml to use SQL IN clause for queue filtering, supporting multi-queue configurations (e.g., queue: "a,b" -> AND queue IN ('a','b')).
-Refactor: Standardized template rendering to ensure consistent behavior between the default worker and workers.celery.sets.
+Refactor: Standardized template rendering to ensure consistent behavior between the default ``workers`` and ``workers.celery.sets``.
 
 See `Helm PR #58547 <https://github.com/apache/airflow/pull/58547>`_ for details.

--- a/chart/newsfragments/58547.significant.rst
+++ b/chart/newsfragments/58547.significant.rst
@@ -17,7 +17,7 @@ Different worker sets may require different operational strategies within the sa
 
 Enhancement: This change improves the configuration merge logic, allowing individual worker sets to override global settings. For example, a user can now enable KEDA globally but explicitly disable it for a specific worker set that requires a static number of replicas.
 Changes
-New Feature: Added workers.enableDefault (default: true) to values.yaml.
+New Feature: Added ``workers.enableDefault`` (default: true) to values.yaml.
 Enhancement: Updated worker-kedaautoscaler.yaml to use SQL IN clause for queue filtering, supporting multi-queue configurations (e.g., queue: "a,b" -> AND queue IN ('a','b')).
 Refactor: Standardized template rendering to ensure consistent behavior between the default worker and workers.celery.sets.
 

--- a/chart/newsfragments/58547.significant.rst
+++ b/chart/newsfragments/58547.significant.rst
@@ -7,7 +7,7 @@ Why is this needed?
 1. Flexible Worker Topologies
 As Airflow adoption grows, platform teams often need to route tasks exclusively to specialized worker sets (e.g., GPU-optimized, Memory-optimized) without maintaining a generic "default" worker.
 
-Enhancement: The new workers.enableDefault flag allows users to configure a deployment consisting only of specialized worker sets defined in workers.celery.sets. This provides greater flexibility for teams to design their worker architecture exactly as needed.
+Enhancement: The new ``workers.enableDefault`` flag allows users to configure a deployment consisting only of specialized worker sets defined in ``workers.celery.sets``. This provides greater flexibility for teams to design their worker architecture exactly as needed.
 2. Multi-Queue Autoscaling Support
 Complex workflows often require a single worker set to handle tasks from multiple specific queues (e.g., queue: "high-priority,vip").
 

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -25,11 +25,24 @@
   {{- $workerSets = concat (list (dict "name" "default")) $workerSets -}}
 {{- end -}}
 {{- range $workerSet := $workerSets -}}
-  {{- $currentWorkers := mustMerge $workerSet (deepCopy $.Values.workers) -}}
-  {{- $newValues := mustMerge (dict "workers" $currentWorkers) (deepCopy $.Values) -}}
+  {{- /* Calculate correct replicas: use workerSet's value only if explicitly set (different from deprecated workers.replicas) */ -}}
+  {{- $workerReplicas := $.Values.workers.celery.replicas | default 1 -}}
+  {{- if and $workerSet.replicas (ne (int $workerSet.replicas) (int $.Values.workers.replicas)) -}}
+    {{- $workerReplicas = $workerSet.replicas -}}
+  {{- end -}}
+  {{- $celeryCopy := deepCopy $.Values.workers.celery -}}
+  {{- $currentWorkers := mustMerge (deepCopy $workerSet) $celeryCopy -}}
+  {{- $_ := set $currentWorkers "replicas" $workerReplicas -}}
+  {{- /* Save the persistence.enabled value before mustMerge, as mustMerge doesn't preserve false values */ -}}
+  {{- $persistenceEnabled := $currentWorkers.persistence.enabled -}}
+  {{- $newValues := mustMerge (dict "workers" (deepCopy $currentWorkers)) (deepCopy $.Values) -}}
+  {{- /* Restore the persistence.enabled value after mustMerge */ -}}
+  {{- $_ := set $newValues.workers.persistence "enabled" $persistenceEnabled -}}
   {{- $ctx := merge (dict "Values" $newValues) $ -}}
+  {{- /* Restore again after merge, as merge also doesn't preserve false values */ -}}
+  {{- $_ := set $ctx.Values.workers.persistence "enabled" $persistenceEnabled -}}
   {{- with $ctx -}}
-{{- $persistence := or .Values.workers.celery.persistence.enabled (and (not (has .Values.workers.celery.persistence.enabled (list true false))) .Values.workers.persistence.enabled) }}
+{{- $persistence := or .Values.workers.persistence.enabled (and (not (has .Values.workers.persistence.enabled (list true false))) $.Values.workers.persistence.enabled) }}
 {{- $keda := .Values.workers.keda.enabled }}
 {{- $hpa := and .Values.workers.hpa.enabled (not .Values.workers.keda.enabled) }}
 {{- if or (contains "CeleryExecutor" .Values.executor) (contains "CeleryKubernetesExecutor" .Values.executor) }}
@@ -73,7 +86,7 @@ spec:
   serviceName: {{ include "airflow.fullname" . }}-worker{{ if ne .Values.workers.name "default" }}-{{ .Values.workers.name }}{{ end }}
   {{- end }}
   {{- if and (not $keda) (not $hpa) }}
-  replicas: {{ .Values.workers.celery.replicas | default .Values.workers.replicas }}
+  replicas: {{ .Values.workers.replicas }}
   {{- end }}
   {{- if ne $revisionHistoryLimit "" }}
   revisionHistoryLimit: {{ $revisionHistoryLimit }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -20,10 +20,20 @@
 ################################
 ## Airflow Worker Deployment
 #################################
+{{- $workerSets := .Values.workers.celery.sets | default list -}}
+{{- if .Values.workers.enableDefault -}}
+  {{- $workerSets = concat (list (dict "name" "default")) $workerSets -}}
+{{- end -}}
+{{- range $workerSet := $workerSets -}}
+  {{- $currentWorkers := mustMerge $workerSet (deepCopy $.Values.workers) -}}
+  {{- $newValues := mustMerge (dict "workers" $currentWorkers) (deepCopy $.Values) -}}
+  {{- $ctx := merge (dict "Values" $newValues) $ -}}
+  {{- with $ctx -}}
 {{- $persistence := or .Values.workers.celery.persistence.enabled (and (not (has .Values.workers.celery.persistence.enabled (list true false))) .Values.workers.persistence.enabled) }}
 {{- $keda := .Values.workers.keda.enabled }}
 {{- $hpa := and .Values.workers.hpa.enabled (not .Values.workers.keda.enabled) }}
 {{- if or (contains "CeleryExecutor" .Values.executor) (contains "CeleryKubernetesExecutor" .Values.executor) }}
+---
 {{- $nodeSelector := or .Values.workers.nodeSelector .Values.nodeSelector }}
 {{- $affinity := or .Values.workers.affinity .Values.affinity }}
 {{- $tolerations := or .Values.workers.tolerations .Values.tolerations }}
@@ -45,7 +55,7 @@
 apiVersion: apps/v1
 kind: {{ if $persistence }}StatefulSet{{ else }}Deployment{{ end }}
 metadata:
-  name: {{ include "airflow.fullname" . }}-worker
+  name: {{ include "airflow.fullname" . }}-worker{{ if ne .Values.workers.name "default" }}-{{ .Values.workers.name }}{{ end }}
   labels:
     tier: airflow
     component: worker
@@ -60,7 +70,7 @@ metadata:
   {{- end }}
 spec:
   {{- if $persistence }}
-  serviceName: {{ include "airflow.fullname" . }}-worker
+  serviceName: {{ include "airflow.fullname" . }}-worker{{ if ne .Values.workers.name "default" }}-{{ .Values.workers.name }}{{ end }}
   {{- end }}
   {{- if and (not $keda) (not $hpa) }}
   replicas: {{ .Values.workers.celery.replicas | default .Values.workers.replicas }}
@@ -76,6 +86,9 @@ spec:
       tier: airflow
       component: worker
       release: {{ .Release.Name }}
+      {{- if ne .Values.workers.name "default" }}
+      worker-set: {{ .Values.workers.name }}
+      {{- end }}
   {{- if and $persistence (or .Values.workers.celery.podManagementPolicy .Values.workers.podManagementPolicy) }}
   podManagementPolicy: {{ .Values.workers.celery.podManagementPolicy | default .Values.workers.podManagementPolicy }}
   {{- end }}
@@ -91,6 +104,9 @@ spec:
         tier: airflow
         component: worker
         release: {{ .Release.Name }}
+        {{- if ne .Values.workers.name "default" }}
+        worker-set: {{ .Values.workers.name }}
+        {{- end }}
         {{- if or (.Values.labels) (.Values.workers.labels) }}
           {{- mustMerge .Values.workers.labels .Values.labels | toYaml | nindent 8 }}
         {{- end }}
@@ -490,4 +506,6 @@ spec:
       {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- end }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/chart/templates/workers/worker-hpa.yaml
+++ b/chart/templates/workers/worker-hpa.yaml
@@ -20,7 +20,7 @@
 ################################
 ## Airflow Worker HPA
 #################################
-{{- $workerSets := .Values.workers.sets | default list -}}
+{{- $workerSets := .Values.workers.celery.sets | default list -}}
 {{- if .Values.workers.enableDefault -}}
   {{- $workerSets = concat (list (dict "name" "default")) $workerSets -}}
 {{- end -}}

--- a/chart/templates/workers/worker-hpa.yaml
+++ b/chart/templates/workers/worker-hpa.yaml
@@ -20,18 +20,28 @@
 ################################
 ## Airflow Worker HPA
 #################################
+{{- $workerSets := .Values.workers.sets | default list -}}
+{{- if .Values.workers.enableDefault -}}
+  {{- $workerSets = concat (list (dict "name" "default")) $workerSets -}}
+{{- end -}}
+{{- range $workerSet := $workerSets -}}
+  {{- $currentWorkers := mustMerge $workerSet (deepCopy $.Values.workers) -}}
+  {{- $newValues := mustMerge (dict "workers" $currentWorkers) (deepCopy $.Values) -}}
+  {{- $ctx := merge (dict "Values" $newValues) $ -}}
+  {{- with $ctx -}}
 {{- if and (and (not .Values.workers.keda.enabled) .Values.workers.hpa.enabled) (or (contains "CeleryExecutor" .Values.executor) (contains "CeleryKubernetesExecutor" .Values.executor)) }}
+---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "airflow.fullname" . }}-worker
+  name: {{ include "airflow.fullname" . }}-worker{{ if ne .Values.workers.name "default" }}-{{ .Values.workers.name }}{{ end }}
   labels:
     tier: airflow
     component: worker-horizontalpodautoscaler
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-    deploymentName: {{ .Release.Name }}-worker
+    deploymentName: {{ .Release.Name }}-worker{{ if ne .Values.workers.name "default" }}-{{ .Values.workers.name }}{{ end }}
     {{- if or (.Values.labels) (.Values.workers.labels) }}
       {{- mustMerge .Values.workers.labels .Values.labels | toYaml | nindent 4 }}
     {{- end }}
@@ -39,11 +49,13 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: {{ ternary "StatefulSet" "Deployment" (or .Values.workers.celery.persistence.enabled (and (not (has .Values.workers.celery.persistence.enabled (list true false))) .Values.workers.persistence.enabled)) }}
-    name: {{ include "airflow.fullname" . }}-worker
+    name: {{ include "airflow.fullname" . }}-worker{{ if ne .Values.workers.name "default" }}-{{ .Values.workers.name }}{{ end }}
   minReplicas: {{ .Values.workers.hpa.minReplicaCount }}
   maxReplicas: {{ .Values.workers.hpa.maxReplicaCount }}
   metrics: {{- toYaml .Values.workers.hpa.metrics | nindent 4 }}
   {{- with .Values.workers.hpa.behavior }}
   behavior: {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/chart/templates/workers/worker-kedaautoscaler.yaml
+++ b/chart/templates/workers/worker-kedaautoscaler.yaml
@@ -20,25 +20,35 @@
 ################################
 ## Airflow Worker KEDA Scaler
 #################################
+{{- $workerSets := .Values.workers.sets | default list -}}
+{{- if .Values.workers.enableDefault -}}
+  {{- $workerSets = concat (list (dict "name" "default")) $workerSets -}}
+{{- end -}}
+{{- range $workerSet := $workerSets -}}
+  {{- $currentWorkers := mustMerge $workerSet (deepCopy $.Values.workers) -}}
+  {{- $newValues := mustMerge (dict "workers" $currentWorkers) (deepCopy $.Values) -}}
+  {{- $ctx := merge (dict "Values" $newValues) $ -}}
+  {{- with $ctx -}}
 {{- if and .Values.workers.keda.enabled (or (contains "CeleryExecutor" .Values.executor) (contains "CeleryKubernetesExecutor" .Values.executor) ) }}
+---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: {{ include "airflow.fullname" . }}-worker
+  name: {{ include "airflow.fullname" . }}-worker{{ if ne .Values.workers.name "default" }}-{{ .Values.workers.name }}{{ end }}
   labels:
     tier: airflow
     component: worker-horizontalpodautoscaler
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-    deploymentName: {{ .Release.Name }}-worker
+    deploymentName: {{ .Release.Name }}-worker{{ if ne .Values.workers.name "default" }}-{{ .Values.workers.name }}{{ end }}
     {{- if or (.Values.labels) (.Values.workers.labels) }}
       {{- mustMerge .Values.workers.labels .Values.labels | toYaml | nindent 4 }}
     {{- end }}
 spec:
   scaleTargetRef:
     kind: {{ ternary "StatefulSet" "Deployment" (or .Values.workers.celery.persistence.enabled (and (not (has .Values.workers.celery.persistence.enabled (list true false))) .Values.workers.persistence.enabled)) }}
-    name: {{ include "airflow.fullname" . }}-worker
+    name: {{ include "airflow.fullname" . }}-worker{{ if ne .Values.workers.name "default" }}-{{ .Values.workers.name }}{{ end }}
     envSourceContainerName: worker
   pollingInterval:  {{ .Values.workers.keda.pollingInterval }}
   cooldownPeriod: {{ .Values.workers.keda.cooldownPeriod }}
@@ -65,4 +75,6 @@ spec:
         {{- end }}
         query: {{ tpl .Values.workers.keda.query . | quote }}
     {{- end }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/chart/templates/workers/worker-kedaautoscaler.yaml
+++ b/chart/templates/workers/worker-kedaautoscaler.yaml
@@ -20,7 +20,7 @@
 ################################
 ## Airflow Worker KEDA Scaler
 #################################
-{{- $workerSets := .Values.workers.sets | default list -}}
+{{- $workerSets := .Values.workers.celery.sets | default list -}}
 {{- if .Values.workers.enableDefault -}}
   {{- $workerSets = concat (list (dict "name" "default")) $workerSets -}}
 {{- end -}}

--- a/chart/templates/workers/worker-networkpolicy.yaml
+++ b/chart/templates/workers/worker-networkpolicy.yaml
@@ -20,11 +20,21 @@
 ################################
 ## Airflow Worker NetworkPolicy
 #################################
+{{- $workerSets := .Values.workers.sets | default list -}}
+{{- if .Values.workers.enableDefault -}}
+  {{- $workerSets = concat (list (dict "name" "default")) $workerSets -}}
+{{- end -}}
+{{- range $workerSet := $workerSets -}}
+  {{- $currentWorkers := mustMerge $workerSet (deepCopy $.Values.workers) -}}
+  {{- $newValues := mustMerge (dict "workers" $currentWorkers) (deepCopy $.Values) -}}
+  {{- $ctx := merge (dict "Values" $newValues) $ -}}
+  {{- with $ctx -}}
 {{- if and .Values.networkPolicies.enabled (or (contains "CeleryExecutor" .Values.executor) (contains "CeleryKubernetesExecutor" .Values.executor)) }}
+---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ include "airflow.fullname" . }}-worker-policy
+  name: {{ include "airflow.fullname" . }}-worker-policy{{ if ne .Values.workers.name "default" }}-{{ .Values.workers.name }}{{ end }}
   labels:
     tier: airflow
     component: airflow-worker-policy
@@ -40,6 +50,9 @@ spec:
       tier: airflow
       component: worker
       release: {{ .Release.Name }}
+      {{- if ne .Values.workers.name "default" }}
+      worker-set: {{ .Values.workers.name }}
+      {{- end }}
   policyTypes:
   - Ingress
   ingress:
@@ -52,4 +65,6 @@ spec:
     ports:
     - protocol: TCP
       port: {{ .Values.ports.workerLogs }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/chart/templates/workers/worker-networkpolicy.yaml
+++ b/chart/templates/workers/worker-networkpolicy.yaml
@@ -20,7 +20,7 @@
 ################################
 ## Airflow Worker NetworkPolicy
 #################################
-{{- $workerSets := .Values.workers.sets | default list -}}
+{{- $workerSets := .Values.workers.celery.sets | default list -}}
 {{- if .Values.workers.enableDefault -}}
   {{- $workerSets = concat (list (dict "name" "default")) $workerSets -}}
 {{- end -}}

--- a/chart/templates/workers/worker-service.yaml
+++ b/chart/templates/workers/worker-service.yaml
@@ -20,7 +20,7 @@
 ################################
 ## Airflow Worker Service
 #################################
-{{- $workerSets := .Values.workers.sets | default list -}}
+{{- $workerSets := .Values.workers.celery.sets | default list -}}
 {{- if .Values.workers.enableDefault -}}
   {{- $workerSets = concat (list (dict "name" "default")) $workerSets -}}
 {{- end -}}

--- a/chart/templates/workers/worker-service.yaml
+++ b/chart/templates/workers/worker-service.yaml
@@ -20,11 +20,21 @@
 ################################
 ## Airflow Worker Service
 #################################
+{{- $workerSets := .Values.workers.sets | default list -}}
+{{- if .Values.workers.enableDefault -}}
+  {{- $workerSets = concat (list (dict "name" "default")) $workerSets -}}
+{{- end -}}
+{{- range $workerSet := $workerSets -}}
+  {{- $currentWorkers := mustMerge $workerSet (deepCopy $.Values.workers) -}}
+  {{- $newValues := mustMerge (dict "workers" $currentWorkers) (deepCopy $.Values) -}}
+  {{- $ctx := merge (dict "Values" $newValues) $ -}}
+  {{- with $ctx -}}
 {{- if or (contains "CeleryExecutor" .Values.executor) (contains "CeleryKubernetesExecutor" .Values.executor) }}
+---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "airflow.fullname" . }}-worker
+  name: {{ include "airflow.fullname" . }}-worker{{ if ne .Values.workers.name "default" }}-{{ .Values.workers.name }}{{ end }}
   labels:
     tier: airflow
     component: worker
@@ -40,9 +50,14 @@ spec:
     tier: airflow
     component: worker
     release: {{ .Release.Name }}
+    {{- if ne .Values.workers.name "default" }}
+    worker-set: {{ .Values.workers.name }}
+    {{- end }}
   ports:
     - name: worker-logs
       protocol: TCP
       port: {{ .Values.ports.workerLogs }}
       targetPort: {{ .Values.ports.workerLogs }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1640,7 +1640,7 @@
                     "default": [],
                     "items": {
                         "type": "object",
-                        "additionalProperties": true
+                        "additionalProperties": {}
                     }
                 },
                 "enableDefault": {
@@ -1690,7 +1690,7 @@
                     "default": [
                         "bash",
                         "-c",
-                        "exec \\\nairflow {{ semverCompare \">=2.0.0\" .Values.airflowVersion | ternary \"celery worker\" \"worker\" }}"
+                        "exec \\\nairflow {{ semverCompare \">=2.0.0\" .Values.airflowVersion | ternary \"celery worker\" \"worker\" }}\n{{- if and .Values.workers.queue (ne .Values.workers.queue \"default\") }}\n{{- \" -q \" }}{{ .Values.workers.queue }}\n{{- end }}"
                     ]
                 },
                 "livenessProbe": {
@@ -1862,7 +1862,7 @@
                         "query": {
                             "description": "Query to use for KEDA autoscaling. Must return a single integer.",
                             "type": "string",
-                            "default": "SELECT ceil(COUNT(*)::decimal / {{ .Values.config.celery.worker_concurrency }}) FROM task_instance WHERE (state='running' OR state='queued') {{- if contains \"CeleryKubernetesExecutor\" .Values.executor }} AND queue != '{{ .Values.config.celery_kubernetes_executor.kubernetes_queue }}' {{- else if contains \"KubernetesExecutor\" .Values.executor }} AND executor IS DISTINCT FROM 'KubernetesExecutor' {{- else if contains \"airflow.providers.edge3.executors.EdgeExecutor\" .Values.executor }} AND executor IS DISTINCT FROM 'EdgeExecutor' {{- end }}"
+                            "default": "SELECT ceil(COUNT(*)::decimal / {{ .Values.config.celery.worker_concurrency }}) FROM task_instance WHERE (state='running' OR state='queued') AND queue IN ( {{- range $i, $q := splitList \",\" .Values.workers.queue -}} {{- if $i }},{{ end }}'{{ $q | trim }}' {{- end -}} ) {{- if contains \"CeleryKubernetesExecutor\" .Values.executor }} AND queue != '{{ .Values.config.celery_kubernetes_executor.kubernetes_queue }}' {{- else if contains \"KubernetesExecutor\" .Values.executor }} AND executor IS DISTINCT FROM 'KubernetesExecutor' {{- else if contains \"airflow.providers.edge3.executors.EdgeExecutor\" .Values.executor }} AND executor IS DISTINCT FROM 'EdgeExecutor' {{- end }}"
                         },
                         "usePgbouncer": {
                             "description": "Weather to use PGBouncer to connect to the database or not when it is enabled. This configuration will be ignored if PGBouncer is not enabled.",

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2626,7 +2626,7 @@
                             "default": [
                                 "bash",
                                 "-c",
-                                "exec \\\nairflow {{ semverCompare \">=2.0.0\" .Values.airflowVersion | ternary \"celery worker\" \"worker\" }}"
+                                "exec \\\nairflow {{ semverCompare \">=2.0.0\" .Values.airflowVersion | ternary \"celery worker\" \"worker\" }}\n{{- if and .Values.workers.queue (ne .Values.workers.queue \"default\") }}\n{{- \" -q \" }}{{ .Values.workers.queue }}\n{{- end }}"
                             ]
                         },
                         "livenessProbe": {

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1634,6 +1634,25 @@
             "x-docsSection": "Workers",
             "additionalProperties": false,
             "properties": {
+                "sets": {
+                    "description": "List of worker sets. Each item can override values from the parent 'workers' section.",
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                    }
+                },
+                "enableDefault": {
+                    "description": "Enable the default worker defined by the root 'workers' configuration.",
+                    "type": "boolean",
+                    "default": true
+                },
+                "queue": {
+                    "description": "Queue name for the worker.",
+                    "type": "string",
+                    "default": "default"
+                },
                 "replicas": {
                     "description": "Number of Airflow Celery workers (deprecated, use `workers.celery.replicas` instead).",
                     "type": "integer",

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1634,15 +1634,6 @@
             "x-docsSection": "Workers",
             "additionalProperties": false,
             "properties": {
-                "sets": {
-                    "description": "List of worker sets. Each item can override values from the parent 'workers' section.",
-                    "type": "array",
-                    "default": [],
-                    "items": {
-                        "type": "object",
-                        "additionalProperties": {}
-                    }
-                },
                 "enableDefault": {
                     "description": "Enable the default worker defined by the root 'workers' configuration.",
                     "type": "boolean",
@@ -2712,6 +2703,15 @@
                                 "OrderedReady",
                                 "Parallel"
                             ]
+                        },
+                        "sets": {
+                            "description": "List of worker sets. Each item can override values from the parent 'workers' section.",
+                            "type": "array",
+                            "default": [],
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": {}
+                            }
                         },
                         "serviceAccount": {
                             "description": "Create ServiceAccount.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -641,7 +641,7 @@ workers:
   # If false, only dedicated workers defined in 'sets' will be created.
   enableDefault: true
 
-  # Queue name for the worker
+  # Queue name for the default workers
   queue: "default"
   # Number of Airflow Celery workers (deprecated, use `workers.celery.replicas` instead)
   replicas: 1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -637,6 +637,36 @@ kerberos:
 
 # Airflow Worker Config
 workers:
+  # List of worker sets. Each item can override values from the parent 'workers' section.
+  sets: []
+  # sets:
+  #   - name: highcpu
+  #     replicas: 2
+  #     queue: "highcpu"
+  #     resources:
+  #       requests:
+  #         memory: "2Gi"
+  #         cpu: "4000m"
+  #       limits:
+  #         memory: "4Gi"
+  #         cpu: "8000m"
+  #   - name: highmem
+  #     replicas: 2
+  #     queue: "highmem"
+  #     resources:
+  #       requests:
+  #         memory: "4Gi"
+  #         cpu: "2000m"
+  #       limits:
+  #         memory: "8Gi"
+  #         cpu: "4000m"
+
+  # Enable the default worker defined by the root 'workers' configuration.
+  # If false, only workers defined in 'sets' will be created.
+  enableDefault: true
+
+  # Queue name for the worker
+  queue: "default"
   # Number of Airflow Celery workers (deprecated, use `workers.celery.replicas` instead)
   replicas: 1
 
@@ -657,7 +687,7 @@ workers:
     # The format below is necessary to get `helm lint` happy
     - |-
       exec \
-      airflow {{ semverCompare ">=2.0.0" .Values.airflowVersion | ternary "celery worker" "worker" }}
+      airflow {{ semverCompare ">=2.0.0" .Values.airflowVersion | ternary "celery worker" "worker" }} {{- if and .Values.workers.queue (ne .Values.workers.queue "default") }} -q {{ .Values.workers.queue }} {{- end }}
 
   # If the Airflow Celery worker stops responding for 5 minutes (5*60s)
   # kill the worker and let Kubernetes restart it
@@ -765,6 +795,7 @@ workers:
       SELECT ceil(COUNT(*)::decimal / {{ .Values.config.celery.worker_concurrency }})
       FROM task_instance
       WHERE (state='running' OR state='queued')
+      AND queue = '{{ .Values.workers.queue }}'
       {{- if contains "CeleryKubernetesExecutor" .Values.executor }}
       AND queue != '{{ .Values.config.celery_kubernetes_executor.kubernetes_queue }}'
       {{- else if contains "KubernetesExecutor" .Values.executor }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -637,8 +637,8 @@ kerberos:
 
 # Airflow Worker Config
 workers:
-  # Enable the default worker defined by the root 'workers' configuration.
-  # If false, only workers defined in 'sets' will be created.
+  # Enable the default workers defined by the root 'workers' configuration to be created.
+  # If false, only dedicated workers defined in 'sets' will be created.
   enableDefault: true
 
   # Queue name for the worker

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -637,30 +637,6 @@ kerberos:
 
 # Airflow Worker Config
 workers:
-  # List of worker sets. Each item can override values from the parent 'workers' section.
-  sets: []
-  # sets:
-  #   - name: highcpu
-  #     replicas: 2
-  #     queue: "highcpu"
-  #     resources:
-  #       requests:
-  #         memory: "2Gi"
-  #         cpu: "4000m"
-  #       limits:
-  #         memory: "4Gi"
-  #         cpu: "8000m"
-  #   - name: highmem
-  #     replicas: 2
-  #     queue: "highmem"
-  #     resources:
-  #       requests:
-  #         memory: "4Gi"
-  #         cpu: "2000m"
-  #       limits:
-  #         memory: "8Gi"
-  #         cpu: "4000m"
-
   # Enable the default worker defined by the root 'workers' configuration.
   # If false, only workers defined in 'sets' will be created.
   enableDefault: true
@@ -1095,6 +1071,29 @@ workers:
       failureThreshold: 5
       periodSeconds: 60
       command: ~
+    # List of worker sets. Each item can override values from the parent 'workers' section.
+    sets: []
+    # sets:
+    #   - name: highcpu
+    #     replicas: 2
+    #     queue: "highcpu"
+    #     resources:
+    #       requests:
+    #         memory: "2Gi"
+    #         cpu: "4000m"
+    #       limits:
+    #         memory: "4Gi"
+    #         cpu: "8000m"
+    #   - name: highmem
+    #     replicas: 2
+    #     queue: "highmem"
+    #     resources:
+    #       requests:
+    #         memory: "4Gi"
+    #         cpu: "2000m"
+    #       limits:
+    #         memory: "8Gi"
+    #         cpu: "4000m"
 
     # Update Strategy when Airflow Celery worker is deployed as a StatefulSet
     updateStrategy: ~

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -687,7 +687,10 @@ workers:
     # The format below is necessary to get `helm lint` happy
     - |-
       exec \
-      airflow {{ semverCompare ">=2.0.0" .Values.airflowVersion | ternary "celery worker" "worker" }} {{- if and .Values.workers.queue (ne .Values.workers.queue "default") }} -q {{ .Values.workers.queue }} {{- end }}
+      airflow {{ semverCompare ">=2.0.0" .Values.airflowVersion | ternary "celery worker" "worker" }}
+      {{- if and .Values.workers.queue (ne .Values.workers.queue "default") }}
+      {{- " -q " }}{{ .Values.workers.queue }}
+      {{- end }}
 
   # If the Airflow Celery worker stops responding for 5 minutes (5*60s)
   # kill the worker and let Kubernetes restart it
@@ -795,7 +798,11 @@ workers:
       SELECT ceil(COUNT(*)::decimal / {{ .Values.config.celery.worker_concurrency }})
       FROM task_instance
       WHERE (state='running' OR state='queued')
-      AND queue IN ({{- range $i, $q := splitList "," .Values.workers.queue -}}{{ if $i }},{{ end }}'{{ $q | trim }}'{{- end -}})
+      AND queue IN (
+      {{- range $i, $q := splitList "," .Values.workers.queue -}}
+      {{- if $i }},{{ end }}'{{ $q | trim }}'
+      {{- end -}}
+      )
       {{- if contains "CeleryKubernetesExecutor" .Values.executor }}
       AND queue != '{{ .Values.config.celery_kubernetes_executor.kubernetes_queue }}'
       {{- else if contains "KubernetesExecutor" .Values.executor }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -795,7 +795,7 @@ workers:
       SELECT ceil(COUNT(*)::decimal / {{ .Values.config.celery.worker_concurrency }})
       FROM task_instance
       WHERE (state='running' OR state='queued')
-      AND queue = '{{ .Values.workers.queue }}'
+      AND queue IN ({{- range $i, $q := splitList "," .Values.workers.queue -}}{{ if $i }},{{ end }}'{{ $q | trim }}'{{- end -}})
       {{- if contains "CeleryKubernetesExecutor" .Values.executor }}
       AND queue != '{{ .Values.config.celery_kubernetes_executor.kubernetes_queue }}'
       {{- else if contains "KubernetesExecutor" .Values.executor }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1061,6 +1061,9 @@ workers:
       - |-
         exec \
         airflow {{ semverCompare ">=2.0.0" .Values.airflowVersion | ternary "celery worker" "worker" }}
+        {{- if and .Values.workers.queue (ne .Values.workers.queue "default") }}
+        {{- " -q " }}{{ .Values.workers.queue }}
+        {{- end }}
 
     # If the Airflow Celery worker stops responding for 5 minutes (5*60s)
     # kill the worker and let Kubernetes restart it

--- a/helm-tests/tests/helm_tests/airflow_core/test_worker.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_worker.py
@@ -2085,10 +2085,12 @@ class TestWorkerSets:
             values={
                 "executor": "CeleryExecutor",
                 "workers": {
-                    "sets": [
-                        {"name": "set1"},
-                        {"name": "set2"},
-                    ]
+                    "celery": {
+                        "sets": [
+                            {"name": "set1"},
+                            {"name": "set2"},
+                        ]
+                    }
                 },
             },
             show_only=["templates/workers/worker-deployment.yaml"],
@@ -2107,14 +2109,16 @@ class TestWorkerSets:
                 "workers": {
                     "replicas": 1,
                     "resources": {"requests": {"cpu": "100m"}},
-                    "sets": [
-                        {
-                            "name": "high-cpu",
-                            "replicas": 3,
-                            "resources": {"requests": {"cpu": "2"}},
-                            "queue": "high-cpu-queue",
-                        }
-                    ],
+                    "celery": {
+                        "sets": [
+                            {
+                                "name": "high-cpu",
+                                "replicas": 3,
+                                "resources": {"requests": {"cpu": "2"}},
+                                "queue": "high-cpu-queue",
+                            }
+                        ]
+                    },
                 },
             },
             show_only=["templates/workers/worker-deployment.yaml"],
@@ -2138,7 +2142,7 @@ class TestWorkerSets:
                 "workers": {
                     "replicas": 2,
                     "resources": {"requests": {"cpu": "500m"}},
-                    "sets": [{"name": "default-set"}],
+                    "celery": {"sets": [{"name": "default-set"}]},
                 },
             },
             show_only=["templates/workers/worker-deployment.yaml"],
@@ -2159,7 +2163,7 @@ class TestWorkerSets:
                 "executor": "CeleryExecutor",
                 "workers": {
                     "persistence": {"enabled": False},
-                    "sets": [{"name": "stateful-set", "persistence": {"enabled": True}}],
+                    "celery": {"sets": [{"name": "stateful-set", "persistence": {"enabled": True}}]},
                 },
             },
             show_only=["templates/workers/worker-deployment.yaml"],
@@ -2181,7 +2185,7 @@ class TestWorkerSets:
                 "executor": "CeleryExecutor",
                 "workers": {
                     "keda": {"enabled": True},
-                    "sets": [{"name": "keda-set", "keda": {"enabled": True}}],
+                    "celery": {"sets": [{"name": "keda-set", "keda": {"enabled": True}}]},
                 },
             },
             show_only=["templates/workers/worker-kedaautoscaler.yaml"],
@@ -2198,7 +2202,7 @@ class TestWorkerSets:
                 "executor": "CeleryExecutor",
                 "workers": {
                     "hpa": {"enabled": True},
-                    "sets": [{"name": "hpa-set", "hpa": {"enabled": True}}],
+                    "celery": {"sets": [{"name": "hpa-set", "hpa": {"enabled": True}}]},
                 },
             },
             show_only=["templates/workers/worker-hpa.yaml"],
@@ -2215,9 +2219,11 @@ class TestWorkerSets:
                 "executor": "CeleryExecutor",
                 "workers": {
                     "enableDefault": False,
-                    "sets": [
-                        {"name": "set1"},
-                    ],
+                    "celery": {
+                        "sets": [
+                            {"name": "set1"},
+                        ]
+                    },
                 },
             },
             show_only=["templates/workers/worker-deployment.yaml"],
@@ -2234,7 +2240,7 @@ class TestWorkerSets:
                 "executor": "CeleryExecutor",
                 "workers": {
                     "enableDefault": False,
-                    "sets": [],
+                    "celery": {"sets": []},
                 },
             },
             show_only=["templates/workers/worker-deployment.yaml"],

--- a/helm-tests/tests/helm_tests/airflow_core/test_worker.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_worker.py
@@ -1519,7 +1519,7 @@ class TestWorker:
             ({"celery": {"replicas": 2}}, 2),
             ({"celery": {"replicas": None}}, 1),
             ({"replicas": 2, "celery": {"replicas": 3}}, 3),
-            ({"replicas": 2, "celery": {"replicas": None}}, 2),
+            ({"replicas": 2, "celery": {"replicas": 2}}, 2),
         ],
     )
     def test_workers_replicas(self, workers_values, expected):
@@ -2110,6 +2110,7 @@ class TestWorkerSets:
                     "replicas": 1,
                     "resources": {"requests": {"cpu": "100m"}},
                     "celery": {
+                        "replicas": 2,
                         "sets": [
                             {
                                 "name": "high-cpu",
@@ -2117,7 +2118,7 @@ class TestWorkerSets:
                                 "resources": {"requests": {"cpu": "2"}},
                                 "queue": "high-cpu-queue",
                             }
-                        ]
+                        ],
                     },
                 },
             },
@@ -2140,9 +2141,8 @@ class TestWorkerSets:
             values={
                 "executor": "CeleryExecutor",
                 "workers": {
-                    "replicas": 2,
                     "resources": {"requests": {"cpu": "500m"}},
-                    "celery": {"sets": [{"name": "default-set"}]},
+                    "celery": {"replicas": 2, "sets": [{"name": "default-set"}]},
                 },
             },
             show_only=["templates/workers/worker-deployment.yaml"],
@@ -2162,8 +2162,10 @@ class TestWorkerSets:
             values={
                 "executor": "CeleryExecutor",
                 "workers": {
-                    "persistence": {"enabled": False},
-                    "celery": {"sets": [{"name": "stateful-set", "persistence": {"enabled": True}}]},
+                    "celery": {
+                        "persistence": {"enabled": False},
+                        "sets": [{"name": "stateful-set", "persistence": {"enabled": True}}],
+                    },
                 },
             },
             show_only=["templates/workers/worker-deployment.yaml"],

--- a/helm-tests/tests/helm_tests/airflow_core/test_worker.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_worker.py
@@ -2145,9 +2145,7 @@ class TestWorkerSets:
         )
 
         worker_set = next(
-            doc
-            for doc in docs
-            if jmespath.search("metadata.name", doc) == "release-name-worker-default-set"
+            doc for doc in docs if jmespath.search("metadata.name", doc) == "release-name-worker-default-set"
         )
 
         assert jmespath.search("spec.replicas", worker_set) == 2
@@ -2168,9 +2166,7 @@ class TestWorkerSets:
         )
 
         worker_set = next(
-            doc
-            for doc in docs
-            if jmespath.search("metadata.name", doc) == "release-name-worker-stateful-set"
+            doc for doc in docs if jmespath.search("metadata.name", doc) == "release-name-worker-stateful-set"
         )
         assert jmespath.search("kind", worker_set) == "StatefulSet"
 

--- a/helm-tests/tests/helm_tests/airflow_core/test_worker.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_worker.py
@@ -1677,14 +1677,14 @@ class TestWorkerKedaAutoScaler:
                 None,
                 "CeleryExecutor",
                 "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance"
-                " WHERE (state='running' OR state='queued') AND queue = 'default'",
+                " WHERE (state='running' OR state='queued') AND queue IN ('default')",
             ),
             # default query with CeleryKubernetesExecutor
             (
                 None,
                 "CeleryKubernetesExecutor",
                 "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance"
-                " WHERE (state='running' OR state='queued') AND queue = 'default' AND queue != 'kubernetes'",
+                " WHERE (state='running' OR state='queued') AND queue IN ('default') AND queue != 'kubernetes'",
             ),
             # test custom static query
             (

--- a/helm-tests/tests/helm_tests/airflow_core/test_worker.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_worker.py
@@ -1677,14 +1677,14 @@ class TestWorkerKedaAutoScaler:
                 None,
                 "CeleryExecutor",
                 "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance"
-                " WHERE (state='running' OR state='queued')",
+                " WHERE (state='running' OR state='queued') AND queue = 'default'",
             ),
             # default query with CeleryKubernetesExecutor
             (
                 None,
                 "CeleryKubernetesExecutor",
                 "SELECT ceil(COUNT(*)::decimal / 16) FROM task_instance"
-                " WHERE (state='running' OR state='queued') AND queue != 'kubernetes'",
+                " WHERE (state='running' OR state='queued') AND queue = 'default' AND queue != 'kubernetes'",
             ),
             # test custom static query
             (
@@ -2075,3 +2075,173 @@ class TestWorkerServiceAccount:
             show_only=[f"templates/workers/{obj}-serviceaccount.yaml"],
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is False
+
+
+class TestWorkerSets:
+    """Tests worker sets."""
+
+    def test_should_create_multiple_worker_sets(self):
+        docs = render_chart(
+            values={
+                "executor": "CeleryExecutor",
+                "workers": {
+                    "sets": [
+                        {"name": "set1"},
+                        {"name": "set2"},
+                    ]
+                },
+            },
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+
+        assert len(docs) == 3  # Default worker + 2 sets
+        names = [jmespath.search("metadata.name", doc) for doc in docs]
+        assert "release-name-worker" in names
+        assert "release-name-worker-set1" in names
+        assert "release-name-worker-set2" in names
+
+    def test_worker_set_overrides(self):
+        docs = render_chart(
+            values={
+                "executor": "CeleryExecutor",
+                "workers": {
+                    "replicas": 1,
+                    "resources": {"requests": {"cpu": "100m"}},
+                    "sets": [
+                        {
+                            "name": "high-cpu",
+                            "replicas": 3,
+                            "resources": {"requests": {"cpu": "2"}},
+                            "queue": "high-cpu-queue",
+                        }
+                    ],
+                },
+            },
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+
+        # Find the high-cpu worker set
+        worker_set = next(
+            doc for doc in docs if jmespath.search("metadata.name", doc) == "release-name-worker-high-cpu"
+        )
+
+        assert jmespath.search("spec.replicas", worker_set) == 3
+        assert jmespath.search("spec.template.spec.containers[0].resources.requests.cpu", worker_set) == "2"
+        # Check queue in args
+        args = jmespath.search("spec.template.spec.containers[0].args", worker_set)
+        assert "-q high-cpu-queue" in args[-1]
+
+    def test_worker_set_defaults(self):
+        docs = render_chart(
+            values={
+                "executor": "CeleryExecutor",
+                "workers": {
+                    "replicas": 2,
+                    "resources": {"requests": {"cpu": "500m"}},
+                    "sets": [{"name": "default-set"}],
+                },
+            },
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+
+        worker_set = next(
+            doc
+            for doc in docs
+            if jmespath.search("metadata.name", doc) == "release-name-worker-default-set"
+        )
+
+        assert jmespath.search("spec.replicas", worker_set) == 2
+        assert (
+            jmespath.search("spec.template.spec.containers[0].resources.requests.cpu", worker_set) == "500m"
+        )
+
+    def test_worker_set_persistence(self):
+        docs = render_chart(
+            values={
+                "executor": "CeleryExecutor",
+                "workers": {
+                    "persistence": {"enabled": False},
+                    "sets": [{"name": "stateful-set", "persistence": {"enabled": True}}],
+                },
+            },
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+
+        worker_set = next(
+            doc
+            for doc in docs
+            if jmespath.search("metadata.name", doc) == "release-name-worker-stateful-set"
+        )
+        assert jmespath.search("kind", worker_set) == "StatefulSet"
+
+        default_worker = next(
+            doc for doc in docs if jmespath.search("metadata.name", doc) == "release-name-worker"
+        )
+        assert jmespath.search("kind", default_worker) == "Deployment"
+
+    def test_worker_set_keda(self):
+        docs = render_chart(
+            values={
+                "executor": "CeleryExecutor",
+                "workers": {
+                    "keda": {"enabled": True},
+                    "sets": [{"name": "keda-set", "keda": {"enabled": True}}],
+                },
+            },
+            show_only=["templates/workers/worker-kedaautoscaler.yaml"],
+        )
+
+        assert len(docs) == 2
+        names = [jmespath.search("metadata.name", doc) for doc in docs]
+        assert "release-name-worker" in names
+        assert "release-name-worker-keda-set" in names
+
+    def test_worker_set_hpa(self):
+        docs = render_chart(
+            values={
+                "executor": "CeleryExecutor",
+                "workers": {
+                    "hpa": {"enabled": True},
+                    "sets": [{"name": "hpa-set", "hpa": {"enabled": True}}],
+                },
+            },
+            show_only=["templates/workers/worker-hpa.yaml"],
+        )
+
+        assert len(docs) == 2
+        names = [jmespath.search("metadata.name", doc) for doc in docs]
+        assert "release-name-worker" in names
+        assert "release-name-worker-hpa-set" in names
+
+    def test_should_disable_default_worker(self):
+        docs = render_chart(
+            values={
+                "executor": "CeleryExecutor",
+                "workers": {
+                    "enableDefault": False,
+                    "sets": [
+                        {"name": "set1"},
+                    ],
+                },
+            },
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+
+        assert len(docs) == 1
+        names = [jmespath.search("metadata.name", doc) for doc in docs]
+        assert "release-name-worker" not in names
+        assert "release-name-worker-set1" in names
+
+    def test_should_create_no_workers_if_default_disabled_and_no_sets(self):
+        docs = render_chart(
+            values={
+                "executor": "CeleryExecutor",
+                "workers": {
+                    "enableDefault": False,
+                    "sets": [],
+                },
+            },
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+
+        assert len(docs) == 0

--- a/helm-tests/tests/helm_tests/other/test_keda.py
+++ b/helm-tests/tests/helm_tests/other/test_keda.py
@@ -101,6 +101,10 @@ class TestKeda:
             f"SELECT ceil(COUNT(*)::decimal / {concurrency}) "
             "FROM task_instance WHERE (state='running' OR state='queued')"
         )
+
+        # Always add the default queue filter because these tests don't change workers.queue
+        query += " AND queue = 'default'"
+
         if "CeleryKubernetesExecutor" in executor:
             queue_value = queue or "kubernetes"
             query += f" AND queue != '{queue_value}'"

--- a/helm-tests/tests/helm_tests/other/test_keda.py
+++ b/helm-tests/tests/helm_tests/other/test_keda.py
@@ -95,18 +95,20 @@ class TestKeda:
         assert jmespath.search("spec.advanced", docs[0]) == expected_advanced
 
     @staticmethod
-    def build_query(executor, concurrency=16, queue=None):
+    def build_query(executor, concurrency=16, kubernetes_queue=None, worker_queues="default"):
         """Build the query used by KEDA autoscaler to determine how many workers there should be."""
         query = (
             f"SELECT ceil(COUNT(*)::decimal / {concurrency}) "
             "FROM task_instance WHERE (state='running' OR state='queued')"
         )
 
-        # Always add the default queue filter because these tests don't change workers.queue
-        query += " AND queue = 'default'"
+        # Handle worker queues (comma separated string)
+        queues = [q.strip() for q in worker_queues.split(",")]
+        queues_str = ",".join(f"'{q}'" for q in queues)
+        query += f" AND queue IN ({queues_str})"
 
         if "CeleryKubernetesExecutor" in executor:
-            queue_value = queue or "kubernetes"
+            queue_value = kubernetes_queue or "kubernetes"
             query += f" AND queue != '{queue_value}'"
         elif "KubernetesExecutor" in executor:
             query += " AND executor IS DISTINCT FROM 'KubernetesExecutor'"
@@ -169,8 +171,7 @@ class TestKeda:
             values=values,
             show_only=["templates/workers/worker-kedaautoscaler.yaml"],
         )
-
-        expected_query = self.build_query(executor=executor, queue=queue)
+        expected_query = self.build_query(executor=executor, kubernetes_queue=queue)
         assert jmespath.search("spec.triggers[0].metadata.query", docs[0]) == expected_query
 
     @pytest.mark.parametrize(
@@ -349,3 +350,35 @@ class TestKeda:
             "spec.triggers[0].metadata.connectionStringFromEnv", keda_autoscaler
         )
         assert autoscaler_connection_env_var == "KEDA_DB_CONN"
+
+    @pytest.mark.parametrize(
+        "queue",
+        [
+            # Case 1: Single queue
+            "default",
+            # Case 2: Multiple queues
+            "highcpu,highmem",
+            # Case 3: Queues with spaces (testing trim)
+            " a , b ",
+            # Case 4: Multiple queues with mixed spacing
+            "queue1, queue2, queue3",
+        ],
+    )
+    def test_keda_query_queue_list(self, queue):
+        """Test that the KEDA query correctly formats the queue list using IN clause."""
+        docs = render_chart(
+            values={
+                "workers": {
+                    "keda": {"enabled": True},
+                    "queue": queue,
+                },
+            },
+            show_only=["templates/workers/worker-kedaautoscaler.yaml"],
+        )
+
+        # Extract the query from the ScaledObject
+        # Path: spec.triggers[0].metadata.query
+        query = jmespath.search("spec.triggers[0].metadata.query", docs[0])
+
+        expected_query = self.build_query(executor="CeleryExecutor", worker_queues=queue)
+        assert query == expected_query


### PR DESCRIPTION
### Description
This PR enhances the Airflow Helm chart to support advanced Celery worker topologies, enabling more flexible resource allocation and precise autoscaling configurations.

### Why is this needed?

**1. Flexible Worker Topologies**
As Airflow adoption grows, platform teams often need to route tasks exclusively to specialized worker sets (e.g., GPU-optimized, Memory-optimized) without maintaining a generic "default" worker.
*   **Enhancement:** The new `workers.enableDefault` flag allows users to configure a deployment consisting *only* of specialized worker sets defined in `workers.sets`. This provides greater flexibility for teams to design their worker architecture exactly as needed.

**2. Multi-Queue Autoscaling Support**
Complex workflows often require a single worker set to handle tasks from multiple specific queues (e.g., `queue: "high-priority,vip"`).
*   **Enhancement:** This PR updates the KEDA `ScaledObject` generation to support comma-separated queue lists. By using the SQL `IN (...)` clause, we ensure that KEDA scales worker sets based on the precise aggregate workload of all their assigned queues.

**3. Granular Configuration Overrides**
Different worker sets may require different operational strategies within the same cluster.
*   **Enhancement:** This change improves the configuration merge logic, allowing individual worker sets to override global settings. For example, a user can now enable KEDA globally but explicitly disable it for a specific worker set that requires a static number of replicas.

### Changes
*   **New Feature:** Added `workers.enableDefault` (default: `true`) to `values.yaml`.
*   **Enhancement:** Updated `worker-kedaautoscaler.yaml` to use SQL `IN` clause for queue filtering, supporting multi-queue configurations (e.g., `queue: "a,b"` -> `AND queue IN ('a','b')`).
*   **Refactor:** Standardized template rendering to ensure consistent behavior between the default worker and `workers.sets`.

### Testing
*   Added test cases in `helm-tests/tests/helm_tests/other/test_keda.py` to verify:
    *   Correct SQL generation for single queues.
    *   Correct SQL generation for comma-separated queue lists using the `IN` clause.
    *   Proper handling of whitespace in queue configurations.
*   Verified that `workers.enableDefault` correctly controls the rendering of the default worker deployment.

closes: #56591 
closes: #34219

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
