### PR TITLE
Feat: Support URL params for pre-filling Trigger and Backfill forms

### DIFF
--- a/airflow-core/docs/core-concepts/params.rst
+++ b/airflow-core/docs/core-concepts/params.rst
@@ -409,3 +409,50 @@ Disabling Runtime Param Modification
 
 The ability to update params while triggering a Dag depends on the flag ``core.dag_run_conf_overrides_params``.
 Setting this config to ``False`` will effectively turn your default params into constants.
+
+To pre-populate values in the form when publishing a link to the trigger form you can call the trigger URL ``/dags/<dag_name>/trigger/single`` or ``/dags/<dag_name>/trigger/backfill``,
+and add query parameters to the URL.
+
+There are two trigger form URLs available, each supporting a different set of query parameters:
+
+* ``/trigger/single``:
+  - ``conf`` - JSON configuration.
+  - ``run_id`` - run identifier.
+  - ``logical_date`` - execution date in ``YYYY-MM-DDTHH:mm:ss.SSS`` format. Defaults to the current timestamp if not provided.
+  - ``note`` - note attached to the DAG run.
+
+* ``/trigger/backfill``:
+  - ``conf`` - JSON configuration, applied to all runs.
+  - ``from_date`` - start of the backfill window in ``YYYY-MM-DDTHH:mm:ss`` format.
+  - ``to_date`` - end of the backfill window in ``YYYY-MM-DDTHH:mm:ss`` format.
+  - ``max_active_runs`` - maximum concurrent runs. Defaults to ``1``.
+  - ``reprocess_behavior`` - determines how existing runs are reprocessed. Supported values are:
+    * ``failed`` - Missing and Errored Runs
+    * ``completed`` - All Runs
+    * ``none`` - Missing Runs
+  - ``run_backwards`` - if set to true, the backfill is scheduled in reverse order. Defaults to ``false``.
+
+The trigger form now supports two different ways of providing ``conf`` values. The available input methods are summarized in the table below:
+
+.. list-table:: ``conf`` parameter usage
+   :header-rows: 1
+   :widths: 15 35 55
+
+   * - Form
+     - Usage
+     - Example
+   * - JSON (explicit)
+     - Provide the entire configuration as a JSON object.
+       This form has higher priority if present.
+     - ``/dags/{dag_id}/trigger/single?conf={"foo":"bar","x":123}``
+   * - Key-value (implicit)
+     - If ``conf`` is not specified, any query parameter that is not a reserved keyword
+       will be automatically collected into ``conf``.
+     - ``/dags/{dag_id}/trigger/single?run_id=myrun&foo=bar&x=123``
+       results in ``conf={"foo":"bar","x":"123"}``
+
+For example, you can pass the pathname and query like below:
+
+``/dags/{dag_id}/trigger/single?run_id=my_run_dag&logical_date=2025-09-06T12:34:56.789&conf={"foo":"bar"}&note=run_note``
+
+``/dags/{dag_id}/trigger/backfill?from_date=2025-09-01T00:00:00&to_date=2025-09-03T23:59:59&conf={"abc":"loo"}&max_active_runs=2&reprocess_behavior=failed&run_backwards=true``

--- a/airflow-core/docs/core-concepts/params.rst
+++ b/airflow-core/docs/core-concepts/params.rst
@@ -427,9 +427,11 @@ There are two trigger form URLs available, each supporting a different set of qu
   - ``to_date`` - end of the backfill window in ``YYYY-MM-DDTHH:mm:ss`` format.
   - ``max_active_runs`` - maximum concurrent runs. Defaults to ``1``.
   - ``reprocess_behavior`` - determines how existing runs are reprocessed. Supported values are:
+
     * ``failed`` - Missing and Errored Runs
     * ``completed`` - All Runs
     * ``none`` - Missing Runs
+
   - ``run_backwards`` - if set to true, the backfill is scheduled in reverse order. Defaults to ``false``.
 
 The trigger form now supports two different ways of providing ``conf`` values. The available input methods are summarized in the table below:

