### PR TITLE
Refactor SQLA2 test-dag-sources

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -413,6 +413,7 @@ repos:
             ^airflow-ctl.*\.py$|
             ^airflow-core/src/airflow/models/.*\.py$|
             ^airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py$|
+            ^airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_sources.py$|
             ^providers/openlineage/.*\.py$|
             ^task_sdk.*\.py$
         pass_filenames: true

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_sources.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_sources.py
@@ -137,11 +137,8 @@ class TestGetDAGSource:
         # force reserialization
         test_dag.doc_md = "new doc"
         force_reserialization(test_dag.dag_id, "dag-folder")
-        dagcode = (
-            session.query(DagCode)
-            .filter(DagCode.fileloc == test_dag.fileloc)
-            .order_by(DagCode.id.desc())
-            .first()
+        dagcode = session.scalar(
+            select(DagCode).where(DagCode.fileloc == test_dag.fileloc).order_by(DagCode.id.desc()).limit(1)
         )
         assert dagcode.dag_version.version_number == 2
         # populate the latest dagcode with a value


### PR DESCRIPTION
Refactors test_dag_sources.py to use SQLAlchemy v2

Related Issue:
https://github.com/apache/airflow/issues/59402