### PR TITLE
docs: Clarify that masking in Connection extra JSON is keyword-dependent

### DIFF
--- a/airflow-core/docs/security/secrets/mask-sensitive-values.rst
+++ b/airflow-core/docs/security/secrets/mask-sensitive-values.rst
@@ -20,8 +20,10 @@
 Masking sensitive data
 ----------------------
 
-Airflow will by default mask Connection passwords and sensitive Variables and keys from a Connection's
-extra (JSON) field when they appear in Task logs, in the Variable and in the Rendered fields views of the UI.
+Airflow will by default mask Connection passwords, sensitive Variables, and keys from a Connection's
+extra (JSON) field whose names contain one or more of the sensitive keywords when they appear in Task logs,
+in the Variables UI, and in the Rendered fields views of the UI. Keys in the extra JSON that do not include
+any of these sensitive keywords will not be redacted automatically.
 
 It does this by looking for the specific *value* appearing anywhere in your output. This means that if you
 have a connection with a password of ``a``, then every instance of the letter a in your logs will be replaced


### PR DESCRIPTION
## What changes
Updated the documentation to clarify that Airflow only masks keys in a Connection's extra JSON field if their names contain specific sensitive keywords, not all keys.

## Why
The current documentation states "keys from a Connection's extra (JSON) field" which is misleading as it implies all keys are masked. In reality, only keys whose names contain sensitive keywords (like `password`, `token`, `api_key`, etc.) are masked.

## Fixes
Closes #58514

## Testing
Documentation change only - no code changes required.