### PR TITLE
Make cleanup-pods cronjob conditional on kubernetes executor

### DIFF
--- a/chart/templates/cleanup/cleanup-cronjob.yaml
+++ b/chart/templates/cleanup/cleanup-cronjob.yaml
@@ -20,7 +20,7 @@
 ################################
 ## Airflow Cleanup Pods CronJob
 #################################
-{{- if .Values.cleanup.enabled }}
+{{- if (and .Values.cleanup.enabled (contains "KubernetesExecutor" .Values.executor)) }}
 {{- $nodeSelector := or .Values.cleanup.nodeSelector .Values.nodeSelector }}
 {{- $affinity := or .Values.cleanup.affinity .Values.affinity }}
 {{- $tolerations := or .Values.cleanup.tolerations .Values.tolerations }}
@@ -66,7 +66,6 @@ spec:
               {{- mustMerge .Values.cleanup.labels .Values.labels | toYaml | nindent 12 }}
             {{- end }}
           annotations:
-            sidecar.istio.io/inject: "false"
             {{- if .Values.airflowPodAnnotations }}
               {{- toYaml .Values.airflowPodAnnotations | nindent 12 }}
             {{- end }}

--- a/chart/templates/cleanup/cleanup-serviceaccount.yaml
+++ b/chart/templates/cleanup/cleanup-serviceaccount.yaml
@@ -20,7 +20,8 @@
 ################################
 ## Airflow Cleanup ServiceAccount
 #################################
-{{- if and .Values.cleanup.serviceAccount.create .Values.cleanup.enabled }}
+{{- if (and .Values.cleanup.enabled (contains "KubernetesExecutor" .Values.executor)) }}
+{{- if .Values.cleanup.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.cleanup.serviceAccount.automountServiceAccountToken }}
@@ -38,4 +39,5 @@ metadata:
   {{- with .Values.cleanup.serviceAccount.annotations }}
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2804,7 +2804,8 @@ quotas: {}
 # Define default/max/min values for pods and containers in namespace
 limits: []
 
-# This runs as a CronJob to cleanup old pods.
+# This runs as a CronJob to cleanup old pods spawned by the KubernetesExecutor.
+# It is required to have KubernetesExecutor enabled.
 cleanup:
   enabled: false
   # Run every 15 minutes (templated).

