### PR TITLE
Fix formatting error in Breeze setup instructions

### DIFF
--- a/contributing-docs/03a_contributors_quick_start_beginners.rst
+++ b/contributing-docs/03a_contributors_quick_start_beginners.rst
@@ -37,6 +37,7 @@ Prerequisites
 * `Basic Git <https://docs.github.com/en/get-started/git-basics/set-up-git>`__ (**only** required for the Breeze path below)
 
 For Breeze (local development):
+
 * `Docker Desktop <https://www.docker.com/products/docker-desktop/>`__
 * `Podman <https://podman.io/>`__, a drop-in, license-friendly replacement for Docker Desktop
 * `Docker Compose <https://docs.docker.com/compose/install/>`__


### PR DESCRIPTION
Added a newline before the list so that the documentation renders the bullet points correctly.

Diff:
<img width="1874" height="536" alt="CleanShot 2025-11-27 at 13 45 46@2x" src="https://github.com/user-attachments/assets/2d89012e-4b5b-4631-97dd-75564af9f034" />
