### PR TITLE
Check team boundaries in connections

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/connections.py
@@ -18,11 +18,12 @@
 from __future__ import annotations
 
 import logging
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Path, status
 
 from airflow.api_fastapi.execution_api.datamodels.connection import ConnectionResponse
-from airflow.api_fastapi.execution_api.deps import JWTBearerDep
+from airflow.api_fastapi.execution_api.deps import JWTBearerDep, get_team_name_dep
 from airflow.exceptions import AirflowNotFoundException
 from airflow.models.connection import Connection
 
@@ -57,10 +58,12 @@ log = logging.getLogger(__name__)
         status.HTTP_403_FORBIDDEN: {"description": "Task does not have access to the connection"},
     },
 )
-def get_connection(connection_id: str) -> ConnectionResponse:
+def get_connection(
+    connection_id: str, team_name: Annotated[str | None, Depends(get_team_name_dep)]
+) -> ConnectionResponse:
     """Get an Airflow connection."""
     try:
-        connection = Connection.get_connection_from_secrets(connection_id)
+        connection = Connection.get_connection_from_secrets(connection_id, team_name=team_name)
     except AirflowNotFoundException:
         raise HTTPException(
             status.HTTP_404_NOT_FOUND,

--- a/airflow-core/src/airflow/secrets/environment_variables.py
+++ b/airflow-core/src/airflow/secrets/environment_variables.py
@@ -30,7 +30,13 @@ VAR_ENV_PREFIX = "AIRFLOW_VAR_"
 class EnvironmentVariablesBackend(BaseSecretsBackend):
     """Retrieves Connection object and Variable from environment variable."""
 
-    def get_conn_value(self, conn_id: str) -> str | None:
+    def get_conn_value(self, conn_id: str, team_name: str | None = None) -> str | None:
+        if team_name and (
+            team_var := os.environ.get(f"{CONN_ENV_PREFIX}_{team_name.upper()}___" + conn_id.upper())
+        ):
+            # Format to set a team specific connection: AIRFLOW_CONN__<TEAM_ID>___<CONN_ID>
+            return team_var
+
         return os.environ.get(CONN_ENV_PREFIX + conn_id.upper())
 
     def get_variable(self, key: str, team_name: str | None = None) -> str | None:

--- a/airflow-core/src/airflow/secrets/local_filesystem.py
+++ b/airflow-core/src/airflow/secrets/local_filesystem.py
@@ -344,7 +344,7 @@ class LocalFilesystemBackend(BaseSecretsBackend, LoggingMixin):
             return {}
         return load_configs_dict(self.configs_file)
 
-    def get_connection(self, conn_id: str) -> Connection | None:
+    def get_connection(self, conn_id: str, team_name: str | None = None) -> Connection | None:
         if conn_id in self._local_connections:
             return self._local_connections[conn_id]
         return None

--- a/airflow-core/tests/unit/always/test_secrets.py
+++ b/airflow-core/tests/unit/always/test_secrets.py
@@ -40,15 +40,15 @@ class TestConnectionsFromSecrets:
     def test_get_connection_second_try(self, mock_env_get, mock_meta_get):
         mock_env_get.side_effect = [None]  # return None
         Connection.get_connection_from_secrets("fake_conn_id")
-        mock_meta_get.assert_called_once_with(conn_id="fake_conn_id")
-        mock_env_get.assert_called_once_with(conn_id="fake_conn_id")
+        mock_meta_get.assert_called_once_with(conn_id="fake_conn_id", team_name=None)
+        mock_env_get.assert_called_once_with(conn_id="fake_conn_id", team_name=None)
 
     @mock.patch("airflow.secrets.metastore.MetastoreBackend.get_connection")
     @mock.patch("airflow.secrets.environment_variables.EnvironmentVariablesBackend.get_connection")
     def test_get_connection_first_try(self, mock_env_get, mock_meta_get):
         mock_env_get.return_value = Connection("something")  # returns something
         Connection.get_connection_from_secrets("fake_conn_id")
-        mock_env_get.assert_called_once_with(conn_id="fake_conn_id")
+        mock_env_get.assert_called_once_with(conn_id="fake_conn_id", team_name=None)
         mock_meta_get.assert_not_called()
 
     @conf_vars(
@@ -115,7 +115,7 @@ class TestConnectionsFromSecrets:
         conn = Connection.get_connection_from_secrets(conn_id="test_mysql")
 
         # Assert that SystemsManagerParameterStoreBackend.get_conn_uri was called
-        mock_get_connection.assert_called_once_with(conn_id="test_mysql")
+        mock_get_connection.assert_called_once_with(conn_id="test_mysql", team_name=None)
 
         assert conn.get_uri() == "mysql://airflow:airflow@host:5432/airflow"
 

--- a/airflow-core/tests/unit/models/test_connection.py
+++ b/airflow-core/tests/unit/models/test_connection.py
@@ -29,6 +29,7 @@ from airflow.models import Connection
 from airflow.sdk.exceptions import AirflowRuntimeError, ErrorType
 from airflow.sdk.execution_time.comms import ErrorResponse
 
+from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import clear_db_connections
 
 if TYPE_CHECKING:
@@ -409,8 +410,37 @@ class TestConnection:
         mock_task_sdk_connection.get.assert_not_called()
 
         # Verify the backends were called
-        mock_env_backend.assert_called_once_with(conn_id="test_conn")
-        mock_db_backend.assert_called_once_with(conn_id="test_conn")
+        mock_env_backend.assert_called_once_with(conn_id="test_conn", team_name=None)
+        mock_db_backend.assert_called_once_with(conn_id="test_conn", team_name=None)
+
+    @pytest.mark.db_test
+    @conf_vars({("core", "multi_team"): "True"})
+    @mock.patch.dict(sys.modules, {"airflow.sdk.execution_time.task_runner": None})
+    @mock.patch("airflow.sdk.Connection")
+    @mock.patch("airflow.secrets.environment_variables.EnvironmentVariablesBackend.get_connection")
+    @mock.patch("airflow.secrets.metastore.MetastoreBackend.get_connection")
+    def test_get_connection_from_secrets_metastore_backend_with_team(
+        self, mock_db_backend, mock_env_backend, mock_task_sdk_connection, testing_team
+    ):
+        """Test the get_connection_from_secrets should call all the backends."""
+
+        mock_env_backend.return_value = None
+        mock_db_backend.return_value = Connection(conn_id="test_conn", conn_type="test", password="pass")
+
+        # Mock TaskSDK Connection to verify it is never imported
+        mock_task_sdk_connection.get.side_effect = Exception("TaskSDKConnection should not be used")
+
+        result = Connection.get_connection_from_secrets("test_conn", team_name=testing_team.name)
+
+        expected_connection = Connection(conn_id="test_conn", conn_type="test", password="pass")
+
+        # Verify the result is from MetastoreBackend
+        assert result.conn_id == expected_connection.conn_id
+        assert result.conn_type == expected_connection.conn_type
+
+        # Verify the backends were called
+        mock_env_backend.assert_called_once_with(conn_id="test_conn", team_name=testing_team.name)
+        mock_db_backend.assert_called_once_with(conn_id="test_conn", team_name=testing_team.name)
 
     @pytest.mark.db_test
     def test_get_team_name(self, testing_team: Team, session: Session):

--- a/providers/amazon/src/airflow/providers/amazon/aws/secrets/secrets_manager.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/secrets/secrets_manager.py
@@ -197,11 +197,12 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
 
         return conn_d
 
-    def get_conn_value(self, conn_id: str) -> str | None:
+    def get_conn_value(self, conn_id: str, team_name: str | None = None) -> str | None:
         """
         Get serialized representation of Connection.
 
         :param conn_id: connection id
+        :param team_name: Team name associated to the task trying to access the connection (if any)
         """
         if self.connections_prefix is None:
             return None

--- a/providers/amazon/src/airflow/providers/amazon/aws/secrets/systems_manager.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/secrets/systems_manager.py
@@ -132,11 +132,12 @@ class SystemsManagerParameterStoreBackend(BaseSecretsBackend, LoggingMixin):
         session = SessionFactory(conn=conn_config).create_session()
         return session.client(service_name="ssm", **client_kwargs)
 
-    def get_conn_value(self, conn_id: str) -> str | None:
+    def get_conn_value(self, conn_id: str, team_name: str | None = None) -> str | None:
         """
         Get param value.
 
         :param conn_id: connection id
+        :param team_name: Team name associated to the task trying to access the connection (if any)
         """
         if self.connections_prefix is None:
             return None

--- a/providers/google/src/airflow/providers/google/cloud/secrets/secret_manager.py
+++ b/providers/google/src/airflow/providers/google/cloud/secrets/secret_manager.py
@@ -149,11 +149,12 @@ class CloudSecretManagerBackend(BaseSecretsBackend, LoggingMixin):
         prefix = self.connections_prefix + self.sep
         return _SecretManagerClient.is_valid_secret_name(prefix)
 
-    def get_conn_value(self, conn_id: str) -> str | None:
+    def get_conn_value(self, conn_id: str, team_name: str | None = None) -> str | None:
         """
         Get serialized representation of Connection.
 
         :param conn_id: connection id
+        :param team_name: Team name associated to the task trying to access the connection (if any)
         """
         if self.connections_prefix is None:
             return None

--- a/providers/hashicorp/src/airflow/providers/hashicorp/secrets/vault.py
+++ b/providers/hashicorp/src/airflow/providers/hashicorp/secrets/vault.py
@@ -186,7 +186,7 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
     if TYPE_CHECKING:
         from airflow.models.connection import Connection
 
-    def get_connection(self, conn_id: str) -> Connection | None:
+    def get_connection(self, conn_id: str, team_name: str | None = None) -> Connection | None:
         """
         Get connection from Vault as secret.
 

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/secrets/key_vault.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/secrets/key_vault.py
@@ -144,11 +144,12 @@ class AzureKeyVaultBackend(BaseSecretsBackend, LoggingMixin):
         client = SecretClient(vault_url=self.vault_url, credential=credential, **self.kwargs)
         return client
 
-    def get_conn_value(self, conn_id: str) -> str | None:
+    def get_conn_value(self, conn_id: str, team_name: str | None = None) -> str | None:
         """
         Get a serialized representation of Airflow Connection from an Azure Key Vault secret.
 
         :param conn_id: The Airflow connection id to retrieve
+        :param team_name: Team name associated to the task trying to access the connection (if any)
         """
         if self.connections_prefix is None:
             return None

--- a/providers/yandex/src/airflow/providers/yandex/secrets/lockbox.py
+++ b/providers/yandex/src/airflow/providers/yandex/secrets/lockbox.py
@@ -145,11 +145,12 @@ class LockboxSecretBackend(BaseSecretsBackend, LoggingMixin):
         self.sep = sep
         self.endpoint = endpoint
 
-    def get_conn_value(self, conn_id: str) -> str | None:
+    def get_conn_value(self, conn_id: str, team_name: str | None = None) -> str | None:
         """
         Retrieve from Secrets Backend a string value representing the Connection object.
 
         :param conn_id: Connection ID
+        :param team_name: Team name associated to the task trying to access the connection (if any)
         :return: Connection Value
         """
         if self.connections_prefix is None:

--- a/shared/secrets_backend/src/airflow_shared/secrets_backend/base.py
+++ b/shared/secrets_backend/src/airflow_shared/secrets_backend/base.py
@@ -33,7 +33,7 @@ class BaseSecretsBackend(ABC):
         """
         return f"{path_prefix}{sep}{secret_id}"
 
-    def get_conn_value(self, conn_id: str) -> str | None:
+    def get_conn_value(self, conn_id: str, team_name: str | None = None) -> str | None:
         """
         Retrieve from Secrets Backend a string value representing the Connection object.
 
@@ -41,6 +41,7 @@ class BaseSecretsBackend(ABC):
         ``get_connection`` instead.
 
         :param conn_id: connection id
+        :param team_name: Team name associated to the task trying to access the connection (if any)
         """
         raise NotImplementedError
 
@@ -106,14 +107,15 @@ class BaseSecretsBackend(ABC):
             return conn_class.from_uri(conn_id=conn_id, uri=value)
         return conn_class(conn_id=conn_id, uri=value)
 
-    def get_connection(self, conn_id: str):
+    def get_connection(self, conn_id: str, team_name: str | None = None):
         """
         Return connection object with a given ``conn_id``.
 
         :param conn_id: connection id
+        :param team_name: Team name associated to the task trying to access the connection (if any)
         :return: Connection object or None
         """
-        value = self.get_conn_value(conn_id=conn_id)
+        value = self.get_conn_value(conn_id=conn_id, team_name=team_name)
         if value:
             return self.deserialize_connection(conn_id=conn_id, value=value)
         return None

--- a/task-sdk/src/airflow/sdk/execution_time/secrets/execution_api.py
+++ b/task-sdk/src/airflow/sdk/execution_time/secrets/execution_api.py
@@ -35,7 +35,7 @@ class ExecutionAPISecretsBackend(BaseSecretsBackend):
     processes, not in API server/scheduler processes.
     """
 
-    def get_conn_value(self, conn_id: str) -> str | None:
+    def get_conn_value(self, conn_id: str, team_name: str | None = None) -> str | None:
         """
         Get connection URI via SUPERVISOR_COMMS.
 
@@ -43,11 +43,13 @@ class ExecutionAPISecretsBackend(BaseSecretsBackend):
         """
         raise NotImplementedError("Use get_connection instead")
 
-    def get_connection(self, conn_id: str) -> Connection | None:  # type: ignore[override]
+    def get_connection(self, conn_id: str, team_name: str | None = None) -> Connection | None:  # type: ignore[override]
         """
         Return connection object by routing through SUPERVISOR_COMMS.
 
         :param conn_id: connection id
+        :param team_name: Name of the team associated to the task trying to access the connection.
+            Unused here because the team name is inferred from the task ID provided in the execution API JWT token.
         :return: Connection object or None if not found
         """
         from airflow.sdk.execution_time.comms import ErrorResponse, GetConnection
@@ -93,8 +95,8 @@ class ExecutionAPISecretsBackend(BaseSecretsBackend):
         Return variable value by routing through SUPERVISOR_COMMS.
 
         :param key: Variable key
-        :param team_id: ID of the team associated to the task trying to access the variable.
-            Unused here because the team ID is inferred from the task ID provided in the execution API JWT token.
+        :param team_name: Name of the team associated to the task trying to access the variable.
+            Unused here because the team name is inferred from the task ID provided in the execution API JWT token.
         :return: Variable value or None if not found
         """
         from airflow.sdk.execution_time.comms import ErrorResponse, GetVariable, VariableResult


### PR DESCRIPTION
Similar to #58905 but for connections.

Update execution API to only retrieve connections belonging to the same team (when multi-team is on).

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
