### PR TITLE
Fix UI e2e workflow_dispatch to pull Docker Hub images and compile UI assets

### DIFF
--- a/.github/workflows/ui-e2e-tests.yml
+++ b/.github/workflows/ui-e2e-tests.yml
@@ -129,6 +129,15 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: 21
+      - name: "Compile UI assets (for image build fallback)"
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          cd airflow-core/src/airflow/ui
+          pnpm install --frozen-lockfile
+          pnpm build
+          cd ../api_fastapi/auth/managers/simple/ui
+          pnpm install --frozen-lockfile
+          pnpm build
       - name: "Install Playwright browsers and dependencies"
         run: |
           cd airflow-core/src/airflow/ui


### PR DESCRIPTION
Fixes two issues with workflow_dispatch for UI e2e tests:
1. Pull Docker Hub images when specified
When running with --image-name apache/airflow:3.1.4, the command now tries to pull from Docker Hub first before falling back to building from source.
2. Compile UI assets for build fallback
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
