### PR TITLE
Fix UI e2e tests to use bundled Chromium instead of system Chrome

### DIFF
--- a/airflow-core/src/airflow/ui/playwright.config.ts
+++ b/airflow-core/src/airflow/ui/playwright.config.ts
@@ -50,7 +50,6 @@ export default defineConfig({
             "--window-size=1920,1080",
             "--window-position=0,0",
           ],
-          channel: "chrome",
           ignoreDefaultArgs: ["--enable-automation"],
         },
       },


### PR DESCRIPTION
The Chromium UI e2e tests started failing in canary because the GitHub runner image updated from 20251124.448 to 20251202.455 and Chrome is no longer pre-installed at /opt/google/chrome/chrome.
This PR removes channel: "chrome" from playwright.config.ts so Playwright uses its bundled Chromium instead of relying on system Chrome.
Failed run: https://github.com/apache/airflow/actions/runs/20110899789/job/57714593194

**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
