### PR TITLE
feat: Add JobDependenciesRunFacet to asset-triggered OL DAG events

### DIFF
--- a/providers/google/tests/unit/google/cloud/operators/test_dataproc.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_dataproc.py
@@ -440,10 +440,10 @@ OPENLINEAGE_HTTP_TRANSPORT_EXAMPLE_SPARK_PROPERTIES = {
 OPENLINEAGE_PARENT_JOB_EXAMPLE_SPARK_PROPERTIES = {
     "spark.openlineage.parentJobName": "dag_id.task_id",
     "spark.openlineage.parentJobNamespace": "default",
-    "spark.openlineage.parentRunId": "01931885-2800-7be7-aa8d-aaa15c337267",
+    "spark.openlineage.parentRunId": "11111111-1111-1111-1111-111111111111",
     "spark.openlineage.rootParentJobName": "dag_id",
     "spark.openlineage.rootParentJobNamespace": "default",
-    "spark.openlineage.rootParentRunId": "01931885-2800-7be7-aa8d-aaa15c337267",
+    "spark.openlineage.rootParentRunId": "22222222-2222-2222-2222-222222222222",
 }
 
 
@@ -1430,13 +1430,15 @@ class TestDataprocSubmitJobOperator(DataprocJobTestBase):
         op.execute(context=self.mock_context)
         assert not mock_defer.called
 
-    @mock.patch("airflow.providers.openlineage.plugins.adapter.generate_static_uuid")
+    @mock.patch("airflow.providers.openlineage.plugins.adapter.build_dag_run_ol_run_id")
+    @mock.patch("airflow.providers.openlineage.plugins.adapter.build_task_instance_ol_run_id")
     @mock.patch("airflow.providers.google.cloud.openlineage.utils._is_openlineage_provider_accessible")
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_execute_openlineage_parent_job_info_injection(
-        self, mock_hook, mock_ol_accessible, mock_static_uuid
+        self, mock_hook, mock_ol_accessible, task_ol_run_id, dag_ol_run_id
     ):
-        mock_static_uuid.return_value = "01931885-2800-7be7-aa8d-aaa15c337267"
+        task_ol_run_id.return_value = "11111111-1111-1111-1111-111111111111"
+        dag_ol_run_id.return_value = "22222222-2222-2222-2222-222222222222"
         job_config = {
             "placement": {"cluster_name": CLUSTER_NAME},
             "pyspark_job": {
@@ -1456,10 +1458,10 @@ class TestDataprocSubmitJobOperator(DataprocJobTestBase):
                     "spark.openlineage.transport.type": "console",
                     "spark.openlineage.parentJobName": "dag_id.task_id",
                     "spark.openlineage.parentJobNamespace": "default",
-                    "spark.openlineage.parentRunId": "01931885-2800-7be7-aa8d-aaa15c337267",
+                    "spark.openlineage.parentRunId": "11111111-1111-1111-1111-111111111111",
                     "spark.openlineage.rootParentJobName": "dag_id",
                     "spark.openlineage.rootParentJobNamespace": "default",
-                    "spark.openlineage.rootParentRunId": "01931885-2800-7be7-aa8d-aaa15c337267",
+                    "spark.openlineage.rootParentRunId": "22222222-2222-2222-2222-222222222222",
                 },
             },
         }
@@ -1499,15 +1501,17 @@ class TestDataprocSubmitJobOperator(DataprocJobTestBase):
             metadata=METADATA,
         )
 
-    @mock.patch("airflow.providers.openlineage.plugins.adapter.generate_static_uuid")
+    @mock.patch("airflow.providers.openlineage.plugins.adapter.build_dag_run_ol_run_id")
+    @mock.patch("airflow.providers.openlineage.plugins.adapter.build_task_instance_ol_run_id")
     @mock.patch("airflow.providers.openlineage.utils.spark.get_openlineage_listener")
     @mock.patch("airflow.providers.google.cloud.openlineage.utils._is_openlineage_provider_accessible")
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_execute_openlineage_http_transport_info_injection(
-        self, mock_hook, mock_ol_accessible, mock_ol_listener, mock_static_uuid
+        self, mock_hook, mock_ol_accessible, mock_ol_listener, task_ol_run_id, dag_ol_run_id
     ):
         mock_ol_accessible.return_value = True
