### PR TITLE
Shorten the path to import conf from airflow task sdk

### DIFF
--- a/task-sdk/docs/api.rst
+++ b/task-sdk/docs/api.rst
@@ -30,7 +30,7 @@ Defining Dags
 
 Configuration
 -------------
-.. autoapiclass:: airflow.sdk.conf
+.. autodata:: airflow.sdk.conf
 
 Decorators
 ----------

--- a/task-sdk/docs/api.rst
+++ b/task-sdk/docs/api.rst
@@ -28,6 +28,10 @@ Defining Dags
 .. autoapiclass:: airflow.sdk.DAG
 
 
+Configuration
+-------------
+.. autoapiclass:: airflow.sdk.conf
+
 Decorators
 ----------
 .. autoapifunction:: airflow.sdk.dag

--- a/task-sdk/docs/api.rst
+++ b/task-sdk/docs/api.rst
@@ -30,7 +30,9 @@ Defining Dags
 
 Configuration
 -------------
-.. autodata:: airflow.sdk.conf
+
+The ``conf`` object is available as part of the Task SDK. It provides an interface to the
+configurations, allowing you to read and interact with Airflow configuration values.
 
 Decorators
 ----------

--- a/task-sdk/src/airflow/sdk/__init__.py
+++ b/task-sdk/src/airflow/sdk/__init__.py
@@ -56,6 +56,7 @@ __all__ = [
     "asset",
     "chain",
     "chain_linear",
+    "conf",
     "cross_downstream",
     "dag",
     "get_current_context",
@@ -72,6 +73,9 @@ __version__ = "1.2.0"
 if TYPE_CHECKING:
     from airflow.sdk.api.datamodels._generated import DagRunState, TaskInstanceState, TriggerRule, WeightRule
     from airflow.sdk.bases.hook import BaseHook
+    from airflow.sdk.configuration import AirflowSDKConfigParser
+
+    conf: AirflowSDKConfigParser
     from airflow.sdk.bases.notifier import BaseNotifier
     from airflow.sdk.bases.operator import BaseOperator, chain, chain_linear, cross_downstream
     from airflow.sdk.bases.operatorlink import BaseOperatorLink
@@ -141,6 +145,7 @@ __lazy_imports: dict[str, str] = {
     "asset": ".definitions.asset.decorators",
     "chain": ".bases.operator",
     "chain_linear": ".bases.operator",
+    "conf": ".configuration",
     "cross_downstream": ".bases.operator",
     "dag": ".definitions.dag",
     "get_current_context": ".definitions.context",

--- a/task-sdk/src/airflow/sdk/__init__.py
+++ b/task-sdk/src/airflow/sdk/__init__.py
@@ -73,13 +73,11 @@ __version__ = "1.2.0"
 if TYPE_CHECKING:
     from airflow.sdk.api.datamodels._generated import DagRunState, TaskInstanceState, TriggerRule, WeightRule
     from airflow.sdk.bases.hook import BaseHook
-    from airflow.sdk.configuration import AirflowSDKConfigParser
-
-    conf: AirflowSDKConfigParser
     from airflow.sdk.bases.notifier import BaseNotifier
     from airflow.sdk.bases.operator import BaseOperator, chain, chain_linear, cross_downstream
     from airflow.sdk.bases.operatorlink import BaseOperatorLink
     from airflow.sdk.bases.sensor import BaseSensorOperator, PokeReturnValue
+    from airflow.sdk.configuration import AirflowSDKConfigParser
     from airflow.sdk.definitions.asset import Asset, AssetAlias, AssetAll, AssetAny, AssetWatcher
     from airflow.sdk.definitions.asset.decorators import asset
     from airflow.sdk.definitions.asset.metadata import Metadata
@@ -106,6 +104,8 @@ if TYPE_CHECKING:
     from airflow.sdk.definitions.variable import Variable
     from airflow.sdk.definitions.xcom_arg import XComArg
     from airflow.sdk.io.path import ObjectStoragePath
+
+    conf: AirflowSDKConfigParser
 
 __lazy_imports: dict[str, str] = {
     "Asset": ".definitions.asset",

--- a/task-sdk/src/airflow/sdk/__init__.pyi
+++ b/task-sdk/src/airflow/sdk/__init__.pyi
@@ -34,6 +34,7 @@ from airflow.sdk.bases.sensor import (
     BaseSensorOperator as BaseSensorOperator,
     PokeReturnValue as PokeReturnValue,
 )
+from airflow.sdk.configuration import AirflowSDKConfigParser
 from airflow.sdk.definitions.asset import (
     Asset as Asset,
     AssetAlias as AssetAlias,
@@ -71,6 +72,8 @@ from airflow.sdk.definitions.variable import Variable as Variable
 from airflow.sdk.definitions.xcom_arg import XComArg as XComArg
 from airflow.sdk.execution_time.cache import SecretCache as SecretCache
 from airflow.sdk.io.path import ObjectStoragePath as ObjectStoragePath
+
+conf: AirflowSDKConfigParser
 
 __all__ = [
     "__version__",
@@ -120,6 +123,7 @@ __all__ = [
     "task",
     "task_group",
     "teardown",
+    "conf",
 ]
 
 __version__: str

--- a/task-sdk/src/airflow/sdk/configuration.py
+++ b/task-sdk/src/airflow/sdk/configuration.py
@@ -144,7 +144,7 @@ class AirflowSDKConfigParser(_SharedAirflowConfigParser):
 
         Unit tests load values from `unit_tests.cfg` to ensure consistent behavior. Realistically we should
         not have this needed but this is temporary to help fix the tests that use dag_maker and rely on few
-        confs.
+        configurations.
 
         The SDK does not expand template variables (FERNET_KEY, JWT_SECRET_KEY, etc.) because it does not use
         the config fields that require expansion.

--- a/task-sdk/tests/task_sdk/docs/test_docs_inventory.py
+++ b/task-sdk/tests/task_sdk/docs/test_docs_inventory.py
@@ -76,7 +76,8 @@ def test_docs_inventory_matches_public_api(tmp_path):
     public = set(getattr(sdk, "__all__", [])) - {"__version__"}
 
     extras = {"AirflowParsingContext"}
-    excluded_from_docs = set()
+    # we do not want to document the class for `conf` but a description is present in the docs
+    excluded_from_docs = {"conf"}
     missing = (public - documented) - excluded_from_docs
     assert not missing, f"Public API items missing in docs: {missing}"
     unexpected = (documented - public) - extras


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

`from airflow.sdk.configuration import conf` is too long of a path for users and providers to consume `conf` from. It would be much more convenient if it were `from airflow.sdk import conf`

Tested that below works as expected:
```python
from airflow.sdk import conf
conf.get("core", "security")
Out[3]: ''
conf.get("api", "port")
Out[4]: '8080'
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
