### PR TITLE
Remove imports of airflow and airflow.sdk from shared secrets_backend

### DIFF
--- a/task-sdk/src/airflow/sdk/configuration.py
+++ b/task-sdk/src/airflow/sdk/configuration.py
@@ -195,6 +195,7 @@ def initialize_secrets_backends(
 
     Uses SDK's conf instead of Core's conf.
     """
+    from airflow.sdk.definitions.connection import Connection
     from airflow.sdk.module_loading import import_string
 
     backend_list = []
@@ -214,6 +215,9 @@ def initialize_secrets_backends(
 
     for class_name in default_backends:
         secrets_backend_cls = import_string(class_name)
+        if not hasattr(secrets_backend_cls, "set_connection_class"):
+            raise ValueError(f"{secrets_backend_cls} does not have set_connection_class method")
+        secrets_backend_cls.set_connection_class(Connection)
         backend_list.append(secrets_backend_cls())
 
     return backend_list


### PR DESCRIPTION
Shared secrets backend distribution should not import anything from airflow or airflow.sdk. So far it was detecting which connection class to return based on _AIRFLOW_PROCESS_CONTEXT but this was a bit brittle and required the shared class to know about the users.

This PR replaces it with injectong the connection class from outside by "set_connection_class". In both - task-sdk and airflow-core, the backends are initialized in a very similar way (this code will be soon extracted to common configuration) - but at the moment of initialization, we already know if we are in "airflow-core" or "task-sdk" context, so we can inject approproate Connection class.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
