### PR TITLE
Refactor SQLA2 test_deadline

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -413,6 +413,7 @@ repos:
             ^airflow-ctl.*\.py$|
             ^airflow-core/src/airflow/models/.*\.py$|
             ^airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py$|
+            ^airflow-core/tests/unit/models/test_deadline.py$|
             ^providers/openlineage/.*\.py$|
             ^task_sdk.*\.py$
         pass_filenames: true

--- a/airflow-core/tests/unit/models/test_deadline.py
+++ b/airflow-core/tests/unit/models/test_deadline.py
@@ -23,6 +23,7 @@ from unittest import mock
 
 import pytest
 import time_machine
+from sqlalchemy import func, select
 from sqlalchemy.exc import SQLAlchemyError
 
 from airflow.api_fastapi.core_api.datamodels.dag_run import DAGRunResponse
@@ -97,9 +98,9 @@ def dagrun(session, dag_maker):
         dag_maker.create_dagrun(state=DagRunState.QUEUED, logical_date=DEFAULT_DATE)
 
         session.commit()
-        assert session.query(DagRun).count() == 1
+        assert session.scalar(select(func.count()).select_from(DagRun)) == 1
 
-        return session.query(DagRun).one()
+        return session.scalars(select(DagRun)).one()
 
 
 @pytest.fixture


### PR DESCRIPTION
Refactors test_deadline.py to use SQLAlchemy v2

## Related Issue:
https://github.com/apache/airflow/issues/59402
