### PR TITLE
fix: Prevent duplicate task execution on scheduler crash (Celery exec…

### DIFF
--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
@@ -574,6 +574,15 @@ class CeleryExecutor(BaseExecutor):
         ti = workload.ti
         self.queued_tasks[ti.key] = workload
 
+        if session is not None:
+            from airflow.models.taskinstance import TaskInstance as TIModel
+
+            ti_id = str(ti.id)
+            ti_model = session.get(TIModel, ti_id)
+            if ti_model:
+                ti_model.external_executor_id = ti_id
+                session.flush()
+
 
 def _get_parser() -> argparse.ArgumentParser:
     """


### PR DESCRIPTION
# Fix: Prevent duplicate task execution on scheduler crash (Celery executor)

## Problem

Tasks can be executed twice when the scheduler crashes between sending a task to Celery and persisting the `external_executor_id` in the database. This happens because:

1. Task is sent to Celery → Celery generates `task_id`
2. Task starts running on worker → transitions to `RUNNING` state
3. **Crash window**: Scheduler hasn't yet processed events to set `external_executor_id`
4. Scheduler restarts → can't adopt task (no executor ID) → resets task → duplicate execution

Fixes #58570

## Solution

Use the existing TaskInstance UUID (`ti.id`) as the `external_executor_id` by setting it **before** sending the task to Celery, eliminating the race condition.

## Backward Compatibility

Fully backward compatible:
- Event buffer still used as fallback for old workers
- Only sets `external_executor_id` if session is available
