### PR TITLE
Improved how relative imports are allowed for shared distributions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -778,7 +778,11 @@ testing = ["dev", "providers.tests", "tests_common", "tests", "system", "unit", 
 "providers/**/tests/*" = ["D", "TID253", "S101", "TRY002"]
 "performance/tests/*" = ["S101"]
 
-# All of the modules which have an extra license header (i.e. that we copy from another project) need to
+# Shared distributions SHOULD use relative imports when referencing each other
+# This one disables 'ban-relative-imports'.
+"shared/*/src/**" = ["TID252"]
+
+# All the modules which have an extra license header (i.e. that we copy from another project) need to
 # ignore E402 -- module level import not at top level
 "scripts/ci/prek/*.py" = [ "E402" ]
 "airflow-core/src/airflow/api/auth/backend/kerberos_auth.py" = [ "E402" ]

--- a/scripts/ci/prek/check_shared_distributions_structure.py
+++ b/scripts/ci/prek/check_shared_distributions_structure.py
@@ -164,11 +164,7 @@ def check_ruff(pyproject: dict, shared_path: Path) -> tuple[bool, dict]:
 def check_ruff_lint_rules(ruff: dict, shared_path: Path) -> bool:
     ruff_lint = ruff.get("lint", {})
     per_file_ignores = ruff_lint.get("per-file-ignores", {})
-    flake8_tidy_imports = ruff_lint.get("flake8-tidy-imports", {})
-    if (
-        per_file_ignores.get("!src/*", None) == ["D", "S101", "TRY002"]
-        and flake8_tidy_imports.get("ban-relative-imports", None) == "parents"
-    ):
+    if per_file_ignores.get("!src/*", None) == ["D", "S101", "TRY002"]:
         console.print(
             f"  tool.ruff.lint rules are correct for [magenta]{shared_path.name}[/magenta] [bold green]OK[/bold green]"
         )

--- a/shared/README.md
+++ b/shared/README.md
@@ -56,7 +56,8 @@ good (and we don't have to test an ever increasing matrix of versions to ensure 
 The one caveat to this is due to the side-effect that these shared modules are going to be
 imported from different locations (for example `airflow._shared.timezones.timezone` and
 `airflow.sdk._shared.timezones.timezone`) then any imports inside the shared code to other parts
-of shared libraries _must_ make use of relative imports, and possibly needs `# noqa: TID252`
+of shared libraries _must_ make use of relative imports (but only in sources - tests are still
+required to use absolute imports).
 
 For example, to use the shared timezone library from another shared library, let's say
 `shared/logging/src/airflow_shared/logging/config.py` you would have

--- a/shared/configuration/pyproject.toml
+++ b/shared/configuration/pyproject.toml
@@ -49,7 +49,3 @@ src = ["src"]
 [tool.ruff.lint.per-file-ignores]
 # Ignore Doc rules et al for anything outside of tests
 "!src/*" = ["D", "S101", "TRY002"]
-
-[tool.ruff.lint.flake8-tidy-imports]
-# Override the workspace level default
-ban-relative-imports = "parents"

--- a/shared/logging/pyproject.toml
+++ b/shared/logging/pyproject.toml
@@ -48,7 +48,3 @@ src = ["src"]
 [tool.ruff.lint.per-file-ignores]
 # Ignore Doc rules et al for anything outside of tests
 "!src/*" = ["D", "S101", "TRY002"]
-
-[tool.ruff.lint.flake8-tidy-imports]
-# Override the workspace level default
-ban-relative-imports = "parents"

--- a/shared/secrets_masker/pyproject.toml
+++ b/shared/secrets_masker/pyproject.toml
@@ -49,7 +49,3 @@ src = ["src"]
 [tool.ruff.lint.per-file-ignores]
 # Ignore Doc rules et al for anything outside of tests
 "!src/*" = ["D", "S101", "TRY002"]
-
-[tool.ruff.lint.flake8-tidy-imports]
-# Override the workspace level default
-ban-relative-imports = "parents"

--- a/shared/timezones/pyproject.toml
+++ b/shared/timezones/pyproject.toml
@@ -47,7 +47,3 @@ src = ["src"]
 [tool.ruff.lint.per-file-ignores]
 # Ignore Doc rules et al for anything outside of tests
 "!src/*" = ["D", "S101", "TRY002"]
-
-[tool.ruff.lint.flake8-tidy-imports]
-# Override the workspace level default
-ban-relative-imports = "parents"


### PR DESCRIPTION
Previously we disallowed "parent" relative imports in shared distributions and required to use TID252 noqa comment for those, however this was not the best idea. It's ok to use `..` relative imports in the shared distributions (to refer other shared distributions). Also it's ok to use them inside the library, and it's NOK to use them in `tests` for shared library.

This new way of allowing all kinds of relative rules for all shared src/** is much more appropriate.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
