### PR TITLE
Consistently exclude Python 3.14

### DIFF
--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -41,7 +41,7 @@ license-files = ["LICENSE", "NOTICE"]
 # proactively. This way we also have a chance to test it with Python 3.14 and bump the upper binding
 # and manually mark providers that do not support it yet with !-3.14 - until they support it - which will
 # also exclude resolving uv workspace dependencies for those providers.
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10,!=3.14"
 authors = [
     { name = "Apache Software Foundation", email = "dev@airflow.apache.org" },
 ]

--- a/airflow-ctl-tests/pyproject.toml
+++ b/airflow-ctl-tests/pyproject.toml
@@ -26,7 +26,7 @@ description = "Airflow CTL tests for Apache Airflow"
 classifiers = [
     "Private :: Do Not Upload",
 ]
-requires-python = ">=3.10,!=3.13"
+requires-python = ">=3.10,!=3.14"
 authors = [
     { name = "Apache Software Foundation", email = "dev@airflow.apache.org" },
 ]

--- a/airflow-ctl/pyproject.toml
+++ b/airflow-ctl/pyproject.toml
@@ -26,7 +26,7 @@ license-files = ["LICENSE", "NOTICE"]
 # out-of-the box. Airflow-ctl is a small tool that does not have many dependencies and does not use
 # sophisticated features of Python, so it should work with Python 3.14+ once all it's dependencies are
 # updated to support it.
