### PR TITLE
Fix deferred mode KubernetesPodOperator:  fast-fail pod start errors (ErrImagePull/ImagePullBackOff)

### DIFF
--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_pod_manager.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_pod_manager.py
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
 def pod_factory():
     def _make(
         *,
-        pod_phase: PodPhase = PodPhase.RUNNING,
+        pod_phase: str = PodPhase.RUNNING,
         container_name: str = "base",
         terminated: bool = False,
         waiting_reason: str | None = None,


### PR DESCRIPTION
# Overview

We found an issue with deferred mode and ErrImagePull handling. When the Triggerer emits an error event and the pod enters ErrImagePull, the KubernetesPodOperator continues waiting in await_pod_completion even though the pod will never start (image does not exist). This PR applies the same fast-fail logic used during startup to await_pod_completion, aborting the wait when image pull errors are detected. It also includes ImagePullBackOff so long check intervals don’t cause unnecessary retries and timeouts.


# Change Summary

* Add ImagePullBackOff to fast-fail detection.
* Apply fast-fail detection in await_pod_completion to stop waiting on pods that cannot start.
* Add unit tests covering await_pod_completion image pull error paths.
