### PR TITLE
Fix trigger ui enum parameter field is a dictionary when param.value is null

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldSelector.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldSelector.tsx
@@ -47,6 +47,11 @@ const inferType = (param: ParamSpec) => {
     return "array";
   }
 
+  // Missing value, return 'null' as typeof(null) = 'dict'
+  if (param.value === null) {
+    return "null";
+  }
+
   return typeof param.value;
 };
 
@@ -61,7 +66,7 @@ const isFieldDate = (fieldType: string, fieldSchema: ParamSchema) =>
 const isFieldDateTime = (fieldType: string, fieldSchema: ParamSchema) =>
   fieldType === "string" && fieldSchema.format === "date-time";
 
-const enumTypes = ["string", "number", "integer"];
+const enumTypes = ["null", "string", "number", "integer"];
 
 const isFieldDropdown = (fieldType: string, fieldSchema: ParamSchema) =>
   enumTypes.includes(fieldType) && Array.isArray(fieldSchema.enum);


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/56427
## Problem
When an Enum is used as a parameter in a DAG definition with no default value (or any Param, with no value or type), the field is rendered as a dictionary which might be confusing. 

This is the trigger form's parameters with an enum with no default values, and an empty paramter.
<img width="900" height="880" alt="before" src="https://github.com/user-attachments/assets/f64d5eba-cc39-4b0a-9352-d4294705634b" />

## Solution
- Add 'null' to accepted enum types. (Complies with JSON schema validation)
- Add a condition to return 'null' as the type, when a parameter's value is undefined

Now the enum is a drop down, and the empty parameter is a string field
<img width="900" height="540" alt="after" src="https://github.com/user-attachments/assets/e86eb015-d218-4089-a7e2-c61e2a4a32a1" />

This solves the enum issue, and addresses null values, yet I am unsure if this should be the intended behavior when handling missing default values. Browsing the docs, Param either has default value, or a type defined.
Anyway, I'm open to ideas!


