### PR TITLE
Fixing LLM providers tests

### DIFF
--- a/providers/pinecone/tests/system/pinecone/example_create_pod_index.py
+++ b/providers/pinecone/tests/system/pinecone/example_create_pod_index.py
@@ -26,27 +26,26 @@ try:
 except ImportError:
     # Airflow 2 path
     from airflow.decorators import task, teardown  # type: ignore[attr-defined,no-redef]
-from airflow.providers.pinecone.operators.pinecone import CreatePodIndexOperator
+from airflow.providers.pinecone.operators.pinecone import CreateServerlessIndexOperator
 
 index_name = os.getenv("INDEX_NAME", "test")
 
 
 with DAG(
     "example_pinecone_create_pod_index",
-    schedule="@once",
+    schedule=None,
     start_date=datetime(2024, 1, 1),
     catchup=False,
 ) as dag:
     # [START howto_operator_create_pod_index]
     # reference: https://docs.pinecone.io/reference/api/control-plane/create_index
-    create_index = CreatePodIndexOperator(
+    create_index = CreateServerlessIndexOperator(
         task_id="pinecone_create_pod_index",
         index_name=index_name,
         dimension=3,
-        replicas=1,
-        shards=1,
-        pods=1,
-        pod_type="p1.x1",
+        cloud="aws",
+        region="us-west-2",
+        metric="cosine",
     )
     # [END howto_operator_create_pod_index]
 

--- a/providers/pinecone/tests/system/pinecone/example_pinecone_cohere.py
+++ b/providers/pinecone/tests/system/pinecone/example_pinecone_cohere.py
@@ -25,11 +25,13 @@ try:
     from airflow.sdk import task, teardown
 except ImportError:
     # Airflow 2 path
-    from airflow.decorators import setup, task, teardown  # type: ignore[attr-defined,no-redef]
+    from airflow.decorators import task, teardown  # type: ignore[attr-defined,no-redef]
 from airflow.providers.cohere.operators.embedding import CohereEmbeddingOperator
-from airflow.providers.pinecone.operators.pinecone import PineconeIngestOperator, \
-    CreateServerlessIndexOperator
 from airflow.providers.pinecone.hooks.pinecone import PineconeHook
+from airflow.providers.pinecone.operators.pinecone import (
+    CreateServerlessIndexOperator,
+    PineconeIngestOperator,
+)
 
 index_name = os.getenv("INDEX_NAME", "example-pinecone-index")
 namespace = os.getenv("NAMESPACE", "example-pinecone-index")
@@ -43,7 +45,6 @@ with DAG(
     start_date=datetime(2023, 1, 1),
     catchup=False,
 ) as dag:
-
     create_index = CreateServerlessIndexOperator(
         task_id="pinecone_create_serverless_index",
         index_name=index_name,
@@ -76,7 +77,6 @@ with DAG(
     @teardown
     @task
     def delete_index():
-
         hook = PineconeHook()
         hook.delete_index(index_name=index_name)
 

--- a/providers/pinecone/tests/system/pinecone/example_pinecone_cohere.py
+++ b/providers/pinecone/tests/system/pinecone/example_pinecone_cohere.py
@@ -22,7 +22,7 @@ from datetime import datetime
 from airflow import DAG
 
 try:
-    from airflow.sdk import setup, task, teardown
+    from airflow.sdk import task, teardown
 except ImportError:
     # Airflow 2 path
     from airflow.decorators import setup, task, teardown  # type: ignore[attr-defined,no-redef]

--- a/providers/pinecone/tests/system/pinecone/example_pinecone_openai.py
+++ b/providers/pinecone/tests/system/pinecone/example_pinecone_openai.py
@@ -27,7 +27,10 @@ except ImportError:
     # Airflow 2 path
     from airflow.decorators import task, teardown  # type: ignore[attr-defined,no-redef]
 from airflow.providers.openai.operators.openai import OpenAIEmbeddingOperator
-from airflow.providers.pinecone.operators.pinecone import CreateServerlessIndexOperator, PineconeIngestOperator
+from airflow.providers.pinecone.operators.pinecone import (
+    CreateServerlessIndexOperator,
+    PineconeIngestOperator,
+)
 
 index_name = os.getenv("INDEX_NAME", "example-pinecone-index")
 namespace = os.getenv("NAMESPACE", "example-pinecone-index")

--- a/providers/pinecone/tests/system/pinecone/example_pinecone_openai.py
+++ b/providers/pinecone/tests/system/pinecone/example_pinecone_openai.py
@@ -27,7 +27,7 @@ except ImportError:
     # Airflow 2 path
     from airflow.decorators import task, teardown  # type: ignore[attr-defined,no-redef]
 from airflow.providers.openai.operators.openai import OpenAIEmbeddingOperator
-from airflow.providers.pinecone.operators.pinecone import CreatePodIndexOperator, PineconeIngestOperator
+from airflow.providers.pinecone.operators.pinecone import CreateServerlessIndexOperator, PineconeIngestOperator
 
 index_name = os.getenv("INDEX_NAME", "example-pinecone-index")
 namespace = os.getenv("NAMESPACE", "example-pinecone-index")
@@ -79,10 +79,13 @@ with DAG(
     start_date=datetime(2023, 1, 1),
     catchup=False,
 ) as dag:
-    create_index = CreatePodIndexOperator(
+    create_index = CreateServerlessIndexOperator(
         task_id="create_index",
         index_name=index_name,
         dimension=1536,
+        cloud="aws",
+        region="us-west-2",
+        metric="cosine",
     )
 
     embed_task = OpenAIEmbeddingOperator(


### PR DESCRIPTION
DESCRIPTION: Pinecone index creation has shifted from server to serverless and due to this, our LLM provider tests started failing, this PR is to fix the same.

TESTS:
Before:
<img width="1911" height="954" alt="image" src="https://github.com/user-attachments/assets/091ffe8e-276a-4878-baf7-7c439f6eafe6" />

After:
<img width="1850" height="691" alt="image" src="https://github.com/user-attachments/assets/512aeeeb-1e97-4836-8555-be7aec48f2d6" />
