### PR TITLE
Unique run_id across manually triggered Dags with schedules

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
@@ -127,9 +127,8 @@ class TriggerDAGRunPostBody(StrictBaseModel):
                 )
             else:
                 data_interval = dag.timetable.infer_manual_data_interval(
-                    run_after=coerced_logical_date or timezone.coerce_datetime(run_after)
+                    run_after=coerced_logical_date
                 )
-                run_after = data_interval.end
 
         run_id = self.dag_run_id or dag.timetable.generate_run_id(
             run_type=DagRunType.MANUAL,

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
@@ -126,9 +126,7 @@ class TriggerDAGRunPostBody(StrictBaseModel):
                     end=timezone.coerce_datetime(self.data_interval_end),
                 )
             else:
-                data_interval = dag.timetable.infer_manual_data_interval(
-                    run_after=coerced_logical_date
-                )
+                data_interval = dag.timetable.infer_manual_data_interval(run_after=coerced_logical_date)
 
         run_id = self.dag_run_id or dag.timetable.generate_run_id(
             run_type=DagRunType.MANUAL,


### PR DESCRIPTION
## Problem
Manual triggers of scheduled Dags could generate the same run_id repeatedly (often aligned to the schedule boundary). Triggering the same Dag twice would then fail with a 409 Conflict due to a duplicate run_id

## Solution
When a manual trigger provides a logical_date, Airflow still infers the correct data_interval for the run, but it no longer rewrites run_after to the scheduled data_interval.end. This keeps manual trigger run_ids based on the actual trigger time  making them unique across repeated manual triggers.

- Added a regression test that creates a scheduled Dag, triggers it twice, and asserts the returned dag_run_id values are different:

Manual testing in breeze triggering a daily scheduled dag via manual trigger runids:
scheduled__2025-12-15T00:00:00+00:00
manual__2025-12-15T04:16:39.584387+00:00
manual__2025-12-15T04:16:50.627593+00:00
manual__2025-12-15T04:18:07.769612+00:00

## Related
Fixes #59342