### PR TITLE
Keycloak CLI: add dry run functionality

### DIFF
--- a/providers/keycloak/docs/auth-manager/manage/permissions.rst
+++ b/providers/keycloak/docs/auth-manager/manage/permissions.rst
@@ -41,6 +41,10 @@ CLI commands take the following parameters:
 * ``--user-realm``: Keycloak user realm
 * ``--client-id``: Keycloak client id (default: admin-cli)
 
+They also take the following optional parameters:
+
+* ``--dry-run``: If set, the command will check the connection to Keycloak and print the actions that would be performed, without actually executing them.
+
 Please check the `Keycloak auth manager CLI </cli-refs.html>`_ documentation for more information about accepted parameters.
 
 One-go creation of permissions

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/cli/commands.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/cli/commands.py
@@ -112,41 +112,66 @@ def _get_client_uuid(args):
     return matches[0]["id"]
 
 
-def _create_scopes(client: KeycloakAdmin, client_uuid: str):
+def _get_scopes_to_create() -> list[dict]:
+    """Get the list of scopes to be created."""
     scopes = [{"name": method} for method in get_args(ResourceMethod)]
     scopes.extend([{"name": "MENU"}, {"name": "LIST"}])
+    return scopes
+
+
+def _create_scopes(client: KeycloakAdmin, client_uuid: str):
+    scopes = _get_scopes_to_create()
+
     for scope in scopes:
         client.create_client_authz_scopes(client_id=client_uuid, payload=scope)
 
     print("Scopes created successfully.")
 
 
-def _create_resources(client: KeycloakAdmin, client_uuid: str):
-    all_scopes = client.get_client_authz_scopes(client_uuid)
+def _get_resources_to_create(
+    all_scopes: list[dict],
+) -> tuple[list[tuple[str, list[dict]]], list[tuple[str, list[dict]]]]:
+    """
+    Get the list of resources to be created.
+
+    Returns a tuple of (standard_resources, menu_resources).
+    Each is a list of tuples (resource_name, scopes_list).
+    """
     scopes = [
         {"id": scope["id"], "name": scope["name"]}
         for scope in all_scopes
         if scope["name"] in ["GET", "POST", "PUT", "DELETE", "LIST"]
     ]
+    menu_scopes = [
+        {"id": scope["id"], "name": scope["name"]} for scope in all_scopes if scope["name"] == "MENU"
+    ]
 
-    for resource in KeycloakResource:
+    standard_resources = [(resource.value, scopes) for resource in KeycloakResource]
+    menu_resources = [(item.value, menu_scopes) for item in MenuItem]
+
+    return standard_resources, menu_resources
+
+
+def _create_resources(client: KeycloakAdmin, client_uuid: str):
+    all_scopes = client.get_client_authz_scopes(client_uuid)
+    standard_resources, menu_resources = _get_resources_to_create(all_scopes)
+
+    for resource_name, scopes in standard_resources:
         client.create_client_authz_resource(
             client_id=client_uuid,
             payload={
-                "name": resource.value,
+                "name": resource_name,
                 "scopes": scopes,
             },
             skip_exists=True,
         )
 
     # Create menu item resources
