### PR TITLE
Improve startup information printed when Breeze starts

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/developer_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/developer_commands.py
@@ -489,7 +489,7 @@ def shell(
         verbose_commands=verbose_commands,
         warn_image_upgrade_needed=warn_image_upgrade_needed,
     )
-    perform_environment_checks()
+    perform_environment_checks(quiet=shell_params.quiet)
     rebuild_or_pull_ci_image_if_needed(command_params=shell_params)
     result = enter_shell(shell_params=shell_params)
     fix_ownership_using_docker()
@@ -700,6 +700,7 @@ def start_airflow(
         use_uv=use_uv,
         uv_http_timeout=uv_http_timeout,
     )
+    perform_environment_checks(quiet=shell_params.quiet)
     rebuild_or_pull_ci_image_if_needed(command_params=shell_params)
     result = enter_shell(shell_params=shell_params)
     fix_ownership_using_docker()

--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -531,7 +531,7 @@ def check_executable_entrypoint_permissions(quiet: bool = False):
                 f"repository should only be checked out on a filesystem that is POSIX compliant."
             )
             sys.exit(1)
-    if not quiet:
+    if get_verbose() and not quiet:
         get_console().print("[success]Executable permissions on entrypoints are OK[/]")
 
 
@@ -542,6 +542,8 @@ def perform_environment_checks(quiet: bool = False):
     check_docker_version(quiet)
     check_docker_compose_version(quiet)
     check_executable_entrypoint_permissions(quiet)
+    if not quiet:
+        get_console().print(f"[success]Host python version is {sys.version}[/]")
 
 
 def get_docker_syntax_version() -> str:
@@ -810,6 +812,7 @@ def execute_command_in_shell(
         shell_params.extra_args = (command,)
         if get_verbose():
             get_console().print(f"[info]Command to execute: '{command}'[/]")
+    perform_environment_checks(quiet=shell_params.quiet)
     return enter_shell(shell_params, output=output, signal_error=signal_error)
 
 
@@ -827,7 +830,6 @@ def enter_shell(
     * shuts down existing project
     * executes the command to drop the user to Breeze shell
     """
-    perform_environment_checks(quiet=shell_params.quiet)
     fix_ownership_using_docker(quiet=shell_params.quiet)
     cleanup_python_generated_files()
     if read_from_cache_file("suppress_asciiart") is None and not shell_params.quiet:


### PR DESCRIPTION
We were using lru_cache to only print environment check output once, but the method was called once with quiet = False and once without, which made it double-print the output.

The check was done in both - commmands and "docker_utils.enter_shell" and that was really unnecessary.

This PR changes it so that environment check is done only once at the command entry, also the "executable bit" information that was somewhat useless is now replaced with printing a detailed version of Python used - which might help with diagnostics of some strange issues in case the output is copy&pasted.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
