### PR TITLE
feat(param): add source to Param

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/services/ui/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/ui/connections.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import logging
 from collections.abc import MutableMapping
 from functools import cache
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from airflow.api_fastapi.core_api.datamodels.connections import (
     ConnectionHookFieldBehavior,
@@ -68,6 +68,7 @@ class HookMetaService:
             description: str = "",
             default: str | None = None,
             widget=None,
+            source: Literal["Dag", "task"] | None = None,
         ):
             type: str | list[str] = [self.param_type, "null"]
             enum = {}
@@ -82,6 +83,7 @@ class HookMetaService:
                 default=default,
                 title=label,
                 description=description or None,
+                source=source or None,
                 type=type,
                 **format,
                 **enum,

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/ui/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/ui/connections.py
@@ -68,7 +68,7 @@ class HookMetaService:
             description: str = "",
             default: str | None = None,
             widget=None,
-            source: Literal["Dag", "task"] | None = None,
+            source: Literal["dag", "task"] | None = None,
         ):
             type: str | list[str] = [self.param_type, "null"]
             enum = {}

--- a/airflow-core/src/airflow/serialization/definitions/param.py
+++ b/airflow-core/src/airflow/serialization/definitions/param.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import collections.abc
 import copy
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from airflow.serialization.definitions.notset import NOTSET, is_arg_set
 
@@ -31,11 +31,18 @@ if TYPE_CHECKING:
 class SerializedParam:
     """Server-side param class for deserialization."""
 
-    def __init__(self, default: Any = NOTSET, description: str | None = None, **schema):
+    def __init__(
+        self,
+        default: Any = NOTSET,
+        description: str | None = None,
+        source: Literal["Dag", "task"] | None = None,
+        **schema,
+    ):
         # No validation needed - the SDK already validated the default.
         self.value = default
         self.description = description
         self.schema = schema
+        self.source = source
 
     def resolve(self, *, raises: bool = False) -> Any:
         """
@@ -66,6 +73,7 @@ class SerializedParam:
             "value": self.resolve(),
             "schema": self.schema,
             "description": self.description,
+            "source": self.source,
         }
 
 

--- a/airflow-core/src/airflow/serialization/definitions/param.py
+++ b/airflow-core/src/airflow/serialization/definitions/param.py
@@ -35,7 +35,7 @@ class SerializedParam:
         self,
         default: Any = NOTSET,
         description: str | None = None,
-        source: Literal["Dag", "task"] | None = None,
+        source: Literal["dag", "task"] | None = None,
         **schema,
     ):
         # No validation needed - the SDK already validated the default.

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -1037,6 +1037,7 @@ class BaseSerialization:
             "default": cls.serialize(param.value),
             "description": cls.serialize(param.description),
             "schema": cls.serialize(param.schema),
+            "source": cls.serialize(getattr(param, "source", None)),
         }
 
     @classmethod
@@ -1048,7 +1049,7 @@ class BaseSerialization:
         this class's ``serialize`` method.  So before running through ``deserialize``,
         we first verify that it's necessary to do.
         """
-        attrs = ("default", "description", "schema")
+        attrs = ("default", "description", "schema", "source")
         kwargs = {}
 
         def is_serialized(val):
@@ -1068,6 +1069,7 @@ class BaseSerialization:
         return SerializedParam(
             default=kwargs.get("default"),
             description=kwargs.get("description"),
+            source=kwargs.get("source", None),
             **(kwargs.get("schema") or {}),
         )
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py
@@ -944,7 +944,14 @@ class TestDagDetails(TestDagEndpoint):
             "next_dagrun_run_after": None,
             "owners": ["airflow"],
             "owner_links": {},
-            "params": {"foo": {"value": 1, "schema": {}, "description": None}},
+            "params": {
+                "foo": {
+                    "value": 1,
+                    "schema": {},
+                    "description": None,
+                    "source": None,
+                }
+            },
             "relative_fileloc": "test_dags.py",
             "render_template_as_native_obj": False,
             "timetable_summary": None,
