### PR TITLE
A few more missing compat imports in example dags

### DIFF
--- a/providers/amazon/tests/system/amazon/aws/example_appflow.py
+++ b/providers/amazon/tests/system/amazon/aws/example_appflow.py
@@ -26,7 +26,12 @@ from airflow.providers.amazon.aws.operators.appflow import (
     AppflowRunFullOperator,
 )
 from airflow.providers.common.compat.sdk import DAG, chain
-from airflow.providers.standard.operators.bash import BashOperator
+
+try:
+    from airflow.providers.standard.operators.bash import BashOperator
+except ImportError:
+    # Fallback for older Airflow versions
+    from airflow.operators.bash import BashOperator  # type: ignore[no-redef]
 
 from system.amazon.aws.utils import SystemTestContextBuilder
 

--- a/providers/amazon/tests/system/amazon/aws/example_http_to_s3.py
+++ b/providers/amazon/tests/system/amazon/aws/example_http_to_s3.py
@@ -20,7 +20,12 @@ from datetime import datetime
 
 from airflow.providers.amazon.aws.operators.s3 import S3CreateBucketOperator, S3DeleteBucketOperator
 from airflow.providers.amazon.aws.transfers.http_to_s3 import HttpToS3Operator
-from airflow.providers.standard.operators.bash import BashOperator
+
+try:
+    from airflow.providers.standard.operators.bash import BashOperator
+except ImportError:
+    # Fallback for older Airflow versions
+    from airflow.operators.bash import BashOperator  # type: ignore[no-redef]
 
 from tests_common.test_utils.api_client_helpers import make_authenticated_rest_api_request
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS

--- a/providers/amazon/tests/system/amazon/aws/utils/k8s.py
+++ b/providers/amazon/tests/system/amazon/aws/utils/k8s.py
@@ -16,7 +16,11 @@
 # under the License.
 from __future__ import annotations
 
-from airflow.providers.standard.operators.bash import BashOperator
+try:
+    from airflow.providers.standard.operators.bash import BashOperator
+except ImportError:
+    # Fallback for older Airflow versions
+    from airflow.operators.bash import BashOperator  # type: ignore[no-redef]
 
 
 def get_describe_pod_operator(cluster_name: str, pod_name: str) -> BashOperator:


### PR DESCRIPTION
Ensuring AWS example dags support Airflow 2.X

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
