### PR TITLE
Update statsd_datadog_tags config documentation to include dependencies

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1142,7 +1142,8 @@ metrics:
       default: "False"
     statsd_datadog_tags:
       description: |
-        List of datadog tags attached to all metrics(e.g: ``key1:value1,key2:value2``)
+        List of datadog tags attached to all metrics(e.g: ``key1:value1,key2:value2``). Require
+        ``statsd_datadog_enabled`` to be ``True``, and ``apache-airflow-providers-datadog`` installed.
       version_added: 2.0.0
       type: string
       example: ~


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->

Currently if `apache-airflow-providers-datadog` is missing, stats.py only prints a [log error](https://github.com/apache/airflow/blob/7f8b088e1238d12db8b4e3ddc697141f618e6d0b/airflow-core/src/airflow/stats.py#L43) and replace with `NoStatsLogger` without exceptions, making it hard to debug missing tags.
```
{stats.py:42} ERROR - Could not configure StatsClient: No module named ‘datadog’, using NoStatsLogger instead.
```