### PR TITLE
Don't crash the scheduler on a stray ADRQ

### DIFF
--- a/airflow-core/src/airflow/models/asset.py
+++ b/airflow-core/src/airflow/models/asset.py
@@ -49,6 +49,7 @@ if TYPE_CHECKING:
 
     from sqlalchemy.orm import Session
 
+    from airflow.models.dag import DagModel
     from airflow.models.trigger import Trigger
     from airflow.sdk.definitions.asset import Asset, AssetAlias
 
@@ -714,8 +715,8 @@ class AssetDagRunQueue(Base):
     asset_id: Mapped[int] = mapped_column(Integer, primary_key=True, nullable=False)
     target_dag_id: Mapped[str] = mapped_column(StringID(), primary_key=True, nullable=False)
     created_at: Mapped[datetime] = mapped_column(UtcDateTime, default=timezone.utcnow, nullable=False)
-    asset = relationship("AssetModel", viewonly=True)
-    dag_model = relationship("DagModel", viewonly=True)
+    asset: Mapped[AssetModel] = relationship("AssetModel", viewonly=True)
+    dag_model: Mapped[DagModel] = relationship("DagModel", viewonly=True)
 
     __tablename__ = "asset_dag_run_queue"
     __table_args__ = (

--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -41,7 +41,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import Mapped, Session, backref, load_only, relationship
+from sqlalchemy.orm import Mapped, Session, backref, joinedload, load_only, relationship
 from sqlalchemy.sql import expression
 
 from airflow import settings
@@ -598,20 +598,29 @@ class DagModel(Base):
 
         evaluator = AssetEvaluator(session)
 
-        def dag_ready(dag_id: str, cond: BaseAsset, statuses: dict[AssetUniqueKey, bool]) -> bool | None:
+        def dag_ready(dag_id: str, cond: BaseAsset, statuses: dict[AssetUniqueKey, bool]) -> bool:
             try:
                 return evaluator.run(cond, statuses)
             except AttributeError:
                 # if dag was serialized before 2.9 and we *just* upgraded,
                 # we may be dealing with old version.  In that case,
                 # just wait for the dag to be reserialized.
-                log.warning("dag '%s' has old serialization; skipping DAG run creation.", dag_id)
-                return None
+                log.warning("Dag '%s' has old serialization; skipping run creation.", dag_id)
+                return False
+            except Exception:
+                log.exception("Dag '%s' failed to be evaluated; assuming not ready", dag_id)
+                return False
 
         # this loads all the ADRQ records.... may need to limit num dags
         adrq_by_dag: dict[str, list[AssetDagRunQueue]] = defaultdict(list)
-        for r in session.scalars(select(AssetDagRunQueue)):
-            adrq_by_dag[r.target_dag_id].append(r)
+        for adrq in session.scalars(select(AssetDagRunQueue).options(joinedload(AssetDagRunQueue.dag_model))):
+            if adrq.dag_model.asset_expression is None:
+                # The dag referenced does not actually depend on an asset! This
+                # could happen if the dag DID depend on an asset at some point,
+                # but no longer does. Delete the stale adrq.
+                session.delete(adrq)
+            else:
+                adrq_by_dag[adrq.target_dag_id].append(adrq)
 
         dag_statuses: dict[str, dict[AssetUniqueKey, bool]] = {
             dag_id: {AssetUniqueKey.from_asset(adrq.asset): True for adrq in adrqs}

--- a/airflow-core/tests/unit/models/test_dag.py
+++ b/airflow-core/tests/unit/models/test_dag.py
@@ -2066,6 +2066,35 @@ class TestDagModel:
         query, _ = DagModel.dags_needing_dagruns(session)
         assert [dm.dag_id for dm in query] == ["consumer"]
 
+    @pytest.mark.want_activate_assets
+    @pytest.mark.need_serialized_dag
+    def test_dags_needing_dagruns_checking_stale_adrq(self, dag_maker, session):
+        asset = Asset(name="1", uri="s3://bucket/assets/1")
+        dag_id_to_test = "test"
+
+        # Dag 'test' depends on an outlet in 'producer'.
+        with dag_maker(dag_id="producer", schedule=None, session=session):
+            op = EmptyOperator(task_id="op", outlets=asset)
+        dr = dag_maker.create_dagrun()
+        outlet_ti = dr.get_task_instance("op")
+        outlet_ti.refresh_from_task(op)
+        with dag_maker(dag_id=dag_id_to_test, schedule=asset, session=session):
+            pass
+
+        # An adrq should be created when the outlet task is run.
+        outlet_ti.run()
+        query, _ = DagModel.dags_needing_dagruns(session)
+        assert [dm.dag_id for dm in query] == [dag_id_to_test]
+        assert session.scalars(select(AssetDagRunQueue.target_dag_id)).all() == [dag_id_to_test]
+
+        # Now the dag is changed to NOT depend on 'producer'.
+        # Rerunning dags_needing_dagruns should clear up that adrq.
+        with dag_maker(dag_id=dag_id_to_test, schedule=None, session=session):
+            pass
+        query, _ = DagModel.dags_needing_dagruns(session)
+        assert query.all() == []
+        assert session.scalars(select(AssetDagRunQueue.target_dag_id)).all() == []
+
     def test_max_active_runs_not_none(self, testing_dag_bundle):
         dag = DAG(
             dag_id="test_max_active_runs_not_none",


### PR DESCRIPTION
In edge cases, an ADRQ could end up being processed when the dag does not depend on assets. This would cause the scheduler to crash since there are no assets against the dag to be evaluated.

An additional check is added before asset evaluation to ensure the dag actually has assets to be evaluated. In case this check still lets some edge cases past, the scheduler now does not crash when asset evaluation fails, but logs an error message while leaving the ADRQ where it is.