### PR TITLE
Add configurable metadata db indexes

### DIFF
--- a/airflow-core/docs/howto/index.rst
+++ b/airflow-core/docs/howto/index.rst
@@ -56,4 +56,5 @@ configuring an Airflow environment.
     dynamic-dag-generation
     docker-compose/index
     run-with-self-signed-certificate
+    performance
     memory-profiling

--- a/airflow-core/docs/howto/performance.rst
+++ b/airflow-core/docs/howto/performance.rst
@@ -1,0 +1,48 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+..   http://www.apache.org/licenses/LICENSE-2.0
+
+.. Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+
+Performance tuning (API and UI)
+===============================
+
+This guide collects pragmatic tips that improve Airflow performance for API and UI workloads.
+
+Configurable metadata indexes
+-----------------------------
+
+Airflow can create additional database indexes on startup to accelerate common queries used by the API and UI.
+This is helpful in larger deployments where filtering and lookups on high‑cardinality columns become hot paths.
+
+Use :ref:`config:database__metadata_indexes` to declare a list of index specifications.
+Each entry must follow the ``table(column1, column2, ...)`` syntax (no schema qualification).
+
+- Indexes are created at API server startup. Existing indexes are detected and skipped.
+- On PostgreSQL, indexes are created ``CONCURRENTLY`` to avoid blocking writes during creation.
+- On other databases (e.g. MySQL, SQLite), a best‑effort non‑blocking creation is attempted; if not supported,
+  a standard index creation is used.
+- Only Airflow metadata tables should be targeted. Do not include schema qualifiers.
+
+When to use:
+
+- Slow API list/detail endpoints caused by frequent scans or lookups on columns like ``dag_id``, ``task_id``,
+  ``run_id``, timestamps (e.g. ``dttm``), or status fields.
+- UI pages that load large lists or perform heavy filtering on metadata tables.
+
+Additional Notes:
+
+- Review query plans (e.g. via ``EXPLAIN``) to choose effective column sets and ordering for your workload.
+- Composite indexes should list columns in selectivity order appropriate to your most common predicates.
+- Indexes incur write overhead; add only those that materially improve your read paths.

--- a/airflow-core/src/airflow/api_fastapi/app.py
+++ b/airflow-core/src/airflow/api_fastapi/app.py
@@ -25,6 +25,7 @@ from fastapi import FastAPI
 from starlette.routing import Mount
 
 from airflow.api_fastapi.common.dagbag import create_dag_bag
