### PR TITLE
Fix toast notification description text truncation

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/ui/Toaster/Toaster.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ui/Toaster/Toaster.tsx
@@ -29,7 +29,9 @@ export const Toaster = () => (
           <Stack flex="1" gap="1" maxWidth="100%">
             {Boolean(toast.title) ? <Toast.Title>{toast.title}</Toast.Title> : undefined}
             {Boolean(toast.description) ? (
-              <Toast.Description>{toast.description}</Toast.Description>
+              <Toast.Description overflowWrap="break-word" wordBreak="break-word">
+                {toast.description}
+              </Toast.Description>
             ) : undefined}
           </Stack>
           {toast.action ? <Toast.ActionTrigger>{toast.action.label}</Toast.ActionTrigger> : undefined}


### PR DESCRIPTION
Fixes an issue where long text in toast notification descriptions was being truncated instead of wrapping to multiple lines.


## Before
<img width="1040" height="610" alt="image" src="https://github.com/user-attachments/assets/ccbf5bf0-4264-4020-bc26-941a89046c2e" />



## After

Added `wordBreak="break-word"` and `overflowWrap="break-word"` styles to Toast.Description component to enable proper text wrapping

<img width="2168" height="1397" alt="Screenshot 2025-12-12 at 4 16 53 PM" src="https://github.com/user-attachments/assets/f46d19d6-4043-422e-b881-6594001ad0d3" />


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
