### PR TITLE
Fix `breeze setup autocomplete` references

### DIFF
--- a/dev/breeze/doc/01_installation.rst
+++ b/dev/breeze/doc/01_installation.rst
@@ -430,7 +430,7 @@ also force reinstalling the autocomplete via:
 
    breeze setup autocomplete --force
 
-These are all available flags of ``setup-autocomplete`` command:
+These are all available flags of ``setup autocomplete`` command:
 
 .. image:: ./images/output_setup_autocomplete.svg
   :target: https://raw.githubusercontent.com/apache/airflow/main/dev/breeze/images/output_setup_autocomplete.svg

--- a/dev/breeze/src/airflow_breeze/utils/visuals.py
+++ b/dev/breeze/src/airflow_breeze/utils/visuals.py
@@ -126,7 +126,7 @@ CHEATSHEET = f"""
     integration or starting complete Airflow using `start-airflow` command as well as ways
     of cleaning up the installation.
 
-    Make sure to run `setup-autocomplete` to get the commands and options auto-completable
+    Make sure to run `breeze setup autocomplete` to get the commands and options auto-completable
     in your shell.
 
     You can disable this cheatsheet by running:

--- a/scripts/tools/setup_breeze
+++ b/scripts/tools/setup_breeze
@@ -72,7 +72,7 @@ function check_breeze_installed() {
             echo
             if "${MY_DIR}/confirm" "installing and modifying the startup scripts"; then
                 uv tool install -e "${AIRFLOW_SOURCES}/dev/breeze/" --force
-                ${BREEZE_BINARY} setup-autocomplete --force --answer yes
+                ${BREEZE_BINARY} setup autocomplete --force --answer yes
                 echo
                 echo "${COLOR_YELLOW}Please close and re-open the shell and retry. Then rerun your last command!${COLOR_RESET}"
                 echo


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

The `./scripts/tools/setup_breeze` script fails to install autocompletions. To reproduce:

<details>

```bash
❯ which breeze &>/dev/null && rm -vf $(which breeze)
removed '/home/bswck/.local/bin/breeze'
 
❯ ./scripts/tools/setup_breeze 

The 'breeze' is not on path. Breeze should be installed and 'breeze' should be available on your PATH!

Installing Breeze. This will install breeze via uv and modify your /bin/bash to run it


Please confirm installing and modifying the startup scripts. Are you sure? [y/N/q]
y
The answer is 'yes'. installing and modifying the startup scripts. This can take some time!
Resolved 108 packages in 28ms
Uninstalled 1 package in 1ms
Installed 1 package in 7ms
 ~ apache-airflow-breeze==0.0.1 (from file:///home/bswck/Apache/airflow/dev/breeze)
Installed 1 executable: breeze
                                                                                                                                                                
 Usage: breeze [OPTIONS] COMMAND [ARGS]...                                                                                                                      
                                                                                                                                                                
                                                                                                                                                                
 Try running the '--help' flag for more information.                                                                                                            
                                                                                                                                                                
╭─ Error ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ No such command 'setup-autocomplete'.                                                                                                                        │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
                                                                                                                                                                
                                                                                                                                                                
 To find out more, visit https://github.com/apache/airflow/blob/main/dev/breeze/doc/01_installation.rst
```

</details>

In #25449, the `setup-autocomplete` command became `setup autocomplete`, but `${BREEZE_BINARY} setup-autocomplete` in the setup script (which used to be `./breeze` back then) wasn't fixed up -- https://github.com/apache/airflow/pull/25449/commits/31fb5ffc0ace553e3afc9c6c1084434d6daf5620#diff-7e92c11499fd4106a899eeb457db8277bd6f09dd29e683f33ae704e12fa29caeR73. A trickier one :)

I've fixed the old-fashion command invocation, and I've corrected the remaining stale references to `setup-autocomplete` in the docs.

You shouldn't find `setup-autocomplete` now anywhere but in CSS class names.

cc @potiuk (hi! :grin:)

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