@@ -1034,7 +1041,14 @@ class TestDagDetails(TestDagEndpoint):
             "next_dagrun_run_after": None,
             "owners": ["airflow"],
             "owner_links": {},
-            "params": {"foo": {"value": 1, "schema": {}, "description": None}},
+            "params": {
+                "foo": {
+                    "value": 1,
+                    "schema": {},
+                    "description": None,
+                    "source": None,
+                }
+            },
             "relative_fileloc": "test_dags.py",
             "render_template_as_native_obj": False,
             "timetable_summary": None,

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_tasks.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_tasks.py
@@ -102,7 +102,7 @@ class TestGetTask(TestTaskEndpoint):
             "extra_links": [],
             "operator_name": "EmptyOperator",
             "owner": "airflow",
-            "params": {"foo": {"value": "bar", "schema": {}, "description": None}},
+            "params": {"foo": {"value": "bar", "schema": {}, "description": None, "source": "task"}},
             "pool": "default_pool",
             "pool_slots": 1.0,
             "priority_weight": 1.0,
@@ -180,7 +180,14 @@ class TestGetTask(TestTaskEndpoint):
             "extra_links": [],
             "operator_name": "EmptyOperator",
             "owner": "airflow",
-            "params": {"is_unscheduled": {"value": True, "schema": {}, "description": None}},
+            "params": {
+                "is_unscheduled": {
+                    "value": True,
+                    "schema": {},
+                    "description": None,
+                    "source": "task",
+                }
+            },
             "pool": "default_pool",
             "pool_slots": 1.0,
             "priority_weight": 1.0,
@@ -239,7 +246,14 @@ class TestGetTask(TestTaskEndpoint):
             "extra_links": [],
             "operator_name": "EmptyOperator",
             "owner": "airflow",
-            "params": {"foo": {"value": "bar", "schema": {}, "description": None}},
+            "params": {
+                "foo": {
+                    "value": "bar",
+                    "schema": {},
+                    "description": None,
+                    "source": "task",
+                }
+            },
             "pool": "default_pool",
             "pool_slots": 1.0,
             "priority_weight": 1.0,
@@ -304,7 +318,14 @@ class TestGetTasks(TestTaskEndpoint):
                     "extra_links": [],
                     "operator_name": "EmptyOperator",
                     "owner": "airflow",
-                    "params": {"foo": {"value": "bar", "schema": {}, "description": None}},
+                    "params": {
+                        "foo": {
+                            "value": "bar",
+                            "schema": {},
+                            "description": None,
+                            "source": "task",
+                        }
+                    },
                     "pool": "default_pool",
                     "pool_slots": 1.0,
                     "priority_weight": 1.0,
@@ -459,7 +480,14 @@ class TestGetTasks(TestTaskEndpoint):
                     "extra_links": [],
                     "operator_name": "EmptyOperator",
                     "owner": "airflow",
-                    "params": {"is_unscheduled": {"value": True, "schema": {}, "description": None}},
+                    "params": {
+                        "is_unscheduled": {
+                            "value": True,
+                            "schema": {},
+                            "description": None,
+                            "source": "task",
+                        }
+                    },
                     "pool": "default_pool",
                     "pool_slots": 1.0,
                     "priority_weight": 1.0,

--- a/airflow-core/tests/unit/serialization/test_dag_serialization.py
+++ b/airflow-core/tests/unit/serialization/test_dag_serialization.py
@@ -1193,6 +1193,7 @@ class TestStringifiedDAGs:
             "value": None if param.value is NOTSET else param.value,
             "schema": param.schema,
             "description": param.description,