--- a/airflow-core/docs/core-concepts/params.rst
+++ b/airflow-core/docs/core-concepts/params.rst
@@ -410,6 +410,9 @@ Disabling Runtime Param Modification
 The ability to update params while triggering a Dag depends on the flag ``core.dag_run_conf_overrides_params``.
 Setting this config to ``False`` will effectively turn your default params into constants.
 
+Pre-populating Trigger Form via URL
+-----------------------------------
+
 To pre-populate values in the form when publishing a link to the trigger form you can call the trigger URL ``/dags/<dag_name>/trigger/single`` or ``/dags/<dag_name>/trigger/backfill``,
 and add query parameters to the URL.
 
@@ -434,7 +437,7 @@ There are two trigger form URLs available, each supporting a different set of qu
 
   - ``run_backwards`` - if set to true, the backfill is scheduled in reverse order. Defaults to ``false``.
 
-The trigger form now supports two different ways of providing ``conf`` values. The available input methods are summarized in the table below:
+The trigger form supports two different ways of providing ``conf`` values. The available input methods are summarized in the table below:
 
 .. list-table:: ``conf`` parameter usage
    :header-rows: 1

--- a/airflow-core/src/airflow/ui/src/components/ConfigForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ConfigForm.tsx
@@ -35,6 +35,7 @@ type ConfigFormProps<T extends FieldValues = FieldValues> = {
     date?: unknown;
   };
   readonly initialParamsDict: { paramsDict: ParamsSpec };
