### PR TITLE
Fix automatic backport workflow race condition

### DIFF
--- a/.github/workflows/automatic-backport.yml
+++ b/.github/workflows/automatic-backport.yml
@@ -35,6 +35,14 @@ jobs:
         id: get-sha
         run: echo "COMMIT_SHA=${GITHUB_SHA}" >> $GITHUB_ENV
 
+      # Adding a slight delay to allow GitHub's API to associate the merge commit with the PR.
+      # This is needed because GH has a consistency of 6-10+ seconds
+      # to process the commit and PR association after a merge based on some of our past runs.
+      # Without this delay, the listPullRequestsAssociatedWithCommit API call may return an empty array
+      # even though a PR was just merged, causing backports to be skipped.
+      - name: Add delay for GitHub to process PR merge
+        run: sleep 15
+
       - name: Find PR information
         id: pr-info
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
@@ -57,7 +65,7 @@ jobs:
                 console.log(`Backport branches: ${backportBranches}`);
                 core.setOutput('branches', JSON.stringify(backportBranches));
             } else {
-                console.log('No pull request found for this commit.');
+                console.log('⚠️ No pull request found for this commit.');
                 core.setOutput('branches', '[]');
             }
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

The automatic backport workflow was intermittently skipping PRs that should be backported, even when they had `backport-to-*` labels. After some investigation, I could see a race condition with GitHub's API.

Examples:

For successful runs:
```shell script
Run actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
  with:
    script: const { data: pullRequest } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
      owner: context.repo.owner,
      repo: context.repo.repo,
      commit_sha: process.env.GITHUB_SHA
  });
  if (pullRequest.length > 0) {
      const pr = pullRequest[0];
      const backportBranches = pr.labels
            .filter(label => label.name.startsWith('backport-to-'))
            .map(label => label.name.replace('backport-to-', ''));
  
      console.log(`Commit ${process.env.GITHUB_SHA} is associated with PR ${pr.number}`);
      console.log(`Backport branches: ${backportBranches}`);
      core.setOutput('branches', JSON.stringify(backportBranches));
  } else {
      console.log('No pull request found for this commit.');
      core.setOutput('branches', '[]');
  }
  
    github-token: ***
    debug: false
    user-agent: actions/github-script
    result-encoding: json
    retries: 0
    retry-exempt-status-codes: 400,401,403,404,422
  env:
    COMMIT_SHA: c03fc7943009b02072ad275dd31e54f927bff889
    GITHUB_TOKEN: ***
Commit c03fc7943009b02072ad275dd31e54f927bff889 is associated with PR 57853
Backport branches: v3-1-test
```

For failed runs:
```shell script
1s
Run actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
  with:
    script: const { data: pullRequest } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
      owner: context.repo.owner,
      repo: context.repo.repo,
      commit_sha: process.env.GITHUB_SHA
  });
  if (pullRequest.length > 0) {
      const pr = pullRequest[0];
      const backportBranches = pr.labels
            .filter(label => label.name.startsWith('backport-to-'))
            .map(label => label.name.replace('backport-to-', ''));
  
      console.log(`Commit ${process.env.GITHUB_SHA} is associated with PR ${pr.number}`);
      console.log(`Backport branches: ${backportBranches}`);
      core.setOutput('branches', JSON.stringify(backportBranches));
  } else {
      console.log('No pull request found for this commit.');
      core.setOutput('branches', '[]');
  }
  
    github-token: ***
    debug: false
    user-agent: actions/github-script
    result-encoding: json
    retries: 0
    retry-exempt-status-codes: 400,401,403,404,422
  env:
    COMMIT_SHA: caafc704462cc15bedde67ef416d870ceabd13e8
    GITHUB_TOKEN: ***
No pull request found for this commit.
```

The root cause seems to be that when a PR is merged to `main`, the workflow immediately queries GH `listPullRequestsAssociatedWithCommit` API to find the PR and check for backport labels. However, this API call seems to need time to process the merge and associate the commit with the PR.


Performed analysis on couple of PRs and this is my finding:
| PR # | Commit (short) | Merge Time | Workflow Start | API Call Time | Time to API Call | Result | Current Status |
|------|----------------|------------|----------------|---------------|------------------|--------|----------------|
| 57853 | c03fc794 | 2025-11-17 13:42:26 | 13:42:29 (+3s) | 13:42:33 | **7 seconds** | Found | PR associated |
| 58575 | caafc704 | 2025-11-22 10:23:24 | 10:23:26 (+2s) | 10:23:30 | **6 seconds** | Not found | Now associated |
| 58587 | 19e0a9ad | 2025-11-26 00:35:10 | 00:35:13 (+3s) | 00:35:18 | **8 seconds** | Not found | Now associated |
| 58696 | 6d36d7b4 | 2025-11-26 00:47:54 | 00:47:57 (+3s) | 00:48:01 | **7 seconds** | Not found | Now associated |



To solve this, I have two options:
1. Add some sort of retry mechanism while calling the API. Complex implementation but could work.

2. [Chosen Now] Added a `15` second delay before querying the API. This gives the backend sufficient time to process the merge commit and establish the PR association, ensuring backport labels are consistently detected.

Why 15 seconds?
- Observed failures occurred at 6-8 seconds for my dataset
- 15 seconds provides ~2 times safety margin
- Simple solution that handles worst case timing

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
