### PR TITLE
Remove Legacy Query Object Usage from test_command.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -413,6 +413,7 @@ repos:
             ^airflow-ctl.*\.py$|
             ^airflow-core/src/airflow/models/.*\.py$|
             ^airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py$|
+            ^airflow-core/tests/unit/cli/commands/test_task_command.py$|
             ^task_sdk.*\.py$
         pass_filenames: true
       - id: update-supported-versions

--- a/airflow-core/tests/unit/cli/commands/test_task_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_task_command.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
+from sqlalchemy import delete
 
 from airflow._shared.timezones import timezone
 from airflow.cli import cli_parser
@@ -63,12 +64,10 @@ ROOT_FOLDER = Path(__file__).parents[4].resolve()
 
 def reset(dag_id):
     with create_session() as session:
-        tis = session.query(TaskInstance).filter_by(dag_id=dag_id)
-        tis.delete()
-        runs = session.query(DagRun).filter_by(dag_id=dag_id)
-        runs.delete()
-        session.query(DagModel).filter_by(dag_id=dag_id).delete()
-        session.query(SerializedDagModel).filter_by(dag_id=dag_id).delete()
+        session.execute(delete(TaskInstance).where(TaskInstance.dag_id == dag_id))
+        session.execute(delete(DagRun).where(DagRun.dag_id == dag_id))
+        session.execute(delete(DagModel).where(DagModel.dag_id == dag_id))
+        session.execute(delete(SerializedDagModel).where(SerializedDagModel.dag_id == dag_id))
 
 
 @contextmanager


### PR DESCRIPTION

related: #59402

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
