### PR TITLE
Add log record when listening dag is partitioned but run has no key

### DIFF
--- a/airflow-core/src/airflow/assets/manager.py
+++ b/airflow-core/src/airflow/assets/manager.py
@@ -140,7 +140,11 @@ class AssetManager(LoggingMixin):
             )
         )
         if not asset_model:
-            cls.logger().warning("AssetModel %s not found", asset)
+            msg = f"AssetModel {asset} not found; cannot create asset event."
+            cls.logger().warning(msg)
+            # if there is a task_instance, write to task log
+            if task_instance is not None and hasattr(task_instance, "log"):
+                task_instance.log.warning(msg)
             return None
 
         if not asset_model.active:

--- a/airflow-core/tests/unit/assets/test_manager.py
+++ b/airflow-core/tests/unit/assets/test_manager.py
@@ -69,6 +69,7 @@ def create_mock_dag():
 
 class TestAssetManager:
     def test_register_asset_change_asset_doesnt_exist(self, mock_task_instance):
+        mock_task_instance = mock.Mock()
         asset = Asset(uri="asset_doesnt_exist", name="not exist")
 
         mock_session = mock.Mock(spec=Session)
@@ -84,6 +85,7 @@ class TestAssetManager:
         # AssetDagRunQueue rows
         mock_session.add.assert_not_called()
         mock_session.merge.assert_not_called()
+        mock_task_instance.log.warning.assert_called()
 
     def test_register_asset_change(self, session, dag_maker, mock_task_instance, testing_dag_bundle):
         asset_manager = AssetManager()


### PR DESCRIPTION
closes: #59060

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
