### PR TITLE
Decouple xcom public API from using XcomEncoder

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/xcom.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/xcom.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import copy
+import json
 from typing import Annotated
 
 from fastapi import Depends, HTTPException, Query, status
@@ -256,7 +257,7 @@ def create_xcom_entry(
         )
 
     try:
-        value = XComModel.serialize_value(request_body.value)
+        value = json.dumps(request_body.value)
     except (ValueError, TypeError):
         raise HTTPException(
             status.HTTP_400_BAD_REQUEST, f"Couldn't serialise the XCom with key: `{request_body.key}`"
@@ -314,7 +315,7 @@ def update_xcom_entry(
 ) -> XComResponseNative:
     """Update an existing XCom entry."""
     # Check if XCom entry exists
-    xcom_new_value = XComModel.serialize_value(patch_body.value)
+    xcom_new_value = json.dumps(patch_body.value)
     xcom_entry = session.scalar(
         select(XComModel)
         .where(
@@ -335,6 +336,6 @@ def update_xcom_entry(
         )
 
     # Update XCom entry
-    xcom_entry.value = XComModel.serialize_value(xcom_new_value)
+    xcom_entry.value = json.dumps(xcom_new_value)
 
     return XComResponseNative.model_validate(xcom_entry)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

For xcom API, `XcomModel. serialize_value` is in the end routed through to the XcomEncoder: https://github.com/apache/airflow/blob/main/airflow-core/src/airflow/utils/json.py#L23-L45 which uses serde.

As part of [Move over serde library to task sdk](https://github.com/apache/airflow/issues/58885), realised that this would make it hard to get rid of serde occurrences in airflow core. 

`XcomEncoder` in this case is used in POST/PATCH as: `XComModel.serialize_value(patch_body.value)` when really it should not need the `XcomEncoder` -> only JSON can come in via API and no unexpected objects, so this one essentially is just doing: `json.dumps(value)` and not `json.dumps(value, cls=XComEncoder)`.

Making this change is an effort to decouple serde from airflow-core.


Tried the REST API for POST and PATCH without and with my change as we see same results:

Patch:
```python
"\"{\\\"data\\\": [1, 2, 3], \\\"metadata\\\": {\\\"timestamp\\\": \\\"2024-01-01\\\", \\\"count\\\": 6}}\""
"\"{\\\"data\\\": [1, 2, 3], \\\"metadata\\\": {\\\"timestamp\\\": \\\"2024-01-01\\\", \\\"count\\\": 7}}\""
```



Post:
```python
"{\"data\": [1, 2, 3], \"metadata\": {\"timestamp\": \"2024-01-01\", \"count\": 5}}"
"{\"data\": [1, 2, 3], \"metadata\": {\"timestamp\": \"2024-01-01\", \"count\": 6}}"
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
