### PR TITLE
Fix mypy errors in sql_to_s3 due to pandas stub bump

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/sql_to_s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/sql_to_s3.py
@@ -191,7 +191,7 @@ class SqlToS3Operator(BaseOperator):
             if df[col].dtype.name == "object" and file_format == FILE_FORMAT.PARQUET:
                 # if the type wasn't identified or converted, change it to a string so if can still be
                 # processed.
-                df[col] = df[col].astype(str)
+                df[col] = cast("pd.Series", df[col].astype(str))
 
             if "float" in df[col].dtype.name and df[col].hasnans:
                 # inspect values to determine if dtype of non-null values is int or float
@@ -201,13 +201,13 @@ class SqlToS3Operator(BaseOperator):
                     # The type ignore can be removed here if https://github.com/numpy/numpy/pull/23690
                     # is merged and released as currently NumPy does not consider None as valid for x/y.
                     df[col] = np.where(df[col].isnull(), None, df[col])  # type: ignore[call-overload]
-                    df[col] = df[col].astype(pd.Int64Dtype())
+                    df[col] = cast("pd.Series", df[col].astype(pd.Int64Dtype()))
                 elif np.isclose(notna_series, notna_series.astype(int)).all():
                     # set to float dtype that retains floats and supports NaNs
                     # The type ignore can be removed here if https://github.com/numpy/numpy/pull/23690
                     # is merged and released
                     df[col] = np.where(df[col].isnull(), None, df[col])  # type: ignore[call-overload]
-                    df[col] = df[col].astype(pd.Float64Dtype())
+                    df[col] = cast("pd.Series", df[col].astype(pd.Float64Dtype()))
 
     @staticmethod
     def _strip_suffixes(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

CI fails with:
```shell script
  providers/amazon/src/airflow/providers/amazon/aws/transfers/sql_to_s3.py:194: error: No overload variant of "__setitem__" of "DataFrame" matches argument types "Hashable", "Series[str]" 
  [call-overload]
                      df[col] = df[col].astype(str)
                      ^~~~~~~
  providers/amazon/src/airflow/providers/amazon/aws/transfers/sql_to_s3.py:194: note: Possible overload variants:
  providers/amazon/src/airflow/providers/amazon/aws/transfers/sql_to_s3.py:194: note:     def __setitem__(self, int | slice[Any, Any, Any] | ndarray[Any, dtype[integer[Any]]] | Index[Any] | list[int] | Series[int] | tuple[int, int] | tuple[slice[Any, Any, Any] | ndarray[Any, dtype[integer[Any]]] | Index[Any] | list[int] | Series[int], int] | tuple[slice[Any, Any, Any] | ndarray[Any, dtype[integer[Any]]] | Index[Any] | list[int] | Series[int], slice[Any, Any, Any] | ndarray[Any, dtype[integer[Any]]] | Index[Any] | list[int] | Series[int]] | tuple[int, slice[Any, Any, Any] | ndarray[Any, dtype[integer[Any]]] | Index[Any] | list[int] | Series[int]], str | bytes | date | datetime | timedelta | <7 more items> | complex | integer[Any] | floating[Any] | complexfloating[Any, Any] | IndexOpsMixin[Any, Any] | Sequence[str | bytes | date | datetime | timedelta | <7 more items> | complex | integer[Any] | floating[Any] | complexfloating[Any, Any]] | DataFrame | ndarray[tuple[Any, ...], dtype[Any]] | NAType | NaTType | Mapping[Hashable, str | bytes | date | datetime | timedelta | <7 more items> | complex | integer[Any] | floating[Any] | complexfloating[Any, Any] | NAType | NaTType] | None, /) -> None
  providers/amazon/src/airflow/providers/amazon/aws/transfers/sql_to_s3.py:194: note:     def [ScalarT: str | bytes | date | datetime | timedelta | <7 more items> | complex | integer[Any] | floating[Any] | complexfloating[Any, Any]] __setitem__(self, Series[bool] | ndarray[Any, dtype[bool_]] | list[bool] | str | str_ | <9 more items>, str | bytes | date | datetime | timedelta | <20 more items> | None, /) -> None
  providers/amazon/src/airflow/providers/amazon/aws/transfers/sql_to_s3.py:194: note:     def __setitem__(self, tuple[tuple[IndexOpsMixin[Any, Any] | Series[bool] | ndarray[Any, dtype[bool_]] | list[bool] | str | bytes | date | datetime | timedelta | <7 more items> | complex | integer[Any] | floating[Any] | complexfloating[Any, Any] | Sequence[str | bytes | date | datetime | timedelta | <7 more items> | complex | integer[Any] | floating[Any] | complexfloating[Any, Any]] | slice[Any, Any, Any], ...], Hashable], str | bytes | date | datetime | timedelta | <7 more items> | complex | integer[Any] | floating[Any] | complexfloating[Any, Any] | NAType | NaTType | ExtensionArray | ndarray[Any, dtype[Any]] | IndexOpsMixin[Any, Any] | Sequence[str | bytes | date | datetime | timedelta | <7 more items> | complex | integer[Any] | floating[Any] | complexfloating[Any, Any]] | Sequence[Sequence[str | bytes | date | datetime | timedelta | <7 more items> | complex | integer[Any] | floating[Any] | complexfloating[Any, Any]]] | Mapping[Hashable, str | bytes | date | datetime | timedelta | <7 more items> | complex | integer[Any] | floating[Any] | complexfloating[Any, Any] | NAType | NaTType] | None, /) -> None
  providers/amazon/src/airflow/providers/amazon/aws/transfers/sql_to_s3.py:194: note:     def __setitem__(self, IndexOpsMixin[Any, Any] | DataFrame, str | bytes | date | datetime | timedelta | <7 more items> | complex | integer[Any] | floating[Any] | complexfloating[Any, Any] | NAType | NaTType | ExtensionArray | ndarray[Any, dtype[Any]] | IndexOpsMixin[Any, Any] | Sequence[str | bytes | date | datetime | timedelta | <7 more items> | complex | integer[Any] | floating[Any] | complexfloating[Any, Any]] | Sequence[Sequence[str | bytes | date | datetime | timedelta | <7 more items> | complex | integer[Any] | floating[Any] | complexfloating[Any, Any]]] | Mapping[Hashable, str | bytes | date | datetime | timedelta | <7 more items> | complex | integer[Any] | floating[Any] | complexfloating[Any, Any] | NAType | NaTType] | None, /) -> None
  providers/amazon/src/airflow/providers/amazon/aws/transfers/sql_to_s3.py:204: error: No overload variant of "__setitem__" of "DataFrame" matches argument types "Hashable", "Series[int]" 
  [call-overload]
                          df[col] = df[col].astype(pd.Int64Dtype())
```

This seems to be due to pandas-stub version bump and this change: https://github.com/pandas-dev/pandas-stubs/commit/3c9e24351eb895476838faee2603e6502e4eb7e0


To fix this, adding explicit `cast()` calls to properly handle `pandas-stubs 2.3.3` stricter type checking for DataFrame
column assignments. This ensures type safety while maintaining runtime behavior as well.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
