### PR TITLE
Fix for object rendering in HITL interface

### DIFF
--- a/airflow-core/src/airflow/ui/src/utils/hitl.test.ts
+++ b/airflow-core/src/airflow/ui/src/utils/hitl.test.ts
@@ -1,0 +1,65 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import type { TFunction } from "i18next";
+import { describe, it, expect, vi } from "vitest";
+
+import type { HITLDetail } from "openapi/requests/types.gen";
+
+import { getHITLParamsDict } from "./hitl";
+
+const mockTranslate = vi.fn((key: string) => key) as unknown as TFunction;
+
+const createMockHITLDetail = (overrides?: Partial<HITLDetail>): HITLDetail =>
+  ({
+    assigned_users: [],
+    body: "Test Body",
+    chosen_options: [],
+    created_at: new Date().toISOString(),
+    defaults: ["Option1"],
+    multiple: false,
+    options: ["Option1", "Option2"],
+    params: {},
+    params_input: {},
+    response_received: false,
+    subject: "Test Subject",
+    task_instance: {
+      dag_id: "test_dag",
+      dag_run_id: "test_run",
+      map_index: -1,
+      state: "deferred",
+      task_id: "test_task",
+    },
+    ...overrides,
+  }) as HITLDetail;
+
+describe("getHITLParamsDict", () => {
+  it("correctly types object parameters as 'object' instead of 'string'", () => {
+    const hitlDetail = createMockHITLDetail({
+      params: {
+        objectParam: { key: "value", nested: { data: 123 } },
+      },
+    });
+
+    const searchParams = new URLSearchParams();
+    const paramsDict = getHITLParamsDict(hitlDetail, mockTranslate, searchParams);
+
+    expect(paramsDict.objectParam?.schema.type).toBe("object");
+    expect(paramsDict.objectParam?.value).toEqual({ key: "value", nested: { data: 123 } });
+  });
+});

--- a/airflow-core/src/airflow/ui/src/utils/hitl.ts
+++ b/airflow-core/src/airflow/ui/src/utils/hitl.ts
@@ -70,7 +70,7 @@ export const getHITLParamsDict = (
   searchParams: URLSearchParams,
 ): ParamsSpec => {
   const paramsDict: ParamsSpec = {};
-  const { preloadedHITLOptions } = getPreloadHITLFormData(searchParams, hitlDetail);
+  const { preloadedHITLOptions, preloadedHITLParams } = getPreloadHITLFormData(searchParams, hitlDetail);
   const isApprovalTask =
     hitlDetail.options.includes("Approve") &&
     hitlDetail.options.includes("Reject") &&
@@ -113,8 +113,35 @@ export const getHITLParamsDict = (
       }
       const paramData = hitlDetail.params[key] as ParamsSpec | undefined;
 
+      // Check if there's a preloaded value from URL params
+      let finalValue = preloadedHITLParams[key] ?? value;
+
+      // If preloaded value is a string that might be JSON, try to parse it
+      if (typeof finalValue === "string" && finalValue.trim().startsWith("{")) {
+        try {
+          const parsed: unknown = JSON.parse(finalValue);
+
+          if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+            finalValue = parsed;
+          }
+        } catch {
+          // If parsing fails, keep the string value
+        }
+      }
+
       const description: string =
         paramData && typeof paramData.description === "string" ? paramData.description : "";
+
+      // Determine the type based on the final value
+      let valueType: string;
+
+      if (typeof finalValue === "number") {
+        valueType = "number";
+      } else if (typeof finalValue === "object" && finalValue !== null && !Array.isArray(finalValue)) {
+        valueType = "object";
+      } else {
+        valueType = "string";
+      }
 
       const schema: ParamSchema = {
         const: undefined,
@@ -129,7 +156,7 @@ export const getHITLParamsDict = (
         minLength: undefined,
         section: undefined,
         title: key,
-        type: typeof value === "number" ? "number" : "string",
+        type: valueType,
         values_display: undefined,
         ...(paramData?.schema && typeof paramData.schema === "object" ? paramData.schema : {}),
       };
@@ -137,7 +164,7 @@ export const getHITLParamsDict = (
       paramsDict[key] = {
         description,
         schema,
-        value: paramData?.value ?? value,
+        value: paramData?.value ?? finalValue,
       };
     });
   }


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

HITL Approve UI does not correctly display object DAG parameters. These were being displayed as `[object Object]` (see below).

<img width="1236" height="1114" alt="image" src="https://github.com/user-attachments/assets/36c738fc-0935-435c-97d8-10f150f4a49b" />

Main change (hitl.ts):
- Added support for preloading parameter values from URL query strings
- Added JSON parsing for string values that look like JSON objects
- Fixed type detection to correctly identify object parameters (instead of defaulting to string)
Test file (hitl.test.ts):
- New test verifying object parameters are typed as 'object'



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
