### PR TITLE
Fix Theme Configs

### DIFF
--- a/airflow-core/src/airflow/ui/src/theme.ts
+++ b/airflow-core/src/airflow/ui/src/theme.ts
@@ -20,7 +20,7 @@
 /* eslint-disable perfectionist/sort-objects */
 
 /* eslint-disable max-lines */
-import { createSystem, defaultConfig, defineConfig } from "@chakra-ui/react";
+import { createSystem, defaultConfig, defineConfig, mergeConfigs } from "@chakra-ui/react";
 import type { CSSProperties } from "react";
 
 import type { Theme } from "openapi/requests/types.gen";
@@ -35,7 +35,7 @@ const generateSemanticTokens = (color: string, darkContrast: string = "white") =
   focusRing: { value: { _light: `{colors.${color}.800}`, _dark: `{colors.${color}.200}` } },
 });
 
-const defaultTheme = {
+const defaultAirflowTheme = {
   // See https://chakra-ui.com/docs/theming/colors for more information on the colors used here.
   tokens: {
     colors: {
@@ -398,11 +398,13 @@ const defaultTheme = {
 };
 
 export const createTheme = (userTheme?: Theme) => {
-  const customConfig = defineConfig({
-    theme: typeof userTheme === "undefined" ? defaultTheme : { ...defaultTheme, ...userTheme },
-  });
+  const defaultAirflowConfig = defineConfig({ theme: defaultAirflowTheme });
 
-  return createSystem(defaultConfig, customConfig);
+  const userConfig = defineConfig({ theme: userTheme ?? {} });
+
+  const mergedConfig = mergeConfigs(defaultConfig, defaultAirflowConfig, userConfig);
+
+  return createSystem(mergedConfig);
 };
 
 export const defaultSystem = createTheme();


### PR DESCRIPTION
Configs were not merged properly, creating issues in the semantic tokens which were not recognized as chakra color palette but plain strings. CF here the 'queued' color appears white, and the css variables are not correct. 

###Before
<img width="1883" height="790" alt="Screenshot 2025-12-15 at 18 04 02" src="https://github.com/user-attachments/assets/e8565701-4518-4b03-a996-7bfc9ea16fb2" />


### After
<img width="1914" height="885" alt="Screenshot 2025-12-15 at 18 03 19" src="https://github.com/user-attachments/assets/716c1486-1a10-4950-9a6b-bd6302239ddc" />
