### PR TITLE
Snowflake: Support passing OAuth scope parameter in client_credentials flow

### DIFF
--- a/providers/snowflake/docs/connections/snowflake.rst
+++ b/providers/snowflake/docs/connections/snowflake.rst
@@ -60,6 +60,8 @@ Extra (optional)
     * ``authenticator``: To connect using OAuth set this parameter ``oauth``.
     * ``token_endpoint``: Specify token endpoint for external OAuth provider.
     * ``grant_type``: Specify grant type for OAuth authentication. Currently supported: ``refresh_token`` (default), ``client_credentials``.
+    * ``oauth_scope``: Optional OAuth scope to include when using the ``client_credentials`` grant type.
+      Some identity providers (e.g., Okta, Auth0) require a scope when issuing client credentials tokens.
     * ``refresh_token``: Specify refresh_token for OAuth connection.
     * ``azure_conn_id``: Azure Connection ID to be used for retrieving the OAuth token using Azure Entra authentication. Login and Password fields aren't required when using this method. Scope for the Azure OAuth token can be set in the config option ``azure_oauth_scope`` under the section ``[snowflake]``. Requires `apache-airflow-providers-microsoft-azure>=12.8.0`.
     * ``private_key_file``: Specify the path to the private key file.


### PR DESCRIPTION
## Description

This PR adds support for passing an optional OAuth `scope` parameter when using the
`client_credentials` grant type in `SnowflakeHook.get_oauth_token`.

Many identity providers (Okta, Auth0, Azure AD, corporate IdPs) require or recommend including a scope
in client-credential OAuth exchanges. Currently, Airflow cannot send a scope value, forcing users to
apply custom patches or weaken their IdP requirements.

This PR introduces an optional extra field on the Snowflake connection:

extra: {"oauth_scope": "your-scope-value"}

less
Copy code

When present and the `grant_type` is `client_credentials`, the hook will send:

scope=<value>

markdown
Copy code

in the POST body to the token endpoint.  
If no scope is provided, the existing behavior is unchanged.

## Tests

This PR updates the OAuth unit tests to validate:

- Scope is not included for refresh token grant (existing behavior unchanged)
- Scope *is* included when:
  - `grant_type=client_credentials`
  - `oauth_scope` is provided
- Scope is omitted when the field is empty or not provided
- Existing OAuth tests continue to pass untouched

## Cross-provider compatibility

This matches patterns already used in Azure OAuth (`azure_oauth_scope`).

## Related Issue

Closes #58815
