### PR TITLE
Eliminate race condition in a test due to xdist runs

### DIFF
--- a/dev/breeze/tests/test_packages.py
+++ b/dev/breeze/tests/test_packages.py
@@ -401,6 +401,23 @@ TASK_SDK_INIT_PY = AIRFLOW_ROOT_PATH / "task-sdk" / "src" / "airflow" / "sdk" / 
 AIRFLOWCTL_INIT_PY = AIRFLOW_ROOT_PATH / "airflow-ctl" / "src" / "airflowctl" / "__init__.py"
 
 
+@pytest.fixture
+def restore_version_files():
+    # save contents of all version files before test starts
+    version_files = [
+        AIRFLOW_CORE_INIT_PY,
+        TASK_SDK_INIT_PY,
+        AIRFLOWCTL_INIT_PY,
+    ]
+    original_contents = {f: f.read_text() for f in version_files if f.exists()}
+
+    yield
+
+    # restore original contents after test
+    for fp, content in original_contents.items():
+        fp.write_text(content)
+
+
 @pytest.mark.parametrize(
     ("distributions", "init_file_path", "version_suffix", "floored_version_suffix"),
     [
@@ -428,7 +445,11 @@ AIRFLOWCTL_INIT_PY = AIRFLOW_ROOT_PATH / "airflow-ctl" / "src" / "airflowctl" / 
     ],
 )
 def test_apply_version_suffix_to_non_provider_pyproject_tomls(
-    distributions: tuple[str, ...], init_file_path: Path, version_suffix: str, floored_version_suffix: str
+    restore_version_files,
+    distributions: tuple[str, ...],
+    init_file_path: Path,
+    version_suffix: str,
+    floored_version_suffix: str,
 ):
     """
     Test the apply_version_suffix function with different version suffixes for pyproject.toml of non-provider.


### PR DESCRIPTION


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Saw errors like this in one of the CI runs:
```python
_ test_apply_version_suffix_to_non_provider_pyproject_tomls[distributions1-init_file_path1-.dev1+testversion34-.dev0] _
[gw2] linux -- Python 3.10.19 /home/runner/.local/share/uv/tools/apache-airflow-breeze/bin/python

distributions = ('airflow-core', '.')
init_file_path = PosixPath('/home/runner/work/airflow/airflow/airflow-core/src/airflow/__init__.py')
version_suffix = '.dev1+testversion34', floored_version_suffix = '.dev0'

    @pytest.mark.parametrize(
        ("distributions", "init_file_path", "version_suffix", "floored_version_suffix"),
        [
            (("airflow-core", "."), AIRFLOW_CORE_INIT_PY, ".dev0", ".dev0"),
            (("airflow-core", "."), AIRFLOW_CORE_INIT_PY, ".dev1+testversion34", ".dev0"),
            (("airflow-core", "."), AIRFLOW_CORE_INIT_PY, "rc2", "rc1"),
            (("airflow-core", "."), AIRFLOW_CORE_INIT_PY, "rc2.dev0+localversion35", "rc1.dev0"),
            (("airflow-core", "."), AIRFLOW_CORE_INIT_PY, "rc1", "rc1"),
            (("airflow-core", "."), AIRFLOW_CORE_INIT_PY, "a2", "a1"),
            (("airflow-core", "."), AIRFLOW_CORE_INIT_PY, "b1", "b1"),
            (("airflow-core", "."), AIRFLOW_CORE_INIT_PY, "b1+testversion34", "b1"),
            (("airflow-core", "."), AIRFLOW_CORE_INIT_PY, ".post1", ".post1"),
            (("task-sdk",), TASK_SDK_INIT_PY, ".dev0", ".dev0"),
            (("task-sdk",), TASK_SDK_INIT_PY, "rc2", "rc1"),
            (("task-sdk",), TASK_SDK_INIT_PY, "rc13", "rc1"),
            (("task-sdk",), TASK_SDK_INIT_PY, "a1", "a1"),
            (("task-sdk",), TASK_SDK_INIT_PY, "b3", "b1"),
            (("task-sdk",), TASK_SDK_INIT_PY, ".post1", ".post1"),
            (("airflow-ctl",), AIRFLOWCTL_INIT_PY, ".dev0", ".dev0"),
            (("airflow-ctl",), AIRFLOWCTL_INIT_PY, "rc2", "rc1"),
            (("airflow-ctl",), AIRFLOWCTL_INIT_PY, "rc13", "rc1"),
            (("airflow-ctl",), AIRFLOWCTL_INIT_PY, "a1", "a1"),
            (("airflow-ctl",), AIRFLOWCTL_INIT_PY, "b3", "b1"),
            (("airflow-ctl",), AIRFLOWCTL_INIT_PY, ".post1", ".post1"),
        ],
    )
    def test_apply_version_suffix_to_non_provider_pyproject_tomls(
        distributions: tuple[str, ...], init_file_path: Path, version_suffix: str, floored_version_suffix: str
    ):
        """
        Test the apply_version_suffix function with different version suffixes for pyproject.toml of non-provider.
        """
        try:
            import tomllib
        except ImportError:
            import tomli as tomllib
        distribution_paths = [AIRFLOW_ROOT_PATH / distribution for distribution in distributions]
        original_pyproject_toml_paths = [path / "pyproject.toml" for path in distribution_paths]
        original_contents = [path.read_text() for path in original_pyproject_toml_paths]
        original_init_py = init_file_path.read_text()
>       with apply_version_suffix_to_non_provider_pyproject_tomls(
            version_suffix, init_file_path, original_pyproject_toml_paths
        ) as modified_pyproject_toml_paths:

/home/runner/work/airflow/airflow/dev/breeze/tests/test_packages.py:444: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/opt/hostedtoolcache/Python/3.10.19/arm64/lib/python3.10/contextlib.py:135: in __enter__
    return next(self.gen)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

version_suffix = '.dev1+testversion34'
init_file_path = PosixPath('/home/runner/work/airflow/airflow/airflow-core/src/airflow/__init__.py')
pyproject_toml_paths = [PosixPath('/home/runner/work/airflow/airflow/airflow-core/pyproject.toml'), PosixPath('/home/runner/work/airflow/airflow/pyproject.toml')]

    @contextmanager
    def apply_version_suffix_to_non_provider_pyproject_tomls(
        version_suffix: str, init_file_path: Path, pyproject_toml_paths: list[Path]
    ) -> Generator[list[Path], None, None]:
        from packaging.version import Version
    
        original_version_search = re.search('__version__ = "([^"]+)"', init_file_path.read_text())
        # Search beta version
        beta_version_search = re.search('__version__ = "([^"]+)b[0-9]+"', init_file_path.read_text())
        if not original_version_search:
            raise RuntimeError(f"Could not find __version__ in {init_file_path}")
        original_distribution_version = original_version_search.group(1)
        packaging_version = Version(original_distribution_version)
        # Forgiving check for beta versions
        if not beta_version_search and packaging_version.base_version != str(packaging_version):
>           raise RuntimeError(
                f"The package version in {init_file_path} should be `simple version` "
                f"(no suffixes) and it is `{original_distribution_version}`."
            )
E           RuntimeError: The package version in /home/runner/work/airflow/airflow/airflow-core/src/airflow/__init__.py should be `simple version` (no suffixes) and it is `3.2.0.dev0`.

/home/runner/work/airflow/airflow/dev/breeze/src/airflow_breeze/utils/packages.py:1142: RuntimeError
=========================== short test summary info ============================
```

Upon investigating, it seems that this is because of a race condition occurring due to parallel run of tests using pytest xdist.

This is what happens:
- First test case: Modifies version to 3.2.0.dev0
- Next test case: Starts running in parallel or before test case 0 finishes cleanup
- This test case reads the file and sees `3.2.0.dev0` instead of `3.2.0` and because the validation doesn't handle that, this fails.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
