### PR TITLE
Add on_task_instance_skipped listener hookspec

### DIFF
--- a/airflow-core/src/airflow/listeners/spec/taskinstance.py
+++ b/airflow-core/src/airflow/listeners/spec/taskinstance.py
@@ -56,10 +56,19 @@ def on_task_instance_skipped(
     task_instance: RuntimeTaskInstance | TaskInstance,
 ):
     """
-    Execute when task instance is skipped.
+    Execute when a task instance skips itself by raising AirflowSkipException.
 
-    This is called when a task raises AirflowSkipException, indicating
-    the task intentionally skipped its execution.
+    This hook is called only when a task has started execution and then
+    intentionally skips itself by raising AirflowSkipException.
+
+    Note: This does NOT cover tasks skipped by:
+        - Trigger rules (e.g., upstream failures)
+        - BranchPythonOperator (tasks not in selected branch)
+        - ShortCircuitOperator
+        - Scheduler-level decisions
+
+    For comprehensive skip tracking, use DAG-level listeners
+    (on_dag_run_success/on_dag_run_failed) which provide complete task state.
 
     :param previous_state: Previous state of the task instance (can be None)
     :param task_instance: The task instance object (RuntimeTaskInstance when called

--- a/airflow-core/src/airflow/listeners/spec/taskinstance.py
+++ b/airflow-core/src/airflow/listeners/spec/taskinstance.py
@@ -48,3 +48,20 @@ def on_task_instance_failed(
     error: None | str | BaseException,
 ):
     """Execute when task state changes to FAIL. previous_state can be None."""
+
+
+@hookspec
+def on_task_instance_skipped(
+    previous_state: TaskInstanceState | None,
+    task_instance: RuntimeTaskInstance | TaskInstance,
+):
+    """
+    Execute when task instance is skipped.
+
+    This is called when a task raises AirflowSkipException, indicating
+    the task intentionally skipped its execution.
+
+    :param previous_state: Previous state of the task instance (can be None)
+    :param task_instance: The task instance object (RuntimeTaskInstance when called
+        from task execution context, TaskInstance when called from API server)
+    """

--- a/airflow-core/src/airflow/listeners/spec/taskinstance.py
+++ b/airflow-core/src/airflow/listeners/spec/taskinstance.py
@@ -56,19 +56,18 @@ def on_task_instance_skipped(
     task_instance: RuntimeTaskInstance | TaskInstance,
 ):
     """
-    Execute when a task instance skips itself by raising AirflowSkipException.
+    Execute when a task instance skips itself during execution.
 
     This hook is called only when a task has started execution and then
-    intentionally skips itself by raising AirflowSkipException.
+    intentionally skips itself (e.g., by raising AirflowSkipException).
 
-    Note: This does NOT cover tasks skipped by:
-        - Trigger rules (e.g., upstream failures)
-        - BranchPythonOperator (tasks not in selected branch)
-        - ShortCircuitOperator
-        - Scheduler-level decisions
+    Note: This function will NOT cover tasks that were skipped by scheduler, before execution began, such as:
+        - Skips due to trigger rules (e.g., upstream failures)
+        - Skips from operators like BranchPythonOperator, ShortCircuitOperator, or similar mechanisms
+        - Any other situation in which the scheduler decides not to schedule a task for execution
 
-    For comprehensive skip tracking, use DAG-level listeners
-    (on_dag_run_success/on_dag_run_failed) which provide complete task state.
+    For comprehensive tracking of skipped tasks, use DAG-level listeners
+    (on_dag_run_success/on_dag_run_failed) which may have access to all task states.
 
     :param previous_state: Previous state of the task instance (can be None)
     :param task_instance: The task instance object (RuntimeTaskInstance when called

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1456,6 +1456,12 @@ def finalize(
             log.exception("error calling listener")
     elif state == TaskInstanceState.SKIPPED:
         _run_task_state_change_callbacks(task, "on_skipped_callback", context, log)
+        try:
+            get_listener_manager().hook.on_task_instance_skipped(
+                previous_state=TaskInstanceState.RUNNING, task_instance=ti
+            )
+        except Exception:
+            log.exception("error calling listener")
     elif state == TaskInstanceState.UP_FOR_RETRY:
         _run_task_state_change_callbacks(task, "on_retry_callback", context, log)
         try:


### PR DESCRIPTION
## Summary

This PR adds a new listener hookspec `on_task_instance_skipped` that is called when a task raises `AirflowSkipException`.

**Related issue:** closes #59370

## Motivation

The current listener interface provides hooks for:
- `on_task_instance_running` - when a task starts
- `on_task_instance_success` - when a task succeeds
- `on_task_instance_failed` - when a task fails

But there is no hook for when a task is skipped via `AirflowSkipException`. This gap prevents listener implementations from handling self-skipping tasks.

## Scope & Limitations

> **Important:** This hook is called **only** when a task raises `AirflowSkipException` during execution — i.e., when a task has actually started and then skips itself.

This hook does **NOT** cover tasks skipped by:
- Trigger rules (e.g., upstream failures)
- `BranchPythonOperator` (tasks not in the selected branch)
- `ShortCircuitOperator`
- Manual state changes via UI/API
- Scheduler-level decisions

For comprehensive skip tracking across all skip types, use DAG-level events (`on_dag_run_success`/`on_dag_run_failed`) which include `AirflowStateRunFacet` with the complete `tasksState` map.

## Changes

| File | Description |
|------|-------------|
| `airflow-core/src/airflow/listeners/spec/taskinstance.py` | Added `on_task_instance_skipped` hookspec |
| `task-sdk/src/airflow/sdk/execution_time/task_runner.py` | Call listener in `finalize()` when state is SKIPPED |
| `task-sdk/tests/task_sdk/execution_time/test_task_runner.py` | Added test for skipped listener |

## Follow-up

OpenLineage provider implementation will be submitted in a separate PR after this is merged.

## Testing

- Added unit test `test_task_runner_calls_listeners_skipped` that verifies the listener is called when a task raises `AirflowSkipException`

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
