### PR TITLE
Return dag tags in alphabetical order

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dags.py
@@ -84,6 +84,16 @@ class DAGResponse(BaseModel):
     next_dagrun_run_after: datetime | None
     owners: list[str]
 
+    @field_validator("tags", mode="before")
+    @classmethod
+    def sort_tags(cls, v: Any) -> list[Any]:
+        """Sort tags alphabetically by name."""
+        if v is None:
+            return []
+        if isinstance(v, list):
+            return sorted(v, key=lambda tag: tag.name if hasattr(tag, "name") else str(tag))
+        return v
+
     @field_validator("owners", mode="before")
     @classmethod
     def get_owners(cls, v: Any) -> list[str] | None:

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dags.py
@@ -28,6 +28,7 @@ from pydantic import (
     AliasGenerator,
     ConfigDict,
     computed_field,
+    field_serializer,
     field_validator,
 )
 
@@ -83,6 +84,11 @@ class DAGResponse(BaseModel):
     next_dagrun_data_interval_end: datetime | None
     next_dagrun_run_after: datetime | None
     owners: list[str]
+
+    @field_serializer("tags")
+    def serialize_tags(self, tags: list[DagTagResponse]) -> list[DagTagResponse]:
+        """Sort tags alphabetically by name."""
+        return sorted(tags, key=lambda tag: tag.name)
 
     @field_validator("owners", mode="before")
     @classmethod

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py
@@ -526,40 +526,6 @@ class TestGetDags(TestDagEndpoint):
         assert body["total_entries"] == 1
         assert [dag["dag_id"] for dag in body["dags"]] == expected_ids
 
-    def test_get_dags_tags_sorted_alphabetically(self, session, test_client):
-        """Test that tags are returned in alphabetical order."""
-        # Create a DAG with multiple tags in non-alphabetical order
-        dag_id = "test_dag_sorted_tags"
-        dag_model = DagModel(
-            dag_id=dag_id,
-            bundle_name="dag_maker",
-            fileloc=f"/tmp/{dag_id}.py",
-            is_stale=False,
-        )
-        session.add(dag_model)
-        session.flush()
-
-        # Add tags in non-alphabetical order
-        tag_names = ["zebra", "alpha", "mike", "bravo"]
-        for tag_name in tag_names:
-            tag = DagTag(name=tag_name, dag_id=dag_id)
-            session.add(tag)
-
-        session.commit()
-
-        response = test_client.get("/dags")
-        assert response.status_code == 200
-        body = response.json()
-
-        # Find our test DAG in the response
-        test_dag = next((d for d in body["dags"] if d["dag_id"] == dag_id), None)
-        assert test_dag is not None
-
-        # Verify tags are sorted alphabetically
-        tag_names_in_response = [tag["name"] for tag in test_dag["tags"]]
-        expected_sorted_tags = sorted(tag_names)
-        assert tag_names_in_response == expected_sorted_tags
-
     def test_get_dags_no_n_plus_one_queries(self, session, test_client):
         """Test that fetching DAGs with tags doesn't trigger n+1 queries."""
         num_dags = 5

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py
@@ -526,6 +526,40 @@ class TestGetDags(TestDagEndpoint):
         assert body["total_entries"] == 1
         assert [dag["dag_id"] for dag in body["dags"]] == expected_ids
 
+    def test_get_dags_tags_sorted_alphabetically(self, session, test_client):
+        """Test that tags are returned in alphabetical order."""
+        # Create a DAG with multiple tags in non-alphabetical order
+        dag_id = "test_dag_sorted_tags"
+        dag_model = DagModel(
+            dag_id=dag_id,
+            bundle_name="dag_maker",
+            fileloc=f"/tmp/{dag_id}.py",
+            is_stale=False,
+        )
+        session.add(dag_model)
+        session.flush()
+
+        # Add tags in non-alphabetical order
+        tag_names = ["zebra", "alpha", "mike", "bravo"]
+        for tag_name in tag_names:
+            tag = DagTag(name=tag_name, dag_id=dag_id)
+            session.add(tag)
+
+        session.commit()
+
+        response = test_client.get("/dags")
+        assert response.status_code == 200
+        body = response.json()
+
+        # Find our test DAG in the response
+        test_dag = next((d for d in body["dags"] if d["dag_id"] == dag_id), None)
+        assert test_dag is not None
+
+        # Verify tags are sorted alphabetically
+        tag_names_in_response = [tag["name"] for tag in test_dag["tags"]]
+        expected_sorted_tags = sorted(tag_names)
+        assert tag_names_in_response == expected_sorted_tags
+
     def test_get_dags_no_n_plus_one_queries(self, session, test_client):
         """Test that fetching DAGs with tags doesn't trigger n+1 queries."""
         num_dags = 5
@@ -1213,6 +1247,33 @@ class TestGetDag(TestDagEndpoint):
             "relative_fileloc": "test_dags.py",
         }
         assert res_json == expected
+
+    def test_get_dag_tags_sorted_alphabetically(self, session, test_client, dag_maker):
+        """Test that tags are returned in alphabetical order for a single DAG."""
+        dag_id = "test_dag_single_sorted_tags"
+
+        # Create a DAG using dag_maker
+        with dag_maker(dag_id=dag_id, schedule=None):
+            EmptyOperator(task_id="task1")
+
+        dag_maker.sync_dagbag_to_db()
+
+        # Add tags in non-alphabetical order
+        tag_names = ["zebra", "alpha", "mike", "bravo"]
+        for tag_name in tag_names:
+            tag = DagTag(name=tag_name, dag_id=dag_id)
+            session.add(tag)
+
+        session.commit()
+
+        response = test_client.get(f"/dags/{dag_id}")
+        assert response.status_code == 200
+        res_json = response.json()
+
+        # Verify tags are sorted alphabetically
+        tag_names_in_response = [tag["name"] for tag in res_json["tags"]]
+        expected_sorted_tags = sorted(tag_names)
+        assert tag_names_in_response == expected_sorted_tags
 
     def test_get_dag_should_response_401(self, unauthenticated_test_client):
         response = unauthenticated_test_client.get(f"/dags/{DAG1_ID}")


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Alternative solution suggested in  https://github.com/apache/airflow/pull/56478. Returns DAG tags ordered alphabetically from the API (rather than ordering in the UI) so they are rendered in the UI alphabetically.



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
