### PR TITLE
UI: Update PoolBar to separate Scheduled and Deferred slots

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
@@ -159,17 +159,6 @@
     "placeholder": "Add a note...",
     "taskInstance": "Task Instance Note"
   },
-  "pools": {
-    "deferred": "Deferred",
-    "includeDeferred": "Include Deferred",
-    "open": "Open",
-    "pools_one": "pool",
-    "pools_other": "pools",
-    "queued": "Queued",
-    "running": "Running",
-    "scheduled": "Scheduled",
-    "totalPools": "Total Pools"
-  },
   "reset": "Reset",
   "runId": "Run ID",
   "runTypes": {
@@ -209,6 +198,7 @@
     "failed": "Failed",
     "no_status": "No Status",
     "none": "No Status",
+    "open": "Open",
     "planned": "Planned",
     "queued": "Queued",
     "removed": "Removed",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
@@ -161,12 +161,14 @@
   },
   "pools": {
     "deferred": "Deferred",
+    "includeDeferred": "Include Deferred",
     "open": "Open",
     "pools_one": "pool",
     "pools_other": "pools",
     "queued": "Queued",
     "running": "Running",
-    "scheduled": "Scheduled"
+    "scheduled": "Scheduled",
+    "totalPools": "Total Pools"
   },
   "reset": "Reset",
   "runId": "Run ID",

--- a/airflow-core/src/airflow/ui/src/components/PoolBar.tsx
+++ b/airflow-core/src/airflow/ui/src/components/PoolBar.tsx
@@ -16,11 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Flex, Link, Box } from "@chakra-ui/react";
+import { Box, Flex, Text, VStack, Link, HStack } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 import { Link as RouterLink } from "react-router-dom";
 
-import type { PoolResponse } from "openapi/requests/types.gen";
+import type { PoolResponse, TaskInstanceState } from "openapi/requests/types.gen";
+import { StateIcon } from "src/components/StateIcon";
 import { Tooltip } from "src/components/ui";
 import { SearchParamsKeys } from "src/constants/searchParams";
 import { type Slots, slotConfigs } from "src/utils/slots";
@@ -36,52 +37,99 @@ export const PoolBar = ({
 }) => {
   const { t: translate } = useTranslation("common");
 
+  const isDashboard = Boolean(poolsWithSlotType);
+  const includeDeferredInBar = "include_deferred" in pool && pool.include_deferred;
+  const barSlots = ["running", "queued", "open"];
+
+  if (isDashboard || includeDeferredInBar) {
+    barSlots.push("deferred");
+  }
+  const infoSlots = ["scheduled"];
+
+  if (!isDashboard && !includeDeferredInBar) {
+    infoSlots.push("deferred");
+  }
+
+  const preparedSlots = slotConfigs.map((config) => {
+    const slotType = config.key.replace("_slots", "") as TaskInstanceState;
+
+    return {
+      ...config,
+      label: translate(`common:pools.${slotType}`),
+      slotType,
+      slotValue: (pool[config.key] as number | undefined) ?? 0,
+    };
+  });
+
   return (
-    <>
-      {slotConfigs.map(({ color, icon, key }) => {
-        const slotValue = pool[key];
-        const flexValue = slotValue / totalSlots || 0;
+    <VStack align="stretch" gap={1} w="100%">
+      <Flex bg="bg.muted" borderRadius="md" h="20px" overflow="hidden" w="100%">
+        {preparedSlots
+          .filter((slot) => barSlots.includes(slot.slotType) && slot.slotValue > 0)
+          .map((slot) => {
+            const flexValue = slot.slotValue / totalSlots || 0;
 
-        if (flexValue === 0) {
-          return undefined;
-        }
+            const poolContent = (
+              <Tooltip
+                content={slot.label}
+                contentProps={{
+                  _dark: {
+                    bg: "gray.700",
+                    color: `${slot.color}.solid`,
+                  },
+                  bg: "white",
+                  color: `${slot.color}.solid`,
+                }}
+                key={slot.key}
+                showArrow={false}
+              >
+                <Flex
+                  alignItems="center"
+                  bg={`${slot.color}.solid`}
+                  color={`${slot.color}.contrast`}
+                  gap={1}
+                  h="100%"
+                  justifyContent="center"
+                  overflow="hidden"
+                  px={1}
+                  w="100%"
+                >
+                  {slot.icon}
+                  <Text fontSize="xs" fontWeight="bold" truncate>
+                    {slot.slotValue}
+                  </Text>
+                </Flex>
+              </Tooltip>
+            );
 
-        const slotType = key.replace("_slots", "");
-        const poolCount = poolsWithSlotType ? poolsWithSlotType[key] : 0;
-        const tooltipContent = `${translate(`pools.${slotType}`)}: ${slotValue} (${poolCount} ${translate("pools.pools", { count: poolCount })})`;
-        const poolContent = (
-          <Tooltip content={tooltipContent} key={key}>
-            <Flex
-              alignItems="center"
-              bg={`${color}.solid`}
-              color={`${color}.contrast`}
-              gap={1}
-              h="100%"
-              justifyContent="center"
-              px={1}
-              textAlign="center"
-              w="100%"
-            >
-              {icon}
-              {slotValue}
-            </Flex>
-          </Tooltip>
-        );
+            return slot.color !== "success" && "name" in pool ? (
+              <Link asChild flex={flexValue} key={slot.key}>
+                <RouterLink
+                  to={`/task_instances?${SearchParamsKeys.STATE}=${slot.color}&${SearchParamsKeys.POOL}=${pool.name}`}
+                >
+                  {poolContent}
+                </RouterLink>
+              </Link>
+            ) : (
+              <Box flex={flexValue} key={slot.key}>
+                {poolContent}
+              </Box>
+            );
+          })}
+      </Flex>
 
-        return color !== "success" && "name" in pool ? (
-          <Link asChild display="flex" flex={flexValue} key={key}>
-            <RouterLink
-              to={`/task_instances?${SearchParamsKeys.STATE}=${color}&${SearchParamsKeys.POOL}=${pool.name}`}
-            >
-              {poolContent}
-            </RouterLink>
-          </Link>
-        ) : (
-          <Box display="flex" flex={flexValue} key={key}>
-            {poolContent}
-          </Box>
-        );
-      })}
-    </>
+      <HStack gap={4} wrap="wrap">
+        {preparedSlots
+          .filter((slot) => infoSlots.includes(slot.slotType) && slot.slotValue > 0)
+          .map((slot) => (
+            <HStack gap={1} key={slot.key}>
+              <StateIcon size={12} state={slot.slotType} />
+              <Text color="fg.muted" fontSize="xs" fontWeight="medium">
+                {slot.label}: {slot.slotValue}
+              </Text>
+            </HStack>
+          ))}
+      </HStack>
+    </VStack>
   );
 };

