### PR TITLE
add base-container-name annotation to kpo pods

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -264,6 +264,7 @@ class KubernetesPodOperator(BaseOperator):
     KILL_ISTIO_PROXY_SUCCESS_MSG = "HTTP/1.1 200"
     POD_CHECKED_KEY = "already_checked"
     POST_TERMINATION_TIMEOUT = 120
+    BASE_CONTAINER_NAME_ANNOTATION_KEY = "airflow.apache.org/base-container-name"
 
     template_fields: Sequence[str] = (
         "image",
@@ -1393,6 +1394,10 @@ class KubernetesPodOperator(BaseOperator):
                 "airflow_kpo_in_cluster": str(self.hook.is_in_cluster),
             }
         )
+        # Add base container name annotation
+        if pod.metadata.annotations is None:
+            pod.metadata.annotations = {}
+        pod.metadata.annotations[self.BASE_CONTAINER_NAME_ANNOTATION_KEY] = self.base_container_name
         pod_mutation_hook(pod)
         return pod
 

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -264,7 +264,7 @@ class KubernetesPodOperator(BaseOperator):
     KILL_ISTIO_PROXY_SUCCESS_MSG = "HTTP/1.1 200"
     POD_CHECKED_KEY = "already_checked"
     POST_TERMINATION_TIMEOUT = 120
-    BASE_CONTAINER_NAME_ANNOTATION_KEY = "airflow.apache.org/base-container-name"
+    BASE_CONTAINER_NAME_ANNOTATION_KEY = "org.apache.airflow/base-container-name"
 
     template_fields: Sequence[str] = (
         "image",

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -443,6 +443,40 @@ class TestKubernetesPodOperator:
             "airflow_kpo_in_cluster": str(k.hook.is_in_cluster),
         }
 
+    def test_base_container_name_annotation_default(self):
+        """Test that base container name annotation is added with default value."""
+        k = KubernetesPodOperator(
+            name="test",
+            task_id="task",
+        )
+        pod = k.build_pod_request_obj(create_context(k))
+        assert pod.metadata.annotations is not None
+        assert pod.metadata.annotations[KubernetesPodOperator.BASE_CONTAINER_NAME_ANNOTATION_KEY] == "base"
+
+    def test_base_container_name_annotation_custom(self):
+        """Test that base container name annotation is added with custom value."""
+        k = KubernetesPodOperator(
+            name="test",
+            task_id="task",
+            base_container_name="custom-container",
+        )
+        pod = k.build_pod_request_obj(create_context(k))
+        assert pod.metadata.annotations is not None
+        assert pod.metadata.annotations[KubernetesPodOperator.BASE_CONTAINER_NAME_ANNOTATION_KEY] == "custom-container"
+
+    def test_base_container_name_annotation_with_existing_annotations(self):
+        """Test that base container name annotation is added even when annotations already exist."""
+        k = KubernetesPodOperator(
+            name="test",
+            task_id="task",
+            annotations={"existing": "annotation"},
+            base_container_name="my-container",
+        )
+        pod = k.build_pod_request_obj(create_context(k))
+        assert pod.metadata.annotations is not None
+        assert pod.metadata.annotations["existing"] == "annotation"
+        assert pod.metadata.annotations[KubernetesPodOperator.BASE_CONTAINER_NAME_ANNOTATION_KEY] == "my-container"
+
     def test_find_custom_pod_labels(self):
         k = KubernetesPodOperator(
             labels={"foo": "bar", "hello": "airflow"},


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
## Description
this PR adds a `airflow.apache.org/base-container-name` annotation to KPO pods so that an external controller responsible for monitoring KPO pods can know "which container is actually doing meaningful work".

## But Why
when configured to get logs from more than just the base container TI will wait for all those containers to exit before proceeding to a terminal state. Which means if a sidecar is hanging doing nothing forever, the KPO tasks will get stuck.


https://github.com/apache/airflow/blob/main/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py#L769-L793
https://github.com/apache/airflow/blob/main/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py#L769-L793

so if `get_logs=True` and `container_logs=True`  or "hanging-sidecar-name" in `container_logs` then the TI will get stuck in running even though it is not doing anything useful.

this gives an external controller the information it needs to decide if it can kill a pod that's not longer doing useful task execution.

this is related to https://github.com/apache/airflow/issues/58968 and is the minimum change to allow a user to solve this problem outside of airflow. I'm not sure how best to solve this problem inside airflow's architecture but this issue hasn't got much traction.



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
