### PR TITLE
Add CloudWatch log streaming to ECS Executor

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/executors/ecs/utils.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/executors/ecs/utils.py
@@ -52,6 +52,7 @@ CONFIG_DEFAULTS = {
     "assign_public_ip": "False",
     "platform_version": "LATEST",
     "check_health_on_startup": "True",
+    "cloudwatch_logs_enabled": "False",
 }
 
 
@@ -98,6 +99,12 @@ class AllEcsConfigKeys(RunTaskKwargsConfigKeys):
     MAX_RUN_TASK_ATTEMPTS = "max_run_task_attempts"
     REGION_NAME = "region_name"
     RUN_TASK_KWARGS = "run_task_kwargs"
+
+    # CloudWatch log fetching configuration
+    CLOUDWATCH_LOGS_ENABLED = "cloudwatch_logs_enabled"
+    CLOUDWATCH_LOGS_GROUP = "cloudwatch_logs_group"
+    CLOUDWATCH_LOGS_STREAM_PREFIX = "cloudwatch_logs_stream_prefix"
+    CLOUDWATCH_LOGS_REGION = "cloudwatch_logs_region"
 
 
 class EcsExecutorException(Exception):


### PR DESCRIPTION
Implements `get_task_log()` for the ECS Executor to fetch live logs from CloudWatch and display them in the Airflow UI during task execution.

Currently the ECS Executor doesn't implement this method, so users can't see task logs in the UI while tasks are running. This follows the same pattern as KubernetesExecutor.

## Changes

- Added `get_task_log()` method that fetches logs from CloudWatch using `AwsLogsHook`
- Added config options: `cloudwatch_logs_enabled`, `cloudwatch_logs_group`, `cloudwatch_logs_stream_prefix`, `cloudwatch_logs_region`
- Disabled by default (opt-in)

## Configuration

```ini
[aws_ecs_executor]
cloudwatch_logs_enabled = True
cloudwatch_logs_group = /ecs/airflow-tasks
cloudwatch_logs_stream_prefix = ecs
cloudwatch_logs_region = us-east-1
```

ECS task definition must use the `awslogs` log driver with matching config. Scheduler needs `logs:GetLogEvents` IAM permission.

## Testing

- Added unit tests for all new functionality
- All existing tests pass