### PR TITLE
Add delete_active_pod cleanup mode and unit tests for process_pod_deletion

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -234,7 +234,8 @@ class KubernetesPodOperator(BaseOperator):
     :param log_pod_spec_on_failure: Log the pod's specification if a failure occurs
     :param on_finish_action: What to do when the pod reaches its final state, or the execution is interrupted.
         If "delete_pod", the pod will be deleted regardless its state; if "delete_succeeded_pod",
-        only succeeded pod will be deleted. You can set to "keep_pod" to keep the pod.
+        only succeeded pod will be deleted. You can set to "keep_pod" to keep the pod. "delete_active_pod" deletes
+        pods that are still active (Pending or Running).
     :param termination_message_policy: The termination message policy of the base container.
         Default value is "File"
     :param active_deadline_seconds: The active_deadline_seconds which translates to active_deadline_seconds
@@ -1029,7 +1030,11 @@ class KubernetesPodOperator(BaseOperator):
         pod_phase = remote_pod.status.phase if hasattr(remote_pod, "status") else None
 
         # if the pod fails or success, but we don't want to delete it
-        if pod_phase != PodPhase.SUCCEEDED or self.on_finish_action == OnFinishAction.KEEP_POD:
+        if (
+            pod_phase != PodPhase.SUCCEEDED
+            or self.on_finish_action == OnFinishAction.KEEP_POD
+            or self.on_finish_action == OnFinishAction.DELETE_ACTIVE_POD
+        ):
             self.patch_already_checked(remote_pod, reraise=False)
 
         failed = (pod_phase != PodPhase.SUCCEEDED and not istio_enabled) or (
@@ -1165,13 +1170,21 @@ class KubernetesPodOperator(BaseOperator):
     def process_pod_deletion(self, pod: k8s.V1Pod, *, reraise=True) -> bool:
         with _optionally_suppress(reraise=reraise):
             if pod is not None:
-                should_delete_pod = (self.on_finish_action == OnFinishAction.DELETE_POD) or (
-                    self.on_finish_action == OnFinishAction.DELETE_SUCCEEDED_POD
-                    and (
-                        pod.status.phase == PodPhase.SUCCEEDED
-                        or container_is_succeeded(pod, self.base_container_name)
+                should_delete_pod = (
+                    (self.on_finish_action == OnFinishAction.DELETE_POD)
+                    or (
+                        self.on_finish_action == OnFinishAction.DELETE_SUCCEEDED_POD
+                        and (
+                            pod.status.phase == PodPhase.SUCCEEDED
+                            or container_is_succeeded(pod, self.base_container_name)
+                        )
+                    )
+                    or (
+                        self.on_finish_action == OnFinishAction.DELETE_ACTIVE_POD
+                        and (pod.status.phase == PodPhase.RUNNING or pod.status.phase == PodPhase.PENDING)
                     )
                 )
+
                 if should_delete_pod:
                     self.log.info("Deleting pod: %s", pod.metadata.name)
                     self.pod_manager.delete_pod(pod)

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -926,6 +926,7 @@ class OnFinishAction(str, enum.Enum):
 
     KEEP_POD = "keep_pod"
     DELETE_POD = "delete_pod"
+    DELETE_ACTIVE_POD = "delete_active_pod"
     DELETE_SUCCEEDED_POD = "delete_succeeded_pod"
 
 

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -720,6 +720,53 @@ class TestKubernetesPodOperator:
         mock_find.assert_called_once_with("default", context=context)
 
     @pytest.mark.parametrize(
+        ("on_finish_action", "pod_phase", "should_delete"),
+        [
+            (OnFinishAction.DELETE_POD, PodPhase.PENDING, True),
+            (OnFinishAction.DELETE_POD, PodPhase.RUNNING, True),
+            (OnFinishAction.DELETE_POD, PodPhase.SUCCEEDED, True),
+            (OnFinishAction.DELETE_POD, PodPhase.FAILED, True),
+            (OnFinishAction.DELETE_SUCCEEDED_POD, PodPhase.PENDING, False),
+            (OnFinishAction.DELETE_SUCCEEDED_POD, PodPhase.RUNNING, False),
+            (OnFinishAction.DELETE_SUCCEEDED_POD, PodPhase.SUCCEEDED, True),
+            (OnFinishAction.DELETE_SUCCEEDED_POD, PodPhase.FAILED, False),
+            (OnFinishAction.DELETE_ACTIVE_POD, PodPhase.PENDING, True),
+            (OnFinishAction.DELETE_ACTIVE_POD, PodPhase.RUNNING, True),
+            (OnFinishAction.DELETE_ACTIVE_POD, PodPhase.SUCCEEDED, False),
+            (OnFinishAction.DELETE_ACTIVE_POD, PodPhase.FAILED, False),
+        ],
+    )
+    @patch(f"{POD_MANAGER_CLASS}.delete_pod")
+    def test_process_pod_deletion(self, delete_pod_mock, on_finish_action, pod_phase, should_delete):
+        """Test KubernetesPodOperator pod cleanup behavior across all modes and pod phases."""
+
+        k = KubernetesPodOperator(
+            namespace="default",
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            labels={"foo": "bar"},
+            name="test",
+            task_id="task",
+            do_xcom_push=False,
+        )
+
+        k.on_finish_action = on_finish_action
+
+        pod = MagicMock()
+        pod.metadata.name = "pod-name"
+        pod.status.phase = pod_phase
+
+        result = k.process_pod_deletion(pod)
+
+        # Assert deletion side-effect behavior
+        if should_delete:
+            delete_pod_mock.assert_called_once_with(pod)
+        else:
+            delete_pod_mock.assert_not_called()
+
+        assert result == should_delete
+
+    @pytest.mark.parametrize(
         "pod_phase",
         [
             PodPhase.SUCCEEDED,
@@ -918,6 +965,8 @@ class TestKubernetesPodOperator:
             ({"on_finish_action": "keep_pod"}, True, False),
             ({"on_finish_action": "delete_succeeded_pod"}, False, True),
             ({"on_finish_action": "delete_succeeded_pod"}, True, False),
+            ({"on_finish_action": "delete_active_pod"}, True, True),
+            ({"on_finish_action": "delete_active_pod"}, False, True),
         ],
     )
     @patch(f"{POD_MANAGER_CLASS}.delete_pod")
@@ -995,6 +1044,7 @@ class TestKubernetesPodOperator:
             pytest.param({"on_finish_action": "delete_pod"}, True, id="delete-pod"),
             pytest.param({"on_finish_action": "delete_succeeded_pod"}, False, id="delete-succeeded-pod"),
             pytest.param({"on_finish_action": "keep_pod"}, False, id="keep-pod"),
+            pytest.param({"on_finish_action": "delete_active_pod"}, False, id="delete-active-pod"),
         ],
     )
     @patch(f"{POD_MANAGER_CLASS}.delete_pod")
@@ -1614,6 +1664,8 @@ class TestKubernetesPodOperator:
             ({"on_finish_action": "delete_pod"}, True, True),
             ({"on_finish_action": "delete_succeeded_pod"}, False, True),
             ({"on_finish_action": "delete_succeeded_pod"}, True, False),
+            ({"on_finish_action": "delete_active_pod"}, False, False),
+            ({"on_finish_action": "delete_active_pod"}, True, False),
         ],
     )
     @patch(f"{POD_MANAGER_CLASS}.delete_pod")
