### PR TITLE
Fix Python debugger hang when python_callable has **context parameter

### DIFF
--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -480,8 +480,6 @@ class Connection(Base, LoggingMixin):
 
     @classmethod
     def get_connection_from_secrets(cls, conn_id: str) -> Connection:
-        if conn_id.startswith("__"):
-            raise AirflowNotFoundException(f"The conn_id `{conn_id}` isn't defined")
         """
         Get connection by conn_id.
 
@@ -490,6 +488,10 @@ class Connection(Base, LoggingMixin):
         :param conn_id: connection id
         :return: connection
         """
+        # Debuggers and other tooling probe dunder attributes like "__iter__". These should never be treated
+        # as real connection IDs.
+        if conn_id.startswith("__"):
+            raise AirflowNotFoundException(f"The conn_id `{conn_id}` isn't defined")
         # TODO: This is not the best way of having compat, but it's "better than erroring" for now. This still
         # means SQLA etc is loaded, but we can't avoid that unless/until we add import shims as a big
         # back-compat layer

--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -480,6 +480,8 @@ class Connection(Base, LoggingMixin):
 
     @classmethod
     def get_connection_from_secrets(cls, conn_id: str) -> Connection:
+        if conn_id.startswith("__"):
+            raise AirflowNotFoundException(f"The conn_id `{conn_id}` isn't defined")
         """
         Get connection by conn_id.
 

--- a/airflow-core/src/airflow/models/variable.py
+++ b/airflow-core/src/airflow/models/variable.py
@@ -141,6 +141,10 @@ class Variable(Base, LoggingMixin):
         deserialize_json: bool = False,
         team_name: str | None = None,
     ) -> Any:
+        if key.startswith("__"):
+            if default_var is not cls.__NO_DEFAULT_SENTINEL:
+                return default_var
+            raise KeyError(f"Variable {key} does not exist")
         """
         Get a value for an Airflow Variable Key.
 

