### PR TITLE
feat: add OpenFaaS connection type and documentation

### DIFF
--- a/providers/openfaas/docs/connections/openfaas.rst
+++ b/providers/openfaas/docs/connections/openfaas.rst
@@ -1,0 +1,39 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+
+.. _howto/connection:openfaas:
+
+OpenFaaS Connection
+===================
+The OpenFaaS connection type provides connection to an OpenFaaS gateway.
+
+Configuring the Connection
+--------------------------
+Host (required)
+    The OpenFaaS gateway URL (e.g., ``http://gateway.openfaas:8080``).
+
+Login (optional)
+    Username for basic authentication if your OpenFaaS gateway requires authentication.
+
+Password (optional)
+    Password for basic authentication if your OpenFaaS gateway requires authentication.
+
+Extra (optional)
+    Specify the extra parameters (as JSON dictionary) that can be used in the OpenFaaS
+    connection.

--- a/providers/openfaas/docs/connections/openfaas.rst
+++ b/providers/openfaas/docs/connections/openfaas.rst
@@ -21,6 +21,7 @@
 
 OpenFaaS Connection
 ===================
+
 The OpenFaaS connection type provides connection to an OpenFaaS gateway.
 
 Configuring the Connection

--- a/providers/openfaas/docs/connections/openfaas.rst
+++ b/providers/openfaas/docs/connections/openfaas.rst
@@ -26,6 +26,7 @@ The OpenFaaS connection type provides connection to an OpenFaaS gateway.
 
 Configuring the Connection
 --------------------------
+
 Host (required)
     The OpenFaaS gateway URL (e.g., ``http://gateway.openfaas:8080``).
 

--- a/providers/openfaas/docs/index.rst
+++ b/providers/openfaas/docs/index.rst
@@ -32,6 +32,13 @@
 .. toctree::
     :hidden:
     :maxdepth: 1
+    :caption: Guides
+
+    Connection types <connections/openfaas>
+
+.. toctree::
+    :hidden:
+    :maxdepth: 1
     :caption: References
 
     Python API <_api/airflow/providers/openfaas/index>

--- a/providers/openfaas/provider.yaml
+++ b/providers/openfaas/provider.yaml
@@ -62,3 +62,7 @@ hooks:
   - integration-name: OpenFaaS
     python-modules:
       - airflow.providers.openfaas.hooks.openfaas
+
+connection-types:
+  - hook-class-name: airflow.providers.openfaas.hooks.openfaas.OpenFaasHook
+    connection-type: openfaas

--- a/providers/openfaas/src/airflow/providers/openfaas/get_provider_info.py
+++ b/providers/openfaas/src/airflow/providers/openfaas/get_provider_info.py
@@ -37,4 +37,10 @@ def get_provider_info():
         "hooks": [
             {"integration-name": "OpenFaaS", "python-modules": ["airflow.providers.openfaas.hooks.openfaas"]}
         ],
+        "connection-types": [
+            {
+                "hook-class-name": "airflow.providers.openfaas.hooks.openfaas.OpenFaasHook",
+                "connection-type": "openfaas",
+            }
+        ],
     }

--- a/providers/openfaas/src/airflow/providers/openfaas/hooks/openfaas.py
+++ b/providers/openfaas/src/airflow/providers/openfaas/hooks/openfaas.py
@@ -32,7 +32,7 @@ class OpenFaasHook(BaseHook):
     Interact with OpenFaaS to query, deploy, invoke and update function.
 
     :param function_name: Name of the function, Defaults to None
-    :param conn_id: OpenFaaS connection to use, Defaults to open_faas_default
+    :param conn_id: OpenFaaS connection to use, defaults to ``open_faas_default``
         for example host : http://openfaas.faas.com
     """
 

--- a/providers/openfaas/src/airflow/providers/openfaas/hooks/openfaas.py
+++ b/providers/openfaas/src/airflow/providers/openfaas/hooks/openfaas.py
@@ -32,15 +32,28 @@ class OpenFaasHook(BaseHook):
     Interact with OpenFaaS to query, deploy, invoke and update function.
 
     :param function_name: Name of the function, Defaults to None
-    :param conn_id: openfaas connection to use, Defaults to open_faas_default
-        for example host : http://openfaas.faas.com, Connection Type : Http
+    :param conn_id: OpenFaaS connection to use, Defaults to open_faas_default
+        for example host : http://openfaas.faas.com
     """
+
+    conn_name_attr = "conn_id"
+    default_conn_name = "open_faas_default"
+    conn_type = "openfaas"
+    hook_name = "OpenFaaS"
 
     GET_FUNCTION = "/system/function/"
     INVOKE_ASYNC_FUNCTION = "/async-function/"
     INVOKE_FUNCTION = "/function/"
     DEPLOY_FUNCTION = "/system/functions"
     UPDATE_FUNCTION = "/system/functions"
+
+    @classmethod
+    def get_ui_field_behaviour(cls) -> dict[str, Any]:
+        """Return custom field behaviour."""
+        return {
+            "hidden_fields": ["schema", "port", "login", "password", "extra"],
+            "relabeling": {},
+        }
 
     def __init__(self, function_name=None, conn_id: str = "open_faas_default", *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)

--- a/providers/openfaas/tests/unit/openfaas/hooks/test_openfaas.py
+++ b/providers/openfaas/tests/unit/openfaas/hooks/test_openfaas.py
@@ -157,3 +157,10 @@ class TestOpenFaasHook:
         mock_connection = Connection(host="http://open-faas.io")
         mock_get_connection.return_value = mock_connection
         assert self.hook.deploy_function(False, {}) is None
+
+    def test_get_ui_field_behaviour(self):
+        expected = {
+            "hidden_fields": ["schema", "port", "login", "password", "extra"],
+            "relabeling": {},
+        }
+        assert self.hook.get_ui_field_behaviour() == expected


### PR DESCRIPTION
## Why
Related Issue : [#28790](https://github.com/apache/airflow/issues/28790) (OpenFaasHook section)

## What
- `hooks/openfaas.py` - Added connection class attributes and `get_ui_field_behaviour()`
- `provider.yaml` - Added `connection-types` section
- `get_provider_info.py` - Added `connection-types` entry
- `docs/connections/openfaas.rst` - New connection documentation
- `docs/index.rst` - Added link to connection docs

## Test
Run `breeze start-airflow` and verify that `OpenFaaS` appears in the `Connection Type` dropdown menu.
<img width="1716" height="796" alt="image" src="https://github.com/user-attachments/assets/395da001-0a7d-421d-97a4-e128015347c9" />
