### PR TITLE
Prevent dag-processor crash on encountering Excel files in the DAG directory

### DIFF
--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -631,7 +631,7 @@ class DagFileProcessorManager(LoggingMixin):
                         if might_contain_dag(info.filename, True, z):
                             yield os.path.join(abs_path, info.filename)
             except zipfile.BadZipFile:
-                self.log.exception("There was an error accessing ZIP file %s %s", abs_path)
+                self.log.exception("There was an error accessing ZIP file %s", abs_path)
 
         rel_filelocs: list[str] = []
         for info in present:


### PR DESCRIPTION
One of our data analysts found a novel way to crash Airflow's dag-processor by uploading an Excel file to Airflow's DAG directory! Normally, Airflow should print a warning message and say that the Excel file is an invalid zip file (MS Office .xlsx/.docx/etc. documents are all zip archives). In this case however, Airflow has the wrong number of `%s`s when logging the warning, which causes Airflow's dag-processor to crash when handling the `zipfile.BadZipFile` exception. This PR fixes the crash by fixing the warning message to have the correct number of `%s`s in its format string.

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
