### PR TITLE
Remove global from breeze testing commands

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/testing_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/testing_commands.py
@@ -22,6 +22,7 @@ import signal
 import sys
 from collections.abc import Generator
 from datetime import datetime
+from functools import cache
 from multiprocessing.pool import Pool
 from time import sleep
 
@@ -122,8 +123,6 @@ GRACE_CONTAINER_STOP_TIMEOUT = 10  # Timeout in seconds to wait for containers t
 
 LOW_MEMORY_CONDITION = 8 * 1024 * 1024 * 1024  # 8 GB
 DEFAULT_TOTAL_TEST_TIMEOUT = 60 * 60  # 60 minutes
-
-logs_already_dumped = False
 
 option_skip_docker_compose_deletion = click.option(
     "--skip-docker-compose-deletion",
@@ -267,8 +266,8 @@ def _run_test(
             notify_on_unhealthy_backend_container(
                 project_name=project_name, backend=shell_params.backend, output=output
             )
-        if os.environ.get("CI") == "true" and result.returncode != 0 and not logs_already_dumped:
-            get_console(output=output).print(f"[error]Test failed with {result.returncode}. Dumping logs[/]")
+        if os.environ.get("CI") == "true" and result.returncode != 0:
+            get_console(output=output).print(f"[error]Test failed with {result.returncode}.[/]")
             _dump_container_logs(output=output, shell_params=shell_params)
     finally:
         if not skip_docker_compose_down:
@@ -303,8 +302,9 @@ def _get_project_names(shell_params: ShellParams) -> tuple[str, str]:
     return compose_project_name, project_name
 
 
+@cache  # Note: using functools.cache to avoid multiple dumps in the same run
 def _dump_container_logs(output: Output | None, shell_params: ShellParams):
-    global logs_already_dumped
+    get_console().print("[warning]Dumping container logs[/]")
     ps_result = run_command(
         ["docker", "ps", "--all", "--format", "{{.Names}}"],
         check=True,
@@ -330,7 +330,6 @@ def _dump_container_logs(output: Output | None, shell_params: ShellParams):
                 check=False,
                 stdout=outfile,
             )
-    logs_already_dumped = True
 
 
 def _run_tests_in_pool(
@@ -1599,7 +1598,6 @@ class TimeoutHandler:
         get_console().print("[warning]Stopping all running containers[/]:")
         self._print_all_containers()
         if os.environ.get("CI") == "true":
-            get_console().print("[warning]Dumping container logs first[/]")
             _dump_container_logs(output=None, shell_params=self.shell_params)
         list_of_containers = self._get_running_containers().stdout.splitlines()
         get_console().print("[warning]Attempting to send TERM signal to all remaining containers:")

--- a/dev/breeze/src/airflow_breeze/params/shell_params.py
+++ b/dev/breeze/src/airflow_breeze/params/shell_params.py
@@ -812,3 +812,11 @@ class ShellParams:
                 "[error]When using the Keycloak integration the backend must be Postgres![/]\n"
             )
             sys.exit(2)
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, ShellParams):
+            return False
+        return self.__dict__ == other.__dict__
+
+    def __hash__(self) -> int:
+        return self.__dict__.__hash__()

--- a/dev/breeze/src/airflow_breeze/params/shell_params.py
+++ b/dev/breeze/src/airflow_breeze/params/shell_params.py
@@ -819,4 +819,4 @@ class ShellParams:
         return self.__dict__ == other.__dict__
 
     def __hash__(self) -> int:
-        return self.__dict__.__hash__()
+        return hash(tuple(sorted(self.__dict__.items())))

--- a/dev/breeze/src/airflow_breeze/params/shell_params.py
+++ b/dev/breeze/src/airflow_breeze/params/shell_params.py
@@ -819,4 +819,4 @@ class ShellParams:
         return self.__dict__ == other.__dict__
 
     def __hash__(self) -> int:
-        return hash(tuple(sorted(self.__dict__.items())))
+        return hash(str(self.__dict__))


### PR DESCRIPTION
Another small increment to remove global statements for PR https://github.com/apache/airflow/pull/58116

This just removes some global statements in breeze for preventing redundant log dumping. Just using functools.cache()

`global` is evil. Also in breeze :-D

(No need to backport in my view)