### PR TITLE
Mask secrets properly when using deprecated import path

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/secrets_masker.py
+++ b/task-sdk/src/airflow/sdk/execution_time/secrets_masker.py
@@ -27,10 +27,13 @@ from __future__ import annotations
 
 import warnings
 
+# Note: This import from airflow-core is ok, as this is a compatibility module which we will remove in 3.2 anyways
+from airflow.utils.deprecation_tools import DeprecatedImportWarning
+
 warnings.warn(
     "Importing from 'airflow.sdk.execution_time.secrets_masker' is deprecated and will be removed in a future version. "
     "Please use 'airflow.sdk._shared.secrets_masker' instead.",
-    DeprecationWarning,
+    DeprecatedImportWarning,
     stacklevel=2,
 )
 
@@ -38,6 +41,11 @@ warnings.warn(
 def __getattr__(name: str):
     """Dynamically import attributes from the shared secrets_masker location."""
     try:
+        if name == "mask_secret":
+            from airflow.sdk.log import mask_secret
+
+            return mask_secret
+
         import airflow.sdk._shared.secrets_masker as new_module
 
         return getattr(new_module, name)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

The deprecated import path 'airflow.sdk.execution_time.secrets_masker' was redirecting mask_secret() to a single-process implementation that only masked secrets in the task subprocess. This caused secrets to not be masked in logs because the supervisor process (which writes logs) did not receive masking instructions through this message: https://github.com/apache/airflow/blob/main/task-sdk/src/airflow/sdk/log.py#L244-L250

Users importing `mask_secret` from the old path would see their secrets appear unmasked in task logs despite calling `mask_secret()` successfully.

The compatibility shim now redirects `mask_secret` to the supervisor aware implementation in `airflow.sdk.log` that properly masks secrets in both the task and supervisor processes.

### Testing

DAG used:
```python
import sys
from time import sleep

from airflow.sdk import DAG, Variable
from airflow.providers.standard.operators.python import PythonOperator
from airflow.exceptions import AirflowTaskTimeout

from airflow.sdk.execution_time.secrets_masker import mask_secret

mask_secret("username")


def py_callable():
    print("Hello World!")
    print("This is an username: username")
    print(f"This is in dict form: {{'key': 'username'}}")
    print(f"This is in list form: {[1, 2, 3, 'username']}")


with DAG(
    dag_id="testing_secrets_masker",
    schedule=None,
    catchup=False,
    tags=["hello", "world"],
) as dag:
    my_task = PythonOperator(
        task_id="say_hello",
        python_callable=py_callable,
    )

```

Before the change:
<img width="1745" height="401" alt="image" src="https://github.com/user-attachments/assets/464d9b2c-4533-419e-b979-f7f9c6045ce9" />


After the change:

<img width="1745" height="401" alt="image" src="https://github.com/user-attachments/assets/0d30d225-360a-409f-ab71-1f0ee8cfc689" />


I also fixed the deprecation warning which was not being emitted.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
