### PR TITLE
helm: correctly derive celery sync_parallelism from scheduler CPU limits

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -1147,3 +1147,18 @@ capabilities:
             app: keda-operator
   {{- end }}
 {{- end }}
+
+{{/*
+Convert a Kubernetes CPU limit (e.g., "500m", "1.5", "2", "750m") into an integer number of CPU cores.
+*/}}
+{{- define "cpu_count" -}}
+  {{- $v := toString . -}}
+    {{- if hasSuffix "m" $v -}}
+      {{- /* millicores path: e.g. 500m, 1500m */ -}}
+      {{- $m := float64 (trimSuffix "m" $v) -}}
+      {{- int (ceil (divf $m 1000)) -}}
+    {{- else -}}
+      {{- /* plain cores: e.g. 0.5, 1, 1.5 */ -}}
+      {{- int (ceil (float64 $v)) -}}
+    {{- end -}}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -3011,6 +3011,7 @@ config:
   celery:
     flower_url_prefix: '{{ ternary "" .Values.ingress.flower.path (eq .Values.ingress.flower.path "/") }}'
     worker_concurrency: 16
+    sync_parallelism: '{{ include "cpu_count" (((.Values.scheduler).resources).limits).cpu }}'
   scheduler:
     standalone_dag_processor: '{{ ternary "True" "False" (or (semverCompare ">=3.0.0" .Values.airflowVersion) (.Values.dagProcessor.enabled | default false)) }}'
     # statsd params included for Airflow 1.10 backward compatibility; moved to [metrics] in 2.0


### PR DESCRIPTION
**What**
Derive celery sync_parallelism from the scheduler's resources.limits.cpu when it is defined.

**Why**
The default value of `sync_parallelism` in Airflow is `0`, which causes it to fall back to `multiprocessing.cpu_count`:
https://github.com/apache/airflow/blob/97cd1c9c99030be89cebaddc2e342359fc01b5b8/providers/celery/src/airflow/providers/celery/executors/celery_executor.py#L311

In containerized environments, cpu_count() returns the number of host machine cores, rather than the number of cores actually allocated to the container - see: https://github.com/python/cpython/issues/80235

This leads to incorrect behavior. For example:
If the scheduler container has 500m CPU allocated but is running on a 16 vCPU node, Airflow will incorrectly spawn 15 (as there is minus 1) processes instead of 1 when sending Celery tasks via apply_async and when there are >= 15 tasks in queued state, leading to unnecessary resource contention and overhead.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
