### PR TITLE
Fix airflow/task-sdk relase PMC checks

### DIFF
--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -756,6 +756,7 @@ As a PMC member, you should be able to clone the SVN repository
 or update it if you already checked it out:
 
 ```shell script
+cd ${AIRFLOW_REPO_ROOT}
 cd ..
 [ -d asf-dist ] || svn checkout --depth=immediates https://dist.apache.org/repos/dist asf-dist
 svn update --set-depth=infinity asf-dist/dev/airflow
@@ -772,12 +773,12 @@ Optionally you can use the `breeze release-management check-release-files` comma
 present in SVN. This command may also help with verifying installation of the packages.
 
 ```shell script
-breeze release-management check-release-files airflow --version ${VERSION_RC} --path-to-airflow-svn "${PATH_TO_AIRFLOW_SVN}"
+breeze release-management check-release-files airflow --version ${VERSION_RC}
 ```
 
 
 ```shell script
-breeze release-management check-release-files task-sdk --version ${TASK_SDK_VERSION_RC} --path-to-airflow-svn "${PATH_TO_AIRFLOW_SVN}/task-sdk"
+breeze release-management check-release-files task-sdk --version ${TASK_SDK_VERSION_RC}
 ```
 
 ## Licence check

--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -4380,7 +4380,7 @@ def check_release_files(
         if release_type == "airflow":
             directory = path_to_airflow_svn / version
         elif release_type == "task-sdk":
-            directory = path_to_airflow_svn / version
+            directory = path_to_airflow_svn / "task-sdk" / version
         elif release_type == "airflow-ctl":
             directory = path_to_airflow_svn / "airflow-ctl" / version
         elif release_type == "python-client":
@@ -4412,10 +4412,14 @@ def check_release_files(
         )
     elif release_type == "airflow":
         missing_files = check_airflow_release(files, version)
-        create_docker(AIRFLOW_DOCKER.format(version), dockerfile_path)
+        create_docker(AIRFLOW_DOCKER.format(version, version), dockerfile_path)
     elif release_type == "task-sdk":
         missing_files = check_task_sdk_release(files, version)
-        create_docker(TASK_SDK_DOCKER.format(version), dockerfile_path)
+        airflow_version = version.replace("1", "3", 1)
+        create_docker(
+            TASK_SDK_DOCKER.format(version, airflow_version, airflow_version, airflow_version),
+            dockerfile_path,
+        )
     elif release_type == "airflow-ctl":
         missing_files = check_airflow_ctl_release(files, version)
         create_docker(AIRFLOW_CTL_DOCKER.format(version), dockerfile_path)

--- a/dev/breeze/src/airflow_breeze/utils/check_release_files.py
+++ b/dev/breeze/src/airflow_breeze/utils/check_release_files.py
@@ -33,16 +33,16 @@ RUN cd airflow-core; uv sync --no-sources
 AIRFLOW_DOCKER = """\
 FROM python:3.10
 
-# Upgrade
-RUN pip install "apache-airflow=={}"
+RUN pip install "apache-airflow=={}" \
+    --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-{}/constraints-3.10.txt"
 
 """
 
 TASK_SDK_DOCKER = """\
 FROM python:3.10
 
-# Upgrade
-RUN pip install "apache-airflow-task-sdk=={}"
+RUN pip install "apache-airflow-task-sdk=={}" "apache-airflow-core=={}" "apache-airflow=={}"\
+  --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-{}/constraints-3.10.txt"
 
 """
 


### PR DESCRIPTION
There were few small issues with the airflow/task-sdk release-checks:

* one cd was missing in the process
* task-sdk folder was not pointing to the right sub-folder.
* Dockerfile.pmc should use constraints and for task-sdk they should install also apache-airflow and apache-airflow-core as those are not dependencies of task-sdk and pip failed to find them without --pre flag.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