--- a/helm-tests/tests/helm_tests/airflow_aux/test_airflow_common.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_airflow_common.py
@@ -193,6 +193,7 @@ class TestAirflowCommon:
             name=release_name,
             values={
                 "airflowPodAnnotations": {"test-annotation/safe-to-evict": "true"},
+                "executor": "CeleryExecutor,KubernetesExecutor",
                 "cleanup": {"enabled": True},
                 "databaseCleanup": {"enabled": True},
                 "flower": {"enabled": True},
@@ -227,6 +228,7 @@ class TestAirflowCommon:
         """Test affinity, tolerations, etc are correctly applied on all pods created."""
         k8s_objects = render_chart(
             values={
+                "executor": "CeleryExecutor,KubernetesExecutor",
                 "cleanup": {"enabled": True},
                 "databaseCleanup": {"enabled": True},
                 "flower": {"enabled": True},
@@ -459,6 +461,7 @@ class TestAirflowCommon:
     def test_priority_class_name(self):
         docs = render_chart(
             values={
+                "executor": "CeleryExecutor,KubernetesExecutor",
                 "flower": {"enabled": True, "priorityClassName": "low-priority-flower"},
                 "pgbouncer": {"enabled": True, "priorityClassName": "low-priority-pgbouncer"},
                 "scheduler": {"priorityClassName": "low-priority-scheduler"},

--- a/helm-tests/tests/helm_tests/airflow_aux/test_annotations.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_annotations.py
@@ -42,6 +42,7 @@ class TestServiceAccountAnnotations:
         [
             (
                 {
+                    "executor": "KubernetesExecutor",
                     "cleanup": {
                         "enabled": True,
                         "serviceAccount": {
@@ -450,12 +451,13 @@ class TestServiceAccountAnnotations:
         ),
         (
             {
+                "executor": "KubernetesExecutor",
                 "cleanup": {
                     "enabled": True,
                     "podAnnotations": {
                         "example": "cleanup",
                     },
-                }
+                },
             },
             "templates/cleanup/cleanup-cronjob.yaml",
             {

--- a/helm-tests/tests/helm_tests/airflow_aux/test_basic_helm_chart.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_basic_helm_chart.py
@@ -518,8 +518,12 @@ class TestBaseChartTest:
                 expected_labels["executor"] = "CeleryExecutor"
                 if executor == "CeleryExecutor,KubernetesExecutor":
                     expected_labels["executor"] = "CeleryExecutor-KubernetesExecutor"
-            actual_labels = kind_k8s_obj_labels_tuples.pop((k8s_object_name, kind))
-            assert actual_labels == expected_labels
+
+            if component and component == "airflow-cleanup-pods" and executor == "CeleryExecutor":
+                assert (k8s_object_name, kind) not in kind_k8s_obj_labels_tuples
+            else:
+                actual_labels = kind_k8s_obj_labels_tuples.pop((k8s_object_name, kind))
+                assert actual_labels == expected_labels
 
         if kind_k8s_obj_labels_tuples:
             warnings.warn(f"Unchecked objects: {kind_k8s_obj_labels_tuples.keys()}")
@@ -531,7 +535,7 @@ class TestBaseChartTest:
             name=release_name,
             values={
                 "labels": {"label1": "value1", "label2": "value2"},
-                "executor": "CeleryExecutor",
+                "executor": "CeleryExecutor,KubernetesExecutor",
                 "dagProcessor": {"enabled": True},
                 "pgbouncer": {"enabled": True},
                 "redis": {"enabled": True},

--- a/helm-tests/tests/helm_tests/airflow_aux/test_cleanup_pods.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_cleanup_pods.py
@@ -24,9 +24,23 @@ from chart_utils.helm_template_generator import render_chart
 class TestCleanupDeployment:
     """Tests cleanup pods deployments."""
 
-    def test_should_have_a_schedule_with_defaults(self):
+    def test_should_not_create_cronjob_when_no_executor(self):
         doc = render_chart(
             values={
+                "cleanup": {"enabled": True},
+            },
+            show_only=["templates/cleanup/cleanup-cronjob.yaml"],
+        )
+
+        assert not doc, (
+            "Expected no CronJob to be created when cleanup is enabled without kubernetes executor set."
+        )
+
+    @pytest.mark.parametrize("executor", ["KubernetesExecutor", "CeleryExecutor,KubernetesExecutor"])
+    def test_should_have_a_schedule_with_defaults_and_executor_set(self, executor):
+        doc = render_chart(
+            values={
+                "executor": executor,
                 "cleanup": {"enabled": True},
             },
             show_only=["templates/cleanup/cleanup-cronjob.yaml"],
@@ -58,6 +72,7 @@ class TestCleanupDeployment:
         doc = render_chart(
             name=release_name,
             values={
+                "executor": "KubernetesExecutor",
                 "cleanup": {
                     "enabled": True,
                     "schedule": schedule_value,
@@ -72,9 +87,22 @@ class TestCleanupDeployment:
 class TestCleanupPods:
     """Tests cleanup of pods."""
 
-    def test_should_create_cronjob_for_enabled_cleanup(self):
+    def test_should_not_create_cronjob_when_not_kubernetes(self):
         docs = render_chart(
             values={
+                "executor": "CeleryExecutor",
+                "cleanup": {"enabled": True},
+            },
+            show_only=["templates/cleanup/cleanup-cronjob.yaml"],
+        )
+
+        assert not docs, "Expected no CronJob to be created when executor is not KubernetesExecutor."
+
+    @pytest.mark.parametrize("executor", ["KubernetesExecutor", "CeleryExecutor,KubernetesExecutor"])
+    def test_should_create_cronjob_for_enabled_cleanup_and_proper_executor(self, executor):
+        docs = render_chart(
+            values={
+                "executor": executor,
                 "cleanup": {"enabled": True},
             },
             show_only=["templates/cleanup/cleanup-cronjob.yaml"],
@@ -101,7 +129,7 @@ class TestCleanupPods:
 
     def test_should_pass_validation_with_v1beta1_api(self):
         render_chart(
-            values={"cleanup": {"enabled": True}},
+            values={"executor": "KubernetesExecutor", "cleanup": {"enabled": True}},
             show_only=["templates/cleanup/cleanup-cronjob.yaml"],
             kubernetes_version="1.16.0",
         )  # checks that no validation exception is raised
@@ -109,6 +137,7 @@ class TestCleanupPods:
     def test_should_change_image_when_set_airflow_image(self):
         docs = render_chart(
             values={
+                "executor": "KubernetesExecutor",
                 "cleanup": {"enabled": True},
                 "images": {"airflow": {"repository": "airflow", "tag": "test"}},
             },
@@ -123,6 +152,7 @@ class TestCleanupPods:
     def test_should_create_valid_affinity_tolerations_and_node_selector(self):
         docs = render_chart(
             values={
+                "executor": "KubernetesExecutor",
                 "cleanup": {
                     "enabled": True,
                     "affinity": {
@@ -142,7 +172,7 @@ class TestCleanupPods:
                         {"key": "dynamic-pods", "operator": "Equal", "value": "true", "effect": "NoSchedule"}
                     ],
                     "nodeSelector": {"diskType": "ssd"},
-                }
+                },
             },
             show_only=["templates/cleanup/cleanup-cronjob.yaml"],
         )
@@ -176,7 +206,11 @@ class TestCleanupPods:
 
     def test_scheduler_name(self):
         docs = render_chart(
-            values={"cleanup": {"enabled": True}, "schedulerName": "airflow-scheduler"},
+            values={
+                "executor": "KubernetesExecutor",
+                "cleanup": {"enabled": True},
+                "schedulerName": "airflow-scheduler",
+            },
             show_only=["templates/cleanup/cleanup-cronjob.yaml"],
         )
 
@@ -190,7 +224,8 @@ class TestCleanupPods:
 
     def test_default_command_and_args(self):
         docs = render_chart(
-            values={"cleanup": {"enabled": True}}, show_only=["templates/cleanup/cleanup-cronjob.yaml"]
+            values={"executor": "KubernetesExecutor", "cleanup": {"enabled": True}},
+            show_only=["templates/cleanup/cleanup-cronjob.yaml"],
         )
 
         assert jmespath.search("spec.jobTemplate.spec.template.spec.containers[0].command", docs[0]) is None
@@ -203,6 +238,7 @@ class TestCleanupPods:
     def test_should_add_extraEnvs(self):
         docs = render_chart(
             values={
+                "executor": "KubernetesExecutor",
                 "cleanup": {
                     "enabled": True,
                     "env": [{"name": "TEST_ENV_1", "value": "test_env_1"}],
@@ -219,7 +255,10 @@ class TestCleanupPods:
     @pytest.mark.parametrize("args", [None, ["custom", "args"]])
     def test_command_and_args_overrides(self, command, args):
         docs = render_chart(
-            values={"cleanup": {"enabled": True, "command": command, "args": args}},
+            values={
+                "executor": "KubernetesExecutor",
+                "cleanup": {"enabled": True, "command": command, "args": args},
+            },
             show_only=["templates/cleanup/cleanup-cronjob.yaml"],
         )
 
@@ -231,11 +270,12 @@ class TestCleanupPods:
     def test_command_and_args_overrides_are_templated(self):
         docs = render_chart(
             values={
+                "executor": "KubernetesExecutor",
                 "cleanup": {
                     "enabled": True,
                     "command": ["{{ .Release.Name }}"],
                     "args": ["{{ .Release.Service }}"],
-                }
+                },
             },
             show_only=["templates/cleanup/cleanup-cronjob.yaml"],
         )
@@ -248,6 +288,7 @@ class TestCleanupPods:
     def test_should_set_labels_to_jobs_from_cronjob(self):
         docs = render_chart(
             values={
+                "executor": "KubernetesExecutor",
                 "cleanup": {"enabled": True},
                 "labels": {"project": "airflow"},
             },
@@ -264,6 +305,7 @@ class TestCleanupPods:
     def test_should_add_component_specific_labels(self):
         docs = render_chart(
             values={
+                "executor": "KubernetesExecutor",
                 "cleanup": {
                     "enabled": True,
                     "labels": {"test_label": "test_label_value"},
@@ -281,6 +323,7 @@ class TestCleanupPods:
     def test_should_add_component_specific_annotations(self):
         docs = render_chart(
             values={
+                "executor": "KubernetesExecutor",
                 "cleanup": {
                     "enabled": True,
                     "jobAnnotations": {"test_cronjob_annotation": "test_cronjob_annotation_value"},
@@ -318,6 +361,7 @@ class TestCleanupPods:
         }
         docs = render_chart(
             values={
+                "executor": "KubernetesExecutor",
                 "cleanup": {
                     "enabled": True,
                     "resources": resources,
@@ -333,6 +377,7 @@ class TestCleanupPods:
     def test_should_set_job_history_limits(self):
         docs = render_chart(
             values={
+                "executor": "KubernetesExecutor",
                 "cleanup": {
                     "enabled": True,
                     "failedJobsHistoryLimit": 2,
@@ -347,6 +392,7 @@ class TestCleanupPods:
     def test_should_set_zero_job_history_limits(self):
         docs = render_chart(
             values={
+                "executor": "KubernetesExecutor",
                 "cleanup": {
                     "enabled": True,
                     "failedJobsHistoryLimit": 0,
@@ -361,6 +407,7 @@ class TestCleanupPods:
     def test_no_airflow_local_settings(self):
         docs = render_chart(
             values={
+                "executor": "KubernetesExecutor",
                 "cleanup": {"enabled": True},
                 "airflowLocalSettings": None,
             },
@@ -374,6 +421,7 @@ class TestCleanupPods:
     def test_airflow_local_settings(self):
         docs = render_chart(
             values={
+                "executor": "KubernetesExecutor",
                 "cleanup": {"enabled": True},
                 "airflowLocalSettings": "# Well hello!",
             },
@@ -389,6 +437,7 @@ class TestCleanupPods:
     def test_global_volumes_and_volume_mounts(self):
         docs = render_chart(
             values={
+                "executor": "KubernetesExecutor",
                 "cleanup": {"enabled": True},
                 "volumes": [{"name": "test-volume", "emptyDir": {}}],
                 "volumeMounts": [{"name": "test-volume", "mountPath": "/test"}],
@@ -408,9 +457,24 @@ class TestCleanupPods:
 class TestCleanupServiceAccount:
     """Tests cleanup of service accounts."""
 
-    def test_should_add_component_specific_labels(self):
+    def test_should_not_add_service_account_when_not_kubernetes(self):
         docs = render_chart(
             values={
+                "executor": "CeleryExecutor",
+                "cleanup": {
+                    "enabled": True,
+                    "labels": {"test_label": "test_label_value"},
+                },
+            },
+            show_only=["templates/cleanup/cleanup-serviceaccount.yaml"],
+        )
+        assert not docs, "Expected no ServiceAccount to be created when executor is not KubernetesExecutor."
+
+    @pytest.mark.parametrize("executor", ["KubernetesExecutor", "CeleryExecutor,KubernetesExecutor"])
+    def test_should_add_component_specific_labels(self, executor):
+        docs = render_chart(
+            values={
+                "executor": executor,
                 "cleanup": {
                     "enabled": True,
                     "labels": {"test_label": "test_label_value"},
@@ -425,6 +489,7 @@ class TestCleanupServiceAccount:
     def test_default_automount_service_account_token(self):
         docs = render_chart(
             values={
+                "executor": "KubernetesExecutor",
                 "cleanup": {
                     "enabled": True,
                 },
@@ -436,6 +501,7 @@ class TestCleanupServiceAccount:
     def test_overridden_automount_service_account_token(self):
         docs = render_chart(
             values={
+                "executor": "KubernetesExecutor",
                 "cleanup": {"enabled": True, "serviceAccount": {"automountServiceAccountToken": False}},
             },
             show_only=["templates/cleanup/cleanup-serviceaccount.yaml"],

--- a/helm-tests/tests/helm_tests/security/test_rbac.py
+++ b/helm-tests/tests/helm_tests/security/test_rbac.py
@@ -331,6 +331,7 @@ class TestRBAC:
             values={
                 "airflowVersion": "3.0.0",
                 "fullnameOverride": "test-rbac",
+                "executor": "CeleryExecutor,KubernetesExecutor",
                 "cleanup": {
                     "enabled": True,
                     "serviceAccount": {
@@ -415,6 +416,7 @@ class TestRBAC:
             values={
                 "airflowVersion": "3.0.0",
                 "fullnameOverride": "test-rbac",
+                "executor": "CeleryExecutor,KubernetesExecutor",
                 "cleanup": {
                     "enabled": True,
                     "serviceAccount": {


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

When trying to run `cleanup` cronjob on a CeleryExecutor, the cronjob errors when trying to exec airflow kubernetes:
```
airflow command error: argument GROUP_OR_COMMAND: invalid choice: 'kubernetes' (choose from api-server, assets, backfill, celery, cheat-sheet, config, connections, dag-processor, dags, db, db-manager, fab-db, info, jobs, kerberos, permissions-cleanup, plugins, pools, providers, roles, rotate-fernet-key, scheduler, standalone, sync-perm, tasks, triggerer, users, variables, version), see help above.
Usage: airflow [-h] GROUP_OR_COMMAND ...
....
Options:
  -h, --help            show this help message and exit
stream closed: EOF for airflow/airflow-cleanup-29401785-bq5zs (airflow-cleanup-pods)
```

Once KubernetesExecutor is enabled, the error above goes away and the cronjob runs to completion.

This PR makes it so the cronjob and its respective service account become conditional on KubernetesExecutor.

Also removed the  `sidecar.istio.io/inject: "false"` from cleanup-pods as requested in https://github.com/apache/airflow/pull/58155#discussion_r2551918332

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
