### PR TITLE
Add Neo4jSensor to Neo4j Provider

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -376,6 +376,8 @@ customizable
 customizations
 cwd
 cx
+Cypher
+cypher
 Daemonize
 daemonize
 daemonized

--- a/providers/neo4j/docs/index.rst
+++ b/providers/neo4j/docs/index.rst
@@ -36,6 +36,7 @@
 
     Connection types <connections/neo4j>
     Operators <operators/neo4j>
+    Sensors <sensors/neo4j>
 
 .. toctree::
     :hidden:

--- a/providers/neo4j/docs/sensors/neo4j.rst
+++ b/providers/neo4j/docs/sensors/neo4j.rst
@@ -1,0 +1,222 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+
+.. _howto/sensor:neo4j:
+
+Neo4jSensor
+============
+
+The :class:`~airflow.providers.neo4j.sensors.neo4j.Neo4jSensor` executes a Cypher query
+in a Neo4j database until the returned value satisfies a condition.
+
+The sensor runs the query repeatedly at the defined ``poke_interval`` until:
+
+* A callable provided in ``failure`` evaluates to ``True``, which raises an exception.
+* A callable provided in ``success`` evaluates to ``True``, which marks the sensor as successful.
+* Otherwise, the truthiness of the selected value determines success.
+
+The sensor uses :class:`~airflow.providers.neo4j.hooks.neo4j.Neo4jHook` and the
+`Neo4j Python driver <https://neo4j.com/developer/python/>`_ for communication
+with the database.
+
+Prerequisites
+-------------
+
+To use the Neo4j sensor:
+
+* A Neo4j instance must be reachable from the Airflow environment.
+* A valid Neo4j connection must be configured in Airflow (for example
+  ``neo4j_default``), as described in :ref:`howto/connection:neo4j`.
+* The ``neo4j`` provider package must be installed in your Airflow environment.
+
+Basic Usage
+-----------
+
+The simplest use case is to run a Cypher query and rely on the first value of the
+first row to determine success. Any truthy value will mark the sensor as successful.
+
+Example: Wait for at least one ``Person`` node to exist:
+
+.. code-block:: python
+
+   from airflow import DAG
+   from airflow.utils.dates import days_ago
+   from airflow.providers.neo4j.sensors.neo4j import Neo4jSensor
+
+   with DAG(
+       dag_id="example_neo4j_sensor_basic",
+       start_date=days_ago(1),
+       schedule=None,
+       catchup=False,
+   ):
+       wait_person_exists = Neo4jSensor(
+           task_id="wait_person_exists",
+           neo4j_conn_id="neo4j_default",
+           cypher="MATCH (p:Person) RETURN count(p) > 0",
+       )
+
+In this example, the Cypher query returns a single boolean value. When it becomes
+``True``, the sensor succeeds.
+
+Templating
+----------
+
+The following fields of :class:`~airflow.providers.neo4j.sensors.neo4j.Neo4jSensor`
+are templated:
+
+* ``cypher``
+* ``parameters``
+
+This allows you to build dynamic queries using Jinja templates based on the
+execution context.
+
+Example: Use execution date in the query:
+
+.. code-block:: python
+
+   wait_events_for_date = Neo4jSensor(
+       task_id="wait_events_for_date",
+       neo4j_conn_id="neo4j_default",
+       cypher="""
+           MATCH (e:Event)
+           WHERE e.date = $event_date
+           RETURN count(e) > 0
+       """,
+       parameters={"event_date": "{{ ds }}"},
+   )
+
+Advanced Usage
+--------------
+
+Custom success and failure conditions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can provide callables for ``success`` and ``failure`` to implement more complex
+logic. Each callable receives the selected value and must return a boolean.
+
+Note: ``failure`` condition takes priority over the ``success`` condition.
+
+* ``success(value)`` – if provided, the sensor succeeds when this returns ``True``.
+* ``failure(value)`` – if provided and returns ``True``, the sensor raises
+  :class:`~airflow.exceptions.AirflowException`.
+
+Example: Wait until a count reaches at least 10, and fail if it ever exceeds 1,000:
+
+.. code-block:: python
+
+   def success_when_at_least_10(value):
+       return value >= 10
+
+
+   def fail_when_too_large(value):
+       return value > 1000
+
+
+   wait_count_in_range = Neo4jSensor(
+       task_id="wait_count_in_range",
+       neo4j_conn_id="neo4j_default",
+       cypher="MATCH (n:Item) RETURN count(n)",
+       success=success_when_at_least_10,
+       failure=fail_when_too_large,
+   )
+
+Using a custom selector
+~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, the sensor applies ``operator.itemgetter(0)`` to the first row of the
+result set, effectively selecting the first value of the first row. You can override
+this with a custom ``selector`` callable.
+
+The ``selector`` receives the first row as a tuple and must return a single value
+to be used by ``success`` / ``failure`` or for truthiness evaluation.
+
+Example: Select a specific column from the row:
+
+.. code-block:: python
+
+   from operator import itemgetter
+
+   # Assume the query returns rows of the form (count, status)
+   wait_status_ok = Neo4jSensor(
+       task_id="wait_status_ok",
+       neo4j_conn_id="neo4j_default",
+       cypher="MATCH (s:ServiceStatus) RETURN s.count, s.status ORDER BY s.timestamp DESC LIMIT 1",
+       selector=itemgetter(1),  # pick the 'status' column
+       success=lambda status: status == "OK",
+   )
+
+Handling empty results
+~~~~~~~~~~~~~~~~~~~~~~
+
+If the query returns no rows:
+
+* When ``fail_on_empty=False`` (default), the sensor simply returns ``False`` and
+  will be re-scheduled for the next poke.
+* When ``fail_on_empty=True``, the sensor raises
+  :class:`~airflow.exceptions.AirflowException`.
+
+Example: Fail immediately if there are no results:
+
+.. code-block:: python
+
+   wait_non_empty = Neo4jSensor(
+       task_id="wait_non_empty",
+       neo4j_conn_id="neo4j_default",
+       cypher="MATCH (o:Order) RETURN o.id LIMIT 1",
+       fail_on_empty=True,
+   )
+
+Reference
+---------
+
+Parameters
+~~~~~~~~~~
+
+``neo4j_conn_id``
+    Connection ID to use for connecting to Neo4j. Defaults to ``"neo4j_default"``.
+
+``cypher``
+    Cypher statement to execute. This field is templated.
+
+``parameters``
+    Dictionary of query parameters passed to the Cypher statement. This field
+    is templated.
+
+``success``
+    Optional callable that receives the selected value and returns a boolean.
+    When provided, the sensor succeeds only when this callable returns ``True``.
+
+``failure``
+    Optional callable that receives the selected value. If provided and it
+    returns ``True``, the sensor raises :class:`~airflow.exceptions.AirflowException``.
+
+``selector``
+    Callable that receives the first row of the query result as a tuple and
+    returns a single value to be evaluated. Defaults to selecting the first
+    element of the row with ``operator.itemgetter(0)``.
+
+``fail_on_empty``
+    When set to ``True``, the sensor raises an exception if the query returns
+    no rows. When ``False`` (default), the sensor simply returns ``False`` and
+    will poke again later.
+
+``**kwargs``
+    Additional keyword arguments passed to
+    :class:`~airflow.providers.common.compat.sdk.BaseSensorOperator`, such as
+    ``poke_interval``, ``timeout``, or ``mode``.

--- a/providers/neo4j/provider.yaml
+++ b/providers/neo4j/provider.yaml
@@ -78,6 +78,10 @@ hooks:
     python-modules:
       - airflow.providers.neo4j.hooks.neo4j
 
+sensors:
+  - integration-name: Neo4j
+    python-modules:
+      - airflow.providers.neo4j.sensors.neo4j
 
 connection-types:
   - hook-class-name: airflow.providers.neo4j.hooks.neo4j.Neo4jHook

--- a/providers/neo4j/provider.yaml
+++ b/providers/neo4j/provider.yaml
@@ -66,6 +66,7 @@ integrations:
     external-doc-url: https://neo4j.com/
     how-to-guide:
       - /docs/apache-airflow-providers-neo4j/operators/neo4j.rst
+      - /docs/apache-airflow-providers-neo4j/sensors/neo4j.rst
     tags: [software]
 
 operators:

--- a/providers/neo4j/src/airflow/providers/neo4j/get_provider_info.py
+++ b/providers/neo4j/src/airflow/providers/neo4j/get_provider_info.py
@@ -38,6 +38,9 @@ def get_provider_info():
             {"integration-name": "Neo4j", "python-modules": ["airflow.providers.neo4j.operators.neo4j"]}
         ],
         "hooks": [{"integration-name": "Neo4j", "python-modules": ["airflow.providers.neo4j.hooks.neo4j"]}],
+        "sensors": [
+            {"integration-name": "Neo4j", "python-modules": ["airflow.providers.neo4j.sensors.neo4j"]}
+        ],
         "connection-types": [
             {"hook-class-name": "airflow.providers.neo4j.hooks.neo4j.Neo4jHook", "connection-type": "neo4j"}
         ],

--- a/providers/neo4j/src/airflow/providers/neo4j/get_provider_info.py
+++ b/providers/neo4j/src/airflow/providers/neo4j/get_provider_info.py
@@ -30,7 +30,10 @@ def get_provider_info():
             {
                 "integration-name": "Neo4j",
                 "external-doc-url": "https://neo4j.com/",
-                "how-to-guide": ["/docs/apache-airflow-providers-neo4j/operators/neo4j.rst"],
+                "how-to-guide": [
+                    "/docs/apache-airflow-providers-neo4j/operators/neo4j.rst",
+                    "/docs/apache-airflow-providers-neo4j/sensors/neo4j.rst",
+                ],
                 "tags": ["software"],
             }
         ],

--- a/providers/neo4j/src/airflow/providers/neo4j/sensors/__init__.py
+++ b/providers/neo4j/src/airflow/providers/neo4j/sensors/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/neo4j/src/airflow/providers/neo4j/sensors/neo4j.py
+++ b/providers/neo4j/src/airflow/providers/neo4j/sensors/neo4j.py
@@ -1,0 +1,130 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from operator import itemgetter
+from typing import TYPE_CHECKING, Any
+
+from airflow.exceptions import AirflowException
+from airflow.providers.common.compat.sdk import BaseSensorOperator
+from airflow.providers.neo4j.hooks.neo4j import Neo4jHook
+
+if TYPE_CHECKING:
+    try:
+        from airflow.sdk.definitions.context import Context
+    except ImportError:
+        from airflow.utils.context import Context
+
+
+class Neo4jSensor(BaseSensorOperator):
+    """
+    Executes a Cypher query in Neo4j until the returned value satisfies a condition.
+
+    The query runs repeatedly at the defined poke interval until:
+      * A callable provided in ``failure`` evaluates to True, which raises an exception.
+      * A callable provided in ``success`` evaluates to True, which marks success.
+      * Otherwise, the truthiness of the selected value determines success.
+
+    Example
+    -------
+    .. code-block:: python
+
+        wait_person_exists = Neo4jSensor(
+            task_id="wait_person_exists",
+            neo4j_conn_id="neo4j_default",
+            cypher="MATCH (p:Person) RETURN count(p) > 0",
+        )
+
+    :param neo4j_conn_id: Connection ID to use for connecting to Neo4j.
+    :param cypher: Cypher statement to execute. (Templated)
+    :param parameters: Query parameters. (Templated)
+    :param success: Callable that receives the selected value and returns a boolean.
+    :param failure: Callable that receives the selected value; if it returns True, an error is raised.
+    :param selector: Function that extracts a single value from the first row of the result.
+    :param fail_on_empty: When True, raises if the query returns no rows.
+    """
+
+    template_fields: Sequence[str] = ("cypher", "parameters")
+    template_fields_renderers = {"cypher": "sql", "parameters": "json"}
+
+    def __init__(
+        self,
+        *,
+        neo4j_conn_id: str = "neo4j_default",
+        cypher: str,
+        parameters: dict[str, Any] | None = None,
+        success: Callable[[Any], bool] | None = None,
+        failure: Callable[[Any], bool] | None = None,
+        selector: Callable[[tuple[Any, ...]], Any] = itemgetter(0),
+        fail_on_empty: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.neo4j_conn_id = neo4j_conn_id
+        self.cypher = cypher
+        self.parameters = parameters
+        self.success = success
+        self.failure = failure
+        self.selector = selector
+        self.fail_on_empty = fail_on_empty
+
+    @staticmethod
+    def _row_to_tuple(record: Any) -> tuple[Any, ...]:
+        if record is None:
+            return ()
+        if hasattr(record, "values"):
+            try:
+                return tuple(record.values())
+            except Exception:
+                pass
+        if isinstance(record, dict):
+            return tuple(record.values())
+        if isinstance(record, (list, tuple)):
+            return tuple(record)
+        return (record,)
+
+    def poke(self, context: Context) -> bool:
+        hook = Neo4jHook(conn_id=self.neo4j_conn_id)
+        self.log.info("Executing Cypher: %s (parameters=%s)", self.cypher, self.parameters)
+        rows = hook.run(self.cypher, self.parameters)
+
+        if not rows:
+            if self.fail_on_empty:
+                raise AirflowException("No rows returned, raising as per parameter 'fail_on_empty=True'")
+            return False
+
+        first_row = self._row_to_tuple(rows[0])
+
+        if not callable(self.selector):
+            raise AirflowException(f"Parameter 'selector' is not callable: {self.selector!r}")
+
+        value = self.selector(first_row)
+
+        if self.failure is not None:
+            if callable(self.failure):
+                if self.failure(value):
+                    raise AirflowException(f"Failure criteria met: failure({value!r}) returned True")
+            else:
+                raise AirflowException(f"Parameter 'failure' is not callable: {self.failure!r}")
+
+        if self.success is not None:
+            if callable(self.success):
+                return bool(self.success(value))
+            raise AirflowException(f"Parameter 'success' is not callable: {self.success!r}")
+
+        return bool(value)

--- a/providers/neo4j/tests/system/neo4j/example_neo4j_sensor.py
+++ b/providers/neo4j/tests/system/neo4j/example_neo4j_sensor.py
@@ -1,0 +1,66 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Example use of Neo4j Sensor with a Neo4j Operator.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+
+from airflow import DAG
+from airflow.providers.neo4j.operators.neo4j import Neo4jOperator
+from airflow.providers.neo4j.sensors.neo4j import Neo4jSensor
+
+ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID")
+DAG_ID = "example_neo4j_sensor"
+
+with DAG(
+    DAG_ID,
+    start_date=datetime(2025, 1, 1),
+    schedule=None,
+    tags=["example"],
+    catchup=False,
+) as dag:
+    # [START run_query_neo4j_sensor]
+
+    run_query_neo4j_sensor = Neo4jSensor(
+        task_id="run_query_neo4j_sensor",
+        neo4j_conn_id="neo4j_default",
+        cypher="RETURN 1 AS value",
+        success=lambda x: x == 1,
+        poke_interval=5,
+        timeout=60,
+    )
+    # [END run_query_neo4j_sensor]
+
+    run_query_neo4j_operator = Neo4jOperator(
+        task_id="run_query_neo4j_operator",
+        neo4j_conn_id="neo4j_default",
+        parameters={"name": "Tom Hanks"},
+        sql="CREATE (actor {name: $name})",
+        dag=dag,
+    )
+
+    run_query_neo4j_sensor >> run_query_neo4j_operator
+
+from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
+
+# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+test_run = get_test_run(dag)

--- a/providers/neo4j/tests/unit/neo4j/sensors/__init__.py
+++ b/providers/neo4j/tests/unit/neo4j/sensors/__init__.py
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/neo4j/tests/unit/neo4j/sensors/test_neo4j.py
+++ b/providers/neo4j/tests/unit/neo4j/sensors/test_neo4j.py
@@ -39,7 +39,7 @@ class TestNeo4jSensor:
         mock_neo4j_hook_conn = mock_neo4j_hook.return_value
         mock_neo4j_hook_conn.run.return_value = [{"person_count": 50}]
 
-        cypher = "MATCH (n:Person) RETURN COUNT(n) AS person_count"
+        cypher = "MATCH (p:Person) RETURN COUNT(p) AS person_count"
 
         sensor = Neo4jSensor(task_id="neo4j_sensor_check", neo4j_conn_id="neo4j_default", cypher=cypher)
 

--- a/providers/neo4j/tests/unit/neo4j/sensors/test_neo4j.py
+++ b/providers/neo4j/tests/unit/neo4j/sensors/test_neo4j.py
@@ -1,0 +1,306 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from airflow.exceptions import AirflowException
+from airflow.models.dag import DAG
+from airflow.providers.common.compat.sdk import timezone
+from airflow.providers.neo4j.sensors.neo4j import Neo4jSensor
+
+DEFAULT_DATE = timezone.datetime(2015, 1, 1)
+TEST_DAG_ID = "unit_test_neo4j_dag"
+
+
+class TestNeo4jSensor:
+    def setup_method(self):
+        args = {"owner": "airflow", "start_date": DEFAULT_DATE}
+        self.dag = DAG(TEST_DAG_ID, schedule=None, default_args=args)
+
+    @mock.patch("airflow.providers.neo4j.sensors.neo4j.Neo4jHook")
+    def test_neo4j_sensor_smoke_test(self, mock_neo4j_hook):
+        mock_neo4j_hook_conn = mock_neo4j_hook.return_value
+        mock_neo4j_hook_conn.run.return_value = [{"person_count": 50}]
+
+        cypher = "MATCH (n:Person) RETURN COUNT(n) AS person_count"
+
+        sensor = Neo4jSensor(task_id="neo4j_sensor_check", neo4j_conn_id="neo4j_default", cypher=cypher)
+
+        assert sensor.poke(mock.MagicMock()) is True
+        mock_neo4j_hook.assert_called_once_with(conn_id="neo4j_default")
+        mock_neo4j_hook_conn.run.assert_called_once_with(cypher, None)
+
+    @mock.patch("airflow.providers.neo4j.sensors.neo4j.Neo4jHook")
+    def test_neo4j_sensor_poke_empty_default(self, mock_neo4j_hook):
+        mock_neo4j_hook_conn = mock_neo4j_hook.return_value
+        mock_neo4j_hook_conn.run.return_value = []
+
+        cypher = "MATCH (n:NoSuchLabel) RETURN n.id AS id"
+
+        sensor = Neo4jSensor(
+            task_id="neo4j_sensor_check",
+            neo4j_conn_id="neo4j_default",
+            cypher=cypher,
+            parameters=None,
+        )
+        assert sensor.poke(mock.MagicMock()) is False
+
+    @mock.patch("airflow.providers.neo4j.sensors.neo4j.Neo4jHook")
+    def test_neo4j_sensor_poke_empty_false(self, mock_neo4j_hook):
+        mock_neo4j_hook_conn = mock_neo4j_hook.return_value
+        mock_neo4j_hook_conn.run.return_value = []
+
+        cypher = "MATCH (n:NoSuchLabel) RETURN n.id AS id"
+
+        sensor = Neo4jSensor(
+            task_id="neo4j_sensor_check",
+            neo4j_conn_id="neo4j_default",
+            cypher=cypher,
+            parameters=None,
+            fail_on_empty=False,
+        )
+        assert sensor.poke(mock.MagicMock()) is False
+
+    @mock.patch("airflow.providers.neo4j.sensors.neo4j.Neo4jHook")
+    def test_neo4j_sensor_poke_empty_true(self, mock_neo4j_hook):
+        mock_neo4j_hook_conn = mock_neo4j_hook.return_value
+        mock_neo4j_hook_conn.run.return_value = []
+
+        cypher = "MATCH (n:NoSuchLabel) RETURN n.id AS id"
+
+        sensor = Neo4jSensor(
+            task_id="neo4j_sensor_check",
+            neo4j_conn_id="neo4j_default",
+            cypher=cypher,
+            parameters=None,
+            fail_on_empty=True,
+        )
+        with pytest.raises(AirflowException):
+            sensor.poke(mock.MagicMock())
+
+    @mock.patch("airflow.providers.neo4j.sensors.neo4j.Neo4jHook")
+    def test_neo4j_sensor_poke_default_true_value(self, mock_neo4j_hook):
+        mock_neo4j_hook_conn = mock_neo4j_hook.return_value
+        mock_neo4j_hook_conn.run.return_value = [{"value": 1}]
+
+        cypher = "RETURN 1 AS value"
+
+        sensor = Neo4jSensor(
+            task_id="neo4j_sensor_check",
+            neo4j_conn_id="neo4j_default",
+            cypher=cypher,
+            parameters=None,
+        )
+
+        assert sensor.poke(mock.MagicMock()) is True
+
+    @mock.patch("airflow.providers.neo4j.sensors.neo4j.Neo4jHook")
+    def test_neo4j_sensor_poke_default_false_value(self, mock_neo4j_hook):
+        mock_neo4j_hook_conn = mock_neo4j_hook.return_value
+        mock_neo4j_hook_conn.run.return_value = [{"value": 0}]
+
+        cypher = "RETURN 0 AS value"
+
+        sensor = Neo4jSensor(
+            task_id="neo4j_sensor_check",
+            neo4j_conn_id="neo4j_default",
+            cypher=cypher,
+            parameters=None,
+        )
+
+        assert sensor.poke(mock.MagicMock()) is False
+
+    @mock.patch("airflow.providers.neo4j.sensors.neo4j.Neo4jHook")
+    def test_neo4j_sensor_poke_failure_precedence(self, mock_neo4j_hook):
+        mock_neo4j_hook_conn = mock_neo4j_hook.return_value
+        mock_neo4j_hook_conn.run.return_value = [{"value": 10}]
+
+        success = mock.MagicMock(side_effect=lambda v: v == 10)
+        failure = mock.MagicMock(side_effect=lambda v: v == 10)
+
+        cypher = "RETURN 10 AS value"
+
+        sensor = Neo4jSensor(
+            task_id="neo4j_sensor_check",
+            neo4j_conn_id="neo4j_default",
+            cypher=cypher,
+            success=success,
+            failure=failure,
+        )
+
+        with pytest.raises(AirflowException):
+            sensor.poke(mock.MagicMock())
+
+        failure.assert_called_once()
+        success.assert_not_called()
+
+    @mock.patch("airflow.providers.neo4j.sensors.neo4j.Neo4jHook")
+    def test_neo4j_sensor_poke_failure_non_callable(self, mock_neo4j_hook):
+        mock_neo4j_hook_conn = mock_neo4j_hook.return_value
+        mock_neo4j_hook_conn.run.return_value = [{"value": 10}]
+
+        cypher = "RETURN 10 AS value"
+
+        sensor = Neo4jSensor(
+            task_id="neo4j_sensor_check", neo4j_conn_id="neo4j_default", cypher=cypher, failure="value = 10"
+        )
+        with pytest.raises(AirflowException) as ctx:
+            sensor.poke(mock.MagicMock())
+
+        assert str(ctx.value) == "Parameter 'failure' is not callable: 'value = 10'"
+
+    @mock.patch("airflow.providers.neo4j.sensors.neo4j.Neo4jHook")
+    def test_neo4j_sensor_poke_failure_default(self, mock_neo4j_hook):
+        mock_neo4j_hook_conn = mock_neo4j_hook.return_value
+        mock_neo4j_hook_conn.run.return_value = [{"value": 1}]
+
+        cypher = "RETURN 1 AS value"
+
+        sensor = Neo4jSensor(
+            task_id="neo4j_sensor_check",
+            neo4j_conn_id="neo4j_default",
+            cypher=cypher,
+            failure=lambda x: x == 0,
+        )
+
+        assert sensor.poke(mock.MagicMock()) is True
+
+    @mock.patch("airflow.providers.neo4j.sensors.neo4j.Neo4jHook")
+    def test_neo4j_sensor_poke_success_true(self, mock_neo4j_hook):
+        mock_neo4j_hook_conn = mock_neo4j_hook.return_value
+        mock_neo4j_hook_conn.run.return_value = [{"value": 15}]
+
+        cypher = "RETURN 15 AS value"
+
+        sensor = Neo4jSensor(
+            task_id="neo4j_sensor_check",
+            neo4j_conn_id="neo4j_default",
+            cypher=cypher,
+            success=lambda x: x > 10,
+        )
+        assert sensor.poke(mock.MagicMock()) is True
+
+    @mock.patch("airflow.providers.neo4j.sensors.neo4j.Neo4jHook")
+    def test_neo4j_sensor_poke_success_false(self, mock_neo4j_hook):
+        mock_neo4j_hook_conn = mock_neo4j_hook.return_value
+        mock_neo4j_hook_conn.run.return_value = [{"value": 10}]
+
+        cypher = "RETURN 10 AS value"
+
+        sensor = Neo4jSensor(
+            task_id="neo4j_sensor_check",
+            neo4j_conn_id="neo4j_default",
+            cypher=cypher,
+            success=lambda x: x > 10,
+        )
+        assert sensor.poke(mock.MagicMock()) is False
+
+    @mock.patch("airflow.providers.neo4j.sensors.neo4j.Neo4jHook")
+    def test_neo4j_sensor_poke_success_non_callable(self, mock_neo4j_hook):
+        mock_neo4j_hook_conn = mock_neo4j_hook.return_value
+        mock_neo4j_hook_conn.run.return_value = [{"value": 10}]
+
+        cypher = "RETURN 10 AS value"
+
+        sensor = Neo4jSensor(
+            task_id="neo4j_sensor_check",
+            neo4j_conn_id="neo4j_default",
+            cypher=cypher,
+            success="value = 10",
+        )
+        with pytest.raises(AirflowException) as ctx:
+            sensor.poke(mock.MagicMock())
+
+        assert str(ctx.value) == "Parameter 'success' is not callable: 'value = 10'"
+
+    @mock.patch("airflow.providers.neo4j.sensors.neo4j.Neo4jHook")
+    def test_neo4j_sensor_poke_selector_default(self, mock_neo4j_hook):
+        mock_neo4j_hook_conn = mock_neo4j_hook.return_value
+        mock_neo4j_hook_conn.run.return_value = [{"first_name": "John", "last_name": "Doe"}]
+
+        cypher = "MATCH (n:Person{id:'John Doe'}) RETURN n.first_name AS first_name, n.last_name AS last_name"
+
+        sensor = Neo4jSensor(
+            task_id="neo4j_sensor_check",
+            neo4j_conn_id="neo4j_default",
+            cypher=cypher,
+            success=lambda x: x == "John",
+        )
+        assert sensor.poke(mock.MagicMock()) is True
+
+    @mock.patch("airflow.providers.neo4j.sensors.neo4j.Neo4jHook")
+    def test_neo4j_sensor_poke_selector_custom(self, mock_neo4j_hook):
+        mock_neo4j_hook_conn = mock_neo4j_hook.return_value
+        mock_neo4j_hook_conn.run.return_value = [{"first_name": "John", "last_name": "Doe"}]
+
+        cypher = "MATCH (n:Person{id:'John Doe'}) RETURN n.first_name AS first_name, n.last_name AS last_name"
+
+        sensor = Neo4jSensor(
+            task_id="neo4j_sensor_check",
+            neo4j_conn_id="neo4j_default",
+            cypher=cypher,
+            success=lambda x: x == "Doe",
+            selector=lambda x: x[1],
+        )
+        assert sensor.poke(mock.MagicMock()) is True
+
+    @mock.patch("airflow.providers.neo4j.sensors.neo4j.Neo4jHook")
+    def test_neo4j_sensor_poke_selector_non_callable(self, mock_neo4j_hook):
+        mock_neo4j_hook_conn = mock_neo4j_hook.return_value
+        mock_neo4j_hook_conn.run.return_value = [{"first_name": "John", "last_name": "Doe"}]
+
+        cypher = "MATCH (n:Person{id:'John Doe'}) RETURN n.first_name AS first_name, n.last_name AS last_name"
+
+        sensor = Neo4jSensor(
+            task_id="neo4j_sensor_check",
+            neo4j_conn_id="neo4j_default",
+            cypher=cypher,
+            success=lambda x: x == "John",
+            selector="first_name",
+        )
+        with pytest.raises(AirflowException) as ctx:
+            sensor.poke(mock.MagicMock())
+
+        assert str(ctx.value) == "Parameter 'selector' is not callable: 'first_name'"
+
+    @mock.patch("airflow.providers.neo4j.sensors.neo4j.Neo4jHook")
+    def test_neo4j_sensor_poke_templated_parameters(self, mock_neo4j_hook):
+        mock_neo4j_hook_conn = mock_neo4j_hook.return_value
+        mock_neo4j_hook_conn.run.return_value = [{"c": 100}]
+
+        cypher = "MATCH (n:$node_label) RETURN COUNT(n) as total_person"
+
+        sensor = Neo4jSensor(
+            task_id="neo4j_sensor_check",
+            neo4j_conn_id="neo4j_default",
+            cypher=cypher,
+            parameters={"node_label": "{{ target_node_label }}"},
+            success=lambda x: x == 100,
+        )
+
+        sensor.render_template_fields(context={"target_node_label": "Person"})
+
+        assert sensor.parameters == {"node_label": "Person"}
+        assert sensor.poke(context=mock.MagicMock()) is True
+
+        mock_neo4j_hook_conn.run.assert_called_once_with(
+            cypher,
+            {"node_label": "Person"},
+        )


### PR DESCRIPTION
**This PR adds a Neo4jSensor to the Neo4j Provider.** 

* It **functions similarly to existing SQL-based sensor** of polling the neo4j graph database (here with Cypher) for a condition to be met.

* The Neo4j query run is called from the `Neo4jHook` class to connect with a Neo4j graph database instead of `DbApiHook` which lead to the necessity for adding a separate Sensor to Neo4j.

# Airflow Components Added
* `Neo4jSensor` - Polls (Executes a Cypher query in Neo4j) until the returned value satisfies a condition.

# Tests
* `Unit Tests` - Added and tested within breeze using pytest for possible combinations and functionalities

# Static Checks
* `Prek` - Prek hooks were run within breeze for my commits and passed static checks.  

# Documentation
* `Neo4jSensor Documentation` - added to the `providers/neo4j/docs/neo4j/sensors/neo4j.rst`

# Spelling Word List
* `Cypher` - Term was added to the `docs/spelling_wordlist.txt` for the documentation generation.


