### PR TITLE
Fix KubernetesPodOperator XCom sidecar hang on Alpine

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -927,7 +927,7 @@ class PodManager(LoggingMixin):
             # fallback command for containers that don't support pgrep -u
             fallback_xcom_kill_command = (
                 "for f in /proc/[0-9]*/comm; do "
-                "[ -O $f ] && read c < $f && [ \"$c\" = \"sh\" ] && pid=${f%/comm} && kill -2 ${pid##*/}; "
+                '[ -O $f ] && read c < $f && [ "$c" = "sh" ] && pid=${f%/comm} && kill -2 ${pid##*/}; '
                 "done"
             )
             try:

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -919,12 +919,13 @@ class PodManager(LoggingMixin):
                 _preload_content=False,
             )
         ) as resp:
-            self._exec_pod_command(
-                resp,
+            alpine_fallback = (
                 "for f in /proc/[0-9]*/comm; do "
                 "[ -O $f ] && read c < $f && [ \"$c\" = \"sh\" ] && pid=${f%/comm} && kill -2 ${pid##*/}; "
-                "done",
+                "done"
             )
+            # Try original command first, fallback to /proc loop (Alpine/BusyBox)
+            self._exec_pod_command(resp, alpine_fallback)
 
     def _exec_pod_command(self, resp, command: str) -> str | None:
         res = ""

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -212,6 +212,10 @@ class PodNotFoundException(AirflowException):
     """Expected pod does not exist in kube-api."""
 
 
+class PodCommandException(AirflowException):
+    """When a pod command execution fails."""
+
+
 class PodLogsConsumer:
     """
     Responsible for pulling pod logs from a stream with checking a container status before reading data.
@@ -919,12 +923,18 @@ class PodManager(LoggingMixin):
                 _preload_content=False,
             )
         ) as resp:
-            self._exec_pod_command(
-                resp,
+            xcom_kill_command = "kill -2 $(pgrep -u $(id -u) -f 'sh')"
+            # fallback command for containers that don't support pgrep -u
+            fallback_xcom_kill_command = (
                 "for f in /proc/[0-9]*/comm; do "
                 "[ -O $f ] && read c < $f && [ \"$c\" = \"sh\" ] && pid=${f%/comm} && kill -2 ${pid##*/}; "
-                "done",
+                "done"
             )
+            try:
+                self._exec_pod_command(resp, xcom_kill_command)
+            except PodCommandException:
+                self.log.info("Primary kill command failed, trying fallback command")
+                self._exec_pod_command(resp, fallback_xcom_kill_command)
 
     def _exec_pod_command(self, resp, command: str) -> str | None:
         res = ""
@@ -940,8 +950,8 @@ class PodManager(LoggingMixin):
             while resp.peek_stderr():
                 error_res += resp.read_stderr()
             if error_res:
-                self.log.info("stderr from command: %s", error_res)
-                break
+                self.log.warning("stderr from command: %s", error_res)
+                raise PodCommandException(f"Command failed with stderr: {error_res}")
             if res:
                 return res
         return None

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -919,39 +919,32 @@ class PodManager(LoggingMixin):
                 _preload_content=False,
             )
         ) as resp:
-            xcom_kill_command = "kill -2 $(pgrep -u $(id -u) -f 'sh')"
-            # fallback command for containers that don't support pgrep -u
-            fallback_xcom_kill_command = (
+            self._exec_pod_command(
+                resp,
                 "for f in /proc/[0-9]*/comm; do "
                 "[ -O $f ] && read c < $f && [ \"$c\" = \"sh\" ] && pid=${f%/comm} && kill -2 ${pid##*/}; "
-                "done"
+                "done",
             )
-            result, error = self._exec_pod_command(resp, xcom_kill_command)
-            
-            if error:
-                self.log.info("Primary kill command failed, trying fallback command")
-                self._exec_pod_command(resp, fallback_xcom_kill_command)
 
-    def _exec_pod_command(self, resp, command: str) -> tuple[str | None, str | None]:
-        """Execute a command in the pod and return the result and error (result, error)."""
+    def _exec_pod_command(self, resp, command: str) -> str | None:
         res = ""
-        error_res = ""
         if not resp.is_open():
-            return None, None
+            return None
         self.log.info("Running command... %s", command)
         resp.write_stdin(f"{command}\n")
         while resp.is_open():
             resp.update(timeout=1)
             while resp.peek_stdout():
                 res += resp.read_stdout()
+            error_res = ""
             while resp.peek_stderr():
                 error_res += resp.read_stderr()
             if error_res:
                 self.log.info("stderr from command: %s", error_res)
                 break
             if res:
-                return res, error_res or None
-        return res or None, error_res or None
+                return res
+        return None
 
     def _await_init_container_start(self, pod: V1Pod, container_name: str):
         while True:

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -919,7 +919,12 @@ class PodManager(LoggingMixin):
                 _preload_content=False,
             )
         ) as resp:
-            self._exec_pod_command(resp, "kill -2 $(pgrep -u $(id -u) -f 'sh')")
+            self._exec_pod_command(
+                resp,
+                "for f in /proc/[0-9]*/comm; do "
+                "[ -O $f ] && read c < $f && [ \"$c\" = \"sh\" ] && pid=${f%/comm} && kill -2 ${pid##*/}; "
+                "done",
+            )
 
     def _exec_pod_command(self, resp, command: str) -> str | None:
         res = ""

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -919,33 +919,39 @@ class PodManager(LoggingMixin):
                 _preload_content=False,
             )
         ) as resp:
-            alpine_fallback = (
+            xcom_kill_command = "kill -2 $(pgrep -u $(id -u) -f 'sh')"
+            # fallback command for containers that don't support pgrep -u
+            fallback_xcom_kill_command = (
                 "for f in /proc/[0-9]*/comm; do "
                 "[ -O $f ] && read c < $f && [ \"$c\" = \"sh\" ] && pid=${f%/comm} && kill -2 ${pid##*/}; "
                 "done"
             )
-            # Try original command first, fallback to /proc loop (Alpine/BusyBox)
-            self._exec_pod_command(resp, alpine_fallback)
+            result, error = self._exec_pod_command(resp, xcom_kill_command)
+            
+            if error:
+                self.log.info("Primary kill command failed, trying fallback command")
+                self._exec_pod_command(resp, fallback_xcom_kill_command)
 
-    def _exec_pod_command(self, resp, command: str) -> str | None:
+    def _exec_pod_command(self, resp, command: str) -> tuple[str | None, str | None]:
+        """Execute a command in the pod and return the result and error (result, error)."""
         res = ""
+        error_res = ""
         if not resp.is_open():
-            return None
+            return None, None
         self.log.info("Running command... %s", command)
         resp.write_stdin(f"{command}\n")
         while resp.is_open():
             resp.update(timeout=1)
             while resp.peek_stdout():
                 res += resp.read_stdout()
-            error_res = ""
             while resp.peek_stderr():
                 error_res += resp.read_stderr()
             if error_res:
                 self.log.info("stderr from command: %s", error_res)
                 break
             if res:
-                return res
-        return None
+                return res, error_res or None
+        return res or None, error_res or None
 
     def _await_init_container_start(self, pod: V1Pod, container_name: str):
         while True:


### PR DESCRIPTION
The [extract_xcom_kill] method previously used  to identify and kill the sidecar process. However, the  implementation in some Alpine/BusyBox versions does not support the  flag, causing the command to fail and the sidecar to hang indefinitely. This commit replaces the  command with a portable shell loop that iterates over  to identify processes owned by the current user. This ensures compatibility with all Alpine versions and removes the dependency on .

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---

Bug Report: KubernetesPodOperator XCom Sidecar Hangs due to pgrep missing -u option
Title
KubernetesPodOperator XCom sidecar hangs indefinitely because "pgrep -u" is not supported in some Alpine versions

Description
The KubernetesPodOperator injects a sidecar container to capture XCom values. Once the main container completes, Airflow attempts to terminate this sidecar to allow the Pod to complete.

The termination logic in PodManager.extract_xcom_kill executes the following command inside the sidecar:

kill -2 $(pgrep -u $(id -u) -f 'sh')

This command relies on pgrep supporting the -u (user) flag to filter processes by the current user. However, many lightweight container images used for sidecars (like alpine) use BusyBox's implementation of pgrep. Some versions of BusyBox pgrep do not support the -u flag, causing the command to fail with an invalid option error.

As a result:
The kill command fails.
The sidecar container continues running (executing its infinite sleep loop).
The Pod remains in the Running phase.
The Airflow task eventually times out despite the main work completing successfully.
Impact:
Task Hangs: Tasks that successfully finish their work will hang until the operator times out and causing task to fail.
False Failures: Successful tasks are marked as failed due to timeout.

**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
