### PR TITLE
[TESTENV] Pytest plugin allowing to load custom Airflow config

### DIFF
--- a/devel-common/src/tests_common/pytest_plugin.py
+++ b/devel-common/src/tests_common/pytest_plugin.py
@@ -380,6 +380,12 @@ def pytest_addoption(parser: pytest.Parser):
         help="Disable internal capture warnings.",
     )
     group.addoption(
+        "--load-config",
+        action="store",
+        dest="load_config",
+        help="[DANGER] Load an airflow config file instead of test environment defaults [DANGER]",
+    )
+    group.addoption(
         "--warning-output-path",
         action="store",
         dest="warning_output_path",
@@ -408,6 +414,19 @@ def initialize_airflow_tests(request):
     airflow_home = os.environ.get("AIRFLOW_HOME") or os.path.join(home, "airflow")
 
     print(f"Home of the user: {home}\nAirflow home {airflow_home}")
+
+    if request.config.option.load_config:
+        from airflow.configuration import AIRFLOW_CONFIG, conf, load_standard_airflow_configuration
+
+        saved_af_conf = AIRFLOW_CONFIG
+        AIRFLOW_CONFIG = request.config.option.load_config
+        try:
+            load_standard_airflow_configuration(conf)
+        except:
+            raise
+        finally:
+            AIRFLOW_CONFIG = saved_af_conf
+        conf.validate()
 
     if not skip_db_tests and not request.config.option.no_db_init:
         _initialize_airflow_db(request.config.option.db_init, airflow_home)


### PR DESCRIPTION
---
This proposal is linked with https://github.com/apache/airflow/pull/59390
Please address them together, if possible :pray: 

## Proposal: Airflow Pytest Plugin allowing to load custom configuration

Currently the Airflow confguration workflows, combined with the Airflow Pytest Plugin restrain test execution very strictly to pre-configured defaults. 

While unit tests can easily overcome this issue (using the `conf_vars` fixture) there is no workaround when using Airflow System Tests. 

It's highly understandable to make sure no mistake can happen across test and perhaps other deployment configuration settings.

On the other hand, a clearly indicated pytest option (only impacting the scope of the given test run) may be a sufficiently safe bet to avoid interference with non-testing Airflow runs. The advantage of the pytest CLI argument is an elegant, clean usage on pipelines. 

(Currently the same impact can only be achieved by re-loading the desired  config within test space.)
