### PR TITLE
Fix : 'airflow connections test' failure by adding DB fallback

### DIFF
--- a/airflow-core/src/airflow/cli/commands/connection_command.py
+++ b/airflow-core/src/airflow/cli/commands/connection_command.py
@@ -367,9 +367,15 @@ def connections_test(args) -> None:
         raise SystemExit(1)
 
     print(f"Retrieving connection: {args.conn_id!r}")
+    conn = None
     try:
         conn = Connection.get_connection_from_secrets(args.conn_id)
     except AirflowNotFoundException:
+        pass
+    if conn is None:
+        with create_session() as session:
+            conn = session.scalar(select(Connection).where(Connection.conn_id == args.conn_id))
+    if conn is None:
         console.print("[bold yellow]\nConnection not found.\n")
         raise SystemExit(1)
 


### PR DESCRIPTION
## Description
This PR resolves an issue where the `airflow connections test` CLI command would fail with "Connection not found" or "conn_id isn't defined", even when the connection was clearly visible using `airflow connections list`.

**The Issue:**
Previously, `connections_test` relied solely on `Connection.get_connection_from_secrets(args.conn_id)`. If the secrets backend failed to retrieve the connection (e.g., due to environment issues or Hook initialization failures), the CLI would exit with an error, ignoring the fact that the connection might exist in the Metastore Database.
In contrast, `connections_list` queries the database directly, creating a discrepancy between the two commands.

**The Fix:**
I have updated `airflow/cli/commands/connection_command.py` to implement a fallback mechanism:
1. It first attempts to retrieve the connection via the Secrets Backend (existing behavior).
2. If that fails (throws `AirflowNotFoundException` or returns `None`), it now explicitly checks the Database using `create_session`.
3. This ensures that if a connection exists in the DB, the CLI can still attempt to test it.

## Related Issue
Closes #58567

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
