### PR TITLE
Fix startup issue with `breeze start-airflow` command for airflow 2 due to dependencies

### DIFF
--- a/scripts/in_container/install_airflow_and_providers.py
+++ b/scripts/in_container/install_airflow_and_providers.py
@@ -1005,13 +1005,12 @@ def install_airflow_and_providers(
                 github_actions=github_actions,
                 check=False,
             )
-            result = run_command(
-                ["uv", "pip", "install", "typing-extensions>=4.15.0"],
+            console.print("[bright_blue]Upgrading typing-extensions for compatibility with pydantic_core")
+            run_command(
+                ["uv", "pip", "install", "--upgrade", "--no-deps", "typing-extensions>=4.15.0"],
                 github_actions=github_actions,
-                check=True,
+                check=False,
             )
-            if result.returncode != 0:
-                console.print("[warning]Installation of typing-extensions>=4.15.0 failed.")
             console.print("[yellow]Uninstalling Airflow-3 only providers")
             console.print(
                 "[yellow]Patching airflow 2 __init__.py -> replacing `from future`"

--- a/scripts/in_container/install_airflow_and_providers.py
+++ b/scripts/in_container/install_airflow_and_providers.py
@@ -1005,6 +1005,13 @@ def install_airflow_and_providers(
                 github_actions=github_actions,
                 check=False,
             )
+            result = run_command(
+                ["uv", "pip", "install", "typing-extensions>=4.15.0"],
+                github_actions=github_actions,
+                check=True,
+            )
+            if result.returncode != 0:
+                console.print("[warning]Installation of typing-extensions>=4.15.0 failed.")
             console.print("[yellow]Uninstalling Airflow-3 only providers")
             console.print(
                 "[yellow]Patching airflow 2 __init__.py -> replacing `from future`"


### PR DESCRIPTION
## Why

When I run `start-airflow` command with Airflow 2

```bash
breeze start-airflow --backend postgres --mount-sources providers-and-tests --use-airflow-version 2.11.0
```

I encountered the following error that `Pydantic` is not able to import `Sentinel` from `typing_extensions`



<details>
  <summary>Full Error Traceback</summary>

```
Sourcing environment variables from environment_variables.env in /files/airflow-breeze-config


Sourcing the initialization script from init.sh in /files/airflow-breeze-config


Checking backend and integrations.

PostgreSQL: OK.  


Starting Airflow

/usr/python/lib/python3.10/site-packages/airflow/metrics/base_stats_logger.py:22 RemovedInAirflow3Warning: Timer and timing metrics publish in seconds were deprecated. It is enabled by default from Airflow 3 onwards. Enable timer_unit_consistency to publish all the timer and timing metrics in milliseconds.
[2025-11-24T04:52:17.161+0000] {configuration.py:1348} WARNING - cannot import name 'Sentinel' from 'typing_extensions' (/usr/python/lib/python3.10/site-packages/typing_extensions.py)
[2025-11-24T04:52:17.162+0000] {cli_parser.py:80} WARNING - cannot load CLI commands from auth manager: The object could not be loaded. Please check "auth_manager" key in "core" section. Current value: "airflow.providers.fab.auth_manager.fab_auth_manager.FabAuthManager".
[2025-11-24T04:52:17.162+0000] {cli_parser.py:81} WARNING - Authentication manager is not configured and webserver will not be able to start.
DB: postgresql+psycopg2://postgres:***@postgres/airflow
Performing upgrade to the metadata database postgresql+psycopg2://postgres:***@postgres/airflow
Traceback (most recent call last):
  File "/usr/python/bin/airflow", line 10, in <module>
    sys.exit(main())
  File "/usr/python/lib/python3.10/site-packages/airflow/__main__.py", line 62, in main
    args.func(args)
  File "/usr/python/lib/python3.10/site-packages/airflow/cli/cli_config.py", line 49, in command
    return func(*args, **kwargs)
  File "/usr/python/lib/python3.10/site-packages/airflow/utils/cli.py", line 116, in wrapper
    return f(*args, **kwargs)
  File "/usr/python/lib/python3.10/site-packages/airflow/utils/providers_configuration_loader.py", line 55, in wrapped_function
    return func(*args, **kwargs)
  File "/usr/python/lib/python3.10/site-packages/airflow/cli/commands/db_command.py", line 140, in migratedb
    db.upgradedb(
  File "/usr/python/lib/python3.10/site-packages/airflow/utils/session.py", line 97, in wrapper
    return func(*args, session=session, **kwargs)
  File "/usr/python/lib/python3.10/site-packages/airflow/utils/db.py", line 1628, in upgradedb
    import_all_models()
  File "/usr/python/lib/python3.10/site-packages/airflow/models/__init__.py", line 60, in import_all_models
    __getattr__(name)
  File "/usr/python/lib/python3.10/site-packages/airflow/models/__init__.py", line 79, in __getattr__
    val = import_string(f"{path}.{name}")
  File "/usr/python/lib/python3.10/site-packages/airflow/utils/module_loading.py", line 39, in import_string
    module = import_module(module_path)
  File "/usr/python/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/usr/python/lib/python3.10/site-packages/airflow/models/dag.py", line 100, in <module>
    from airflow.jobs.job import run_job
  File "/usr/python/lib/python3.10/site-packages/airflow/jobs/job.py", line 35, in <module>
    from airflow.serialization.pydantic.job import JobPydantic
  File "/usr/python/lib/python3.10/site-packages/airflow/serialization/pydantic/job.py", line 23, in <module>
    from airflow.utils.pydantic import BaseModel as BaseModelPydantic, ConfigDict
  File "/usr/python/lib/python3.10/site-packages/airflow/utils/pydantic.py", line 40, in <module>
    from pydantic import BaseModel, ConfigDict, PlainSerializer, PlainValidator, ValidationInfo
  File "/usr/python/lib/python3.10/site-packages/pydantic/__init__.py", line 5, in <module>
    from ._migration import getattr_migration
  File "/usr/python/lib/python3.10/site-packages/pydantic/_migration.py", line 4, in <module>
    from pydantic.warnings import PydanticDeprecatedSince20
  File "/usr/python/lib/python3.10/site-packages/pydantic/warnings.py", line 5, in <module>
    from .version import version_short
  File "/usr/python/lib/python3.10/site-packages/pydantic/version.py", line 7, in <module>
    from pydantic_core import __version__ as __pydantic_core_version__
  File "/usr/python/lib/python3.10/site-packages/pydantic_core/__init__.py", line 6, in <module>
    from typing_extensions import Sentinel
ImportError: cannot import name 'Sentinel' from 'typing_extensions' (/usr/python/lib/python3.10/site-packages/typing_extensions.py)
Failed to run 'airflow db migrate'.
This could be because you are installing old airflow version
Attempting to run deprecated 'airflow db init' instead.
/usr/python/lib/python3.10/site-packages/airflow/metrics/base_stats_logger.py:22 RemovedInAirflow3Warning: Timer and timing metrics publish in seconds were deprecated. It is enabled by default from Airflow 3 onwards. Enable timer_unit_consistency to publish all the timer and timing metrics in milliseconds.
[2025-11-24T04:52:20.968+0000] {configuration.py:1348} WARNING - cannot import name 'Sentinel' from 'typing_extensions' (/usr/python/lib/python3.10/site-packages/typing_extensions.py)
[2025-11-24T04:52:20.969+0000] {cli_parser.py:80} WARNING - cannot load CLI commands from auth manager: The object could not be loaded. Please check "auth_manager" key in "core" section. Current value: "airflow.providers.fab.auth_manager.fab_auth_manager.FabAuthManager".
[2025-11-24T04:52:20.969+0000] {cli_parser.py:81} WARNING - Authentication manager is not configured and webserver will not be able to start.
/usr/python/lib/python3.10/site-packages/airflow/utils/providers_configuration_loader.py:55 DeprecationWarning: `db init` is deprecated.  Use `db migrate` instead to migrate the db and/or airflow connections create-default-connections to create the default connections
DB: postgresql+psycopg2://postgres:***@postgres/airflow
Traceback (most recent call last):
  File "/usr/python/bin/airflow", line 10, in <module>
    sys.exit(main())
  File "/usr/python/lib/python3.10/site-packages/airflow/__main__.py", line 62, in main
    args.func(args)
  File "/usr/python/lib/python3.10/site-packages/airflow/cli/cli_config.py", line 49, in command
    return func(*args, **kwargs)
  File "/usr/python/lib/python3.10/site-packages/airflow/utils/providers_configuration_loader.py", line 55, in wrapped_function
    return func(*args, **kwargs)
  File "/usr/python/lib/python3.10/site-packages/airflow/cli/commands/db_command.py", line 56, in initdb
    db.initdb()
  File "/usr/python/lib/python3.10/site-packages/airflow/utils/session.py", line 97, in wrapper
    return func(*args, session=session, **kwargs)
  File "/usr/python/lib/python3.10/site-packages/airflow/utils/db.py", line 794, in initdb
    import_all_models()
  File "/usr/python/lib/python3.10/site-packages/airflow/models/__init__.py", line 60, in import_all_models
    __getattr__(name)
  File "/usr/python/lib/python3.10/site-packages/airflow/models/__init__.py", line 79, in __getattr__
    val = import_string(f"{path}.{name}")
  File "/usr/python/lib/python3.10/site-packages/airflow/utils/module_loading.py", line 39, in import_string
    module = import_module(module_path)
  File "/usr/python/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/usr/python/lib/python3.10/site-packages/airflow/models/dag.py", line 100, in <module>
    from airflow.jobs.job import run_job
  File "/usr/python/lib/python3.10/site-packages/airflow/jobs/job.py", line 35, in <module>
    from airflow.serialization.pydantic.job import JobPydantic
  File "/usr/python/lib/python3.10/site-packages/airflow/serialization/pydantic/job.py", line 23, in <module>
    from airflow.utils.pydantic import BaseModel as BaseModelPydantic, ConfigDict
  File "/usr/python/lib/python3.10/site-packages/airflow/utils/pydantic.py", line 40, in <module>
    from pydantic import BaseModel, ConfigDict, PlainSerializer, PlainValidator, ValidationInfo
  File "/usr/python/lib/python3.10/site-packages/pydantic/__init__.py", line 5, in <module>
    from ._migration import getattr_migration
  File "/usr/python/lib/python3.10/site-packages/pydantic/_migration.py", line 4, in <module>
    from pydantic.warnings import PydanticDeprecatedSince20
  File "/usr/python/lib/python3.10/site-packages/pydantic/warnings.py", line 5, in <module>
    from .version import version_short
  File "/usr/python/lib/python3.10/site-packages/pydantic/version.py", line 7, in <module>
    from pydantic_core import __version__ as __pydantic_core_version__
  File "/usr/python/lib/python3.10/site-packages/pydantic_core/__init__.py", line 6, in <module>
    from typing_extensions import Sentinel
ImportError: cannot import name 'Sentinel' from 'typing_extensions' (/usr/python/lib/python3.10/site-packages/typing_extensions.py)

Error: check_environment returned 1. Exiting.

Error 1 returned
```

</details>

## What

`Sentinel` was released in `typing-extensions==4.14.0` according to https://github.com/python/typing_extensions/releases.

Running `uv pip install typing-extensions>=4.15.0` under `if version.major == 2:` branch can resolve the error, but I'm not sure if this is the right way to solve it.

