### PR TITLE
Fix double serialization in XCom PATCH API endpoint

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/xcom.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/xcom.py
@@ -314,7 +314,6 @@ def update_xcom_entry(
 ) -> XComResponseNative:
     """Update an existing XCom entry."""
     # Check if XCom entry exists
-    xcom_new_value = XComModel.serialize_value(patch_body.value)
     xcom_entry = session.scalar(
         select(XComModel)
         .where(
@@ -334,7 +333,7 @@ def update_xcom_entry(
             f"The XCom with key: `{xcom_key}` with mentioned task instance doesn't exist.",
         )
 
-    # Update XCom entry
-    xcom_entry.value = XComModel.serialize_value(xcom_new_value)
+    # Update XCom entry - serialize the value only once
+    xcom_entry.value = XComModel.serialize_value(patch_body.value)
 
     return XComResponseNative.model_validate(xcom_entry)


### PR DESCRIPTION
The update_xcom_entry endpoint was calling XComModel.serialize_value twice, causing values to be excessively serialized. This made the updated XCom values unusable when retrieved by tasks.

Changes:
- Removed duplicate XComModel.serialize_value call in update_xcom_entry
- Fixed existing test to remove double serialization in assertion
- Added comprehensive test to verify patched values are correctly serialized and can be retrieved/deserialized properly

Fixes: https://github.com/apache/airflow/issues/59032

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