-        mock_static_uuid.return_value = "01931885-2800-7be7-aa8d-aaa15c337267"
+        task_ol_run_id.return_value = "11111111-1111-1111-1111-111111111111"
+        dag_ol_run_id.return_value = "22222222-2222-2222-2222-222222222222"
         fake_listener = mock.MagicMock()
         mock_ol_listener.return_value = fake_listener
         fake_listener.adapter.get_or_create_openlineage_client.return_value.transport = HttpTransport(
@@ -1556,15 +1560,17 @@ class TestDataprocSubmitJobOperator(DataprocJobTestBase):
             metadata=METADATA,
         )
 
-    @mock.patch("airflow.providers.openlineage.plugins.adapter.generate_static_uuid")
+    @mock.patch("airflow.providers.openlineage.plugins.adapter.build_dag_run_ol_run_id")
+    @mock.patch("airflow.providers.openlineage.plugins.adapter.build_task_instance_ol_run_id")
     @mock.patch("airflow.providers.openlineage.utils.spark.get_openlineage_listener")
     @mock.patch("airflow.providers.google.cloud.openlineage.utils._is_openlineage_provider_accessible")
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_execute_openlineage_all_info_injection(
-        self, mock_hook, mock_ol_accessible, mock_ol_listener, mock_static_uuid
+        self, mock_hook, mock_ol_accessible, mock_ol_listener, task_ol_run_id, dag_ol_run_id
     ):
         mock_ol_accessible.return_value = True
-        mock_static_uuid.return_value = "01931885-2800-7be7-aa8d-aaa15c337267"
+        task_ol_run_id.return_value = "11111111-1111-1111-1111-111111111111"
+        dag_ol_run_id.return_value = "22222222-2222-2222-2222-222222222222"
         fake_listener = mock.MagicMock()
         mock_ol_listener.return_value = fake_listener
         fake_listener.adapter.get_or_create_openlineage_client.return_value.transport = HttpTransport(
@@ -2591,14 +2597,16 @@ class TestDataprocWorkflowTemplateInstantiateInlineOperator:
         )
         mock_op.return_value.result.assert_not_called()
 
-    @mock.patch("airflow.providers.openlineage.plugins.adapter.generate_static_uuid")
+    @mock.patch("airflow.providers.openlineage.plugins.adapter.build_dag_run_ol_run_id")
+    @mock.patch("airflow.providers.openlineage.plugins.adapter.build_task_instance_ol_run_id")
     @mock.patch("airflow.providers.google.cloud.openlineage.utils._is_openlineage_provider_accessible")
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_execute_openlineage_parent_job_info_injection(
-        self, mock_hook, mock_ol_accessible, mock_static_uuid
+        self, mock_hook, mock_ol_accessible, task_ol_run_id, dag_ol_run_id
     ):
         mock_ol_accessible.return_value = True
-        mock_static_uuid.return_value = "01931885-2800-7be7-aa8d-aaa15c337267"
+        task_ol_run_id.return_value = "11111111-1111-1111-1111-111111111111"
+        dag_ol_run_id.return_value = "22222222-2222-2222-2222-222222222222"
         template = {
             **WORKFLOW_TEMPLATE,
             "jobs": [
@@ -2643,10 +2651,10 @@ class TestDataprocWorkflowTemplateInstantiateInlineOperator:
                             "spark.sql.shuffle.partitions": "1",
                             "spark.openlineage.parentJobName": "dag_id.task_id",
                             "spark.openlineage.parentJobNamespace": "default",
-                            "spark.openlineage.parentRunId": "01931885-2800-7be7-aa8d-aaa15c337267",
+                            "spark.openlineage.parentRunId": "11111111-1111-1111-1111-111111111111",
                             "spark.openlineage.rootParentJobName": "dag_id",
                             "spark.openlineage.rootParentJobNamespace": "default",
-                            "spark.openlineage.rootParentRunId": "01931885-2800-7be7-aa8d-aaa15c337267",
+                            "spark.openlineage.rootParentRunId": "22222222-2222-2222-2222-222222222222",
                         },
                     },
                 },
@@ -2784,15 +2792,17 @@ class TestDataprocWorkflowTemplateInstantiateInlineOperator:
             metadata=METADATA,
         )
 
