### PR TITLE
Remove global from prek CI scripts

### DIFF
--- a/scripts/ci/prek/check_providers_subpackages_all_have_init.py
+++ b/scripts/ci/prek/check_providers_subpackages_all_have_init.py
@@ -55,8 +55,12 @@ PATH_EXTENSION_STRING = '__path__ = __import__("pkgutil").extend_path(__path__, 
 
 ALLOWED_SUB_FOLDERS_OF_TESTS = ["unit", "system", "integration"]
 
-should_fail = False
-fatal_error = False
+
+class _ErrorSignals:
+    should_fail: bool = False
+    fatal_error: bool = False
+
+
 missing_init_dirs: list[Path] = []
 missing_path_extension_dirs: list[Path] = []
 
@@ -77,10 +81,8 @@ def _what_kind_of_test_init_py_needed(base_path: Path, folder: Path) -> tuple[bo
         if folder.name not in ALLOWED_SUB_FOLDERS_OF_TESTS:
             console.print(f"[red]Unexpected folder {folder} in {base_path}[/]")
             console.print(f"[yellow]Only {ALLOWED_SUB_FOLDERS_OF_TESTS} should be sub-folders of tests.[/]")
-            global should_fail
-            global fatal_error
-            should_fail = True
-            fatal_error = True
+            _ErrorSignals.should_fail = True
+            _ErrorSignals.fatal_error = True
         return True, True
     if depth == 2:
         # For known sub-packages that can occur in several packages we need to add __path__ extension
@@ -162,20 +164,20 @@ if __name__ == "__main__":
             init_file = missing_init_dir / "__init__.py"
             init_file.write_text("".join(prefixed_licensed_txt))
             console.print(f"[yellow]Added missing __init__.py file:[/] {init_file}")
-            should_fail = True
+            _ErrorSignals.should_fail = True
 
     for missing_extension_dir in missing_path_extension_dirs:
         init_file = missing_extension_dir / "__init__.py"
         init_file.write_text(init_file.read_text() + PATH_EXTENSION_STRING + "\n")
         console.print(f"[yellow]Added missing path extension to __init__.py file[/] {init_file}")
-        should_fail = True
+        _ErrorSignals.should_fail = True
 
-    if should_fail:
+    if _ErrorSignals.should_fail:
         console.print(
             "\n[yellow]The missing __init__.py files have been created. "
             "Please add these new files to a commit."
         )
-        if fatal_error:
+        if _ErrorSignals.fatal_error:
             console.print("[red]Also please remove the extra test folders listed above!")
         sys.exit(1)
     console.print("[green]All __init__.py files are present and have necessary extensions.[/]")

--- a/scripts/in_container/run_check_imports_in_providers.py
+++ b/scripts/in_container/run_check_imports_in_providers.py
@@ -26,11 +26,9 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.resolve()))
 from in_container_utils import console, get_provider_base_dir_from_path, get_provider_id_from_path
 
-errors_found = False
 
-
-def check_imports():
-    global errors_found
+def check_imports() -> bool:
+    errors_found = False
     cmd = [
         "ruff",
         "analyze",
@@ -80,11 +78,10 @@ def check_imports():
                         f"\n"
                     )
                     errors_found = True
+    return errors_found
 
 
-check_imports()
-
-if errors_found:
+if check_imports():
     console.print("\n[red]Errors found in imports![/]\n")
     sys.exit(1)
 else:


### PR DESCRIPTION
Another small increment to remove global statements for PR https://github.com/apache/airflow/pull/58116

This removes global statement in prek CI scripts. Once does not need a `global`, the other can be wrapped in a class to hold static variables.

`global` is evil.