### PR TITLE
Remove global from celery provider

### DIFF
--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
@@ -84,24 +84,23 @@ OPERATION_TIMEOUT = conf.getfloat("celery", "operation_timeout")
 # Make it constant for unit test.
 CELERY_FETCH_ERR_MSG_HEADER = "Error fetching Celery task state"
 
-celery_configuration = None
+
+def get_celery_configuration() -> dict[str, Any]:
+    """Get the Celery configuration dictionary."""
+    if conf.has_option("celery", "celery_config_options"):
+        return conf.getimport("celery", "celery_config_options")
+
+    from airflow.providers.celery.executors.default_celery import DEFAULT_CELERY_CONFIG
+
+    return DEFAULT_CELERY_CONFIG
 
 
 @providers_configuration_loaded
 def _get_celery_app() -> Celery:
     """Init providers before importing the configuration, so the _SECRET and _CMD options work."""
-    global celery_configuration
-
-    if conf.has_option("celery", "celery_config_options"):
-        celery_configuration = conf.getimport("celery", "celery_config_options")
-    else:
-        from airflow.providers.celery.executors.default_celery import DEFAULT_CELERY_CONFIG
-
-        celery_configuration = DEFAULT_CELERY_CONFIG
-
     celery_app_name = conf.get("celery", "CELERY_APP_NAME")
 
-    return Celery(celery_app_name, config_source=celery_configuration)
+    return Celery(celery_app_name, config_source=get_celery_configuration())
 
 
 app = _get_celery_app()

--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
@@ -31,6 +31,7 @@ import sys
 import traceback
 from collections.abc import Collection, Mapping, MutableMapping, Sequence
 from concurrent.futures import ProcessPoolExecutor
+from functools import cache
 from typing import TYPE_CHECKING, Any
 
 from celery import Celery, Task, states as celery_states
@@ -85,6 +86,7 @@ OPERATION_TIMEOUT = conf.getfloat("celery", "operation_timeout")
 CELERY_FETCH_ERR_MSG_HEADER = "Error fetching Celery task state"
 
 
+@cache
 def get_celery_configuration() -> dict[str, Any]:
     """Get the Celery configuration dictionary."""
     if conf.has_option("celery", "celery_config_options"):

--- a/providers/celery/tests/integration/celery/test_celery_executor.py
+++ b/providers/celery/tests/integration/celery/test_celery_executor.py
@@ -79,7 +79,7 @@ def _prepare_app(broker_url=None, execute=None):
         execute_name = "execute_command"
         execute = execute or celery_executor_utils.execute_command.__wrapped__
 
-    test_config = dict(celery_executor_utils.celery_configuration)
+    test_config = dict(celery_executor_utils.get_celery_configuration())
     test_config.update({"broker_url": broker_url})
     test_app = Celery(broker_url, config_source=test_config)
     test_execute = test_app.task(execute)
@@ -168,7 +168,7 @@ class TestCeleryExecutor:
                     run_id="abc",
                     try_number=0,
                     priority_weight=1,
-                    queue=celery_executor_utils.celery_configuration["task_default_queue"],
+                    queue=celery_executor_utils.get_celery_configuration()["task_default_queue"],
                     executor_config=executor_config,
                 )
                 keys = [

--- a/providers/celery/tests/unit/celery/executors/test_celery_executor.py
+++ b/providers/celery/tests/unit/celery/executors/test_celery_executor.py
@@ -86,7 +86,7 @@ def _prepare_app(broker_url=None, execute=None):
         execute_name = "execute_command"
         execute = execute or celery_executor_utils.execute_command.__wrapped__
 
-    test_config = dict(celery_executor_utils.celery_configuration)
+    test_config = dict(celery_executor_utils.get_celery_configuration())
     test_config.update({"broker_url": broker_url})
     test_app = Celery(broker_url, config_source=test_config)
     test_execute = test_app.task(execute)


### PR DESCRIPTION
Another small increment to remove global statements for PR https://github.com/apache/airflow/pull/58116

This removes global statement in celery, a classsic thing where `functools.cache()` can help. Also centralization of config retrieval in this case makes code better in general.

`global` is evil.