### PR TITLE
Add max_trigger_to_select_per_loop conf to respect Triggerer HA setup

### DIFF
--- a/airflow-core/docs/authoring-and-scheduling/deferring.rst
+++ b/airflow-core/docs/authoring-and-scheduling/deferring.rst
@@ -457,6 +457,19 @@ This means it's possible, but unlikely, for triggers to run in multiple places a
 
 Note that every extra ``triggerer`` you run results in an extra persistent connection to your database.
 
+Balance the workload for HA Triggerers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 3.2.0
+
+A Triggerer will select only ``[triggerer] max_trigger_to_select_per_loop`` triggers per loop to avoid starving other Triggerers in HA deployments. It is recommended to set this value significantly lower than ``[triggerer] capacity`` to help keep the load balanced across Triggerers. Currently, the default value of ``max_trigger_to_select_per_loop`` is ``50``, while the default ``capacity`` is ``1000``.
+
+According to `benchmarks <https://github.com/apache/airflow/pull/58803#pullrequestreview-3549403487>`_, two Triggerers can still claim 1,000 triggers within one second while maintaining an almost even load distribution with the default settings.
+
+You can determine a suitable value for your deployment by creating a large number of triggers (for example, by triggering a Dag with many deferrable tasks) and observing both how the load is distributed across Triggerers in your environment and how long it takes for all Triggerers to pick up the triggers.
+
+
+
 Difference between Mode='reschedule' and Deferrable=True in Sensors
 -------------------------------------------------------------------
 

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -2324,6 +2324,15 @@ triggerer:
       type: float
       example: ~
       default: "30"
+    max_trigger_to_select_per_loop:
+      description: |
+        Maximum number of triggers to select per loop. Set this notably lower than ``[triggerer] capacity``
+        to keep load balanced across triggerers in HA deployments.
+        Benchmarks show that two triggerers can still claim about 1,000 triggers within one second by default.
+      version_added: 3.2.0
+      type: integer
+      example: ~
+      default: "10"
 kerberos:
   description: ~
   options:

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -2332,7 +2332,7 @@ triggerer:
       version_added: 3.2.0
       type: integer
       example: ~
-      default: "10"
+      default: "50"
 kerberos:
   description: ~
   options:

--- a/airflow-core/src/airflow/models/trigger.py
+++ b/airflow-core/src/airflow/models/trigger.py
@@ -31,6 +31,7 @@ from sqlalchemy.sql.functions import coalesce
 
 from airflow._shared.timezones import timezone
 from airflow.assets.manager import AssetManager
+from airflow.configuration import conf
 from airflow.models import Callback
 from airflow.models.asset import AssetWatcherModel
 from airflow.models.base import Base
@@ -111,6 +112,8 @@ class Trigger(Base):
     assets = association_proxy("asset_watchers", "asset")
 
     callback = relationship("Callback", back_populates="trigger", uselist=False)
