### PR TITLE
Change task log source display to hidden by default

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.test.tsx
@@ -57,24 +57,26 @@ describe("Task log source", () => {
     await waitForLogs();
 
     let logLine = screen.getByTestId("virtualized-item-2");
-    const source = logLine.querySelector('[data-key="logger"]');
-    const loc = logLine.querySelector('[data-key="loc"]');
 
-    expect(source).toBeVisible();
-    expect(source).toHaveProperty("innerText", "source=airflow.models.dagbag.DagBag");
+    // Source should be hidden by default
+    expect(logLine.querySelector('[data-key="logger"]')).toBeNull();
+    expect(logLine.querySelector('[data-key="loc"]')).toBeNull();
 
-    expect(loc).toBeVisible();
-    expect(loc).toHaveProperty("innerText", "loc=dagbag.py:593");
-
+    // Toggle source on
     fireEvent.keyDown(document.activeElement ?? document.body, { code: "KeyS", key: "S" });
     fireEvent.keyPress(document.activeElement ?? document.body, { code: "KeyS", key: "S" });
     fireEvent.keyUp(document.activeElement ?? document.body, { code: "KeyS", key: "S" });
 
     logLine = screen.getByTestId("virtualized-item-2");
+    const source = logLine.querySelector('[data-key="logger"]');
+    const loc = logLine.querySelector('[data-key="loc"]');
 
-    // These should now find nothing
-    expect(logLine.querySelector('[data-key="logger"]')).toBeNull();
-    expect(logLine.querySelector('[data-key="loc"]')).toBeNull();
+    // Source should now be visible
+    expect(source).toBeVisible();
+    expect(source).toHaveProperty("innerText", "source=airflow.models.dagbag.DagBag");
+
+    expect(loc).toBeVisible();
+    expect(loc).toHaveProperty("innerText", "loc=dagbag.py:593");
   });
 });
 describe("Task log grouping", () => {

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.tsx
@@ -81,7 +81,7 @@ export const Logs = () => {
     "log_show_timestamp",
     defaultShowTimestamp,
   );
-  const [showSource, setShowSource] = useLocalStorage<boolean>("log_show_source", true);
+  const [showSource, setShowSource] = useLocalStorage<boolean>("log_show_source", false);
   const [fullscreen, setFullscreen] = useState(false);
   const [expanded, setExpanded] = useState(false);
 


### PR DESCRIPTION
  Update the default behavior for task log source display from shown
  to hidden, providing a cleaner initial view of logs. Users can still
  toggle source visibility using the settings menu