### PR TITLE
fix(ui): Preserve variable value formatting in edit dialog (#58648)

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/EditVariableButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/EditVariableButton.tsx
@@ -36,6 +36,14 @@ type Props = {
 const EditVariableButton = ({ disabled, variable }: Props) => {
   const { t: translate } = useTranslation("admin");
   const { onClose, onOpen, open } = useDisclosure();
+  const formatValue = (value: string): string => {
+    try {
+      const parsed = JSON.parse(value);
+      return JSON.stringify(parsed, null, 2);
+    } catch {
+      return value;
+    }
+  };
   const initialVariableValue: VariableBody = {
     description: variable.description ?? "",
     key: variable.key,


### PR DESCRIPTION
**Description**

This PR fixes the variable editor to preserve JSON formatting when editing variables in the Airflow UI.

**Problem:**
In Airflow 3.x, variable values are displayed as minified single-line strings in the edit dialog, making it difficult to read and edit structured data like JSON and YAML.

**Solution:**
Added a `formatValue` function in `EditVariableButton.tsx` that formats JSON values with proper indentation (2 spaces) when the edit dialog is opened. Non-JSON values are preserved as-is.

**Changes:**
- Modified `EditVariableButton.tsx` to add `formatValue` function
- JSON values are formatted using `JSON.stringify(parsed, null, 2)`
- Non-JSON values are displayed unchanged

**Testing:**
1. Created test variable with formatted JSON
2. Verified formatting is preserved in edit dialog
3. Tested with YAML values - preserved as-is

**Screenshots:**

**Before:**
Value field shows: `{"key": "val", "key2": "val2"}`
<img width="789" height="375" alt="截圖 2025-11-27 下午2 10 13" src="https://github.com/user-attachments/assets/aa67688f-33db-4ac2-962d-e42ec7bb27d3" />


**After:**
Value field shows:

```
{
  "key": "val",
  "key2": "val2"
}
```
<img width="886" height="466" alt="截圖 2025-11-27 下午2 10 39" src="https://github.com/user-attachments/assets/a1eafb66-5946-41c9-97e6-72e58796bd9d" />


**Related Issue(s):**
Closes #58648

