### PR TITLE
Add back `SimpleAllAdminMiddleware`

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/middleware.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/middleware.py
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from airflow.api_fastapi.auth.managers.simple.services.login import SimpleAuthManagerLogin
+
+
+class SimpleAllAdminMiddleware(BaseHTTPMiddleware):
+    """Middleware that automatically generates and includes auth header for simple auth manager."""
+
+    async def dispatch(self, request: Request, call_next):
+        # Starlette Request is expected to be immutable, but we modify it to add the auth header
+        # https://github.com/fastapi/fastapi/issues/2727#issuecomment-770202019
+        token = SimpleAuthManagerLogin.create_token_all_admins()
+        request.scope["headers"].append((b"authorization", f"Bearer {token}".encode()))
+        return await call_next(request)

--- a/airflow-core/src/airflow/api_fastapi/core_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/app.py
@@ -31,6 +31,7 @@ from starlette.staticfiles import StaticFiles
 from starlette.templating import Jinja2Templates
 
 from airflow.api_fastapi.auth.tokens import get_signing_key
+from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.settings import AIRFLOW_PATH
 
@@ -185,6 +186,10 @@ def init_middlewares(app: FastAPI) -> None:
     from airflow.api_fastapi.auth.middlewares.refresh_token import JWTRefreshMiddleware
 
     app.add_middleware(JWTRefreshMiddleware)
+    if conf.getboolean("core", "simple_auth_manager_all_admins"):
+        from airflow.api_fastapi.auth.managers.simple.middleware import SimpleAllAdminMiddleware
+
+        app.add_middleware(SimpleAllAdminMiddleware)
 
 
 def init_ui_plugins(app: FastAPI) -> None:

--- a/airflow-core/tests/unit/api_fastapi/auth/managers/simple/test_middleware.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/managers/simple/test_middleware.py
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from airflow.api_fastapi.app import create_app
+
+from tests_common.test_utils.config import conf_vars
+
+pytestmark = pytest.mark.db_test
+
+
+@pytest.fixture
+def all_access_test_client():
+    with conf_vars(
+        {
+            ("core", "simple_auth_manager_all_admins"): "true",
+            ("webserver", "expose_config"): "true",
+        }
+    ):
+        app = create_app()
+        yield TestClient(app)
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("GET", "/api/v2/assets"),
+        ("POST", "/api/v2/backfills"),
+        ("GET", "/api/v2/config"),
+        ("GET", "/api/v2/dags"),
+        ("POST", "/api/v2/dags/{dag_id}/clearTaskInstances"),
+        ("GET", "/api/v2/dags/{dag_id}/dagRuns"),
+        ("GET", "/api/v2/eventLogs"),
+        ("GET", "/api/v2/jobs"),
+        ("GET", "/api/v2/variables"),
+        ("GET", "/api/v2/version"),
+    ],
+)
+def test_all_endpoints_without_auth_header(all_access_test_client, method, path):
+    response = all_access_test_client.request(method, path)
+    assert response.status_code not in {401, 403}, (
+        f"Unexpected status code {response.status_code} for {method} {path}"
+    )


### PR DESCRIPTION
`SimpleAllAdminMiddleware` was removed while updating authentication in Airflow. I thought it was no longer necessary because the back-end now handles the token, therefore there is no need for the front-end to provide the JWT token.

However, this middleware can still be useful when calling the Airflow API directly (not through the UI). It avoid having to provide a JWT token.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
