### PR TITLE
Fix duration chart duration format

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/DurationChart.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DurationChart.tsx
@@ -36,7 +36,7 @@ import { useNavigate } from "react-router-dom";
 
 import type { TaskInstanceResponse, GridRunsResponse } from "openapi/requests/types.gen";
 import { getComputedCSSVariableValue } from "src/theme";
-import { DEFAULT_DATETIME_FORMAT } from "src/utils/datetimeUtils";
+import { DEFAULT_DATETIME_FORMAT, renderDuration } from "src/utils/datetimeUtils";
 
 ChartJS.register(
   CategoryScale,
@@ -103,7 +103,7 @@ export const DurationChart = ({
     borderColor: "grey",
     borderWidth: 1,
     label: {
-      content: (ctx: PartialEventContext) => average(ctx, 1).toFixed(2),
+      content: (ctx: PartialEventContext) => renderDuration(average(ctx, 1), false) ?? "0",
       display: true,
       position: "end",
     },
@@ -115,7 +115,7 @@ export const DurationChart = ({
     borderColor: "grey",
     borderWidth: 1,
     label: {
-      content: (ctx: PartialEventContext) => average(ctx, 0).toFixed(2),
+      content: (ctx: PartialEventContext) => renderDuration(average(ctx, 0), false) ?? "0",
       display: true,
       position: "end",
     },
@@ -209,6 +209,17 @@ export const DurationChart = ({
                 runAnnotation,
               },
             },
+            tooltip: {
+              callbacks: {
+                label: (context) => {
+                  const datasetLabel = context.dataset.label ?? "";
+
+                  const formatted = renderDuration(context.parsed.y, false) ?? "0";
+
+                  return datasetLabel ? `${datasetLabel}: ${formatted}` : formatted;
+                },
+              },
+            },
           },
           responsive: true,
           scales: {
@@ -220,6 +231,13 @@ export const DurationChart = ({
               title: { align: "end", display: true, text: translate("common:dagRun.runAfter") },
             },
             y: {
+              ticks: {
+                callback: (value) => {
+                  const num = typeof value === "number" ? value : Number(value);
+
+                  return renderDuration(num, false) ?? "0";
+                },
+              },
               title: { align: "end", display: true, text: translate("common:duration") },
             },
           },

--- a/airflow-core/src/airflow/ui/src/utils/datetimeUtils.ts
+++ b/airflow-core/src/airflow/ui/src/utils/datetimeUtils.ts
@@ -26,13 +26,16 @@ dayjs.extend(tz);
 export const DEFAULT_DATETIME_FORMAT = "YYYY-MM-DD HH:mm:ss";
 export const DEFAULT_DATETIME_FORMAT_WITH_TZ = `${DEFAULT_DATETIME_FORMAT} z`;
 
-export const renderDuration = (durationSeconds: number | null | undefined): string | undefined => {
+export const renderDuration = (
+  durationSeconds: number | null | undefined,
+  withMilliseconds: boolean = true,
+): string | undefined => {
   if (durationSeconds === null || durationSeconds === undefined || durationSeconds <= 0.01) {
     return undefined;
   }
 
   // If under 60 seconds, render milliseconds
-  if (durationSeconds < 60) {
+  if (durationSeconds < 60 && withMilliseconds) {
     return dayjs.duration(Number(durationSeconds.toFixed(3)), "seconds").format("HH:mm:ss.SSS");
   }
 


### PR DESCRIPTION
Related:
https://github.com/apache/airflow/issues/49507#issuecomment-3528172668

### Before
<img width="1412" height="486" alt="Screenshot 2025-11-21 at 14 25 48" src="https://github.com/user-attachments/assets/a8a06bd1-6361-4562-a001-7d71823dfa4c" />


### After
<img width="1562" height="664" alt="Screenshot 2025-11-21 at 14 25 33" src="https://github.com/user-attachments/assets/a8f226ca-a26b-4455-b0b2-be2f1cf349c6" />
