### PR TITLE
Fix incorrect backfill duration calculation in Grid view

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/ui/common.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/ui/common.py
@@ -81,10 +81,10 @@ class GridRunsResponse(BaseModel):
     run_type: DagRunType
 
     @computed_field
-    def duration(self) -> int:
+    def duration(self) -> float:
         if self.start_date:
             end_date = self.end_date or timezone.utcnow()
-            return (end_date - self.start_date).seconds
+            return (end_date - self.start_date).total_seconds()
         return 0
 
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -1924,7 +1924,7 @@ components:
         run_type:
           $ref: '#/components/schemas/DagRunType'
         duration:
-          type: integer
+          type: number
           title: Duration
           readOnly: true
       type: object

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -7810,7 +7810,7 @@ export const $GridRunsResponse = {
             '$ref': '#/components/schemas/DagRunType'
         },
         duration: {
-            type: 'integer',
+            type: 'number',
             title: 'Duration',
             readOnly: true
         }

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_grid.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_grid.py
@@ -58,7 +58,7 @@ INNER_TASK_GROUP_SUB_TASK = "inner_task_group_sub_task"
 
 GRID_RUN_1 = {
     "dag_id": "test_dag",
-    "duration": 0,
+    "duration": 283996800.0,
     "end_date": "2024-12-31T00:00:00Z",
     "run_after": "2024-11-30T00:00:00Z",
     "run_id": "run_1",
@@ -69,7 +69,7 @@ GRID_RUN_1 = {
 
 GRID_RUN_2 = {
     "dag_id": "test_dag",
-    "duration": 0,
+    "duration": 283996800.0,
     "end_date": "2024-12-31T00:00:00Z",
     "run_after": "2024-11-30T00:00:00Z",
     "run_id": "run_2",
@@ -528,7 +528,7 @@ class TestGetGridDataEndpoint:
         assert response.json() == [
             {
                 "dag_id": "test_dag",
-                "duration": 0,
+                "duration": 283996800.0,
                 "end_date": "2024-12-31T00:00:00Z",
                 "run_after": "2024-11-30T00:00:00Z",
                 "run_id": "run_1",
@@ -538,7 +538,7 @@ class TestGetGridDataEndpoint:
             },
             {
                 "dag_id": "test_dag",
-                "duration": 0,
+                "duration": 283996800.0,
                 "end_date": "2024-12-31T00:00:00Z",
                 "run_after": "2024-11-30T00:00:00Z",
                 "run_id": "run_2",


### PR DESCRIPTION
The duration was calculated using timedelta.seconds which,
 returns only the seconds component, not the total duration.
This caused backfills lasting more than a day to show incorrect durations.

Changed to use total_seconds() which correctly returns the full duration.

Related: https://github.com/apache/airflow/issues/58752