### PR TITLE
Fix exception when logging stdout with a custom %-fmt string.

### DIFF
--- a/shared/logging/src/airflow_shared/logging/percent_formatter.py
+++ b/shared/logging/src/airflow_shared/logging/percent_formatter.py
@@ -50,6 +50,16 @@ class _LazyLogRecordDict(collections.abc.Mapping):
         # Roughly compatible with names from https://github.com/python/cpython/blob/v3.13.7/Lib/logging/__init__.py#L571
         # Plus with ColoredLog added in
 
+        # If there is no callsite info (often for stdout/stderr), show the same sort of thing that stdlib
+        # logging would
+        # https://github.com/python/cpython/blob/d3c888b4ec15dbd7d6b6ef4f15b558af77c228af/Lib/logging/__init__.py#L1652C34-L1652C48
+        if key == "lineno":
+            return self.event.get("lineno", 0)
+        if key == "filename":
+            return self.event.get("filename", "(unknown file)")
+        if key == "funcName":
+            return self.event.get("funcName", "(unknown function)")
+
         if key in PercentFormatRender.callsite_parameters:
             return self.event.get(PercentFormatRender.callsite_parameters[key].value)
         if key == "name":

--- a/shared/logging/tests/logging/test_percent_formatter.py
+++ b/shared/logging/tests/logging/test_percent_formatter.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from unittest import mock
+
+from airflow_shared.logging.percent_formatter import PercentFormatRender
+
+
+class TestPercentFormatRender:
+    def test_no_callsite(self):
+        fmter = PercentFormatRender("%(filename)s:%(lineno)d %(message)s")
+
+        formatted = fmter(mock.Mock(name="Logger"), "info", {"event": "our msg"})
+
+        assert formatted == "(unknown file):0 our msg"


### PR DESCRIPTION
For instance, if you set this config

```ini
[logging]
log_format={%%(filename)s:%%(lineno)d} --- %%(message)s
```

this would blow up with an error like this on printing anything from a
trigger, killing the triggerer process:

```
2025-11-03 14:13:27   File "/usr/local/lib/python3.12/site-packages/airflow/_shared/logging/percent_formatter.py", line 149, in __call__
2025-11-03 14:13:27     sio.write(self._fmt % params)
2025-11-03 14:13:27               ~~~~~~~~~~^~~~~~~~
2025-11-03 14:13:27 TypeError: %d format: a real number is required, not NoneType
```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
