### PR TITLE
Batch asset active queries with configurable size

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -2074,6 +2074,13 @@ scheduler:
       type: integer
       example: ~
       default: "60"
+    asset_active_batch_size:
+      description: |
+        Batch size used when activating or orphaning assets to avoid oversized SQL ``IN`` clauses.
+      version_added: 3.3.0
+      type: integer
+      example: ~
+      default: "500"
     pool_metrics_interval:
       description: |
         How often (in seconds) should pool usage stats be sent to StatsD (if statsd_on is enabled)


### PR DESCRIPTION
Add asset_active_batch_size config (default 500) and batch asset activation/orphaning SQL to keep IN clauses manageable. This fixes a 'psycopg2.errors.StatementTooComplex' error where this query can exceed the maximum stack depth in some cases.

Add unit tests for batched selects / deletes.

New tests: pytest airflow-core/tests/unit/jobs/test_scheduler_job.py -k asset_batch

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

<!-- Please keep an empty line above the dashes. -->
---