### PR TITLE
Add deprecated_options entry for dag_file_processor_timeout

### DIFF
--- a/shared/configuration/src/airflow_shared/configuration/parser.py
+++ b/shared/configuration/src/airflow_shared/configuration/parser.py
@@ -128,6 +128,7 @@ class AirflowConfigParser(ConfigParser):
     # When reading new option, the old option will be checked to see if it exists. If it does a
     # DeprecationWarning will be issued and the old option will be used instead
     deprecated_options: dict[tuple[str, str], tuple[str, str, str]] = {
+        ("dag_processor", "dag_file_processor_timeout"): ("core", "dag_file_processor_timeout", "3.0"),
         ("dag_processor", "refresh_interval"): ("scheduler", "dag_dir_list_interval", "3.0"),
         ("api", "host"): ("webserver", "web_server_host", "3.0"),
         ("api", "port"): ("webserver", "web_server_port", "3.0"),


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Adds missing `deprecated_options` entry for `dag_file_processor_timeout` when it was moved from `[core]` to `[dag_processor]` in Airflow 3.0. Without this entry, config values set in the old `[core]` section were ignored, causing the dag processor to use the default 50 second timeout instead of user-configured values.

#### Which issue(s) this PR is related to:

Fixes #58995

#### Note:

The `deprecated_options` dict was recently moved from `airflow-core/src/airflow/configuration.py` to `shared/configuration/src/airflow_shared/configuration/parser.py`.

#### Does this PR introduce a user-facing change?

```release-note
NONE