-    @mock.patch("airflow.providers.openlineage.plugins.adapter.generate_static_uuid")
+    @mock.patch("airflow.providers.openlineage.plugins.adapter.build_dag_run_ol_run_id")
+    @mock.patch("airflow.providers.openlineage.plugins.adapter.build_task_instance_ol_run_id")
     @mock.patch("airflow.providers.openlineage.utils.spark.get_openlineage_listener")
     @mock.patch("airflow.providers.google.cloud.openlineage.utils._is_openlineage_provider_accessible")
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_execute_openlineage_transport_info_injection(
-        self, mock_hook, mock_ol_accessible, mock_ol_listener, mock_static_uuid
+        self, mock_hook, mock_ol_accessible, mock_ol_listener, task_ol_run_id, dag_ol_run_id
     ):
         mock_ol_accessible.return_value = True
-        mock_static_uuid.return_value = "01931885-2800-7be7-aa8d-aaa15c337267"
+        task_ol_run_id.return_value = "11111111-1111-1111-1111-111111111111"
+        dag_ol_run_id.return_value = "22222222-2222-2222-2222-222222222222"
         fake_listener = mock.MagicMock()
         mock_ol_listener.return_value = fake_listener
         fake_listener.adapter.get_or_create_openlineage_client.return_value.transport = HttpTransport(
@@ -2892,15 +2902,17 @@ class TestDataprocWorkflowTemplateInstantiateInlineOperator:
             metadata=METADATA,
         )
 
-    @mock.patch("airflow.providers.openlineage.plugins.adapter.generate_static_uuid")
+    @mock.patch("airflow.providers.openlineage.plugins.adapter.build_dag_run_ol_run_id")
+    @mock.patch("airflow.providers.openlineage.plugins.adapter.build_task_instance_ol_run_id")
     @mock.patch("airflow.providers.openlineage.utils.spark.get_openlineage_listener")
     @mock.patch("airflow.providers.google.cloud.openlineage.utils._is_openlineage_provider_accessible")
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_execute_openlineage_all_info_injection(
-        self, mock_hook, mock_ol_accessible, mock_ol_listener, mock_static_uuid
+        self, mock_hook, mock_ol_accessible, mock_ol_listener, task_ol_run_id, dag_ol_run_id
     ):
         mock_ol_accessible.return_value = True
-        mock_static_uuid.return_value = "01931885-2800-7be7-aa8d-aaa15c337267"
+        task_ol_run_id.return_value = "11111111-1111-1111-1111-111111111111"
+        dag_ol_run_id.return_value = "22222222-2222-2222-2222-222222222222"
         fake_listener = mock.MagicMock()
         mock_ol_listener.return_value = fake_listener
         fake_listener.adapter.get_or_create_openlineage_client.return_value.transport = HttpTransport(
@@ -3419,7 +3431,8 @@ class TestDataprocCreateBatchOperator:
         mock_log.info.assert_any_call("Batch with given id already exists.")
 
     @mock.patch.object(DataprocCreateBatchOperator, "log", new_callable=mock.MagicMock)
-    @mock.patch("airflow.providers.openlineage.plugins.adapter.generate_static_uuid")
+    @mock.patch("airflow.providers.openlineage.plugins.adapter.build_dag_run_ol_run_id")
+    @mock.patch("airflow.providers.openlineage.plugins.adapter.build_task_instance_ol_run_id")
     @mock.patch("airflow.providers.google.cloud.openlineage.utils._is_openlineage_provider_accessible")
     @mock.patch(DATAPROC_PATH.format("Batch.to_dict"))
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
@@ -3428,11 +3441,13 @@ class TestDataprocCreateBatchOperator:
         mock_hook,
         to_dict_mock,
         mock_ol_accessible,
-        mock_static_uuid,
+        task_ol_run_id,
+        dag_ol_run_id,
         mock_log,
     ):
         mock_ol_accessible.return_value = True
