### PR TITLE
Extend airflow_ti_running metrics by scheduled, queued and deferred

### DIFF
--- a/airflow-core/docs/administration-and-deployment/logging-monitoring/metrics.rst
+++ b/airflow-core/docs/administration-and-deployment/logging-monitoring/metrics.rst
@@ -263,8 +263,17 @@ Name                                                 Description
 ``triggerer.capacity_left.<hostname>``               Capacity left on a triggerer to run triggers (described by hostname)
 ``triggerer.capacity_left``                          Capacity left on a triggerer to run triggers (described by hostname).
                                                      Metric with hostname tagging.
+``ti.scheduled.<queue>.<dag_id>.<task_id>``          Number of scheduled tasks in a given Dag.
+``ti.scheduled``                                     Number of scheduled tasks in a given Dag.
+                                                     Metric with queue, dag_id and task_id tagging.
+``ti.queued.<queue>.<dag_id>.<task_id>``             Number of queued tasks in a given Dag.
+``ti.queued``                                        Number of queued tasks in a given Dag.
+                                                     Metric with queue, dag_id and task_id tagging.
 ``ti.running.<queue>.<dag_id>.<task_id>``            Number of running tasks in a given Dag. As ti.start and ti.finish can run out of sync this metric shows all running tis.
 ``ti.running``                                       Number of running tasks in a given Dag. As ti.start and ti.finish can run out of sync this metric shows all running tis.
+                                                     Metric with queue, dag_id and task_id tagging.
+``ti.deferred.<queue>.<dag_id>.<task_id>``           Number of deferred tasks in a given Dag.
+``ti.deferred``                                      Number of deferred tasks in a given Dag.
                                                      Metric with queue, dag_id and task_id tagging.
 ==================================================== ========================================================================
 

--- a/airflow-core/docs/administration-and-deployment/scheduler.rst
+++ b/airflow-core/docs/administration-and-deployment/scheduler.rst
@@ -261,9 +261,9 @@ However, you can also look at other non-performance-related scheduler configurat
   period.
 
 
-- :ref:`config:scheduler__running_metrics_interval`
+- :ref:`config:scheduler__ti_metrics_interval`
 
-  How often (in seconds) should running task instance stats be sent to StatsD
+  How often (in seconds) should task instance (scheduled, queued, running and deferred) stats be sent to StatsD
   (if statsd_on is enabled). This is a *relatively* expensive query to compute
   this, so this should be set to match the same period as your StatsD roll-up
   period.

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -2081,9 +2081,10 @@ scheduler:
       type: float
       example: ~
       default: "5.0"
-    running_metrics_interval:
+    ti_metrics_interval:
       description: |
-        How often (in seconds) should running task instance stats be sent to StatsD (if statsd_on is enabled)
+        How often (in seconds) should task instance (scheduled, queued, running and deferred) stats
+        be sent to StatsD (if statsd_on is enabled)
       version_added: 3.0.0
       type: float
       example: ~

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2468,16 +2468,14 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             }
 
             for (dag_id, task_id, queue), count in ti_metrics.items():
-                # Replace '.' with '__' in task_id to avoid StatsD metric hierarchy conflicts from task group separators
-                Stats.gauge(f"ti.{state}.{queue}.{dag_id}.{task_id.replace('.', '__')}", count)
+                Stats.gauge(f"ti.{state}.{queue}.{dag_id}.{task_id}", count)
                 Stats.gauge(f"ti.{state}", count, tags={"queue": queue, "dag_id": dag_id, "task_id": task_id})
 
             for prev_key in self.previous_ti_metrics[state]:
                 # Reset previously exported stats that are no longer present in current metrics to zero
                 if prev_key not in ti_metrics:
                     dag_id, task_id, queue = prev_key
