### PR TITLE
[discussion-54853] update webserver probe to new api

### DIFF
--- a/chart/templates/webserver/webserver-deployment.yaml
+++ b/chart/templates/webserver/webserver-deployment.yaml
@@ -212,7 +212,7 @@ spec:
               containerPort: {{ .Values.ports.airflowUI }}
           livenessProbe:
             httpGet:
-              path: {{ if .Values.config.webserver.base_url }}{{- with urlParse (tpl .Values.config.webserver.base_url .) }}{{ .path }}{{ end }}{{ end }}/health
+              path: {{ if .Values.config.webserver.base_url }}{{- with urlParse (tpl .Values.config.webserver.base_url .) }}{{ .path }}{{ end }}{{ end }}/api/v2/version
               port: {{ .Values.ports.airflowUI }}
               {{- if .Values.config.webserver.base_url}}
               httpHeaders:

--- a/chart/templates/webserver/webserver-deployment.yaml
+++ b/chart/templates/webserver/webserver-deployment.yaml
@@ -212,7 +212,7 @@ spec:
               containerPort: {{ .Values.ports.airflowUI }}
           livenessProbe:
             httpGet:
-              path: {{ if .Values.config.webserver.base_url }}{{- with urlParse (tpl .Values.config.webserver.base_url .) }}{{ .path }}{{ end }}{{ end }}/api/v2/version
+              path: {{ if .Values.config.webserver.base_url }}{{- with urlParse (tpl .Values.config.webserver.base_url .) }}{{ .path }}{{ end }}{{ end }}{{ if semverCompare "<3.0.0" .Values.airflowVersion }}/health{{ else }}/api/v2/version{{ end }}
               port: {{ .Values.ports.airflowUI }}
               {{- if .Values.config.webserver.base_url}}
               httpHeaders:
@@ -226,7 +226,7 @@ spec:
             periodSeconds: {{ .Values.webserver.livenessProbe.periodSeconds }}
           readinessProbe:
             httpGet:
-              path: {{ if .Values.config.webserver.base_url }}{{- with urlParse (tpl .Values.config.webserver.base_url .) }}{{ .path }}{{ end }}{{ end }}/api/v2/version
+              path: {{ if .Values.config.webserver.base_url }}{{- with urlParse (tpl .Values.config.webserver.base_url .) }}{{ .path }}{{ end }}{{ end }}{{ if semverCompare "<3.0.0" .Values.airflowVersion }}/health{{ else }}/api/v2/version{{ end }}
               port: {{ .Values.ports.airflowUI }}
               {{- if .Values.config.webserver.base_url }}
               httpHeaders:
@@ -240,7 +240,7 @@ spec:
             periodSeconds: {{ .Values.webserver.readinessProbe.periodSeconds }}
           startupProbe:
             httpGet:
-              path: {{ if .Values.config.webserver.base_url }}{{- with urlParse (tpl .Values.config.webserver.base_url .) }}{{ .path }}{{ end }}{{ end }}/api/v2/version
+              path: {{ if .Values.config.webserver.base_url }}{{- with urlParse (tpl .Values.config.webserver.base_url .) }}{{ .path }}{{ end }}{{ end }}{{ if semverCompare "<3.0.0" .Values.airflowVersion }}/health{{ else }}/api/v2/version{{ end }}
               port: {{ .Values.ports.airflowUI }}
               {{- if .Values.config.webserver.base_url}}
               httpHeaders:

--- a/chart/templates/webserver/webserver-deployment.yaml
+++ b/chart/templates/webserver/webserver-deployment.yaml
@@ -226,7 +226,7 @@ spec:
             periodSeconds: {{ .Values.webserver.livenessProbe.periodSeconds }}
           readinessProbe:
             httpGet:
-              path: {{ if .Values.config.webserver.base_url }}{{- with urlParse (tpl .Values.config.webserver.base_url .) }}{{ .path }}{{ end }}{{ end }}/health
+              path: {{ if .Values.config.webserver.base_url }}{{- with urlParse (tpl .Values.config.webserver.base_url .) }}{{ .path }}{{ end }}{{ end }}/api/v2/version
               port: {{ .Values.ports.airflowUI }}
               {{- if .Values.config.webserver.base_url }}
               httpHeaders:
@@ -240,7 +240,7 @@ spec:
             periodSeconds: {{ .Values.webserver.readinessProbe.periodSeconds }}
           startupProbe:
             httpGet:
-              path: {{ if .Values.config.webserver.base_url }}{{- with urlParse (tpl .Values.config.webserver.base_url .) }}{{ .path }}{{ end }}{{ end }}/health
+              path: {{ if .Values.config.webserver.base_url }}{{- with urlParse (tpl .Values.config.webserver.base_url .) }}{{ .path }}{{ end }}{{ end }}/api/v2/version
               port: {{ .Values.ports.airflowUI }}
               {{- if .Values.config.webserver.base_url}}
               httpHeaders:

