### PR TITLE
fix(sftp): add default port to SFTPHookAsync

### DIFF
--- a/providers/sftp/src/airflow/providers/sftp/hooks/sftp.py
+++ b/providers/sftp/src/airflow/providers/sftp/hooks/sftp.py
@@ -704,10 +704,10 @@ class SFTPHookAsync(BaseHook):
     def __init__(  # nosec: B107
         self,
         sftp_conn_id: str = default_conn_name,
-        host: str = "",
-        port: int = SSH_PORT,
-        username: str = "",
-        password: str = "",
+        host: str | None = None,
+        port: int | None = None,
+        username: str | None = None,
+        password: str | None = None,
         known_hosts: str = default_known_hosts,
         key_file: str = "",
         passphrase: str = "",
@@ -763,11 +763,19 @@ class SFTPHookAsync(BaseHook):
         if conn.extra is not None:
             self._parse_extras(conn)  # type: ignore[arg-type]
 
-        conn_config: dict[str, Any] = {
-            "host": conn.host,
-            "port": conn.port if conn.port is not None else SSH_PORT,
-            "username": conn.login,
-            "password": conn.password,
+        def _get_value(self_val, conn_val, default=None):
+            """Return the first non-None value among self, conn, default."""
+            if self_val is not None:
+                return self_val
+            if conn_val is not None:
+                return conn_val
+            return default
+
+        conn_config = {
+            "host": _get_value(self.host, conn.host),
+            "port": _get_value(self.port, conn.port, SSH_PORT),
+            "username": _get_value(self.username, conn.login),
+            "password": _get_value(self.password, conn.password),
         }
         if self.key_file:
             conn_config.update(client_keys=self.key_file)

--- a/providers/sftp/src/airflow/providers/sftp/hooks/sftp.py
+++ b/providers/sftp/src/airflow/providers/sftp/hooks/sftp.py
@@ -34,6 +34,7 @@ from typing import IO, TYPE_CHECKING, Any, cast
 
 import asyncssh
 from asgiref.sync import sync_to_async
+from paramiko.config import SSH_PORT
 
 from airflow.exceptions import (
     AirflowException,
@@ -704,7 +705,7 @@ class SFTPHookAsync(BaseHook):
         self,
         sftp_conn_id: str = default_conn_name,
         host: str = "",
-        port: int = 22,
+        port: int = SSH_PORT,
         username: str = "",
         password: str = "",
         known_hosts: str = default_known_hosts,
@@ -764,7 +765,7 @@ class SFTPHookAsync(BaseHook):
 
         conn_config: dict[str, Any] = {
             "host": conn.host,
-            "port": conn.port,
+            "port": conn.port if conn.port is not None else SSH_PORT,
             "username": conn.login,
             "password": conn.password,
         }

--- a/providers/sftp/tests/unit/sftp/hooks/test_sftp.py
+++ b/providers/sftp/tests/unit/sftp/hooks/test_sftp.py
@@ -886,6 +886,35 @@ class TestSFTPHookAsync:
 
         mock_connect.assert_called_with(**expected_connection_details)
 
+    @pytest.mark.asyncio
+    @patch("asyncssh.connect", new_callable=AsyncMock)
+    @patch("airflow.providers.sftp.hooks.sftp.SFTPHookAsync.get_connection")
+    async def test_connection_port_default_to_22(self, mock_get_connection, mock_connect):
+        from unittest.mock import Mock, call
+
+        mock_get_connection.return_value = Mock(
+            host="localhost",
+            port=None,
+            login="username",
+            password="password",
+            extra="{}",
+            extra_dejson={},
+        )
+
+        hook = SFTPHookAsync()
+        await hook._get_conn()
+        assert mock_connect.mock_calls == [
+            call(
+                host="localhost",
+                # Even if the port is not specified in conn_config, it should still default to 22.
+                # This behavior is consistent with STPHook.
+                port=22,
+                username="username",
+                password="password",
+                known_hosts=None,
+            ),
+        ]
+
     @patch("airflow.providers.sftp.hooks.sftp.SFTPHookAsync._get_conn")
     @pytest.mark.asyncio
     async def test_list_directory_path_does_not_exist(self, mock_hook_get_conn):

--- a/providers/sftp/tests/unit/sftp/hooks/test_sftp.py
+++ b/providers/sftp/tests/unit/sftp/hooks/test_sftp.py
@@ -915,6 +915,38 @@ class TestSFTPHookAsync:
             ),
         ]
 
+    @pytest.mark.asyncio
+    @patch("asyncssh.connect", new_callable=AsyncMock)
+    @patch("airflow.providers.sftp.hooks.sftp.SFTPHookAsync.get_connection")
+    async def test_init_argument_not_ignored(self, mock_get_connection, mock_connect):
+        from unittest.mock import Mock, call
+
+        mock_get_connection.return_value = Mock(
+            host="localhost",
+            port=None,
+            login="username",
+            password="password",
+            extra="{}",
+            extra_dejson={},
+        )
+
+        hook = SFTPHookAsync(
+            host="localhost-from-init",
+            port=25,
+            username="username-from-init",
+            password="password-from-init",
+        )
+        await hook._get_conn()
+        assert mock_connect.mock_calls == [
+            call(
+                host="localhost-from-init",
+                port=25,
+                username="username-from-init",
+                password="password-from-init",
+                known_hosts=None,
+            ),
+        ]
+
     @patch("airflow.providers.sftp.hooks.sftp.SFTPHookAsync._get_conn")
     @pytest.mark.asyncio
     async def test_list_directory_path_does_not_exist(self, mock_hook_get_conn):


### PR DESCRIPTION
## Why
If the port is not set in Airflow UI for `SFTPHookAsync`, it will not default to port 22, which is inconsistent with `SFTPHook`. During debugging, I also found out lots of arguments are ignored in `SFTPHookAsync`

## What
Fallback to port 22 if not set and use the arguments passed through `SFTPHookAsyn.__init__`. 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