+            "source": None,
         }
 
     @pytest.mark.parametrize(

--- a/providers/standard/src/airflow/providers/standard/operators/hitl.py
+++ b/providers/standard/src/airflow/providers/standard/operators/hitl.py
@@ -87,6 +87,10 @@ class HITLOperator(BaseOperator):
         if hasattr(ParamsDict, "filter_params_by_source"):
             # Params that exist only in Dag level does not make sense to appear in HITLOperator
             self.params = ParamsDict.filter_params_by_source(self.params, source="task")
+        elif self.params:
+            self.log.debug(
+                "ParamsDict.filter_params_by_source not available; HITLOperator will also include Dag level params."
+            )
 
         self.notifiers: Sequence[BaseNotifier] = (
             [notifiers] if isinstance(notifiers, BaseNotifier) else notifiers or []

--- a/providers/standard/src/airflow/providers/standard/operators/hitl.py
+++ b/providers/standard/src/airflow/providers/standard/operators/hitl.py
@@ -84,6 +84,9 @@ class HITLOperator(BaseOperator):
         self.multiple = multiple
 
         self.params: ParamsDict = params if isinstance(params, ParamsDict) else ParamsDict(params or {})
+        if hasattr(self.params, "filter_params_by_source"):
+            # Params that exist only in Dag level does not make sense to appear in HITLOperator
+            self.params = ParamsDict.filter_params_by_source(self.params, source="task")
 
         self.notifiers: Sequence[BaseNotifier] = (
             [notifiers] if isinstance(notifiers, BaseNotifier) else notifiers or []

--- a/providers/standard/src/airflow/providers/standard/operators/hitl.py
+++ b/providers/standard/src/airflow/providers/standard/operators/hitl.py
@@ -84,7 +84,7 @@ class HITLOperator(BaseOperator):
         self.multiple = multiple
 
         self.params: ParamsDict = params if isinstance(params, ParamsDict) else ParamsDict(params or {})
-        if hasattr(self.params, "filter_params_by_source"):
+        if hasattr(ParamsDict, "filter_params_by_source"):
             # Params that exist only in Dag level does not make sense to appear in HITLOperator
             self.params = ParamsDict.filter_params_by_source(self.params, source="task")
 

--- a/providers/standard/tests/unit/standard/triggers/test_hitl.py
+++ b/providers/standard/tests/unit/standard/triggers/test_hitl.py
@@ -21,7 +21,7 @@ from typing import Any
 
 import pytest
 
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_1_PLUS
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_1_PLUS, AIRFLOW_V_3_2_PLUS
 
 if not AIRFLOW_V_3_1_PLUS:
     pytest.skip("Human in the loop public API compatible with Airflow >= 3.1.0", allow_module_level=True)
@@ -50,7 +50,12 @@ def default_trigger_args() -> dict[str, Any]:
         "ti_id": TI_ID,
         "options": ["1", "2", "3", "4", "5"],
         "params": {
-            "input": {"value": 1, "schema": {}, "description": None},
+            "input": {
+                "value": 1,
+                "schema": {},
+                "description": None,
+                "source": "task",
+            },
         },
         "multiple": False,
     }
@@ -65,11 +70,20 @@ class TestHITLTrigger:
             **default_trigger_args,
         )
         classpath, kwargs = trigger.serialize()
+
+        expected_params_in_trigger_kwargs: dict[str, dict[str, Any]]
+        if AIRFLOW_V_3_2_PLUS:
+            expected_params_in_trigger_kwargs = {
+                "input_1": {"value": 1, "description": None, "schema": {}, "source": "task"}
+            }
+        else:
+            expected_params_in_trigger_kwargs = {"input_1": {"value": 1, "description": None, "schema": {}}}
+
         assert classpath == "airflow.providers.standard.triggers.hitl.HITLTrigger"
         assert kwargs == {
             "ti_id": TI_ID,
             "options": ["1", "2", "3", "4", "5"],
-            "params": {"input": {"value": 1, "description": None, "schema": {}}},
+            "params": expected_params_in_trigger_kwargs,
             "defaults": ["1"],
             "multiple": False,
             "timeout_datetime": None,

--- a/providers/standard/tests/unit/standard/triggers/test_hitl.py
+++ b/providers/standard/tests/unit/standard/triggers/test_hitl.py
@@ -74,10 +74,10 @@ class TestHITLTrigger:
         expected_params_in_trigger_kwargs: dict[str, dict[str, Any]]
         if AIRFLOW_V_3_2_PLUS:
             expected_params_in_trigger_kwargs = {
-                "input_1": {"value": 1, "description": None, "schema": {}, "source": "task"}
+                "input": {"value": 1, "description": None, "schema": {}, "source": "task"}
             }
         else:
-            expected_params_in_trigger_kwargs = {"input_1": {"value": 1, "description": None, "schema": {}}}
+            expected_params_in_trigger_kwargs = {"input": {"value": 1, "description": None, "schema": {}}}
 
         assert classpath == "airflow.providers.standard.triggers.hitl.HITLTrigger"
         assert kwargs == {

--- a/task-sdk/src/airflow/sdk/bases/operator.py
+++ b/task-sdk/src/airflow/sdk/bases/operator.py
@@ -138,6 +138,7 @@ def _get_parent_defaults(dag: DAG | None, task_group: TaskGroup | None) -> tuple
         return {}, ParamsDict()
     dag_args = copy.copy(dag.default_args)
     dag_params = copy.deepcopy(dag.params)
+    dag_params._fill_missing_param_source("Dag")
     if task_group:
         if task_group.default_args and not isinstance(task_group.default_args, collections.abc.Mapping):
             raise TypeError("default_args must be a mapping")
@@ -155,13 +156,20 @@ def get_merged_defaults(
     if task_params:
         if not isinstance(task_params, collections.abc.Mapping):
             raise TypeError(f"params must be a mapping, got {type(task_params)}")
+
+        task_params = ParamsDict(task_params)
+        task_params._fill_missing_param_source("task")
         params.update(task_params)
+
     if task_default_args:
         if not isinstance(task_default_args, collections.abc.Mapping):
             raise TypeError(f"default_args must be a mapping, got {type(task_params)}")
         args.update(task_default_args)
         with contextlib.suppress(KeyError):
-            params.update(task_default_args["params"] or {})
+            if params_from_default_args := ParamsDict(task_default_args["params"] or {}):
+                params_from_default_args._fill_missing_param_source("task")
+                params.update(params_from_default_args)
+
     return args, params
 
 

--- a/task-sdk/src/airflow/sdk/bases/operator.py
+++ b/task-sdk/src/airflow/sdk/bases/operator.py
@@ -138,7 +138,7 @@ def _get_parent_defaults(dag: DAG | None, task_group: TaskGroup | None) -> tuple
         return {}, ParamsDict()
     dag_args = copy.copy(dag.default_args)
     dag_params = copy.deepcopy(dag.params)
-    dag_params._fill_missing_param_source("Dag")
+    dag_params._fill_missing_param_source("dag")
     if task_group:
         if task_group.default_args and not isinstance(task_group.default_args, collections.abc.Mapping):
             raise TypeError("default_args must be a mapping")

--- a/task-sdk/src/airflow/sdk/definitions/param.py
+++ b/task-sdk/src/airflow/sdk/definitions/param.py
@@ -55,7 +55,7 @@ class Param:
         self,
         default: Any = NOTSET,
         description: str | None = None,
-        source: Literal["Dag", "task"] | None = None,
+        source: Literal["dag", "task"] | None = None,
         **kwargs,
     ):
         if default is not NOTSET:
@@ -277,7 +277,7 @@ class ParamsDict(MutableMapping[str, Any]):
 
     def _fill_missing_param_source(
         self,
-        source: Literal["Dag", "task"] | None = None,
+        source: Literal["dag", "task"] | None = None,
     ) -> None:
         for key in self.__dict:
             if self.__dict[key].source is None:

--- a/task-sdk/src/airflow/sdk/definitions/param.py
+++ b/task-sdk/src/airflow/sdk/definitions/param.py
@@ -284,7 +284,7 @@ class ParamsDict(MutableMapping[str, Any]):
                 self.__dict[key].source = source
 
     @staticmethod
-    def filter_params_by_source(params: ParamsDict, source: Literal["Dag", "task"]) -> ParamsDict:
+    def filter_params_by_source(params: ParamsDict, source: Literal["dag", "task"]) -> ParamsDict:
         return ParamsDict(
             {key: param for key, param in params.__dict.items() if param.source == source},
         )

--- a/task-sdk/src/airflow/sdk/definitions/param.py
+++ b/task-sdk/src/airflow/sdk/definitions/param.py
@@ -21,7 +21,7 @@ import copy
 import json
 import logging
 from collections.abc import ItemsView, Iterable, Mapping, MutableMapping, ValuesView
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 from airflow.sdk.definitions._internal.mixins import ResolveMixin
 from airflow.sdk.definitions._internal.types import NOTSET, is_arg_set
@@ -51,15 +51,27 @@ class Param:
 
     CLASS_IDENTIFIER = "__class"
 
-    def __init__(self, default: Any = NOTSET, description: str | None = None, **kwargs):
+    def __init__(
+        self,
+        default: Any = NOTSET,
+        description: str | None = None,
+        source: Literal["Dag", "task", "Dag run"] | None = None,
+        **kwargs,
+    ):
         if default is not NOTSET:
             self._check_json(default)
         self.value = default
         self.description = description
         self.schema = kwargs.pop("schema") if "schema" in kwargs else kwargs
+        self.source = source
 
     def __copy__(self) -> Param:
-        return Param(self.value, self.description, schema=self.schema)
+        return Param(
+            self.value,
+            self.description,
+            schema=self.schema,
+            source=self.source,
+        )
 
     @staticmethod
     def _check_json(value):
@@ -119,14 +131,24 @@ class Param:
         return self.value is not NOTSET and self.value is not None
 
     def serialize(self) -> dict:
-        return {"value": self.value, "description": self.description, "schema": self.schema}
+        return {
+            "value": self.value,
+            "description": self.description,
+            "schema": self.schema,
+            "source": self.source,
+        }
 
     @staticmethod
     def deserialize(data: dict[str, Any], version: int) -> Param:
         if version > Param.__version__:
             raise TypeError("serialized version > class version")
 
-        return Param(default=data["value"], description=data["description"], schema=data["schema"])
+        return Param(
+            default=data["value"],
+            description=data["description"],
+            schema=data["schema"],
+            source=data.get("source", None),
+        )
 
 
 class ParamsDict(MutableMapping[str, Any]):
@@ -252,6 +274,20 @@ class ParamsDict(MutableMapping[str, Any]):
             raise TypeError("serialized version > class version")
 
         return ParamsDict(data)
+
+    def _fill_missing_param_source(
+        self,
+        source: Literal["Dag", "task"] | None = None,
+    ) -> None:
+        for key in self.__dict:
+            if self.__dict[key].source is None:
+                self.__dict[key].source = source
+
+    @staticmethod
+    def filter_params_by_source(params: ParamsDict, source: Literal["Dag", "task"]) -> ParamsDict:
+        return ParamsDict(
+            {key: param for key, param in params.__dict.items() if param.source == source},
+        )
 
 
 class DagParam(ResolveMixin):

--- a/task-sdk/src/airflow/sdk/definitions/param.py
+++ b/task-sdk/src/airflow/sdk/definitions/param.py
@@ -55,7 +55,7 @@ class Param:
         self,
         default: Any = NOTSET,
         description: str | None = None,
-        source: Literal["Dag", "task", "Dag run"] | None = None,
+        source: Literal["Dag", "task"] | None = None,
         **kwargs,
     ):
         if default is not NOTSET:

--- a/task-sdk/tests/task_sdk/bases/test_operator.py
+++ b/task-sdk/tests/task_sdk/bases/test_operator.py
@@ -810,7 +810,7 @@ class TestBaseOperator:
             )
 
         for key, expected_source in (
-            ("param from Dag", "Dag"),
+            ("param from Dag", "dag"),
             ("overwritten by task", "task"),
             ("param from task", "task"),
         ):

--- a/task-sdk/tests/task_sdk/bases/test_operator.py
+++ b/task-sdk/tests/task_sdk/bases/test_operator.py
@@ -41,6 +41,7 @@ from airflow.sdk.bases.operator import (
 )
 from airflow.sdk.definitions.dag import DAG
 from airflow.sdk.definitions.edges import Label
+from airflow.sdk.definitions.param import ParamsDict
 from airflow.sdk.definitions.taskgroup import TaskGroup
 from airflow.sdk.definitions.template import literal
 from airflow.task.priority_strategy import _DownstreamPriorityWeightStrategy, _UpstreamPriorityWeightStrategy
@@ -784,6 +785,36 @@ class TestBaseOperator:
 
         task.render_template_fields(context={"foo": "whatever", "bar": "whatever"})
         assert mock_jinja_env.call_count == 1
+
+    def test_params_source(self):
+        # Test bug when copying an operator attached to a Dag
+        with DAG(
+            "dag0",
+            params=ParamsDict(
+                {
+                    "param from Dag": "value1",
+                    "overwritten by task": "value 2",
+                }
+            ),
+            schedule=None,
+            start_date=DEFAULT_DATE,
+        ):
+            op1 = MockOperator(
+                task_id="task1",
+                params=ParamsDict(
+                    {
+                        "overwritten by task": "value 3",
+                        "param from task": "value 4",
+                    }
+                ),
+            )
+
+        for key, expected_source in (
+            ("param from Dag", "Dag"),
+            ("overwritten by task", "task"),
+            ("param from task", "task"),
+        ):
+            assert op1.params.get_param(key).source == expected_source
 
     def test_deepcopy(self):
         # Test bug when copying an operator attached to a Dag

--- a/task-sdk/tests/task_sdk/definitions/test_param.py
+++ b/task-sdk/tests/task_sdk/definitions/test_param.py
@@ -312,8 +312,8 @@ class TestParamsDict:
         pd = ParamsDict({"key": Param("value", type="string")})
         assert repr(pd) == "{'key': 'value'}"
 
-    @pytest.mark.parametrize("source", ("Dag", "task"))
-    def test_fill_missing_param_source(self, source: Literal["Dag", "task"]):
+    @pytest.mark.parametrize("source", ("dag", "task"))
+    def test_fill_missing_param_source(self, source: Literal["dag", "task"]):
         pd = ParamsDict(
             {
                 "key": Param("value", type="string"),
@@ -327,7 +327,7 @@ class TestParamsDict:
     def test_fill_missing_param_source_not_overwrite_existing(self):
         pd = ParamsDict(
             {
-                "key": Param("value", type="string", source="Dag"),
+                "key": Param("value", type="string", source="dag"),
                 "key2": "value2",
                 "key3": "value3",
             }
@@ -343,7 +343,7 @@ class TestParamsDict:
     def test_filter_params_by_source(self):
         pd = ParamsDict(
             {
-                "key": Param("value", type="string", source="Dag"),
+                "key": Param("value", type="string", source="dag"),
                 "key2": Param("value", source="task"),
             }
         )

--- a/task-sdk/tests/task_sdk/definitions/test_param.py
+++ b/task-sdk/tests/task_sdk/definitions/test_param.py
@@ -334,7 +334,7 @@ class TestParamsDict:
         )
         pd._fill_missing_param_source("task")
         for key, expected_source in (
-            ("key", "Dag"),
+            ("key", "dag"),
             ("key2", "task"),
             ("key3", "task"),
         ):

--- a/task-sdk/tests/task_sdk/definitions/test_param.py
+++ b/task-sdk/tests/task_sdk/definitions/test_param.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 from contextlib import nullcontext
+from typing import Literal
 
 import pytest
 
@@ -207,10 +208,13 @@ class TestParam:
     def test_dump(self):
         p = Param("hello", description="world", type="string", minLength=2)
         dump = p.dump()
-        assert dump["__class"] == "airflow.sdk.definitions.param.Param"
-        assert dump["value"] == "hello"
-        assert dump["description"] == "world"
-        assert dump["schema"] == {"type": "string", "minLength": 2}
+        assert dump == {
+            "__class": "airflow.sdk.definitions.param.Param",
+            "value": "hello",
+            "description": "world",
+            "schema": {"type": "string", "minLength": 2},
+            "source": None,
+        }
 
     @pytest.mark.parametrize(
         "param",
@@ -307,3 +311,47 @@ class TestParamsDict:
     def test_repr(self):
         pd = ParamsDict({"key": Param("value", type="string")})
         assert repr(pd) == "{'key': 'value'}"
+
+    @pytest.mark.parametrize("source", ("Dag", "task"))
+    def test_fill_missing_param_source(self, source: Literal["Dag", "task"]):
+        pd = ParamsDict(
+            {
+                "key": Param("value", type="string"),
+                "key2": "value2",
+            }
+        )
+        pd._fill_missing_param_source(source)
+        for param in pd.values():
+            assert param.source == source
+
+    def test_fill_missing_param_source_not_overwrite_existing(self):
+        pd = ParamsDict(
+            {
+                "key": Param("value", type="string", source="Dag"),
+                "key2": "value2",
+                "key3": "value3",
+            }
+        )
+        pd._fill_missing_param_source("task")
+        for key, expected_source in (
+            ("key", "Dag"),
+            ("key2", "task"),
+            ("key3", "task"),
+        ):
+            assert pd.get_param(key).source == expected_source
+
+    def test_filter_params_by_source(self):
+        pd = ParamsDict(
+            {
+                "key": Param("value", type="string", source="Dag"),
+                "key2": Param("value", source="task"),
+            }
+        )
+        assert ParamsDict.filter_params_by_source(pd, "Dag") == ParamsDict(
+            {"key": Param("value", type="string", source="Dag")},
+        )
+        assert ParamsDict.filter_params_by_source(pd, "task") == ParamsDict(
+            {
+                "key2": Param("value", source="task"),
+            }
+        )

--- a/task-sdk/tests/task_sdk/definitions/test_param.py
+++ b/task-sdk/tests/task_sdk/definitions/test_param.py
@@ -347,8 +347,8 @@ class TestParamsDict:
                 "key2": Param("value", source="task"),
             }
         )
-        assert ParamsDict.filter_params_by_source(pd, "Dag") == ParamsDict(
-            {"key": Param("value", type="string", source="Dag")},
+        assert ParamsDict.filter_params_by_source(pd, "dag") == ParamsDict(
+            {"key": Param("value", type="string", source="dag")},
         )
         assert ParamsDict.filter_params_by_source(pd, "task") == ParamsDict(
             {


### PR DESCRIPTION
## Why
We merge Dag params and task params as task params, and there's no way to distinguish Dag params and task params. It was by design back then. In most cases, users can ignore the Dag level params if they don't need them. But in some cases, such as HITLOperator, we need to distinguish params from different sources, since the param exists only at the Dag level and has no meaning to them, and causes confusion in the "Required Action" tab. 

## What
* task-sdk
    * Add source to `Param`
    * Update source when merging the params
    * Add method `filter_params_by_source` to `ParamsDict`
* standard provider
    * filter only task-level param if `ParamsDict.filter_params_by_source` is available
* core
    * serialize `Param.source` 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
