### PR TITLE
Add missing ca translations to v3-1-test

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/ca/assets.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ca/assets.json
@@ -1,5 +1,6 @@
 {
   "consumingDags": "Dags consumidors",
+  "consumingTasks": "Tasques consumidores",
   "createEvent": {
     "button": "Crear esdeveniment",
     "manual": {
@@ -21,6 +22,7 @@
     },
     "title": "Crear esdeveniment d'Asset per {{name}}"
   },
+  "extra": "Extra",
   "group": "Grup",
   "lastAssetEvent": "Darrer esdeveniment d'Asset",
   "name": "Nom",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ca/browse.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ca/browse.json
@@ -1,9 +1,5 @@
 {
   "auditLog": {
-    "actions": {
-      "collapseAllExtra": "Col·lapsar tots els camps extra json",
-      "expandAllExtra": "Expandir tots els camps extra json"
-    },
     "columns": {
       "event": "Esdeveniment",
       "extra": "Extra",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ca/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ca/common.json
@@ -25,6 +25,7 @@
     "requiredActions": "Accions requerides",
     "xcoms": "XComs"
   },
+  "collapseAllExtra": "Col·lapsar tots els camps extra json",
   "collapseDetailsPanel": "Col·lapsar el panell de detalls",
   "createdAssetEvent_one": "Esdeveniment d'Asset creat",
   "createdAssetEvent_other": "Esdeveniments d'Asset creats",
@@ -89,6 +90,7 @@
     "back": "Tornar",
     "defaultMessage": "S'ha produït un error inesperat",
     "home": "Inici",
+    "invalidUrl": "Pàgina no trobada. Si us plau, comprova la URL i torna-ho a provar.",
     "notFound": "Pàgina no trobada",
     "title": "Error"
   },
@@ -98,6 +100,7 @@
     "hotkey": "e",
     "tooltip": "Prem {{hotkey}} per alternar l'expansió"
   },
+  "expandAllExtra": "Expandir tots els camps extra json",
   "expression": {
     "all": "Tots",
     "and": "I",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

"backport" to v3-1-test of https://github.com/apache/airflow/pull/59110
Superseeds #59190. It should only have 1 commit now

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
