### PR TITLE
Fix clear task instance dialog tasks states

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunDialog.tsx
@@ -22,13 +22,14 @@ import { useTranslation } from "react-i18next";
 import { CgRedo } from "react-icons/cg";
 
 import { useDagServiceGetDagDetails } from "openapi/queries";
-import type { DAGRunResponse } from "openapi/requests/types.gen";
+import type { DAGRunResponse, TaskInstanceResponse } from "openapi/requests/types.gen";
 import { ActionAccordion } from "src/components/ActionAccordion";
 import { Button, Dialog, Checkbox } from "src/components/ui";
 import SegmentedControl from "src/components/ui/SegmentedControl";
 import { useClearDagRunDryRun } from "src/queries/useClearDagRunDryRun";
 import { useClearDagRun } from "src/queries/useClearRun";
 import { usePatchDagRun } from "src/queries/usePatchDagRun";
+import { isStatePending, useAutoRefresh } from "src/utils";
 
 type Props = {
   readonly dagRun: DAGRunResponse;
@@ -51,9 +52,17 @@ const ClearRunDialog = ({ dagRun, onClose, open }: Props) => {
     dagId,
   });
 
+  const refetchInterval = useAutoRefresh({ dagId });
+
   const { data: affectedTasks = { task_instances: [], total_entries: 0 } } = useClearDagRunDryRun({
     dagId,
     dagRunId,
+    options: {
+      refetchInterval: (query) =>
+        query.state.data?.task_instances.some((ti: TaskInstanceResponse) => isStatePending(ti.state))
+          ? refetchInterval
+          : false,
+    },
     requestBody: { only_failed: onlyFailed, run_on_latest_version: runOnLatestVersion },
   });
 


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/55828

While some dry run TIs are pending, setup auto refresh. Stop refreshing when all TIs are settled in the modal.

Also fixed a small issue with 'initialValue' for the param selector which was causing an initial request to the dryRun endpoint that wasn't needed.

### Before

https://github.com/user-attachments/assets/0d687d1e-46c3-4722-98ae-17e3e821ba7e



### After

https://github.com/user-attachments/assets/03f631ff-24d2-4d70-8a81-0f8ea174d174


(Same for clearing a whole dagrun)