### PR TITLE
feat: discord embeds for notifier

### DIFF
--- a/providers/discord/docs/index.rst
+++ b/providers/discord/docs/index.rst
@@ -35,6 +35,7 @@
     :caption: Guides
 
     Connection types <connections/discord-webhook>
+    Discord Notifications <notifications/index>
 
 .. toctree::
     :hidden:

--- a/providers/discord/docs/notifications/discord_notifier_howto_guide.rst
+++ b/providers/discord/docs/notifications/discord_notifier_howto_guide.rst
@@ -1,0 +1,70 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+How-to Guide for Discord notifications
+========================================
+
+Introduction
+------------
+Discord notifier (:class:`airflow.providers.discord.notifications.discord.DiscordNotifier`) allows users to send
+messages to a discord channel using the various ``on_*_callbacks`` at both the Dag level and Task level
+
+
+Example Code:
+-------------
+
+.. code-block:: python
+
+    from datetime import datetime
+    from airflow import DAG
+    from airflow.providers.standard.operators.bash import BashOperator
+    from airflow.providers.discord.notifications.embed import Embed, EmbedAuthor, EmbedFooter, EmbedField
+    from airflow.providers.discord.notifications.discord import DiscordNotifier
+
+    with DAG(
+        start_date=datetime(2025, 1, 1),
+        on_success_callback=[
+            DiscordNotifier(
+                text="The Dag {{ dag.dag_id }} succeeded",
+            )
+        ],
+    ):
+        BashOperator(
+            task_id="mytask",
+            on_failure_callback=[
+                DiscordNotifier(
+                    text="The task {{ ti.task_id }} failed",
+                    embed=Embed(
+                        title="Hello ~~people~~ world :wave: The task {{ ti.task_id }} failed",
+                        description="You can use [links](https://discord.com) or emojis :smile: 😎\n```\nAnd also code blocks\n```",
+                        color=4321431,
+                        timestamp="2025-11-23T19:05:15.292Z",
+                        url="https://discord.com",
+                        author=EmbedAuthor(
+                            name="Author",
+                            url="https://discord.com",
+                            icon_url="https://cdn.discordapp.com/embed/avatars/0.png",
+                        ),
+                        footer=EmbedFooter(
+                            text="Footer text", icon_url="https://cdn.discordapp.com/embed/avatars/0.png"
+                        ),
+                        fields=[EmbedField(name="Field 1, *lorem* **ipsum**, ~~dolor~~", value="Field value")],
+                    ),
+                )
+            ],
+            bash_command="fail",
+        )

--- a/providers/discord/docs/notifications/index.rst
+++ b/providers/discord/docs/notifications/index.rst
@@ -1,0 +1,27 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+
+Discord Notifications
+=====================
+
+.. toctree::
+    :maxdepth: 1
+    :glob:
+
+    *

