### PR TITLE
chore: use OL macros instead of building OL ids from scratch

### DIFF
--- a/providers/databricks/tests/unit/databricks/hooks/test_databricks_sql.py
+++ b/providers/databricks/tests/unit/databricks/hooks/test_databricks_sql.py
@@ -569,7 +569,7 @@ def test_get_openlineage_database_specific_lineage_with_old_openlineage_provider
     hook.get_openlineage_database_info = lambda x: mock.MagicMock(authority="auth", scheme="scheme")
 
     expected_err = (
-        "OpenLineage provider version `1.99.0` is lower than required `2.3.0`, "
+        "OpenLineage provider version `1.99.0` is lower than required `2.5.0`, "
         "skipping function `emit_openlineage_events_for_databricks_queries` execution"
     )
     with pytest.raises(AirflowOptionalProviderFeatureException, match=expected_err):

--- a/providers/dbt/cloud/tests/unit/dbt/cloud/utils/test_openlineage.py
+++ b/providers/dbt/cloud/tests/unit/dbt/cloud/utils/test_openlineage.py
@@ -27,8 +27,14 @@ from packaging.version import parse
 from airflow.exceptions import AirflowOptionalProviderFeatureException
 from airflow.providers.dbt.cloud.hooks.dbt import DbtCloudHook
 from airflow.providers.dbt.cloud.operators.dbt import DbtCloudRunJobOperator
-from airflow.providers.dbt.cloud.utils.openlineage import generate_openlineage_events_from_dbt_cloud_run
+from airflow.providers.dbt.cloud.utils.openlineage import (
+    _get_parent_run_metadata,
+    generate_openlineage_events_from_dbt_cloud_run,
+)
+from airflow.providers.openlineage.conf import namespace
 from airflow.providers.openlineage.extractors import OperatorLineage
+from airflow.utils import timezone
+from airflow.utils.state import TaskInstanceState
 
 TASK_ID = "dbt_test"
 DAG_ID = "dbt_dag"
@@ -94,12 +100,13 @@ def get_dbt_artifact(*args, **kwargs):
     [
         ("1.99.0", True),
         ("2.0.0", True),
-        ("2.3.0", False),
+        ("2.3.0", True),
+        ("2.5.0", False),
         ("2.99.0", False),
     ],
 )
 def test_previous_version_openlineage_provider(value, is_error):
-    """When using OpenLineage, the dbt-cloud provider now depends on openlineage provider >= 2.3"""
+    """When using OpenLineage, the dbt-cloud provider now depends on openlineage provider >= 2.4"""
 
     def _mock_version(package):
         if package == "apache-airflow-providers-openlineage":
@@ -110,7 +117,7 @@ def test_previous_version_openlineage_provider(value, is_error):
     mock_task_instance = MagicMock()
 
     expected_err = (
-        f"OpenLineage provider version `{value}` is lower than required `2.3.0`, "
+        f"OpenLineage provider version `{value}` is lower than required `2.5.0`, "
         "skipping function `generate_openlineage_events_from_dbt_cloud_run` execution"
     )
 
@@ -126,8 +133,32 @@ def test_previous_version_openlineage_provider(value, is_error):
                 generate_openlineage_events_from_dbt_cloud_run(mock_operator, mock_task_instance)
 
 
+def test_get_parent_run_metadata():
+    logical_date = timezone.datetime(2025, 1, 1)
+    dr = MagicMock(logical_date=logical_date, clear_number=0)
+    mock_ti = MagicMock(
+        dag_id="dag_id",
+        task_id="task_id",
+        map_index=1,
+        try_number=1,
+        logical_date=logical_date,
+        state=TaskInstanceState.SUCCESS,
+        dag_run=dr,
+    )
+    mock_ti.get_template_context.return_value = {"dag_run": dr}
+
+    result = _get_parent_run_metadata(mock_ti)
+
+    assert result.run_id == "01941f29-7c00-7087-8906-40e512c257bd"
+    assert result.job_namespace == namespace()
+    assert result.job_name == "dag_id.task_id"
+    assert result.root_parent_run_id == "01941f29-7c00-743e-b109-28b18d0a19c5"
+    assert result.root_parent_job_namespace == namespace()
+    assert result.root_parent_job_name == "dag_id"
+
+
 class TestGenerateOpenLineageEventsFromDbtCloudRun:
-    @patch("importlib.metadata.version", return_value="2.3.0")
+    @patch("importlib.metadata.version", return_value="3.0.0")
     @patch("airflow.providers.openlineage.plugins.listener.get_openlineage_listener")
     @patch("airflow.providers.openlineage.plugins.adapter.OpenLineageAdapter.build_task_instance_run_id")
     @patch("airflow.providers.openlineage.plugins.adapter.OpenLineageAdapter.build_dag_run_id")

--- a/providers/snowflake/src/airflow/providers/snowflake/utils/openlineage.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/utils/openlineage.py
@@ -23,7 +23,6 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import quote, urlparse, urlunparse
 
 from airflow.providers.common.compat.openlineage.check import require_openlineage_version
-from airflow.providers.snowflake.version_compat import AIRFLOW_V_3_0_PLUS
 from airflow.utils import timezone
 
 if TYPE_CHECKING:
@@ -109,60 +108,6 @@ def fix_snowflake_sqlalchemy_uri(uri: str) -> str:
     return urlunparse((parts.scheme, hostname, parts.path, parts.params, parts.query, parts.fragment))
 
 
