### PR TITLE
Changed the imports to the new sdk for the connection class in base secret manager

### DIFF
--- a/airflow-core/src/airflow/secrets/base_secrets.py
+++ b/airflow-core/src/airflow/secrets/base_secrets.py
@@ -19,8 +19,12 @@ from __future__ import annotations
 from abc import ABC
 from typing import TYPE_CHECKING
 
+# This is added to support both Airflow 2.x and Airflow 3.x
 if TYPE_CHECKING:
-    from airflow.models.connection import Connection
+    try:
+        from airflow.sdk import Connection
+    except ImportError:
+        from airflow.models.connection import Connection
 
 
 class BaseSecretsBackend(ABC):
@@ -58,7 +62,11 @@ class BaseSecretsBackend(ABC):
         :param value: the serialized representation of the Connection object
         :return: the deserialized Connection
         """
-        from airflow.models.connection import Connection
+        # This is added to support both Airflow 2.x and Airflow 3.x
+        try:
+            from airflow.sdk import Connection
+        except ImportError:
+            from airflow.models.connection import Connection
 
         value = value.strip()
         if value[0] == "{":


### PR DESCRIPTION
In AWS Secret Manager provider we are inheriting from the BaseSecretManager class which is still using older import leading to 
WARNING Using Connection.from_json from `airflow.models` is deprecated.Please use `from_json` on Connection from sdk(airflow.sdk.Connection) instead
So moved the import from the new sdk which will remove the WARNING message of deprecated import. I have added try catch to keep the backward compatibility which can be removed once we deprecate the older classes.
SS for previous output:
<img width="1047" height="232" alt="Screenshot 2025-11-30 at 8 41 00 PM" src="https://github.com/user-attachments/assets/0c6e8be7-e650-4654-986e-675ed65d84ec" />
SS for new output:
<img width="1048" height="321" alt="Screenshot 2025-11-30 at 8 41 09 PM" src="https://github.com/user-attachments/assets/24ddb70b-9e9d-4c1f-8f9d-e5abda6aac96" />
