### PR TITLE
Allow swc and esbuild install script for SAM

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/package.json
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/package.json
@@ -59,5 +59,11 @@
     "@typescript-eslint/eslint-plugin": "8.50.0",
     "@typescript-eslint/utils": "^8.50.0",
     "@typescript-eslint/parser": "8.50.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@swc/core",
+      "esbuild"
+    ]
   }
 }


### PR DESCRIPTION
Similarly to other packages, allow install script for `swc/core` and `esbuild`. 

### Before:
<img width="623" height="401" alt="Screenshot 2025-12-18 at 16 00 30" src="https://github.com/user-attachments/assets/52ed0514-789e-4d8c-8c86-fbbf0a565d74" />


### After:
<img width="615" height="450" alt="Screenshot 2025-12-18 at 16 00 22" src="https://github.com/user-attachments/assets/2c75ea43-6e3e-412d-bdb9-e62095cc2009" />