-def _get_logical_date(task_instance):
-    # todo: remove when min airflow version >= 3.0
-    if AIRFLOW_V_3_0_PLUS:
-        dagrun = task_instance.get_template_context()["dag_run"]
-        return dagrun.logical_date or dagrun.run_after
-
-    if hasattr(task_instance, "logical_date"):
-        date = task_instance.logical_date
-    else:
-        date = task_instance.execution_date
-
-    return date
-
-
-def _get_dag_run_clear_number(task_instance):
-    # todo: remove when min airflow version >= 3.0
-    if AIRFLOW_V_3_0_PLUS:
-        dagrun = task_instance.get_template_context()["dag_run"]
-        return dagrun.clear_number
-    return task_instance.dag_run.clear_number
-
-
-# todo: move this run_id logic into OpenLineage's listener to avoid differences
-def _get_ol_run_id(task_instance) -> str:
-    """
-    Get OpenLineage run_id from TaskInstance.
-
-    It's crucial that the task_instance's run_id creation logic matches OpenLineage's listener implementation.
-    Only then can we ensure that the generated run_id aligns with the Airflow task,
-    enabling a proper connection between events.
-    """
-    from airflow.providers.openlineage.plugins.adapter import OpenLineageAdapter
-
-    # Generate same OL run id as is generated for current task instance
-    return OpenLineageAdapter.build_task_instance_run_id(
-        dag_id=task_instance.dag_id,
-        task_id=task_instance.task_id,
-        logical_date=_get_logical_date(task_instance),
-        try_number=task_instance.try_number,
-        map_index=task_instance.map_index,
-    )
-
-
-# todo: move this run_id logic into OpenLineage's listener to avoid differences
-def _get_ol_dag_run_id(task_instance) -> str:
-    from airflow.providers.openlineage.plugins.adapter import OpenLineageAdapter
-
-    return OpenLineageAdapter.build_dag_run_id(
-        dag_id=task_instance.dag_id,
-        logical_date=_get_logical_date(task_instance),
-        clear_number=_get_dag_run_clear_number(task_instance),
-    )
-
-
 def _get_parent_run_facet(task_instance):
     """
     Retrieve the ParentRunFacet associated with a specific Airflow task instance.
@@ -173,22 +118,39 @@ def _get_parent_run_facet(task_instance):
     """
     from openlineage.client.facet_v2 import parent_run
 
-    from airflow.providers.openlineage.conf import namespace
+    from airflow.providers.openlineage.plugins.macros import (
+        lineage_job_name,
+        lineage_job_namespace,
+        lineage_root_job_name,
+        lineage_root_run_id,
+        lineage_run_id,
+    )
 
-    parent_run_id = _get_ol_run_id(task_instance)
-    root_parent_run_id = _get_ol_dag_run_id(task_instance)
+    parent_run_id = lineage_run_id(task_instance)
+    parent_job_name = lineage_job_name(task_instance)
+    parent_job_namespace = lineage_job_namespace()
+
+    root_parent_run_id = lineage_root_run_id(task_instance)
+    rot_parent_job_name = lineage_root_job_name(task_instance)
+
+    try:  # Added in OL provider 2.9.0, try to use it if possible
+        from airflow.providers.openlineage.plugins.macros import lineage_root_job_namespace
+
+        root_parent_job_namespace = lineage_root_job_namespace(task_instance)
+    except ImportError:
+        root_parent_job_namespace = lineage_job_namespace()
 
     return parent_run.ParentRunFacet(
         run=parent_run.Run(runId=parent_run_id),
         job=parent_run.Job(
-            namespace=namespace(),
-            name=f"{task_instance.dag_id}.{task_instance.task_id}",
+            namespace=parent_job_namespace,
+            name=parent_job_name,
         ),
         root=parent_run.Root(
             run=parent_run.RootRun(runId=root_parent_run_id),
             job=parent_run.RootJob(
-                name=task_instance.dag_id,
-                namespace=namespace(),
+                name=rot_parent_job_name,
+                namespace=root_parent_job_namespace,
             ),
         ),
     )
@@ -299,7 +261,7 @@ def _create_snowflake_event_pair(
     return start, end
 
 
-@require_openlineage_version(provider_min_version="2.3.0")
+@require_openlineage_version(provider_min_version="2.5.0")
 def emit_openlineage_events_for_snowflake_queries(
     task_instance,
     hook: SnowflakeHook | SnowflakeSqlApiHook | None = None,

--- a/providers/snowflake/tests/unit/snowflake/hooks/test_snowflake.py
+++ b/providers/snowflake/tests/unit/snowflake/hooks/test_snowflake.py
@@ -1046,7 +1046,7 @@ class TestPytestSnowflakeHook:
         hook.get_openlineage_database_info = lambda x: mock.MagicMock(authority="auth", scheme="scheme")
 
         expected_err = (
-            "OpenLineage provider version `1.99.0` is lower than required `2.3.0`, "
+            "OpenLineage provider version `1.99.0` is lower than required `2.5.0`, "
             "skipping function `emit_openlineage_events_for_snowflake_queries` execution"
         )
         with pytest.raises(AirflowOptionalProviderFeatureException, match=expected_err):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Some providers are building OpenLineage ids from scratch when emitting child events. Since we already require OL provider version in all of those cases for the function to run, we can switch to using OL macros, so that the ID generation logic stays only on OL provider. To make it happen I updated the required OL provider version from 2.3 to 2.5, since the root macro needed a [fix](https://github.com/apache/airflow/pull/51210) that was included in 2.4.0 of OL provider and another from 2.5.0 [here](https://github.com/apache/airflow/pull/51932)


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
