### PR TITLE
Fix mypy errors for RayHook

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/hooks/vertex_ai/ray.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/vertex_ai/ray.py
@@ -52,7 +52,7 @@ class RayHook(GoogleBaseHook):
                 return [__encode_value(nested_value) for nested_value in value]
             if not isinstance(value, dict) and isinstance(value, MutableMapping):
                 return {key: __encode_value(nested_value) for key, nested_value in dict(value).items()}
-            if dataclasses.is_dataclass(value):
+            if dataclasses.is_dataclass(value) and not isinstance(value, type):
                 return dataclasses.asdict(value)
             return value
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Mypy 1.19 started complaining of:
```shell script
  providers/google/src/airflow/providers/google/cloud/hooks/vertex_ai/ray.py:56: error: Argument 1 to "asdict" has incompatible type "DataclassInstance | type[DataclassInstance]"; expected
  "DataclassInstance"  [arg-type]
                      return dataclasses.asdict(value)
                                                ^~~~~
  Found 1 error in 1 file (checked 4046 source files)

  Error 1 returned
  You are running mypy with the folders selected. If you want to reproduce it locally, you need to run the following command:
```

The error is because mypy is stricter about this now. The issue is that dataclass.isdataclass returns True for both classes and instances: https://docs.python.org/3/library/dataclasses.html#dataclasses.is_dataclass and this causes a runtime error because `dataclass.asdict` can only be used on instances.

To ensure that fix doesnt break functionality, this is what I checked:
```python
Python 3.13.3 (main, Apr  8 2025, 13:54:08) [Clang 17.0.0 (clang-1700.0.13.3)] on darwin
import dataclasses
@dataclasses.dataclass
class Example:
    name: str
instance = Example(name="test")
class_type = Example
dataclasses.is_dataclass(instance)
Out[3]: True
dataclasses.is_dataclass(class_type)
Out[4]: True
dataclasses.is_dataclass(instance) and not isinstance(instance, type)
Out[5]: True
dataclasses.is_dataclass(class_type) and not isinstance(class_type, type)
Out[6]: False
    
if dataclasses.is_dataclass(class_type) and not isinstance(class_type, type):
    print("I am here")
    print(dataclasses.asdict(class_type))
    
if dataclasses.is_dataclass(instance) and not isinstance(instance, type):
    print(dataclasses.asdict(instance))
    
{'name': 'test'}
```


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
