### PR TITLE
automatically inject OL info into Glue job in GlueJobOperator

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/glue.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/glue.py
@@ -37,6 +37,9 @@ from airflow.providers.amazon.aws.triggers.glue import (
 )
 from airflow.providers.amazon.aws.utils import validate_execute_complete_event
 from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
+from airflow.providers.amazon.aws.utils.openlineage import (
+    inject_parent_job_information_into_glue_script_args,
+)
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
@@ -139,10 +142,14 @@ class GlueJobOperator(AwsBaseOperator[GlueJobHook]):
         job_poll_interval: int | float = 6,
         waiter_delay: int = 60,
         waiter_max_attempts: int = 75,
+        openlineage_inject_parent_job_info: bool = conf.getboolean(
+            "openlineage", "spark_inject_parent_job_info", fallback=False
+        ),
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.job_name = job_name
+        self._openlineage_inject_parent_job_info = openlineage_inject_parent_job_info
         self.job_desc = job_desc
         self.script_location = script_location
         self.concurrent_run_limit = concurrent_run_limit or 1
@@ -217,6 +224,9 @@ class GlueJobOperator(AwsBaseOperator[GlueJobHook]):
 
         :return: the current Glue job ID.
         """
+        if self._openlineage_inject_parent_job_info:
+            self.log.debug("Injecting OpenLineage parent job information into Glue script_args.")
+            self.script_args = inject_parent_job_information_into_glue_script_args(self.script_args, context)
         self.log.info(
             "Initializing AWS Glue Job: %s. Wait for completion: %s",
             self.job_name,

--- a/providers/amazon/src/airflow/providers/amazon/aws/utils/openlineage.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/utils/openlineage.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any
 
 from airflow.providers.amazon.aws.hooks.redshift_sql import RedshiftSQLHook
@@ -28,9 +29,13 @@ from airflow.providers.common.compat.openlineage.facet import (
     SchemaDatasetFacet,
     SchemaDatasetFacetFields,
 )
+from airflow.providers.common.compat.openlineage.utils.spark import get_parent_job_information
 
 if TYPE_CHECKING:
     from airflow.providers.amazon.aws.hooks.redshift_data import RedshiftDataHook
+    from airflow.utils.context import Context
+
+log = logging.getLogger(__name__)
 
 
 def get_facets_from_redshift_table(
@@ -136,3 +141,148 @@ def get_identity_column_lineage_facet(
         }
     )
     return column_lineage_facet
+
+
+def _parse_glue_customer_env_vars(env_vars_string: str | None) -> dict[str, str]:
+    """
+    Parse the --customer-driver-env-vars format into a dict.
+
+    Format: "KEY1=VAL1,KEY2=\"val2,val2 val2\""
+    - Simple values: KEY=VALUE
+    - Values with commas/spaces: KEY="value with, spaces"
+
+    Args:
+        env_vars_string: The environment variables string from Glue script args.
+
+    Returns:
+        Dict of key-value pairs.
+    """
+    if not env_vars_string:
+        return {}
+
+    result: dict[str, str] = {}
+    current = ""
+    in_quotes = False
+
+    for char in env_vars_string:
+        if char == '"' and (not current or current[-1] != "\\"):
+            in_quotes = not in_quotes
+            current += char
+        elif char == "," and not in_quotes:
+            if "=" in current:
+                key, value = current.split("=", 1)
+                # Strip surrounding quotes if present
+                value = value.strip()
+                if value.startswith('"') and value.endswith('"'):
+                    value = value[1:-1]
+                result[key.strip()] = value
+            current = ""
+        else:
+            current += char
+
+    # Handle last element
+    if current and "=" in current:
+        key, value = current.split("=", 1)
+        value = value.strip()
+        if value.startswith('"') and value.endswith('"'):
+            value = value[1:-1]
+        result[key.strip()] = value
+
+    return result
+
+
+def _format_glue_customer_env_vars(env_vars: dict[str, str]) -> str:
+    """
+    Format a dict back into the --customer-driver-env-vars string format.
+
+    - Values containing commas, spaces, or quotes need quoting
+    - Quotes within values need escaping
+
+    Args:
+        env_vars: Dict of environment variables.
+
+    Returns:
+        String in format "KEY1=VAL1,KEY2=\"val2\""
+    """
+    parts = []
+    for key, value in env_vars.items():
+        # Quote if contains special chars
+        if "," in value or " " in value or '"' in value:
+            escaped_value = value.replace('"', '\\"')
+            parts.append(f'{key}="{escaped_value}"')
+        else:
+            parts.append(f"{key}={value}")
+    return ",".join(parts)
+
+
+def _is_parent_job_info_present_in_glue_env_vars(script_args: dict[str, Any]) -> bool:
+    """
+    Check if any OpenLineage parent job env vars are already set.
+
+    Args:
+        script_args: The Glue job's script_args dict.
+
+    Returns:
+        True if any OL parent job env vars are present.
+    """
+    # Check --customer-driver-env-vars
+    driver_env_vars_str = script_args.get("--customer-driver-env-vars", "")
+    driver_env_vars = _parse_glue_customer_env_vars(driver_env_vars_str)
+
+    # Also check --customer-executor-env-vars
+    executor_env_vars_str = script_args.get("--customer-executor-env-vars", "")
+    executor_env_vars = _parse_glue_customer_env_vars(executor_env_vars_str)
+
+    all_env_vars = {**driver_env_vars, **executor_env_vars}
+
+    # Check if ANY OpenLineage parent env var is present
+    return any(
+        key.startswith("OPENLINEAGE_PARENT") or key.startswith("OPENLINEAGE_ROOT_PARENT")
+        for key in all_env_vars
+    )
+
+
+def inject_parent_job_information_into_glue_script_args(
+    script_args: dict[str, Any], context: Context
+) -> dict[str, Any]:
+    """
+    Inject OpenLineage parent job info into Glue script_args.
+
+    The parent job information is injected via the --customer-driver-env-vars argument,
+    which sets environment variables in the Spark driver process.
+
+    - If OpenLineage provider is not available, skip injection
+    - If user already set any OPENLINEAGE_PARENT_* or OPENLINEAGE_ROOT_PARENT_* env vars,
+      skip injection to preserve user-provided values
+    - Merge with existing --customer-driver-env-vars if present
+    - Return new dict (don't mutate original)
+
+    Args:
+        script_args: The Glue job's script_args dict.
+        context: Airflow task context.
+
+    Returns:
+        Modified script_args with OpenLineage env vars injected.
+    """
+    info = get_parent_job_information(context)
+    if info is None:
+        return script_args
+
+    existing_env_vars_str = script_args.get("--customer-driver-env-vars", "")
+    existing_env_vars = _parse_glue_customer_env_vars(existing_env_vars_str)
+
+    ol_env_vars = {
+        "OPENLINEAGE_PARENT_JOB_NAMESPACE": info.parent_job_namespace,
+        "OPENLINEAGE_PARENT_JOB_NAME": info.parent_job_name,
+        "OPENLINEAGE_PARENT_RUN_ID": info.parent_run_id,
+        "OPENLINEAGE_ROOT_PARENT_JOB_NAMESPACE": info.root_parent_job_namespace,
+        "OPENLINEAGE_ROOT_PARENT_JOB_NAME": info.root_parent_job_name,
+        "OPENLINEAGE_ROOT_PARENT_RUN_ID": info.root_parent_run_id,
+    }
+
+    merged_env_vars = {**existing_env_vars, **ol_env_vars}
+
+    new_script_args = {**script_args}
+    new_script_args["--customer-driver-env-vars"] = _format_glue_customer_env_vars(merged_env_vars)
+
+    return new_script_args

--- a/providers/common/compat/src/airflow/providers/common/compat/openlineage/utils/spark.py
+++ b/providers/common/compat/src/airflow/providers/common/compat/openlineage/utils/spark.py
@@ -24,12 +24,14 @@ log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from airflow.providers.openlineage.utils.spark import (
+        get_parent_job_information,
         inject_parent_job_information_into_spark_properties,
         inject_transport_information_into_spark_properties,
     )
     from airflow.sdk import Context
 try:
     from airflow.providers.openlineage.utils.spark import (
+        get_parent_job_information,
         inject_parent_job_information_into_spark_properties,
         inject_transport_information_into_spark_properties,
     )
@@ -49,8 +51,12 @@ except ImportError:
         )
         return properties
 
+    def get_parent_job_information(context: Context) -> None:
+        return None
+
 
 __all__ = [
     "inject_parent_job_information_into_spark_properties",
     "inject_transport_information_into_spark_properties",
+    "get_parent_job_information",
 ]

--- a/providers/openlineage/src/airflow/providers/openlineage/utils/spark.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/utils/spark.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 from airflow.providers.openlineage.plugins.listener import get_openlineage_listener
 from airflow.providers.openlineage.plugins.macros import (
@@ -35,6 +35,43 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
+class ParentJobInformation(NamedTuple):
+    """Container for OpenLineage parent job information."""
+
+    parent_job_namespace: str
+    parent_job_name: str
+    parent_run_id: str
+    root_parent_job_namespace: str
+    root_parent_job_name: str
+    root_parent_run_id: str
+
+
+def get_parent_job_information(context: Context) -> ParentJobInformation | None:
+    """
+    Retrieve parent job information from the Airflow context.
+
+    This function extracts OpenLineage parent job details from the task instance,
+    which can be used by various integrations (Spark, Glue, etc.) to propagate
+    lineage information to child jobs.
+
+    Args:
+        context: The Airflow context containing task instance information.
+
+    Returns:
+        ParentJobInformation containing namespace, job name, and run IDs
+        for both parent and root parent.
+    """
+    ti = context["ti"]
+    return ParentJobInformation(
+        parent_job_namespace=lineage_job_namespace(),
+        parent_job_name=lineage_job_name(ti),  # type: ignore[arg-type]
+        parent_run_id=lineage_run_id(ti),  # type: ignore[arg-type]
+        root_parent_job_namespace=lineage_job_namespace(),
+        root_parent_job_name=lineage_root_job_name(ti),  # type: ignore[arg-type]
+        root_parent_run_id=lineage_root_run_id(ti),  # type: ignore[arg-type]
+    )
+
+
 def _get_parent_job_information_as_spark_properties(context: Context) -> dict:
     """
     Retrieve parent job information as Spark properties.
@@ -45,14 +82,14 @@ def _get_parent_job_information_as_spark_properties(context: Context) -> dict:
     Returns:
         Spark properties with the parent job information.
     """
-    ti = context["ti"]
+    info = get_parent_job_information(context)
     return {
-        "spark.openlineage.parentJobNamespace": lineage_job_namespace(),
-        "spark.openlineage.parentJobName": lineage_job_name(ti),  # type: ignore[arg-type]
-        "spark.openlineage.parentRunId": lineage_run_id(ti),  # type: ignore[arg-type]
-        "spark.openlineage.rootParentRunId": lineage_root_run_id(ti),  # type: ignore[arg-type]
-        "spark.openlineage.rootParentJobName": lineage_root_job_name(ti),  # type: ignore[arg-type]
-        "spark.openlineage.rootParentJobNamespace": lineage_job_namespace(),
+        "spark.openlineage.parentJobNamespace": info.parent_job_namespace,
+        "spark.openlineage.parentJobName": info.parent_job_name,
+        "spark.openlineage.parentRunId": info.parent_run_id,
+        "spark.openlineage.rootParentRunId": info.root_parent_run_id,
+        "spark.openlineage.rootParentJobName": info.root_parent_job_name,
+        "spark.openlineage.rootParentJobNamespace": info.root_parent_job_namespace,
     }
 
 


### PR DESCRIPTION
This PR provides feature where GlueJobOperator automatically injects OpenLIneage parent job information into the Spark job properties.

This is analogous to previous PRs adding this functionality to many other Spark related operators, like https://github.com/apache/airflow/pull/44477 - more details about this feature are available there.