### PR TITLE
Fix BaseXCom.get_all to return empty list instead of None

### DIFF
--- a/task-sdk/src/airflow/sdk/bases/xcom.py
+++ b/task-sdk/src/airflow/sdk/bases/xcom.py
@@ -318,7 +318,7 @@ class BaseXCom:
             raise TypeError(f"Expected XComSequenceSliceResult, received: {type(msg)} {msg}")
 
         if not msg.root:
-            return None
+            return []
 
         return [cls.deserialize_value(_XComValueWrapper(value)) for value in msg.root]
 

--- a/task-sdk/tests/task_sdk/bases/test_xcom.py
+++ b/task-sdk/tests/task_sdk/bases/test_xcom.py
@@ -22,7 +22,7 @@ from unittest import mock
 import pytest
 
 from airflow.sdk.bases.xcom import BaseXCom
-from airflow.sdk.execution_time.comms import DeleteXCom, XComResult
+from airflow.sdk.execution_time.comms import DeleteXCom, XComResult, XComSequenceSliceResult
 
 
 class TestBaseXCom:
@@ -70,3 +70,17 @@ class TestBaseXCom:
             assert sent_message.task_id == "test_task"
             assert sent_message.run_id == "test_run"
             assert sent_message.map_index == map_index
+
+    def test_get_all_returns_empty_list_when_no_values_found(self, mock_supervisor_comms):
+        """Test that BaseXCom.get_all returns an empty list instead of None when no values are found."""
+        mock_supervisor_comms.send.return_value = XComSequenceSliceResult(root=[])
+
+        result = BaseXCom.get_all(
+            key="test_key",
+            dag_id="test_dag",
+            task_id="test_task",
+            run_id="test_run",
+        )
+
+        assert result == []
+        assert isinstance(result, list)


### PR DESCRIPTION
## Description
fixes `BaseXCom.get_all()` to return an empty list instead of `None` when no XCom values are found, ensuring the implementation matches the documented behavior.
the `BaseXCom.get_all()` method's docstring explicitly states:
> "XComSequenceSliceResult can never have *None* in it, it returns an empty list if no values were found."

the implementation returned `None` when `msg.root` was empty, which:
Contradicted the documented behavior,Violated type system expectations (`XComSequenceSliceResult.root: list[JsonValue]`)

i can be wrong pls tell me the changes if there is something needed.