### PR TITLE
Fix remote logging S3 connection retrieval in supervisor context

### DIFF
--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -2676,7 +2676,8 @@ def test_remote_logging_conn(remote_logging, remote_conn, expected_env, monkeypa
             with _remote_logging_conn(client):
                 new_keys = os.environ.keys() - env.keys()
                 if remote_logging:
-                    assert new_keys == {expected_env}
+                    # _remote_logging_conn sets both the connection env var and _AIRFLOW_PROCESS_CONTEXT
+                    assert new_keys == {expected_env, "_AIRFLOW_PROCESS_CONTEXT"}
                 else:
                     assert not new_keys
 


### PR DESCRIPTION
Workers were unable to retrieve S3 connection credentials for remote logging even though the credentials were successfully fetched via the API. This caused task logs to fail uploading to S3 with errors like "Unable to find AWS Connection ID" and falling back to boto3 credential strategy.

The root cause was that when _remote_logging_conn sets the connection environment variable, Connection deserialization was using the core Connection class instead of the SDK Connection class. The core Connection class doesn't have the from_uri() method needed for proper URI deserialization in the supervisor context.

This fix sets _AIRFLOW_PROCESS_CONTEXT=client in the _remote_logging_conn context manager, ensuring that Connection deserialization uses the SDK Connection class which properly handles URI deserialization from environment variables.

Fixes #58140


