### PR TITLE
Add dag bundles to `airflow info` command

### DIFF
--- a/airflow-core/src/airflow/cli/commands/info_command.py
+++ b/airflow-core/src/airflow/cli/commands/info_command.py
@@ -33,6 +33,7 @@ import tenacity
 
 from airflow import configuration
 from airflow.cli.simple_table import AirflowConsole
+from airflow.dag_processing.bundles.manager import DagBundlesManager
 from airflow.providers_manager import ProvidersManager
 from airflow.utils.cli import suppress_logs_and_warning
 from airflow.utils.platform import getuser
@@ -229,9 +230,7 @@ class AirflowInfo:
         sql_alchemy_conn = self.anonymizer.process_url(
             configuration.conf.get("database", "SQL_ALCHEMY_CONN", fallback="NOT AVAILABLE")
         )
-        dags_folder = self.anonymizer.process_path(
-            configuration.conf.get("core", "dags_folder", fallback="NOT AVAILABLE")
-        )
+        bundle_names = DagBundlesManager().get_all_bundle_names()
         plugins_folder = self.anonymizer.process_path(
             configuration.conf.get("core", "plugins_folder", fallback="NOT AVAILABLE")
         )
@@ -247,7 +246,7 @@ class AirflowInfo:
             ("executor", executor),
             ("task_logging_handler", self._task_logging_handler()),
             ("sql_alchemy_conn", sql_alchemy_conn),
-            ("dags_folder", dags_folder),
+            ("dag_bundle_names", bundle_names),
             ("plugins_folder", plugins_folder),
             ("base_log_folder", base_log_folder),
             ("remote_base_log_folder", remote_base_log_folder),

--- a/airflow-core/src/airflow/dag_processing/bundles/manager.py
+++ b/airflow-core/src/airflow/dag_processing/bundles/manager.py
@@ -341,6 +341,14 @@ class DagBundlesManager(LoggingMixin):
         for name, cfg in self._bundle_config.items():
             yield cfg.bundle_class(name=name, version=None, **cfg.kwargs)
 
+    def get_all_bundle_names(self) -> Iterable[str]:
+        """
+        Get all bundle names.
+
+        :return: sorted list of bundle names.
+        """
+        return sorted(self._bundle_config.keys())
+
     def view_url(self, name: str, version: str | None = None) -> str | None:
         warnings.warn(
             "The 'view_url' method is deprecated and will be removed when providers "

--- a/airflow-core/tests/unit/cli/commands/test_info_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_info_command.py
@@ -113,7 +113,7 @@ class TestAirflowInfo:
             "plugins_folder",
             "base_log_folder",
             "remote_base_log_folder",
-            "dags_folder",
+            "dag_bundle_names",
             "sql_alchemy_conn",
         }
         assert self.unique_items(instance._airflow_info) == expected

--- a/airflow-core/tests/unit/dag_processing/bundles/test_dag_bundle_manager.py
+++ b/airflow-core/tests/unit/dag_processing/bundles/test_dag_bundle_manager.py
@@ -393,3 +393,7 @@ def test_example_dags_name_is_reserved():
     with conf_vars({("dag_processor", "dag_bundle_config_list"): json.dumps(reserved_name_config)}):
         with pytest.raises(AirflowConfigException, match="Bundle name 'example_dags' is a reserved name."):
             DagBundlesManager().parse_config()
+
+
+def test_get_all_bundle_names():
+    assert DagBundlesManager().get_all_bundle_names() == ["dags-folder", "example_dags"]


### PR DESCRIPTION
Instead of showing the Airflow dags folder, which may not even be in use any more, we now show all of the dag bundle names in the output of `airflow info`.

Before:

```
Apache Airflow
version                | 3.2.0
executor               | LocalExecutor
task_logging_handler   | airflow.utils.log.file_task_handler.FileTaskHandler
sql_alchemy_conn       | ...
dags_folder            | /Users/jedc/airflow/dags
plugins_folder         | /Users/jedc/airflow/plugins
base_log_folder        | /Users/jedc/airflow/logs
remote_base_log_folder |
...
```

After:

```
Apache Airflow
version                | 3.2.0
executor               | LocalExecutor
task_logging_handler   | airflow.utils.log.file_task_handler.FileTaskHandler
sql_alchemy_conn       | ...
dag_bundle_names       | another,dags-folder,my_git_repo
plugins_folder         | /Users/jedc/airflow/plugins
base_log_folder        | /Users/jedc/airflow/logs
remote_base_log_folder |
...
```