### PR TITLE
Fix flower network policy condition when multiple executors

### DIFF
--- a/chart/templates/flower/flower-networkpolicy.yaml
+++ b/chart/templates/flower/flower-networkpolicy.yaml
@@ -21,8 +21,7 @@
 ## Airflow Flower NetworkPolicy
 #################################
 {{- if .Values.flower.enabled }}
-{{- $celery_executors := list "CeleryExecutor" "CeleryKubernetesExecutor"}}
-{{- if and .Values.networkPolicies.enabled (has .Values.executor $celery_executors) }}
+{{- if and .Values.networkPolicies.enabled (or (contains "CeleryExecutor" .Values.executor) (contains "CeleryKubernetesExecutor" .Values.executor)) }}
 {{- $from := or .Values.flower.networkPolicy.ingress.from .Values.flower.extraNetworkPolicies }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/helm-tests/tests/helm_tests/airflow_aux/test_basic_helm_chart.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_basic_helm_chart.py
@@ -327,14 +327,24 @@ class TestBaseChartTest:
         assert ("Service", "test-basic-statsd") not in list_of_kind_names_tuples
         assert ("Deployment", "test-basic-statsd") not in list_of_kind_names_tuples
 
-    @pytest.mark.parametrize("airflow_version", ["2.10.0", "3.0.0", "default"])
-    def test_network_policies_are_valid(self, airflow_version):
+    @pytest.mark.parametrize(
+        "airflow_version, executor",
+        [
+            ["2.10.0", "CeleryExecutor"],
+            ["2.10.0", "CeleryExecutor,KubernetesExecutor"],
+            ["3.0.0", "CeleryExecutor"],
+            ["3.0.0", "CeleryExecutor,KubernetesExecutor"],
+            ["default", "CeleryExecutor"],
+            ["default", "CeleryExecutor,KubernetesExecutor"],
+        ],
+    )
+    def test_network_policies_are_valid(self, airflow_version, executor):
         k8s_objects = render_chart(
             name="test-basic",
             values=self._get_values_with_version(
                 values={
                     "networkPolicies": {"enabled": True},
-                    "executor": "CeleryExecutor",
+                    "executor": executor,
                     "flower": {"enabled": True},
                     "pgbouncer": {"enabled": True},
                 },
@@ -366,14 +376,24 @@ class TestBaseChartTest:
         for kind_name in expected_kind_names:
             assert kind_name in kind_names_tuples
 
-    @pytest.mark.parametrize("airflow_version", ["2.10.0", "3.0.0", "default"])
-    def test_labels_are_valid(self, airflow_version):
+    @pytest.mark.parametrize(
+        "airflow_version, executor",
+        [
+            ["2.10.0", "CeleryExecutor"],
+            ["2.10.0", "CeleryExecutor,KubernetesExecutor"],
+            ["3.0.0", "CeleryExecutor"],
+            ["3.0.0", "CeleryExecutor,KubernetesExecutor"],
+            ["default", "CeleryExecutor"],
+            ["default", "CeleryExecutor,KubernetesExecutor"],
+        ],
+    )
+    def test_labels_are_valid(self, airflow_version, executor):
         """Test labels are correctly applied on all objects created by this chart."""
         release_name = "test-basic"
 
         values = {
             "labels": {"label1": "value1", "label2": "value2"},
-            "executor": "CeleryExecutor",
+            "executor": executor,
             "data": {
                 "resultBackendConnection": {
                     "user": "someuser",
@@ -490,6 +510,8 @@ class TestBaseChartTest:
                 expected_labels["component"] = component
             if k8s_object_name == f"{release_name}-scheduler":
                 expected_labels["executor"] = "CeleryExecutor"
+                if executor == "CeleryExecutor,KubernetesExecutor":
+                    expected_labels["executor"] = "CeleryExecutor-KubernetesExecutor"
             actual_labels = kind_k8s_obj_labels_tuples.pop((k8s_object_name, kind))
             assert actual_labels == expected_labels
 

--- a/helm-tests/tests/helm_tests/airflow_aux/test_basic_helm_chart.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_basic_helm_chart.py
@@ -328,9 +328,10 @@ class TestBaseChartTest:
         assert ("Deployment", "test-basic-statsd") not in list_of_kind_names_tuples
 
     @pytest.mark.parametrize(
-        "airflow_version, executor",
+        ("airflow_version", "executor"),
         [
             ["2.10.0", "CeleryExecutor"],
+            ["2.10.0", "CeleryKubernetesExecutor"],
             ["2.10.0", "CeleryExecutor,KubernetesExecutor"],
             ["3.0.0", "CeleryExecutor"],
             ["3.0.0", "CeleryExecutor,KubernetesExecutor"],
@@ -377,7 +378,7 @@ class TestBaseChartTest:
             assert kind_name in kind_names_tuples
 
     @pytest.mark.parametrize(
-        "airflow_version, executor",
+        ("airflow_version", "executor"),
         [
             ["2.10.0", "CeleryExecutor"],
             ["2.10.0", "CeleryExecutor,KubernetesExecutor"],


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

While updating some tests to use multiple executors I noticed I was havving errors related to flower network policy. Turns out it didnt support multiple executor definition

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
