### PR TITLE
Add missing catalan translations

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/ca/assets.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ca/assets.json
@@ -1,5 +1,9 @@
 {
+  "additional_data": "Dades addicionals",
+  "asset_one": "Asset",
+  "asset_other": "Assets",
   "consumingDags": "Dags consumidors",
+  "consumingTasks": "Tasques consumidores",
   "createEvent": {
     "button": "Crear esdeveniment",
     "manual": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ca/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ca/common.json
@@ -59,6 +59,7 @@
     "dataIntervalEnd": "Fi de l'interval de dades",
     "dataIntervalStart": "Inici de l'interval de dades",
     "lastSchedulingDecision": "Última decisió de programació",
+    "partitionKey": "Clau de partició",
     "queuedAt": "Enviat a cua a les",
     "runAfter": "Executar després de",
     "runType": "Tipus d'execució",
@@ -89,6 +90,7 @@
     "back": "Tornar",
     "defaultMessage": "S'ha produït un error inesperat",
     "home": "Inici",
+    "invalidUrl": "Pàgina no trobada. Si us plau, comprova la URL i torna-ho a provar.",
     "notFound": "Pàgina no trobada",
     "title": "Error"
   },
@@ -108,10 +110,13 @@
   "filters": {
     "durationFrom": "Duració Des de",
     "durationTo": "Duració Fins a",
+    "endTime": "Hora de finalització",
     "logicalDateFrom": "Data Lògica Des de",
     "logicalDateTo": "Data Lògica Fins a",
     "runAfterFrom": "Executar Després de",
-    "runAfterTo": "Executar Després de"
+    "runAfterTo": "Executar Després de",
+    "selectDateRange": "Seleccionar interval de dates",
+    "startTime": "Hora d'inici"
   },
   "logicalDate": "Data Lògica",
   "logout": "Tancar sessió",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ca/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ca/components.json
@@ -50,6 +50,13 @@
     "warning_one": "1 Advertència",
     "warning_other": "{{count}} Advertències"
   },
+  "dateRangeFilter": {
+    "validation": {
+      "invalidDateFormat": "Format de data no vàlid.",
+      "invalidTimeFormat": "Format d'hora no vàlid.",
+      "startBeforeEnd": "La data/hora d'inici ha de ser anterior a la data/hora de finalització"
+    }
+  },
   "durationChart": {
     "duration": "Duració (segons)",
     "lastDagRun_one": "Última execució del Dag",
@@ -116,6 +123,9 @@
     "selectLabel": "Execució única",
     "title": "Executar Dag",
     "toaster": {
+      "error": {
+        "title": "No s'ha pogut executar el Dag"
+      },
       "success": {
         "description": "El Dag s'ha executat correctament.",
         "title": "Execució del Dag correcta"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ca/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ca/dag.json
@@ -114,6 +114,18 @@
     },
     "graphDirection": {
       "label": "Direcció del gràfic"
+    },
+    "taskStreamFilter": {
+      "activeFilter": "Filtre actiu",
+      "clearFilter": "Netejar filtre",
+      "clickTask": "Fes clic a una tasca per seleccionar-la com a arrel del filtre",
+      "label": "Filtrar",
+      "options": {
+        "both": "Aigües amunt i aigües avall",
+        "downstream": "Aigües avall",
+        "upstream": "Aigües amunt"
+      },
+      "selectedTask": "Tasca seleccionada"
     }
   },
   "paramsFailed": "No s'han pogut carregar els paràmetres",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ca/dags.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ca/dags.json
@@ -34,6 +34,10 @@
       "error": "No s'ha pogut rellançar {{type}}",
       "title": "Rellançar {{type}}"
     },
+    "confirmationDialog": {
+      "description": "La tasca es troba en estat {{state}} iniciada per l'usuari {{user}} a les {{time}}. \nL'usuari no pot rellançar aquesta tasca fins que no hagi acabat d'executar-se o fins que un usuari desmarqui l'opció \"Evitar rellançar tasques en execució\" al diàleg de rellançament de tasques.",
+      "title": "No s'ha pogut rellançar la instància de tasca"
+    },
     "delete": {
       "button": "Eliminar {{type}}",
       "dialog": {
@@ -61,6 +65,7 @@
       "future": "Futur",
       "onlyFailed": "Rellançar només tasques fallides",
       "past": "Passat",
+      "preventRunningTasks": "Evitar rellançar tasques en execució",
       "queueNew": "Afegir noves tasques a la cua",
       "runOnLatestVersion": "Executar amb la última versió de la col·lecció",
       "upstream": "Aigües amunt"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ca/hitl.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ca/hitl.json
@@ -1,8 +1,7 @@
 {
   "filters": {
     "body": "Cos",
-    "createdAtFrom": "Creat a partir de",
-    "createdAtTo": "Creat fins a",
+    "createdAt": "Creat a",
     "response": {
       "all": "Totes",
       "pending": "Pendents",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Brings Catalan translations to 100%. `assets.json` will currently show a missing key, but there is an error in the English version I'll fix in a next PR.

@oscarhernandezrodriguez could you please review it?

@jscheffl Should I open a PR to v3-1?


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
