### PR TITLE
Add S3CopyPrefixOperator for copying objects by prefix

### DIFF
--- a/providers/amazon/docs/operators/s3/s3.rst
+++ b/providers/amazon/docs/operators/s3/s3.rst
@@ -129,6 +129,21 @@ The Amazon S3 connection used here needs to have access to both source and desti
     :start-after: [START howto_operator_s3_copy_object]
     :end-before: [END howto_operator_s3_copy_object]
 
+.. _howto/operator:S3CopyPrefixOperator:
+
+Copy Amazon S3 objects by prefix
+================================
+
+To copy all Amazon S3 objects under a prefix from one bucket to another you can use
+:class:`~airflow.providers.amazon.aws.operators.s3.S3CopyPrefixOperator`.
+The Amazon S3 connection used here needs to have access to both source and destination bucket/prefix.
+
+.. exampleinclude:: /../../amazon/tests/system/amazon/aws/example_s3.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_s3_copy_prefix]
+    :end-before: [END howto_operator_s3_copy_prefix]
+
 .. _howto/operator:S3DeleteObjectsOperator:
 
 Delete Amazon S3 objects

--- a/providers/amazon/tests/system/amazon/aws/example_s3.py
+++ b/providers/amazon/tests/system/amazon/aws/example_s3.py
@@ -20,6 +20,7 @@ from datetime import datetime
 
 from airflow.providers.amazon.aws.operators.s3 import (
     S3CopyObjectOperator,
+    S3CopyPrefixOperator,
     S3CreateBucketOperator,
     S3CreateObjectOperator,
     S3DeleteBucketOperator,
@@ -245,6 +246,17 @@ with DAG(
     )
     # [END howto_operator_s3_copy_object]
 
+    # [START howto_operator_s3_copy_prefix]
+    copy_prefix = S3CopyPrefixOperator(
+        task_id="copy_prefix",
+        source_bucket_name=bucket_name,
+        source_bucket_prefix="",
+        dest_bucket_name=bucket_name_2,
+        dest_bucket_prefix="copied/",
+        page_size=800,
+    )
+    # [END howto_operator_s3_copy_prefix]
+
     # [START howto_operator_s3_file_transform]
     file_transform = S3FileTransformOperator(
         task_id="file_transform",
@@ -311,6 +323,7 @@ with DAG(
             sensor_key_with_regex_deferrable,
         ],
         copy_object,
+        copy_prefix,
         file_transform,
         sensor_keys_unchanged,
         # TEST TEARDOWN


### PR DESCRIPTION
## Add S3CopyPrefixOperator for copying objects by prefix

### Description

This PR introduces a new ```S3CopyPrefixOperator``` that enables copying all S3 objects under a specified prefix from a source bucket to a destination bucket. This operator fills a gap in the current S3 operators by providing prefix-based bulk copy functionality.

### What does this operator do?

• Copies all objects matching a specified prefix from source to destination S3 bucket
• Supports cross-bucket
• Handles large datasets through pagination
• Provides configurable error handling (continue on failure or stop on first error)
• Integrates with OpenLineage for data lineage tracking
• Supports Airflow templating for dynamic parameter values

### Why is this needed?

Currently, Airflow's S3 operators allow copying individual objects. For use cases involving copying entire "directory" structures or large numbers of objects sharing a common prefix, users must implement custom solutions or use multiple operator instances. 
This operator provides a native, efficient solution for prefix-based bulk operations.

### Key Features

• **Pagination Support**: Automatically handles large object lists using S3's pagination
• **Error Handling**: Configurable ```continue_on_failure``` parameter for resilient operations
• **Template Fields**: All key parameters support Jinja templating
• **OpenLineage Integration**: Automatic data lineage tracking for copied objects
• **Standard Exception Handling**: Uses RuntimeError following new Airflow guidelines

### Implementation Details

• **Base Class**: Based on ```S3CopyObjectOperator``` for consistency
• **Dependencies**: Uses existing ```S3Hook``` and AWS connection infrastructure
• **Documentation**: Updated ```providers/amazon/docs/operators/s3/s3.rst``` with operator documentation
• **Error Handling**: Follows new Airflow guidelines using standard Python exceptions

### Testing

Includes **14  new unit tests** covering:
  • Basic functionality and successful copying
  • Error scenarios and exception handling
  • Pagination configuration
  • Continue on failure behavior
  • OpenLineage integration
  • Template field functionality

• **System test integration** in ```tests/system/providers/amazon/aws/example_s3.py```
• **All tests pass** in Breeze testing environment

### Usage Example

```python
copy_prefix = S3CopyPrefixOperator(
    task_id='copy_data_files',                                                                                                                                                                                                                                                       
    source_bucket_name='source-bucket',                                                                                                                                                                                                                                              
    source_bucket_key='data/2023/',                                                                                                                                                                                                                                                  
    dest_bucket_name='dest-bucket',                                                                                                                                                                                                                                                  
    dest_bucket_key='archive/data/2023/',                                                                                                                                                                                                                                            
    continue_on_failure=True,                                                                                                                                                                                                                                                        
    aws_conn_id='aws_default'                                                                                                                                                                                                                                                        
)                                                                                                                                                                                                                                                                                    
```                                                                                                                                                                                                                                                                                

### Checklist

• [x] Tests included (14 comprehensive unit tests)
• [x] Documentation updated
• [x] Code follows project coding standards
• [x] All static code checks pass
• [x] Apache license headers added
• [x] PR is focused on single feature
• [x] Local tests pass
• [x] No unrelated changes included
