### PR TITLE
Check for cluster stability just before the transfer

### DIFF
--- a/providers/amazon/tests/system/amazon/aws/example_s3_to_sql.py
+++ b/providers/amazon/tests/system/amazon/aws/example_s3_to_sql.py
@@ -171,6 +171,14 @@ with DAG(
         with open(filepath, newline="") as file:
             return list(csv.reader(file))
 
+    wait_cluster_available_before_transfer = RedshiftClusterSensor(
+        task_id="wait_cluster_available_before_transfer",
+        cluster_identifier=redshift_cluster_identifier,
+        target_status="available",
+        poke_interval=100,
+        timeout=60 * 30,
+    )
+
     transfer_s3_to_sql = S3ToSqlOperator(
         task_id="transfer_s3_to_sql",
         s3_bucket=s3_bucket_name,
@@ -254,6 +262,7 @@ with DAG(
         create_object,
         create_table,
         # TEST BODY
+        wait_cluster_available_before_transfer,
         transfer_s3_to_sql,
         transfer_s3_to_sql_generator,
         check_table,

--- a/providers/amazon/tests/system/amazon/aws/example_sql_to_s3.py
+++ b/providers/amazon/tests/system/amazon/aws/example_sql_to_s3.py
@@ -157,6 +157,14 @@ with DAG(
         wait_for_completion=True,
     )
 
+    wait_cluster_available_before_transfer = RedshiftClusterSensor(
+        task_id="wait_cluster_available_before_transfer",
+        cluster_identifier=redshift_cluster_identifier,
+        target_status="available",
+        poke_interval=100,
+        timeout=60 * 30,
+    )
+
     # [START howto_transfer_sql_to_s3]
     sql_to_s3_task = SqlToS3Operator(
         task_id="sql_to_s3_task",
@@ -203,6 +211,7 @@ with DAG(
         create_table_redshift_data,
         insert_data,
         # TEST BODY
+        wait_cluster_available_before_transfer,
         sql_to_s3_task,
         sql_to_s3_task_with_groupby,
         # TEST TEARDOWN


### PR DESCRIPTION
We seem to get redshift cluster instability just before the transfer starts, add a sensor check just before to ensure the cluster is stable. Best case this will be a no-op that completes immediately if the cluster is available, otherwise it will wait until it is.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
