### PR TITLE
CLI: Add `airflow db would-migrate` command

### DIFF
--- a/airflow-core/docs/howto/usage-cli.rst
+++ b/airflow-core/docs/howto/usage-cli.rst
@@ -271,6 +271,14 @@ Running migrations manually
 
 If desired, you can generate the sql statements for an upgrade and apply each upgrade migration manually, one at a time.  To do so you may use either the ``--range`` (for Airflow version) or ``--revision-range`` (for Alembic revision) option with ``db migrate``.  Do *not* skip running the Alembic revision id update commands; this is how Airflow will know where you are upgrading from the next time you need to.  See :doc:`/migrations-ref` for a mapping between revision and version.
 
+Scripted checks for anticipated migrations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you have a automated script which checks whether a DB migration would take place under the current environment /
+configuration, you may use ``airflow db would-migrate``, which gives an exit code of ``0`` when a migration is not
+needed, an exit code of ``123`` if a migration is needed, and any other non-zero exit code for an unexpected error.
+
+Run ``airflow db would-migrate`` for usage details.
 
 .. _cli-db-downgrade:
 

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -607,6 +607,14 @@ ARG_DB_SQL_ONLY = Arg(
     action="store_true",
     default=False,
 )
+ARG_DB_QUIET = Arg(
+    ("-q", "--quiet"),
+    help="Don't run migrations, and don't print the anticipated sql scripts. "
+    "Return a non-zero exit code when a migration is expected, return a 0 exit code otherwise."
+    "Only usable with the `would-migrate` command.",
+    action="store_true",
+    default=False,
+)
 ARG_DB_SKIP_INIT = Arg(
     ("-s", "--skip-init"),
     help="Only remove tables; do not perform db init.",
@@ -1447,6 +1455,19 @@ DB_COMMANDS = (
             ARG_DB_FROM_VERSION,
             ARG_VERBOSE,
         ),
+    ),
+    ActionCommand(
+        name="would-migrate",
+        help="Checks if a run of `airflow db migrate` would trigger a migration or not. Does not run a migration.",
+        description=(
+            "Check if a migration would take place in the given environment and configuration."
+            "Returns an exit code of `0` if no migration is expected, and a non-zero exit code otherwise."
+            "Does not print any of the potential sql statements if a migration were to occur."
+            "Simply useful for checking if a migration is needed."
+            "To reduce output from this command, may provide ``-q`` or ``--quiet``."
+        ),
+        func=lazy_load_command("airflow.cli.commands.db_command.would_migrate"),
+        args=(ARG_DB_QUIET,),
     ),
     ActionCommand(
         name="downgrade",

--- a/airflow-core/src/airflow/cli/commands/db_command.py
+++ b/airflow-core/src/airflow/cli/commands/db_command.py
@@ -208,6 +208,13 @@ def migratedb(args):
 
 @cli_utils.action_cli(check_db=False)
 @providers_configuration_loaded
+def would_migrate(args):
+    """Check if migration is expected or not, but do not run the migration."""
+    db.migration_expected(quiet=args.quiet)
+
+
+@cli_utils.action_cli(check_db=False)
+@providers_configuration_loaded
 def downgrade(args):
     """Downgrades the metadata database."""
     run_db_downgrade_command(args, db.downgrade, _REVISION_HEADS_MAP)

--- a/airflow-core/tests/unit/cli/commands/test_db_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_db_command.py
@@ -166,7 +166,7 @@ class TestCliDb:
         if mock_quiet:
             args.append("--quiet")
 
-        db_command.would_migrate(self.parser.parse_args(args))
+        db_command.would_migrate(self.parser.parse_args(args))  # type: ignore[attr-defined]
         mock_db_migration_expected.assert_called_once_with(quiet=mock_quiet)
 
     @mock.patch("airflow.cli.commands.db_command.db.check_migrations")

--- a/airflow-core/tests/unit/cli/commands/test_db_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_db_command.py
@@ -159,6 +159,16 @@ class TestCliDb:
         with pytest.raises(SystemExit, match=match):
             db_command.run_db_migrate_command(Args(), fake_command, heads)
 
+    @pytest.mark.parametrize("mock_quiet", [False, True])
+    @mock.patch("airflow.cli.commands.db_command.db.migration_expected")
+    def test_cli_would_migrate(self, mock_db_migration_expected, mock_quiet: bool):
+        args = ["db", "would-migrate"]
+        if mock_quiet:
+            args.append("--quiet")
+
+        db_command.would_migrate(self.parser.parse_args(args))
+        mock_db_migration_expected.assert_called_once_with(quiet=mock_quiet)
+
     @mock.patch("airflow.cli.commands.db_command.db.check_migrations")
     def test_cli_check_migrations(self, mock_wait_for_migrations):
         db_command.check_migrations(self.parser.parse_args(["db", "check-migrations"]))

--- a/airflow-core/tests/unit/utils/test_db.py
+++ b/airflow-core/tests/unit/utils/test_db.py
@@ -323,7 +323,7 @@ class TestDb:
             migration_expected(quiet=quiet)
             assert excinfo.value.code == expected_exit_code
 
-        expected_print_snippet = f"from={from_revision} to={to_revision}"
+        expected_print_snippet = "Migration expected: "
         stdout = temp_stdout.getvalue()
         if quiet:
             assert expected_print_snippet not in stdout


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---

**Related Issues**: None that I'm aware of. Happy to open one to go along with this PR if that is preferable.

## What?
* Add a new `airflow db would-migrate` command to the CLI, which checks if a migration would take place in the given environment and configuration, but does not execute the migration. Exits with an exit code of `0` when there are no pending migrations expected / detected, otherwise has an exit code of `123` when a pending migration is detected / expected.

## Why?
* As far as I'm aware, `airflow db migrate --show-sql-only` is the only way to  check if a migration is expected or not; however, there are a few scenarios and reasons that existing command is not sufficient:
    * When running `airflow db migrate --show-sql-only` from another script, the output of that command is not particularly machine-readable (it [currently prints out a cat](https://github.com/apache/airflow/blob/1dd427a2ff2345972d938903e6a49d0a96290f04/providers/fab/src/airflow/providers/fab/auth_manager/models/db.py#L93) if there's no migration anticipated).
    * Feels slightly less error-prone to check if a migration would happen by using a different command, rather than the migration command itself. In other words, this is less risky than accidentally submitting `airflow db migrate` with the `--show-sql-only` flag missing.
    * Surfacing this information via the exit code makes for a pretty straightforward integration with any bash scripts, for example: 
        ```shell
        airflow db would-migrate -q
        migration_expected=$?
        if [[ $migration_expected -eq 123 ]]; then
          echo "'airflow db migrate' would cause a migration"
          # do extra stuff here
        fi
        ```

## Testing
* Ran `breeze testing core-tests --test-type CLI --run-db-tests-only --backend postgres airflow-core/tests/unit/cli`
* `prek`
* Verified the CLI behavior inside of a `breeze` shell session.