### PR TITLE
add pre loading of airflow module in dag-processor using runtime diff

### DIFF
--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -1212,7 +1212,8 @@ def process_parse_results(
         if conf.getboolean("dag_processor", "parsing_pre_import_modules", fallback=True):
             for module in parsing_result.not_loaded_airflow_modules or []:
                 try:
-                    importlib.import_module(module)
+                    if module not in sys.modules.keys():
+                        importlib.import_module(module)
                 except Exception:
                     log.warning("Error when trying to pre-import module '%s'", module)
     return stat

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -79,6 +79,7 @@ if TYPE_CHECKING:
 
     from sqlalchemy.orm import Session
     from sqlalchemy.sql import Select
+    from structlog.typing import FilteringBoundLogger as Logger
 
     from airflow.callbacks.callback_requests import CallbackRequest
     from airflow.dag_processing.bundles.base import BaseDagBundle
@@ -1151,7 +1152,7 @@ def process_parse_results(
     *,
     is_callback_only: bool = False,
     relative_fileloc: str | None = None,
-    log: logging.Logger | None = None,
+    log: Logger | None = None,
 ) -> DagFileStat:
     """Take the parsing result and stats about the parser process and convert it into a DagFileStat."""
     if is_callback_only:
@@ -1209,7 +1210,7 @@ def process_parse_results(
             stat.import_errors = len(parsing_result.import_errors)
 
         # Load Airflow modules that were not loaded during runtime.
-        if conf.getboolean("dag_processor", "parsing_pre_import_modules", fallback=True):
+        if conf.getboolean("dag_processor", "parsing_pre_import_modules", fallback=True) and log:
             for module in parsing_result.not_loaded_airflow_modules or []:
                 try:
                     if module not in sys.modules.keys():


### PR DESCRIPTION
## Motivation

While [investigating fork-related behavior](https://github.com/apache/airflow/discussions/58143), I found that loading modules that were not imported in the parent process—and therefore had to be loaded each time a child process was spawned—caused significant performance degradation.

Although [some optimizations](https://github.com/apache/airflow/pull/50371) have already been applied to the dag-processor, I would like to propose an additional improvement.

The existing optimization performs static analysis using AST on DAG files and preloads modules declared in import statements. This yields good results for a single DAG. But It cannot detect cases where modules are imported indirectly through nested calls like the following.

```python
# dags/dag_files.py
from plugins.generate_dag import create_dag

for name in names: 
    create_dag(name)
```
```python
# plugins/generate_dag.py

# load heavy module of airflow in here
from airflow.module import ~
from airflow.load import ~
from airflow.dags impot Dag

def create_dag(name):
    with DAG(
        dag_id,
    ) as dag:
    task1 >> task2 >> task3

    return dag
```

As the use of dynamic DAGs has become more common, we need an approach that can handle these cases, which are difficult to detect through static analysis alone. For this reason, I believe comparing which modules are actually imported at runtime is a more effective method, and this PR implements that approach.

## Question

As mentioned in the [previous PR](https://github.com/apache/airflow/pull/50371#issuecomment-2975058197), it seemed that preloading heavy modules (e.g. numpy, k8s, pandas) was also being considered. However, based on the current code, it does not appear that these modules are actually being preloaded.

What are your thoughts on allowing users to define modules they want to preload via configuration, and enabling preloading specifically for those modules?

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