@@ -2163,7 +2215,8 @@ class TestKubernetesPodOperator:
         )
 
     @pytest.mark.parametrize(
-        "on_finish_action", [OnFinishAction.KEEP_POD, OnFinishAction.DELETE_SUCCEEDED_POD]
+        "on_finish_action",
+        [OnFinishAction.KEEP_POD, OnFinishAction.DELETE_ACTIVE_POD, OnFinishAction.DELETE_SUCCEEDED_POD],
     )
     @patch(KUB_OP_PATH.format("patch_already_checked"))
     @patch(KUB_OP_PATH.format("process_pod_deletion"))


### PR DESCRIPTION
**Description**

This PR introduces a new `on_finish_action` mode, `delete_active_pod`, which deletes pods that are in the 'Pending' or 'Running' state when the task finishes. This allows Airflow to clean up zombie or orphaned pods that never reach a terminal phase.

**Why introduce a new flag instead of changing `delete_succeeded_pod`**?

The behavior of `delete_succeeded_pod` was left unchanged to avoid breaking backward compatibility. Changing its semantics to also delete active pods could alter expectations for existing users who rely on the current behavior for debugging or operational workflows. Introducing a new explicit flag ensures clarity while preserving existing behavior.

**Tests**

The deletion logic inside process_pod_deletion previously had no direct unit test coverage.

This PR adds a parameterized test that verifies pod deletion behavior across all supported modes ('delete_pod', 'delete_succeeded_pod', and the new 'delete_active_pod') and pod phases ('Pending', 'Running', 'Completed and Succeeded'). This ensures that the new flag behaves correctly and that existing behavior remains stable. 

Existing tests have been updated where applicable to handle the 'delete_active_pod' cleanup mode. 

**Documentation**

Docstring updated to reflect the new `delete_active_pod` option.

**Related Issues**

 closes: #59083

