### PR TITLE
Add `team_name` to connection public APIs

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
@@ -41,6 +41,7 @@ class ConnectionResponse(BaseModel):
     port: int | None
     password: str | None
     extra: str | None
+    team_name: str | None
 
     @field_validator("password", mode="after")
     @classmethod
@@ -136,6 +137,7 @@ class ConnectionBody(StrictBaseModel):
     port: int | None = Field(default=None)
     password: str | None = Field(default=None)
     extra: str | None = Field(default=None)
+    team_name: str | None = Field(max_length=50, default=None)
 
     @field_validator("extra")
     @classmethod

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -9732,6 +9732,12 @@ components:
           - type: string
           - type: 'null'
           title: Extra
+        team_name:
+          anyOf:
+          - type: string
+            maxLength: 50
+          - type: 'null'
+          title: Team Name
       additionalProperties: false
       type: object
       required:
@@ -9798,6 +9804,11 @@ components:
           - type: string
           - type: 'null'
           title: Extra
+        team_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Team Name
       type: object
       required:
       - connection_id
@@ -9809,6 +9820,7 @@ components:
       - port
       - password
       - extra
+      - team_name
       title: ConnectionResponse
       description: Connection serializer for responses.
     ConnectionTestResponse:

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -1545,6 +1545,18 @@ export const $ConnectionBody = {
                 }
             ],
             title: 'Extra'
+        },
+        team_name: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 50
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Team Name'
         }
     },
     additionalProperties: false,
@@ -1660,10 +1672,21 @@ export const $ConnectionResponse = {
                 }
             ],
             title: 'Extra'
+        },
+        team_name: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Team Name'
         }
     },
     type: 'object',