-        mock_static_uuid.return_value = "01931885-2800-7be7-aa8d-aaa15c337267"
+        task_ol_run_id.return_value = "11111111-1111-1111-1111-111111111111"
+        dag_ol_run_id.return_value = "22222222-2222-2222-2222-222222222222"
         expected_batch = {
             **BATCH,
             "labels": EXPECTED_LABELS,
@@ -3474,16 +3489,25 @@ class TestDataprocCreateBatchOperator:
         mock_log.info.assert_any_call("Batch job %s completed.\nDriver logs: %s", BATCH_ID, logs_link)
 
     @mock.patch.object(DataprocCreateBatchOperator, "log", new_callable=mock.MagicMock)
-    @mock.patch("airflow.providers.openlineage.plugins.adapter.generate_static_uuid")
+    @mock.patch("airflow.providers.openlineage.plugins.adapter.build_dag_run_ol_run_id")
+    @mock.patch("airflow.providers.openlineage.plugins.adapter.build_task_instance_ol_run_id")
     @mock.patch("airflow.providers.openlineage.utils.spark.get_openlineage_listener")
     @mock.patch("airflow.providers.google.cloud.openlineage.utils._is_openlineage_provider_accessible")
     @mock.patch(DATAPROC_PATH.format("Batch.to_dict"))
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_execute_openlineage_transport_info_injection(
-        self, mock_hook, to_dict_mock, mock_ol_accessible, mock_ol_listener, mock_static_uuid, mock_log
+        self,
+        mock_hook,
+        to_dict_mock,
+        mock_ol_accessible,
+        mock_ol_listener,
+        task_ol_run_id,
+        dag_ol_run_id,
+        mock_log,
     ):
         mock_ol_accessible.return_value = True
-        mock_static_uuid.return_value = "01931885-2800-7be7-aa8d-aaa15c337267"
+        task_ol_run_id.return_value = "11111111-1111-1111-1111-111111111111"
+        dag_ol_run_id.return_value = "22222222-2222-2222-2222-222222222222"
         fake_listener = mock.MagicMock()
         mock_ol_listener.return_value = fake_listener
         fake_listener.adapter.get_or_create_openlineage_client.return_value.transport = HttpTransport(
@@ -3533,16 +3557,18 @@ class TestDataprocCreateBatchOperator:
             logs_link,
         )
 
-    @mock.patch("airflow.providers.openlineage.plugins.adapter.generate_static_uuid")
+    @mock.patch("airflow.providers.openlineage.plugins.adapter.build_dag_run_ol_run_id")
+    @mock.patch("airflow.providers.openlineage.plugins.adapter.build_task_instance_ol_run_id")
     @mock.patch("airflow.providers.openlineage.utils.spark.get_openlineage_listener")
     @mock.patch("airflow.providers.google.cloud.openlineage.utils._is_openlineage_provider_accessible")
     @mock.patch(DATAPROC_PATH.format("Batch.to_dict"))
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_execute_openlineage_all_info_injection(
-        self, mock_hook, to_dict_mock, mock_ol_accessible, mock_ol_listener, mock_static_uuid
+        self, mock_hook, to_dict_mock, mock_ol_accessible, mock_ol_listener, task_ol_run_id, dag_ol_run_id
     ):
         mock_ol_accessible.return_value = True
-        mock_static_uuid.return_value = "01931885-2800-7be7-aa8d-aaa15c337267"
+        task_ol_run_id.return_value = "11111111-1111-1111-1111-111111111111"
+        dag_ol_run_id.return_value = "22222222-2222-2222-2222-222222222222"
         fake_listener = mock.MagicMock()
         mock_ol_listener.return_value = fake_listener
         fake_listener.adapter.get_or_create_openlineage_client.return_value.transport = HttpTransport(

--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/adapter.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/adapter.py
@@ -34,14 +34,16 @@ from openlineage.client.facet_v2 import (
     ownership_job,
     tags_job,
 )
-from openlineage.client.uuid import generate_static_uuid
 
 from airflow.providers.common.compat.sdk import Stats, conf as airflow_conf
 from airflow.providers.openlineage import __version__ as OPENLINEAGE_PROVIDER_VERSION, conf
 from airflow.providers.openlineage.utils.utils import (
     OpenLineageRedactor,
+    build_dag_run_ol_run_id,
+    build_task_instance_ol_run_id,
     get_airflow_debug_facet,
     get_airflow_state_run_facet,
+    get_dag_job_dependency_facet,
     get_processing_engine_facet,
 )
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -123,12 +125,7 @@ class OpenLineageAdapter(LoggingMixin):
 
     @staticmethod
     def build_dag_run_id(dag_id: str, logical_date: datetime, clear_number: int) -> str:
-        return str(
-            generate_static_uuid(
-                instant=logical_date,
-                data=f"{conf.namespace()}.{dag_id}.{clear_number}".encode(),
-            )
-        )
+        return build_dag_run_ol_run_id(dag_id=dag_id, logical_date=logical_date, clear_number=clear_number)
 
     @staticmethod
     def build_task_instance_run_id(
@@ -138,11 +135,12 @@ class OpenLineageAdapter(LoggingMixin):
         logical_date: datetime,
         map_index: int,
     ):
-        return str(
-            generate_static_uuid(
-                instant=logical_date,
-                data=f"{conf.namespace()}.{dag_id}.{task_id}.{try_number}.{map_index}".encode(),
-            )
+        return build_task_instance_ol_run_id(
+            dag_id=dag_id,
+            task_id=task_id,
+            try_number=try_number,
+            logical_date=logical_date,
+            map_index=map_index,
         )
 
     def emit(self, event: RunEvent):
@@ -365,6 +363,7 @@ class OpenLineageAdapter(LoggingMixin):
     def dag_started(
         self,
         dag_id: str,
+        run_id: str,
         logical_date: datetime,
         start_date: datetime,
         nominal_start_time: str | None,
@@ -374,10 +373,14 @@ class OpenLineageAdapter(LoggingMixin):
         run_facets: dict[str, RunFacet],
         clear_number: int,
         job_description: str | None,
+        is_asset_triggered: bool,
         job_description_type: str | None = None,
         job_facets: dict[str, JobFacet] | None = None,  # Custom job facets
     ):
         try:
+            job_dependency_facet = {}
+            if is_asset_triggered:
+                job_dependency_facet = get_dag_job_dependency_facet(dag_id=dag_id, dag_run_id=run_id)
             event = RunEvent(
                 eventType=RunState.START,
                 eventTime=start_date.isoformat(),
@@ -396,7 +399,7 @@ class OpenLineageAdapter(LoggingMixin):
                     ),
                     nominal_start_time=nominal_start_time,
                     nominal_end_time=nominal_end_time,
-                    run_facets={**run_facets, **get_airflow_debug_facet()},
+                    run_facets={**run_facets, **get_airflow_debug_facet(), **job_dependency_facet},
                 ),
                 inputs=[],
                 outputs=[],
@@ -424,9 +427,13 @@ class OpenLineageAdapter(LoggingMixin):
         owners: list[str] | None,
         run_facets: dict[str, RunFacet],
         job_description: str | None,
+        is_asset_triggered: bool,
         job_description_type: str | None = None,
     ):
         try:
+            job_dependency_facet = {}
+            if is_asset_triggered:
+                job_dependency_facet = get_dag_job_dependency_facet(dag_id=dag_id, dag_run_id=run_id)
             event = RunEvent(
                 eventType=RunState.COMPLETE,
                 eventTime=end_date.isoformat(),
@@ -446,6 +453,7 @@ class OpenLineageAdapter(LoggingMixin):
                     nominal_end_time=nominal_end_time,
                     run_facets={
                         **get_airflow_state_run_facet(dag_id, run_id, task_ids, dag_run_state),
+                        **job_dependency_facet,
                         **get_airflow_debug_facet(),
                         **run_facets,
                     },
@@ -477,9 +485,13 @@ class OpenLineageAdapter(LoggingMixin):
         msg: str,
         run_facets: dict[str, RunFacet],
         job_description: str | None,
+        is_asset_triggered: bool,
         job_description_type: str | None = None,
     ):
         try:
+            job_dependency_facet = {}
+            if is_asset_triggered:
+                job_dependency_facet = get_dag_job_dependency_facet(dag_id=dag_id, dag_run_id=run_id)
             event = RunEvent(
                 eventType=RunState.FAIL,
                 eventTime=end_date.isoformat(),
@@ -502,6 +514,7 @@ class OpenLineageAdapter(LoggingMixin):
                             message=msg, programmingLanguage="python"
                         ),
                         **get_airflow_state_run_facet(dag_id, run_id, task_ids, dag_run_state),
+                        **job_dependency_facet,
                         **get_airflow_debug_facet(),
                         **run_facets,
                     },