-    scopes = [{"id": scope["id"], "name": scope["name"]} for scope in all_scopes if scope["name"] == "MENU"]
-
-    for item in MenuItem:
+    for resource_name, scopes in menu_resources:
         client.create_client_authz_resource(
             client_id=client_uuid,
             payload={
-                "name": item.value,
+                "name": resource_name,
                 "scopes": scopes,
             },
             skip_exists=True,
@@ -155,63 +180,83 @@ def _create_resources(client: KeycloakAdmin, client_uuid: str):
     print("Resources created successfully.")
 
 
+def _get_permissions_to_create(all_scopes: list[dict], all_resources: list[dict]) -> list[dict]:
+    """
+    Get the actual permissions to be created with filtered scopes/resources.
+
+    Returns a list of permission descriptors with actual filtered data.
+    """
+    perm_configs = [
+        {
+            "name": "ReadOnly",
+            "type": "scope-based",
+            "scope_names": ["GET", "MENU", "LIST"],
+        },
+        {
+            "name": "Admin",
+            "type": "scope-based",
+            "scope_names": list(get_args(ExtendedResourceMethod)) + ["LIST"],
+        },
+        {
+            "name": "User",
+            "type": "resource-based",
+            "resources": [KeycloakResource.DAG.value, KeycloakResource.ASSET.value],
+        },
+        {
+            "name": "Op",
+            "type": "resource-based",
+            "resources": [
+                KeycloakResource.CONNECTION.value,
+                KeycloakResource.POOL.value,
+                KeycloakResource.VARIABLE.value,
+                KeycloakResource.BACKFILL.value,
+            ],
+        },
+    ]
+    result = []
+
+    for config in perm_configs:
+        perm = {"name": config["name"], "type": config["type"]}
+        if config["type"] == "scope-based":
+            # Filter to get actual scope IDs that exist and match
+            filtered_scope_ids = [s["id"] for s in all_scopes if s["name"] in config["scope_names"]]
+            filtered_scope_names = [s["name"] for s in all_scopes if s["name"] in config["scope_names"]]
+            perm["scope_ids"] = filtered_scope_ids
+            perm["scope_names"] = filtered_scope_names
+        else:  # resource-based
+            # Filter to get actual resource IDs that exist and match
+            filtered_resource_ids = [r["_id"] for r in all_resources if r["name"] in config["resources"]]
+            filtered_resource_names = [r["name"] for r in all_resources if r["name"] in config["resources"]]
+            perm["resource_ids"] = filtered_resource_ids
+            perm["resource_names"] = filtered_resource_names
+        result.append(perm)
+
+    return result
+
+
 def _create_permissions(client: KeycloakAdmin, client_uuid: str):
-    _create_read_only_permission(client, client_uuid)
-    _create_admin_permission(client, client_uuid)
-    _create_user_permission(client, client_uuid)
-    _create_op_permission(client, client_uuid)
+    all_scopes = client.get_client_authz_scopes(client_uuid)
+    all_resources = client.get_client_authz_resources(client_uuid)
+    permissions = _get_permissions_to_create(all_scopes, all_resources)
+
+    for perm in permissions:
+        if perm["type"] == "scope-based":
+            _create_scope_based_permission(client, client_uuid, perm["name"], perm["scope_ids"])
+        else:  # resource-based
+            _create_resource_based_permission(client, client_uuid, perm["name"], perm["resource_ids"])
 
     print("Permissions created successfully.")
 
 
-def _create_read_only_permission(client: KeycloakAdmin, client_uuid: str):
-    all_scopes = client.get_client_authz_scopes(client_uuid)
-    scopes = [scope["id"] for scope in all_scopes if scope["name"] in ["GET", "MENU", "LIST"]]
+def _create_scope_based_permission(client: KeycloakAdmin, client_uuid: str, name: str, scope_ids: list[str]):
     payload = {
-        "name": "ReadOnly",
+        "name": name,
         "type": "scope",
         "logic": "POSITIVE",
         "decisionStrategy": "UNANIMOUS",
-        "scopes": scopes,
+        "scopes": scope_ids,
     }
-    _create_permission(client, client_uuid, payload)
 
-
-def _create_admin_permission(client: KeycloakAdmin, client_uuid: str):
-    all_scopes = client.get_client_authz_scopes(client_uuid)
-    scope_names = get_args(ExtendedResourceMethod) + ("LIST",)
-    scopes = [scope["id"] for scope in all_scopes if scope["name"] in scope_names]
-    payload = {
-        "name": "Admin",
-        "type": "scope",
-        "logic": "POSITIVE",
-        "decisionStrategy": "UNANIMOUS",
-        "scopes": scopes,
-    }
-    _create_permission(client, client_uuid, payload)
-
-
-def _create_user_permission(client: KeycloakAdmin, client_uuid: str):
-    _create_resource_based_permission(
-        client, client_uuid, "User", [KeycloakResource.DAG.value, KeycloakResource.ASSET.value]
-    )
-
-
-def _create_op_permission(client: KeycloakAdmin, client_uuid: str):
-    _create_resource_based_permission(
-        client,
-        client_uuid,
-        "Op",
-        [
-            KeycloakResource.CONNECTION.value,
-            KeycloakResource.POOL.value,
-            KeycloakResource.VARIABLE.value,
-            KeycloakResource.BACKFILL.value,
-        ],
-    )
-
-
-def _create_permission(client: KeycloakAdmin, client_uuid: str, payload: dict):
     try:
         client.create_client_authz_scope_permission(
             client_id=client_uuid,
@@ -225,17 +270,14 @@ def _create_permission(client: KeycloakAdmin, client_uuid: str, payload: dict):
 
 
 def _create_resource_based_permission(
-    client: KeycloakAdmin, client_uuid: str, name: str, allowed_resources: list[str]
+    client: KeycloakAdmin, client_uuid: str, name: str, resource_ids: list[str]
 ):
-    all_resources = client.get_client_authz_resources(client_uuid)
-    resources = [resource["_id"] for resource in all_resources if resource["name"] in allowed_resources]
-
     payload = {
         "name": name,
         "type": "scope",
         "logic": "POSITIVE",
         "decisionStrategy": "UNANIMOUS",
-        "resources": resources,
+        "resources": resource_ids,
     }
     client.create_client_authz_resource_based_permission(
         client_id=client_uuid,

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/cli/commands.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/cli/commands.py
@@ -52,7 +52,7 @@ def create_scopes_command(args):
     client = _get_client(args)
     client_uuid = _get_client_uuid(args)
 
-    _create_scopes(client, client_uuid, dry_run=args.dry_run)
+    _create_scopes(client, client_uuid, _dry_run=args.dry_run)
 
 
 @cli_utils.action_cli
@@ -63,7 +63,7 @@ def create_resources_command(args):
     client = _get_client(args)
     client_uuid = _get_client_uuid(args)
 
-    _create_resources(client, client_uuid, dry_run=args.dry_run)
+    _create_resources(client, client_uuid, _dry_run=args.dry_run)
 
 
 @cli_utils.action_cli
@@ -74,7 +74,7 @@ def create_permissions_command(args):
     client = _get_client(args)
     client_uuid = _get_client_uuid(args)
 
-    _create_permissions(client, client_uuid, dry_run=args.dry_run)
+    _create_permissions(client, client_uuid, _dry_run=args.dry_run)
 
 
 @cli_utils.action_cli
@@ -85,9 +85,9 @@ def create_all_command(args):
     client = _get_client(args)
     client_uuid = _get_client_uuid(args)
 
-    _create_scopes(client, client_uuid, dry_run=args.dry_run)
-    _create_resources(client, client_uuid, dry_run=args.dry_run)
-    _create_permissions(client, client_uuid, dry_run=args.dry_run)
+    _create_scopes(client, client_uuid, _dry_run=args.dry_run)
+    _create_resources(client, client_uuid, _dry_run=args.dry_run)
+    _create_permissions(client, client_uuid, _dry_run=args.dry_run)
 
 
 def _get_client(args):
@@ -124,7 +124,7 @@ def _get_scopes_to_create() -> list[dict]:
     return scopes
 
 
-def _preview_scopes(client: KeycloakAdmin, client_uuid: str, **kwargs):
+def _preview_scopes(*args, **kwargs):
     """Preview scopes that would be created."""
     scopes = _get_scopes_to_create()
     print("Scopes to be created:")
@@ -134,7 +134,7 @@ def _preview_scopes(client: KeycloakAdmin, client_uuid: str, **kwargs):
 
 
 @dry_run_preview(_preview_scopes)
-def _create_scopes(client: KeycloakAdmin, client_uuid: str, **kwargs):
+def _create_scopes(client: KeycloakAdmin, client_uuid: str, *, _dry_run: bool = False):
     """Create Keycloak scopes."""
     scopes = _get_scopes_to_create()
 
@@ -171,7 +171,7 @@ def _get_resources_to_create(
     return standard_resources, menu_resources
 
 
-def _preview_resources(client: KeycloakAdmin, client_uuid: str, **kwargs):
+def _preview_resources(client: KeycloakAdmin, client_uuid: str):
     """Preview resources that would be created."""
     standard_resources, menu_resources = _get_resources_to_create(client, client_uuid)
 
@@ -188,7 +188,7 @@ def _preview_resources(client: KeycloakAdmin, client_uuid: str, **kwargs):
 
 
 @dry_run_preview(_preview_resources)
-def _create_resources(client: KeycloakAdmin, client_uuid: str, **kwargs):
+def _create_resources(client: KeycloakAdmin, client_uuid: str, *, _dry_run: bool = False):
     """Create Keycloak resources."""
     standard_resources, menu_resources = _get_resources_to_create(client, client_uuid)
 
@@ -274,7 +274,7 @@ def _get_permissions_to_create(client: KeycloakAdmin, client_uuid: str) -> list[
     return result
 
 
-def _preview_permissions(client: KeycloakAdmin, client_uuid: str, **kwargs):
+def _preview_permissions(client: KeycloakAdmin, client_uuid: str):
     """Preview permissions that would be created."""
     permissions = _get_permissions_to_create(client, client_uuid)
 
@@ -290,7 +290,7 @@ def _preview_permissions(client: KeycloakAdmin, client_uuid: str, **kwargs):
 
 
 @dry_run_preview(_preview_permissions)
-def _create_permissions(client: KeycloakAdmin, client_uuid: str, **kwargs):
+def _create_permissions(client: KeycloakAdmin, client_uuid: str, *, _dry_run: bool = False):
     """Create Keycloak permissions."""
     permissions = _get_permissions_to_create(client, client_uuid)
 

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/cli/commands.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/cli/commands.py
@@ -57,6 +57,9 @@ def create_scopes_command(args):
 
     _create_scopes(client, client_uuid, args.dry_run)
 
+    if args.dry_run:
+        print("Dry run for creating scopes completed.")
+
 
 @cli_utils.action_cli
 @providers_configuration_loaded

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/cli/definition.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/cli/definition.py
@@ -39,6 +39,11 @@ ARG_USER_REALM = Arg(
     ("--user-realm",), help="Realm name where the user used to create resources is", default="master"
 )
 ARG_CLIENT_ID = Arg(("--client-id",), help="ID of the client used to create resources", default="admin-cli")
+ARG_DRY_RUN = Arg(
+    ("--dry-run",),
+    help="Perform a dry run without creating any resources",
+    action="store_true",
+)
 
 
 ################
@@ -50,7 +55,7 @@ KEYCLOAK_AUTH_MANAGER_COMMANDS = (
         name="create-scopes",
         help="Create scopes in Keycloak",
         func=lazy_load_command("airflow.providers.keycloak.auth_manager.cli.commands.create_scopes_command"),
-        args=(ARG_USERNAME, ARG_PASSWORD, ARG_USER_REALM, ARG_CLIENT_ID),
+        args=(ARG_USERNAME, ARG_PASSWORD, ARG_USER_REALM, ARG_CLIENT_ID, ARG_DRY_RUN),
     ),
     ActionCommand(
         name="create-resources",
@@ -58,7 +63,7 @@ KEYCLOAK_AUTH_MANAGER_COMMANDS = (
         func=lazy_load_command(
             "airflow.providers.keycloak.auth_manager.cli.commands.create_resources_command"
         ),
-        args=(ARG_USERNAME, ARG_PASSWORD, ARG_USER_REALM, ARG_CLIENT_ID),
+        args=(ARG_USERNAME, ARG_PASSWORD, ARG_USER_REALM, ARG_CLIENT_ID, ARG_DRY_RUN),
     ),
     ActionCommand(
         name="create-permissions",
@@ -66,12 +71,12 @@ KEYCLOAK_AUTH_MANAGER_COMMANDS = (
         func=lazy_load_command(
             "airflow.providers.keycloak.auth_manager.cli.commands.create_permissions_command"
         ),
-        args=(ARG_USERNAME, ARG_PASSWORD, ARG_USER_REALM, ARG_CLIENT_ID),
+        args=(ARG_USERNAME, ARG_PASSWORD, ARG_USER_REALM, ARG_CLIENT_ID, ARG_DRY_RUN),
     ),
     ActionCommand(
         name="create-all",
         help="Create all entities (scopes, resources and permissions) in Keycloak",
         func=lazy_load_command("airflow.providers.keycloak.auth_manager.cli.commands.create_all_command"),
-        args=(ARG_USERNAME, ARG_PASSWORD, ARG_USER_REALM, ARG_CLIENT_ID),
+        args=(ARG_USERNAME, ARG_PASSWORD, ARG_USER_REALM, ARG_CLIENT_ID, ARG_DRY_RUN),
     ),
 )

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/cli/utils.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/cli/utils.py
@@ -1,0 +1,81 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable
+from typing import Any
+
+
+def dry_run_message_wrap(func: Callable) -> Callable:
+    """Wrap CLI commands to display dry-run messages."""
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        # detect args object (first positional or keyword)
+        if args:
+            arg_obj = args[0]
+        else:
+            arg_obj = kwargs.get("args")
+
+        dry_run = getattr(arg_obj, "dry_run", False)
+
+        if dry_run:
+            print(
+                "Performing dry run. "
+                "It will check the connection to Keycloak but won't create any resources.\n"
+            )
+
+        result = func(*args, **kwargs)
+
+        if dry_run:
+            print("Dry run completed.")
+
+        return result
+
+    return wrapper
+
+
+def dry_run_preview(preview_func: Callable[..., None]) -> Callable:
+    """
+    Handle dry-run preview logic for create functions.
+
+    When dry_run=True, executes the preview function and returns early.
+    Otherwise, proceeds with normal execution without passing dry_run
+    to the decorated function.
+
+    :param preview_func: Function to call for previewing what would be created.
+                        Should accept the same arguments as the decorated function.
+    """
+
+    def decorator(func: Callable) -> Callable:
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs) -> Any:
+            # Extract dry_run from kwargs (default to False if not provided)
+            dry_run = kwargs.pop("dry_run", False)
+
+            if dry_run:
+                # Pass args and remaining kwargs to preview function
+                preview_func(*args, **kwargs)
+                return None
+
+            # Pass args and remaining kwargs to actual function
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/cli/utils.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/cli/utils.py
@@ -66,7 +66,7 @@ def dry_run_preview(preview_func: Callable[..., None]) -> Callable:
         @functools.wraps(func)
         def wrapper(*args, **kwargs) -> Any:
             # Extract dry_run from kwargs (default to False if not provided)
-            dry_run = kwargs.pop("dry_run", False)
+            dry_run = kwargs.pop("_dry_run", False)
 
             if dry_run:
                 # Pass args and remaining kwargs to preview function

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/cli/test_commands.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/cli/test_commands.py
@@ -26,10 +26,6 @@ from airflow.api_fastapi.auth.managers.base_auth_manager import ResourceMethod
 from airflow.api_fastapi.common.types import MenuItem
 from airflow.cli import cli_parser
 from airflow.providers.keycloak.auth_manager.cli.commands import (
-    _create_admin_permission,
-    _create_op_permission,
-    _create_read_only_permission,
-    _create_user_permission,
     create_all_command,
     create_permissions_command,
     create_resources_command,
@@ -170,28 +166,26 @@ class TestCommands:
             )
         client.create_client_authz_resource.assert_has_calls(calls)
 
-    @patch("airflow.providers.keycloak.auth_manager.cli.commands._create_op_permission")
-    @patch("airflow.providers.keycloak.auth_manager.cli.commands._create_user_permission")
-    @patch("airflow.providers.keycloak.auth_manager.cli.commands._create_admin_permission")
-    @patch("airflow.providers.keycloak.auth_manager.cli.commands._create_read_only_permission")
     @patch("airflow.providers.keycloak.auth_manager.cli.commands._get_client")
     def test_create_permissions(
         self,
         mock_get_client,
-        mock_create_read_only_permission,
-        mock_create_admin_permission,
-        mock__create_user_permission,
-        mock_create_op_permission,
     ):
         client = Mock()
         mock_get_client.return_value = client
-        scopes = [{"id": "1", "name": "GET"}]
+        scopes = [{"id": "1", "name": "GET"}, {"id": "2", "name": "MENU"}, {"id": "3", "name": "LIST"}]
+        resources = [
+            {"_id": "r1", "name": "Dag"},
+            {"_id": "r2", "name": "Asset"},
+            {"_id": "r3", "name": "Connection"},
+        ]
 
         client.get_clients.return_value = [
             {"id": "dummy-id", "clientId": "dummy-client"},
             {"id": "test-id", "clientId": "test_client_id"},
         ]
         client.get_client_authz_scopes.return_value = scopes
+        client.get_client_authz_resources.return_value = resources
 
         params = [
             "keycloak-auth-manager",
@@ -209,10 +203,60 @@ class TestCommands:
             create_permissions_command(self.arg_parser.parse_args(params))
 
         client.get_clients.assert_called_once_with()
-        mock_create_read_only_permission.assert_called_once_with(client, "test-id")
-        mock_create_admin_permission.assert_called_once_with(client, "test-id")
-        mock__create_user_permission.assert_called_once_with(client, "test-id")
-        mock_create_op_permission.assert_called_once_with(client, "test-id")
+        client.get_client_authz_scopes.assert_called_once_with("test-id")
+        client.get_client_authz_resources.assert_called_once_with("test-id")
+
+        # Verify scope-based permissions are created with correct payloads
+        scope_calls = [
+            call(
+                client_id="test-id",
+                payload={
+                    "name": "ReadOnly",
+                    "type": "scope",
+                    "logic": "POSITIVE",
+                    "decisionStrategy": "UNANIMOUS",
+                    "scopes": ["1", "2", "3"],  # GET, MENU, LIST
+                },
+            ),
+            call(
+                client_id="test-id",
+                payload={
+                    "name": "Admin",
+                    "type": "scope",
+                    "logic": "POSITIVE",
+                    "decisionStrategy": "UNANIMOUS",
+                    "scopes": ["1", "2", "3"],  # GET, MENU, LIST (only these exist in mock)
+                },
+            ),
+        ]
+        client.create_client_authz_scope_permission.assert_has_calls(scope_calls, any_order=True)
+
+        # Verify resource-based permissions are created with correct payloads
+        resource_calls = [
+            call(
+                client_id="test-id",
+                payload={
+                    "name": "User",
+                    "type": "scope",
+                    "logic": "POSITIVE",
+                    "decisionStrategy": "UNANIMOUS",
+                    "resources": ["r1", "r2"],  # Dag, Asset
+                },
+                skip_exists=True,
+            ),
+            call(
+                client_id="test-id",
+                payload={
+                    "name": "Op",
+                    "type": "scope",
+                    "logic": "POSITIVE",
+                    "decisionStrategy": "UNANIMOUS",
+                    "resources": ["r3"],  # Connection
+                },
+                skip_exists=True,
+            ),
+        ]
+        client.create_client_authz_resource_based_permission.assert_has_calls(resource_calls, any_order=True)
 
     @patch("airflow.providers.keycloak.auth_manager.cli.commands._create_permissions")
     @patch("airflow.providers.keycloak.auth_manager.cli.commands._create_resources")
@@ -254,99 +298,3 @@ class TestCommands:
         mock_create_scopes.assert_called_once_with(client, "test-id")
         mock_create_resources.assert_called_once_with(client, "test-id")
         mock_create_permissions.assert_called_once_with(client, "test-id")
-
-    def test_create_permissions_read_only(self):
-        client = Mock()
-        scopes = [{"id": "1", "name": "GET"}, {"id": "2", "name": "MENU"}, {"id": "3", "name": "PUT"}]
-
-        client.get_client_authz_scopes.return_value = scopes
-
-        _create_read_only_permission(client, "test-id")
-
-        client.get_client_authz_scopes.assert_called_once_with("test-id")
-        client.create_client_authz_scope_permission.assert_called_once_with(
-            client_id="test-id",
-            payload={
-                "name": "ReadOnly",
-                "type": "scope",
-                "logic": "POSITIVE",
-                "decisionStrategy": "UNANIMOUS",
-                "scopes": ["1", "2"],
-            },
-        )
-
-    def test_create_permissions_admin(self):
-        client = Mock()
-        scopes = [
-            {"id": "1", "name": "GET"},
-            {"id": "2", "name": "MENU"},
-            {"id": "3", "name": "PUT"},
-            {"id": "4", "name": "LIST"},
-            {"id": "5", "name": "DUMMY"},
-        ]
-
-        client.get_client_authz_scopes.return_value = scopes
-
-        _create_admin_permission(client, "test-id")
-
-        client.get_client_authz_scopes.assert_called_once_with("test-id")
-        client.create_client_authz_scope_permission.assert_called_once_with(
-            client_id="test-id",
-            payload={
-                "name": "Admin",
-                "type": "scope",
-                "logic": "POSITIVE",
-                "decisionStrategy": "UNANIMOUS",
-                "scopes": ["1", "2", "3", "4"],
-            },
-        )
-
-    def test_create_permissions_user(self):
-        client = Mock()
-        resources = [
-            {"_id": "1", "name": "Dag"},
-            {"_id": "2", "name": "Asset"},
-            {"_id": "3", "name": "Variable"},
-        ]
-
-        client.get_client_authz_resources.return_value = resources
-
-        _create_user_permission(client, "test-id")
-
-        client.get_client_authz_resources.assert_called_once_with("test-id")
-        client.create_client_authz_resource_based_permission.assert_called_once_with(
-            client_id="test-id",
-            payload={
-                "name": "User",
-                "type": "scope",
-                "logic": "POSITIVE",
-                "decisionStrategy": "UNANIMOUS",
-                "resources": ["1", "2"],
-            },
-            skip_exists=True,
-        )
-
-    def test_create_permissions_op(self):
-        client = Mock()
-        resources = [
-            {"_id": "1", "name": "Dag"},
-            {"_id": "2", "name": "Connection"},
-            {"_id": "3", "name": "Variable"},
-        ]
-
-        client.get_client_authz_resources.return_value = resources
-
-        _create_op_permission(client, "test-id")
-
-        client.get_client_authz_resources.assert_called_once_with("test-id")
-        client.create_client_authz_resource_based_permission.assert_called_once_with(
-            client_id="test-id",
-            payload={
-                "name": "Op",
-                "type": "scope",
-                "logic": "POSITIVE",
-                "decisionStrategy": "UNANIMOUS",
-                "resources": ["2", "3"],
-            },
-            skip_exists=True,
-        )

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/cli/test_commands.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/cli/test_commands.py
@@ -295,9 +295,9 @@ class TestCommands:
             create_all_command(self.arg_parser.parse_args(params))
 
         client.get_clients.assert_called_once_with()
-        mock_create_scopes.assert_called_once_with(client, "test-id", False)
-        mock_create_resources.assert_called_once_with(client, "test-id", False)
-        mock_create_permissions.assert_called_once_with(client, "test-id", False)
+        mock_create_scopes.assert_called_once_with(client, "test-id", dry_run=False)
+        mock_create_resources.assert_called_once_with(client, "test-id", dry_run=False)
+        mock_create_permissions.assert_called_once_with(client, "test-id", dry_run=False)
 
     @patch("airflow.providers.keycloak.auth_manager.cli.commands._get_client")
     def test_create_scopes_dry_run(self, mock_get_client):
@@ -439,6 +439,6 @@ class TestCommands:
 
         client.get_clients.assert_called_once_with()
         # In dry-run mode, all helper functions should be called with dry_run=True
-        mock_create_scopes.assert_called_once_with(client, "test-id", True)
-        mock_create_resources.assert_called_once_with(client, "test-id", True)
-        mock_create_permissions.assert_called_once_with(client, "test-id", True)
+        mock_create_scopes.assert_called_once_with(client, "test-id", dry_run=True)
+        mock_create_resources.assert_called_once_with(client, "test-id", dry_run=True)
+        mock_create_permissions.assert_called_once_with(client, "test-id", dry_run=True)

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/cli/test_commands.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/cli/test_commands.py
@@ -295,9 +295,9 @@ class TestCommands:
             create_all_command(self.arg_parser.parse_args(params))
 
         client.get_clients.assert_called_once_with()
-        mock_create_scopes.assert_called_once_with(client, "test-id", dry_run=False)
-        mock_create_resources.assert_called_once_with(client, "test-id", dry_run=False)
-        mock_create_permissions.assert_called_once_with(client, "test-id", dry_run=False)
+        mock_create_scopes.assert_called_once_with(client, "test-id", _dry_run=False)
+        mock_create_resources.assert_called_once_with(client, "test-id", _dry_run=False)
+        mock_create_permissions.assert_called_once_with(client, "test-id", _dry_run=False)
 
     @patch("airflow.providers.keycloak.auth_manager.cli.commands._get_client")
     def test_create_scopes_dry_run(self, mock_get_client):
@@ -439,6 +439,6 @@ class TestCommands:
 
         client.get_clients.assert_called_once_with()
         # In dry-run mode, all helper functions should be called with dry_run=True
-        mock_create_scopes.assert_called_once_with(client, "test-id", dry_run=True)
-        mock_create_resources.assert_called_once_with(client, "test-id", dry_run=True)
-        mock_create_permissions.assert_called_once_with(client, "test-id", dry_run=True)
+        mock_create_scopes.assert_called_once_with(client, "test-id", _dry_run=True)
+        mock_create_resources.assert_called_once_with(client, "test-id", _dry_run=True)
+        mock_create_permissions.assert_called_once_with(client, "test-id", _dry_run=True)

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/cli/test_utils.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/cli/test_utils.py
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from airflow.providers.keycloak.auth_manager.cli.utils import dry_run_message_wrap, dry_run_preview
+
+
+class TestDryRunMessageWrap:
+    def test_prints_messages_when_dry_run_true(self, capsys):
+        @dry_run_message_wrap
+        def test_func(args):
+            return "executed"
+
+        args = MagicMock()
+        args.dry_run = True
+        result = test_func(args)
+
+        captured = capsys.readouterr()
+        assert "Performing dry run" in captured.out
+        assert "Dry run completed" in captured.out
+        assert result == "executed"
+
+
+class TestDryRunPreview:
+    def test_calls_preview_when_dry_run_true(self):
+        preview_called = []
+
+        def preview_func(*args, **kwargs):
+            preview_called.append(True)
+
+        @dry_run_preview(preview_func)
+        def actual_func(*args, **kwargs):
+            return "actual"
+
+        result = actual_func(_dry_run=True)
+        assert result is None
+        assert len(preview_called) == 1
+
+    def test_calls_actual_when_dry_run_false(self):
+        @dry_run_preview(lambda *a, **k: None)
+        def actual_func(*args, **kwargs):
+            return "actual"
+
+        result = actual_func(_dry_run=False)
+        assert result == "actual"


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

The first time I ran the create_* commands I checked the code to understand the changes that would happen in the keycloak instance. I have added the `--dry-run` that shows what will happen without actually creating anything.

- The first commit refactors the `commands.py` file so that `get_resource_*` methods are available to generate the the resources that need to be created.
 - The second commit adds the dry mode logic.
 - The last commit refactors the dry mode logic. It adds `_preview_*` methods that handle printing the dry run info. These methods are executed using decorators, that should make the code more readable.

Since it is "dynamic", adding new entities in the `get_resource_*` methods will automatically generate the appropriate dry run prints so this feature should be low maintenance.

Example of running the `create_all` command with `--dry-run` flag:

```
Performing dry run for creating all entities. It will check the connection to Keycloak but won't create any entity.

Scopes to be created:
  - GET
  - POST
  - PUT
  - DELETE
  - MENU
  - LIST

Resources to be created:
  - Asset (scopes: DELETE, GET, LIST, POST, PUT)
  - AssetAlias (scopes: DELETE, GET, LIST, POST, PUT)
  - Backfill (scopes: DELETE, GET, LIST, POST, PUT)
  - Configuration (scopes: DELETE, GET, LIST, POST, PUT)
  - Connection (scopes: DELETE, GET, LIST, POST, PUT)
  - Custom (scopes: DELETE, GET, LIST, POST, PUT)
  - Dag (scopes: DELETE, GET, LIST, POST, PUT)
  - Menu (scopes: DELETE, GET, LIST, POST, PUT)
  - Pool (scopes: DELETE, GET, LIST, POST, PUT)
  - Variable (scopes: DELETE, GET, LIST, POST, PUT)
  - View (scopes: DELETE, GET, LIST, POST, PUT)

Menu item resources to be created:
  - Required Actions (scopes: MENU)
  - Assets (scopes: MENU)
  - Audit Log (scopes: MENU)
  - Config (scopes: MENU)
  - Connections (scopes: MENU)
  - Dags (scopes: MENU)
  - Docs (scopes: MENU)
  - Plugins (scopes: MENU)
  - Pools (scopes: MENU)
  - Providers (scopes: MENU)
  - Variables (scopes: MENU)
  - XComs (scopes: MENU)

Permissions to be created:
  - ReadOnly (type: scope-based, scopes: GET, LIST, MENU)
  - Admin (type: scope-based, scopes: DELETE, GET, LIST, MENU, POST, PUT)
  - User (type: resource-based, resources: Asset, Dag)
  - Op (type: resource-based, resources: Backfill, Connection, Pool, Variable)

Dry run for creating all entities completed.
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
