### PR TITLE
Add toaster notifications for Connection Test

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/admin.json
@@ -49,6 +49,12 @@
     "searchPlaceholder": "Search Connections",
     "test": "Test Connection",
     "testDisabled": "Test connection feature is disabled. Please contact an administrator to enable it.",
+    "testError": {
+      "title": "Test Connection Failed"
+    },
+    "testSuccess": {
+      "title": "Test Connection Successful"
+    },
     "typeMeta": {
       "error": "Failed to retrieve Connection Type Meta",
       "standardFields": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
@@ -313,14 +313,6 @@
         "title": "Import {{resourceName}} Request Submitted"
       }
     },
-    "test": {
-      "error": {
-        "title": "Test Connection Failed"
-      },
-      "success": {
-        "title": "Test Connection Successful"
-      }
-    },
     "update": {
       "error": "Update {{resourceName}} Request Failed",
       "success": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
@@ -313,6 +313,14 @@
         "title": "Import {{resourceName}} Request Submitted"
       }
     },
+    "test": {
+      "error": {
+        "title": "Test Connection Failed"
+      },
+      "success": {
+        "title": "Test Connection Successful"
+      }
+    },
     "update": {
       "error": "Update {{resourceName}} Request Failed",
       "success": {

--- a/airflow-core/src/airflow/ui/src/queries/useTestConnection.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useTestConnection.ts
@@ -17,12 +17,31 @@
  * under the License.
  */
 import type { Dispatch, SetStateAction } from "react";
+import { useTranslation } from "react-i18next";
 
 import { useConnectionServiceTestConnection } from "openapi/queries";
 import type { ConnectionTestResponse } from "openapi/requests/types.gen";
+import { toaster } from "src/components/ui";
 
 export const useTestConnection = (setConnected: Dispatch<SetStateAction<boolean | undefined>>) => {
-  const onSuccess = (res: ConnectionTestResponse) => setConnected(res.status);
+  const { t: translate } = useTranslation("common");
+
+  const onSuccess = (res: ConnectionTestResponse) => {
+    setConnected(res.status);
+    if (res.status) {
+      toaster.create({
+        description: res.message,
+        title: translate("toaster.test.success.title"),
+        type: "success",
+      });
+    } else {
+      toaster.create({
+        description: res.message,
+        title: translate("toaster.test.error.title"),
+        type: "error",
+      });
+    }
+  };
 
   const onError = () => {
     setConnected(false);

--- a/airflow-core/src/airflow/ui/src/queries/useTestConnection.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useTestConnection.ts
@@ -24,20 +24,20 @@ import type { ConnectionTestResponse } from "openapi/requests/types.gen";
 import { toaster } from "src/components/ui";
 
 export const useTestConnection = (setConnected: Dispatch<SetStateAction<boolean | undefined>>) => {
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation("admin");
 
   const onSuccess = (res: ConnectionTestResponse) => {
     setConnected(res.status);
     if (res.status) {
       toaster.create({
         description: res.message,
-        title: translate("toaster.test.success.title"),
+        title: translate("connections.testSuccess.title"),
         type: "success",
       });
     } else {
       toaster.create({
         description: res.message,
-        title: translate("toaster.test.error.title"),
+        title: translate("connections.testError.title"),
         type: "error",
       });
     }


### PR DESCRIPTION
closes: #59299

## Before
Currently, when testing a connection in the Airflow UI, users can see the success or failure result in the icon, but no toaster-style notification is displayed.
Because there is no notification, users cannot easily see why the connection test failed.

<img width="2168" height="1397" alt="image" src="https://github.com/user-attachments/assets/85ef9f3a-9970-4a73-8573-0f1178f720e4" />


## After
A toaster-style error notification is now displayed with details explaining why the test failed.

https://github.com/user-attachments/assets/98bb12e7-3c9f-4f73-b351-8b1b0d216dbf

<img width="520" height="305" alt="image" src="https://github.com/user-attachments/assets/0ab6c37b-b405-467e-a7c3-244addf0b168" />


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
