### PR TITLE
Fix GitHub Actions workflow: remove unsupported --previous-release option

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -381,7 +381,7 @@ jobs:
       - name: "Check Airflow release process command"
         run: >
           breeze release-management start-release --version 3.1.0
-          --previous-release 3.0.0 --answer yes --dry-run
+          --answer yes --dry-run
       - name: "Test providers metadata generation"
         run: |
           git remote add apache https://github.com/apache/airflow.git


### PR DESCRIPTION

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Fixes the failing GitHub Actions test in `basic-tests.yml` that was using the removed `--previous-release` option for the `breeze release-management start-release` command.

## Problem

The workflow test was failing with:
```
Error: No such option: --previous-release
```

This option was removed in commit `bef558dfb2` (PR #59468) when the `remove_old_release` function was refactored to automatically find and remove old releases from SVN.

## Solution

Removed the `--previous-release 3.0.0` option from the `start-release` command invocation in the GitHub Actions workflow, as the command now only requires:
- `--version` (required)
- `--task-sdk-version` (optional)
- `--answer`
- `--dry-run`

## Related Changes

- Original removal: commit `bef558dfb2` - (#59468)
- Related commit: `a9f095e6fc` - (#59455)

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
