### PR TITLE
fix(rst): ensure blank line before bullet lists

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -3521,6 +3521,7 @@ using ``pyproject.toml``. Airflow is now compliant with those accepted PEPs:
 * `PEP-685 Comparison of extra names for optional distribution dependencies <https://www.python.org/dev/peps/pep-0685/>`__
 
 Also we implement multiple license files support coming from Draft, not yet accepted (but supported by ``hatchling``) PEP:
+
 * `PEP 639 Improving License Clarity with Better Package Metadata <https://peps.python.org/pep-0639/>`__
 
 This has almost no noticeable impact on users if they are using modern Python packaging and development tools, generally

--- a/airflow-ctl/docs/installation/prerequisites.rst
+++ b/airflow-ctl/docs/installation/prerequisites.rst
@@ -30,6 +30,7 @@ Keyring Backend
 airflowctl uses keyring to store the API token securely. This ensures that the token is not stored in plain text and is only accessible to authorized users.
 
 Recommended keyring backends are:
+
 * `macOS Keychain <https://en.wikipedia.org/wiki/Keychain_%28software%29>`_
 * `Freedesktop Secret Service <http://standards.freedesktop.org/secret-service/>`_ supports many DE including GNOME (requires `secretstorage <https://pypi.python.org/pypi/secretstorage>`_)
 * `KDE4 & KDE5 KWallet <https://en.wikipedia.org/wiki/KWallet>`_ (requires `dbus <https://pypi.python.org/pypi/dbus-python>`_)

--- a/contributing-docs/17_architecture_diagrams.rst
+++ b/contributing-docs/17_architecture_diagrams.rst
@@ -24,8 +24,9 @@ automatically updated when the code changes. The diagrams are generated using pr
 static checks below) but they can also be generated manually by running the corresponding Python code.
 
 To run the code you need to install the dependencies in the virtualenv you use to run it:
+
 * ``pip install diagrams rich``. You need to have graphviz installed in your
-system (``brew install graphviz`` on macOS for example).
+  system (``brew install graphviz`` on macOS for example).
 
 The source code of the diagrams are next to the generated diagram, the difference is that the source
 code has ``.py`` extension and the generated diagram has ``.png`` extension. The prek hook ``generate-airflow-diagrams``

--- a/providers/google/docs/operators/cloud/compute_ssh.rst
+++ b/providers/google/docs/operators/cloud/compute_ssh.rst
@@ -64,5 +64,6 @@ More information
 """"""""""""""""
 
 See Google Compute Engine API documentation and Cloud OS Login API documentation
+
 * `Google Cloud API Documentation <https://cloud.google.com/compute/docs/reference/rest/v1/>`__
 * `Google Cloud OS Login API Documentation <https://cloud.google.com/compute/docs/oslogin/rest>`_.

--- a/providers/google/docs/operators/transfer/mssql_to_gcs.rst
+++ b/providers/google/docs/operators/transfer/mssql_to_gcs.rst
@@ -46,5 +46,6 @@ Reference
 ---------
 
 For further information, look at:
+
 * `Microsoft SQL Server Documentation <https://docs.microsoft.com/en-us/sql/?view=sql-server-ver15>`__
 * `Google Cloud Storage Documentation <https://cloud.google.com/storage/>`__

--- a/providers/google/docs/operators/transfer/mysql_to_gcs.rst
+++ b/providers/google/docs/operators/transfer/mysql_to_gcs.rst
@@ -49,5 +49,6 @@ Reference
 ---------
 
 For further information, look at:
+
 * `MySQL Documentation <https://dev.mysql.com/doc/>`__
 * `Google Cloud Storage Documentation <https://cloud.google.com/storage/>`__

--- a/providers/google/docs/operators/transfer/oracle_to_gcs.rst
+++ b/providers/google/docs/operators/transfer/oracle_to_gcs.rst
@@ -49,5 +49,6 @@ Reference
 ---------
 
 For further information, look at:
+
 * `oracledb Documentation <https://python-oracledb.readthedocs.io/en/latest/>`__
 * `Google Cloud Storage Documentation <https://cloud.google.com/storage/>`__

--- a/providers/google/docs/operators/transfer/postgres_to_gcs.rst
+++ b/providers/google/docs/operators/transfer/postgres_to_gcs.rst
@@ -49,4 +49,5 @@ Reference
 ---------
 
 For further information, look at:
+
 * `Google Cloud Storage Documentation <https://cloud.google.com/storage/>`__

--- a/reproducible_build.yaml
+++ b/reproducible_build.yaml
@@ -1,2 +1,2 @@
-release-notes-hash: c75fd3d515f4f98b2bfe7e7de34dd4c6
-source-date-epoch: 1763195195
+release-notes-hash: 432ad22f4ad3cfecdb41fcbb83162ae6
+source-date-epoch: 1764223516


### PR DESCRIPTION
## Why

Notice that #58748 fixed a bullet points rendering issue caused by missing blank lines before `*`, but some files still have the same problem. This PR adds a fix for them.

For example:
<img width="984" height="171" alt="image" src="https://github.com/user-attachments/assets/e734fea4-b018-44bb-8f32-01f0b3ac0450" />

## How

I used a simple script below to check that bullet points render properly and fixed them manually.

<details>
<summary>Script to find bullet points format error</summary>

```python
from pathlib import Path


def is_bullet_line(line: str) -> bool:
    return line.startswith("* ")


def is_blank(line: str) -> bool:
    return line.strip() == ""


def main():
    for rst in Path(".").rglob("*.rst"):
        lines = rst.read_text(encoding="utf-8").splitlines()

        for i, line in enumerate(lines):
            if not is_bullet_line(line):
                continue

            if i == 0:
                continue

            prev = lines[i - 1]

            if is_blank(prev):
                continue
            if (
                prev.startswith("*")
                or prev.startswith(" ")
                or prev.startswith("=")
                or prev.startswith("''")
                or prev.startswith("~")
                or prev.startswith("-")
            ):
                continue

            print(f"{rst}:{i + 1}: " f'bullet "*" should be preceded by a blank line')


if __name__ == "__main__":
    main()
```

</details>

## Optional / Future

- Maybe I could integrate a rst linter in pre-commit hook later.