### PR TITLE
Bugfix/mask sensitive values in cli

### DIFF
--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -806,6 +806,11 @@ ARG_OPTION = Arg(
     ("option",),
     help="The option name",
 )
+ARG_HIDE_SENSITIVE = Arg(
+    ("--hide-sensitive",),
+    action="store_true",
+    help="When used with --show-values, hide sensitive values (passwords, keys, tokens, etc.) and only show non-sensitive configuration values.",
+)
 ARG_CONFIG_SHOW_VALUES = Arg(
     ("--show-values",),
     action="store_true",
@@ -1743,7 +1748,8 @@ CONFIG_COMMANDS = (
             ARG_EXCLUDE_PROVIDERS,
             ARG_DEFAULTS,
             ARG_VERBOSE,
-            ARG_CONFIG_SHOW_VALUES
+            ARG_HIDE_SENSITIVE,
+            ARG_CONFIG_SHOW_VALUES,
         ),
     ),
     ActionCommand(

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -806,6 +806,15 @@ ARG_OPTION = Arg(
     ("option",),
     help="The option name",
 )
+ARG_CONFIG_SHOW_VALUES = Arg(
+    ("--show-values",),
+    action="store_true",
+    help=(
+        "Show configuration values. "
+        "By default only option names are shown and values (including potentially "
+        "sensitive ones) are hidden."
+    ),
+)
 
 # lint
 ARG_LINT_CONFIG_SECTION = Arg(
@@ -1734,6 +1743,7 @@ CONFIG_COMMANDS = (
             ARG_EXCLUDE_PROVIDERS,
             ARG_DEFAULTS,
             ARG_VERBOSE,
+            ARG_CONFIG_SHOW_VALUES
         ),
     ),
     ActionCommand(

--- a/airflow-core/src/airflow/cli/commands/config_command.py
+++ b/airflow-core/src/airflow/cli/commands/config_command.py
@@ -38,8 +38,7 @@ from airflow.utils.providers_configuration_loader import providers_configuration
 @providers_configuration_loaded
 def show_config(args):
     """Show current application configuration."""
-    show_values = getattr(args, "show_values", False)
-    if not show_values:
+    if not args.show_values:
         print(
             "Values are hidden by default. Use `--show-values` to display them (may include sensitive data).",
             file=sys.stderr,
@@ -55,7 +54,7 @@ def show_config(args):
             include_providers=not args.exclude_providers,
             comment_out_everything=args.comment_out_everything or args.defaults,
             only_defaults=args.defaults,
-            non_sensitive=args.non_sensitive,
+            hide_sensitive=args.hide_sensitive,
             show_values=args.show_values,
         )
         code = output.getvalue()

--- a/airflow-core/src/airflow/cli/commands/config_command.py
+++ b/airflow-core/src/airflow/cli/commands/config_command.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 import shutil
+import sys
 from dataclasses import dataclass
 from io import StringIO
 from typing import Any, NamedTuple
@@ -37,6 +38,12 @@ from airflow.utils.providers_configuration_loader import providers_configuration
 @providers_configuration_loaded
 def show_config(args):
     """Show current application configuration."""
+    show_values = getattr(args, "show_values", False)
+    if not show_values:
+        print(
+            "Values are hidden by default. Use `--show-values` to display them (may include sensitive data).",
+            file=sys.stderr,
+        )
     with StringIO() as output:
         conf.write(
             output,
@@ -48,6 +55,8 @@ def show_config(args):
             include_providers=not args.exclude_providers,
             comment_out_everything=args.comment_out_everything or args.defaults,
             only_defaults=args.defaults,
+            non_sensitive=args.non_sensitive,
+            show_values=args.show_values,
         )
         code = output.getvalue()
     if should_use_colors(args):

--- a/airflow-core/src/airflow/configuration.py
+++ b/airflow-core/src/airflow/configuration.py
@@ -747,6 +747,7 @@ def write_default_airflow_configuration_if_needed() -> AirflowConfigParser:
                 include_providers=True,
                 extra_spacing=True,
                 only_defaults=True,
+                show_values=True,
             )
     return conf
 

--- a/airflow-core/tests/unit/core/test_configuration.py
+++ b/airflow-core/tests/unit/core/test_configuration.py
@@ -696,7 +696,7 @@ class TestConf:
     def test_write_should_respect_env_variable(self):
         parser = AirflowConfigParser()
         with StringIO() as string_file:
-            parser.write(string_file)
+            parser.write(string_file, show_values=True)
             content = string_file.getvalue()
         assert "dags_folder = /tmp/test_folder" in content
 
@@ -1020,7 +1020,7 @@ class TestConf:
         test_conf.set("test_json", "my_json_config", json_string)
 
         with StringIO() as string_file:
-            test_conf.write(string_file, include_descriptions=False, include_env_vars=False)
+            test_conf.write(string_file, include_descriptions=False, include_env_vars=False, show_values=True)
             content = string_file.getvalue()
 
         expected_formatted_string = (
@@ -1047,7 +1047,7 @@ class TestConf:
         test_conf.set("test_multiline", "my_string_config", multiline_string)
 
         with StringIO() as string_file:
-            test_conf.write(string_file, include_descriptions=False, include_env_vars=False)
+            test_conf.write(string_file, include_descriptions=False, include_env_vars=False, show_values=True)
             content = string_file.getvalue()
 
         expected_raw_output = "my_string_config = This is the first line.\nThis is the second line.\n"

--- a/shared/configuration/src/airflow_shared/configuration/parser.py
+++ b/shared/configuration/src/airflow_shared/configuration/parser.py
@@ -1594,29 +1594,39 @@ class AirflowConfigParser(ConfigParser):
         needs_separation: bool,
         only_defaults: bool,
         section_to_write: str,
+        hide_sensitive: bool,
+        is_sensitive: bool,
+        show_values: bool = False,
     ):
         default_value = self.get_default_value(section_to_write, option, raw=True)
         if only_defaults:
             value = default_value
         else:
             value = self.get(section_to_write, option, fallback=default_value, raw=True)
-        if value is None:
+        if not show_values:
             file.write(f"# {option} = \n")
         else:
-            if comment_out_everything:
-                value_lines = value.splitlines()
-                value = "\n# ".join(value_lines)
-                file.write(f"# {option} = {value}\n")
+            if hide_sensitive and is_sensitive:
+                value = "< hidden >"
             else:
-                if "\n" in value:
-                    try:
-                        value = json.dumps(json.loads(value), indent=4)
-                        value = value.replace(
-                            "\n", "\n    "
-                        )  # indent multi-line JSON to satisfy configparser format
-                    except JSONDecodeError:
-                        pass
-                file.write(f"{option} = {value}\n")
+                pass
+            if value is None:
+                file.write(f"# {option} = \n")
+            else:
+                if comment_out_everything:
+                    value_lines = value.splitlines()
+                    value = "\n# ".join(value_lines)
+                    file.write(f"# {option} = {value}\n")
+                else:
+                    if "\n" in value:
+                        try:
+                            value = json.dumps(json.loads(value), indent=4)
+                            value = value.replace(
+                                "\n", "\n    "
+                            )  # indent multi-line JSON to satisfy configparser format
+                        except JSONDecodeError:
+                            pass
+                    file.write(f"{option} = {value}\n")
         if needs_separation:
             file.write("\n")
 
@@ -1630,9 +1640,10 @@ class AirflowConfigParser(ConfigParser):
         include_env_vars: bool = True,
         include_providers: bool = True,
         comment_out_everything: bool = False,
-        hide_sensitive_values: bool = False,
+        hide_sensitive: bool = False,
         extra_spacing: bool = True,
         only_defaults: bool = False,
+        show_values: bool = False,
         **kwargs: Any,
     ) -> None:
         """
@@ -1675,6 +1686,10 @@ class AirflowConfigParser(ConfigParser):
                             section_to_write=section_to_write,
                             sources_dict=sources_dict,
                         )
+                        is_sensitive = (
+                            section_to_write.lower(),
+                            option.lower(),
+                        ) in self.sensitive_config_values
                         self._write_value(
                             file=file,
                             option=option,
@@ -1682,6 +1697,9 @@ class AirflowConfigParser(ConfigParser):
                             needs_separation=needs_separation,
                             only_defaults=only_defaults,
                             section_to_write=section_to_write,
+                            hide_sensitive=hide_sensitive,
+                            is_sensitive=is_sensitive,
+                            show_values=show_values,
                         )
                     if include_descriptions and not needs_separation:
                         # extra separation between sections in case last option did not need it


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
related: https://github.com/apache/airflow/issues/55947
## The purpose of this PR:
Mask sensitive values in cli
The sensitive values are:
```
secret_key
jwt_secret
asset_manager_kwargs
fernet_key
sql_alchemy_conn
sql_alchemy_conn_async
sql_alchemy_engine_args
remote_task_handler_kwargs
backend_kwargs
sentry_dsn
secret_key
secrets_backend_kwargs
```
### What this PR changed:
- ~Add two parameter `hide_sensitive_values`, and `is_sensitive` in `def _write_value`~
- ~Add logic to check if the value is sensitive. If it is, print the value as "< hidden >", if not, print the original value.~
- Add `hide_sensitive`, `show_values`, and `is_sensitive` to `_write_value()`
- Update `_write_value` so that it print keys by default, and print values(including sensitive values) only when `show_values` is specified.
- Allow `hide_sensitive` to be used together with `show_values` to display values while masking sensitive information.



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
