### PR TITLE
Fix TI overview trend count link

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Task/Overview/Overview.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Task/Overview/Overview.tsx
@@ -96,7 +96,7 @@ export const Overview = () => {
           })}
           route={{
             pathname: "task_instances",
-            search: `${SearchParamsKeys.STATE}=failed`,
+            search: `${SearchParamsKeys.TASK_STATE}=failed`,
           }}
           startDate={startDate}
         />


### PR DESCRIPTION
Redirection link is wrong. Therefore the TI state filter is not found by the TI table.

### Before

https://github.com/user-attachments/assets/3e499c06-f79f-49ae-a120-d5aa9a3fbcdc


### After

https://github.com/user-attachments/assets/2ba1be1a-914a-4112-a629-8c6a9d306cb9