--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
@@ -47,6 +47,7 @@ from airflow.providers.openlineage.utils.utils import (
     get_task_documentation,
     get_task_parent_run_facet,
     get_user_provided_run_facets,
+    is_dag_run_asset_triggered,
     is_operator_disabled,
     is_selective_lineage_enabled,
     print_warning,
@@ -669,6 +670,7 @@ class OpenLineageListener:
             self.submit_callable(
                 self.adapter.dag_started,
                 dag_id=dag_run.dag_id,
+                run_id=dag_run.run_id,
                 logical_date=date,
                 start_date=dag_run.start_date,
                 nominal_start_time=data_interval_start,
@@ -685,6 +687,7 @@ class OpenLineageListener:
                     **get_airflow_dag_run_facet(dag_run),
                     **get_dag_parent_run_facet(getattr(dag_run, "conf", {})),
                 },
+                is_asset_triggered=is_dag_run_asset_triggered(dag_run),
             )
         except BaseException as e:
             self.log.warning("OpenLineage received exception in method on_dag_run_running", exc_info=e)
@@ -736,6 +739,7 @@ class OpenLineageListener:
                     **get_airflow_dag_run_facet(dag_run),
                     **get_dag_parent_run_facet(getattr(dag_run, "conf", {})),
                 },
+                is_asset_triggered=is_dag_run_asset_triggered(dag_run),
             )
         except BaseException as e:
             self.log.warning("OpenLineage received exception in method on_dag_run_success", exc_info=e)
