### PR TITLE
Fix go back button from fab security iframe

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Security.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Security.tsx
@@ -18,6 +18,7 @@
  */
 import { Box } from "@chakra-ui/react";
 import { useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 import { useAuthLinksServiceGetAuthMenus } from "openapi/queries";
 import { ProgressBar } from "src/components/ui";
@@ -37,6 +38,16 @@ export const Security = () => {
 
   const link = authLinks?.extra_menu_items.find((mi) => mi.text.toLowerCase().replace(" ", "-") === page);
 
+  const navigate = useNavigate();
+
+  const onLoad = () => {
+    const iframe: HTMLIFrameElement | null = document.querySelector("#security-iframe");
+
+    if (iframe?.contentWindow && !iframe.contentWindow.location.pathname.startsWith("/auth/")) {
+      navigate("/");
+    }
+  };
+
   if (!link) {
     if (isLoading) {
       return (
@@ -51,7 +62,17 @@ export const Security = () => {
 
   return (
     <Box flexGrow={1} m={-3}>
-      <iframe sandbox={SANDBOX} src={link.href} style={{ height: "100%", width: "100%" }} title={link.text} />
+      {
+        // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
+        <iframe
+          id="security-iframe"
+          onLoad={onLoad}
+          sandbox={SANDBOX}
+          src={link.href}
+          style={{ height: "100%", width: "100%" }}
+          title={link.text}
+        />
+      }
     </Box>
   );
 };


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/58032

This is not perfect as it will always redirect to the app homepage (not the true host 'previous' page, i.e if I'm coming from `browse`, it won't go back to browse, same for grid view for instance, everything will go back to the homepage from the fab security iframe), that's an easy first step resolution. We can always improve if we feel like this minor drawback should be fixed.

https://github.com/user-attachments/assets/e046d20f-b688-43c7-a5f9-fec2cdd50bdd

