### PR TITLE
Add modules that have not deprecated Query usage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -434,28 +434,7 @@ repos:
             ^airflow-ctl.*\.py$|
             ^airflow-core/.*\.py$|
             ^dev/airflow_perf/scheduler_dag_execution_timing.py$|
-            ^providers/amazon/tests/system/amazon/aws/example_kinesis_analytics.py$|
-            ^providers/amazon/tests/unit/amazon/aws/transfers/test_s3_to_sql.py$|
-            ^providers/celery/.*\.py$|
-            ^providers/cncf/kubernetes/.*\.py$|
-            ^providers/databricks/.*\.py$|
-            ^providers/edge3/.*\.py$|
-            ^providers/elasticsearch/src/airflow/providers/elasticsearch/log/es_task_handler.py$|
-            ^providers/mysql/.*\.py$|
-            ^providers/openlineage/.*\.py$|
-            ^providers/opensearch/src/airflow/providers/opensearch/log/os_task_handler.py$|
-            ^providers/google/src/airflow/providers/google/cloud/triggers/bigquery\.py$|
-            ^providers/google/src/airflow/providers/google/cloud/triggers/dataproc\.py$|
-            ^providers/google/tests/system/google/gcp_api_client_helpers\.py$|
-            ^providers/google/tests/unit/google/cloud/utils/gcp_authenticator\.py$|
-            ^providers/google/tests/unit/google/marketing_platform/operators/test_campaign_manager\.py$|
-            ^providers/standard/tests/unit/standard/operators/test_latest_only_operator\.py$|
-            ^providers/standard/tests/unit/standard/operators/test_trigger_dagrun\.py$|
-            ^providers/standard/tests/unit/standard/operators/test_weekday\.py$|
-            ^providers/standard/tests/unit/standard/operators/test_datetime\.py$|
-            ^providers/standard/tests/unit/standard/operators/test_branch_operator\.py$|
-            ^providers/standard/tests/unit/standard/sensors/test_external_task_sensor\.py$|
-            ^providers/standard/tests/unit/standard/utils/test_skipmixin\.py$|
+            ^providers/.*\.py$|
             ^task_sdk.*\.py$|
             ^devel-common/src/tests_common/pytest_plugin\.py$|
             ^devel-common/src/tests_common/test_utils/.*\.py$


### PR DESCRIPTION
Part of removing deprecated `SQLAlchemy Query` usage.


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