@@ -788,6 +792,7 @@ class OpenLineageListener:
                     **get_airflow_dag_run_facet(dag_run),
                     **get_dag_parent_run_facet(getattr(dag_run, "conf", {})),
                 },
+                is_asset_triggered=is_dag_run_asset_triggered(dag_run),
             )
         except BaseException as e:
             self.log.warning("OpenLineage received exception in method on_dag_run_failed", exc_info=e)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
When DagRun is triggered by Asset Events, OL has no visibility into what were the emitting jobs. This PR adds JobDependenciesRunFacet to DAG events, with information about this connection. Now OL consumers will be able to track exactly from which runs the asset events are coming from, improving RCA dramatically.

So when DAG A is scheduled on 2 Assets: ASSET1 and ASSET2, when those two asset are produced by tasks in other dags, the OL DAG event for DAG A, will have the information what were the Asset Events consumed by this dagrun, and from which exact task runs and dagruns of other DAGs they came from (with OL run id of those task runs that produced assets as well !).

I've also added a possibility to create a JobDependency from AssetEvent.extra, so that users who emit Asset Events manually via the API can also attach OpenLineage job information that will be included in the facet.

## Example 1:
In that scenario, we have two dags that are correlated together through an Asset. Currently Ol even have information about dag schedule and about task outlets, but that's all it has - no information about actual run correlation, only job level.
```
from airflow import DAG, Asset
from airflow.providers.standard.operators.bash import BashOperator
from datetime import datetime

sample_dataset = Asset("s3://my-bucket/sample-data.csv")
sample_dataset2 = Asset("gs://my-bucket/another_data.csv")

with DAG(
    dag_id="dag_asset_producer",
    schedule=None,
    catchup=False,
    start_date=datetime(2024, 1, 1)
) as dag:
    create_dataset_task = BashOperator(
        task_id="create_dataset",
        bash_command="sleep 1;",
        outlets=[sample_dataset],
    )

with DAG(
    dag_id="dag_asset_consumer2",
    schedule=[sample_dataset],
    catchup=False,
    start_date=datetime(2024, 1, 1)
) as consumer_dag2:

    process_data_task2 = BashOperator(
        task_id="process_dataset2",
        bash_command="sleep 1;",
    )
```

