### PR TITLE
Fix DAG Processor health check threshold matching the pattern used by…

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -2509,6 +2509,17 @@ dag_processor:
       type: integer
       example: ~
       default: "30"
+    health_check_threshold:
+      description: |
+        If the last dag processor heartbeat happened more than
+        ``[dag_processor] health_check_threshold`` ago (in seconds),
+        dag processor is considered unhealthy.
+        This is used by the health check in the **/health** endpoint and in ``airflow jobs check``
+        CLI for DagProcessorJob.
+      version_added: 3.2.0
+      type: integer
+      example: ~
+      default: "30"
     disable_bundle_versioning:
       description: |
         Always run tasks with the latest code.  If set to True, the bundle version will not

--- a/airflow-core/src/airflow/jobs/job.py
+++ b/airflow-core/src/airflow/jobs/job.py
@@ -77,6 +77,8 @@ def health_check_threshold(job_type: str, heartrate: int) -> int | float:
         health_check_threshold_value = conf.getint("scheduler", "scheduler_health_check_threshold")
     elif job_type == "TriggererJob":
         health_check_threshold_value = conf.getfloat("triggerer", "triggerer_health_check_threshold")
+    elif job_type == "DagProcessorJob":
+        health_check_threshold_value = conf.getint("dag_processor", "health_check_threshold")
     else:
         health_check_threshold_value = heartrate * grace_multiplier
     return health_check_threshold_value

--- a/airflow-core/tests/unit/jobs/test_base_job.py
+++ b/airflow-core/tests/unit/jobs/test_base_job.py
@@ -27,7 +27,7 @@ from sqlalchemy.exc import OperationalError
 
 from airflow._shared.timezones import timezone
 from airflow.executors.local_executor import LocalExecutor
-from airflow.jobs.job import Job, most_recent_job, perform_heartbeat, run_job
+from airflow.jobs.job import Job, health_check_threshold, most_recent_job, perform_heartbeat, run_job
 from airflow.listeners.listener import get_listener_manager
 from airflow.utils.session import create_session
 from airflow.utils.state import State
@@ -200,7 +200,7 @@ class TestJob:
         job.latest_heartbeat = timezone.utcnow() - datetime.timedelta(seconds=10)
         assert job.is_alive() is False, "Completed jobs even with recent heartbeat should not be alive"
 
-    @pytest.mark.parametrize("job_type", ["SchedulerJob", "TriggererJob"])
+    @pytest.mark.parametrize("job_type", ["SchedulerJob", "TriggererJob", "DagProcessorJob"])
     def test_is_alive_scheduler(self, job_type):
         job = Job(heartrate=10, state=State.RUNNING, job_type=job_type)
         assert job.is_alive() is True
@@ -282,3 +282,18 @@ class TestJob:
             hb_callback.reset_mock()
             perform_heartbeat(job=job, heartbeat_callback=hb_callback, only_if_necessary=True)
             assert hb_callback.called is False
+
+    @pytest.mark.parametrize(
+        ("job_type", "config_section", "config_key", "threshold_value"),
+        [
+            ("DagProcessorJob", "dag_processor", "health_check_threshold", 120),
+            ("SchedulerJob", "scheduler", "scheduler_health_check_threshold", 180),
+            ("TriggererJob", "triggerer", "triggerer_health_check_threshold", 90),
+        ],
+    )
+    def test_health_check_threshold(self, job_type, config_section, config_key, threshold_value):
+        with conf_vars({(config_section, config_key): str(threshold_value)}):
+            assert health_check_threshold(job_type, 30) == threshold_value
+
+    def test_health_check_threshold_unknown_job_uses_heartrate_fallback(self):
+        assert health_check_threshold("UnknownJob", 30) == 30 * 2.1


### PR DESCRIPTION

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #58667
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
Fixes #58667

## Problem
DAG Processor health checks were failing incorrectly. **Root cause**: `health_check_threshold()` has explicit handling for SchedulerJob and TriggererJob, but DagProcessorJob falls through to the default case using `heartrate * 2.1`. With a 10s heartbeat, this gives a 21s threshold vs 30s for scheduler/triggerer, causing false unhealthy reports.

## Solution
Added dedicated `dag_processor_health_check_threshold` config (default: 30s) following the same pattern as scheduler/triggerer.

**Modified files:**
- `config.yml`: Added config option in `[dag_processor]` section
- `job.py`: Added elif clause in `health_check_threshold()` for DagProcessorJob
- `test_base_job.py`: Extended test coverage for all job types + fallback behavior

## Tests
- Updated `test_is_alive_scheduler` to include DagProcessorJob
- Added parametrized `test_health_check_threshold()` for all 3 job types
- Added `test_health_check_threshold_unknown_job_uses_heartrate_fallback()`
- All 22 tests passing

**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
