### PR TITLE
Stubbing missing tests for asset events and asset operations

### DIFF
--- a/task-sdk-integration-tests/tests/task_sdk_tests/test_asset_event_operations.py
+++ b/task-sdk-integration-tests/tests/task_sdk_tests/test_asset_event_operations.py
@@ -18,10 +18,12 @@
 Integration tests for Asset Event operations.
 
 These tests validate the Execution API endpoints for Asset Event operations:
-- get(): Get asset events by name or URI
+- get(): Get asset events by name, URI, or alias
 """
 
 from __future__ import annotations
+
+import pytest
 
 from airflow.sdk.api.datamodels._generated import AssetEventsResponse
 from task_sdk_tests import console
@@ -64,3 +66,27 @@ def test_asset_event_get_not_found(sdk_client_for_assets):
     assert isinstance(response, AssetEventsResponse)
     assert len(response.asset_events) == 0, "Expected empty list for non-existent asset"
     console.print("[green]✅ Asset event get (not found) test passed!")
+
+
+@pytest.mark.skip(reason="TODO: Implement Asset Event get_by_uri test")
+def test_asset_event_get_by_uri(sdk_client_for_assets, asset_test_setup):
+    """
+    Test getting asset events by URI.
+
+    Expected: AssetEventsResponse with events
+    Endpoint: GET /execution/asset-events/by-asset?uri={uri}
+    """
+    console.print("[yellow]TODO: Implement test_asset_event_get_by_uri")
+    raise NotImplementedError("test_asset_event_get_by_uri not implemented")
+
+
+@pytest.mark.skip(reason="TODO: Implement Asset Event get_by_alias test")
+def test_asset_event_get_by_alias(sdk_client_for_assets):
+    """
+    Test getting asset events by alias name.
+
+    Expected: AssetEventsResponse with events
+    Endpoint: GET /execution/asset-events/by-asset-alias?name={alias_name}
+    """
+    console.print("[yellow]TODO: Implement test_asset_event_get_by_alias")
+    raise NotImplementedError("test_asset_event_get_by_alias not implemented")

--- a/task-sdk-integration-tests/tests/task_sdk_tests/test_asset_operations.py
+++ b/task-sdk-integration-tests/tests/task_sdk_tests/test_asset_operations.py
@@ -19,10 +19,12 @@
 Integration tests for Asset operations.
 
 These tests validate the Execution API endpoints for Asset operations:
-- get(): Get asset by name
+- get(): Get asset by name or URI
 """
 
 from __future__ import annotations
+
+import pytest
 
 from airflow.sdk.api.datamodels._generated import AssetResponse
 from airflow.sdk.execution_time.comms import ErrorResponse
@@ -63,3 +65,27 @@ def test_asset_get_by_name_not_found(sdk_client_for_assets):
     assert isinstance(response, ErrorResponse)
     assert str(response.error).endswith("ASSET_NOT_FOUND")
     console.print("[green]Asset get by name (not found) test passed!")
+
+
+@pytest.mark.skip(reason="TODO: Implement Asset get_by_uri test")
+def test_asset_get_by_uri(sdk_client_for_assets, asset_test_setup):
+    """
+    Test getting asset by URI.
+
+    Expected: AssetResponse with asset details
+    Endpoint: GET /execution/assets/by-uri?uri={uri}
+    """
+    console.print("[yellow]TODO: Implement test_asset_get_by_uri")
+    raise NotImplementedError("test_asset_get_by_uri not implemented")
+
+
+@pytest.mark.skip(reason="TODO: Implement Asset get_by_uri (not found) test")
+def test_asset_get_by_uri_not_found(sdk_client_for_assets):
+    """
+    Test getting non-existent asset by URI.
+
+    Expected: ErrorResponse with ASSET_NOT_FOUND error
+    Endpoint: GET /execution/assets/by-uri?uri={uri}
+    """
+    console.print("[yellow]TODO: Implement test_asset_get_by_uri_not_found")
+    raise NotImplementedError("test_asset_get_by_uri_not_found not implemented")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Turns out I missed stubbing some of the tests here during the time I created the issue: https://github.com/apache/airflow/issues/58178. Likely because these endpoints were being worked on in parallel.

Just adding stubs for those too.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
