### PR TITLE
Add pdbs for triggerer and workers

### DIFF
--- a/chart/templates/triggerer/triggerer-poddisruptionbudget.yaml
+++ b/chart/templates/triggerer/triggerer-poddisruptionbudget.yaml
@@ -20,8 +20,7 @@
 ################################
 ## Airflow Triggerer PodDisruptionBudget
 #################################
-{{- if .Values.triggerer.enabled }}
-{{- if .Values.triggerer.podDisruptionBudget.enabled }}
+{{- if and .Values.triggerer.enabled .Values.triggerer.podDisruptionBudget.enabled }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/chart/templates/triggerer/triggerer-poddisruptionbudget.yaml
+++ b/chart/templates/triggerer/triggerer-poddisruptionbudget.yaml
@@ -31,7 +31,7 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-    {{- if or (.Values.labels) (.Values.triggerer.labels) }}
+    {{- if or .Values.labels .Values.triggerer.labels }}
       {{- mustMerge .Values.triggerer.labels .Values.labels | toYaml | nindent 4 }}
     {{- end }}
 spec:

--- a/chart/templates/triggerer/triggerer-poddisruptionbudget.yaml
+++ b/chart/templates/triggerer/triggerer-poddisruptionbudget.yaml
@@ -1,0 +1,46 @@
+{{/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/}}
+
+################################
+## Airflow Triggerer PodDisruptionBudget
+#################################
+{{- if .Values.triggerer.enabled }}
+{{- if .Values.triggerer.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "airflow.fullname" . }}-triggerer-pdb
+  labels:
+    tier: airflow
+    component: triggerer
+    release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+    {{- if or (.Values.labels) (.Values.triggerer.labels) }}
+      {{- mustMerge .Values.triggerer.labels .Values.labels | toYaml | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      tier: airflow
+      component: triggerer
+      release: {{ .Release.Name }}
+  {{- toYaml .Values.triggerer.podDisruptionBudget.config | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/chart/templates/triggerer/triggerer-poddisruptionbudget.yaml
+++ b/chart/templates/triggerer/triggerer-poddisruptionbudget.yaml
@@ -42,4 +42,3 @@ spec:
       release: {{ .Release.Name }}
   {{- toYaml .Values.triggerer.podDisruptionBudget.config | nindent 2 }}
 {{- end }}
-{{- end }}

--- a/chart/templates/workers/worker-poddisruptionbudget.yaml
+++ b/chart/templates/workers/worker-poddisruptionbudget.yaml
@@ -31,7 +31,7 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-    {{- if or (.Values.labels) (.Values.workers.labels) }}
+    {{- if or .Values.labels .Values.workers.labels }}
       {{- mustMerge .Values.workers.labels .Values.labels | toYaml | nindent 4 }}
     {{- end }}
 spec:

--- a/chart/templates/workers/worker-poddisruptionbudget.yaml
+++ b/chart/templates/workers/worker-poddisruptionbudget.yaml
@@ -20,7 +20,6 @@
 ################################
 ## Airflow Worker PodDisruptionBudget
 #################################
-{{- if .Values.workers.enabled }}
 {{- if .Values.workers.podDisruptionBudget.enabled }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -42,5 +41,4 @@ spec:
       component: worker
       release: {{ .Release.Name }}
   {{- toYaml .Values.workers.podDisruptionBudget.config | nindent 2 }}
-{{- end }}
 {{- end }}

--- a/chart/templates/workers/worker-poddisruptionbudget.yaml
+++ b/chart/templates/workers/worker-poddisruptionbudget.yaml
@@ -1,0 +1,46 @@
+{{/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/}}
+
+################################
+## Airflow Worker PodDisruptionBudget
+#################################
+{{- if .Values.workers.enabled }}
+{{- if .Values.workers.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "airflow.fullname" . }}-worker-pdb
+  labels:
+    tier: airflow
+    component: worker
+    release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+    {{- if or (.Values.labels) (.Values.workers.labels) }}
+      {{- mustMerge .Values.workers.labels .Values.labels | toYaml | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      tier: airflow
+      component: worker
+      release: {{ .Release.Name }}
+  {{- toYaml .Values.workers.podDisruptionBudget.config | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2160,6 +2160,41 @@
                         }
                     }
                 },
+                "podDisruptionBudget": {
+                    "description": "Worker pod disruption budget.",
+                    "type": "object",
+                    "additionalProperties": true,
+                    "properties": {
+                        "enabled": {
+                            "description": "Enable pod disruption budget.",
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "config": {
+                            "description": "Disruption budget configuration.",
+                            "type": "object",
+                            "additionalProperties": true,
+                            "properties": {
+                                "maxUnavailable": {
+                                    "description": "Max unavailable pods for worker.",
+                                    "type": [
+                                        "integer",
+                                        "string"
+                                    ],
+                                    "default": 1
+                                },
+                                "minAvailable": {
+                                    "description": "Min available pods for worker.",
+                                    "type": [
+                                        "integer",
+                                        "string"
+                                    ],
+                                    "default": 1
+                                }
+                            }
+                        }
+                    }
+                },
                 "resources": {
                     "description": "Resource configuration for Airflow Celery workers and pods created with pod-template-file.",
                     "type": "object",
@@ -3450,6 +3485,41 @@
                             "default": {},
                             "additionalProperties": {
                                 "type": "string"
+                            }
+                        }
+                    }
+                },
+                "podDisruptionBudget": {
+                    "description": "Triggerer pod disruption budget.",
+                    "type": "object",
+                    "additionalProperties": true,
+                    "properties": {
+                        "enabled": {
+                            "description": "Enable pod disruption budget.",
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "config": {
+                            "description": "Disruption budget configuration.",
+                            "type": "object",
+                            "additionalProperties": true,
+                            "properties": {
+                                "maxUnavailable": {
+                                    "description": "Max unavailable pods for triggerer.",
+                                    "type": [
+                                        "integer",
+                                        "string"
+                                    ],
+                                    "default": 1
+                                },
+                                "minAvailable": {
+                                    "description": "Min available pods for triggerer.",
+                                    "type": [
+                                        "integer",
+                                        "string"
+                                    ],
+                                    "default": 1
+                                }
                             }
                         }
                     }

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -692,6 +692,16 @@ workers:
   # Airflow Celery workers and pods created with pod-template-file
   containerLifecycleHooks: {}
 
+  # Worker pod disruption budget
+  podDisruptionBudget:
+    enabled: false
+
+    # PDB configuration
+    config:
+      # minAvailable and maxUnavailable are mutually exclusive
+      maxUnavailable: 1
+      # minAvailable: 1
+
   # Create ServiceAccount for Airflow Celery workers and pods created with pod-template-file
   serviceAccount:
     # default value is true
@@ -1933,6 +1943,16 @@ triggerer:
     fixPermissions: false
     # Annotations to add to triggerer volumes
     annotations: {}
+
+  # Triggerer pod disruption budget
+  podDisruptionBudget:
+    enabled: false
+
+    # PDB configuration
+    config:
+      # minAvailable and maxUnavailable are mutually exclusive
+      maxUnavailable: 1
+      # minAvailable: 1
 
   resources: {}
   #  limits:

--- a/helm-tests/tests/helm_tests/airflow_core/test_pdb_triggerer.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_pdb_triggerer.py
@@ -29,13 +29,6 @@ class TestTriggererPdb:
             show_only=["templates/triggerer/triggerer-poddisruptionbudget.yaml"],
         )  # checks that no validation exception is raised
 
-    def test_should_pass_validation_with_just_pdb_enabled_v1beta1(self):
-        render_chart(
-            values={"triggerer": {"podDisruptionBudget": {"enabled": True}}},
-            show_only=["templates/triggerer/triggerer-poddisruptionbudget.yaml"],
-            kubernetes_version="1.16.0",
-        )  # checks that no validation exception is raised
-
     def test_should_add_component_specific_labels(self):
         docs = render_chart(
             values={

--- a/helm-tests/tests/helm_tests/airflow_core/test_pdb_triggerer.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_pdb_triggerer.py
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import jmespath
+from chart_utils.helm_template_generator import render_chart
+
+
+class TestTriggererPdb:
+    """Tests Triggerer PDB."""
+
+    def test_should_pass_validation_with_just_pdb_enabled_v1(self):
+        render_chart(
+            values={"triggerer": {"podDisruptionBudget": {"enabled": True}}},
+            show_only=["templates/triggerer/triggerer-poddisruptionbudget.yaml"],
+        )  # checks that no validation exception is raised
+
+    def test_should_pass_validation_with_just_pdb_enabled_v1beta1(self):
+        render_chart(
+            values={"triggerer": {"podDisruptionBudget": {"enabled": True}}},
+            show_only=["templates/triggerer/triggerer-poddisruptionbudget.yaml"],
+            kubernetes_version="1.16.0",
+        )  # checks that no validation exception is raised
+
+    def test_should_add_component_specific_labels(self):
+        docs = render_chart(
+            values={
+                "triggerer": {
+                    "podDisruptionBudget": {"enabled": True},
+                    "labels": {"test_label": "test_label_value"},
+                },
+            },
+            show_only=["templates/triggerer/triggerer-poddisruptionbudget.yaml"],
+        )
+
+        assert "test_label" in jmespath.search("metadata.labels", docs[0])
+        assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
+
+    def test_should_pass_validation_with_pdb_enabled_and_min_available_param(self):
+        render_chart(
+            values={
+                "triggerer": {
+                    "podDisruptionBudget": {
+                        "enabled": True,
+                        "config": {"maxUnavailable": None, "minAvailable": 1},
+                    }
+                }
+            },
+            show_only=["templates/triggerer/triggerer-poddisruptionbudget.yaml"],
+        )  # checks that no validation exception is raised

--- a/helm-tests/tests/helm_tests/airflow_core/test_pdb_worker.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_pdb_worker.py
@@ -29,13 +29,6 @@ class TestWorkerPdb:
             show_only=["templates/workers/worker-poddisruptionbudget.yaml"],
         )  # checks that no validation exception is raised
 
-    def test_should_pass_validation_with_just_pdb_enabled_v1beta1(self):
-        render_chart(
-            values={"workers": {"podDisruptionBudget": {"enabled": True}}},
-            show_only=["templates/workers/worker-poddisruptionbudget.yaml"],
-            kubernetes_version="1.16.0",
-        )  # checks that no validation exception is raised
-
     def test_should_add_component_specific_labels(self):
         docs = render_chart(
             values={

--- a/helm-tests/tests/helm_tests/airflow_core/test_pdb_worker.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_pdb_worker.py
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import jmespath
+from chart_utils.helm_template_generator import render_chart
+
+
+class TestWorkerPdb:
+    """Tests Worker PDB."""
+
+    def test_should_pass_validation_with_just_pdb_enabled_v1(self):
+        render_chart(
+            values={"workers": {"podDisruptionBudget": {"enabled": True}}},
+            show_only=["templates/workers/worker-poddisruptionbudget.yaml"],
+        )  # checks that no validation exception is raised
+
+    def test_should_pass_validation_with_just_pdb_enabled_v1beta1(self):
+        render_chart(
+            values={"workers": {"podDisruptionBudget": {"enabled": True}}},
+            show_only=["templates/workers/worker-poddisruptionbudget.yaml"],
+            kubernetes_version="1.16.0",
+        )  # checks that no validation exception is raised
+
+    def test_should_add_component_specific_labels(self):
+        docs = render_chart(
+            values={
+                "workers": {
+                    "podDisruptionBudget": {"enabled": True},
+                    "labels": {"test_label": "test_label_value"},
+                },
+            },
+            show_only=["templates/workers/worker-poddisruptionbudget.yaml"],
+        )
+
+        assert "test_label" in jmespath.search("metadata.labels", docs[0])
+        assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
+
+    def test_should_pass_validation_with_pdb_enabled_and_min_available_param(self):
+        render_chart(
+            values={
+                "workers": {
+                    "podDisruptionBudget": {
+                        "enabled": True,
+                        "config": {"maxUnavailable": None, "minAvailable": 1},
+                    },
+                }
+            },
+            show_only=["templates/workers/worker-poddisruptionbudget.yaml"],
+        )  # checks that no validation exception is raised


### PR DESCRIPTION
## Description

This will add the ability to set pod disruption budget resources for either the triggerer and/or worker pods.  These are disabled by default as to not cause a breaking change in the helm chart.

## Why

We are running multiple instances of triggerer pods as well as worker pods.  When we have a cluster event that may take out a node having the PDB allows us to not have multiple instances of the same pods go down at the same time.

---
