### PR TITLE
Fix(UI): Improve mobile responsiveness of Dashboard sections

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/Assets/AssetEvents.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Assets/AssetEvents.tsx
@@ -70,7 +70,7 @@ export const AssetEvents = ({
 
   return (
     <Box borderBottomWidth={0} borderRadius={8} borderWidth={1} p={4} py={2} {...rest}>
-      <Flex alignItems="center" justify="space-between">
+      <Flex alignItems="center" flexWrap="wrap" justify="space-between">
         <HStack>
           <StateBadge colorPalette="brand" fontSize="md" variant="solid">
             <FiDatabase />

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/HistoricalMetrics.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/HistoricalMetrics.tsx
@@ -85,7 +85,7 @@ export const HistoricalMetrics = () => {
           setStartDate={setStartDate}
           startDate={startDate}
         />
-        <SimpleGrid columns={{ base: 10 }} gap={2}>
+        <SimpleGrid columns={{ base: 1, md: 10 }} gap={2}>
           <GridItem colSpan={{ base: 7 }}>
             {isLoading ? <MetricSectionSkeleton /> : undefined}
             {!isLoading && data !== undefined && (

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/HistoricalMetrics.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/HistoricalMetrics.tsx
@@ -85,8 +85,8 @@ export const HistoricalMetrics = () => {
           setStartDate={setStartDate}
           startDate={startDate}
         />
-        <SimpleGrid columns={{ base: 1, md: 10 }} gap={2}>
-          <GridItem colSpan={{ base: 7 }}>
+        <SimpleGrid columns={{ base: 1, lg: 10 }} gap={2}>
+          <GridItem colSpan={{ base: 1, lg: 7 }}>
             {isLoading ? <MetricSectionSkeleton /> : undefined}
             {!isLoading && data !== undefined && (
               <Box>
@@ -99,7 +99,7 @@ export const HistoricalMetrics = () => {
               </Box>
             )}
           </GridItem>
-          <GridItem colSpan={{ base: 3 }}>
+          <GridItem colSpan={{ base: 1, lg: 3 }}>
             <AssetEvents
               data={assetEventsData}
               isLoading={isLoadingAssetEvents}


### PR DESCRIPTION
## **Fix: Responsive layout issue in Historical Metrics (Asset Events box)**

This PR fixes a UI responsiveness issue reported in **#58133**, where the *Asset Events* section inside **Historical Metrics** was overflowing and misaligned on smaller screens.

### **What was happening**
- The *Asset Events* card was not respecting grid boundaries.
- On smaller screens, it was shifting downward and appearing **outside** the main grid.
- The sort dropdown (`Newest First`) was also overflowing the parent container.

### **What this PR changes**
- Adds responsive Chakra UI props to ensure proper wrapping inside the `SimpleGrid`.
- Prevents the AssetEvents box from overflowing horizontally.
- Ensures both the *Dag Run Metrics* and *Asset Events* sections stack properly on mobile.
- Maintains minimal and clean changes without affecting other UI components.

### Before (Broken)
- Asset Events box overflowing outside container  
- Sort dropdown escaping layout
<img width="337" height="605" alt="Screenshot from 2025-11-28 16-26-15" src="https://github.com/user-attachments/assets/e89688a9-365e-441f-a0c3-686616411305" />

### After (Fixed)
- Fully responsive  
- Boxes stack correctly on small screens  
- No overflow; consistent spacing

[Screencast from 2025-11-28 13-29-02.webm](https://github.com/user-attachments/assets/62adb9d3-f197-41dc-86f0-56a01c5922da)

### Notes
- Pure UI fix; no backend or functional logic changed.
- Does not introduce any breaking changes.
- No new dependencies added.

---

**related: #58133**

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
