### PR TITLE
Clarify the OpenTelemetry configuration instructions

### DIFF
--- a/airflow-core/docs/administration-and-deployment/logging-monitoring/metrics.rst
+++ b/airflow-core/docs/administration-and-deployment/logging-monitoring/metrics.rst
@@ -63,7 +63,8 @@ To use OpenTelemetry you must first install the required packages:
 
    pip install 'apache-airflow[otel]'
 
-Add the following lines to your configuration file e.g. ``airflow.cfg``
+An OpenTelemetry `Collector <https://opentelemetry.io/docs/concepts/components/#collector>`_ (or compatible service) is required for connectivity to a metrics backend.
+Add the Collector details to your configuration file e.g. ``airflow.cfg``
 
 .. code-block:: ini
 
@@ -73,6 +74,7 @@ Add the following lines to your configuration file e.g. ``airflow.cfg``
     otel_port = 8889
     otel_prefix = airflow
     otel_interval_milliseconds = 30000  # The interval between exports, defaults to 60000
+    otel_service = Airflow
     otel_ssl_active = False
 
 .. note::


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
It may not be clear to a new OTel user that a collector (proxy) is **required** between Airflow and the metrics backend. This is doubly confusing because:
1. A collector is optional [according to the OTel docs](https://opentelemetry.io/docs/collector/#when-to-use-a-collector).
2. In the case of a Prometheus backend, [its docs that discuss the producer configurations](https://prometheus.io/docs/guides/opentelemetry/#send-opentelemetry-metrics-to-the-prometheus-server) show that a `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` needs to be specified, but the example doesn't "map" to the `[metrics]` configuration fields, i.e.
    ```none
    OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=http://localhost:9090/api/v1/otlp/v1/metrics
                         otel_ssl_active~~~~
                                      otel_host~~~~~~~~~             ~~~~~~~~~~~~~~~default suffix?
                                                otel_port~~~~ ~~~~~~custom subpath?
    ```

Currently, the fact these settings expect an OTel Collector is only mentioned in the Airflow configuration reference. This PR adds an explicit mention in the main docs that a collector (and not, say, Prometheus directly) should be specified.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
