### PR TITLE
Add one as a fallback grid value for number of dagruns

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
@@ -84,12 +84,12 @@ const getOptions = (translate: (key: string) => string) =>
 const getWidthBasedConfig = (width: number, enableResponsiveOptions: boolean) => {
   const breakpoints = enableResponsiveOptions
     ? [
-        { limit: 100, min: 1600, options: ["5", "10", "25", "50"] }, // xl: extra large screens
-        { limit: 25, min: 1024, options: ["5", "10", "25"] }, // lg: large screens
-        { limit: 10, min: 384, options: ["5", "10"] }, // md: medium screens
-        { limit: 5, min: 0, options: ["5"] }, // sm: small screens and below
+        { limit: 100, min: 1600, options: ["1", "5", "10", "25", "50"] }, // xl: extra large screens
+        { limit: 25, min: 1024, options: ["1", "5", "10", "25"] }, // lg: large screens
+        { limit: 10, min: 384, options: ["1", "5", "10"] }, // md: medium screens
+        { limit: 5, min: 0, options: ["1", "5"] }, // sm: small screens and below
       ]
-    : [{ limit: 5, min: 0, options: ["5", "10", "25", "50"] }];
+    : [{ limit: 5, min: 0, options: ["1", "5", "10", "25", "50"] }];
 
   const config = breakpoints.find(({ min }) => width >= min) ?? breakpoints[breakpoints.length - 1];
 


### PR DESCRIPTION
Always add 1 as a possible value.

Grid view is sometimes slow to display for very large dags. This ensures a fallback option for people to still be able to use the UI in case the dag is huge and the value of 5 is still too high for a smooth experience.
<img width="1575" height="645" alt="Screenshot 2025-11-25 at 17 30 35" src="https://github.com/user-attachments/assets/226f7475-eed5-48de-b0af-7701546764a1" />
<img width="627" height="702" alt="Screenshot 2025-11-25 at 17 33 02" src="https://github.com/user-attachments/assets/b6aef271-40eb-413e-8616-a1c575ab09c7" />

