### PR TITLE
Use filelock to fix race condition in version suffix test for xdist runs

### DIFF
--- a/dev/breeze/tests/test_packages.py
+++ b/dev/breeze/tests/test_packages.py
@@ -401,6 +401,18 @@ TASK_SDK_INIT_PY = AIRFLOW_ROOT_PATH / "task-sdk" / "src" / "airflow" / "sdk" / 
 AIRFLOWCTL_INIT_PY = AIRFLOW_ROOT_PATH / "airflow-ctl" / "src" / "airflowctl" / "__init__.py"
 
 
+@pytest.fixture
+def lock_version_files():
+    from filelock import FileLock
+
+    lock_file = AIRFLOW_ROOT_PATH / ".version_files.lock"
+    with FileLock(lock_file):
+        yield
+    if lock_file.exists():
+        lock_file.unlink()
+
+
+@pytest.mark.usefixtures("lock_version_files")
 @pytest.mark.parametrize(
     ("distributions", "init_file_path", "version_suffix", "floored_version_suffix"),
     [
@@ -436,37 +448,28 @@ def test_apply_version_suffix_to_non_provider_pyproject_tomls(
     """
     Test the apply_version_suffix function with different version suffixes for pyproject.toml of non-provider.
     """
-    from filelock import FileLock
-
-    lock_file = AIRFLOW_ROOT_PATH / ".version_files.lock"
-    lock = FileLock(lock_file)
     try:
-        with lock:
-            try:
-                import tomllib
-            except ImportError:
-                import tomli as tomllib
-            distribution_paths = [AIRFLOW_ROOT_PATH / distribution for distribution in distributions]
-            original_pyproject_toml_paths = [path / "pyproject.toml" for path in distribution_paths]
-            original_contents = [path.read_text() for path in original_pyproject_toml_paths]
-            original_init_py = init_file_path.read_text()
-            with apply_version_suffix_to_non_provider_pyproject_tomls(
-                version_suffix, init_file_path, original_pyproject_toml_paths
-            ) as modified_pyproject_toml_paths:
-                modified_contents = [path.read_text() for path in modified_pyproject_toml_paths]
+        import tomllib
+    except ImportError:
+        import tomli as tomllib
+    distribution_paths = [AIRFLOW_ROOT_PATH / distribution for distribution in distributions]
+    original_pyproject_toml_paths = [path / "pyproject.toml" for path in distribution_paths]
+    original_contents = [path.read_text() for path in original_pyproject_toml_paths]
+    original_init_py = init_file_path.read_text()
+    with apply_version_suffix_to_non_provider_pyproject_tomls(
+        version_suffix, init_file_path, original_pyproject_toml_paths
+    ) as modified_pyproject_toml_paths:
+        modified_contents = [path.read_text() for path in modified_pyproject_toml_paths]
 
-                original_tomls = [tomllib.loads(content) for content in original_contents]
-                modified_tomls = [tomllib.loads(content) for content in modified_contents]
-                modified_init_py = init_file_path.read_text()
+        original_tomls = [tomllib.loads(content) for content in original_contents]
+        modified_tomls = [tomllib.loads(content) for content in modified_contents]
+        modified_init_py = init_file_path.read_text()
 
-            assert original_init_py != modified_init_py
-            assert version_suffix in modified_init_py
+    assert original_init_py != modified_init_py
+    assert version_suffix in modified_init_py
 
-            for i, original_toml in enumerate(original_tomls):
-                modified_toml = modified_tomls[i]
-                _check_dependencies_modified_properly(
-                    original_toml, modified_toml, version_suffix, floored_version_suffix
-                )
-    finally:
-        if lock_file.exists():
-            lock_file.unlink()
+    for i, original_toml in enumerate(original_tomls):
+        modified_toml = modified_tomls[i]
+        _check_dependencies_modified_properly(
+            original_toml, modified_toml, version_suffix, floored_version_suffix
+        )


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

I attempted to fix a breeze test in https://github.com/apache/airflow/pull/58593 and tried eliminating race condition for xdist runs through that fix, but that fix isn't good enough. Mentioned here: https://github.com/apache/airflow/pull/58593#discussion_r2554261194

Instead, we could use a file lock by `filelock` library to retrieve a lock and run the critical section code that patches the toml file version to not unnecessarily mock and achieve more of an integration test behavior than mocking and not catching the issue. Used filelock library for this: https://py-filelock.readthedocs.io/en/latest/index.html which provides a platform independent file lock that will be a one stop solution for our runs.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
