### PR TITLE
nit: rename TriggerDagRunOperator._defer to deferrable

### DIFF
--- a/providers/standard/src/airflow/providers/standard/operators/trigger_dagrun.py
+++ b/providers/standard/src/airflow/providers/standard/operators/trigger_dagrun.py
@@ -135,8 +135,7 @@ class TriggerDagRunOperator(BaseOperator):
     :param skip_when_already_exists: Set to true to mark the task as SKIPPED if a DAG run of the triggered
         DAG for the same logical date already exists.
     :param fail_when_dag_is_paused: If the dag to trigger is paused, DagIsPaused will be raised.
-    :param deferrable: If waiting for completion, whether or not to defer the task until done,
-        default is ``False``.
+    :param deferrable: If waiting for completion, whether to defer the task until done, default is ``False``.
     :param openlineage_inject_parent_info: whether to include OpenLineage metadata about the parent task
         in the triggered DAG run's conf, enabling improved lineage tracking. The metadata is only injected
         if OpenLineage is enabled and running. This option does not modify any other part of the conf,
@@ -193,7 +192,7 @@ class TriggerDagRunOperator(BaseOperator):
         self.skip_when_already_exists = skip_when_already_exists
         self.fail_when_dag_is_paused = fail_when_dag_is_paused
         self.openlineage_inject_parent_info = openlineage_inject_parent_info
-        self._defer = deferrable
+        self.deferrable = deferrable
         self.logical_date = logical_date
         if logical_date is NOTSET:
             self.logical_date = NOTSET
@@ -277,7 +276,7 @@ class TriggerDagRunOperator(BaseOperator):
             allowed_states=self.allowed_states,
             failed_states=self.failed_states,
             poke_interval=self.poke_interval,
-            deferrable=self._defer,
+            deferrable=self.deferrable,
         )
 
     def _trigger_dag_af_2(self, context, run_id, parsed_logical_date):
@@ -318,7 +317,7 @@ class TriggerDagRunOperator(BaseOperator):
 
         if self.wait_for_completion:
             # Kick off the deferral process
-            if self._defer:
+            if self.deferrable:
                 self.defer(
                     trigger=DagStateTrigger(
                         dag_id=self.trigger_dag_id,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Just a nit for consistency, all other operators save information about deferral as `self.deferrable`, this one was saving it as `self._defer`. This should have no influence on execution and will help OL listener include that task attr in OL events.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
