### PR TITLE
Fix task-sdk-integration-tests not running when only test files change

### DIFF
--- a/.github/workflows/ci-amd-arm.yml
+++ b/.github/workflows/ci-amd-arm.yml
@@ -758,6 +758,11 @@ jobs:
       docker-cache: ${{ needs.build-info.outputs.docker-cache }}
       disable-airflow-repo-cache: ${{ needs.build-info.outputs.disable-airflow-repo-cache }}
       prod-image-build: ${{ needs.build-info.outputs.prod-image-build }}
+    if: |
+      always() &&
+      needs.build-info.outputs.prod-image-build == 'true' &&
+      !cancelled() &&
+      (needs.build-ci-images.result == 'success' || needs.build-ci-images.result == 'skipped')
 
   additional-prod-image-tests:
     name: "Additional PROD image tests"

--- a/.github/workflows/ci-amd-arm.yml
+++ b/.github/workflows/ci-amd-arm.yml
@@ -758,11 +758,6 @@ jobs:
       docker-cache: ${{ needs.build-info.outputs.docker-cache }}
       disable-airflow-repo-cache: ${{ needs.build-info.outputs.disable-airflow-repo-cache }}
       prod-image-build: ${{ needs.build-info.outputs.prod-image-build }}
-    if: |
-      always() &&
-      needs.build-info.outputs.prod-image-build == 'true' &&
-      !cancelled() &&
-      (needs.build-ci-images.result == 'success' || needs.build-ci-images.result == 'skipped')
 
   additional-prod-image-tests:
     name: "Additional PROD image tests"

--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -945,6 +945,7 @@ class SelectiveChecks:
             self.run_unit_tests
             or self.docs_build
             or self.run_kubernetes_tests
+            or self.run_task_sdk_integration_tests
             or self.run_helm_tests
             or self.run_ui_tests
             or self.pyproject_toml_changed

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -630,7 +630,7 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "all-python-versions-list-as-string": DEFAULT_PYTHON_MAJOR_MINOR_VERSION,
                     "python-versions": f"['{DEFAULT_PYTHON_MAJOR_MINOR_VERSION}']",
                     "python-versions-list-as-string": DEFAULT_PYTHON_MAJOR_MINOR_VERSION,
-                    "ci-image-build": "false",
+                    "ci-image-build": "true",
                     "prod-image-build": "true",
                     "run-api-tests": "false",
                     "run-helm-tests": "false",

--- a/task-sdk-integration-tests/tests/task_sdk_tests/test_task_sdk_health.py
+++ b/task-sdk-integration-tests/tests/task_sdk_tests/test_task_sdk_health.py
@@ -21,10 +21,8 @@ from task_sdk_tests import console
 
 def test_task_sdk_health(sdk_client, task_sdk_api_version):
     """Test Task SDK health check using session setup."""
-    client = sdk_client
-
     console.print("[yellow]Making health check request...")
-    response = client.get("health/ping", headers={"Airflow-API-Version": task_sdk_api_version})
+    response = sdk_client.get("health/ping")
 
     console.print(" Health Check Response ".center(72, "="))
     console.print(f"[bright_blue]Status Code:[/] {response.status_code}")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

When only `task-sdk-integration-tests` files are modified, the tests fail to run because the PROD image build step is blocked by a skipped CI image build dependency. This prevents validation of Task SDK integration changes in CI.

Flow:
1. When only `task-sdk-integration-tests/` files change:
   - `ci-image-build = false` → `build-ci-images` job is **skipped**
   - `prod-image-build = true` → PROD images needed
2. However, `build-prod-images` has `needs: [build-ci-images]` dependency
3. Result: PROD images aren't built leading to tests not runninl

To fix this, I did this:
Added this conditional to the `build-prod-image` flow:
```shell script
if: |
  always() &&
  needs.build-info.outputs.prod-image-build == 'true' &&
  !cancelled() &&
  (needs.build-ci-images.result == 'success' || needs.build-ci-images.result == 'skipped')
```

This means that:
- PROD images build when needed, even if CI images are skipped
- PROD images don't build if CI images fail
- Task SDK integration tests run correctly

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