--- a/airflow-core/src/airflow/ui/src/components/PoolBar.tsx
+++ b/airflow-core/src/airflow/ui/src/components/PoolBar.tsx
@@ -55,7 +55,7 @@ export const PoolBar = ({
 
     return {
       ...config,
-      label: translate(`common:pools.${slotType}`),
+      label: translate(`common:states.${slotType}`),
       slotType,
       slotValue: (pool[config.key] as number | undefined) ?? 0,
     };
@@ -70,19 +70,7 @@ export const PoolBar = ({
             const flexValue = slot.slotValue / totalSlots || 0;
 
             const poolContent = (
-              <Tooltip
-                content={slot.label}
-                contentProps={{
-                  _dark: {
-                    bg: "gray.700",
-                    color: `${slot.color}.solid`,
-                  },
-                  bg: "white",
-                  color: `${slot.color}.solid`,
-                }}
-                key={slot.key}
-                showArrow={false}
-              >
+              <Tooltip content={slot.label} key={slot.key} showArrow={true}>
                 <Flex
                   alignItems="center"
                   bg={`${slot.color}.solid`}

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/PoolSummary/PoolSummary.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/PoolSummary/PoolSummary.tsx
@@ -99,9 +99,7 @@ export const PoolSummary = () => {
       {isLoading ? (
         <Skeleton borderRadius="full" h={8} w="100%" />
       ) : (
-        <Flex bg="bg" borderRadius="full" display="flex" overflow="hidden" w="100%">
-          <PoolBar pool={aggregatePool} poolsWithSlotType={poolsWithSlotType} totalSlots={totalSlots} />
-        </Flex>
+        <PoolBar pool={aggregatePool} poolsWithSlotType={poolsWithSlotType} totalSlots={totalSlots} />
       )}
     </Box>
   );

--- a/airflow-core/src/airflow/ui/src/pages/Pools/PoolBarCard.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Pools/PoolBarCard.tsx
@@ -61,11 +61,8 @@ const PoolBarCard = ({ pool }: PoolBarCardProps) => {
           )}
         </VStack>
       </Flex>
-
       <Box margin={4}>
-        <Flex bg="bg.muted" borderRadius="md" h="20px" overflow="hidden" w="100%">
-          <PoolBar pool={pool} totalSlots={pool.slots} />
-        </Flex>
+        <PoolBar pool={pool} totalSlots={pool.slots} />
       </Box>
     </Box>
   );


### PR DESCRIPTION
## Description
This PR addresses issue #53826.

Currently, the Pool Bar visually includes `Scheduled` and `Deferred` states inside the progress bar. This can be misleading as these states do not typically consume open pool slots, making the pool look "fuller" than it actually is.

**Changes introduced:**
1.  **PoolBar.tsx:** Updated the filter logic to only display active slots (`Running`, `Queued`, `Open`) inside the visual bar.
2.  **PoolBarCard.tsx:** Added logic to display `Scheduled` and `Deferred` counts as text/icons below the bar on the Pools administration page.
3.  **PoolSummary.tsx:** Applied the same text display logic to the Dashboard "Pool Slots" widget for consistency.

## Screenshots
**Before:**
<img width="1826" height="399" alt="Screenshot from 2025-12-10 16-18-34" src="https://github.com/user-attachments/assets/01ce2a5c-6ef1-47ed-80f7-5d2711ec59d5" />
<img width="1826" height="399" alt="Screenshot from 2025-12-10 16-18-42" src="https://github.com/user-attachments/assets/8ce968ed-b764-4f20-b780-06b6879690b7" />

**After:**
<img width="1826" height="399" alt="Screenshot from 2025-12-10 16-21-51" src="https://github.com/user-attachments/assets/3a2a2fba-fffc-4c5a-a3b1-6f9128653fb7" />
<img width="1826" height="380" alt="Screenshot from 2025-12-10 16-22-32" src="https://github.com/user-attachments/assets/65b06ca5-86e6-492d-9b5e-1b1c043994bf" />
<img width="1826" height="380" alt="Screenshot from 2025-12-10 16-22-12" src="https://github.com/user-attachments/assets/df9a3879-47aa-4003-9300-fb9e62a0798c" />


## Related Issue
Closes #53826

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
