### PR TITLE
Fix client bypassed pydantic validation to enforce datetime & fix corresponding unittest

### DIFF
--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -289,7 +289,7 @@ class TaskInstanceOperations:
     def get_reschedule_start_date(self, id: uuid.UUID, try_number: int = 1) -> TaskRescheduleStartDate:
         """Get the start date of a task reschedule via the API server."""
         resp = self.client.get(f"task-reschedules/{id}/start_date", params={"try_number": try_number})
-        return TaskRescheduleStartDate.model_construct(start_date=resp.json())
+        return TaskRescheduleStartDate(start_date=resp.json())
 
     def get_count(
         self,

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -1267,7 +1267,7 @@ class TestTaskRescheduleOperations:
         result = client.task_instances.get_reschedule_start_date(id=ti_id, try_number=1)
 
         assert isinstance(result, TaskRescheduleStartDate)
-        assert result.start_date == "2024-01-01T00:00:00Z"
+        assert result.start_date == datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
 
 
 class TestHITLOperations:


### PR DESCRIPTION
## Problem
ti.get_first_reschedule_date() returns a string instead of a datetime object when running due to TaskRescheduleStartDate.model_construct() bypasses Pydantic validation. The corresponding unit test also tested against a string.

## Solution
Use the standard Pydantic constructor instead of model_construct() to ensure it parses the ISO string into a timezone-aware datetime object and fixes the associated test.

## Related Issue
Closes #58777