### PR TITLE
Add more common methods to ExecutorConfig shim

### DIFF
--- a/airflow-core/src/airflow/executors/base_executor.py
+++ b/airflow-core/src/airflow/executors/base_executor.py
@@ -117,6 +117,21 @@ class ExecutorConf:
     def getboolean(self, *args, **kwargs) -> bool:
         return conf.getboolean(*args, **kwargs, team_name=self.team_name)
 
+    def getjson(self, *args, **kwargs):
+        return conf.getjson(*args, **kwargs, team_name=self.team_name)
+
+    def getint(self, *args, **kwargs):
+        return conf.getint(*args, **kwargs, team_name=self.team_name)
+
+    def getsection(self, section: str) -> dict[str, str | int | float | bool] | None:
+        return conf.getsection(section, team_name=self.team_name)
+
+    def has_option(self, *args, **kwargs) -> bool:
+        return conf.has_option(*args, **kwargs, team_name=self.team_name)
+
+    def get_mandatory_value(self, *args, **kwargs) -> str:
+        return conf.get_mandatory_value(*args, **kwargs, team_name=self.team_name)
+
 
 class BaseExecutor(LoggingMixin):
     """

--- a/airflow-core/tests/unit/core/test_configuration.py
+++ b/airflow-core/tests/unit/core/test_configuration.py
@@ -240,9 +240,11 @@ result_backend = BAR
             default_section = test_conf.getsection("celery")
             # TODO: here and below, should we also assert the expected result_backend? To ensure the values were merged together? Do we even expect that?
             assert default_section["worker_concurrency"] == 99
+            assert default_section["result_backend"] == "FOO"
 
             team_section = test_conf.getsection("celery", team_name="unit_test_team")
             assert team_section["worker_concurrency"] == 88
+            assert team_section["result_backend"] == "BAR"
 
     def test_has_option_with_team_name(self):
         """Test has_option with team_name parameter."""

--- a/airflow-core/tests/unit/executors/test_base_executor.py
+++ b/airflow-core/tests/unit/executors/test_base_executor.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import logging
+import textwrap
 from datetime import timedelta
 from unittest import mock
 from uuid import UUID
@@ -357,3 +358,175 @@ def test_state_running():
     # Running state should not remove a command as running
     assert executor.running
     assert executor.event_buffer[key] == (TaskInstanceState.RUNNING, info)
+
+
+@mock.patch.dict("os.environ", {}, clear=True)
+class TestExecutorConf:
+    """Test ExecutorConf shim class that provides team-specific configuration access."""
+
+    def test_executor_conf_get(self):
+        """Test ExecutorConf.get() passes team_name to underlying conf.get()."""
+        from airflow.configuration import conf
+        from airflow.executors.base_executor import ExecutorConf
+
+        test_config = textwrap.dedent(
+            """
+            [celery]
+            result_backend = DEFAULT_VALUE
+
+            [test_team=celery]
+            result_backend = TEAM_VALUE
+            """
+        )
+        conf.read_string(test_config)
+
+        # Test without team_name
+        executor_conf = ExecutorConf(team_name=None)
+        assert executor_conf.get("celery", "result_backend") == "DEFAULT_VALUE"
+
+        # Test with team_name
+        team_executor_conf = ExecutorConf(team_name="test_team")
+        assert team_executor_conf.get("celery", "result_backend") == "TEAM_VALUE"
+
+    def test_executor_conf_getboolean(self):
+        """Test ExecutorConf.getboolean() passes team_name to underlying conf.getboolean()."""
+        from airflow.configuration import conf
+        from airflow.executors.base_executor import ExecutorConf
+
+        test_config = textwrap.dedent(
+            """
+            [celery]
+            ssl_active = true
+
+            [test_team=celery]
+            ssl_active = false
+            """
+        )
+        conf.read_string(test_config)
+
+        executor_conf = ExecutorConf(team_name=None)
+        assert executor_conf.getboolean("celery", "ssl_active") is True
+
+        team_executor_conf = ExecutorConf(team_name="test_team")
+        assert team_executor_conf.getboolean("celery", "ssl_active") is False
+
+    def test_executor_conf_getint(self):
+        """Test ExecutorConf.getint() passes team_name to underlying conf.getint()."""
+        from airflow.configuration import conf
+        from airflow.executors.base_executor import ExecutorConf
+
+        test_config = textwrap.dedent(
+            """
+            [celery]
+            worker_concurrency = 16
+
+            [test_team=celery]
+            worker_concurrency = 32
+            """
+        )
+        conf.read_string(test_config)
+
+        executor_conf = ExecutorConf(team_name=None)
+        assert executor_conf.getint("celery", "worker_concurrency") == 16
+
+        team_executor_conf = ExecutorConf(team_name="test_team")
+        assert team_executor_conf.getint("celery", "worker_concurrency") == 32
+
+    def test_executor_conf_getjson(self):
+        """Test ExecutorConf.getjson() passes team_name to underlying conf.getjson()."""
+        from airflow.configuration import conf
+        from airflow.executors.base_executor import ExecutorConf
+
+        test_config = textwrap.dedent(
+            """
+            [celery]
+            broker_transport_options = {"visibility_timeout": 3600}
+
+            [test_team=celery]
+            broker_transport_options = {"visibility_timeout": 7200}
+            """
+        )
+        conf.read_string(test_config)
+
+        executor_conf = ExecutorConf(team_name=None)
+        assert executor_conf.getjson("celery", "broker_transport_options") == {"visibility_timeout": 3600}
+
+        team_executor_conf = ExecutorConf(team_name="test_team")
+        assert team_executor_conf.getjson("celery", "broker_transport_options") == {
+            "visibility_timeout": 7200
+        }
+
+    def test_executor_conf_getsection(self):
+        """Test ExecutorConf.getsection() passes team_name to underlying conf.getsection()."""
+        from airflow.configuration import conf
+        from airflow.executors.base_executor import ExecutorConf
+
+        test_config = textwrap.dedent(
+            """
+            [celery]
+            worker_concurrency = 16
+            result_backend = DEFAULT_BACKEND
+
+            [test_team=celery]
+            worker_concurrency = 32
+            result_backend = TEAM_BACKEND
+            """
+        )
+        conf.read_string(test_config)
+
+        executor_conf = ExecutorConf(team_name=None)
+        section = executor_conf.getsection("celery")
+        assert section["worker_concurrency"] == 16
+        assert section["result_backend"] == "DEFAULT_BACKEND"
+
+        team_executor_conf = ExecutorConf(team_name="test_team")
+        team_section = team_executor_conf.getsection("celery")
+        assert team_section["worker_concurrency"] == 32
+        assert team_section["result_backend"] == "TEAM_BACKEND"
+
+    def test_executor_conf_has_option(self):
+        """Test ExecutorConf.has_option() passes team_name to underlying conf.has_option()."""
+        from airflow.configuration import conf
+        from airflow.executors.base_executor import ExecutorConf
+
+        test_config = textwrap.dedent(
+            """
+            [celery]
+            result_backend = DEFAULT
+
+            [test_team=celery]
+            result_backend = TEAM
+            team_specific_option = VALUE
+            """
+        )
+        conf.read_string(test_config)
+
+        executor_conf = ExecutorConf(team_name=None)
+        assert executor_conf.has_option("celery", "result_backend") is True
+        assert executor_conf.has_option("celery", "team_specific_option") is False
+
+        team_executor_conf = ExecutorConf(team_name="test_team")
+        assert team_executor_conf.has_option("celery", "result_backend") is True
+        assert team_executor_conf.has_option("celery", "team_specific_option") is True
+
+    def test_executor_conf_get_mandatory_value(self):
+        """Test ExecutorConf.get_mandatory_value() passes team_name to underlying conf.get_mandatory_value()."""
+        from airflow.configuration import conf
+        from airflow.executors.base_executor import ExecutorConf
+
+        test_config = textwrap.dedent(
+            """
+            [celery]
+            broker_url = redis://localhost
+
+            [test_team=celery]
+            broker_url = redis://team-redis
+            """
+        )
+        conf.read_string(test_config)
+
+        executor_conf = ExecutorConf(team_name=None)
+        assert executor_conf.get_mandatory_value("celery", "broker_url") == "redis://localhost"
+
+        team_executor_conf = ExecutorConf(team_name="test_team")
+        assert team_executor_conf.get_mandatory_value("celery", "broker_url") == "redis://team-redis"


### PR DESCRIPTION
Executors like Celery use more advanced config methods so ExecutorConfig must be updated to support these before those executors can be moved to support multi-team airflow.

Also team-ify a few more operations in the Airflow config parser itself.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
