### PR TITLE
Close zh-TW translation gaps

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/assets.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/assets.json
@@ -3,6 +3,7 @@
   "asset_many": "資源",
   "asset_one": "資源",
   "consumingDags": "消費者 Dags",
+  "consumingTasks": "消費者任務",
   "createEvent": {
     "button": "建立事件",
     "manual": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/common.json
@@ -90,6 +90,7 @@
     "back": "返回",
     "defaultMessage": "發生未預期的錯誤",
     "home": "首頁",
+    "invalidUrl": "找不到頁面。請檢查 URL 並重試。",
     "notFound": "找不到頁面",
     "title": "錯誤"
   },
@@ -109,10 +110,9 @@
   "filters": {
     "durationFrom": "從執行時間",
     "durationTo": "到執行時間",
-    "logicalDateFrom": "從邏輯日期",
-    "logicalDateTo": "到邏輯日期",
-    "runAfterFrom": "從最早可執行時間",
-    "runAfterTo": "到最早可執行時間"
+    "endTime": "結束時間",
+    "selectDateRange": "選擇日期範圍",
+    "startTime": "起始時間"
   },
   "logicalDate": "邏輯日期",
   "logout": "登出",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/components.json
@@ -53,7 +53,7 @@
     "validation": {
       "invalidDateFormat": "無效的日期格式",
       "invalidTimeFormat": "無效的時間格式",
-      "startBeforeEnd": "開始日期/時間必須在結束日期/時間之前"
+      "startBeforeEnd": "開始時間必須在結束時間之前"
     }
   },
   "durationChart": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/components.json
@@ -49,6 +49,13 @@
     "warning_one": "1 個警告",
     "warning_other": "{{count}} 個警告"
   },
+  "dateRangeFilter": {
+    "validation": {
+      "invalidDateFormat": "無效的日期格式",
+      "invalidTimeFormat": "無效的時間格式",
+      "startBeforeEnd": "開始日期/時間必須在結束日期/時間之前"
+    }
+  },
   "durationChart": {
     "duration": "持續時間 (秒)",
     "lastDagRun_one": "最近 1 次 Dag 執行",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/dag.json
@@ -114,6 +114,18 @@
     },
     "graphDirection": {
       "label": "圖表方向"
+    },
+    "taskStreamFilter": {
+      "activeFilter": "啟用過濾器",
+      "clearFilter": "清除過濾器",
+      "clickTask": "點擊一個任務以將其選為過濾根",
+      "label": "過濾器",
+      "options": {
+        "both": "上游和下游",
+        "downstream": "下游",
+        "upstream": "上游"
+      },
+      "selectedTask": "選定任務"
     }
   },
   "paramsFailed": "載入參數失敗",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/dags.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/dags.json
@@ -34,6 +34,10 @@
       "error": "清除 {{type}} 時發生錯誤",
       "title": "清除 {{type}}"
     },
+    "confirmationDialog": {
+      "description": "此任務目前處於 {{state}} 狀態，由使用者 {{user}} 於 {{time}} 啟動。\n除非任務執行完畢，或是在清除任務對話框中取消勾選「防止重新執行執行中的任務」選項，否則無法清除此任務。",
+      "title": "無法清除任務實例"
+    },
     "delete": {
       "button": "刪除 {{type}}",
       "dialog": {
@@ -61,6 +65,7 @@
       "future": "未來",
       "onlyFailed": "只清除失敗任務",
       "past": "過去",
+      "preventRunningTasks": "如果任務正在運行，則阻止重新運行",
       "queueNew": "排隊新任務",
       "runOnLatestVersion": "執行最新套件包版本",
       "upstream": "上游"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/hitl.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/hitl.json
@@ -1,8 +1,7 @@
 {
   "filters": {
     "body": "內文",
-    "createdAtFrom": "從建立時間",
-    "createdAtTo": "到建立時間",
+    "createdAt": "建立於",
     "response": {
       "all": "全部",
       "pending": "待回應",


### PR DESCRIPTION
Just realized that these translation keys should've been removed in #56173, they are unused.

```
      filters.logicalDateTo
      filters.logicalDateFrom
      filters.runAfterTo
      filters.runAfterFrom
```

I will open a separate PR to remove these keys from all files, keeping this PR focused on the zh-TW translations.

Also, as far as I know, we don't currently have a script to check for unused keys. I'll try to implement one.

<img width="1254" height="1096" alt="CleanShot 2025-11-24 at 21 25 55@2x" src="https://github.com/user-attachments/assets/c08104ee-6e11-446a-935f-2c59aa42e347" />



<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