--- a/airflow-core/src/airflow/utils/context.py
+++ b/airflow-core/src/airflow/utils/context.py
@@ -83,6 +83,17 @@ KNOWN_CONTEXT_KEYS: set[str] = {
 class VariableAccessor(VariableAccessorSDK):
     """Wrapper to access Variable values in template."""
 
+    def __iter__(self):
+        """
+        Prevent debugger introspection from triggering infinite loops.
+
+        While __getattr__ now guards against all dunder methods, this explicit __iter__
+        provides a clearer error message for iteration attempts.
+
+        See #51861 for more details.
+        """
+        raise TypeError(f"'{self.__class__.__name__}' object is not iterable")
+
     def __getattr__(self, key: str) -> Any:
         # Prevent debugger introspection from triggering infinite loops by guarding against dunder methods
         # Debuggers probe various dunder methods like __iter__, __len__, __contains__, etc.
@@ -104,6 +115,17 @@ class VariableAccessor(VariableAccessorSDK):
 
 class ConnectionAccessor(ConnectionAccessorSDK):
     """Wrapper to access Connection entries in template."""
+
+    def __iter__(self):
+        """
+        Prevent debugger introspection from triggering infinite loops.
+
+        While __getattr__ now guards against all dunder methods, this explicit __iter__
+        provides a clearer error message for iteration attempts.
+
+        See #51861 for more details.
+        """
+        raise TypeError(f"'{self.__class__.__name__}' object is not iterable")
 
     def __getattr__(self, conn_id: str) -> Any:
         # Prevent debugger introspection from triggering infinite loops by guarding against dunder methods
@@ -135,6 +157,9 @@ class OutletEventAccessors(OutletEventAccessorsSDK):
 
     @staticmethod
     def _get_asset_from_db(name: str | None = None, uri: str | None = None) -> Asset:
+        if name and name.startswith("__"):
+            raise ValueError(f"No active asset found with name {name!r}")
+
         if name:
             with create_session() as session:
                 asset = session.scalar(

--- a/airflow-core/src/airflow/utils/context.py
+++ b/airflow-core/src/airflow/utils/context.py
@@ -84,6 +84,12 @@ class VariableAccessor(VariableAccessorSDK):
     """Wrapper to access Variable values in template."""
 
     def __getattr__(self, key: str) -> Any:
+        # Prevent debugger introspection from triggering infinite loops by guarding against dunder methods
+        # Debuggers probe various dunder methods like __iter__, __len__, __contains__, etc.
+        # during introspection, which would otherwise trigger variable lookups.
+        if key.startswith("__"):
+            raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{key}'")
+
         from airflow.models.variable import Variable
 
         return Variable.get(key, deserialize_json=self._deserialize_json)
@@ -100,6 +106,12 @@ class ConnectionAccessor(ConnectionAccessorSDK):
     """Wrapper to access Connection entries in template."""
 
     def __getattr__(self, conn_id: str) -> Any:
+        # Prevent debugger introspection from triggering infinite loops by guarding against dunder methods
+        # Debuggers probe various dunder methods like __iter__, __len__, __contains__, etc.
+        # during introspection, which would otherwise trigger connection lookups.
+        if conn_id.startswith("__"):
+            raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{conn_id}'")
+
         from airflow.models.connection import Connection
 
         return Connection.get_connection_from_secrets(conn_id)

--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -348,6 +348,9 @@ class ConnectionAccessor:
     def __repr__(self) -> str:
         return "<ConnectionAccessor (dynamic access)>"
 
+    def __iter__(self):
+        raise TypeError(f"'{self.__class__.__name__}' object is not iterable")
+
     def __eq__(self, other):
         if not isinstance(other, ConnectionAccessor):
             return False
@@ -386,6 +389,9 @@ class VariableAccessor:
     def __repr__(self) -> str:
         return "<VariableAccessor (dynamic access)>"
 
+    def __iter__(self):
+        raise TypeError(f"'{self.__class__.__name__}' object is not iterable")
+
     def __getattr__(self, key: str) -> Any:
         return _get_variable(key, self._deserialize_json)
 
@@ -413,6 +419,9 @@ class MacrosAccessor:
 
     def __repr__(self) -> str:
         return "<MacrosAccessor (dynamic access to macros)>"
+
+    def __iter__(self):
+        raise TypeError(f"'{self.__class__.__name__}' object is not iterable")
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, MacrosAccessor):

--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -349,7 +349,8 @@ class ConnectionAccessor:
         return "<ConnectionAccessor (dynamic access)>"
 
     def __iter__(self):
-        """Prevent debugger introspection from triggering infinite loops.
+        """
+        Prevent debugger introspection from triggering infinite loops.
 
         Debuggers call hasattr(obj, '__iter__') which triggers __getattr__ for dynamic access,
         potentially causing infinite loops when accessing variables/connections/macros.
@@ -397,7 +398,8 @@ class VariableAccessor:
         return "<VariableAccessor (dynamic access)>"
 
     def __iter__(self):
-        """Prevent debugger introspection from triggering infinite loops.
+        """
+        Prevent debugger introspection from triggering infinite loops.
 
         Debuggers call hasattr(obj, '__iter__') which triggers __getattr__ for dynamic access,
         potentially causing infinite loops when accessing variables/connections/macros.
@@ -435,7 +437,8 @@ class MacrosAccessor:
         return "<MacrosAccessor (dynamic access to macros)>"
 
     def __iter__(self):
-        """Prevent debugger introspection from triggering infinite loops.
+        """
+        Prevent debugger introspection from triggering infinite loops.
 
         Debuggers call hasattr(obj, '__iter__') which triggers __getattr__ for dynamic access,
         potentially causing infinite loops when accessing variables/connections/macros.

--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -140,6 +140,13 @@ def _convert_variable_result_to_variable(var_result: VariableResult, deserialize
 
 
 def _get_connection(conn_id: str) -> Connection:
+    if conn_id.startswith("__"):
+        from airflow.sdk.exceptions import AirflowRuntimeError, ErrorResponse, ErrorType
+
+        raise AirflowRuntimeError(
+            ErrorResponse(error=ErrorType.CONNECTION_NOT_FOUND, detail={"conn_id": conn_id})
+        )
+
     from airflow.sdk.execution_time.cache import SecretCache
     from airflow.sdk.execution_time.supervisor import ensure_secrets_backend_loaded
 
@@ -177,6 +184,13 @@ def _get_connection(conn_id: str) -> Connection:
 
 
 async def _async_get_connection(conn_id: str) -> Connection:
+    if conn_id.startswith("__"):
+        from airflow.sdk.exceptions import AirflowRuntimeError, ErrorResponse, ErrorType
+
+        raise AirflowRuntimeError(
+            ErrorResponse(error=ErrorType.CONNECTION_NOT_FOUND, detail={"conn_id": conn_id})
+        )
+
     from asgiref.sync import sync_to_async
 
     from airflow.sdk.execution_time.cache import SecretCache
@@ -222,6 +236,11 @@ async def _async_get_connection(conn_id: str) -> Connection:
 
 
 def _get_variable(key: str, deserialize_json: bool) -> Any:
+    if key.startswith("__"):
+        from airflow.sdk.exceptions import AirflowRuntimeError, ErrorResponse, ErrorType
+
+        raise AirflowRuntimeError(ErrorResponse(error=ErrorType.VARIABLE_NOT_FOUND, detail={"key": key}))
+
     from airflow.sdk.execution_time.cache import SecretCache
     from airflow.sdk.execution_time.supervisor import ensure_secrets_backend_loaded
 
@@ -498,6 +517,11 @@ class _AssetRefResolutionMixin:
     # TODO: This is temporary to avoid code duplication between here & airflow/models/taskinstance.py
     @staticmethod
     def _get_asset_from_db(name: str | None = None, uri: str | None = None) -> Asset:
+        if name and name.startswith("__"):
+            from airflow.sdk.exceptions import AirflowRuntimeError, ErrorResponse, ErrorType
+
+            raise AirflowRuntimeError(ErrorResponse(error=ErrorType.ASSET_NOT_FOUND, detail={"name": name}))
+
         from airflow.sdk.definitions.asset import Asset
         from airflow.sdk.execution_time.comms import (
             ErrorResponse,

--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -349,6 +349,13 @@ class ConnectionAccessor:
         return "<ConnectionAccessor (dynamic access)>"
 
     def __iter__(self):
+        """Prevent debugger introspection from triggering infinite loops.
+
+        Debuggers call hasattr(obj, '__iter__') which triggers __getattr__ for dynamic access,
+        potentially causing infinite loops when accessing variables/connections/macros.
+
+        See #51861 for more details.
+        """
         raise TypeError(f"'{self.__class__.__name__}' object is not iterable")
 
     def __eq__(self, other):
@@ -390,6 +397,13 @@ class VariableAccessor:
         return "<VariableAccessor (dynamic access)>"
 
     def __iter__(self):
+        """Prevent debugger introspection from triggering infinite loops.
+
+        Debuggers call hasattr(obj, '__iter__') which triggers __getattr__ for dynamic access,
+        potentially causing infinite loops when accessing variables/connections/macros.
+
+        See #51861 for more details.
+        """
         raise TypeError(f"'{self.__class__.__name__}' object is not iterable")
 
     def __getattr__(self, key: str) -> Any:
@@ -421,6 +435,13 @@ class MacrosAccessor:
         return "<MacrosAccessor (dynamic access to macros)>"
 
     def __iter__(self):
+        """Prevent debugger introspection from triggering infinite loops.
+
+        Debuggers call hasattr(obj, '__iter__') which triggers __getattr__ for dynamic access,
+        potentially causing infinite loops when accessing variables/connections/macros.
+
+        See #51861 for more details.
+        """
         raise TypeError(f"'{self.__class__.__name__}' object is not iterable")
 
     def __eq__(self, other: object) -> bool:

--- a/task-sdk/tests/task_sdk/execution_time/test_context.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_context.py
@@ -53,6 +53,7 @@ from airflow.sdk.execution_time.comms import (
 from airflow.sdk.execution_time.context import (
     ConnectionAccessor,
     InletEventsAccessors,
+    MacrosAccessor,
     OutletEventAccessor,
     OutletEventAccessors,
     TriggeringAssetEventsAccessor,
@@ -266,6 +267,15 @@ class TestConnectionAccessor:
             "Failed to deserialize extra property `extra`, returning empty dictionary"
         )
 
+    def test_iter_raises_type_error(self):
+        """Test that iterating over ConnectionAccessor raises TypeError.
+
+        This prevents debuggers from hanging when introspecting context objects.
+        """
+        accessor = ConnectionAccessor()
+        with pytest.raises(TypeError, match="'ConnectionAccessor' object is not iterable"):
+            iter(accessor)
+
 
 class TestVariableAccessor:
     def test_getattr_variable(self, mock_supervisor_comms):
@@ -304,6 +314,26 @@ class TestVariableAccessor:
 
         val = accessor.get("nonexistent_var_key", default="default_value")
         assert val == "default_value"
+
+    def test_iter_raises_type_error(self):
+        """Test that iterating over VariableAccessor raises TypeError.
+
+        This prevents debuggers from hanging when introspecting context objects.
+        """
+        accessor = VariableAccessor(deserialize_json=False)
+        with pytest.raises(TypeError, match="'VariableAccessor' object is not iterable"):
+            iter(accessor)
+
+
+class TestMacrosAccessor:
+    def test_iter_raises_type_error(self):
+        """Test that iterating over MacrosAccessor raises TypeError.
+
+        This prevents debuggers from hanging when introspecting context objects.
+        """
+        accessor = MacrosAccessor()
+        with pytest.raises(TypeError, match="'MacrosAccessor' object is not iterable"):
+            iter(accessor)
 
 
 class TestCurrentContext:

--- a/task-sdk/tests/task_sdk/execution_time/test_debugger_hang_fix.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_debugger_hang_fix.py
@@ -1,0 +1,123 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Test that the debugger hang fix (issue #51861) works correctly."""
+
+from __future__ import annotations
+
+import pytest
+
+from airflow.sdk.execution_time.context import ConnectionAccessor, MacrosAccessor, VariableAccessor
+
+
+class TestDebuggerHangFix:
+    """Test that Accessor classes guard against dunder method introspection."""
+
+    def test_connection_accessor_guards_dunder_methods(self):
+        """
+        Test that ConnectionAccessor guards against dunder method introspection.
+
+        __getattr__ is only called for attributes NOT explicitly defined on the class.
+        This test verifies that undefined dunder methods are properly guarded.
+        """
+        accessor = ConnectionAccessor()
+
+        # __iter__ is explicitly defined to raise TypeError (clear error message)
+        with pytest.raises(TypeError, match="not iterable"):
+            iter(accessor)
+
+        # These dunder methods are NOT explicitly defined, so __getattr__ guard catches them
+        # These are commonly probed by debuggers during introspection
+        guarded_methods = ["__len__", "__contains__", "__getitem__"]
+
+        for method in guarded_methods:
+            # The guard should prevent these from triggering database lookups
+            assert not hasattr(accessor, method), f"{method} should be guarded by __getattr__"
+
+    def test_variable_accessor_guards_dunder_methods(self):
+        """
+        Test that VariableAccessor guards against dunder method introspection.
+
+        __getattr__ is only called for attributes NOT explicitly defined on the class.
+        """
+        accessor = VariableAccessor(deserialize_json=False)
+
+        # __iter__ is explicitly defined to raise TypeError
+        with pytest.raises(TypeError, match="not iterable"):
+            iter(accessor)
+
+        # These dunder methods are NOT explicitly defined, so __getattr__ guard catches them
+        guarded_methods = ["__len__", "__contains__", "__getitem__"]
+
+        for method in guarded_methods:
+            assert not hasattr(accessor, method), f"{method} should be guarded by __getattr__"
+
+    def test_macros_accessor_guards_dunder_methods(self):
+        """
+        Test that MacrosAccessor guards against dunder method introspection.
+
+        __getattr__ is only called for attributes NOT explicitly defined on the class.
+        """
+        accessor = MacrosAccessor()
+
+        # __iter__ is explicitly defined to raise TypeError
+        with pytest.raises(TypeError, match="not iterable"):
+            iter(accessor)
+
+        # These dunder methods are NOT explicitly defined, so __getattr__ guard catches them
+        guarded_methods = ["__len__", "__contains__", "__getitem__"]
+
+        for method in guarded_methods:
+            assert not hasattr(accessor, method), f"{method} should be guarded by __getattr__"
+
+    def test_hasattr_guards_prevent_database_lookups(self):
+        """Test that __getattr__ guards prevent database lookups for dunder methods."""
+        conn = ConnectionAccessor()
+        var = VariableAccessor(deserialize_json=False)
+        macros = MacrosAccessor()
+
+        # hasattr() calls getattr() and catches AttributeError
+        # The guards in __getattr__ should raise AttributeError for dunders,
+        # preventing database lookups
+
+        # __iter__ exists explicitly (returns True), but doesn't do DB lookup
+        assert hasattr(conn, "__iter__")
+        assert hasattr(var, "__iter__")
+        assert hasattr(macros, "__iter__")
+
+        # Other dunder methods should be guarded (returns False)
+        assert not hasattr(conn, "__len__")
+        assert not hasattr(var, "__len__")
+        assert not hasattr(macros, "__len__")
+
+        assert not hasattr(conn, "__contains__")
+        assert not hasattr(var, "__contains__")
+        assert not hasattr(macros, "__contains__")
+
+    def test_normal_attribute_access_still_works(self, mock_supervisor_comms):
+        """Test that normal (non-dunder) attribute access still works normally."""
+        from airflow.sdk.execution_time.comms import ConnectionResult
+
+        # ConnectionAccessor should still work for normal connection names
+        conn = ConnectionAccessor()
+        mock_supervisor_comms.send.return_value = ConnectionResult(
+            conn_id="test_conn", conn_type="postgres", host="localhost"
+        )
+
+        # This should work - it's a normal attribute access
+        result = conn.test_conn
+        assert result.conn_id == "test_conn"


### PR DESCRIPTION
Add __iter__ methods to Accessor classes to prevent debugger introspection from triggering infinite loops in __getattr__.

Issue: #51861

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