-    required: ['connection_id', 'conn_type', 'description', 'host', 'login', 'schema', 'port', 'password', 'extra'],
+    required: ['connection_id', 'conn_type', 'description', 'host', 'login', 'schema', 'port', 'password', 'extra', 'team_name'],
     title: 'ConnectionResponse',
     description: 'Connection serializer for responses.'
 } as const;

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -468,6 +468,7 @@ export type ConnectionBody = {
     port?: number | null;
     password?: string | null;
     extra?: string | null;
+    team_name?: string | null;
 };
 
 /**
@@ -491,6 +492,7 @@ export type ConnectionResponse = {
     port: number | null;
     password: string | null;
     extra: string | null;
+    team_name: string | null;
 };
 
 /**

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
@@ -21,10 +21,11 @@ from importlib.metadata import PackageNotFoundError, metadata
 from unittest import mock
 
 import pytest
+from sqlalchemy.orm import Session
 
 from airflow.models import Connection
 from airflow.secrets.environment_variables import CONN_ENV_PREFIX
-from airflow.utils.session import provide_session
+from airflow.utils.session import NEW_SESSION, provide_session
 
 from tests_common.test_utils.api_fastapi import _check_last_log
 from tests_common.test_utils.asserts import assert_queries_count
@@ -56,7 +57,7 @@ TEST_CONN_TYPE_3 = "test_type_3"
 
 
 @provide_session
-def _create_connection(session) -> None:
+def _create_connection(team_name: str | None = None, session: Session = NEW_SESSION) -> None:
     connection_model = Connection(
         conn_id=TEST_CONN_ID,
         conn_type=TEST_CONN_TYPE,
@@ -64,13 +65,14 @@ def _create_connection(session) -> None:
         host=TEST_CONN_HOST,
         port=TEST_CONN_PORT,
         login=TEST_CONN_LOGIN,
+        team_name=team_name,
     )
     session.add(connection_model)
 
 
 @provide_session
-def _create_connections(session) -> None:
-    _create_connection(session)
+def _create_connections(session: Session = NEW_SESSION) -> None:
+    _create_connection(session=session)
     connection_model_2 = Connection(
         conn_id=TEST_CONN_ID_2,
         conn_type=TEST_CONN_TYPE_2,
@@ -92,8 +94,8 @@ class TestConnectionEndpoint:
     def teardown_method(self) -> None:
         clear_db_connections()
 
-    def create_connection(self):
-        _create_connection()
+    def create_connection(self, team_name: str | None = None):
+        _create_connection(team_name=team_name)
 
     def create_connections(self):
         _create_connections()
@@ -126,13 +128,14 @@ class TestDeleteConnection(TestConnectionEndpoint):
 
 
 class TestGetConnection(TestConnectionEndpoint):
-    def test_get_should_respond_200(self, test_client, session):
-        self.create_connection()
+    def test_get_should_respond_200(self, test_client, testing_team, session):
+        self.create_connection(team_name=testing_team.name)
         response = test_client.get(f"/connections/{TEST_CONN_ID}")
         assert response.status_code == 200
         body = response.json()
         assert body["connection_id"] == TEST_CONN_ID
         assert body["conn_type"] == TEST_CONN_TYPE
+        assert body["team_name"] == testing_team.name
 
     def test_should_respond_401(self, unauthenticated_test_client):
         response = unauthenticated_test_client.get(f"/connections/{TEST_CONN_ID}")
@@ -278,6 +281,25 @@ class TestPostConnection(TestConnectionEndpoint):
         assert len(connection) == 1
         _check_last_log(session, dag_id=None, event="post_connection", logical_date=None)
 
+    def test_post_should_respond_201_with_team(self, test_client, session, testing_team):
+        response = test_client.post(
+            "/connections",
+            json={"connection_id": TEST_CONN_ID, "conn_type": TEST_CONN_TYPE, "team_name": testing_team.name},
+        )
+        assert response.status_code == 201
+        assert response.json() == {
+            "connection_id": TEST_CONN_ID,
+            "conn_type": TEST_CONN_TYPE,
+            "description": None,
+            "extra": None,
+            "host": None,
+            "login": None,
+            "password": None,
+            "port": None,
+            "schema": None,
+            "team_name": testing_team.name,
+        }
+
     def test_should_respond_401(self, unauthenticated_test_client):
         response = unauthenticated_test_client.post("/connections", json={})
         assert response.status_code == 401
@@ -343,6 +365,7 @@ class TestPostConnection(TestConnectionEndpoint):
                     "password": "***",
                     "port": None,
                     "schema": None,
+                    "team_name": None,
                 },
             ),
             (
@@ -357,6 +380,7 @@ class TestPostConnection(TestConnectionEndpoint):
                     "password": "***",
                     "port": None,
                     "schema": None,
+                    "team_name": None,
                 },
             ),
             (
@@ -376,6 +400,7 @@ class TestPostConnection(TestConnectionEndpoint):
                     "password": "***",
                     "port": None,
                     "schema": None,
+                    "team_name": None,
                 },
             ),
         ],
@@ -403,6 +428,7 @@ class TestPatchConnection(TestConnectionEndpoint):
                     "password": None,
                     "port": TEST_CONN_PORT,
                     "schema": None,
+                    "team_name": None,
                 },
             ),
             (
@@ -417,6 +443,7 @@ class TestPatchConnection(TestConnectionEndpoint):
                     "password": None,
                     "port": TEST_CONN_PORT,
                     "schema": None,
+                    "team_name": None,
                 },
             ),
             (
@@ -436,6 +463,7 @@ class TestPatchConnection(TestConnectionEndpoint):
                     "password": None,
                     "port": 80,
                     "schema": None,
+                    "team_name": None,
                 },
             ),
             (
@@ -450,6 +478,7 @@ class TestPatchConnection(TestConnectionEndpoint):
                     "password": None,
                     "port": TEST_CONN_PORT,
                     "schema": None,
+                    "team_name": None,
                 },
             ),
             (
@@ -464,6 +493,7 @@ class TestPatchConnection(TestConnectionEndpoint):
                     "password": None,
                     "port": 80,
                     "schema": None,
+                    "team_name": None,
                 },
             ),
             (
@@ -484,6 +514,7 @@ class TestPatchConnection(TestConnectionEndpoint):
                     "password": "test_password_patch",
                     "port": 80,
                     "schema": None,
+                    "team_name": None,
                 },
             ),
             (
@@ -505,6 +536,7 @@ class TestPatchConnection(TestConnectionEndpoint):
                     "password": None,
                     "port": 80,
                     "schema": None,
+                    "team_name": None,
                 },
             ),
             (
@@ -524,6 +556,7 @@ class TestPatchConnection(TestConnectionEndpoint):
                     "password": None,
                     "port": TEST_CONN_PORT,
                     "schema": "http_patch",
+                    "team_name": None,
                 },
             ),
             (
@@ -548,11 +581,11 @@ class TestPatchConnection(TestConnectionEndpoint):
                     "password": None,
                     "port": None,
                     "schema": None,
+                    "team_name": None,
                 },
             ),
         ],
     )
-    @provide_session
     def test_patch_should_respond_200(
         self, test_client, body: dict[str, str], expected_result: dict[str, str], session
     ):
@@ -563,6 +596,29 @@ class TestPatchConnection(TestConnectionEndpoint):
         _check_last_log(session, dag_id=None, event="patch_connection", logical_date=None)
 
         assert response.json() == expected_result
+
+    def test_patch_with_team_should_respond_200(self, test_client, testing_team, session):
+        self.create_connection()
+
+        response = test_client.patch(
+            f"/connections/{TEST_CONN_ID}",
+            json={"connection_id": TEST_CONN_ID, "conn_type": "new_type", "team_name": testing_team.name},
+        )
+        assert response.status_code == 200
+        _check_last_log(session, dag_id=None, event="patch_connection", logical_date=None)
+
+        assert response.json() == {
+            "conn_type": "new_type",
+            "connection_id": TEST_CONN_ID,
+            "description": TEST_CONN_DESCRIPTION,
+            "extra": None,
+            "host": TEST_CONN_HOST,
+            "login": TEST_CONN_LOGIN,
+            "password": None,
+            "port": TEST_CONN_PORT,
+            "schema": None,
+            "team_name": testing_team.name,
+        }
 
     def test_should_respond_401(self, unauthenticated_test_client):
         response = unauthenticated_test_client.patch(f"/connections/{TEST_CONN_ID}", json={})
@@ -593,6 +649,7 @@ class TestPatchConnection(TestConnectionEndpoint):
                     "schema": None,
                     "password": None,
                     "description": TEST_CONN_DESCRIPTION,
+                    "team_name": None,
                 },
                 {"update_mask": ["login", "port"]},
             ),
@@ -614,6 +671,7 @@ class TestPatchConnection(TestConnectionEndpoint):
                     "schema": None,
                     "password": None,
                     "description": TEST_CONN_DESCRIPTION,
+                    "team_name": None,
                 },
                 {"update_mask": ["login", "port"]},
             ),
@@ -629,6 +687,7 @@ class TestPatchConnection(TestConnectionEndpoint):
                     "schema": None,
                     "password": None,
                     "description": TEST_CONN_DESCRIPTION,
+                    "team_name": None,
                 },
                 {"update_mask": ["host"]},
             ),
@@ -649,6 +708,7 @@ class TestPatchConnection(TestConnectionEndpoint):
                     "schema": None,
                     "password": None,
                     "description": TEST_CONN_DESCRIPTION,
+                    "team_name": None,
                 },
                 {"update_mask": ["host", "port"]},
             ),
@@ -664,6 +724,7 @@ class TestPatchConnection(TestConnectionEndpoint):
                     "schema": None,
                     "password": None,
                     "description": TEST_CONN_DESCRIPTION,
+                    "team_name": None,
                 },
                 {"update_mask": ["login"]},
             ),
@@ -684,6 +745,7 @@ class TestPatchConnection(TestConnectionEndpoint):
                     "password": None,
                     "schema": None,
                     "description": TEST_CONN_DESCRIPTION,
+                    "team_name": None,
                 },
                 {"update_mask": ["host"]},
             ),
@@ -706,6 +768,7 @@ class TestPatchConnection(TestConnectionEndpoint):
                     "password": None,
                     "schema": "new_schema",
                     "description": TEST_CONN_DESCRIPTION,
+                    "team_name": None,
                 },
                 {"update_mask": ["schema", "extra"]},
             ),
@@ -818,6 +881,7 @@ class TestPatchConnection(TestConnectionEndpoint):
                     "password": "***",
                     "port": 8080,
                     "schema": None,
+                    "team_name": None,
                 },
                 {"update_mask": ["password"]},
             ),
@@ -833,6 +897,7 @@ class TestPatchConnection(TestConnectionEndpoint):
                     "password": "***",
                     "port": 8080,
                     "schema": None,
+                    "team_name": None,
                 },
                 {"update_mask": ["password"]},
             ),
@@ -853,6 +918,7 @@ class TestPatchConnection(TestConnectionEndpoint):
                     "password": "***",
                     "port": 8080,
                     "schema": None,
+                    "team_name": None,
                 },
                 {"update_mask": ["password", "extra"]},
             ),

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -203,6 +203,10 @@ class ConfigSection(BaseModel):
     options: Annotated[list[ConfigOption], Field(title="Options")]
 
 
+class TeamName(RootModel[str]):
+    root: Annotated[str, Field(max_length=50, title="Team Name")]
+
+
 class ConnectionBody(BaseModel):
     """
     Connection Serializer for requests body.
@@ -220,6 +224,7 @@ class ConnectionBody(BaseModel):
     port: Annotated[int | None, Field(title="Port")] = None
     password: Annotated[str | None, Field(title="Password")] = None
     extra: Annotated[str | None, Field(title="Extra")] = None
+    team_name: Annotated[TeamName | None, Field(title="Team Name")] = None
 
 
 class ConnectionResponse(BaseModel):
@@ -236,6 +241,7 @@ class ConnectionResponse(BaseModel):
     port: Annotated[int | None, Field(title="Port")] = None
     password: Annotated[str | None, Field(title="Password")] = None
     extra: Annotated[str | None, Field(title="Extra")] = None
+    team_name: Annotated[str | None, Field(title="Team Name")] = None
 
 
 class ConnectionTestResponse(BaseModel):
@@ -912,10 +918,6 @@ class ValidationError(BaseModel):
     loc: Annotated[list[str | int], Field(title="Location")]
     msg: Annotated[str, Field(title="Message")]
     type: Annotated[str, Field(title="Error Type")]
-
-
-class TeamName(RootModel[str]):
-    root: Annotated[str, Field(max_length=50, title="Team Name")]
 
 
 class VariableBody(BaseModel):


### PR DESCRIPTION
Add `team_name` to connection public APIs. Another PR will be created later to handle the task execution environment (execution API).

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
