### PR TITLE
Fix backfill run_on_latest_version defaulting to False instead of True

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/backfills.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/backfills.py
@@ -36,6 +36,7 @@ class BackfillPostBody(StrictBaseModel):
     dag_run_conf: dict = {}
     reprocess_behavior: ReprocessBehavior = ReprocessBehavior.NONE
     max_active_runs: int = 10
+    run_on_latest_version: bool = True
 
 
 class BackfillResponse(BaseModel):

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -8965,6 +8965,10 @@ components:
           type: integer
           title: Max Active Runs
           default: 10
+        run_on_latest_version:
+          type: boolean
+          title: Run On Latest Version
+          default: true
       additionalProperties: false
       type: object
       required:

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/backfills.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/backfills.py
@@ -242,6 +242,7 @@ def create_backfill(
             dag_run_conf=backfill_request.dag_run_conf,
             triggering_user_name=user.get_name(),
             reprocess_behavior=backfill_request.reprocess_behavior,
+            run_on_latest_version=backfill_request.run_on_latest_version,
         )
         return BackfillResponse.model_validate(backfill_obj)
 

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -346,10 +346,11 @@ ARG_BACKFILL_REPROCESS_BEHAVIOR = Arg(
 ARG_BACKFILL_RUN_ON_LATEST_VERSION = Arg(
     ("--run-on-latest-version",),
     help=(
-        "(Experimental) If set, the backfill will run tasks using the latest bundle version instead of "
-        "the version that was active when the original Dag run was created."
+        "(Experimental) The backfill will run tasks using the latest bundle version instead of "
+        "the version that was active when the original Dag run was created. Defaults to True."
     ),
     action="store_true",
+    default=True,
 )
 
 

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -458,6 +458,11 @@ export const $BackfillPostBody = {
             type: 'integer',
             title: 'Max Active Runs',
             default: 10
+        },
+        run_on_latest_version: {
+            type: 'boolean',
+            title: 'Run On Latest Version',
+            default: true
         }
     },
     additionalProperties: false,

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -126,6 +126,7 @@ export type BackfillPostBody = {
     };
     reprocess_behavior?: ReprocessBehavior;
     max_active_runs?: number;
+    run_on_latest_version?: boolean;
 };
 
 /**

--- a/airflow-core/tests/unit/cli/commands/test_backfill_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_backfill_command.py
@@ -101,7 +101,7 @@ class TestCliBackfill:
             dag_run_conf=None,
             reprocess_behavior=expected_repro,
             triggering_user_name="root",
-            run_on_latest_version=False,
+            run_on_latest_version=True,
         )
 
     @mock.patch("airflow.cli.commands.backfill_command._create_backfill")
@@ -189,7 +189,7 @@ class TestCliBackfill:
             dag_run_conf={"example_key": "example_value"},
             reprocess_behavior=None,
             triggering_user_name="root",
-            run_on_latest_version=False,
+            run_on_latest_version=True,
         )
 
     def test_backfill_with_invalid_dag_run_conf(self):
@@ -235,5 +235,5 @@ class TestCliBackfill:
             dag_run_conf={},
             reprocess_behavior=None,
             triggering_user_name="root",
-            run_on_latest_version=False,
+            run_on_latest_version=True,
         )

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -1092,6 +1092,7 @@ class BackfillPostBody(BaseModel):
     dag_run_conf: Annotated[dict[str, Any] | None, Field(title="Dag Run Conf")] = {}
     reprocess_behavior: ReprocessBehavior | None = "none"
     max_active_runs: Annotated[int | None, Field(title="Max Active Runs")] = 10
+    run_on_latest_version: Annotated[bool | None, Field(title="Run On Latest Version")] = True
 
 
 class BackfillResponse(BaseModel):


### PR DESCRIPTION
The run_on_latest_version parameter for backfills was incorrectly defaulting to False in the CLI, API, and UI. This fix ensures that backfills default to using the latest bundle version, which is the intended behavior.

Changes:
- Set ARG_BACKFILL_RUN_ON_LATEST_VERSION default to True in CLI
- Add run_on_latest_version field with default=True to BackfillPostBody API model
- Update API route to use request body value instead of hardcoded True
- Update UI form to include run_on_latest_version: true in defaultValues
- Update tests to reflect the new default behavior
- Refactor RunBackfillForm to reduce line count below 250 to comply with max-lines linting rule

