### PR TITLE
Split SDK and serialized asset classes

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -418,7 +418,7 @@ def ti_update_state(
         ti = session.get(TI, ti_id_str)
         if session.bind is not None:
             query = TI.duration_expression_update(timezone.utcnow(), query, session.bind)
-        query = query.values(state=TaskInstanceState.FAILED)
+        query = query.values(state=(updated_state := TaskInstanceState.FAILED))
         if ti is not None:
             _handle_fail_fast_for_dag(ti=ti, dag_id=dag_id, session=session, dag_bag=dag_bag)
 

--- a/airflow-core/src/airflow/assets/manager.py
+++ b/airflow-core/src/airflow/assets/manager.py
@@ -48,7 +48,11 @@ if TYPE_CHECKING:
     from airflow.models.dag import DagModel
     from airflow.models.serialized_dag import SerializedDagModel
     from airflow.models.taskinstance import TaskInstance
-    from airflow.sdk.definitions.asset import Asset, AssetAlias, AssetUniqueKey
+    from airflow.serialization.definitions.assets import (
+        SerializedAsset,
+        SerializedAssetAlias,
+        SerializedAssetUniqueKey,
+    )
     from airflow.timetables.simple import PartitionedAssetTimetable
 
 log = structlog.get_logger(__name__)
@@ -63,11 +67,11 @@ class AssetManager(LoggingMixin):
     """
 
     @classmethod
-    def create_assets(cls, assets: list[Asset], *, session: Session) -> list[AssetModel]:
+    def create_assets(cls, assets: list[SerializedAsset], *, session: Session) -> list[AssetModel]:
         """Create new assets."""
 
-        def _add_one(asset: Asset) -> AssetModel:
-            model = AssetModel.from_public(asset)
+        def _add_one(asset: SerializedAsset) -> AssetModel:
+            model = AssetModel.from_serialized(asset)
             session.add(model)
             cls.notify_asset_created(asset=asset)
             return model
@@ -77,14 +81,14 @@ class AssetManager(LoggingMixin):
     @classmethod
     def create_asset_aliases(
         cls,
-        asset_aliases: list[AssetAlias],
+        asset_aliases: list[SerializedAssetAlias],
         *,
         session: Session,
     ) -> list[AssetAliasModel]:
         """Create new asset aliases."""
 
-        def _add_one(asset_alias: AssetAlias) -> AssetAliasModel:
-            model = AssetAliasModel.from_public(asset_alias)
+        def _add_one(asset_alias: SerializedAssetAlias) -> AssetAliasModel:
+            model = AssetAliasModel.from_serialized(asset_alias)
             session.add(model)
             cls.notify_asset_alias_created(asset_assets=asset_alias)
             return model
@@ -115,7 +119,7 @@ class AssetManager(LoggingMixin):
         cls,
         *,
         task_instance: TaskInstance | None = None,
-        asset: Asset | AssetModel | AssetUniqueKey,
+        asset: SerializedAsset | AssetModel | SerializedAssetUniqueKey,
         extra=None,
         source_alias_names: Collection[str] = (),
         session: Session,
@@ -205,7 +209,7 @@ class AssetManager(LoggingMixin):
             )
         )
 
-        cls.notify_asset_changed(asset=asset_model.to_public())
+        cls.notify_asset_changed(asset=asset_model.to_serialized())
 
         Stats.incr("asset.updates")
 
@@ -223,7 +227,7 @@ class AssetManager(LoggingMixin):
         return asset_event
 
     @staticmethod
-    def notify_asset_created(asset: Asset):
+    def notify_asset_created(asset: SerializedAsset):
         """Run applicable notification actions when an asset is created."""
         try:
             get_listener_manager().hook.on_asset_created(asset=asset)
@@ -231,7 +235,7 @@ class AssetManager(LoggingMixin):
             log.exception("error calling listener")
 
     @staticmethod
-    def notify_asset_alias_created(asset_assets: AssetAlias):
+    def notify_asset_alias_created(asset_assets: SerializedAssetAlias):
         """Run applicable notification actions when an asset alias is created."""
         try:
             get_listener_manager().hook.on_asset_alias_created(asset_alias=asset_assets)
@@ -239,7 +243,7 @@ class AssetManager(LoggingMixin):
             log.exception("error calling listener")
 
     @staticmethod
-    def notify_asset_changed(asset: Asset):
+    def notify_asset_changed(asset: SerializedAsset) -> None:
         """Run applicable notification actions when an asset is changed."""
         try:
             # TODO: AIP-76 this will have to change. needs to know *what* happened to the asset (e.g. partition key)

--- a/airflow-core/src/airflow/listeners/spec/asset.py
+++ b/airflow-core/src/airflow/listeners/spec/asset.py
@@ -22,21 +22,21 @@ from typing import TYPE_CHECKING
 from pluggy import HookspecMarker
 
 if TYPE_CHECKING:
-    from airflow.sdk.definitions.asset import Asset, AssetAlias
+    from airflow.serialization.definitions.assets import SerializedAsset, SerializedAssetAlias
 
 hookspec = HookspecMarker("airflow")
 
 
 @hookspec
-def on_asset_created(asset: Asset):
+def on_asset_created(asset: SerializedAsset):
     """Execute when a new asset is created."""
 
 
 @hookspec
-def on_asset_alias_created(asset_alias: AssetAlias):
+def on_asset_alias_created(asset_alias: SerializedAssetAlias):
     """Execute when a new asset alias is created."""
 
 
 @hookspec
-def on_asset_changed(asset: Asset):
+def on_asset_changed(asset: SerializedAsset):
     """Execute when asset change is registered."""

--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -21,7 +21,7 @@ import logging
 from collections import defaultdict
 from collections.abc import Callable, Collection
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, Union, cast
 
 import pendulum
 import sqlalchemy_jsonfield
@@ -55,8 +55,8 @@ from airflow.models.base import Base, StringID
 from airflow.models.dagbundle import DagBundleModel
 from airflow.models.dagrun import DagRun
 from airflow.models.team import Team
-from airflow.sdk.definitions.asset import Asset, AssetAlias, AssetUniqueKey, BaseAsset
 from airflow.sdk.definitions.deadline import DeadlineAlert
+from airflow.serialization.definitions.assets import SerializedAssetUniqueKey
 from airflow.settings import json
 from airflow.timetables.base import DataInterval, Timetable
 from airflow.timetables.interval import CronDataIntervalTimetable, DeltaDataIntervalTimetable
@@ -71,20 +71,29 @@ if TYPE_CHECKING:
     from typing import TypeAlias
 
     from airflow.models.mappedoperator import MappedOperator
+    from airflow.serialization.definitions.assets import (
+        SerializedAsset,
+        SerializedAssetAlias,
+        SerializedAssetBase,
+    )
     from airflow.serialization.serialized_objects import SerializedBaseOperator, SerializedDAG
 
     Operator: TypeAlias = MappedOperator | SerializedBaseOperator
+    UKey: TypeAlias = SerializedAssetUniqueKey
 
 log = logging.getLogger(__name__)
-
-AssetT = TypeVar("AssetT", bound=BaseAsset)
 
 TAG_MAX_LEN = 100
 
 DagStateChangeCallback = Callable[[Context], None]
 ScheduleInterval = None | str | timedelta | relativedelta
 
-ScheduleArg = ScheduleInterval | Timetable | BaseAsset | Collection[Union["Asset", "AssetAlias"]]
+ScheduleArg = Union[
+    ScheduleInterval,
+    Timetable,
+    "SerializedAssetBase",
+    Collection[Union["SerializedAsset", "SerializedAssetAlias"]],
+]
 
 
 def infer_automated_data_interval(timetable: Timetable, logical_date: datetime) -> DataInterval:
@@ -607,7 +616,7 @@ class DagModel(Base):
 
         evaluator = AssetEvaluator(session)
 
-        def dag_ready(dag_id: str, cond: BaseAsset, statuses: dict[AssetUniqueKey, bool]) -> bool:
+        def dag_ready(dag_id: str, cond: SerializedAssetBase, statuses: dict[UKey, bool]) -> bool:
             try:
                 return evaluator.run(cond, statuses)
             except AttributeError:
@@ -631,8 +640,8 @@ class DagModel(Base):
             else:
                 adrq_by_dag[adrq.target_dag_id].append(adrq)
 
-        dag_statuses: dict[str, dict[AssetUniqueKey, bool]] = {
-            dag_id: {AssetUniqueKey.from_asset(adrq.asset): True for adrq in adrqs}
+        dag_statuses: dict[str, dict[UKey, bool]] = {
+            dag_id: {SerializedAssetUniqueKey.from_asset(adrq.asset): True for adrq in adrqs}
             for dag_id, adrqs in adrq_by_dag.items()
         }
         ser_dags = SerializedDagModel.get_latest_serialized_dags(dag_ids=list(dag_statuses), session=session)

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -111,12 +111,11 @@ if TYPE_CHECKING:
     from sqlalchemy.sql import Update
     from sqlalchemy.sql.elements import ColumnElement
 
+    from airflow.api_fastapi.execution_api.datamodels.asset import AssetProfile
     from airflow.models.dag import DagModel
     from airflow.models.dagrun import DagRun
     from airflow.models.mappedoperator import MappedOperator
     from airflow.sdk import DAG
-    from airflow.sdk.api.datamodels._generated import AssetProfile
-    from airflow.sdk.definitions.asset import AssetUniqueKey
     from airflow.sdk.types import RuntimeTaskInstanceProtocol
     from airflow.serialization.definitions.taskgroup import SerializedTaskGroup
     from airflow.serialization.serialized_objects import SerializedBaseOperator, SerializedDAG
@@ -1314,26 +1313,31 @@ class TaskInstance(Base, LoggingMixin):
         outlet_events: list[dict[str, Any]],
         session: Session = NEW_SESSION,
     ) -> None:
-        from airflow.sdk.definitions.asset import Asset, AssetAlias, AssetNameRef, AssetUniqueKey, AssetUriRef
+        from airflow.serialization.definitions.assets import (
+            SerializedAsset,
+            SerializedAssetNameRef,
+            SerializedAssetUniqueKey,
+            SerializedAssetUriRef,
+        )
 
         # TODO: AIP-76 should we provide an interface to override this, so that the task can
         #  tell the truth if for some reason it touches a different partition?
         #  https://github.com/apache/airflow/issues/58474
         partition_key = ti.dag_run.partition_key
         asset_keys = {
-            AssetUniqueKey(o.name, o.uri)
+            SerializedAssetUniqueKey(o.name, o.uri)
             for o in task_outlets
-            if o.type == Asset.__name__ and o.name and o.uri
+            if o.type == "Asset" and o.name and o.uri
         }
         asset_name_refs = {
-            Asset.ref(name=o.name) for o in task_outlets if o.type == AssetNameRef.__name__ and o.name
+            SerializedAssetNameRef(o.name) for o in task_outlets if o.type == "AssetNameRef" and o.name
         }
         asset_uri_refs = {
-            Asset.ref(uri=o.uri) for o in task_outlets if o.type == AssetUriRef.__name__ and o.uri
+            SerializedAssetUriRef(o.uri) for o in task_outlets if o.type == "AssetUriRef" and o.uri
         }
 
-        asset_models: dict[AssetUniqueKey, AssetModel] = {
-            AssetUniqueKey.from_asset(am): am
+        asset_models: dict[SerializedAssetUniqueKey, AssetModel] = {
+            SerializedAssetUniqueKey.from_asset(am): am
             for am in session.scalars(
                 select(AssetModel).where(
                     AssetModel.active.has(),
@@ -1346,8 +1350,8 @@ class TaskInstance(Base, LoggingMixin):
             )
         }
 
-        asset_event_extras: dict[AssetUniqueKey, dict] = {
-            AssetUniqueKey(**event["dest_asset_key"]): event["extra"]
+        asset_event_extras: dict[SerializedAssetUniqueKey, dict] = {
+            SerializedAssetUniqueKey(**event["dest_asset_key"]): event["extra"]
             for event in outlet_events
             if "source_alias_name" not in event
         }
@@ -1410,7 +1414,7 @@ class TaskInstance(Base, LoggingMixin):
                     session=session,
                 )
 
-        def _asset_event_extras_from_aliases() -> dict[tuple[AssetUniqueKey, str, str], set[str]]:
+        def _asset_event_extras_from_aliases() -> dict[tuple[SerializedAssetUniqueKey, str, str], set[str]]:
             d = defaultdict(set)
             for event in outlet_events:
                 try:
@@ -1419,14 +1423,14 @@ class TaskInstance(Base, LoggingMixin):
                     continue
                 if alias_name not in outlet_alias_names:
                     continue
-                asset_key = AssetUniqueKey(**event["dest_asset_key"])
+                asset_key = SerializedAssetUniqueKey(**event["dest_asset_key"])
                 # fallback for backward compatibility
                 asset_extra_json = json.dumps(event.get("dest_asset_extra", {}), sort_keys=True)
                 asset_event_extra_json = json.dumps(event["extra"], sort_keys=True)
                 d[asset_key, asset_extra_json, asset_event_extra_json].add(alias_name)
             return d
 
-        outlet_alias_names = {o.name for o in task_outlets if o.type == AssetAlias.__name__ and o.name}
+        outlet_alias_names = {o.name for o in task_outlets if o.type == "AssetAlias" and o.name}
         if outlet_alias_names and (event_extras_from_aliases := _asset_event_extras_from_aliases()):
             for (
                 asset_key,
@@ -1434,7 +1438,13 @@ class TaskInstance(Base, LoggingMixin):
                 asset_event_extras_json,
             ), event_aliase_names in event_extras_from_aliases.items():
                 asset_event_extra = json.loads(asset_event_extras_json)
-                asset = Asset(name=asset_key.name, uri=asset_key.uri, extra=json.loads(asset_extra_json))
+                asset = SerializedAsset(
+                    name=asset_key.name,
+                    uri=asset_key.uri,
+                    group="asset",
+                    extra=json.loads(asset_extra_json),
+                    watchers=[],
+                )
                 ti.log.debug("register event for asset %s with aliases %s", asset_key, event_aliase_names)
                 event = asset_manager.register_asset_change(
                     task_instance=ti,

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -1313,6 +1313,7 @@ class TaskInstance(Base, LoggingMixin):
         outlet_events: list[dict[str, Any]],
         session: Session = NEW_SESSION,
     ) -> None:
+        print(task_outlets, outlet_events)
         from airflow.serialization.definitions.assets import (
             SerializedAsset,
             SerializedAssetNameRef,
@@ -1456,7 +1457,7 @@ class TaskInstance(Base, LoggingMixin):
                 )
                 if event is None:
                     ti.log.info("Dynamically creating AssetModel %s", asset_key)
-                    session.add(AssetModel.from_public(asset))
+                    session.add(AssetModel.from_serialized(asset))
                     session.flush()  # So event can set up its asset fk.
                     asset_manager.register_asset_change(
                         task_instance=ti,

--- a/airflow-core/src/airflow/models/trigger.py
+++ b/airflow-core/src/airflow/models/trigger.py
@@ -267,7 +267,7 @@ class Trigger(Base):
             return
         for asset in trigger.assets:
             AssetManager.register_asset_change(
-                asset=asset.to_public(),
+                asset=asset.to_serialized(),
                 extra={"from_trigger": True, "payload": event.payload},
                 session=session,
             )

--- a/airflow-core/src/airflow/serialization/decoders.py
+++ b/airflow-core/src/airflow/serialization/decoders.py
@@ -77,7 +77,7 @@ def smart_decode_trigger_kwargs(d):
     return BaseSerialization.deserialize(d)
 
 
-def decode_asset(var: dict[str, Any]):
+def _decode_asset(var: dict[str, Any]):
     watchers = var.get("watchers", [])
     return SerializedAsset(
         name=var["name"],
@@ -97,9 +97,9 @@ def decode_asset(var: dict[str, Any]):
     )
 
 
-def decode_asset_condition(var: dict[str, Any]) -> SerializedAssetBase:
+def decode_asset_like(var: dict[str, Any]) -> SerializedAssetBase:
     """
-    Decode a previously serialized asset condition.
+    Decode a previously serialized asset-like object.
 
     :meta private:
     """
@@ -110,11 +110,11 @@ def decode_asset_condition(var: dict[str, Any]) -> SerializedAssetBase:
         var = {k: v for k, v in var.items() if k != Encoding.TYPE}
     match typ:
         case DAT.ASSET:
-            return decode_asset(var)
+            return _decode_asset(var)
         case DAT.ASSET_ALL:
-            return SerializedAssetAll([decode_asset_condition(x) for x in var["objects"]])
+            return SerializedAssetAll([decode_asset_like(x) for x in var["objects"]])
         case DAT.ASSET_ANY:
-            return SerializedAssetAny([decode_asset_condition(x) for x in var["objects"]])
+            return SerializedAssetAny([decode_asset_like(x) for x in var["objects"]])
         case DAT.ASSET_ALIAS:
             return SerializedAssetAlias(name=var["name"], group=var["group"])
         case DAT.ASSET_REF:

--- a/airflow-core/src/airflow/serialization/definitions/assets.py
+++ b/airflow-core/src/airflow/serialization/definitions/assets.py
@@ -18,12 +18,292 @@
 
 from __future__ import annotations
 
+import json
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
+
 import attrs
+
+from airflow.api_fastapi.execution_api.datamodels.asset import AssetProfile
+from airflow.serialization.dag_dependency import DagDependency
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Iterator, MutableSequence
+
+    from typing_extensions import Self
+
+    from airflow.models.asset import AssetModel
+
+    AttrsInstance = attrs.AttrsInstance
+else:
+    AttrsInstance = object
+
+
+@attrs.define(frozen=True)
+class SerializedAssetUniqueKey(AttrsInstance):
+    """
+    Columns to identify an unique asset.
+
+    :meta private:
+    """
+
+    name: str
+    uri: str
+
+    @classmethod
+    def from_asset(cls, asset: SerializedAsset | AssetModel) -> Self:
+        return cls(name=asset.name, uri=asset.uri)
+
+    @classmethod
+    def from_str(cls, key: str) -> Self:
+        return cls(**json.loads(key))
+
+    def to_str(self) -> str:
+        return json.dumps(attrs.asdict(self))
+
+    def asprofile(self) -> AssetProfile:
+        return AssetProfile(name=self.name, uri=self.uri, type="Asset")
+
+
+class SerializedAssetBase:
+    """
+    Protocol for all serialized asset-like objects.
+
+    :meta private:
+    """
+
+    def __bool__(self) -> bool:
+        return True
+
+    def as_expression(self) -> Any:
+        """
+        Serialize the asset into its scheduling expression.
+
+        The return value is stored in DagModel for display purposes. It must be
+        JSON-compatible.
+
+        :meta private:
+        """
+        raise NotImplementedError
+
+    def iter_assets(self) -> Iterator[tuple[SerializedAssetUniqueKey, SerializedAsset]]:
+        raise NotImplementedError
+
+    def iter_asset_aliases(self) -> Iterator[tuple[str, SerializedAssetAlias]]:
+        raise NotImplementedError
+
+    def iter_asset_refs(self) -> Iterator[SerializedAssetRef]:
+        raise NotImplementedError
+
+    def iter_dag_dependencies(self, *, source: str, target: str) -> Iterator[DagDependency]:
+        """
+        Iterate a base asset as dag dependency.
+
+        :meta private:
+        """
+        raise NotImplementedError
 
 
 @attrs.define
 class SerializedAssetWatcher:
-    """JSON serializable representation of an asset watcher."""
+    """Serialized representation of an asset watcher."""
 
     name: str
     trigger: dict
+
+
+@attrs.define
+class SerializedAsset(SerializedAssetBase):
+    """Serialized representation of an asset."""
+
+    name: str
+    uri: str
+    group: str
+    extra: dict[str, Any]
+    watchers: MutableSequence[SerializedAssetWatcher]
+
+    def as_expression(self) -> Any:
+        """
+        Serialize the asset into its scheduling expression.
+
+        :meta private:
+        """
+        return {"asset": {"uri": self.uri, "name": self.name, "group": self.group}}
+
+    def iter_assets(self) -> Iterator[tuple[SerializedAssetUniqueKey, SerializedAsset]]:
+        yield SerializedAssetUniqueKey.from_asset(self), self
+
+    def iter_asset_aliases(self) -> Iterator[tuple[str, SerializedAssetAlias]]:
+        return iter(())
+
+    def iter_asset_refs(self) -> Iterator[SerializedAssetRef]:
+        return iter(())
+
+    def iter_dag_dependencies(self, *, source: str, target: str) -> Iterator[DagDependency]:
+        """
+        Iterate an asset as dag dependency.
+
+        :meta private:
+        """
+        yield DagDependency(
+            source=source or "asset",
+            target=target or "asset",
+            label=self.name,
+            dependency_type="asset",
+            # We can't get asset id at this stage.
+            # This will be updated when running SerializedDagModel.get_dag_dependencies
+            dependency_id=SerializedAssetUniqueKey.from_asset(self).to_str(),
+        )
+
+    def asprofile(self) -> AssetProfile:
+        """
+        Profiles Asset to AssetProfile.
+
+        :meta private:
+        """
+        return AssetProfile(name=self.name or None, uri=self.uri or None, type="Asset")
+
+
+class SerializedAssetRef(SerializedAssetBase, AttrsInstance):
+    """Serialized representation of an asset reference."""
+
+    _dependency_type: Literal["asset-name-ref", "asset-uri-ref"]
+
+    def as_expression(self) -> Any:
+        return {"asset_ref": attrs.asdict(self)}
+
+    def iter_assets(self) -> Iterator[tuple[SerializedAssetUniqueKey, SerializedAsset]]:
+        return iter(())
+
+    def iter_asset_aliases(self) -> Iterator[tuple[str, SerializedAssetAlias]]:
+        return iter(())
+
+    def iter_asset_refs(self) -> Iterator[SerializedAssetRef]:
+        yield self
+
+    def iter_dag_dependencies(self, *, source: str = "", target: str = "") -> Iterator[DagDependency]:
+        (dependency_id,) = attrs.astuple(self)
+        yield DagDependency(
+            source=source or self._dependency_type,
+            target=target or self._dependency_type,
+            label=dependency_id,
+            dependency_type=self._dependency_type,
+            dependency_id=dependency_id,
+        )
+
+
+@attrs.define(hash=True)
+class SerializedAssetNameRef(SerializedAssetRef):
+    """Serialized representation of an asset reference by name."""
+
+    name: str
+
+    _dependency_type = "asset-name-ref"
+
+
+@attrs.define(hash=True)
+class SerializedAssetUriRef(SerializedAssetRef):
+    """Serialized representation of an asset reference by URI."""
+
+    uri: str
+
+    _dependency_type = "asset-uri-ref"
+
+
+@attrs.define
+class SerializedAssetAlias(SerializedAssetBase):
+    """Serialized representation of an asset alias."""
+
+    name: str
+    group: str
+
+    def as_expression(self) -> Any:
+        """
+        Serialize the asset alias into its scheduling expression.
+
+        :meta private:
+        """
+        return {"alias": {"name": self.name, "group": self.group}}
+
+    def iter_assets(self) -> Iterator[tuple[SerializedAssetUniqueKey, SerializedAsset]]:
+        return iter(())
+
+    def iter_asset_aliases(self) -> Iterator[tuple[str, SerializedAssetAlias]]:
+        yield self.name, self
+
+    def iter_asset_refs(self) -> Iterator[SerializedAssetRef]:
+        return iter(())
+
+    def iter_dag_dependencies(self, *, source: str = "", target: str = "") -> Iterator[DagDependency]:
+        """
+        Iterate an asset alias and its resolved assets as dag dependency.
+
+        :meta private:
+        """
+        yield DagDependency(
+            source=source or "asset-alias",
+            target=target or "asset-alias",
+            label=self.name,
+            dependency_type="asset-alias",
+            dependency_id=self.name,
+        )
+
+
+@attrs.define
+class SerializedAssetBooleanCondition(SerializedAssetBase):
+    """Serialized representation of an asset condition."""
+
+    objects: list[SerializedAssetBase]
+
+    agg_func: ClassVar[Callable[[Iterable], bool]]
+
+    def iter_assets(self) -> Iterator[tuple[SerializedAssetUniqueKey, SerializedAsset]]:
+        for o in self.objects:
+            yield from o.iter_assets()
+
+    def iter_asset_aliases(self) -> Iterator[tuple[str, SerializedAssetAlias]]:
+        for o in self.objects:
+            yield from o.iter_asset_aliases()
+
+    def iter_asset_refs(self) -> Iterator[SerializedAssetRef]:
+        for o in self.objects:
+            yield from o.iter_asset_refs()
+
+    def iter_dag_dependencies(self, *, source: str, target: str) -> Iterator[DagDependency]:
+        """
+        Iterate asset, asset aliases and their resolved assets  as dag dependency.
+
+        :meta private:
+        """
+        for obj in self.objects:
+            yield from obj.iter_dag_dependencies(source=source, target=target)
+
+
+class SerializedAssetAny(SerializedAssetBooleanCondition):
+    """Serialized representation of an asset "or" relationship."""
+
+    agg_func = any
+
+    def as_expression(self) -> dict[str, Any]:
+        """
+        Serialize the asset into its scheduling expression.
+
+        :meta private:
+        """
+        return {"any": [o.as_expression() for o in self.objects]}
+
+
+class SerializedAssetAll(SerializedAssetBooleanCondition):
+    """Serialized representation of an asset "and" relationship."""
+
+    agg_func = all
+
+    def __repr__(self) -> str:
+        return f"AssetAny({', '.join(map(str, self.objects))})"
+
+    def as_expression(self) -> Any:
+        """
+        Serialize the assets into its scheduling expression.
+
+        :meta private:
+        """
+        return {"all": [o.as_expression() for o in self.objects]}

--- a/airflow-core/src/airflow/serialization/definitions/assets.py
+++ b/airflow-core/src/airflow/serialization/definitions/assets.py
@@ -18,10 +18,12 @@
 
 from __future__ import annotations
 
-from airflow.sdk import AssetWatcher  # TODO: Implement serialized assets.
+import attrs
 
 
-class SerializedAssetWatcher(AssetWatcher):
+@attrs.define
+class SerializedAssetWatcher:
     """JSON serializable representation of an asset watcher."""
 
+    name: str
     trigger: dict

--- a/airflow-core/src/airflow/serialization/encoders.py
+++ b/airflow-core/src/airflow/serialization/encoders.py
@@ -139,9 +139,9 @@ def encode_trigger(trigger: BaseEventTrigger | dict):
     }
 
 
-def encode_asset_condition(a: BaseAsset | SerializedAssetBase) -> dict[str, Any]:
+def encode_asset_like(a: BaseAsset | SerializedAssetBase) -> dict[str, Any]:
     """
-    Encode an asset condition.
+    Encode an asset-like object.
 
     :meta private:
     """
@@ -155,9 +155,9 @@ def encode_asset_condition(a: BaseAsset | SerializedAssetBase) -> dict[str, Any]
         case AssetAlias() | SerializedAssetAlias():
             return {"__type": DAT.ASSET_ALIAS, "name": a.name, "group": a.group}
         case AssetAll() | SerializedAssetAll():
-            return {"__type": DAT.ASSET_ALL, "objects": [encode_asset_condition(x) for x in a.objects]}
+            return {"__type": DAT.ASSET_ALL, "objects": [encode_asset_like(x) for x in a.objects]}
         case AssetAny() | SerializedAssetAny():
-            return {"__type": DAT.ASSET_ANY, "objects": [encode_asset_condition(x) for x in a.objects]}
+            return {"__type": DAT.ASSET_ANY, "objects": [encode_asset_like(x) for x in a.objects]}
         case AssetRef() | SerializedAssetRef():
             return {"__type": DAT.ASSET_REF, **attrs.asdict(a)}
     raise ValueError(f"serialization not implemented for {type(a).__name__!r}")
@@ -233,7 +233,7 @@ class _TimetableSerializer:
 
     @serialize.register
     def _(self, timetable: AssetTriggeredTimetable) -> dict[str, Any]:
-        return {"asset_condition": encode_asset_condition(timetable.asset_condition)}
+        return {"asset_condition": encode_asset_like(timetable.asset_condition)}
 
     @serialize.register
     def _(self, timetable: EventsTimetable) -> dict[str, Any]:
@@ -282,7 +282,7 @@ class _TimetableSerializer:
     @serialize.register
     def _(self, timetable: AssetOrTimeSchedule) -> dict[str, Any]:
         return {
-            "asset_condition": encode_asset_condition(timetable.asset_condition),
+            "asset_condition": encode_asset_like(timetable.asset_condition),
             "timetable": encode_timetable(timetable.timetable),
         }
 
@@ -337,6 +337,6 @@ def ensure_serialized_asset(obj: BaseAsset | SerializedAssetBase) -> SerializedA
     if isinstance(obj, SerializedAssetBase):
         return obj
 
-    from airflow.serialization.decoders import decode_asset_condition
+    from airflow.serialization.decoders import decode_asset_like
 
-    return decode_asset_condition(encode_asset_condition(obj))
+    return decode_asset_like(encode_asset_like(obj))

--- a/airflow-core/src/airflow/timetables/assets.py
+++ b/airflow-core/src/airflow/timetables/assets.py
@@ -65,10 +65,10 @@ class AssetOrTimeSchedule(AssetTriggeredTimetable):
 
     @classmethod
     def deserialize(cls, data: dict[str, typing.Any]) -> Timetable:
-        from airflow.serialization.decoders import decode_asset_condition, decode_timetable
+        from airflow.serialization.decoders import decode_asset_like, decode_timetable
 
         return cls(
-            assets=decode_asset_condition(data["asset_condition"]),
+            assets=decode_asset_like(data["asset_condition"]),
             timetable=decode_timetable(data["timetable"]),
         )
 
@@ -79,10 +79,10 @@ class AssetOrTimeSchedule(AssetTriggeredTimetable):
             raise AirflowTimetableInvalid("all elements in 'assets' must be assets")
 
     def serialize(self) -> dict[str, typing.Any]:
-        from airflow.serialization.encoders import encode_asset_condition, encode_timetable
+        from airflow.serialization.encoders import encode_asset_like, encode_timetable
 
         return {
-            "asset_condition": encode_asset_condition(self.asset_condition),
+            "asset_condition": encode_asset_like(self.asset_condition),
             "timetable": encode_timetable(self.timetable),
         }
 

--- a/airflow-core/src/airflow/timetables/assets.py
+++ b/airflow-core/src/airflow/timetables/assets.py
@@ -75,7 +75,7 @@ class AssetOrTimeSchedule(AssetTriggeredTimetable):
     def validate(self) -> None:
         if isinstance(self.timetable, AssetTriggeredTimetable):
             raise AirflowTimetableInvalid("cannot nest asset timetables")
-        if not isinstance(self.asset_condition, BaseAsset):
+        if not isinstance(self.asset_condition, SerializedAssetBase):
             raise AirflowTimetableInvalid("all elements in 'assets' must be assets")
 
     def serialize(self) -> dict[str, typing.Any]:

--- a/airflow-core/src/airflow/timetables/base.py
+++ b/airflow-core/src/airflow/timetables/base.py
@@ -16,15 +16,22 @@
 # under the License.
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, NamedTuple, Protocol, runtime_checkable
 
-from airflow.sdk.bases.timetable import NullAsset  # TODO: Separate asset definitions.
+from airflow.serialization.definitions.assets import SerializedAssetBase
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator, Sequence
+
     from pendulum import DateTime
 
-    from airflow.sdk.definitions.asset import BaseAsset
+    from airflow.serialization.dag_dependency import DagDependency
+    from airflow.serialization.definitions.assets import (
+        SerializedAsset,
+        SerializedAssetAlias,
+        SerializedAssetRef,
+        SerializedAssetUniqueKey,
+    )
     from airflow.utils.types import DagRunType
 
 
@@ -65,6 +72,35 @@ class TimeRestriction(NamedTuple):
     earliest: DateTime | None
     latest: DateTime | None
     catchup: bool
+
+
+class _NullAsset(SerializedAssetBase):
+    """
+    Sentinel type that represents "no assets".
+
+    This is only implemented to make typing easier in timetables, and not
+    expected to be used anywhere else.
+
+    :meta private:
+    """
+
+    def __bool__(self) -> bool:
+        return False
+
+    def as_expression(self) -> Any:
+        return None
+
+    def iter_assets(self) -> Iterator[tuple[SerializedAssetUniqueKey, SerializedAsset]]:
+        return iter(())
+
+    def iter_asset_aliases(self) -> Iterator[tuple[str, SerializedAssetAlias]]:
+        return iter(())
+
+    def iter_asset_refs(self) -> Iterator[SerializedAssetRef]:
+        return iter(())
+
+    def iter_dag_dependencies(self, source, target) -> Iterator[DagDependency]:
+        return iter(())
 
 
 class DagRunInfo(NamedTuple):
@@ -155,12 +191,8 @@ class Timetable(Protocol):
     as for :class:`~airflow.timetable.simple.ContinuousTimetable`.
     """
 
-    asset_condition: BaseAsset = NullAsset()
-    """The asset condition that triggers a DAG using this timetable.
-
-    If this is not *None*, this should be an asset, or a combination of, that
-    controls the DAG's asset triggers.
-    """
+    asset_condition: SerializedAssetBase = _NullAsset()
+    """The asset condition that triggers a DAG using this timetable."""
 
     @classmethod
     def deserialize(cls, data: dict[str, Any]) -> Timetable:

--- a/airflow-core/src/airflow/timetables/simple.py
+++ b/airflow-core/src/airflow/timetables/simple.py
@@ -177,18 +177,18 @@ class AssetTriggeredTimetable(_TrivialTimetable):
 
     @classmethod
     def deserialize(cls, data: dict[str, Any]) -> Timetable:
-        from airflow.serialization.decoders import decode_asset_condition
+        from airflow.serialization.decoders import decode_asset_like
 
-        return cls(decode_asset_condition(data["asset_condition"]))
+        return cls(decode_asset_like(data["asset_condition"]))
 
     @property
     def summary(self) -> str:
         return "Asset"
 
     def serialize(self) -> dict[str, Any]:
-        from airflow.serialization.encoders import encode_asset_condition
+        from airflow.serialization.encoders import encode_asset_like
 
-        return {"asset_condition": encode_asset_condition(self.asset_condition)}
+        return {"asset_condition": encode_asset_like(self.asset_condition)}
 
     def generate_run_id(
         self,
@@ -266,18 +266,18 @@ class PartitionedAssetTimetable(AssetTriggeredTimetable):
         self.partition_mapper = partition_mapper
 
     def serialize(self) -> dict[str, Any]:
-        from airflow.serialization.serialized_objects import encode_asset_condition, encode_partition_mapper
+        from airflow.serialization.serialized_objects import encode_asset_like, encode_partition_mapper
 
         return {
-            "asset_condition": encode_asset_condition(self.asset_condition),
+            "asset_condition": encode_asset_like(self.asset_condition),
             "partition_mapper": encode_partition_mapper(self.partition_mapper),
         }
 
     @classmethod
     def deserialize(cls, data: dict[str, Any]) -> Timetable:
-        from airflow.serialization.serialized_objects import decode_asset_condition, decode_partition_mapper
+        from airflow.serialization.serialized_objects import decode_asset_like, decode_partition_mapper
 
         return cls(
-            assets=decode_asset_condition(data["asset_condition"]),
+            assets=decode_asset_like(data["asset_condition"]),
             partition_mapper=decode_partition_mapper(data["partition_mapper"]),
         )

--- a/airflow-core/src/airflow/timetables/simple.py
+++ b/airflow-core/src/airflow/timetables/simple.py
@@ -26,7 +26,7 @@ from airflow.timetables.base import DagRunInfo, DataInterval, Timetable
 if TYPE_CHECKING:
     from pendulum import DateTime
 
-    from airflow.sdk.definitions.asset import BaseAsset
+    from airflow.serialization.definitions.assets import SerializedAssetBase
     from airflow.timetables.base import TimeRestriction
     from airflow.utils.types import DagRunType
 
@@ -171,7 +171,7 @@ class AssetTriggeredTimetable(_TrivialTimetable):
 
     description: str = "Triggered by assets"
 
-    def __init__(self, assets: BaseAsset) -> None:
+    def __init__(self, assets: SerializedAssetBase) -> None:
         super().__init__()
         self.asset_condition = assets
 
@@ -260,7 +260,7 @@ class PartitionedAssetTimetable(AssetTriggeredTimetable):
     def summary(self) -> str:
         return "Partitioned Asset"
 
-    def __init__(self, *, assets: BaseAsset, partition_mapper: PartitionMapper) -> None:
+    def __init__(self, assets: SerializedAssetBase, partition_mapper: PartitionMapper) -> None:
         super().__init__(assets=assets)
         self.asset_condition = assets
         self.partition_mapper = partition_mapper

--- a/airflow-core/src/airflow/utils/context.py
+++ b/airflow-core/src/airflow/utils/context.py
@@ -19,19 +19,12 @@
 
 from __future__ import annotations
 
-from collections.abc import (
-    Container,
-)
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, cast
 
 from sqlalchemy import select
 
 from airflow.models.asset import AssetModel
-from airflow.sdk.definitions.context import Context
+from airflow.sdk import Asset, Context
 from airflow.sdk.execution_time.context import (
     ConnectionAccessor as ConnectionAccessorSDK,
     OutletEventAccessors as OutletEventAccessorsSDK,
@@ -41,7 +34,7 @@ from airflow.serialization.definitions.notset import NOTSET, is_arg_set
 from airflow.utils.session import create_session
 
 if TYPE_CHECKING:
-    from airflow.sdk.definitions.asset import Asset
+    from collections.abc import Container
 
 # NOTE: Please keep this in sync with the following:
 # * Context in task-sdk/src/airflow/sdk/definitions/context.py
@@ -145,7 +138,7 @@ class OutletEventAccessors(OutletEventAccessorsSDK):
 
         if asset is None:
             raise ValueError("No active asset found with either name or uri.")
-        return asset.to_public()
+        return Asset(name=asset.name, uri=asset.uri, group=asset.group, extra=asset.extra)
 
 
 def context_merge(context: Context, *args: Any, **kwargs: Any) -> None:

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
@@ -1362,7 +1362,7 @@ class TestPostAssetMaterialize(TestAssets):
     def create_dags(self, setup, dag_maker, session):
         # Depend on 'setup' so it runs first. Otherwise it deletes what we create here.
         assets = {
-            i: am.to_public() for i, am in enumerate(self.create_assets(session=session, num=3), start=1)
+            i: am.to_serialized() for i, am in enumerate(self.create_assets(session=session, num=3), start=1)
         }
         with dag_maker(self.DAG_ASSET1_ID, schedule=None, session=session):
             EmptyOperator(task_id="task", outlets=assets[1])

--- a/airflow-core/tests/unit/assets/test_evaluation.py
+++ b/airflow-core/tests/unit/assets/test_evaluation.py
@@ -20,13 +20,18 @@ from __future__ import annotations
 import pytest
 
 from airflow.assets.evaluation import AssetEvaluator
-from airflow.sdk.definitions.asset import Asset, AssetAlias, AssetAll, AssetAny, AssetUniqueKey
-from airflow.serialization.serialized_objects import BaseSerialization
+from airflow.serialization.definitions.assets import (
+    SerializedAsset,
+    SerializedAssetAlias,
+    SerializedAssetAll,
+    SerializedAssetAny,
+    SerializedAssetUniqueKey,
+)
 
 pytestmark = pytest.mark.db_test
 
-asset1 = Asset(uri="s3://bucket1/data1", name="asset-1")
-asset2 = Asset(uri="s3://bucket2/data2", name="asset-2")
+asset1 = SerializedAsset("asset-1", "s3://bucket1/data1", "asset", {}, [])
+asset2 = SerializedAsset("asset-2", "s3://bucket2/data2", "asset", {}, [])
 
 
 @pytest.fixture
@@ -37,8 +42,8 @@ def evaluator(session):
 @pytest.mark.parametrize(
     ("statuses", "result"),
     [
-        ({AssetUniqueKey.from_asset(asset1): True}, True),
-        ({AssetUniqueKey.from_asset(asset1): False}, False),
+        ({SerializedAssetUniqueKey.from_asset(asset1): True}, True),
+        ({SerializedAssetUniqueKey.from_asset(asset1): False}, False),
         ({}, False),
     ],
 )
@@ -50,13 +55,19 @@ def test_asset_evaluate(evaluator, statuses, result):
     ("condition", "statuses", "result"),
     [
         (
-            AssetAny(asset1, asset2),
-            {AssetUniqueKey.from_asset(asset1): False, AssetUniqueKey.from_asset(asset2): True},
+            SerializedAssetAny([asset1, asset2]),
+            {
+                SerializedAssetUniqueKey.from_asset(asset1): False,
+                SerializedAssetUniqueKey.from_asset(asset2): True,
+            },
             True,
         ),
         (
-            AssetAll(asset1, asset2),
-            {AssetUniqueKey.from_asset(asset1): True, AssetUniqueKey.from_asset(asset2): False},
+            SerializedAssetAll([asset1, asset2]),
+            {
+                SerializedAssetUniqueKey.from_asset(asset1): True,
+                SerializedAssetUniqueKey.from_asset(asset2): False,
+            },
             False,
         ),
     ],
@@ -70,48 +81,42 @@ def test_assset_boolean_condition_evaluate_iter(evaluator, condition, statuses, 
     """
     assert evaluator.run(condition, statuses) is result
     assert dict(condition.iter_assets()) == {
-        AssetUniqueKey("asset-1", "s3://bucket1/data1"): asset1,
-        AssetUniqueKey("asset-2", "s3://bucket2/data2"): asset2,
+        SerializedAssetUniqueKey("asset-1", "s3://bucket1/data1"): asset1,
+        SerializedAssetUniqueKey("asset-2", "s3://bucket2/data2"): asset2,
     }
 
 
 @pytest.mark.parametrize(
     ("inputs", "scenario", "expected"),
     [
-        # Scenarios for AssetAny
-        ((True, True, True), "any", True),
-        ((True, True, False), "any", True),
-        ((True, False, True), "any", True),
-        ((True, False, False), "any", True),
-        ((False, False, True), "any", True),
-        ((False, True, False), "any", True),
-        ((False, True, True), "any", True),
-        ((False, False, False), "any", False),
-        # Scenarios for AssetAll
-        ((True, True, True), "all", True),
-        ((True, True, False), "all", False),
-        ((True, False, True), "all", False),
-        ((True, False, False), "all", False),
-        ((False, False, True), "all", False),
-        ((False, True, False), "all", False),
-        ((False, True, True), "all", False),
-        ((False, False, False), "all", False),
+        # Scenarios for "any"
+        ((True, True, True), SerializedAssetAny, True),
+        ((True, True, False), SerializedAssetAny, True),
+        ((True, False, True), SerializedAssetAny, True),
+        ((True, False, False), SerializedAssetAny, True),
+        ((False, False, True), SerializedAssetAny, True),
+        ((False, True, False), SerializedAssetAny, True),
+        ((False, True, True), SerializedAssetAny, True),
+        ((False, False, False), SerializedAssetAny, False),
+        # Scenarios for "all"
+        ((True, True, True), SerializedAssetAll, True),
+        ((True, True, False), SerializedAssetAll, False),
+        ((True, False, True), SerializedAssetAll, False),
+        ((True, False, False), SerializedAssetAll, False),
+        ((False, False, True), SerializedAssetAll, False),
+        ((False, True, False), SerializedAssetAll, False),
+        ((False, True, True), SerializedAssetAll, False),
+        ((False, False, False), SerializedAssetAll, False),
     ],
 )
 def test_asset_logical_conditions_evaluation_and_serialization(evaluator, inputs, scenario, expected):
-    class_ = AssetAny if scenario == "any" else AssetAll
-    assets = [Asset(uri=f"s3://abc/{i}", name=f"asset_{i}") for i in range(123, 126)]
-    condition = class_(*assets)
+    assets = [SerializedAsset(f"asset_{i}", f"s3://abc/{i}", "asset", {}, []) for i in range(123, 126)]
+    condition = scenario(assets)
 
-    statuses = {AssetUniqueKey.from_asset(asset): status for asset, status in zip(assets, inputs)}
+    statuses = {SerializedAssetUniqueKey.from_asset(asset): status for asset, status in zip(assets, inputs)}
     assert evaluator.run(condition, statuses) == expected, (
         f"Condition evaluation failed for inputs {inputs} and scenario '{scenario}'"
     )
-
-    # Serialize and deserialize the condition to test persistence
-    serialized = BaseSerialization.serialize(condition)
-    deserialized = BaseSerialization.deserialize(serialized)
-    assert evaluator.run(deserialized, statuses) == expected, "Serialization round-trip failed"
 
 
 @pytest.mark.parametrize(
@@ -141,44 +146,36 @@ def test_asset_logical_conditions_evaluation_and_serialization(evaluator, inputs
 )
 def test_nested_asset_conditions_with_serialization(evaluator, status_values, expected_evaluation):
     # Define assets
-    asset1 = Asset(uri="s3://abc/123")
-    asset2 = Asset(uri="s3://abc/124")
-    asset3 = Asset(uri="s3://abc/125")
+    asset1 = SerializedAsset("123", "s3://abc/123", "asset", {}, [])
+    asset2 = SerializedAsset("124", "s3://abc/124", "asset", {}, [])
+    asset3 = SerializedAsset("125", "s3://abc/125", "asset", {}, [])
 
     # Create a nested condition: AssetAll with asset1 and AssetAny with asset2 and asset3
-    nested_condition = AssetAll(asset1, AssetAny(asset2, asset3))
+    nested_condition = SerializedAssetAll([asset1, SerializedAssetAny([asset2, asset3])])
 
     statuses = {
-        AssetUniqueKey.from_asset(asset1): status_values[0],
-        AssetUniqueKey.from_asset(asset2): status_values[1],
-        AssetUniqueKey.from_asset(asset3): status_values[2],
+        SerializedAssetUniqueKey.from_asset(asset1): status_values[0],
+        SerializedAssetUniqueKey.from_asset(asset2): status_values[1],
+        SerializedAssetUniqueKey.from_asset(asset3): status_values[2],
     }
-
     assert evaluator.run(nested_condition, statuses) == expected_evaluation, "Initial evaluation mismatch"
-
-    serialized_condition = BaseSerialization.serialize(nested_condition)
-    deserialized_condition = BaseSerialization.deserialize(serialized_condition)
-
-    assert evaluator.run(deserialized_condition, statuses) == expected_evaluation, (
-        "Post-serialization evaluation mismatch"
-    )
 
 
 class TestAssetAlias:
     @pytest.fixture
     def asset(self):
         """Example asset links to asset alias resolved_asset_alias_2."""
-        return Asset(uri="test://asset1/", name="test_name", group="asset")
+        return SerializedAsset("test_name", "test://asset1/", "asset", {}, [])
 
     @pytest.fixture
     def asset_alias_1(self):
         """Example asset alias links to no assets."""
-        return AssetAlias(name="test_name", group="test")
+        return SerializedAssetAlias("test_name", "test")
 
     @pytest.fixture
     def resolved_asset_alias_2(self):
         """Example asset alias links to asset."""
-        return AssetAlias(name="test_name_2")
+        return SerializedAssetAlias("test_name_2", "test")
 
     @pytest.fixture
     def evaluator(self, session, asset_alias_1, resolved_asset_alias_2, asset):
@@ -193,7 +190,9 @@ class TestAssetAlias:
         return _AssetEvaluator(session)
 
     def test_evaluate_empty(self, evaluator, asset_alias_1, asset):
-        assert evaluator.run(asset_alias_1, {AssetUniqueKey.from_asset(asset): True}) is False
+        assert evaluator.run(asset_alias_1, {SerializedAssetUniqueKey.from_asset(asset): True}) is False
 
     def test_evalute_resolved(self, evaluator, resolved_asset_alias_2, asset):
-        assert evaluator.run(resolved_asset_alias_2, {AssetUniqueKey.from_asset(asset): True}) is True
+        assert (
+            evaluator.run(resolved_asset_alias_2, {SerializedAssetUniqueKey.from_asset(asset): True}) is True
+        )

--- a/airflow-core/tests/unit/cli/commands/test_asset_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_asset_command.py
@@ -116,7 +116,10 @@ def test_cli_assets_alias_details(parser: ArgumentParser, stdout_capture) -> Non
     # No good way to statically compare these.
     undeterministic = {"id": None}
 
-    assert alias_detail_list[0] | undeterministic == undeterministic | {"name": "example-alias", "group": ""}
+    assert alias_detail_list[0] | undeterministic == undeterministic | {
+        "name": "example-alias",
+        "group": "asset",
+    }
 
 
 @mock.patch("airflow.api_fastapi.core_api.datamodels.dag_versions.hasattr")

--- a/airflow-core/tests/unit/dag_processing/test_collection.py
+++ b/airflow-core/tests/unit/dag_processing/test_collection.py
@@ -53,7 +53,7 @@ from airflow.models.dag import DagTag
 from airflow.models.errors import ParseImportError
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.providers.standard.operators.empty import EmptyOperator
-from airflow.providers.standard.triggers.temporal import TimeDeltaTrigger
+from airflow.providers.standard.triggers.file import FileDeleteTrigger
 from airflow.sdk import DAG, Asset, AssetAlias, AssetWatcher
 from airflow.serialization.serialized_objects import LazyDeserializedDAG
 
@@ -140,10 +140,9 @@ class TestAssetModelOperation:
     def test_add_asset_trigger_references(
         self, dag_maker, session, is_active, is_paused, expected_num_triggers
     ):
-        classpath, kwargs = TimeDeltaTrigger(timedelta(seconds=0)).serialize()
         asset = Asset(
             "test_add_asset_trigger_references_asset",
-            watchers=[AssetWatcher(name="test", trigger={"classpath": classpath, "kwargs": kwargs})],
+            watchers=[AssetWatcher(name="test", trigger=FileDeleteTrigger(mock.Mock()))],
         )
 
         with dag_maker(dag_id="test_add_asset_trigger_references_dag", schedule=[asset]) as dag:

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -8170,6 +8170,7 @@ def test_mark_backfills_completed(dag_maker, session):
     assert b.completed_at.timestamp() > 0
 
 
+@pytest.mark.need_serialized_dag
 def test_when_dag_run_has_partition_and_downstreams_listening_then_tables_populated(
     dag_maker,
     session,
@@ -8182,6 +8183,7 @@ def test_when_dag_run_has_partition_and_downstreams_listening_then_tables_popula
     assert dr.partition_key == "abc123"
     [ti] = dr.get_task_instances(session=session)
     session.commit()
+    serialized_outlets = dag.get_task("hi").outlets
 
     with dag_maker(
         dag_id="asset_event_listener",
@@ -8193,7 +8195,7 @@ def test_when_dag_run_has_partition_and_downstreams_listening_then_tables_popula
 
     TaskInstance.register_asset_changes_in_db(
         ti=ti,
-        task_outlets=[asset.asprofile()],
+        task_outlets=[o.asprofile() for o in serialized_outlets],
         outlet_events=[],
         session=session,
     )

--- a/airflow-core/tests/unit/listeners/asset_listener.py
+++ b/airflow-core/tests/unit/listeners/asset_listener.py
@@ -18,16 +18,11 @@
 from __future__ import annotations
 
 import copy
-import typing
 
 from airflow.listeners import hookimpl
 
-if typing.TYPE_CHECKING:
-    from airflow.sdk.definitions.asset import Asset
-
-
-changed: list[Asset] = []
-created: list[Asset] = []
+changed = []
+created = []
 
 
 @hookimpl

--- a/airflow-core/tests/unit/models/test_asset.py
+++ b/airflow-core/tests/unit/models/test_asset.py
@@ -34,6 +34,7 @@ from airflow.models.asset import (
 from airflow.models.dag import DagModel
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.sdk import Asset, AssetAlias
+from airflow.serialization.definitions.assets import SerializedAssetAlias
 
 from tests_common.test_utils.dag import sync_dags_to_db
 
@@ -49,10 +50,11 @@ def clear_assets():
     clear_db_assets()
 
 
-def test_asset_alias_from_public():
-    asset_alias = AssetAlias(name="test_alias")
-    asset_alias_model = AssetAliasModel.from_public(asset_alias)
+def test_asset_alias_from_serialized():
+    asset_alias = SerializedAssetAlias(name="test_alias", group="test_group")
+    asset_alias_model = AssetAliasModel.from_serialized(asset_alias)
     assert asset_alias_model.name == "test_alias"
+    assert asset_alias_model.group == "test_group"
 
 
 class TestAssetAliasModel:

--- a/airflow-core/tests/unit/models/test_taskinstance.py
+++ b/airflow-core/tests/unit/models/test_taskinstance.py
@@ -1767,7 +1767,7 @@ class TestTaskInstance:
         alias_name_1 = "test_outlet_asset_alias_test_case_asset_alias_1"
 
         asm = AssetModel(id=1, uri=asset_uri)
-        session.add_all([asm, AssetActive.for_asset(asm.to_public())])
+        session.add_all([asm, AssetActive.for_asset(asm)])
         session.commit()
 
         with dag_maker(dag_id="producer_dag", schedule=None, serialized=True, session=session):
@@ -1816,7 +1816,7 @@ class TestTaskInstance:
         asset_alias_name_3 = "test_outlet_maa_asset_alias_3"
 
         asm = AssetModel(id=1, uri=asset_uri)
-        session.add_all([asm, AssetActive.for_asset(asm.to_public())])
+        session.add_all([asm, AssetActive.for_asset(asm)])
         session.commit()
 
         with dag_maker(dag_id="producer_dag", schedule=None, serialized=True, session=session):

--- a/airflow-core/tests/unit/serialization/definitions/__init__.py
+++ b/airflow-core/tests/unit/serialization/definitions/__init__.py
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow-core/tests/unit/serialization/definitions/test_assets.py
+++ b/airflow-core/tests/unit/serialization/definitions/test_assets.py
@@ -1,0 +1,97 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from airflow.api_fastapi.execution_api.datamodels.asset import AssetProfile
+from airflow.serialization.definitions.assets import (
+    SerializedAsset,
+    SerializedAssetAlias,
+    SerializedAssetAll,
+    SerializedAssetAny,
+    SerializedAssetUniqueKey,
+)
+
+asset1 = SerializedAsset(
+    name="asset-1",
+    uri="s3://bucket1/data1/",
+    group="group-1",
+    extra={},
+    watchers=[],
+)
+
+
+def test_asset_iter_assets():
+    assert list(asset1.iter_assets()) == [
+        (SerializedAssetUniqueKey("asset-1", "s3://bucket1/data1/"), asset1)
+    ]
+
+
+def test_asset_iter_asset_aliases():
+    base_asset = SerializedAssetAll(
+        [
+            SerializedAssetAlias(name="example-alias-1", group=""),
+            SerializedAsset(name="1", uri="foo://1/", group="", extra={}, watchers=[]),
+            SerializedAssetAny(
+                [
+                    SerializedAsset(name="2", uri="test://2/", group="", extra={}, watchers=[]),
+                    SerializedAssetAlias(name="example-alias-2", group=""),
+                    SerializedAsset(name="3", uri="test://3/", group="", extra={}, watchers=[]),
+                    SerializedAssetAll(
+                        [
+                            SerializedAssetAlias("example-alias-3", group=""),
+                            SerializedAsset(name="4", uri="test://4/", group="", extra={}, watchers=[]),
+                            SerializedAssetAlias("example-alias-4", group=""),
+                        ],
+                    ),
+                ],
+            ),
+            SerializedAssetAll(
+                [
+                    SerializedAssetAlias("example-alias-5", group=""),
+                    SerializedAsset(name="5", uri="test://5/", group="", extra={}, watchers=[]),
+                ],
+            ),
+        ],
+    )
+    assert list(base_asset.iter_asset_aliases()) == [
+        (f"example-alias-{i}", SerializedAssetAlias(name=f"example-alias-{i}", group="")) for i in range(1, 6)
+    ]
+
+
+def test_asset_alias_as_expression():
+    alias = SerializedAssetAlias(name="test_name", group="test")
+    assert alias.as_expression() == {"alias": {"name": "test_name", "group": "test"}}
+
+
+class TestSerializedAssetUniqueKey:
+    def test_from_asset(self):
+        key = SerializedAssetUniqueKey.from_asset(asset1)
+        assert key == SerializedAssetUniqueKey(name="asset-1", uri="s3://bucket1/data1/")
+
+    def test_from_str(self):
+        key = SerializedAssetUniqueKey.from_str('{"name": "test", "uri": "test://test/"}')
+        assert key == SerializedAssetUniqueKey(name="test", uri="test://test/")
+
+    def test_to_str(self):
+        key = SerializedAssetUniqueKey(name="test", uri="test://test/")
+        assert key.to_str() == '{"name": "test", "uri": "test://test/"}'
+
+    def test_asprofile(self):
+        key = SerializedAssetUniqueKey(name="test", uri="test://test/")
+        assert key.asprofile() == AssetProfile(name="test", uri="test://test/", type="Asset")

--- a/airflow-core/tests/unit/serialization/test_serialized_objects.py
+++ b/airflow-core/tests/unit/serialization/test_serialized_objects.py
@@ -691,19 +691,19 @@ def test_hash_property():
     ],
 )
 def test_serde_decode_asset_condition_success(payload, expected_cls):
-    from airflow.serialization.serialized_objects import decode_asset_condition
+    from airflow.serialization.serialized_objects import decode_asset_like
 
-    assert isinstance(decode_asset_condition(payload), expected_cls)
+    assert isinstance(decode_asset_like(payload), expected_cls)
 
 
 def test_serde_decode_asset_condition_unknown_type():
-    from airflow.serialization.serialized_objects import decode_asset_condition
+    from airflow.serialization.serialized_objects import decode_asset_like
 
     with pytest.raises(
         ValueError,
         match="deserialization not implemented for DAT 'UNKNOWN_TYPE'",
     ):
-        decode_asset_condition({"__type": "UNKNOWN_TYPE"})
+        decode_asset_like({"__type": "UNKNOWN_TYPE"})
 
 
 def test_encode_timezone():

--- a/airflow-core/tests/unit/timetables/test_assets_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_assets_timetable.py
@@ -22,14 +22,15 @@ from collections import defaultdict
 from typing import Any
 
 import pytest
-from pendulum import DateTime
-from sqlalchemy.sql import select
+from pendulum import UTC, DateTime
+from sqlalchemy import select
 
 from airflow.models.asset import AssetDagRunQueue, AssetEvent, AssetModel
 from airflow.models.serialized_dag import SerializedDAG, SerializedDagModel
 from airflow.providers.standard.operators.empty import EmptyOperator
-from airflow.sdk.definitions.asset import Asset, AssetAll, AssetAny
-from airflow.timetables.assets import AssetOrTimeSchedule
+from airflow.sdk import Asset, AssetAll, AssetAny, AssetOrTimeSchedule as SdkAssetOrTimeSchedule
+from airflow.serialization.definitions.assets import SerializedAsset, SerializedAssetAll, SerializedAssetAny
+from airflow.timetables.assets import AssetOrTimeSchedule as CoreAssetOrTimeSchedule
 from airflow.timetables.base import DagRunInfo, DataInterval, TimeRestriction, Timetable
 from airflow.timetables.simple import AssetTriggeredTimetable
 from airflow.utils.types import DagRunType
@@ -110,27 +111,37 @@ def test_assets() -> list[Asset]:
 
 
 @pytest.fixture
-def asset_timetable(test_timetable: MockTimetable, test_assets: list[Asset]) -> AssetOrTimeSchedule:
+def sdk_asset_timetable(test_timetable, test_assets) -> SdkAssetOrTimeSchedule:
     """
-    Pytest fixture for creating an AssetOrTimeSchedule object.
+    Pytest fixture for creating an SDK AssetOrTimeSchedule object.
 
     :param test_timetable: The test timetable instance.
     :param test_assets: A list of Asset instances.
     """
-    return AssetOrTimeSchedule(timetable=test_timetable, assets=test_assets)
+    return SdkAssetOrTimeSchedule(timetable=test_timetable, assets=test_assets)
 
 
-def test_serialization(asset_timetable: AssetOrTimeSchedule, monkeypatch: Any) -> None:
+@pytest.fixture
+def core_asset_timetable(test_timetable: MockTimetable) -> CoreAssetOrTimeSchedule:
+    return CoreAssetOrTimeSchedule(
+        timetable=test_timetable,
+        assets=SerializedAssetAll([SerializedAsset("test_asset", "test://asset/", "asset", {}, [])]),
+    )
+
+
+def test_serialization(sdk_asset_timetable: SdkAssetOrTimeSchedule, monkeypatch: Any) -> None:
     """
     Tests the serialization method of AssetOrTimeSchedule.
 
     :param asset_timetable: The AssetOrTimeSchedule instance to test.
     :param monkeypatch: The monkeypatch fixture from pytest.
     """
+    from airflow.serialization.encoders import _serializer
+
     monkeypatch.setattr(
         "airflow.serialization.encoders.encode_timetable", lambda x: "mock_serialized_timetable"
     )
-    serialized = asset_timetable.serialize()
+    serialized = _serializer.serialize(sdk_asset_timetable)
     assert serialized == {
         "timetable": "mock_serialized_timetable",
         "asset_condition": {
@@ -148,7 +159,7 @@ def test_serialization(asset_timetable: AssetOrTimeSchedule, monkeypatch: Any) -
     }
 
 
-def test_deserialization(monkeypatch: Any) -> None:
+def test_deserialization(monkeypatch: Any, core_asset_timetable: CoreAssetOrTimeSchedule) -> None:
     """
     Tests the deserialization method of AssetOrTimeSchedule.
 
@@ -170,49 +181,53 @@ def test_deserialization(monkeypatch: Any) -> None:
             ],
         },
     }
-    deserialized = AssetOrTimeSchedule.deserialize(mock_serialized_data)
-    assert isinstance(deserialized, AssetOrTimeSchedule)
+    deserialized = CoreAssetOrTimeSchedule.deserialize(mock_serialized_data)
+    assert deserialized == core_asset_timetable
 
 
-def test_infer_manual_data_interval(asset_timetable: AssetOrTimeSchedule) -> None:
+def test_infer_manual_data_interval(core_asset_timetable: CoreAssetOrTimeSchedule) -> None:
     """
     Tests the infer_manual_data_interval method of AssetOrTimeSchedule.
 
     :param asset_timetable: The AssetOrTimeSchedule instance to test.
     """
-    run_after = DateTime.now()
-    result = asset_timetable.infer_manual_data_interval(run_after=run_after)
-    assert isinstance(result, DataInterval)
+    run_after = DateTime(2025, 6, 7, 8, 9, tzinfo=UTC)
+    result = core_asset_timetable.infer_manual_data_interval(run_after=run_after)
+    assert result == DataInterval.exact(run_after)
 
 
-def test_next_dagrun_info(asset_timetable: AssetOrTimeSchedule) -> None:
+def test_next_dagrun_info(core_asset_timetable: CoreAssetOrTimeSchedule) -> None:
     """
     Tests the next_dagrun_info method of AssetOrTimeSchedule.
 
     :param asset_timetable: The AssetOrTimeSchedule instance to test.
     """
-    last_interval = DataInterval.exact(DateTime.now())
-    restriction = TimeRestriction(earliest=DateTime.now(), latest=None, catchup=True)
-    result = asset_timetable.next_dagrun_info(
+    last_interval = DataInterval.exact(DateTime(2025, 6, 7, 8, 9, tzinfo=UTC))
+    restriction = TimeRestriction(earliest=None, latest=None, catchup=False)
+    result = core_asset_timetable.next_dagrun_info(
         last_automated_data_interval=last_interval, restriction=restriction
     )
-    assert result is None or isinstance(result, DagRunInfo)
+    assert result == DagRunInfo.interval(
+        DateTime(2025, 6, 8, 8, 9, tzinfo=UTC),
+        DateTime(2025, 6, 9, 8, 9, tzinfo=UTC),
+    )
 
 
-def test_generate_run_id(asset_timetable: AssetOrTimeSchedule) -> None:
+def test_generate_run_id(core_asset_timetable: CoreAssetOrTimeSchedule) -> None:
     """
     Tests the generate_run_id method of AssetOrTimeSchedule.
 
     :param asset_timetable: The AssetOrTimeSchedule instance to test.
     """
-    run_id = asset_timetable.generate_run_id(
+    date = DateTime(2025, 6, 7, 8, 9, tzinfo=UTC)
+    run_id = core_asset_timetable.generate_run_id(
         run_type=DagRunType.MANUAL,
         extra_args="test",
-        logical_date=DateTime.now(),
-        run_after=DateTime.now(),
+        logical_date=date,
+        run_after=date,
         data_interval=None,
     )
-    assert isinstance(run_id, str)
+    assert run_id == "manual__2025-06-07T08:09:00+00:00"
 
 
 @pytest.fixture
@@ -242,17 +257,14 @@ def asset_events(mocker) -> list[AssetEvent]:
     return [event_earlier, event_later]
 
 
-def test_run_ordering_inheritance(asset_timetable: AssetOrTimeSchedule) -> None:
+def test_run_ordering_inheritance(core_asset_timetable) -> None:
     """
     Tests that AssetOrTimeSchedule inherits run_ordering from its parent class correctly.
 
     :param asset_timetable: The AssetOrTimeSchedule instance to test.
     """
-    assert hasattr(asset_timetable, "run_ordering"), (
-        "AssetOrTimeSchedule should have 'run_ordering' attribute"
-    )
-    parent_run_ordering = getattr(AssetTriggeredTimetable, "run_ordering", None)
-    assert asset_timetable.run_ordering == parent_run_ordering, "run_ordering does not match the parent class"
+    assert core_asset_timetable.run_ordering == ("logical_date",)
+    assert core_asset_timetable.run_ordering == AssetTriggeredTimetable.run_ordering
 
 
 @pytest.mark.db_test
@@ -291,53 +303,72 @@ class TestAssetConditionWithTimetable:
         for record in records:
             dag_statuses[record.target_dag_id][record.asset.uri] = True
 
-        serialized_dags = session.execute(
+        serialized_dags = session.scalars(
             select(SerializedDagModel).where(SerializedDagModel.dag_id.in_(dag_statuses.keys()))
-        ).fetchall()
+        )
 
-        for (serialized_dag,) in serialized_dags:
+        for serialized_dag in serialized_dags:
             dag = SerializedDAG.deserialize(serialized_dag.data)
             for asset_uri, status in dag_statuses[dag.dag_id].items():
                 cond = dag.timetable.asset_condition
                 assert evaluator.run(cond, {asset_uri: status}), "DAG trigger evaluation failed"
 
-    def test_dag_with_complex_asset_condition(self, session, dag_maker):
+    def test_dag_with_complex_asset_condition(self, dag_maker):
         # Create Asset instances
         asset1 = Asset(uri="test://asset1", name="hello1")
         asset2 = Asset(uri="test://asset2", name="hello2")
-
-        # Create and add AssetModel instances to the session
-        am1 = AssetModel(uri=asset1.uri, name=asset1.name, group="asset")
-        am2 = AssetModel(uri=asset2.uri, name=asset2.name, group="asset")
-        session.add_all([am1, am2])
-        session.commit()
 
         # Setup a DAG with complex asset triggers (AssetAny with AssetAll)
         with dag_maker(schedule=AssetAny(asset1, AssetAll(asset2, asset1))) as dag:
             EmptyOperator(task_id="hello")
 
-        assert isinstance(dag.timetable.asset_condition, AssetAny), (
-            "DAG's asset trigger should be an instance of AssetAny"
-        )
-        assert any(isinstance(trigger, AssetAll) for trigger in dag.timetable.asset_condition.objects), (
-            "DAG's asset trigger should include AssetAll"
-        )
+        assert dag.timetable.asset_condition == AssetAny(asset1, AssetAll(asset2, asset1))
 
         serialized_triggers = SerializedDAG.serialize(dag.timetable.asset_condition)
-
         deserialized_triggers = SerializedDAG.deserialize(serialized_triggers)
-
-        assert isinstance(deserialized_triggers, AssetAny), (
-            "Deserialized triggers should be an instance of AssetAny"
-        )
-        assert any(isinstance(trigger, AssetAll) for trigger in deserialized_triggers.objects), (
-            "Deserialized triggers should include AssetAll"
+        assert deserialized_triggers == SerializedAssetAny(
+            [
+                SerializedAsset("hello1", "test://asset1/", "asset", {}, []),
+                SerializedAssetAll(
+                    [
+                        SerializedAsset("hello2", "test://asset2/", "asset", {}, []),
+                        SerializedAsset("hello1", "test://asset1/", "asset", {}, []),
+                    ],
+                ),
+            ],
         )
 
         serialized_timetable_dict = SerializedDAG.to_dict(dag)["dag"]["timetable"]["__var"]
-        assert "asset_condition" in serialized_timetable_dict, (
-            "Serialized timetable should contain 'asset_condition'"
-        )
-        assert isinstance(serialized_timetable_dict["asset_condition"], dict), (
-            "Serialized 'asset_condition' should be a dict"
-        )
+        assert serialized_timetable_dict == {
+            "asset_condition": {
+                "__type": "asset_any",
+                "objects": [
+                    {
+                        "__type": "asset",
+                        "name": "hello1",
+                        "uri": "test://asset1/",
+                        "group": "asset",
+                        "extra": {},
+                    },
+                    {
+                        "__type": "asset_all",
+                        "objects": [
+                            {
+                                "__type": "asset",
+                                "name": "hello2",
+                                "uri": "test://asset2/",
+                                "group": "asset",
+                                "extra": {},
+                            },
+                            {
+                                "__type": "asset",
+                                "name": "hello1",
+                                "uri": "test://asset1/",
+                                "group": "asset",
+                                "extra": {},
+                            },
+                        ],
+                    },
+                ],
+            },
+        }

--- a/providers/openlineage/tests/system/openlineage/example_openlineage_schedule_asset_or_time_dag.py
+++ b/providers/openlineage/tests/system/openlineage/example_openlineage_schedule_asset_or_time_dag.py
@@ -41,7 +41,7 @@ if AIRFLOW_VERSION.major == 3:
     schedule = AssetOrTimeSchedule(
         timetable=CronTriggerTimetable("21 13 29 2 4", timezone="UTC"),
         assets=(
-            (Asset(uri="s3://bucket/file.txt", extra={"a": 1}) | Asset(uri="s3://bucket2/file.txt"))
+            (Asset(uri="s3://bucket/file.txt", extra={"a": 1}) | Asset(uri="s3://bucket2/file.txt"))  # type: ignore[arg-type]
             & (Asset(uri="s3://bucket3/file.txt") | Asset(uri="s3://bucket4/file.txt", extra={"b": 2}))
         ),
     )

--- a/providers/standard/tests/unit/standard/decorators/test_python.py
+++ b/providers/standard/tests/unit/standard/decorators/test_python.py
@@ -1029,27 +1029,22 @@ def test_no_warnings(reset_logging_config, caplog):
     assert caplog.messages == []
 
 
+@pytest.mark.need_serialized_dag
 def test_task_decorator_asset(dag_maker, session):
-    if AIRFLOW_V_3_0_PLUS:
-        from airflow.models.asset import AssetActive, AssetModel
-        from airflow.sdk.definitions.asset import Asset
-    else:
-        from airflow.datasets import Dataset as Asset
-        from airflow.models.dataset import DatasetModel as AssetModel
-
     result = None
     uri = "s3://bucket/name"
     asset_name = "test_asset"
 
     if AIRFLOW_V_3_0_PLUS:
+        from airflow.sdk import Asset
+
         asset = Asset(uri=uri, name=asset_name)
     else:
-        asset = Asset(uri)
-    session.add(AssetModel.from_public(asset))
-    if AIRFLOW_V_3_0_PLUS:
-        session.add(AssetActive.for_asset(asset))
+        from airflow.datasets import Dataset as Asset
 
-    with dag_maker(session=session, serialized=True) as dag:
+        asset = Asset(uri)
+
+    with dag_maker(session=session) as dag:
 
         @dag.task()
         def up1() -> Asset:

--- a/task-sdk/src/airflow/sdk/bases/timetable.py
+++ b/task-sdk/src/airflow/sdk/bases/timetable.py
@@ -17,54 +17,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
-from typing import TYPE_CHECKING, Any
-
-from airflow.sdk.definitions.asset import AssetUniqueKey, BaseAsset
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from sqlalchemy.orm import Session
-
-    from airflow.sdk.definitions.asset import Asset, AssetAlias, AssetRef
-    from airflow.serialization.dag_dependency import DagDependency
-
-
-class NullAsset(BaseAsset):
-    """
-    Sentinel type that represents "no assets".
-
-    This is only implemented to make typing easier in timetables, and not
-    expected to be used anywhere else.
-
-    :meta private:
-    """
-
-    def __bool__(self) -> bool:
-        return False
-
-    def __or__(self, other: BaseAsset) -> BaseAsset:
-        return NotImplemented
-
-    def __and__(self, other: BaseAsset) -> BaseAsset:
-        return NotImplemented
-
-    def as_expression(self) -> Any:
-        return None
-
-    def evaluate(self, statuses: dict[AssetUniqueKey, bool], *, session: Session | None = None) -> bool:
-        return False
-
-    def iter_assets(self) -> Iterator[tuple[AssetUniqueKey, Asset]]:
-        return iter(())
-
-    def iter_asset_aliases(self) -> Iterator[tuple[str, AssetAlias]]:
-        return iter(())
-
-    def iter_asset_refs(self) -> Iterator[AssetRef]:
-        return iter(())
-
-    def iter_dag_dependencies(self, source, target) -> Iterator[DagDependency]:
-        return iter(())
+    from airflow.sdk.definitions.asset import BaseAsset
 
 
 class BaseTimetable:
@@ -89,7 +45,7 @@ class BaseTimetable:
     parallelism, such as ``ContinuousTimetable``.
     """
 
-    asset_condition: BaseAsset = NullAsset()
+    asset_condition: BaseAsset | None = None
 
     def validate(self) -> None:
         """

--- a/task-sdk/src/airflow/sdk/definitions/asset/__init__.py
+++ b/task-sdk/src/airflow/sdk/definitions/asset/__init__.py
@@ -17,29 +17,25 @@
 
 from __future__ import annotations
 
-import json
 import logging
 import operator
 import os
 import urllib.parse
 import warnings
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, overload
+from typing import TYPE_CHECKING, Any, ClassVar, overload
 
 import attrs
 
-from airflow.sdk.api.datamodels._generated import AssetProfile
-from airflow.serialization.dag_dependency import DagDependency
-
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Iterator
+    from collections.abc import Collection
     from urllib.parse import SplitResult
 
     from pydantic.types import JsonValue
+    from typing_extensions import Self
 
-    from airflow.models.asset import AssetModel
+    from airflow.sdk.api.datamodels._generated import AssetProfile
     from airflow.sdk.io.path import ObjectStoragePath
-    from airflow.serialization.definitions.assets import SerializedAssetWatcher
     from airflow.triggers.base import BaseEventTrigger
 
     AttrsInstance = attrs.AttrsInstance
@@ -69,7 +65,7 @@ SQL_ALCHEMY_CONN = conf.get("database", "SQL_ALCHEMY_CONN", fallback="NOT AVAILA
 
 
 @attrs.define(frozen=True)
-class AssetUniqueKey(attrs.AttrsInstance):
+class AssetUniqueKey(AttrsInstance):
     """
     Columns to identify an unique asset.
 
@@ -79,19 +75,12 @@ class AssetUniqueKey(attrs.AttrsInstance):
     name: str
     uri: str
 
-    @staticmethod
-    def from_asset(asset: Asset | AssetModel) -> AssetUniqueKey:
-        return AssetUniqueKey(name=asset.name, uri=asset.uri)
+    @classmethod
+    def from_asset(cls, asset: Asset) -> Self:
+        return cls(name=asset.name, uri=asset.uri)
 
     def to_asset(self) -> Asset:
         return Asset(name=self.name, uri=self.uri)
-
-    @staticmethod
-    def from_str(key: str) -> AssetUniqueKey:
-        return AssetUniqueKey(**json.loads(key))
-
-    def to_str(self) -> str:
-        return json.dumps(attrs.asdict(self))
 
     @staticmethod
     def from_profile(profile: AssetProfile) -> AssetUniqueKey:
@@ -116,9 +105,9 @@ class AssetAliasUniqueKey:
 
     name: str
 
-    @staticmethod
-    def from_asset_alias(asset_alias: AssetAlias) -> AssetAliasUniqueKey:
-        return AssetAliasUniqueKey(name=asset_alias.name)
+    @classmethod
+    def from_asset_alias(cls, asset_alias: AssetAlias) -> Self:
+        return cls(name=asset_alias.name)
 
     def to_asset_alias(self) -> AssetAlias:
         return AssetAlias(name=self.name)
@@ -238,9 +227,6 @@ class BaseAsset:
     :meta private:
     """
 
-    def __bool__(self) -> bool:
-        return True
-
     def __or__(self, other: BaseAsset) -> BaseAsset:
         if not isinstance(other, BaseAsset):
             return NotImplemented
@@ -250,34 +236,6 @@ class BaseAsset:
         if not isinstance(other, BaseAsset):
             return NotImplemented
         return AssetAll(self, other)
-
-    def as_expression(self) -> Any:
-        """
-        Serialize the asset into its scheduling expression.
-
-        The return value is stored in DagModel for display purposes. It must be
-        JSON-compatible.
-
-        :meta private:
-        """
-        raise NotImplementedError
-
-    def iter_assets(self) -> Iterator[tuple[AssetUniqueKey, Asset]]:
-        raise NotImplementedError
-
-    def iter_asset_aliases(self) -> Iterator[tuple[str, AssetAlias]]:
-        raise NotImplementedError
-
-    def iter_asset_refs(self) -> Iterator[AssetRef]:
-        raise NotImplementedError
-
-    def iter_dag_dependencies(self, *, source: str, target: str) -> Iterator[DagDependency]:
-        """
-        Iterate a base asset as dag dependency.
-
-        :meta private:
-        """
-        raise NotImplementedError
 
 
 def _validate_asset_watcher_trigger(instance, attribute, value):
@@ -315,7 +273,7 @@ class Asset(os.PathLike, BaseAsset):
         factory=dict,
         converter=_set_extra_default,
     )
-    watchers: list[AssetWatcher | SerializedAssetWatcher] = attrs.field(
+    watchers: list[AssetWatcher] = attrs.field(
         factory=list,
     )
 
@@ -330,7 +288,7 @@ class Asset(os.PathLike, BaseAsset):
         *,
         group: str = ...,
         extra: dict[str, JsonValue] | None = None,
-        watchers: list[AssetWatcher | SerializedAssetWatcher] = ...,
+        watchers: list[AssetWatcher] = ...,
     ) -> None:
         """Canonical; both name and uri are provided."""
 
@@ -341,7 +299,7 @@ class Asset(os.PathLike, BaseAsset):
         *,
         group: str = ...,
         extra: dict[str, JsonValue] | None = None,
-        watchers: list[AssetWatcher | SerializedAssetWatcher] = ...,
+        watchers: list[AssetWatcher] = ...,
     ) -> None:
         """It's possible to only provide the name, either by keyword or as the only positional argument."""
 
@@ -352,7 +310,7 @@ class Asset(os.PathLike, BaseAsset):
         uri: str | ObjectStoragePath,
         group: str = ...,
         extra: dict[str, JsonValue] | None = None,
-        watchers: list[AssetWatcher | SerializedAssetWatcher] = ...,
+        watchers: list[AssetWatcher] = ...,
     ) -> None:
         """It's possible to only provide the URI as a keyword argument."""
 
@@ -363,7 +321,7 @@ class Asset(os.PathLike, BaseAsset):
         *,
         group: str | None = None,
         extra: dict[str, JsonValue] | None = None,
-        watchers: list[AssetWatcher | SerializedAssetWatcher] | None = None,
+        watchers: list[AssetWatcher] | None = None,
     ) -> None:
         if name is None and uri is None:
             raise TypeError("Asset() requires either 'name' or 'uri'")
@@ -444,47 +402,6 @@ class Asset(os.PathLike, BaseAsset):
         except ValueError:
             return None
 
-    def as_expression(self) -> Any:
-        """
-        Serialize the asset into its scheduling expression.
-
-        :meta private:
-        """
-        return {"asset": {"uri": self.uri, "name": self.name, "group": self.group}}
-
-    def iter_assets(self) -> Iterator[tuple[AssetUniqueKey, Asset]]:
-        yield AssetUniqueKey.from_asset(self), self
-
-    def iter_asset_aliases(self) -> Iterator[tuple[str, AssetAlias]]:
-        return iter(())
-
-    def iter_asset_refs(self) -> Iterator[AssetRef]:
-        return iter(())
-
-    def iter_dag_dependencies(self, *, source: str, target: str) -> Iterator[DagDependency]:
-        """
-        Iterate an asset as dag dependency.
-
-        :meta private:
-        """
-        yield DagDependency(
-            source=source or "asset",
-            target=target or "asset",
-            label=self.name,
-            dependency_type="asset",
-            # We can't get asset id at this stage.
-            # This will be updated when running SerializedDagModel.get_dag_dependencies
-            dependency_id=AssetUniqueKey.from_asset(self).to_str(),
-        )
-
-    def asprofile(self) -> AssetProfile:
-        """
-        Profiles Asset to AssetProfile.
-
-        :meta private:
-        """
-        return AssetProfile(name=self.name or None, uri=self.uri or None, type=Asset.__name__)
-
 
 class AssetRef(BaseAsset, AttrsInstance):
     """
@@ -496,30 +413,6 @@ class AssetRef(BaseAsset, AttrsInstance):
     :meta private:
     """
 
-    _dependency_type: Literal["asset-name-ref", "asset-uri-ref"]
-
-    def as_expression(self) -> Any:
-        return {"asset_ref": attrs.asdict(self)}
-
-    def iter_assets(self) -> Iterator[tuple[AssetUniqueKey, Asset]]:
-        return iter(())
-
-    def iter_asset_aliases(self) -> Iterator[tuple[str, AssetAlias]]:
-        return iter(())
-
-    def iter_asset_refs(self) -> Iterator[AssetRef]:
-        yield self
-
-    def iter_dag_dependencies(self, *, source: str = "", target: str = "") -> Iterator[DagDependency]:
-        (dependency_id,) = attrs.astuple(self)
-        yield DagDependency(
-            source=source or self._dependency_type,
-            target=target or self._dependency_type,
-            label=dependency_id,
-            dependency_type=self._dependency_type,
-            dependency_id=dependency_id,
-        )
-
 
 @attrs.define(hash=True)
 class AssetNameRef(AssetRef):
@@ -527,16 +420,12 @@ class AssetNameRef(AssetRef):
 
     name: str
 
-    _dependency_type = "asset-name-ref"
-
 
 @attrs.define(hash=True)
 class AssetUriRef(AssetRef):
     """URI reference to an asset."""
 
     uri: str
-
-    _dependency_type = "asset-uri-ref"
 
 
 class Dataset(Asset):
@@ -551,43 +440,16 @@ class Model(Asset):
     asset_type: ClassVar[str] = "model"
 
 
-@attrs.define(unsafe_hash=False)
+@attrs.define(hash=True)
 class AssetAlias(BaseAsset):
-    """A representation of asset alias which is used to create asset during the runtime."""
+    """
+    A representation of an asset alias.
+
+    An asset alias can be used to create assets at task execution time.
+    """
 
     name: str = attrs.field(validator=_validate_non_empty_identifier)
     group: str = attrs.field(kw_only=True, default="asset", validator=_validate_identifier)
-
-    def as_expression(self) -> Any:
-        """
-        Serialize the asset alias into its scheduling expression.
-
-        :meta private:
-        """
-        return {"alias": {"name": self.name, "group": self.group}}
-
-    def iter_assets(self) -> Iterator[tuple[AssetUniqueKey, Asset]]:
-        return iter(())
-
-    def iter_asset_aliases(self) -> Iterator[tuple[str, AssetAlias]]:
-        yield self.name, self
-
-    def iter_asset_refs(self) -> Iterator[AssetRef]:
-        return iter(())
-
-    def iter_dag_dependencies(self, *, source: str = "", target: str = "") -> Iterator[DagDependency]:
-        """
-        Iterate an asset alias and its resolved assets as dag dependency.
-
-        :meta private:
-        """
-        yield DagDependency(
-            source=source or "asset-alias",
-            target=target or "asset-alias",
-            label=self.name,
-            dependency_type="asset-alias",
-            dependency_id=self.name,
-        )
 
 
 class AssetBooleanCondition(BaseAsset):
@@ -597,39 +459,24 @@ class AssetBooleanCondition(BaseAsset):
     :meta private:
     """
 
-    agg_func: Callable[[Iterable], bool]
+    objects: Collection[BaseAsset]
 
     def __init__(self, *objects: BaseAsset) -> None:
         if not all(isinstance(o, BaseAsset) for o in objects):
             raise TypeError("expect asset expressions in condition")
         self.objects = objects
 
-    def iter_assets(self) -> Iterator[tuple[AssetUniqueKey, Asset]]:
-        for o in self.objects:
-            yield from o.iter_assets()
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return self.objects == other.objects
 
-    def iter_asset_aliases(self) -> Iterator[tuple[str, AssetAlias]]:
-        for o in self.objects:
-            yield from o.iter_asset_aliases()
-
-    def iter_asset_refs(self) -> Iterator[AssetRef]:
-        for o in self.objects:
-            yield from o.iter_asset_refs()
-
-    def iter_dag_dependencies(self, *, source: str, target: str) -> Iterator[DagDependency]:
-        """
-        Iterate asset, asset aliases and their resolved assets  as dag dependency.
-
-        :meta private:
-        """
-        for obj in self.objects:
-            yield from obj.iter_dag_dependencies(source=source, target=target)
+    def __hash__(self) -> int:
+        return hash(tuple(self.objects))
 
 
 class AssetAny(AssetBooleanCondition):
     """Use to combine assets schedule references in an "or" relationship."""
-
-    agg_func = any  # type: ignore[assignment]
 
     def __or__(self, other: BaseAsset) -> BaseAsset:
         if not isinstance(other, BaseAsset):
@@ -639,14 +486,6 @@ class AssetAny(AssetBooleanCondition):
 
     def __repr__(self) -> str:
         return f"AssetAny({', '.join(map(str, self.objects))})"
-
-    def as_expression(self) -> dict[str, Any]:
-        """
-        Serialize the asset into its scheduling expression.
-
-        :meta private:
-        """
-        return {"any": [o.as_expression() for o in self.objects]}
 
 
 class AssetAll(AssetBooleanCondition):
@@ -662,14 +501,6 @@ class AssetAll(AssetBooleanCondition):
 
     def __repr__(self) -> str:
         return f"AssetAll({', '.join(map(str, self.objects))})"
-
-    def as_expression(self) -> Any:
-        """
-        Serialize the assets into its scheduling expression.
-
-        :meta private:
-        """
-        return {"all": [o.as_expression() for o in self.objects]}
 
 
 @attrs.define

--- a/task-sdk/tests/task_sdk/definitions/test_asset.py
+++ b/task-sdk/tests/task_sdk/definitions/test_asset.py
@@ -17,7 +17,6 @@
 
 from __future__ import annotations
 
-import json
 import os
 from collections.abc import Callable
 from unittest import mock
@@ -28,7 +27,6 @@ from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.sdk.api.datamodels._generated import AssetProfile
 from airflow.sdk.definitions.asset import (
     Asset,
-    AssetAlias,
     AssetAll,
     AssetAny,
     AssetUniqueKey,
@@ -40,6 +38,7 @@ from airflow.sdk.definitions.asset import (
 )
 from airflow.sdk.definitions.dag import DAG
 from airflow.sdk.io import ObjectStoragePath
+from airflow.serialization.definitions.assets import SerializedAsset, SerializedAssetAny
 from airflow.serialization.serialized_objects import SerializedDAG
 
 ASSET_MODULE_PATH = "airflow.sdk.definitions.asset"
@@ -206,27 +205,6 @@ def test_asset_logic_operations():
     assert isinstance(result_and, AssetAll)
 
 
-def test_asset_iter_assets():
-    assert list(asset1.iter_assets()) == [(AssetUniqueKey("asset-1", "s3://bucket1/data1"), asset1)]
-
-
-def test_asset_iter_asset_aliases():
-    base_asset = AssetAll(
-        AssetAlias(name="example-alias-1"),
-        Asset("1"),
-        AssetAny(
-            Asset(name="2", uri="test://asset1"),
-            AssetAlias("example-alias-2"),
-            Asset(name="3"),
-            AssetAll(AssetAlias("example-alias-3"), Asset("4"), AssetAlias("example-alias-4")),
-        ),
-        AssetAll(AssetAlias("example-alias-5"), Asset("5")),
-    )
-    assert list(base_asset.iter_asset_aliases()) == [
-        (f"example-alias-{i}", AssetAlias(f"example-alias-{i}")) for i in range(1, 6)
-    ]
-
-
 def test_asset_any_operations():
     result_or = (asset1 | asset2) | asset3
     assert isinstance(result_or, AssetAny)
@@ -262,11 +240,11 @@ def test_asset_trigger_setup_and_serialization(create_test_assets):
     deserialized_dag = SerializedDAG.deserialize_dag(SerializedDAG.serialize_dag(dag))
 
     # Verify serialization and deserialization integrity
-    assert isinstance(deserialized_dag.timetable.asset_condition, AssetAny), (
-        "Deserialized assets should maintain type AssetAny"
-    )
-    assert deserialized_dag.timetable.asset_condition.objects == dag.timetable.asset_condition.objects, (
-        "Deserialized assets should match original"
+    assert deserialized_dag.timetable.asset_condition == SerializedAssetAny(
+        [
+            SerializedAsset(name="hello1", uri="test://asset1/", group="asset", extra={}, watchers=[]),
+            SerializedAsset(name="hello2", uri="test://asset2/", group="asset", extra={}, watchers=[]),
+        ],
     )
 
 
@@ -418,23 +396,9 @@ def test_normalize_uri_valid_uri(mock_get_normalized_scheme):
 
 
 class TestAssetUniqueKey:
-    def test_from_asset(self):
-        asset = Asset(name="test", uri="test://test/")
-
-        assert AssetUniqueKey.from_asset(asset) == AssetUniqueKey(name="test", uri="test://test/")
-
     def test_to_asset(self):
         assert AssetUniqueKey(name="test", uri="test://test/").to_asset() == Asset(
             name="test", uri="test://test/"
-        )
-
-    def test_from_str(self):
-        json_str = json.dumps({"name": "test", "uri": "test://test/"})
-        assert AssetUniqueKey.from_str(json_str) == AssetUniqueKey(name="test", uri="test://test/")
-
-    def test_to_str(self):
-        assert AssetUniqueKey(name="test", uri="test://test/").to_str() == json.dumps(
-            {"name": "test", "uri": "test://test/"}
         )
 
     @pytest.mark.parametrize(
@@ -448,12 +412,6 @@ class TestAssetUniqueKey:
     def test_from_profile(self, name, uri, expected_asset_unique_key):
         profile = AssetProfile(name=name, uri=uri, type="Asset")
         assert AssetUniqueKey.from_profile(profile) == expected_asset_unique_key
-
-
-class TestAssetAlias:
-    def test_as_expression(self):
-        alias = AssetAlias(name="test_name", group="test")
-        assert alias.as_expression() == {"alias": {"name": alias.name, "group": alias.group}}
 
 
 class TestAssetSubclasses:


### PR DESCRIPTION
Next for #52141.

All asset-related classes now have a counterpart in `airflow.serializatio.definitions.assets` prefixed with _Serialized_. Many tweaks in Core to use those types instead.

While working on this, I realised the partition work also currently breaks the SDK-Core boundary. (Specifically PartitionMapper.) We need to figure out a way to do this correctly… cc @Lee-W @dstandish 