+
+    max_trigger_to_select_per_loop = conf.getint("triggerer", "max_trigger_to_select_per_loop", fallback=10)
 
     def __init__(
         self,
@@ -391,6 +394,10 @@ class Trigger(Base):
             remaining_capacity = capacity - len(result)
             if remaining_capacity <= 0:
                 break
+
+            # Limit the number of triggers selected per loop to avoid one triggerer
+            # picking up too many triggers and starving other triggerers for HA setup.
+            remaining_capacity = min(remaining_capacity, cls.max_trigger_to_select_per_loop)
 
             locked_query = with_row_locks(query.limit(remaining_capacity), session, skip_locked=True)
             result.extend(session.execute(locked_query).all())

--- a/airflow-core/src/airflow/models/trigger.py
+++ b/airflow-core/src/airflow/models/trigger.py
@@ -113,7 +113,7 @@ class Trigger(Base):
 
     callback = relationship("Callback", back_populates="trigger", uselist=False)
 
-    max_trigger_to_select_per_loop = conf.getint("triggerer", "max_trigger_to_select_per_loop", fallback=10)
+    max_trigger_to_select_per_loop = conf.getint("triggerer", "max_trigger_to_select_per_loop", fallback=50)
 
     def __init__(
         self,

--- a/airflow-core/tests/unit/models/test_trigger.py
+++ b/airflow-core/tests/unit/models/test_trigger.py
@@ -547,6 +547,97 @@ def test_get_sorted_triggers_different_priority_weights(session, create_task_ins
     ]
 
 
+@pytest.mark.need_serialized_dag
+def test_get_sorted_triggers_dont_starve_for_ha(session, create_task_instance):
+    """
+    Tests that get_sorted_triggers respects max_trigger_to_select_per_loop to prevent
+    starvation in HA setups. When capacity is large, it should limit triggers per loop
+    to avoid one triggerer picking up too many triggers.
+    """
+    # Create 20 callback triggers with different priorities
+    callback_triggers = []
+    for i in range(20):
+        trigger = Trigger(classpath="airflow.triggers.testing.CallbackTrigger", kwargs={})
+        session.add(trigger)
+        session.flush()
+        callback = TriggererCallback(
+            callback_def=AsyncCallback(f"classpath.callback_{i}"), priority_weight=20 - i
+        )
+        callback.trigger = trigger
+        session.add(callback)
+        callback_triggers.append(trigger)
+
+    # Create 20 task instance triggers with different priorities
+    task_triggers = []
+    for i in range(20):
+        logical_date = datetime.datetime(2023, 5, 9, 12, i, 0, tzinfo=pytz.timezone("UTC"))
+        trigger = Trigger(
+            classpath="airflow.triggers.testing.SuccessTrigger",
+            kwargs={},
+            created_date=logical_date,
+        )
+        session.add(trigger)
+        session.flush()
+        ti = create_task_instance(
+            task_id=f"task_{i}",
+            logical_date=logical_date,
+            run_id=f"run_{i}",
+        )
+        ti.priority_weight = 20 - i
+        ti.trigger_id = trigger.id
+        session.add(ti)
+        task_triggers.append(trigger)
+
+    # Create 20 asset triggers
+    asset_triggers = []
+    for i in range(20):
+        logical_date = datetime.datetime(2023, 5, 9, 13, i, 0, tzinfo=pytz.timezone("UTC"))
+        trigger = Trigger(
+            classpath="airflow.triggers.testing.AssetTrigger",
+            kwargs={},
+            created_date=logical_date,
+        )
+        session.add(trigger)
+        session.flush()
+        asset = AssetModel(f"test_asset_{i}")
+        asset.add_trigger(trigger, f"test_asset_watcher_{i}")
+        session.add(asset)
+        asset_triggers.append(trigger)
+
+    session.commit()
+    assert session.query(Trigger).count() == 60
+
+    # Mock max_trigger_to_select_per_loop to 5 for testing
+    with patch.object(Trigger, "max_trigger_to_select_per_loop", 5):
+        # Test with large capacity (100) - should respect max_trigger_to_select_per_loop (5)
+        # and return only 5 triggers from each category (callback, task, asset)
+        trigger_ids_query = Trigger.get_sorted_triggers(capacity=100, alive_triggerer_ids=[], session=session)
+
+        # Should get 5 callbacks (max_trigger_to_select_per_loop), then 5 tasks, then 5 assets
+        # Total: 15 triggers instead of all 60
+        assert len(trigger_ids_query) == 15
+
+        # First 5 should be callback triggers (highest priority first)
+        callback_ids = [t.id for t in callback_triggers[:5]]
+        assert [row[0] for row in trigger_ids_query[:5]] == callback_ids
+
+        # Next 5 should be task triggers (highest priority first)
+        task_ids = [t.id for t in task_triggers[:5]]
+        assert [row[0] for row in trigger_ids_query[5:10]] == task_ids
+
+        # Last 5 should be asset triggers (earliest created_date first)
+        asset_ids = [t.id for t in asset_triggers[:5]]
+        assert [row[0] for row in trigger_ids_query[10:15]] == asset_ids
+
+        # Test with capacity smaller than max_trigger_to_select_per_loop
+        # Should respect capacity instead
+        trigger_ids_query = Trigger.get_sorted_triggers(capacity=3, alive_triggerer_ids=[], session=session)
+
+        # Should get only 3 callback triggers (capacity limit)
+        assert len(trigger_ids_query) == 3
+        assert [row[0] for row in trigger_ids_query] == callback_ids[:3]
+
+
 class SensitiveKwargsTrigger(BaseTrigger):
     """
     A trigger that has sensitive kwargs.


### PR DESCRIPTION
## Why

I found that for Triggerer HA setup, one Triggerer will pick up all the jobs and another Triggerer will be starving because we limit `remaining_capacity` to `[triggerer] capacity` instead of a smaller limit to let another Triggerer to have chance to pick up jobs in the same time.


<details>
<summary>Steps to reproduce</summary>

Before reproducing, we have to change `get_hostname` temporarily to return `return str(os.getpid())` as we will always get some hostname with `breeze` setup on same machine, just to distingush different Triggerer within same container.

https://github.com/apache/airflow/blob/6798aa79586c37e7f7ca8068bb7f369ed9580926/airflow-core/src/airflow/utils/net.py#L52-L56

1. Start Airflow with one Triggerer (normal `breeze start-airflow`) and run the following Dag that produced 1000 mapped deferable tasks.
2. Wait for all mapped tasks are in `deferred` state.
3. Stop the Triggerer and wait for 30 seconds (wait for `[triggerer] job_heartbeat_sec` timeout).
4. Start two Triggerer in different terminal at the same time. (Open different terminal then`breeze exec` and run `airflow triggerer` )
5. We can found that only 1 Triggerer pick up all the jobs and another Triggerer is starving.

```python
from typing import Any

from datetime import timedelta
from airflow.providers.common.compat.sdk import BaseSensorOperator
from airflow.sdk import DAG, task, Context
from airflow.providers.standard.triggers.temporal import TimeDeltaTrigger

class WaitHoursSensor(BaseSensorOperator):
    def __init__(
        self,
        task_id: str,
        trigger_kwargs,
        **kwargs: dict[str, Any],
    ) -> None:
        super().__init__(task_id=task_id, **kwargs)
        self.trigger_kwargs = trigger_kwargs

    def execute(self, context: Context) -> None:
        self.defer(
            trigger=TimeDeltaTrigger(timedelta(hours=self.trigger_kwargs["delta"])),
            method_name="execute_complete",
        )

    def execute_complete(
        self,
        context: Context,
        event: dict[str, Any] | None = None,
    ) -> None:
        print("Wait complete.")
        return


with DAG(dag_id="ha_triggerer", schedule=None):

    @task
    def items_to_process():
        return [{"delta": i+1} for i in range(1000)]

    WaitHoursSensor.partial(task_id="deferable").expand(
        trigger_kwargs=items_to_process(),
    )
```

</details>

<img width="636" height="261" alt="max_trigger_to_select_per_loop" src="https://github.com/user-attachments/assets/7b4c2cb7-e81c-469c-8f98-ec84f4aeff94" />

- **Before Fix**: One picked up `1000` triggers and another picked `0` trigger -> Starving!
- **After Fix**: One picked up `480` triggers and another picked `520` triggers.



## What

- Introduce `[triggerer] max_trigger_to_select_per_loop` config to give the Triggerer(s) chance to pick up triggers in order to make the workloads more balance in HA setup.
- Even though the `max_trigger_to_select_per_loop` is not an exact accurate term as we will use the same limit to select `Callback`,  `TaskInstance` and `Asset` triggers in [get_sorted_triggers](https://github.com/apache/airflow/blob/6798aa79586c37e7f7ca8068bb7f369ed9580926/airflow-core/src/airflow/models/trigger.py#L365-L366) loop.
  - But the main loop of Triggerer is in [load_triggers](https://github.com/apache/airflow/blob/6798aa79586c37e7f7ca8068bb7f369ed9580926/airflow-core/src/airflow/jobs/triggerer_job_runner.py#L527-L528).
  - Which mean we will actually pick `type of triggers(Callback, TI andAsset = 3 for now) * max_trigger_to_select_per_loop(defaut by 10)` in main loop of Triggerer. 