+  readonly openAdvanced?: boolean;
   readonly setErrors: React.Dispatch<
     React.SetStateAction<{
       conf?: string;
@@ -49,6 +50,7 @@ const ConfigForm = <T extends FieldValues = FieldValues>({
   control,
   errors,
   initialParamsDict,
+  openAdvanced = false,
   setErrors,
   setFormError,
 }: ConfigFormProps<T>) => {
@@ -83,7 +85,9 @@ const ConfigForm = <T extends FieldValues = FieldValues>({
   return (
     <Accordion.Root
       collapsible
-      defaultValue={[flexibleFormDefaultSection]}
+      defaultValue={
+        openAdvanced ? [flexibleFormDefaultSection, "advancedOptions"] : [flexibleFormDefaultSection]
+      }
       mb={4}
       overflow="visible"
       size="lg"

--- a/airflow-core/src/airflow/ui/src/components/DagActions/RunBackfillForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DagActions/RunBackfillForm.tsx
@@ -37,11 +37,11 @@ import { useDagParams } from "src/queries/useDagParams";
 import { useParamStore } from "src/queries/useParamStore";
 import { useTogglePause } from "src/queries/useTogglePause";
 import { getTriggerConf } from "src/utils/trigger";
+import type { DagRunTriggerParams } from "src/utils/trigger";
 
 import ConfigForm from "../ConfigForm";
 import { DateTimeInput } from "../DateTimeInput";
 import { ErrorAlert } from "../ErrorAlert";
-import type { DagRunTriggerParams } from "../TriggerDag/TriggerDAGForm";
 import { Checkbox } from "../ui/Checkbox";
 import { getInlineMessage } from "./inlineMessage";
 

--- a/airflow-core/src/airflow/ui/src/components/DagActions/RunBackfillForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DagActions/RunBackfillForm.tsx
@@ -21,8 +21,14 @@ import dayjs from "dayjs";
 import { useEffect, useState } from "react";
 import { Controller, useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+import { useSearchParams } from "react-router-dom";
 
-import type { BackfillPostBody, DAGResponse, DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
+import type {
+  DAGResponse,
+  DAGWithLatestDagRunsResponse,
+  BackfillPostBody,
+  ReprocessBehavior,
+} from "openapi/requests/types.gen";
 import { RadioCardItem, RadioCardLabel, RadioCardRoot } from "src/components/ui/RadioCard";
 import { reprocessBehaviors } from "src/constants/reprocessBehaviourParams";
 import { useCreateBackfill } from "src/queries/useCreateBackfill";
@@ -30,6 +36,7 @@ import { useCreateBackfillDryRun } from "src/queries/useCreateBackfillDryRun";
 import { useDagParams } from "src/queries/useDagParams";
 import { useParamStore } from "src/queries/useParamStore";
 import { useTogglePause } from "src/queries/useTogglePause";
+import { getTriggerConf } from "src/utils/trigger";
 
 import ConfigForm from "../ConfigForm";
 import { DateTimeInput } from "../DateTimeInput";
@@ -52,16 +59,19 @@ const RunBackfillForm = ({ dag, onClose }: RunBackfillFormProps) => {
   const [formError, setFormError] = useState(false);
   const initialParamsDict = useDagParams(dag.dag_id, true);
   const { conf } = useParamStore();
-  const { control, handleSubmit, reset, watch } = useForm<BackfillFormProps>({
+  const [searchParams] = useSearchParams();
+  const reservedKeys = ["from_date", "to_date", "max_active_runs", "reprocess_behavior", "run_backwards"];
+  const urlConf = getTriggerConf(searchParams, reservedKeys);
+  const { control, handleSubmit, reset } = useForm<BackfillFormProps>({
     defaultValues: {
-      conf,
+      conf: urlConf === "{}" ? conf || "{}" : urlConf,
       dag_id: dag.dag_id,
-      from_date: "",
-      max_active_runs: 1,
-      reprocess_behavior: "none",
-      run_backwards: false,
+      from_date: searchParams.get("from_date") ?? "",
+      max_active_runs: parseInt(searchParams.get("max_active_runs") ?? "1", 10) || 1,
+      reprocess_behavior: (searchParams.get("reprocess_behavior") ?? "none") as ReprocessBehavior,
+      run_backwards: searchParams.get("run_backwards") === "true",
       run_on_latest_version: true,
-      to_date: "",
+      to_date: searchParams.get("to_date") ?? "",
     },
     mode: "onBlur",
   });
@@ -91,16 +101,13 @@ const RunBackfillForm = ({ dag, onClose }: RunBackfillFormProps) => {
     if (Boolean(dateValidationError)) {
       setErrors((prev) => ({ ...prev, date: dateValidationError }));
     }
-  }, [dateValidationError]);
-  useEffect(() => {
-    if (conf) {
-      reset((prevValues) => ({ ...prevValues, conf }));
+    if (Boolean(conf) && urlConf === "{}") {
+      reset((prev) => ({ ...prev, conf }));
     }
-  }, [conf, reset]);
-  const dataIntervalStart = watch("from_date");
-  const dataIntervalEnd = watch("to_date");
-  const noDataInterval = !Boolean(dataIntervalStart) || !Boolean(dataIntervalEnd);
-  const dataIntervalInvalid = dayjs(dataIntervalStart).isAfter(dayjs(dataIntervalEnd));
+  }, [dateValidationError, conf, reset, urlConf]);
+
+  const noDataInterval = !Boolean(values.from_date) || !Boolean(values.to_date);
+  const dataIntervalInvalid = dayjs(values.from_date).isAfter(dayjs(values.to_date));
 
   const onSubmit = (fdata: BackfillFormProps) => {
     if (unpause && dag.is_paused) {
@@ -239,6 +246,10 @@ const RunBackfillForm = ({ dag, onClose }: RunBackfillFormProps) => {
           control={control}
           errors={errors}
           initialParamsDict={initialParamsDict}
+          openAdvanced={
+            urlConf !== "{}" ||
+            ["max_active_runs", "reprocess_behavior", "run_backwards"].some((key) => searchParams.has(key))
+          }
           setErrors={setErrors}
           setFormError={setFormError}
         />

--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGAdvancedOptions.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGAdvancedOptions.tsx
@@ -20,8 +20,9 @@ import { Input, Field, Stack } from "@chakra-ui/react";
 import { Controller, type Control } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 
+import type { DagRunTriggerParams } from "src/utils/trigger";
+
 import EditableMarkdown from "./EditableMarkdown";
-import type { DagRunTriggerParams } from "./TriggerDAGForm";
 
 type TriggerDAGAdvancedOptionsProps = {
   readonly control: Control<DagRunTriggerParams>;

--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -185,8 +185,7 @@ const TriggerDAGForm = ({
     setParamsDict(updatedParamsDict);
 
     isSyncedRef.current = true;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [urlConf, urlRunId, urlDate, urlNote, initialParamsDict, reset, setParamsDict]);
+  }, [urlConf, urlRunId, urlDate, urlNote, initialParamsDict, reset, setParamsDict, conf]);
 
   const resetDateError = () => setErrors((prev) => ({ ...prev, date: undefined }));
 

--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGModal.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGModal.tsx
@@ -17,8 +17,9 @@
  * under the License.
  */
 import { Heading, VStack, HStack, Spinner, Center, Text } from "@chakra-ui/react";
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
+import { useParams, useNavigate } from "react-router-dom";
 
 import { useDagServiceGetDag } from "openapi/queries";
 import { Dialog, Tooltip } from "src/components/ui";
@@ -48,7 +49,11 @@ const TriggerDAGModal: React.FC<TriggerDAGModalProps> = ({
   open,
 }) => {
   const { t: translate } = useTranslation("components");
-  const [runMode, setRunMode] = useState<RunMode>(RunMode.SINGLE);
+  const { mode } = useParams();
+  const navigate = useNavigate();
+  const [runMode, setRunMode] = useState<RunMode>(
+    mode === RunMode.BACKFILL ? RunMode.BACKFILL : RunMode.SINGLE,
+  );
   const {
     data: dag,
     isError,
@@ -63,6 +68,17 @@ const TriggerDAGModal: React.FC<TriggerDAGModalProps> = ({
     },
   );
 
+  useEffect(() => {
+    if (mode === RunMode.BACKFILL) {
+      setRunMode(RunMode.BACKFILL);
+    } else {
+      setRunMode(RunMode.SINGLE);
+    }
+  }, [mode]);
+  const handleModeChange = (value: string) => {
+    setRunMode(value as RunMode);
+    navigate(`/dags/${dagId}/trigger/${value}`, { replace: true });
+  };
   const hasSchedule = dag?.timetable_summary !== null;
   const maxDisplayLength = 59; // hard-coded length to prevent dag name overflowing the modal
   const nameOverflowing = dagDisplayName.length > maxDisplayLength;
@@ -98,8 +114,10 @@ const TriggerDAGModal: React.FC<TriggerDAGModalProps> = ({
               {dag ? (
                 <RadioCardRoot
                   my={4}
-                  onChange={(event) => {
-                    setRunMode((event.target as HTMLInputElement).value as RunMode);
+                  onValueChange={(details) => {
+                    if (details.value !== null) {
+                      handleModeChange(details.value);
+                    }
                   }}
                   value={runMode}
                 >

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Overview/Overview.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Overview/Overview.tsx
@@ -20,12 +20,13 @@ import { Box, HStack, Skeleton } from "@chakra-ui/react";
 import dayjs from "dayjs";
 import { lazy, useState, Suspense } from "react";
 import { useTranslation } from "react-i18next";
-import { useParams } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import { useLocalStorage } from "usehooks-ts";
 
 import {
   useAssetServiceGetAssetEvents,
   useDagRunServiceGetDagRuns,
+  useDagServiceGetDag,
   useTaskInstanceServiceGetTaskInstances,
 } from "openapi/queries";
 import { AssetEvents } from "src/components/Assets/AssetEvents";
@@ -33,6 +34,7 @@ import { DurationChart } from "src/components/DurationChart";
 import { NeedsReviewButton } from "src/components/NeedsReviewButton";
 import TimeRangeSelector from "src/components/TimeRangeSelector";
 import { TrendCountButton } from "src/components/TrendCountButton";
+import TriggerDAGModal from "src/components/TriggerDag/TriggerDAGModal";
 import { SearchParamsKeys } from "src/constants/searchParams";
 import { useGridRuns } from "src/queries/useGridRuns.ts";
 
@@ -42,7 +44,10 @@ const defaultHour = "24";
 
 export const Overview = () => {
   const { t: translate } = useTranslation("dag");
-  const { dagId } = useParams();
+  const { dagId, mode } = useParams();
+  const navigate = useNavigate();
+
+  const { data: dagData } = useDagServiceGetDag({ dagId: dagId ?? "" });
 
   const now = dayjs();
   const [startDate, setStartDate] = useState(now.subtract(Number(defaultHour), "hour").toISOString());
@@ -140,6 +145,16 @@ export const Overview = () => {
       <Suspense fallback={<Skeleton height="100px" width="full" />}>
         <FailedLogs failedTasks={failedTasks} />
       </Suspense>
+
+      {dagData ? (
+        <TriggerDAGModal
+          dagDisplayName={dagData.dag_display_name}
+          dagId={dagData.dag_id}
+          isPaused={dagData.is_paused}
+          onClose={() => navigate(`/dags/${dagId}`)}
+          open={Boolean(mode)}
+        />
+      ) : null}
     </Box>
   );
 };

--- a/airflow-core/src/airflow/ui/src/queries/useTrigger.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useTrigger.ts
@@ -29,8 +29,8 @@ import {
   UseGridServiceGetGridRunsKeyFn,
 } from "openapi/queries";
 import type { TriggerDagRunResponse } from "openapi/requests/types.gen";
-import type { DagRunTriggerParams } from "src/components/TriggerDag/TriggerDAGForm";
 import { toaster } from "src/components/ui";
+import type { DagRunTriggerParams } from "src/utils/trigger";
 
 export const useTrigger = ({ dagId, onSuccessConfirm }: { dagId: string; onSuccessConfirm: () => void }) => {
   const queryClient = useQueryClient();
@@ -107,7 +107,7 @@ export const useTrigger = ({ dagId, onSuccessConfirm }: { dagId: string; onSucce
         data_interval_start: formattedDataIntervalStart,
         logical_date: formattedLogicalDate,
         note: checkNote,
-        partition_key: dagRunRequestBody.partitionKey ?? null,
+        partition_key: dagRunRequestBody.partitionKey ?? undefined,
       },
     });
   };

--- a/airflow-core/src/airflow/ui/src/router.tsx
+++ b/airflow-core/src/airflow/ui/src/router.tsx
@@ -160,6 +160,7 @@ export const routerConfig = [
       {
         children: [
           { element: <Overview />, index: true },
+          { element: <Overview />, path: "trigger/:mode?" },
           { element: <DagRuns />, path: "runs" },
           { element: <Tasks />, path: "tasks" },
           { element: <Calendar />, path: "calendar" },

--- a/airflow-core/src/airflow/ui/src/utils/trigger.ts
+++ b/airflow-core/src/airflow/ui/src/utils/trigger.ts
@@ -1,0 +1,46 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Helper to extract configuration from URL search params
+export const getTriggerConf = (searchParams: URLSearchParams, reservedKeys: Array<string>) => {
+  const confParam = searchParams.get("conf");
+
+  // 1. If the user provided direct JSON 'conf' param (e.g., ?conf={"foo":"bar"})
+  if (confParam !== null) {
+    try {
+      const parsed = JSON.parse(confParam) as unknown;
+
+      return JSON.stringify(parsed, undefined, 2);
+    } catch {
+      // Ignore parsing errors
+    }
+  }
+
+  // 2. If the user provided individual key-value params (e.g., ?foo=bar&run_id=123)
+  const collected: Record<string, unknown> = {};
+
+  searchParams.forEach((value, key) => {
+    // Do not include reserved keys (like run_id, date) in the config, as they belong to specific form fields
+    if (!reservedKeys.includes(key) && key !== "conf") {
+      collected[key] = value;
+    }
+  });
+
+  return Object.keys(collected).length > 0 ? JSON.stringify(collected, undefined, 2) : "{}";
+};

--- a/airflow-core/src/airflow/ui/src/utils/trigger.ts
+++ b/airflow-core/src/airflow/ui/src/utils/trigger.ts
@@ -44,3 +44,71 @@ export const getTriggerConf = (searchParams: URLSearchParams, reservedKeys: Arra
 
   return Object.keys(collected).length > 0 ? JSON.stringify(collected, undefined, 2) : "{}";
 };
+
+export type DataIntervalMode = "auto" | "manual";
+
+export type DagRunTriggerParams = {
+  conf: string;
+  dagRunId: string;
+  dataIntervalEnd: string;
+  dataIntervalMode: DataIntervalMode;
+  dataIntervalStart: string;
+  logicalDate: string;
+  note: string;
+  params?: Record<string, unknown>;
+  partitionKey: string | undefined;
+};
+export type TriggerDAGFormProps = {
+  readonly dagDisplayName: string;
+  readonly dagId: string;
+  readonly hasSchedule: boolean;
+  readonly isPaused: boolean;
+  readonly onClose: () => void;
+  readonly open: boolean;
+};
+export const dataIntervalModeOptions: Array<{ label: string; value: DataIntervalMode }> = [
+  { label: "components:triggerDag.dataIntervalAuto", value: "auto" },
+  { label: "components:triggerDag.dataIntervalManual", value: "manual" },
+];
+
+export const extractParamValues = (obj: Record<string, unknown>) => {
+  const out: Record<string, unknown> = {};
+
+  Object.entries(obj).forEach(([key, val]) => {
+    if (val !== null && typeof val === "object" && "value" in val) {
+      out[key] = (val as { value: unknown }).value;
+    } else if (val !== null && typeof val === "object" && "default" in val) {
+      out[key] = (val as { default: unknown }).default;
+    } else {
+      out[key] = val;
+    }
+  });
+
+  return out;
+};
+
+export const mergeUrlParams = (urlConf: string, baseParams: Record<string, unknown>) => {
+  try {
+    const parsed = urlConf === "{}" ? {} : (JSON.parse(urlConf) as Record<string, unknown>);
+
+    return { ...baseParams, ...parsed };
+  } catch {
+    return baseParams;
+  }
+};
+export type ParamEntry = {
+  [key: string]: unknown;
+  value: unknown;
+};
+export const getUpdatedParamsDict = <T>(paramsDict: T, mergedValues: Record<string, unknown>): T => {
+  const updated = structuredClone(paramsDict);
+  const record = updated as Record<string, { value: unknown }>;
+
+  Object.entries(mergedValues).forEach(([key, val]) => {
+    if (record[key] !== undefined) {
+      record[key].value = val;
+    }
+  });
+
+  return updated;
+};

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1523,6 +1523,7 @@ replicaSet
 repo
 repos
 repr
+reprocessed
 req
 reqs
 requeue


### PR DESCRIPTION
closes: #54800

### Description

This PR restores and enhances the ability to pre-populate the **Trigger DAG** and **Backfill** forms via URL query parameters in the Airflow 3.0 UI. This feature existed in Airflow 2.x and is useful for sharing pre-configured run links.

### Key Changes:

1.  **URL Param Parsing:**
    * Implemented using the `useSearchParams` hook (replacing manual parsing logic from stale PRs).
    * Added a utility `getTriggerConf` to handle both JSON strings (`?conf={"a":1}`) and Key-Value pairs (`?a=1`).

2.  **Form Updates:**
    * **Trigger Form:** Supports `run_id`, `logical_date`, `note`, and `conf`.
    * **Backfill Form:** Supports `from_date`, `to_date`, `max_active_runs`, `reprocess_behavior`, and `run_backwards`.
    * **Config Form:** Automatically expands the "Advanced Options" accordion if configuration data is present in the URL.

3.  **Code Quality:**
    * Optimized `RunBackfillForm.tsx` logic to keep the file size strictly under the 250-line linting limit.
    * Ensured consistent naming conventions for backfill parameters (`from_date` / `to_date`) to match the API and UI components.

4.  **Documentation:**
    * Updated `docs/core-concepts/params.rst` to document the supported URL parameters and examples.

### How to reproduce / Test

You can test this by running the UI and navigating to any DAG (e.g., `tutorial`) using the following URLs:

**1. Trigger Single Run (JSON Config):**
The modal should open, fields should be filled, and the JSON editor should show the config.
http://localhost:8080/dags/tutorial/trigger/single?run_id=test_run_01&note=Testing_Note&conf={"environment":"dev","debug":true}


**2. Trigger Single Run (Key-Value Config):**
The "Advanced Options" should open and show `{"foo": "bar"}`.
http://localhost:8080/dags/tutorial/trigger/single?foo=bar&retry=3


**3. Backfill Form:**
The Backfill form should open with dates, max runs, and the "Run Backwards" checkbox pre-selected.
http://localhost:8080/dags/tutorial/trigger/backfill?from_date=2024-01-01T00:00:00&to_date=2024-01-05T00:00:00&max_active_runs=5&run_backwards=true
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
