### PR TITLE
fix(helm): allow additional PodDisruptionBudget config properties

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2857,7 +2857,7 @@
                 "podDisruptionBudget": {
                     "description": "Scheduler pod disruption budget.",
                     "type": "object",
-                    "additionalProperties": false,
+                    "additionalProperties": true,
                     "properties": {
                         "enabled": {
                             "description": "Enable pod disruption budget.",
@@ -2867,7 +2867,7 @@
                         "config": {
                             "description": "Disruption budget configuration.",
                             "type": "object",
-                            "additionalProperties": false,
+                            "additionalProperties": true,
                             "properties": {
                                 "maxUnavailable": {
                                     "description": "Max unavailable pods for scheduler.",
@@ -5159,7 +5159,7 @@
                 "podDisruptionBudget": {
                     "description": "API server pod disruption budget.",
                     "type": "object",
-                    "additionalProperties": false,
+                    "additionalProperties": true,
                     "properties": {
                         "enabled": {
                             "description": "Enable pod disruption budget.",
@@ -5169,7 +5169,7 @@
                         "config": {
                             "description": "Disruption budget configuration.",
                             "type": "object",
-                            "additionalProperties": false,
+                            "additionalProperties": true,
                             "properties": {
                                 "maxUnavailable": {
                                     "description": "Max unavailable pods for API server.",
@@ -5963,7 +5963,7 @@
                 "podDisruptionBudget": {
                     "description": "Webserver pod disruption budget.",
                     "type": "object",
-                    "additionalProperties": false,
+                    "additionalProperties": true,
                     "properties": {
                         "enabled": {
                             "description": "Enable pod disruption budget.",
@@ -5973,7 +5973,7 @@
                         "config": {
                             "description": "Disruption budget configuration.",
                             "type": "object",
-                            "additionalProperties": false,
+                            "additionalProperties": true,
                             "properties": {
                                 "maxUnavailable": {
                                     "description": "Max unavailable pods for webserver.",
@@ -7533,7 +7533,7 @@
                 "podDisruptionBudget": {
                     "description": "PgBouncer PodDisruptionBudget.",
                     "type": "object",
-                    "additionalProperties": false,
+                    "additionalProperties": true,
                     "properties": {
                         "enabled": {
                             "description": "Enabled PodDistributionBudget.",
@@ -7543,7 +7543,7 @@
                         "config": {
                             "description": "Pod distribution configuration.",
                             "type": "object",
-                            "additionalProperties": false,
+                            "additionalProperties": true,
                             "properties": {
                                 "maxUnavailable": {
                                     "description": "Max unavailable pods for PgBouncer.",


### PR DESCRIPTION
**Summary**

The Helm chart templates already allow arbitrary PodDisruptionBudget configuration via:

{{ toYaml .Values.<component>.podDisruptionBudget.config | nindent 2 }}


This means users should be able to set any valid PDB fields, including newer ones such as unhealthyPodEvictionPolicy.

However, the values.schema.json file currently restricts these config blocks with:

"additionalProperties": false


This causes Helm validation to fail when users provide valid PDB fields not explicitly listed in the schema.

**What this PR changes**

This PR updates the schema for all components’ PodDisruptionBudget sections:

podDisruptionBudget.additionalProperties

podDisruptionBudget.config.additionalProperties

These are now set to true, allowing arbitrary valid fields to be passed through exactly as the template already supports.

**Why this is needed**

Without this change, using any non-standard (but fully valid) PDB field results in:

values don't meet the specifications of the schema(s):
<component>.podDisruptionBudget.config: Additional property <x> is not allowed


This prevents users from adopting newer Kubernetes PDB fields and contradicts the behavior of the chart templates.

**Scope of the change**

✔ Only values.schema.json is updated.
✔ No changes to templates or chart behavior.
✔ No functional changes — the schema now reflects the existing intended behavior.

Issue

Fixes: #58650