After this PR, the DAG events for `dag_asset_consumer2`, would contain a facet like:
```
      "jobDependencies": {
        "_producer": "https://github.com/apache/airflow/tree/providers-openlineage/2.9.1",
        "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/JobDependenciesRunFacet.json#/$defs/JobDependenciesRunFacet",
        "downstream": [],
        "upstream": [
          {
            "airflow": {
              "asset_events": [
                {
                  "asset_event_id": 1,
                  "asset_id": 2,
                  "asset_uri": "s3://my-bucket/sample-data.csv",
                  "dag_run_id": "manual__2025-12-17T18:46:43.457674+00:00"
                }
              ]
            },
            "dependency_type": "IMPLICIT_ASSET_DEPENDENCY",
            "job": {
              "name": "dag_asset_producer.create_dataset",
              "namespace": "default"
            },
            "run": {
              "runId": "019b2da2-d001-701f-b2c9-efbaf7c5fb72"
            }
          }
        ]
      },
```
So we have a clear information about the dependency between jobs, OL job / run identifiers and even some metadata about the AssetEvents consumed with Airflow specific information like DagRunID.

# Example 2:
I think the real power of this features shows up when dag gets triggered on multiple assets, usually coming from dags running on different schedules. This is an example produced by the below code.

I've run the first asset producer twice, and it wasn't enough to trigger the consumer that also requires second asset. After running second asset producer, we can see the information about all consumed assets and respective OL job/run information for all **3** runs.

```
from airflow import DAG, Dataset as Asset
from airflow.providers.standard.operators.bash import BashOperator
from datetime import datetime

sample_dataset = Asset("s3://my-bucket/sample-data.csv")
sample_dataset2 = Asset("gs://my-bucket/another_data.csv")


with DAG(
    dag_id="dag_asset_producer",
    schedule=None,
    catchup=False,
    start_date=datetime(2024, 1, 1)
) as dag:
    create_dataset_task = BashOperator(
        task_id="create_dataset",
        bash_command="sleep 1;",
        outlets=[sample_dataset],
    )

with DAG(
    dag_id="dag_asset_producer2",
    schedule=None,
    catchup=False,
    start_date=datetime(2024, 1, 1)
) as dag2:
    create_dataset_task2 = BashOperator(
        task_id="create_dataset",
        bash_command="sleep 1;",
        outlets=[sample_dataset2],
    )

with DAG(
    dag_id="dag_asset_consumer",
    schedule=[sample_dataset, sample_dataset2],
    catchup=False,
    start_date=datetime(2024, 1, 1)
) as consumer_dag:

    process_data_task = BashOperator(
        task_id="process_dataset",
        bash_command="sleep 1;",
    )
```


```
"jobDependencies": {
        "_producer": "https://github.com/apache/airflow/tree/providers-openlineage/2.9.1",
        "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/JobDependenciesRunFacet.json#/$defs/JobDependenciesRunFacet",
        "downstream": [],
        "upstream": [
          {
            "airflow": {
              "asset_events": [
                {
                  "asset_event_id": 5,
                  "asset_id": 2,
                  "asset_uri": "s3://my-bucket/sample-data.csv",
                  "dag_run_id": "manual__2025-12-17T19:05:05.506294+00:00"
                }
              ]
            },
            "dependency_type": "IMPLICIT_ASSET_DEPENDENCY",
            "job": {
              "name": "dag_asset_producer.create_dataset",
              "namespace": "default"
            },
            "run": {
              "runId": "019b2db3-a0e2-707e-a544-85f54e8b1e71"
            }
          },
          {
            "airflow": {
              "asset_events": [
                {
                  "asset_event_id": 6,
                  "asset_id": 2,
                  "asset_uri": "s3://my-bucket/sample-data.csv",
                  "dag_run_id": "manual__2025-12-17T19:05:12.288534+00:00"
                }
              ]
            },
            "dependency_type": "IMPLICIT_ASSET_DEPENDENCY",
            "job": {
              "name": "dag_asset_producer.create_dataset",
              "namespace": "default"
            },
            "run": {
              "runId": "019b2db3-bb60-7086-90bf-4d1db0ee3b1f"
            }
          },
          {
            "airflow": {
              "asset_events": [
                {
                  "asset_event_id": 7,
                  "asset_id": 1,
                  "asset_uri": "gs://my-bucket/another_data.csv",
                  "dag_run_id": "manual__2025-12-17T19:05:19.196364+00:00"
                }
              ]
            },
            "dependency_type": "IMPLICIT_ASSET_DEPENDENCY",
            "job": {
              "name": "dag_asset_producer2.create_dataset",
              "namespace": "default"
            },
            "run": {
              "runId": "019b2db3-d65c-79f0-97c3-9cdacc9468c7"
            }
          }
        ]
      }
```


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
