### PR TITLE
Sync v3-1-stable with v3-1-test to release 3.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Airflow is not a streaming solution, but it is often used to process real-time d
 
 Apache Airflow is tested with:
 
-|            | Main version (dev)           | Stable version (3.1.4) |
+|            | Main version (dev)           | Stable version (3.1.5) |
 |------------|------------------------------|------------------------|
 | Python     | 3.10, 3.11, 3.12, 3.13       | 3.10, 3.11, 3.12, 3.13 |
 | Platform   | AMD64/ARM64(\*)              | AMD64/ARM64(\*)        |
@@ -177,15 +177,15 @@ them to the appropriate format and workflow that your tool requires.
 
 
 ```bash
-pip install 'apache-airflow==3.1.4' \
- --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-3.1.4/constraints-3.10.txt"
+pip install 'apache-airflow==3.1.5' \
+ --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-3.1.5/constraints-3.10.txt"
 ```
 
 2. Installing with extras (i.e., postgres, google)
 
 ```bash
-pip install 'apache-airflow[postgres,google]==3.1.4' \
- --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-3.1.4/constraints-3.10.txt"
+pip install 'apache-airflow[postgres,google]==3.1.5' \
+ --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-3.1.5/constraints-3.10.txt"
 ```
 
 For information on installing provider distributions, check
@@ -299,7 +299,7 @@ Apache Airflow version life cycle:
 
 | Version   | Current Patch/Minor   | State     | First Release   | Limited Maintenance   | EOL/Terminated   |
 |-----------|-----------------------|-----------|-----------------|-----------------------|------------------|
-| 3         | 3.1.4                 | Supported | Apr 22, 2025    | TBD                   | TBD              |
+| 3         | 3.1.5                 | Supported | Apr 22, 2025    | TBD                   | TBD              |
 | 2         | 2.11.0                | Supported | Dec 17, 2020    | Oct 22, 2025          | Apr 22, 2026     |
 | 1.10      | 1.10.15               | EOL       | Aug 27, 2018    | Dec 17, 2020          | June 17, 2021    |
 | 1.9       | 1.9.0                 | EOL       | Jan 03, 2018    | Aug 27, 2018          | Aug 27, 2018     |

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -24,7 +24,7 @@
 
 .. towncrier release notes start
 
-Airflow 3.1.4 (2025-12-10)
+Airflow 3.1.5 (2025-12-12)
 --------------------------
 
 Significant Changes

--- a/airflow-core/docs/installation/supported-versions.rst
+++ b/airflow-core/docs/installation/supported-versions.rst
@@ -29,7 +29,7 @@ Apache Airflow® version life cycle:
 =========  =====================  =========  ===============  =====================  ================
 Version    Current Patch/Minor    State      First Release    Limited Maintenance    EOL/Terminated
 =========  =====================  =========  ===============  =====================  ================
-3          3.1.4                  Supported  Apr 22, 2025     TBD                    TBD
+3          3.1.5                  Supported  Apr 22, 2025     TBD                    TBD
 2          2.11.0                 Supported  Dec 17, 2020     Oct 22, 2025           Apr 22, 2026
 1.10       1.10.15                EOL        Aug 27, 2018     Dec 17, 2020           June 17, 2021
 1.9        1.9.0                  EOL        Jan 03, 2018     Aug 27, 2018           Aug 27, 2018

--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -63,7 +63,7 @@ classifiers = [
 ]
 
 # Version is defined in src/airflow/__init__.py and it is automatically synchronized by prek hook