-                    # Replace '.' with '__' in task_id to avoid StatsD metric hierarchy conflicts from task group separators
-                    Stats.gauge(f"ti.{state}.{queue}.{dag_id}.{task_id.replace('.', '__')}", 0)
+                    Stats.gauge(f"ti.{state}.{queue}.{dag_id}.{task_id}", 0)
                     Stats.gauge(f"ti.{state}", 0, tags={"queue": queue, "dag_id": dag_id, "task_id": task_id})
 
             self.previous_ti_metrics[state] = ti_metrics

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -1452,8 +1452,8 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
         if self._is_metrics_enabled():
             timers.call_regular_interval(
-                conf.getfloat("scheduler", "running_metrics_interval", fallback=30.0),
-                self._emit_running_ti_metrics,
+                conf.getfloat("scheduler", "ti_metrics_interval", fallback=30.0),
+                self._emit_ti_metrics,
             )
 
             timers.call_regular_interval(
@@ -2439,36 +2439,48 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         count_result: int | None = query.count()
         return count_result if count_result is not None else 0
 
-    previous_ti_running_metrics: dict[tuple[str, str, str], int] = {}
+    previous_ti_metrics: dict[State, dict[tuple[str, str, str], int]] = {}
 
     @provide_session
-    def _emit_running_ti_metrics(self, session: Session = NEW_SESSION) -> None:
-        running = (
+    def _emit_ti_metrics(self, session: Session = NEW_SESSION) -> None:
+        metric_states = {State.SCHEDULED, State.QUEUED, State.RUNNING, State.DEFERRED}
+        all_states_metric = (
             session.query(
+                TaskInstance.state,
                 TaskInstance.dag_id,
                 TaskInstance.task_id,
                 TaskInstance.queue,
-                func.count(TaskInstance.task_id).label("running_count"),
+                func.count(TaskInstance.task_id).label("count"),
             )
-            .filter(TaskInstance.state == State.RUNNING)
-            .group_by(TaskInstance.dag_id, TaskInstance.task_id, TaskInstance.queue)
+            .filter(TaskInstance.state.in_(metric_states))
+            .group_by(TaskInstance.state, TaskInstance.dag_id, TaskInstance.task_id, TaskInstance.queue)
             .all()
         )
 
-        ti_running_metrics = {(row.dag_id, row.task_id, row.queue): row.running_count for row in running}
+        for state in metric_states:
+            if state not in self.previous_ti_metrics:
+                self.previous_ti_metrics[state] = {}
 
-        for (dag_id, task_id, queue), count in ti_running_metrics.items():
-            Stats.gauge(f"ti.running.{queue}.{dag_id}.{task_id}", count)
-            Stats.gauge("ti.running", count, tags={"queue": queue, "dag_id": dag_id, "task_id": task_id})
+            ti_metrics = {
+                (row.dag_id, row.task_id, row.queue): row.count
+                for row in all_states_metric
+                if row.state == state
+            }
 
-        for prev_key in self.previous_ti_running_metrics:
-            # reset stats which are not running anymore
-            if prev_key not in ti_running_metrics:
-                dag_id, task_id, queue = prev_key
-                Stats.gauge(f"ti.running.{queue}.{dag_id}.{task_id}", 0)
-                Stats.gauge("ti.running", 0, tags={"queue": queue, "dag_id": dag_id, "task_id": task_id})
+            for (dag_id, task_id, queue), count in ti_metrics.items():
+                # Replace '.' with '__' in task_id to avoid StatsD metric hierarchy conflicts from task group separators
+                Stats.gauge(f"ti.{state}.{queue}.{dag_id}.{task_id.replace('.', '__')}", count)
+                Stats.gauge(f"ti.{state}", count, tags={"queue": queue, "dag_id": dag_id, "task_id": task_id})
 
-        self.previous_ti_running_metrics = ti_running_metrics
+            for prev_key in self.previous_ti_metrics[state]:
+                # Reset previously exported stats that are no longer present in current metrics to zero
+                if prev_key not in ti_metrics:
+                    dag_id, task_id, queue = prev_key
+                    # Replace '.' with '__' in task_id to avoid StatsD metric hierarchy conflicts from task group separators
+                    Stats.gauge(f"ti.{state}.{queue}.{dag_id}.{task_id.replace('.', '__')}", 0)
+                    Stats.gauge(f"ti.{state}", 0, tags={"queue": queue, "dag_id": dag_id, "task_id": task_id})
+
+            self.previous_ti_metrics[state] = ti_metrics
 
     @provide_session
     def _emit_running_dags_metric(self, session: Session = NEW_SESSION) -> None:

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2439,7 +2439,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         count_result: int | None = query.count()
         return count_result if count_result is not None else 0
 
-    previous_ti_metrics: dict[State, dict[tuple[str, str, str], int]] = {}
+    previous_ti_metrics: dict[TaskInstanceState, dict[tuple[str, str, str], int]] = {}
 
     @provide_session
     def _emit_ti_metrics(self, session: Session = NEW_SESSION) -> None:

--- a/chart/files/statsd-mappings.yml
+++ b/chart/files/statsd-mappings.yml
@@ -119,3 +119,24 @@ mappings:
       queue: "$1"
       dag_id: "$2"
       task_id: "$3"
+
+  - match: airflow.ti.queued.*.*.*
+    name: "airflow_ti_queued"
+    labels:
+      queue: "$1"
+      dag_id: "$2"
+      task_id: "$3"
+
+  - match: airflow.ti.scheduled.*.*.*
+    name: "airflow_ti_scheduled"
+    labels:
+      queue: "$1"
+      dag_id: "$2"
+      task_id: "$3"
+
+  - match: airflow.ti.deferred.*.*.*
+    name: "airflow_ti_deferred"
+    labels:
+      queue: "$1"
+      dag_id: "$2"
+      task_id: "$3"

--- a/shared/configuration/src/airflow_shared/configuration/parser.py
+++ b/shared/configuration/src/airflow_shared/configuration/parser.py
@@ -156,6 +156,7 @@ class AirflowConfigParser(ConfigParser):
         ("api", "require_confirmation_dag_change"): ("webserver", "require_confirmation_dag_change", "3.1.0"),
         ("api", "instance_name"): ("webserver", "instance_name", "3.1.0"),
         ("api", "log_config"): ("api", "access_logfile", "3.1.0"),
+        ("scheduler", "ti_metrics_interval"): ("scheduler", "running_metrics_interval", "3.2.0"),
     }
 
     # A mapping of new section -> (old section, since_version).


### PR DESCRIPTION
# Overview

While working with deferred tasks, we found that the airflow_ti_running metric does not include task instances in the deferred state. This change extends metric export to also cover scheduled, queued, and deferred states. With these metrics you can build dashboards that show per-DAG load in running and deferred states, and monitor how many tasks per DAG are waiting for resources in scheduled and queued states.

# Change Summary

* Add ti.scheduled, ti.queued and ti.deferred metrics to the code which exports the ti.running
* Update description with new metrics.
* Add fix for task_id to replace . because task group tasks are breaking the stasd exporting because of using . separator.

* Add ti.scheduled, ti.queued and ti.deferred metrics alongside ti.running.
* Update metric descriptions to reflect the new states.
* Replace . with __ in task_id for StatsD compatibility (task groups use . as a separator, which breaks StatsD’s dot-delimited metric hierarchy).
