### PR TITLE
Fix message of _read_from_logs_server when status_code is 403

### DIFF
--- a/airflow-core/src/airflow/utils/log/file_task_handler.py
+++ b/airflow-core/src/airflow/utils/log/file_task_handler.py
@@ -882,8 +882,8 @@ class FileTaskHandler(logging.Handler):
             if response.status_code == 403:
                 sources.append(
                     "!!!! Please make sure that all your Airflow components (e.g. "
-                    "schedulers, webservers, workers and triggerer) have "
-                    "the same 'secret_key' configured in 'webserver' section and "
+                    "schedulers, api-servers, dag-processors, workers and triggerer) have "
+                    "the same 'secret_key' configured in '[api]' section and "
                     "time is synchronized on all your machines (for example with ntpd)\n"
                     "See more at https://airflow.apache.org/docs/apache-airflow/"
                     "stable/configurations-ref.html#secret-key"


### PR DESCRIPTION
## What
* Version: 3.1.5
* This message is suitable for airflow version < 3.0, but the architecture was changed, webserver was changed to api-server, and dag-processor was added. So I want to change the message correctly.
<img width="4946" height="690" alt="image" src="https://github.com/user-attachments/assets/2e0e85a8-dce6-437f-96ab-88651ae59723" />

## How:
* Change webservers to api-servers.
* Add dag-processors to this message.
* Change webserver to [api].