### PR TITLE
Implement get_config in LocalFilesystemBackend

### DIFF
--- a/airflow-core/src/airflow/secrets/local_filesystem.py
+++ b/airflow-core/src/airflow/secrets/local_filesystem.py
@@ -287,7 +287,7 @@ def load_configs_dict(file_path: str) -> dict[str, str]:
     :param file_path: The location of the file that will be processed.
     :return: A dictionary where the key contains a config name and the value contains the config value.
     """
-    log.debug("Loading configs from a text file")
+    log.debug("Loading configs from text file %s", file_path)
 
     secrets = _parse_secret_file(file_path)
     invalid_keys = [key for key, values in secrets.items() if isinstance(values, list) and len(values) != 1]

--- a/airflow-core/src/airflow/secrets/local_filesystem.py
+++ b/airflow-core/src/airflow/secrets/local_filesystem.py
@@ -278,6 +278,26 @@ def load_connections_dict(file_path: str) -> dict[str, Any]:
     return connection_by_conn_id
 
 
+def load_configs_dict(file_path: str) -> dict[str, str]:
+    """
+    Load configs from a text file.
+
+    ``JSON``, `YAML` and ``.env`` files are supported.
+
+    :param file_path: The location of the file that will be processed.
+    :return: A dictionary where the key contains a config name and the value contains the config value.
+    """
+    log.debug("Loading configs from a text file")
+
+    secrets = _parse_secret_file(file_path)
+    invalid_keys = [key for key, values in secrets.items() if isinstance(values, list) and len(values) != 1]
+    if invalid_keys:
+        raise VariableNotUnique(f'The "{file_path}" file contains multiple values for keys: {invalid_keys}')
+    configs = {key: values[0] if isinstance(values, list) else values for key, values in secrets.items()}
+    log.debug("Loaded %d configs: ", len(configs))
+    return configs
+
+
 class LocalFilesystemBackend(BaseSecretsBackend, LoggingMixin):
     """
     Retrieves Connection objects and Variables from local files.
@@ -288,10 +308,16 @@ class LocalFilesystemBackend(BaseSecretsBackend, LoggingMixin):
     :param connections_file_path: File location with connection data.
     """
 
-    def __init__(self, variables_file_path: str | None = None, connections_file_path: str | None = None):
+    def __init__(
+        self,
+        variables_file_path: str | None = None,
+        connections_file_path: str | None = None,
+        configs_file_path: str | None = None,
+    ):
         super().__init__()
         self.variables_file = variables_file_path
         self.connections_file = connections_file_path
+        self.configs_file = configs_file_path
 
     @property
     def _local_variables(self) -> dict[str, str]:
@@ -310,6 +336,14 @@ class LocalFilesystemBackend(BaseSecretsBackend, LoggingMixin):
             return {}
         return load_connections_dict(self.connections_file)
 
+    @property
+    def _local_configs(self) -> dict[str, str]:
+        if not self.configs_file:
+            self.log.debug("The file for configs is not specified. Skipping")
+            # The user may not specify any file.
+            return {}
+        return load_configs_dict(self.configs_file)
+
     def get_connection(self, conn_id: str) -> Connection | None:
         if conn_id in self._local_connections:
             return self._local_connections[conn_id]
@@ -317,3 +351,6 @@ class LocalFilesystemBackend(BaseSecretsBackend, LoggingMixin):
 
     def get_variable(self, key: str) -> str | None:
         return self._local_variables.get(key)
+
+    def get_config(self, key: str) -> str | None:
+        return self._local_configs.get(key)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

As discussed in Slack, this PR adds the missing `get_config` method to `LocalFilesystemBackend` in order to obtain the `_secret` options from a local file.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
