### PR TITLE
feat: add depth level filter to dag partial subset

### DIFF
--- a/shared/dagnode/src/airflow_shared/dagnode/node.py
+++ b/shared/dagnode/src/airflow_shared/dagnode/node.py
@@ -163,7 +163,7 @@ class GenericDAGNode(Generic[Dag, Task, TaskGroup]):
                 levels_remaining -= 1
 
         return relatives
-    
+
     def get_flat_relatives(self, upstream: bool = False, depth: int | None = None) -> Collection[Task]:
         """
         Get a flat list of relatives, either upstream or downstream.

--- a/task-sdk/src/airflow/sdk/definitions/dag.py
+++ b/task-sdk/src/airflow/sdk/definitions/dag.py
@@ -913,6 +913,7 @@ class DAG:
                     also_include_ids.update(x.task_id for x in t.get_upstreams_only_setups_and_teardowns())
             if t.is_setup and not include_downstream:
                 also_include_ids.update(x.task_id for x in t.downstream_list if x.is_teardown)
+
         also_include: list[Operator] = [self.task_dict[x] for x in also_include_ids]
         direct_upstreams: list[Operator] = []
         if include_direct_upstream:

--- a/task-sdk/src/airflow/sdk/definitions/dag.py
+++ b/task-sdk/src/airflow/sdk/definitions/dag.py
@@ -920,7 +920,7 @@ class DAG:
                     downstream_ids = _collect_relatives(t, upstream=False, max_depth=depth)
                 else:
                     downstream_ids = {rel.task_id for rel in t.get_flat_relatives(upstream=False)}
-                
+
                 also_include_ids.update(downstream_ids)
                 for rel_id in downstream_ids:
                     rel = self.task_dict[rel_id]

--- a/task-sdk/src/airflow/sdk/definitions/dag.py
+++ b/task-sdk/src/airflow/sdk/definitions/dag.py
@@ -881,9 +881,6 @@ class DAG:
         """
         from airflow.sdk.definitions.mappedoperator import MappedOperator
 
-        if depth is not None and depth < 0:
-            raise ValueError(f"depth must be non-negative, got {depth}")
-
         def is_task(obj) -> TypeGuard[Operator]:
             return isinstance(obj, BaseOperator | MappedOperator)
 
@@ -898,49 +895,24 @@ class DAG:
             matched_tasks = [t for t in self.tasks if t.task_id in task_ids]
 
         also_include_ids: set[str] = set()
-
-        def _collect_relatives(task: Operator, upstream: bool, max_depth: int) -> set[str]:
-            """Collect task relatives up to max_levels."""
-            result = set()
-            current_level = [task]
-            for _ in range(max_depth):
-                next_level = []
-                for t in current_level:
-                    relatives = t.upstream_list if upstream else t.downstream_list
-                    for rel in relatives:
-                        if rel.task_id not in result:
-                            result.add(rel.task_id)
-                            next_level.append(rel)
-                current_level = next_level
-            return result
-
         for t in matched_tasks:
             if include_downstream:
-                if depth is not None:
-                    downstream_ids = _collect_relatives(t, upstream=False, max_depth=depth)
-                else:
-                    downstream_ids = {rel.task_id for rel in t.get_flat_relatives(upstream=False)}
-
-                also_include_ids.update(downstream_ids)
-                for rel_id in downstream_ids:
-                    rel = self.task_dict[rel_id]
-                    if rel not in matched_tasks and not rel.is_setup and not rel.is_teardown:
-                        also_include_ids.update(
-                            x.task_id for x in rel.get_upstreams_only_setups_and_teardowns()
-                        )
-
+                for rel in t.get_flat_relatives(upstream=False, depth=depth):
+                    also_include_ids.add(rel.task_id)
+                    if rel not in matched_tasks:  # if it's in there, we're already processing it
+                        # need to include setups and teardowns for tasks that are in multiple
+                        # non-collinear setup/teardown paths
+                        if not rel.is_setup and not rel.is_teardown:
+                            also_include_ids.update(
+                                x.task_id for x in rel.get_upstreams_only_setups_and_teardowns()
+                            )
             if include_upstream:
-                if depth is not None:
-                    upstream_ids = _collect_relatives(t, upstream=True, max_depth=depth)
-                    also_include_ids.update(upstream_ids)
-                else:
-                    also_include_ids.update(x.task_id for x in t.get_upstreams_follow_setups())
+                also_include_ids.update(x.task_id for x in t.get_upstreams_follow_setups(depth=depth))
             else:
                 if not t.is_setup and not t.is_teardown:
                     also_include_ids.update(x.task_id for x in t.get_upstreams_only_setups_and_teardowns())
             if t.is_setup and not include_downstream:
                 also_include_ids.update(x.task_id for x in t.downstream_list if x.is_teardown)
-
         also_include: list[Operator] = [self.task_dict[x] for x in also_include_ids]
         direct_upstreams: list[Operator] = []
         if include_direct_upstream:

--- a/task-sdk/tests/task_sdk/definitions/test_dag.py
+++ b/task-sdk/tests/task_sdk/definitions/test_dag.py
@@ -390,6 +390,19 @@ class TestDag:
         partial = dag.partial_subset("t1", include_downstream=True, include_upstream=False, depth=2)
         assert set(partial.task_dict.keys()) == {"t1", "t2", "t3", "t4"}
 
+    def test_partial_subset_with_negative_depth(self):
+        """Test that partial_subset rejects negative depth values."""
+        with DAG("test_dag", schedule=None, start_date=DEFAULT_DATE) as dag:
+            t1 = BaseOperator(task_id="t1")
+            t2 = BaseOperator(task_id="t2")
+            t1 >> t2
+
+        with pytest.raises(ValueError, match="depth must be non-negative, got -1"):
+            dag.partial_subset("t1", include_downstream=True, depth=-1)
+
+        with pytest.raises(ValueError, match="depth must be non-negative, got -5"):
+            dag.partial_subset("t1", include_upstream=True, depth=-5)
+
     def test_dag_owner_links(self):
         dag = DAG(
             "dag",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Context
After reimplementing the task stream filter in Airflow 3, a feature request was raised by @bbovenzi to add a level parameter in this filtering functionality. In this way, a user could more easily "traverse" a complex DAG when debugging. It will also be easier to see direct dependencies on the more dense nodes. 

Related: #58450 

## Examples

Besides the added test, I hooked it up to the frontend to give the reviewer a bit more of an idea of what's happening, and what we're trying to achieve with this:

Original:
<img width="1155" height="503" alt="image" src="https://github.com/user-attachments/assets/2895fae1-2d64-4334-ad8a-bfcdef98a4fd" />

With root `section_1.task_3` and depth 2:
<img width="1156" height="485" alt="image" src="https://github.com/user-attachments/assets/a5d385f4-0fbc-4896-abef-4943b0b491e8" />

With root `section_1.task_3` and depth 1:
<img width="1145" height="714" alt="image" src="https://github.com/user-attachments/assets/c88ae5c8-b293-4b31-ae5c-88cdb99e7ef6" />

## Note to Reviewer
I found some odd behaviour in the frontend when setting depth 0. The singular task is correctly shown, but keeps rerendering until it disappears. This behaviour **only** happens on depth 0. Depth >= 1, it works perfectly well. 

The tests pass, and following the code, I find I get the expected results. Not sure if this is a bug in the frontend. Thought it would be good to mention it at least. I considered setting the minimum accepted value at 1 but I feel 0 should be accepted too.

Happy to discuss further.

## Testing

I created two scenario's which should show the reviewer the behaviour on a small scale and help verify the functionality. Let me know if there is any need to further elaborate on this.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