+from airflow.api_fastapi.common.db.indexes import init_metadata_indexes
 from airflow.api_fastapi.core_api.app import (
     init_config,
     init_error_handlers,
@@ -103,6 +104,8 @@ def create_app(apps: str = "all") -> FastAPI:
         init_middlewares(app)
 
     init_config(app)
+
+    init_metadata_indexes()
 
     return app
 

--- a/airflow-core/src/airflow/api_fastapi/common/db/indexes.py
+++ b/airflow-core/src/airflow/api_fastapi/common/db/indexes.py
@@ -124,7 +124,7 @@ def init_metadata_indexes() -> list[tuple[str, bool, str | None]]:
     """
     engine = get_engine()
     results: list[tuple[str, bool, str | None]] = []
-    specs = conf.getlist("database", "metadata_indexes", fallback=[], delimiter="|")
+    specs = conf.getlist("database", "metadata_indexes", fallback=None, delimiter="|")
 
     if not specs:
         return results

--- a/airflow-core/src/airflow/api_fastapi/common/db/indexes.py
+++ b/airflow-core/src/airflow/api_fastapi/common/db/indexes.py
@@ -1,0 +1,153 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Sequence
+
+from sqlalchemy import inspect, text
+from sqlalchemy.engine import Connection
+
+from airflow.configuration import conf
+from airflow.settings import get_engine
+
+log = logging.getLogger(__name__)
+
+
+def _parse_index_spec(spec: str) -> tuple[str, list[str]]:
+    """
+    Parse spec format.
+
+    - "table(col1, col2, ...)"
+
+    Whitespace around tokens is ignored.
+    """
+    s = spec.strip()
+    # table(col1,col2)
+    m = re.match(r"^(?P<table>(?:[^().:]+))\s*\(\s*(?P<cols>[^()]+)\s*\)\s*$", s)
+    if m:
+        table_ref = m.group("table").strip()
+        cols_part = m.group("cols").strip()
+        cols = [c.strip() for c in cols_part.split(",") if c.strip()]
+    else:
+        raise ValueError(f"Invalid index spec '{spec}'. Expected 'table(col1,...)'.")
+    if not table_ref or not cols:
+        raise ValueError(f"Invalid index spec '{spec}'. Table name and at least one column are required.")
+    table = table_ref
+    return table, cols
+
+
+def _build_index_name(table: str, cols: Sequence[str]) -> str:
+    """Build a deterministic index name based on table and columns."""
+    base = f"idx_{table}_{'_'.join(cols)}"
+    sanitized = re.sub(r"[^a-zA-Z0-9_]+", "_", base)
+    if len(sanitized) > 63:
+        # Simple truncation with tail hash to avoid collisions
+        import hashlib
+
+        digest = hashlib.sha1(sanitized.encode("utf-8")).hexdigest()[:8]
+        sanitized = f"{sanitized[:54]}_{digest}"
+    return sanitized
+
+
+def _index_exists(conn: Connection, table: str, index_name: str) -> bool:
+    insp = inspect(conn)
+    existing = insp.get_indexes(table)
+    return any(idx.get("name") == index_name for idx in existing or [])
+
+
+def _create_index_postgres(conn: Connection, table: str, cols: Sequence[str], name: str) -> None:
+    qualified_table = table
+    cols_sql = ", ".join(f'"{c}"' for c in cols)
+    # This statement must run outside of a transaction block.
+    ddl = f'CREATE INDEX CONCURRENTLY "{name}" ON {qualified_table} ({cols_sql})'
+    # Commit to allow changing the isolation level
+    conn.commit()
+    conn = conn.execution_options(isolation_level="AUTOCOMMIT")
+    conn.execute(text(ddl))
+
+
+def _create_index_mysql(conn: Connection, table: str, cols: Sequence[str], name: str) -> None:
+    qualified_table = f"`{table}`"
+    cols_sql = ", ".join(f"`{c}`" for c in cols)
+
+    # Prefer ONLINE DDL when possible. MySQL supports ALTER TABLE ... ADD INDEX with algorithm/lock hints.
+    # Try non-blocking first; if it fails, fallback to plain create index.
+    try:
+        conn.execute(
+            text(
+                f"ALTER TABLE {qualified_table} ADD INDEX `{name}` ({cols_sql}) ALGORITHM=INPLACE, LOCK=NONE"
+            )
+        )
+    except Exception as err:
+        log.debug("Online index creation failed for %s: %s. Falling back to CREATE INDEX.", name, err)
+        conn.execute(text(f"CREATE INDEX `{name}` ON {qualified_table} ({cols_sql})"))
+
+
+def _create_index_sqlite(conn: Connection, table: str, cols: Sequence[str], name: str) -> None:
+    cols_sql = ", ".join(f'"{c}"' for c in cols)
+    conn.execute(text(f'CREATE INDEX "{name}" ON "{table}" ({cols_sql})'))
+
+
+def _create_index(conn: Connection, table: str, cols: Sequence[str], name: str) -> None:
+    dialect = conn.dialect.name
+    if dialect == "postgresql":
+        _create_index_postgres(conn, table, cols, name)
+    elif dialect in {"mysql", "mariadb"}:
+        _create_index_mysql(conn, table, cols, name)
+    elif dialect == "sqlite":
+        _create_index_sqlite(conn, table, cols, name)
+    else:
+        raise NotImplementedError(f"Index creation not implemented for dialect '{dialect}'.")
+
+
+def init_metadata_indexes() -> list[tuple[str, bool, str | None]]:
+    """
+    Create configured metadata indexes if they do not already exist.
+
+    Returns a list of (index_name, created, error) tuples for logging/diagnostics.
+    """
+    engine = get_engine()
+    results: list[tuple[str, bool, str | None]] = []
+    specs = conf.getlist("database", "metadata_indexes", fallback=[], delimiter="|")
+
+    if not specs:
+        return results
+
+    with engine.connect() as conn:
+        for spec in specs:
+            try:
+                table, cols = _parse_index_spec(spec)
+            except ValueError as e:
+                log.error("Skipping invalid index spec '%s': %s", spec, e)
+                results.append((spec, False, str(e)))
+                continue
+
+            name = _build_index_name(table, cols)
+            try:
+                if _index_exists(conn, table, name):
+                    log.debug("Index %s already exists on %s", name, table)
+                    results.append((name, False, None))
+                    continue
+                _create_index(conn, table, cols, name)
+                log.info("Created index %s on %s(%s)", name, table, ", ".join(cols))
+                results.append((name, True, None))
+            except Exception as e:
+                log.warning("Failed to create index %s from spec '%s': %s", name, spec, e)
+                results.append((name, False, str(e)))
+    return results

--- a/airflow-core/src/airflow/api_fastapi/common/parameters.py
+++ b/airflow-core/src/airflow/api_fastapi/common/parameters.py
@@ -35,7 +35,7 @@ from typing import (
 from fastapi import Depends, HTTPException, Query, status
 from pendulum.parsing.exceptions import ParserError
 from pydantic import AfterValidator, BaseModel, NonNegativeInt
-from sqlalchemy import Column, and_, case, func, not_, or_, select as sql_select
+from sqlalchemy import Column, and_, func, not_, or_, select as sql_select
 from sqlalchemy.inspection import inspect
 
 from airflow._shared.timezones import timezone
@@ -251,11 +251,6 @@ class SortParam(BaseParam[list[str]]):
             if column is None:
                 column = getattr(self.model, lstriped_orderby)
 
-            # MySQL does not support `nullslast`, and True/False ordering depends on the
-            # database implementation.
-            nullscheck = case((column.isnot(None), 0), else_=1)
-
-            columns.append(nullscheck)
             if order_by_value.startswith("-"):
                 columns.append(column.desc())
             else:

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -712,6 +712,20 @@ database:
       type: integer
       example: ~
       default: "10000"
+    metadata_indexes:
+      description: |
+        JSON list of additional indexes to create on the metadata database at API server startup.
+
+        Each item must be a string specifying the table and one or more columns:
+        - "table(column1, column2, ...)"
+
+        Existing indexes are detected and skipped. On PostgreSQL, indexes are created
+        CONCURRENTLY to avoid locking tables. Other databases attempt non-blocking creation
+        where supported, otherwise fallback to standard index creation.
+      version_added: 3.2.0
+      type: string
+      example: "task_instance(dag_id, task_id, run_id)|log(dttm)|dag_run(dag_id, run_id)"
+      default: ~
 logging:
   description: ~
   options:

--- a/airflow-core/tests/unit/api_fastapi/common/db/test_indexes.py
+++ b/airflow-core/tests/unit/api_fastapi/common/db/test_indexes.py
@@ -1,0 +1,163 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import inspect, text
+
+from airflow.api_fastapi.common.db import indexes
+from airflow.settings import get_engine
+
+from tests_common.test_utils.config import conf_vars
+
+pytestmark = pytest.mark.db_test
+
+
+def _backend() -> str:
+    return get_engine().dialect.name
+
+
+class TestParseIndexSpec:
+    def test_valid(self):
+        table, cols = indexes._parse_index_spec("task_instance(dag_id, task_id, run_id)")
+        assert table == "task_instance"
+        assert cols == ["dag_id", "task_id", "run_id"]
+
+    def test_invalid(self):
+        with pytest.raises(ValueError, match="Invalid index spec 'task_instance'. Expected*"):
+            indexes._parse_index_spec("task_instance")
+        with pytest.raises(ValueError, match=r"Invalid index spec 'task_instance\(,\)'. Table name and"):
+            indexes._parse_index_spec("task_instance(,)")
+
+
+class TestBuildIndexName:
+    @pytest.mark.parametrize(
+        ("table", "cols", "expected"),
+        [
+            ["task_instance", ["dag_id", "run_id", "task_id"], "idx_task_instance_dag_id_run_id_task_id"],
+            [
+                "some_table",
+                ["a" * 40, "b" * 40, "c" * 40],
+                "idx_some_table_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_e28fa017",
+            ],
+        ],
+    )
+    def test_build_index_names(self, table, cols, expected):
+        name = indexes._build_index_name(table, cols)
+        assert name == expected
+
+
+class TestIndexExists:
+    def test_true_after_creation(self):
+        engine = get_engine()
+        table = f"t_exists_{uuid.uuid4().hex[:8]}"
+        index_name = f"idx_{table}_a_b"
+        with engine.begin() as conn:
+            conn.execute(text(f"CREATE TABLE {table} (a INT, b INT)"))
+        try:
+            with engine.connect() as conn:
+                if _backend() == "postgresql":
+                    indexes._create_index_postgres(conn, table, ["a", "b"], index_name)
+                elif _backend() == "mysql":
+                    indexes._create_index_mysql(conn, table, ["a", "b"], index_name)
+                else:
+                    indexes._create_index_sqlite(conn, table, ["a", "b"], index_name)
+            with engine.connect() as conn:
+                assert indexes._index_exists(conn, table, index_name) is True
+        finally:
+            with engine.begin() as conn:
+                conn.execute(text(f"DROP TABLE IF EXISTS {table}"))
+
+
+class TestCreateIndexPostgres:
+    @pytest.mark.backend("postgres")
+    def test_concurrently(self):
+        engine = get_engine()
+        table = "some_table"
+        index_name = f"idx_{table}_a_b"
+        with engine.begin() as conn:
+            conn.execute(text(f"CREATE TABLE {table} (a INT, b INT)"))
+        try:
+            with engine.connect() as conn:
+                indexes._create_index_postgres(conn, table, ["a", "b"], index_name)
+            with engine.connect() as conn:
+                ix = inspect(conn).get_indexes(table)
+                assert any(d.get("name") == index_name for d in ix)
+        finally:
+            with engine.begin() as conn:
+                conn.execute(text(f"DROP TABLE IF EXISTS {table}"))
+
+
+class TestCreateIndexMySQL:
+    @pytest.mark.backend("mysql")
+    def test_online_or_fallback(self):
+        engine = get_engine()
+        table = "some_table"
+        index_name = f"idx_{table}_a_b"
+        with engine.begin() as conn:
+            conn.execute(text(f"CREATE TABLE {table} (a INT, b INT)"))
+        try:
+            with engine.connect() as conn:
+                indexes._create_index_mysql(conn, table, ["a", "b"], index_name)
+            with engine.connect() as conn:
+                ix = inspect(conn).get_indexes(table)
+                assert any(d.get("name") == index_name for d in ix)
+        finally:
+            with engine.begin() as conn:
+                conn.execute(text(f"DROP TABLE IF EXISTS {table}"))
+
+
+class TestCreateIndexSQLite:
+    @pytest.mark.backend("sqlite")
+    def test_if_not_exists(self):
+        engine = get_engine()
+        table = "some_table"
+        index_name = f"idx_{table}_a_b"
+        with engine.begin() as conn:
+            conn.execute(text(f'CREATE TABLE "{table}" (a INT, b INT)'))
+        try:
+            with engine.connect() as conn:
+                indexes._create_index_sqlite(conn, table, ["a", "b"], index_name)
+            with engine.connect() as conn:
+                ix = inspect(conn).get_indexes(table)
+                assert any(d.get("name") == index_name for d in ix)
+        finally:
+            with engine.begin() as conn:
+                conn.execute(text(f'DROP TABLE IF EXISTS "{table}"'))
+
+
+class TestInitMetadataIndexes:
+    def test_creates_from_config(self):
+        engine = get_engine()
+        table = "some_table"
+        with engine.begin() as conn:
+            conn.execute(text(f"CREATE TABLE {table} (a INT, b INT, dttm TIMESTAMP NULL)"))
+        try:
+            specs = [f"{table}(a,b)", f"{table}(dttm)"]
+            with conf_vars({("database", "metadata_indexes"): "|".join(specs)}):
+                res = indexes.init_metadata_indexes()
+            with engine.connect() as conn:
+                ix = inspect(conn).get_indexes(table)
+                names = {d.get("name") for d in ix}
+                assert any(name.startswith(f"idx_{table}_a_b") for name in names)
+                assert any(name.startswith(f"idx_{table}_dttm") for name in names)
+            assert len(res) == 2
+        finally:
+            with engine.begin() as conn:
+                conn.execute(text(f"DROP TABLE IF EXISTS {table}"))


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/57344

Allow to configure additional indexes for the metadata database.


I checked and:
- Default sorting for List endpoint is the primary key of the table. (index is there)
- Default sorting from the UI is `run_after` for `dag_runs` and `TIs` which is indexed, other entities either do not specify anything (defaults to the PK indexed), or specify a column but the cartinality of such entities shouldn't be a problem unless it's a very specific installation.