### PR TITLE
docs: adjust fab access_control misleading docs

### DIFF
--- a/providers/fab/docs/auth-manager/access-control.rst
+++ b/providers/fab/docs/auth-manager/access-control.rst
@@ -333,7 +333,7 @@ It's also possible to add Dag Runs resource permissions in a similar way, but ex
         dag_id="example_fine_grained_access",
         start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
         access_control={
-            "Viewer": {"Dags": {"can_edit", "can_read", "can_delete"}, "Dag Runs": {"can_create"}},
+            "Viewer": {"DAGs": {"can_edit", "can_read", "can_delete"}, "DAG Runs": {"can_create"}},
         },
     )
 


### PR DESCRIPTION
The current example throws an exception on dag parsing 

```
airflow.exceptions.AirflowException: The access_control map for DAG 'everton-test' includes the following invalid resource name: 'Dags'; The set of valid resource names is: dict_keys(['DAGs', 'DAG Runs'])
```

all other files in the repo seems to be using correct resource name, the only broken one was this one on the documentation