### PR TITLE
Fix process context for connections CLI to use Metastore secrets backend

### DIFF
--- a/airflow-core/src/airflow/cli/commands/connection_command.py
+++ b/airflow-core/src/airflow/cli/commands/connection_command.py
@@ -65,6 +65,8 @@ def _connection_mapper(conn: Connection) -> dict[str, Any]:
 @providers_configuration_loaded
 def connections_get(args):
     """Get a connection."""
+    os.environ["_AIRFLOW_PROCESS_CONTEXT"] = "server"
+
     try:
         conn = Connection.get_connection_from_secrets(args.conn_id)
     except AirflowNotFoundException:
@@ -358,6 +360,8 @@ def _import_helper(file_path: str, overwrite: bool) -> None:
 @providers_configuration_loaded
 def connections_test(args) -> None:
     """Test an Airflow connection."""
+    os.environ["_AIRFLOW_PROCESS_CONTEXT"] = "server"
+
     console = AirflowConsole()
     if conf.get("core", "test_connection", fallback="Disabled").lower().strip() != "enabled":
         console.print(


### PR DESCRIPTION
This PR fixes an issue where CLI commands for connections were not correctly setting the process context, which could lead to incorrect secrets backend detection.

The connections_get, connections_test commands were not setting `_AIRFLOW_PROCESS_CONTEXT=server` environment variable.

this environment variable is used by the secrets backend system to determine whether to use MetastoreBackend (server context) or other backends (client context).

## Change
Added `os.environ["_AIRFLOW_PROCESS_CONTEXT"] = "server"` at the beginning of: 
- connections_get() 
- connections_test()

## Before

<img width="745" height="238" alt="Screenshot 2025-12-19 at 11 56 20 AM" src="https://github.com/user-attachments/assets/cb6281c2-db90-4b8b-a202-24202cfd95b5" />


## After
<img width="879" height="291" alt="image" src="https://github.com/user-attachments/assets/74f43081-92d6-46a0-8045-edea3deb6be9" />



related: #59298
This PR does not close the issue yet, but addresses part of the root cause.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
