### PR TITLE
Bugfix/remove global from breeze

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -4223,9 +4223,9 @@ def publish_docs_to_s3(
         docs_to_s3.publish_all_docs()
     if stable_versions:
         docs_to_s3.publish_stable_version_docs()
-    from airflow_breeze.utils.publish_docs_to_s3 import version_error
+    from airflow_breeze.utils.publish_docs_to_s3 import VersionError
 
-    if version_error:
+    if VersionError.has_any_error():
         get_console().print(
             "[error]There was an error with the version of the docs. "
             "Please check the version in the docs and try again.[/]"

--- a/dev/breeze/src/airflow_breeze/utils/publish_docs_to_s3.py
+++ b/dev/breeze/src/airflow_breeze/utils/publish_docs_to_s3.py
@@ -36,7 +36,19 @@ NON_SHORT_NAME_PACKAGES = ["apache-airflow", "apache-airflow-ctl", "docker-stack
 s3_client = boto3.client("s3")
 cloudfront_client = boto3.client("cloudfront")
 
-version_error = False
+
+class VersionError:
+    """Class to track version errors during processing."""
+
+    version_error: bool = False
+
+    @staticmethod
+    def has_any_error() -> bool:
+        return VersionError.version_error
+
+    @staticmethod
+    def set_version_error(value: bool):
+        VersionError.version_error = value
 
 
 def get_cloudfront_distribution(destination_location):
@@ -326,8 +338,7 @@ class S3DocsPublish:
                 all_versions.append(Version(v))
             except ValueError as e:
                 get_console().print(f"[error]Invalid version {v}: {e}\n")
-                global version_error
-                version_error = True
+                VersionError.set_version_error(True)
         all_versions.sort(reverse=True)
         minor_versions: list[str] = []
         good_versions = []

--- a/dev/breeze/src/airflow_breeze/utils/recording.py
+++ b/dev/breeze/src/airflow_breeze/utils/recording.py
@@ -27,8 +27,6 @@ from airflow_breeze.utils.path_utils import in_autocomplete
 if TYPE_CHECKING:
     from rich.console import Console
 
-help_console: Console | None = None
-
 DEFAULT_COLUMNS = 129
 
 
@@ -39,6 +37,8 @@ def generating_command_images() -> bool:
 def enable_recording_of_help_output(path: str, title: str | None, width: str | None, unique_id: str | None):
     import rich_click as click
 
+    help_consoles: list[Console] = []
+
     if not title:
         title = "Breeze screenshot"
     if not width:
@@ -47,8 +47,8 @@ def enable_recording_of_help_output(path: str, title: str | None, width: str | N
         width_int = int(width)
 
     def save_output_as_svg():
-        if help_console:
-            help_console.save_svg(path=path, title=title, unique_id=unique_id)
+        for console in help_consoles:
+            console.save_svg(path=path, title=title, unique_id=unique_id)
 
     atexit.register(save_output_as_svg)
     click.rich_click.MAX_WIDTH = width_int
@@ -67,8 +67,7 @@ def enable_recording_of_help_output(path: str, title: str | None, width: str | N
         recording_config.force_terminal = True
         recording_console = original_create_console(recording_config, file)
         recording_console.record = True
-        global help_console
-        help_console = recording_console
+        help_consoles.append(recording_console)
         return recording_console
 
     rich_click.rich_help_formatter.create_console = create_recording_console

--- a/dev/breeze/src/airflow_breeze/utils/shared_options.py
+++ b/dev/breeze/src/airflow_breeze/utils/shared_options.py
@@ -23,12 +23,8 @@ from airflow_breeze.utils.coertions import coerce_bool_value
 
 
 class _SharedOptions:
-    def get_default_bool_value(env_var: str) -> bool:
-        string_val = os.environ.get(env_var, "")
-        return coerce_bool_value(string_val)
-
-    verbose_value: bool = get_default_bool_value("VERBOSE")
-    dry_run_value: bool = get_default_bool_value("DRY_RUN")
+    verbose_value: bool = coerce_bool_value(os.environ.get("VERBOSE", ""))
+    dry_run_value: bool = coerce_bool_value(os.environ.get("DRY_RUN", ""))
     forced_answer: str | None = None
 
 

--- a/dev/breeze/src/airflow_breeze/utils/shared_options.py
+++ b/dev/breeze/src/airflow_breeze/utils/shared_options.py
@@ -22,48 +22,41 @@ import os
 from airflow_breeze.utils.coertions import coerce_bool_value
 
 
-def __get_default_bool_value(env_var: str) -> bool:
-    string_val = os.environ.get(env_var, "")
-    return coerce_bool_value(string_val)
+class _SharedOptions:
+    def get_default_bool_value(env_var: str) -> bool:
+        string_val = os.environ.get(env_var, "")
+        return coerce_bool_value(string_val)
 
-
-__verbose_value: bool = __get_default_bool_value("VERBOSE")
+    verbose_value: bool = get_default_bool_value("VERBOSE")
+    dry_run_value: bool = get_default_bool_value("DRY_RUN")
+    forced_answer: str | None = None
 
 
 def set_verbose(verbose: bool):
-    global __verbose_value
-    __verbose_value = verbose
+    _SharedOptions.verbose_value = verbose
 
 
 def get_verbose(verbose_override: bool | None = None) -> bool:
     if verbose_override is None:
-        return __verbose_value
+        return _SharedOptions.verbose_value
     return verbose_override
 
 
-__dry_run_value: bool = __get_default_bool_value("DRY_RUN")
-
-
 def set_dry_run(dry_run: bool):
-    global __dry_run_value
-    __dry_run_value = dry_run
+    _SharedOptions.dry_run_value = dry_run
 
 
 def get_dry_run(dry_run_override: bool | None = None) -> bool:
     if dry_run_override is None:
-        return __dry_run_value
+        return _SharedOptions.dry_run_value
     return dry_run_override
 
 
-__forced_answer: str | None = None
-
-
 def set_forced_answer(answer: str | None):
-    global __forced_answer
-    __forced_answer = answer
+    _SharedOptions.forced_answer = answer
 
 
 def get_forced_answer(answer_override: str | None = None) -> str | None:
     if answer_override is None:
-        return __forced_answer
+        return _SharedOptions.forced_answer
     return answer_override


### PR DESCRIPTION
Another small increment to remove global statements for PR https://github.com/apache/airflow/pull/58116

This removes all leftover global statements in breeze. In most cases `global` was mis-used for some minor flags.

`global` is evil. Also in breeze :-D