-requires-python = ">=3.10"
+requires-python = ">=3.10,!=3.14"
 dependencies = [
     # TODO there could be still missing deps such as airflow-core
     "argcomplete>=1.10",

--- a/airflow-e2e-tests/pyproject.toml
+++ b/airflow-e2e-tests/pyproject.toml
@@ -25,7 +25,7 @@ description = "E2E tests for Apache Airflow"
 classifiers = [
     "Private :: Do Not Upload",
 ]
-requires-python = ">=3.10,!=3.13"
+requires-python = ">=3.10,!=3.14"
 authors = [
     { name = "Apache Software Foundation", email = "dev@airflow.apache.org" },
 ]

--- a/chart/pyproject.toml
+++ b/chart/pyproject.toml
@@ -24,7 +24,7 @@ build-backend = "hatchling.build"
 [project]
 name = "apache-airflow-helm-chart"
 description = "Programmatically author, schedule and monitor data pipelines"
-requires-python = ">=3.10"
+requires-python = ">=3.10,!=3.14"
 authors = [
     { name = "Apache Software Foundation", email = "dev@airflow.apache.org" },
 ]

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -26,7 +26,7 @@ description = "Apache Airflow API (Stable)"
 readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,!=3.14"
 authors = [
     { name = "Apache Software Foundation", email = "dev@airflow.apache.org" },
 ]

--- a/dev/breeze/pyproject.toml
+++ b/dev/breeze/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-requires-python = ">=3.10, !=3.13"
+requires-python = ">=3.10,!=3.14"
 
 dependencies = [
     "black>=25.0.0",

--- a/dev/pyproject.toml
+++ b/dev/pyproject.toml
@@ -26,7 +26,7 @@ description = "Development tools for Apache Airflow"
 classifiers = [
     "Private :: Do Not Upload",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.10,!=3.14"
 authors = [
     { name = "Apache Software Foundation", email = "dev@airflow.apache.org" },
 ]

--- a/docker-stack-docs/pyproject.toml
+++ b/docker-stack-docs/pyproject.toml
@@ -24,7 +24,7 @@ build-backend = "hatchling.build"
 [project]
 name = "docker-stack"
 description = "Programmatically author, schedule and monitor data pipelines"
-requires-python = ">=3.10"
+requires-python = ">=3.10,!=3.14"
 authors = [
     { name = "Apache Software Foundation", email = "dev@airflow.apache.org" },
 ]

--- a/docker-tests/pyproject.toml
+++ b/docker-tests/pyproject.toml
@@ -26,7 +26,7 @@ description = "Docker tests for Apache Airflow"
 classifiers = [
     "Private :: Do Not Upload",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.10,!=3.14"
 authors = [
     { name = "Apache Software Foundation", email = "dev@airflow.apache.org" },
 ]

--- a/helm-tests/pyproject.toml
+++ b/helm-tests/pyproject.toml
@@ -26,7 +26,7 @@ description = "Helm tests for Apache Airflow"
 classifiers = [
     "Private :: Do Not Upload",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.10,!=3.14"
 authors = [
     { name = "Apache Software Foundation", email = "dev@airflow.apache.org" },
 ]

--- a/kubernetes-tests/pyproject.toml
+++ b/kubernetes-tests/pyproject.toml
@@ -24,7 +24,7 @@ description = "Kubernetes tests for Apache Airflow"
 classifiers = [
     "Private :: Do Not Upload",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.10,!=3.14"
 authors = [
     { name = "Apache Software Foundation", email = "dev@airflow.apache.org" },
 ]

--- a/performance/pyproject.toml
+++ b/performance/pyproject.toml
@@ -21,7 +21,7 @@ build-backend = "flit_core.buildapi"
 [project]
 name = "apache-airflow-performance"
 version = "0.1.0"
-requires-python = ">=3.10,!=3.13"
+requires-python = ">=3.10,!=3.14"
 description = "Performance testing utilities and DAGs for Apache Airflow"
 readme = { file = "README.md", content-type = "text/markdown" }
 license = "Apache-2.0"

--- a/providers-summary-docs/pyproject.toml
+++ b/providers-summary-docs/pyproject.toml
@@ -24,7 +24,7 @@ build-backend = "hatchling.build"
 [project]
 name = "apache-airflow-providers"
 description = "Programmatically author, schedule and monitor data pipelines"
-requires-python = ">=3.10"
+requires-python = ">=3.10,!=3.14"
 authors = [
     { name = "Apache Software Foundation", email = "dev@airflow.apache.org" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,12 +35,7 @@ description = "Programmatically author, schedule and monitor data pipelines"
 readme = { file = "generated/PYPI_README.md", content-type = "text/markdown" }
 license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE"]
-# We know that it will take a while before we can support Python 3.14 because of all our dependencies
-# It takes about 4-7 months after Python release before we can support it, so we limit it to <3.14
-# proactively. This way we also have a chance to test it with Python 3.14 and bump the upper binding
-# and manually mark providers that do not support it yet with !-3.14 - until they support it - which will
-# also exclude resolving uv workspace dependencies for those providers.
-requires-python = ">=3.10, <3.14"
+requires-python = ">=3.10,!=3.14"
 authors = [
     { name = "Apache Software Foundation", email = "dev@airflow.apache.org" },
 ]

--- a/task-sdk-integration-tests/pyproject.toml
+++ b/task-sdk-integration-tests/pyproject.toml
@@ -26,7 +26,7 @@ description = "Task SDK integration tests for Apache Airflow"
 classifiers = [
     "Private :: Do Not Upload",
 ]
-requires-python = ">=3.10,!=3.13"
+requires-python = ">=3.10,!=3.14"
 authors = [
     { name = "Apache Software Foundation", email = "dev@airflow.apache.org" },
 ]

--- a/task-sdk/pyproject.toml
+++ b/task-sdk/pyproject.toml
@@ -26,7 +26,7 @@ license-files = ["LICENSE", "NOTICE"]
 # in all our providers - and usually it will take a while before we can support it for majority of
 # providers, so we proactively limit it to <3.14.
 # It takes about 4-7 months after Python release before we can support it
-requires-python = ">=3.10, <3.14"
+requires-python = ">=3.10,!=3.14"
 
 authors = [
     {name="Apache Software Foundation", email="dev@airflow.apache.org"},


### PR DESCRIPTION
Since UV and other installers essentially ignore < limit in the python-requires, a good practice is to simply exclude current Python versions that we **know** we are not compatible with rather than using <.

Python 3.14 is a thing now and people will get it by default as latest versions, but we do not run our tests with Python 3.14 yet (not until March/April 2026). Providers have all upper-bind exclusion except those that do not support Python 3.13, but that's ok because they are actually limited by Airflow they can be installed on. But for distributions like airflow-ctl, we should explicitly exclude 3.14 until we support and test it.

This PR synchronizes all python-requires in non-provider distribution to consistently exclude Python 3.14 with !=.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
