### PR TITLE
UI Unify trash icons

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Connections/DeleteConnectionButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/DeleteConnectionButton.tsx
@@ -18,7 +18,7 @@
  */
 import { Flex, useDisclosure, Text, VStack, Heading, Code } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
-import { FiTrash } from "react-icons/fi";
+import { FiTrash2 } from "react-icons/fi";
 
 import { Button, Dialog } from "src/components/ui";
 import ActionButton from "src/components/ui/ActionButton";
@@ -42,7 +42,7 @@ const DeleteConnectionButton = ({ connectionId, disabled }: Props) => {
         actionName={translate("connections.delete.title")}
         colorPalette="danger"
         disabled={disabled}
-        icon={<FiTrash />}
+        icon={<FiTrash2 />}
         onClick={() => {
           onOpen();
         }}
@@ -81,7 +81,7 @@ const DeleteConnectionButton = ({ connectionId, disabled }: Props) => {
                   });
                 }}
               >
-                <FiTrash /> <Text fontWeight="bold">{translate("deleteActions.modal.confirmButton")}</Text>
+                <FiTrash2 /> <Text fontWeight="bold">{translate("deleteActions.modal.confirmButton")}</Text>
               </Button>
             </Flex>
           </Dialog.Body>

--- a/airflow-core/src/airflow/ui/src/pages/Connections/DeleteConnectionsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/DeleteConnectionsButton.tsx
@@ -18,7 +18,7 @@
  */
 import { Code, Flex, Heading, Text, VStack, useDisclosure } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
-import { FiTrash, FiTrash2 } from "react-icons/fi";
+import { FiTrash2 } from "react-icons/fi";
 
 import { ErrorAlert } from "src/components/ErrorAlert";
 import { Button, Dialog } from "src/components/ui";
@@ -85,7 +85,7 @@ const DeleteConnectionsButton = ({ clearSelections, deleteKeys: connectionIds }:
                   mutate({ requestBody: { actions: [{ action: "delete", entities: connectionIds }] } });
                 }}
               >
-                <FiTrash /> <Text as="span">{translate("deleteActions.modal.confirmButton")}</Text>
+                <FiTrash2 /> <Text as="span">{translate("deleteActions.modal.confirmButton")}</Text>
               </Button>
             </Flex>
           </Dialog.Body>

--- a/airflow-core/src/airflow/ui/src/pages/Variables/DeleteVariablesButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/DeleteVariablesButton.tsx
@@ -18,7 +18,7 @@
  */
 import { Flex, useDisclosure, Text, VStack, Heading, Code } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
-import { FiTrash, FiTrash2 } from "react-icons/fi";
+import { FiTrash2 } from "react-icons/fi";
 
 import { ErrorAlert } from "src/components/ErrorAlert";
 import { Button, Dialog } from "src/components/ui";
@@ -91,7 +91,7 @@ const DeleteVariablesButton = ({ clearSelections, deleteKeys: variableKeys }: Pr
                   });
                 }}
               >
-                <FiTrash /> <Text fontWeight="bold">{translate("deleteActions.modal.confirmButton")}</Text>
+                <FiTrash2 /> <Text fontWeight="bold">{translate("deleteActions.modal.confirmButton")}</Text>
               </Button>
             </Flex>
           </Dialog.Body>

--- a/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/DeleteVariableButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/DeleteVariableButton.tsx
@@ -18,7 +18,7 @@
  */
 import { Flex, useDisclosure, Text, VStack, Heading, Code } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
-import { FiTrash } from "react-icons/fi";
+import { FiTrash2 } from "react-icons/fi";
 
 import { Button, Dialog } from "src/components/ui";
 import ActionButton from "src/components/ui/ActionButton";
@@ -42,7 +42,7 @@ const DeleteVariableButton = ({ deleteKey: variableKey, disabled }: Props) => {
         actionName={translate("variables.delete.title")}
         colorPalette="danger"
         disabled={disabled}
-        icon={<FiTrash />}
+        icon={<FiTrash2 />}
         onClick={() => {
           onOpen();
         }}
@@ -81,7 +81,7 @@ const DeleteVariableButton = ({ deleteKey: variableKey, disabled }: Props) => {
                   });
                 }}
               >
-                <FiTrash /> <Text fontWeight="bold">{translate("deleteActions.modal.confirmButton")}</Text>
+                <FiTrash2 /> <Text fontWeight="bold">{translate("deleteActions.modal.confirmButton")}</Text>
               </Button>
             </Flex>
           </Dialog.Body>


### PR DESCRIPTION
There is no need to have two different Trash icons in the UI. Second icon is preferred everywhere, it was mostly used in regards to the first icon.

For instance:
### Before 
<img width="1609" height="263" alt="Screenshot 2025-12-02 at 17 07 55" src="https://github.com/user-attachments/assets/1bcbc702-42c6-4db1-86a6-7aa963a7cf81" />

### After
<img width="1690" height="231" alt="Screenshot 2025-12-02 at 17 07 35" src="https://github.com/user-attachments/assets/adfd8a2e-50fa-4c6c-975e-27db0a41204b" />