--- a/providers/discord/src/airflow/providers/discord/notifications/embed.py
+++ b/providers/discord/src/airflow/providers/discord/notifications/embed.py
@@ -1,0 +1,134 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Discord embed structure.
+
+See:
+    https://discord.com/developers/docs/resources/message#embed-object-embed-structure
+"""
+
+from __future__ import annotations
+
+from typing import Literal, TypedDict
+
+from typing_extensions import NotRequired, Required
+
+EmbedType = Literal["rich"]
+
+
+class EmbedFooter(TypedDict):
+    """
+    EmbedFooter.
+
+    :param text: Footer text.
+    :param icon_url: Url of footer icon (only supports http(s) and attachments).
+    :param proxy_icon_url: A proxy url of footer icon.
+
+    See:
+        https://discord.com/developers/docs/resources/message#embed-object-embed-footer-structure
+    """
+
+    text: str
+    icon_url: NotRequired[str]
+    proxy_icon_url: NotRequired[str]
+
+
+class EmbedField(TypedDict):
+    """
+    EmbedField.
+
+    :param name: Name of the field.
+    :param value: Value of the field.
+    :param inline: Whether or not this field should display inline.
+
+    See:
+        https://discord.com/developers/docs/resources/message#embed-object-embed-field-structure
+    """
+
+    name: str
+    value: str
+    inline: NotRequired[bool]
+
+
+class EmbedProvider(TypedDict, total=False):
+    """
+    EmbedProvider.
+
+    :param name: Name of provider
+    :param url: Url of provider
+
+    See:
+        https://discord.com/developers/docs/resources/message#embed-object-embed-provider-structure
+    """
+
+    name: str
+    url: str
+
+
+class EmbedAuthor(TypedDict, total=False):
+    """
+    EmbedAuthor.
+
+    :param name: Name of author.
+    :param url: Url of author (only supports http(s)).
+    :param icon_url: Url of author icon (only supports http(s) and attachments).
+    :param proxy_icon_url: A proxy url of author icon.
+
+    See:
+        https://discord.com/developers/docs/resources/message#embed-object-embed-author-structure
+    """
+
+    name: Required[str]
+    url: str
+    icon_url: str
+    proxy_icon_url: str
+
+
+class Embed(TypedDict, total=False):
+    """
+    Embed.
+
+    :param title: The text that is placed above the description.
+       Embed titles are limited to 256 characters.
+    :param description: The part of the embed where most of the text is contained.
+       Embed descriptions are limited to 2048 characters.
+    :param type: Type of embed (always "rich" for webhook embeds).
+    :param url: Url of embed.
+    :param timestamp: Timestamp (ISO8601) of embed content.
+    :param color: Color code of the embed.
+    :param footer: Footer information. Footer text is limited to 2048 characters
+    :param provider: Add provider information.
+    :param author: Adds the author block to the embed, always located at the
+       top of the embed.
+    :param fields: Add fields information, max of 25 fields.
+
+    See:
+        https://discord.com/developers/docs/resources/message#embed-object-embed-author-structure
+
+    """
+
+    title: str
+    description: str
+    type: EmbedType
+    url: str
+    timestamp: str
+    color: int
+    footer: EmbedFooter
+    provider: EmbedProvider
+    author: EmbedAuthor
+    fields: list[EmbedField]

--- a/providers/discord/tests/unit/discord/notifications/test_embed.py
+++ b/providers/discord/tests/unit/discord/notifications/test_embed.py
@@ -1,0 +1,68 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from airflow.providers.discord.notifications.embed import (
+    Embed,
+    EmbedAuthor,
+    EmbedField,
+    EmbedFooter,
+    EmbedProvider,
+)
+
+
+def test_embed_footer():
+    footer = EmbedFooter(
+        text="Test footer",
+        icon_url="https://example.com/icon.png",
+        proxy_icon_url="https://example.com/icon.png",
+    )
+    assert footer["text"] == "Test footer"
+    assert footer["icon_url"] == "https://example.com/icon.png"
+    assert footer["proxy_icon_url"] == "https://example.com/icon.png"
+
+
+def test_embed_field():
+    field = EmbedField(name="Test Field", value="Test Value")
+    assert field["name"] == "Test Field"
+    assert field["value"] == "Test Value"
+
+
+def test_embed_provider():
+    provider = EmbedProvider(name="Test Provider", url="https://example.com")
+    assert provider["name"] == "Test Provider"
+    assert provider["url"] == "https://example.com"
+
+
+def test_embed_author():
+    author = EmbedAuthor(
+        name="Test Author",
+        url="https://example.com",
+        icon_url="https://example.com/icon.png",
+        proxy_icon_url="https://example.com/icon.png",
+    )
+    assert author["name"] == "Test Author"
+    assert author["url"] == "https://example.com"
+    assert author["icon_url"] == "https://example.com/icon.png"
+    assert author["proxy_icon_url"] == "https://example.com/icon.png"
+
+
+def test_embed():
+    embed = Embed(title="Test Title", description="Test Description")
+    assert embed["title"] == "Test Title"
+    assert embed["description"] == "Test Description"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Implement message Embeds for the Discord provider. Embeds provide a flexible way to style a Discord message as they can have colored borders, embedded text boxes, links, and other properties.

closes: #46838

-------------------

<img width="1462" height="543" alt="Screenshot 2025-11-23 201426" src="https://github.com/user-attachments/assets/10c23653-e327-41b4-9d1a-9be2b568f25e" />


------------------


```Python
from datetime import timedelta
from airflow import DAG
from airflow.sdk.definitions.deadline import AsyncCallback, DeadlineAlert, DeadlineReference
from airflow.providers.discord.notifications.discord import DiscordNotifier
from airflow.providers.discord.notifications.embed import Embed, EmbedAuthor, EmbedFooter, EmbedField
from airflow.providers.standard.operators.empty import EmptyOperator
from airflow.sdk import task

with DAG(
    dag_id="deadline_discord_alert_example",
    deadline=DeadlineAlert(
        reference=DeadlineReference.DAGRUN_QUEUED_AT,
        interval=timedelta(seconds=20),
        callback=AsyncCallback(
            DiscordNotifier,
            kwargs={
                "text": "You can~~not~~ do `this`.```py\nAnd this.\nprint('Hi')```\n*italics* or _italics_     __*underline italics*__\n**bold**     __**underline bold**__\n***bold italics***  __***underline bold italics***__\n__underline__     ~~Strikethrough~~",
                "embed": Embed(
                    title="Hello ~~people~~ world :wave:",
                    description="You can use [links](https://discord.com) or emojis :smile: 😎\n```\nAnd also code blocks\n```",
                    color=4321431,
                    timestamp="2025-11-23T19:05:15.292Z",
                    url="https://discord.com",
                    author=EmbedAuthor(
                        name="Author",
                        url="https://discord.com",
                        icon_url="https://cdn.discordapp.com/embed/avatars/0.png",

                    ),
                    footer=EmbedFooter(
                        text="Footer text",
                        icon_url="https://cdn.discordapp.com/embed/avatars/0.png"
                    ),
                    fields=[
                        EmbedField(
                            name="Field 1, *lorem* **ipsum**, ~~dolor~~",
                            value="Field value"
                        )
                    ]
                )
            },
        ),
    ),
):
    c = EmptyOperator(task_id="example_task")

    @task()
    def wait():
        import time
        time.sleep(60*5)

    
    c >> wait()

```



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
