### PR TITLE
Fix `@task.kubernetes_cmd` TaskGroup.expand mappings by templating TaskFlow args

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/decorators/kubernetes_cmd.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/decorators/kubernetes_cmd.py
@@ -36,7 +36,8 @@ if TYPE_CHECKING:
 class _KubernetesCmdDecoratedOperator(DecoratedOperator, KubernetesPodOperator):
     custom_operator_name = "@task.kubernetes_cmd"
 
-    template_fields: Sequence[str] = KubernetesPodOperator.template_fields
+    template_fields: Sequence[str] = tuple({"op_args", "op_kwargs", *KubernetesPodOperator.template_fields})
+
     overwrite_rtif_after_execution: bool = True
 
     def __init__(self, *, python_callable: Callable, args_only: bool = False, **kwargs) -> None:
@@ -69,6 +70,8 @@ class _KubernetesCmdDecoratedOperator(DecoratedOperator, KubernetesPodOperator):
         )
 
     def execute(self, context: Context):
+        self.render_template_fields(context)
+
         generated = self._generate_cmds(context)
         if self.args_only:
             self.cmds = []

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/decorators/test_kubernetes_cmd.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/decorators/test_kubernetes_cmd.py
@@ -397,3 +397,26 @@ class TestKubernetesCmdDecorator(TestKubernetesDecoratorsBase):
             self.execute_task(hello_task)
         self.mock_hook.assert_not_called()
         self.mock_create_pod.assert_not_called()
+
+    def test_kubernetes_cmd_template_fields_include_taskflow_args(self):
+        """Test that kubernetes_cmd operator has op_args and op_kwargs in template_fields"""
+        with self.dag_maker:
+
+            @task.kubernetes_cmd(
+                image="python:3.10-slim-buster",
+                in_cluster=False,
+                cluster_context="default",
+                config_file="/tmp/fake_file",
+                namespace="default",
+            )
+            def hello(name: str) -> list[str]:
+                return ["echo", name]
+
+            hello_task = hello("world")
+
+        op = hello_task.operator
+
+        assert "op_args" in op.template_fields
+        assert "op_kwargs" in op.template_fields
+        assert "cmds" in op.template_fields
+        assert "arguments" in op.template_fields


### PR DESCRIPTION

---
Closes #56459

## Problem

`@task.kubernetes_cmd` breaks when used with TaskFlow-style mapping inside a TaskGroup.
The root cause is that we didn't mark TaskFlow arguments (op_args / op_kwargs) as template_fields, thus the validation of the return value of the Python callable occurs before those fields are resolved by the TaskFlow/mapping machinery.

As a result, when `group_task.expand(...)` is used, the name parameter that reaches the task (`echo_cmd` is the task being used in the repro linked within the issue) is still a `MappedArgument` object, and the type check inside `_generate_cmds` sees a non-`str` element and raises the `TypeError: Expected echo_cmd to return a list of strings, but got ['echo', MappedArgument(...)]`.

## Solution

I aligned `@task.kubernetes_cmd` with `@task.kubernetes` with regards to how templated fields are handled, so TaskFlow mappings behave consistently. Concretely, I extended `template_fields` to include `op_args` and `op_kwargs` alongside the existing Kubernetes-specific fields inherited from `KubernetesPodOperator.template_fields`. This ensures that TaskFlow arguments—including mapping metadata such as `MappedArgument` coming from `TaskGroup.expand(...)` will be run through the normal TaskFlow resolution scheme and reach the user function as plain Python values instead of unresolved mapping objects.

Finally, I add a focused unit test, `test_kubernetes_cmd_template_fields_include_taskflow_args`, which creates a simple `@task.kubernetes_cmd` TaskFlow function inside `self.dag_maker`, instantiates it, and asserts that the underlying operator’s `template_fields` include at least `"op_args"` and `"op_kwargs"`. This guards against future refactors accidentally dropping TaskFlow arguments from `template_fields` and reintroducing the original `MappedArgument` type error for `TaskGroup.expand(...)` with `@task.kubernetes_cmd`.

Open to discussion!
