### PR TITLE
Do not delete users from simple auth manager user file

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/services/login.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/services/login.py
@@ -52,7 +52,7 @@ class SimpleAuthManagerLogin:
             )
 
         users = SimpleAuthManager.get_users()
-        passwords = SimpleAuthManager.get_passwords(users)
+        passwords = SimpleAuthManager.get_passwords()
         found_users = [
             user
             for user in users

--- a/airflow-core/tests/unit/api_fastapi/auth/managers/simple/services/test_login.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/managers/simple/services/test_login.py
@@ -56,8 +56,7 @@ class TestLogin:
             }
         ):
             auth_manager.init()
-            users = auth_manager.get_users()
-            passwords = auth_manager.get_passwords(users=users)
+            passwords = auth_manager.get_passwords()
             result = SimpleAuthManagerLogin.create_token(
                 body=LoginBody(username=test_user, password=passwords.get(test_user, "invalid_password")),
                 expiration_time_in_seconds=1,

--- a/airflow-core/tests/unit/api_fastapi/auth/managers/simple/test_simple_auth_manager.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/managers/simple/test_simple_auth_manager.py
@@ -47,7 +47,6 @@ class TestSimpleAuthManager:
             ("", {}),
             ('{"test1": "test1"}', {"test1": "test1"}),
             ('{"test1": "test1", "test2": "test2"}', {"test1": "test1", "test2": "test2"}),
-            ('{"test1": "test1", "test2": "test2", "test3": "test3"}', {"test1": "test1", "test2": "test2"}),
         ],
     )
     def test_get_passwords(self, auth_manager, file_content, expected):
@@ -58,8 +57,7 @@ class TestSimpleAuthManager:
         ):
             with open(auth_manager.get_generated_password_file(), "w") as file:
                 file.write(file_content)
-            users = auth_manager.get_users()
-            passwords = auth_manager.get_passwords(users)
+            passwords = auth_manager.get_passwords()
             assert passwords == expected
 
     def test_init_with_default_user(self, auth_manager):
@@ -87,8 +85,7 @@ class TestSimpleAuthManager:
         ("file_content", "expected"),
         [
             ({"test1": "test1"}, {"test1": "test1"}),
-            ({"test1": "test1", "test2": "test2"}, {"test1": "test1"}),
-            ({"test2": "test2", "test3": "test3"}, {"test1": mock.ANY}),
+            ({"test2": "test2", "test3": "test3"}, {"test1": mock.ANY, "test2": "test2", "test3": "test3"}),
         ],
     )
     def test_init_with_users_with_password(self, auth_manager, file_content, expected):


### PR DESCRIPTION
We should not delete users from the user/password file, even though some users are not defined in the list of users. They might have been deleted but keeping it in the user/password file makes sense in case we want to reuse them later.

It also avoid the CI to override this file and have some local changes.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