--- a/helm-tests/tests/helm_tests/webserver/test_webserver.py
+++ b/helm-tests/tests/helm_tests/webserver/test_webserver.py
@@ -108,15 +108,15 @@ class TestWebserverDeployment:
 
         assert (
             jmespath.search("spec.template.spec.containers[0].livenessProbe.httpGet.path", docs[0])
-            == "/mypath/path/health"
+            == "/mypath/path/api/v2/version"
         )
         assert (
             jmespath.search("spec.template.spec.containers[0].readinessProbe.httpGet.path", docs[0])
-            == "/mypath/path/health"
+            == "/mypath/path/api/v2/version"
         )
         assert (
             jmespath.search("spec.template.spec.containers[0].startupProbe.httpGet.path", docs[0])
-            == "/mypath/path/health"
+            == "/mypath/path/api/v2/version"
         )
 
     @pytest.mark.parametrize(
@@ -183,9 +183,18 @@ class TestWebserverDeployment:
         assert {"name": "Host", "value": "release-name.com"} in jmespath.search(
             "startupProbe.httpGet.httpHeaders", container
         )
-        assert jmespath.search("livenessProbe.httpGet.path", container) == "/mypath/release-name/path/health"
-        assert jmespath.search("readinessProbe.httpGet.path", container) == "/mypath/release-name/path/health"
-        assert jmespath.search("startupProbe.httpGet.path", container) == "/mypath/release-name/path/health"
+        assert (
+            jmespath.search("livenessProbe.httpGet.path", container)
+            == "/mypath/release-name/path/api/v2/version"
+        )
+        assert (
+            jmespath.search("readinessProbe.httpGet.path", container)
+            == "/mypath/release-name/path/api/v2/version"
+        )
+        assert (
+            jmespath.search("startupProbe.httpGet.path", container)
+            == "/mypath/release-name/path/api/v2/version"
+        )
 
     def test_should_add_scheme_to_liveness_and_readiness_and_startup_probes(self):
         docs = render_chart(

--- a/helm-tests/tests/helm_tests/webserver/test_webserver.py
+++ b/helm-tests/tests/helm_tests/webserver/test_webserver.py
@@ -108,15 +108,15 @@ class TestWebserverDeployment:
 
         assert (
             jmespath.search("spec.template.spec.containers[0].livenessProbe.httpGet.path", docs[0])
-            == "/mypath/path/api/v2/version"
+            == "/mypath/path/health"
         )
         assert (
             jmespath.search("spec.template.spec.containers[0].readinessProbe.httpGet.path", docs[0])
-            == "/mypath/path/api/v2/version"
+            == "/mypath/path/health"
         )
         assert (
             jmespath.search("spec.template.spec.containers[0].startupProbe.httpGet.path", docs[0])
-            == "/mypath/path/api/v2/version"
+            == "/mypath/path/health"
         )
 
     @pytest.mark.parametrize(
@@ -185,15 +185,15 @@ class TestWebserverDeployment:
         )
         assert (
             jmespath.search("livenessProbe.httpGet.path", container)
-            == "/mypath/release-name/path/api/v2/version"
+            == "/mypath/release-name/path/health"
         )
         assert (
             jmespath.search("readinessProbe.httpGet.path", container)
-            == "/mypath/release-name/path/api/v2/version"
+            == "/mypath/release-name/path/health"
         )
         assert (
             jmespath.search("startupProbe.httpGet.path", container)
-            == "/mypath/release-name/path/api/v2/version"
+            == "/mypath/release-name/path/health"
         )
 
     def test_should_add_scheme_to_liveness_and_readiness_and_startup_probes(self):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

### Movitvation
- originally motivated by https://github.com/apache/airflow/discussions/54853 I was looking for a way to do liveness probe decoupled from DB performance. The reason is we had issue when DB was slow (or connection pool saturation mentioned in that discussion as well), the webservers were all restarting and the UI was nearly unavailable the whole time. This adds debugging noises (we thought the webserver pods themselves were running out of resources) and also creates a worse impact on the application (UI unavailable > db slowness). 
- additionally, upon looking at the api route code, it looks like the health endpoint is disabled and returning 404. So the probe endpoints of webserver seem to be outdated. https://github.com/apache/airflow/commit/05b32dbe9b327f9fda4d9434211004e0ea714fe6#diff-da26ba2c49d5bc5f117895c11ad7fea6e24615eccd3d27c3300a5026195b5cd8R67

### Changes
- replace the probe endpoints to `api/v2/version` based on this linked issue https://github.com/apache/airflow/issues/49676
  - note: We were using the suggested endpoint `api/v2/monitor/health` but that is prone to metadb healthiness as mentioned above. 


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