-version = "3.1.4"
+version = "3.1.5"
 
 dependencies = [
     "a2wsgi>=1.10.8",
@@ -139,7 +139,7 @@ dependencies = [
     # https://github.com/apache/airflow/issues/56369 , rework universal-pathlib usage
     "universal-pathlib>=0.2.6,<0.3.0",
     "uuid6>=2024.7.10",
-    "apache-airflow-task-sdk<1.2.0,==1.1.4",
+    "apache-airflow-task-sdk<1.2.0,==1.1.5",
     # pre-installed providers
     "apache-airflow-providers-common-compat>=1.7.4",
     "apache-airflow-providers-common-io>=1.6.3",

--- a/airflow-core/src/airflow/__init__.py
+++ b/airflow-core/src/airflow/__init__.py
@@ -25,7 +25,7 @@
 # lib.)  This is required by some IDEs to resolve the import paths.
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
-__version__ = "3.1.4"
+__version__ = "3.1.5"
 
 
 import os

--- a/dev/breeze/src/airflow_breeze/global_constants.py
+++ b/dev/breeze/src/airflow_breeze/global_constants.py
@@ -747,7 +747,7 @@ PROVIDERS_COMPATIBILITY_TESTS_MATRIX: list[dict[str, str | list[str]]] = [
     },
     {
         "python-version": "3.10",
-        "airflow-version": "3.1.4",
+        "airflow-version": "3.1.5",
         "remove-providers": "",
         "run-unit-tests": "true",
     },

--- a/docker-stack-docs/README.md
+++ b/docker-stack-docs/README.md
@@ -31,12 +31,12 @@ Every time a new version of Airflow is released, the images are prepared in the
 [apache/airflow DockerHub](https://hub.docker.com/r/apache/airflow)
 for all the supported Python versions.
 
-You can find the following images there (Assuming Airflow version `3.1.4`):
+You can find the following images there (Assuming Airflow version `3.1.5`):
 
 * `apache/airflow:latest` - the latest released Airflow image with default Python version (3.12 currently)
 * `apache/airflow:latest-pythonX.Y` - the latest released Airflow image with specific Python version
-* `apache/airflow:3.1.4` - the versioned Airflow image with default Python version (3.12 currently)
-* `apache/airflow:3.1.4-pythonX.Y` - the versioned Airflow image with specific Python version
+* `apache/airflow:3.1.5` - the versioned Airflow image with default Python version (3.12 currently)
+* `apache/airflow:3.1.5-pythonX.Y` - the versioned Airflow image with specific Python version
 
 Those are "reference" regular images. They contain the most common set of extras, dependencies and providers that are
 often used by the users and they are good to "try-things-out" when you want to just take Airflow for a spin,
@@ -47,8 +47,8 @@ via [Building the image](https://airflow.apache.org/docs/docker-stack/build.html
 
 * `apache/airflow:slim-latest`              - the latest released Airflow image with default Python version (3.12 currently)
 * `apache/airflow:slim-latest-pythonX.Y`    - the latest released Airflow image with specific Python version
-* `apache/airflow:slim-3.1.4`           - the versioned Airflow image with default Python version (3.12 currently)
-* `apache/airflow:slim-3.1.4-pythonX.Y` - the versioned Airflow image with specific Python version
+* `apache/airflow:slim-3.1.5`           - the versioned Airflow image with default Python version (3.12 currently)
+* `apache/airflow:slim-3.1.5-pythonX.Y` - the versioned Airflow image with specific Python version
 
 The Apache Airflow image provided as convenience package is optimized for size, and
 it provides just a bare minimal set of the extras and dependencies installed and in most cases

--- a/docker-stack-docs/docker-examples/extending/add-airflow-configuration/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/add-airflow-configuration/Dockerfile
@@ -15,7 +15,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:3.1.4
+FROM apache/airflow:3.1.5
 ENV AIRFLOW__CORE__LOAD_EXAMPLES=True
 ENV AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=my_conn_string
 # [END Dockerfile]

--- a/docker-stack-docs/docker-examples/extending/add-apt-packages/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/add-apt-packages/Dockerfile
@@ -15,7 +15,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:3.1.4
+FROM apache/airflow:3.1.5
 USER root
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/docker-stack-docs/docker-examples/extending/add-build-essential-extend/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/add-build-essential-extend/Dockerfile
@@ -15,7 +15,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:3.1.4
+FROM apache/airflow:3.1.5
 USER root
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/docker-stack-docs/docker-examples/extending/add-providers/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/add-providers/Dockerfile
@@ -15,7 +15,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:3.1.4
+FROM apache/airflow:3.1.5
 USER root
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/docker-stack-docs/docker-examples/extending/add-pypi-packages-constraints/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/add-pypi-packages-constraints/Dockerfile
@@ -15,6 +15,6 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:3.1.4
+FROM apache/airflow:3.1.5
 RUN pip install --no-cache-dir "apache-airflow==${AIRFLOW_VERSION}" lxml --constraint "${HOME}/constraints.txt"
 # [END Dockerfile]

--- a/docker-stack-docs/docker-examples/extending/add-pypi-packages-uv/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/add-pypi-packages-uv/Dockerfile
@@ -15,7 +15,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:3.1.4
+FROM apache/airflow:3.1.5
 
 # The `uv` tools is Rust packaging tool that is much faster than `pip` and other installer
 # Support for uv as installation tool is experimental

--- a/docker-stack-docs/docker-examples/extending/add-pypi-packages/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/add-pypi-packages/Dockerfile
@@ -15,6 +15,6 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:3.1.4
+FROM apache/airflow:3.1.5
 RUN pip install --no-cache-dir "apache-airflow==${AIRFLOW_VERSION}" lxml
 # [END Dockerfile]

--- a/docker-stack-docs/docker-examples/extending/add-requirement-packages/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/add-requirement-packages/Dockerfile
@@ -15,7 +15,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:3.1.4
+FROM apache/airflow:3.1.5
 COPY requirements.txt /
 RUN pip install --no-cache-dir "apache-airflow==${AIRFLOW_VERSION}" -r /requirements.txt
 # [END Dockerfile]

--- a/docker-stack-docs/docker-examples/extending/custom-providers/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/custom-providers/Dockerfile
@@ -15,6 +15,6 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:3.1.4
+FROM apache/airflow:3.1.5
 RUN pip install "apache-airflow==${AIRFLOW_VERSION}" --no-cache-dir apache-airflow-providers-docker==2.5.1
 # [END Dockerfile]

--- a/docker-stack-docs/docker-examples/extending/embedding-dags/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/embedding-dags/Dockerfile
@@ -15,7 +15,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:3.1.4
+FROM apache/airflow:3.1.5
 
 COPY --chown=airflow:root test_dag.py /opt/airflow/dags
 

--- a/docker-stack-docs/docker-examples/extending/writable-directory/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/writable-directory/Dockerfile
@@ -15,7 +15,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:3.1.4
+FROM apache/airflow:3.1.5
 RUN umask 0002; \
     mkdir -p ~/writeable-directory
 # [END Dockerfile]

--- a/docker-stack-docs/entrypoint.rst
+++ b/docker-stack-docs/entrypoint.rst
@@ -132,7 +132,7 @@ if you specify extra arguments. For example:
 
 .. code-block:: bash
 
-  docker run -it apache/airflow:3.1.4-python3.10 bash -c "ls -la"
+  docker run -it apache/airflow:3.1.5-python3.10 bash -c "ls -la"
   total 16
   drwxr-xr-x 4 airflow root 4096 Jun  5 18:12 .
   drwxr-xr-x 1 root    root 4096 Jun  5 18:12 ..
@@ -144,7 +144,7 @@ you pass extra parameters. For example:
 
 .. code-block:: bash
 
-  > docker run -it apache/airflow:3.1.4-python3.10 python -c "print('test')"
+  > docker run -it apache/airflow:3.1.5-python3.10 python -c "print('test')"
   test
 
 If first argument equals to ``airflow`` - the rest of the arguments is treated as an Airflow command
@@ -152,13 +152,13 @@ to execute. Example:
 
 .. code-block:: bash
 
-   docker run -it apache/airflow:3.1.4-python3.10 airflow webserver
+   docker run -it apache/airflow:3.1.5-python3.10 airflow webserver
 
 If there are any other arguments - they are simply passed to the "airflow" command
 
 .. code-block:: bash
 
-  > docker run -it apache/airflow:3.1.4-python3.10 help
+  > docker run -it apache/airflow:3.1.5-python3.10 help
     usage: airflow [-h] GROUP_OR_COMMAND ...
 
     Positional Arguments:
@@ -366,7 +366,7 @@ database and creating an ``admin/admin`` Admin user with the following command:
     --env "_AIRFLOW_DB_MIGRATE=true" \
     --env "_AIRFLOW_WWW_USER_CREATE=true" \
     --env "_AIRFLOW_WWW_USER_PASSWORD=admin" \
-      apache/airflow:3.1.4-python3.10 webserver
+      apache/airflow:3.1.5-python3.10 webserver
 
 
 .. code-block:: bash
@@ -375,7 +375,7 @@ database and creating an ``admin/admin`` Admin user with the following command:
     --env "_AIRFLOW_DB_MIGRATE=true" \
     --env "_AIRFLOW_WWW_USER_CREATE=true" \
     --env "_AIRFLOW_WWW_USER_PASSWORD_CMD=echo admin" \
-      apache/airflow:3.1.4-python3.10 webserver
+      apache/airflow:3.1.5-python3.10 webserver
 
 The commands above perform initialization of the SQLite database, create admin user with admin password
 and Admin role. They also forward local port ``8080`` to the webserver port and finally start the webserver.
@@ -415,6 +415,6 @@ Example:
     --env "_AIRFLOW_DB_MIGRATE=true" \
     --env "_AIRFLOW_WWW_USER_CREATE=true" \
     --env "_AIRFLOW_WWW_USER_PASSWORD_CMD=echo admin" \
-      apache/airflow:3.1.4-python3.10 webserver
+      apache/airflow:3.1.5-python3.10 webserver
 
 This method is only available starting from Docker image of Airflow 2.1.1 and above.

--- a/generated/PYPI_README.md
+++ b/generated/PYPI_README.md
@@ -56,7 +56,7 @@ Use Airflow to author workflows (Dags) that orchestrate tasks. The Airflow sched
 
 Apache Airflow is tested with:
 
-|            | Main version (dev)           | Stable version (3.1.4) |
+|            | Main version (dev)           | Stable version (3.1.5) |
 |------------|------------------------------|------------------------|
 | Python     | 3.10, 3.11, 3.12, 3.13       | 3.10, 3.11, 3.12, 3.13 |
 | Platform   | AMD64/ARM64(\*)              | AMD64/ARM64(\*)        |
@@ -130,15 +130,15 @@ them to the appropriate format and workflow that your tool requires.
 
 
 ```bash
-pip install 'apache-airflow==3.1.4' \
- --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-3.1.4/constraints-3.10.txt"
+pip install 'apache-airflow==3.1.5' \
+ --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-3.1.5/constraints-3.10.txt"
 ```
 
 2. Installing with extras (i.e., postgres, google)
 
 ```bash
-pip install 'apache-airflow[postgres,google]==3.1.4' \
- --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-3.1.4/constraints-3.10.txt"
+pip install 'apache-airflow[postgres,google]==3.1.5' \
+ --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-3.1.5/constraints-3.10.txt"
 ```
 
 For information on installing provider distributions, check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,11 +63,11 @@ classifiers = [
 ]
 
 # Version is defined in src/airflow/__init__.py and it is automatically synchronized by prek
-version = "3.1.4"
+version = "3.1.5"
 
 dependencies = [
-    "apache-airflow-task-sdk==1.1.4",
-    "apache-airflow-core==3.1.4",
+    "apache-airflow-task-sdk==1.1.5",
+    "apache-airflow-core==3.1.5",
 ]
 
 packages = []

--- a/reproducible_build.yaml
+++ b/reproducible_build.yaml
@@ -1,2 +1,2 @@
-release-notes-hash: 1cef4f069cb23b395098f97d070d8d0a
-source-date-epoch: 1765212168
+release-notes-hash: 75deb73e4744a67f6467178fb99c93e6
+source-date-epoch: 1765543510

--- a/scripts/ci/prek/supported_versions.py
+++ b/scripts/ci/prek/supported_versions.py
@@ -39,7 +39,7 @@ HEADERS = (
 )
 
 SUPPORTED_VERSIONS = (
-    ("3", "3.1.4", "Supported", "Apr 22, 2025", "TBD", "TBD"),
+    ("3", "3.1.5", "Supported", "Apr 22, 2025", "TBD", "TBD"),
     ("2", "2.11.0", "Supported", "Dec 17, 2020", "Oct 22, 2025", "Apr 22, 2026"),
     ("1.10", "1.10.15", "EOL", "Aug 27, 2018", "Dec 17, 2020", "June 17, 2021"),
     ("1.9", "1.9.0", "EOL", "Jan 03, 2018", "Aug 27, 2018", "Aug 27, 2018"),

--- a/task-sdk/pyproject.toml
+++ b/task-sdk/pyproject.toml
@@ -49,7 +49,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "apache-airflow-core<3.2.0,>=3.1.3",
+    "apache-airflow-core<3.2.0,>=3.1.5",
     "asgiref>=2.3.0",
     "attrs>=24.2.0, !=25.2.0",
     "babel>=2.17.0",

--- a/task-sdk/src/airflow/sdk/__init__.py
+++ b/task-sdk/src/airflow/sdk/__init__.py
@@ -60,7 +60,7 @@ __all__ = [
     "teardown",
 ]
 
-__version__ = "1.1.4"
+__version__ = "1.1.5"
 
 if TYPE_CHECKING:
     from airflow.sdk.api.datamodels._generated import DagRunState, TaskInstanceState, TriggerRule, WeightRule


### PR DESCRIPTION
No changes with 3.1.4 except the version updates:

[Update Airflow Version to 3.1.5](https://github.com/apache/airflow/commit/3224035941c60b4cc6826cc3cd8b2b927345705d)

[Update RELEASE_NOTES.rst](https://github.com/apache/airflow/commit/3963af6583fa703679b84c5bb88656443b6a7069)