### PR TITLE
Add CODEOWNERS entry for Airflow CLI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,6 +26,9 @@
 # Airflow CTL
 /airflow-ctl/ @bugraoz93 @potiuk
 
+# Airflow CLI
+/airflow-core/src/airflow/cli/ @bugraoz93 @poituk
+
 # Auth manager
 /airflow-core/src/airflow/api_fastapi/auth/ @vincbeck
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,7 +27,7 @@
 /airflow-ctl/ @bugraoz93 @potiuk
 
 # Airflow CLI
-/airflow-core/src/airflow/cli/ @bugraoz93 @poituk
+/airflow-core/src/airflow/cli/ @bugraoz93 @potiuk 
 
 # Auth manager
 /airflow-core/src/airflow/api_fastapi/auth/ @vincbeck


### PR DESCRIPTION
Hey team, I would like to follow up closely on CLI changes. These changes will be highly related to migration towards airflowctl. The next AIP I am preparing to discuss is as follows
[AIP-94 Decouple Remote Commands from airflow CLI (to airflowctl)](https://cwiki.apache.org/confluence/x/XorHFg)

I am not sure what you're thinking about being here, @potiuk, but I added you there as well. 
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
