### PR TITLE
Move MappedOperator to serialization

### DIFF
--- a/airflow-core/src/airflow/api/common/mark_tasks.py
+++ b/airflow-core/src/airflow/api/common/mark_tasks.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 from collections.abc import Collection, Iterable, Iterator
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING
 
 from sqlalchemy import and_, or_, select
 from sqlalchemy.orm import lazyload
@@ -33,11 +33,8 @@ from airflow.utils.state import DagRunState, State, TaskInstanceState
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session as SASession
 
-    from airflow.models.mappedoperator import MappedOperator
-    from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
     from airflow.serialization.definitions.dag import SerializedDAG
-
-    Operator: TypeAlias = MappedOperator | SerializedBaseOperator
+    from airflow.serialization.definitions.mappedoperator import Operator
 
 
 @provide_session

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/ui/grid.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/ui/grid.py
@@ -24,9 +24,9 @@ import structlog
 
 from airflow.api_fastapi.common.parameters import state_priority
 from airflow.api_fastapi.core_api.services.ui.task_group import get_task_group_children_getter
-from airflow.models.mappedoperator import MappedOperator
 from airflow.models.taskmap import TaskMap
 from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
+from airflow.serialization.definitions.mappedoperator import SerializedMappedOperator
 from airflow.serialization.definitions.taskgroup import SerializedTaskGroup
 
 log = structlog.get_logger(logger_name=__name__)
@@ -90,7 +90,7 @@ def _find_aggregates(
 
     if node is None:
         return
-    if isinstance(node, MappedOperator):
+    if isinstance(node, SerializedMappedOperator):
         # For unmapped tasks, reflect a single None state so UI shows one square
         mapped_details = details or [{"state": None, "start_date": None, "end_date": None}]
         yield {

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/ui/task_group.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/ui/task_group.py
@@ -24,8 +24,8 @@ from functools import cache
 from operator import methodcaller
 
 from airflow.configuration import conf
-from airflow.models.mappedoperator import MappedOperator, is_mapped
 from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
+from airflow.serialization.definitions.mappedoperator import SerializedMappedOperator, is_mapped
 
 
 @cache
@@ -39,7 +39,7 @@ def get_task_group_children_getter() -> Callable:
 
 def task_group_to_dict(task_item_or_group, parent_group_is_mapped=False):
     """Create a nested dict representation of this TaskGroup and its children used to construct the Graph."""
-    if isinstance(task := task_item_or_group, (SerializedBaseOperator, MappedOperator)):
+    if isinstance(task := task_item_or_group, (SerializedBaseOperator, SerializedMappedOperator)):
         # we explicitly want the short task ID here, not the full doted notation if in a group
         task_display_name = task.task_display_name if task.task_display_name != task.task_id else task.label
         node_operator = {
@@ -83,7 +83,7 @@ def task_group_to_dict(task_item_or_group, parent_group_is_mapped=False):
 
 def task_group_to_dict_grid(task_item_or_group, parent_group_is_mapped=False):
     """Create a nested dict representation of this TaskGroup and its children used to construct the Grid."""
-    if isinstance(task := task_item_or_group, (MappedOperator, SerializedBaseOperator)):
+    if isinstance(task := task_item_or_group, (SerializedMappedOperator, SerializedBaseOperator)):
         mapped = None
         if parent_group_is_mapped or is_mapped(task):
             mapped = True

--- a/airflow-core/src/airflow/cli/commands/task_command.py
+++ b/airflow-core/src/airflow/cli/commands/task_command.py
@@ -62,11 +62,9 @@ if TYPE_CHECKING:
 
     from sqlalchemy.orm.session import Session
 
-    from airflow.models.mappedoperator import MappedOperator
-    from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
+    from airflow.serialization.definitions.mappedoperator import Operator
 
     CreateIfNecessary = Literal[False, "db", "memory"]
-    Operator = MappedOperator | SerializedBaseOperator
 
 log = logging.getLogger(__name__)
 

--- a/airflow-core/src/airflow/models/__init__.py
+++ b/airflow-core/src/airflow/models/__init__.py
@@ -109,7 +109,7 @@ __lazy_imports = {
     "Deadline": "airflow.models.deadline",
     "Log": "airflow.models.log",
     "HITLDetail": "airflow.models.hitl",
-    "MappedOperator": "airflow.models.mappedoperator",
+    "MappedOperator": "airflow.sdk.definitions.mappedoperator",
     "Param": "airflow.sdk.definitions.param",
     "Pool": "airflow.models.pool",
     "RenderedTaskInstanceFields": "airflow.models.renderedtifields",
@@ -136,7 +136,6 @@ if TYPE_CHECKING:
     from airflow.models.db_callback_request import DbCallbackRequest
     from airflow.models.deadline import Deadline
     from airflow.models.log import Log
-    from airflow.models.mappedoperator import MappedOperator
     from airflow.models.pool import Pool
     from airflow.models.renderedtifields import RenderedTaskInstanceFields
     from airflow.models.skipmixin import SkipMixin
@@ -147,6 +146,7 @@ if TYPE_CHECKING:
     from airflow.models.variable import Variable
     from airflow.sdk import DAG, BaseOperator, BaseOperatorLink, Param
     from airflow.sdk.bases.xcom import BaseXCom
+    from airflow.sdk.definitions.mappedoperator import MappedOperator
     from airflow.sdk.execution_time.xcom import XCom
 
 

--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -70,16 +70,13 @@ from airflow.utils.types import DagRunType
 if TYPE_CHECKING:
     from typing import TypeAlias
 
-    from airflow.models.mappedoperator import MappedOperator
     from airflow.serialization.definitions.assets import (
         SerializedAsset,
         SerializedAssetAlias,
         SerializedAssetBase,
     )
-    from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
     from airflow.serialization.definitions.dag import SerializedDAG
 
-    Operator: TypeAlias = MappedOperator | SerializedBaseOperator
     UKey: TypeAlias = SerializedAssetUniqueKey
 
 log = logging.getLogger(__name__)

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -104,17 +104,15 @@ if TYPE_CHECKING:
 
     from airflow._shared.observability.traces.base_tracer import EmptySpan
     from airflow.models.dag_version import DagVersion
-    from airflow.models.mappedoperator import MappedOperator
     from airflow.models.taskinstancekey import TaskInstanceKey
     from airflow.sdk import DAG as SDKDAG
-    from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
     from airflow.serialization.definitions.dag import SerializedDAG
+    from airflow.serialization.definitions.mappedoperator import Operator
 
     CreatedTasks = TypeVar("CreatedTasks", Iterator["dict[str, Any]"], Iterator[TI])
     AttributeValueType: TypeAlias = (
         str | bool | int | float | Sequence[str] | Sequence[bool] | Sequence[int] | Sequence[float]
     )
-    Operator: TypeAlias = MappedOperator | SerializedBaseOperator
 
 RUN_ID_REGEX = r"^(?:manual|scheduled|asset_triggered)__(?:\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+00:00)$"
 
@@ -1529,7 +1527,7 @@ class DagRun(Base, LoggingMixin):
             If the ti does not need expansion, either because the task is not
             mapped, or has already been expanded, *None* is returned.
             """
-            from airflow.models.mappedoperator import is_mapped
+            from airflow.serialization.definitions.mappedoperator import is_mapped
 
             if TYPE_CHECKING:
                 assert ti.task
@@ -1749,7 +1747,7 @@ class DagRun(Base, LoggingMixin):
 
         """
         from airflow.models.expandinput import NotFullyPopulated
-        from airflow.models.mappedoperator import get_mapped_ti_count
+        from airflow.serialization.definitions.mappedoperator import get_mapped_ti_count
 
         tis = self.get_task_instances(session=session)
 
@@ -1891,7 +1889,7 @@ class DagRun(Base, LoggingMixin):
         :param task_creator: Function to create task instances
         """
         from airflow.models.expandinput import NotFullyPopulated
-        from airflow.models.mappedoperator import get_mapped_ti_count
+        from airflow.serialization.definitions.mappedoperator import get_mapped_ti_count
 
         map_indexes: Iterable[int]
         for task in tasks:
@@ -1965,7 +1963,7 @@ class DagRun(Base, LoggingMixin):
         for more details.
         """
         from airflow.models.expandinput import NotFullyPopulated
-        from airflow.models.mappedoperator import get_mapped_ti_count
+        from airflow.serialization.definitions.mappedoperator import get_mapped_ti_count
         from airflow.settings import task_instance_mutation_hook
 
         try:

--- a/airflow-core/src/airflow/models/expandinput.py
+++ b/airflow-core/src/airflow/models/expandinput.py
@@ -35,15 +35,12 @@ from airflow.sdk.definitions._internal.expandinput import (
 )
 
 if TYPE_CHECKING:
-    from typing import TypeAlias, TypeGuard
+    from typing import TypeGuard
 
     from sqlalchemy.orm import Session
 
-    from airflow.models.mappedoperator import MappedOperator
-    from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
+    from airflow.serialization.definitions.mappedoperator import Operator
     from airflow.serialization.definitions.xcom_arg import SchedulerXComArg
-
-    Operator: TypeAlias = MappedOperator | SerializedBaseOperator
 
 
 __all__ = [

--- a/airflow-core/src/airflow/models/referencemixin.py
+++ b/airflow-core/src/airflow/models/referencemixin.py
@@ -21,12 +21,8 @@ from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
-    from typing import TypeAlias
 
-    from airflow.models.mappedoperator import MappedOperator
-    from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
-
-    Operator: TypeAlias = MappedOperator | SerializedBaseOperator
+    from airflow.serialization.definitions.mappedoperator import Operator
 
 
 @runtime_checkable

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -103,7 +103,7 @@ log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from datetime import datetime
-    from typing import Literal, TypeAlias
+    from typing import Literal
 
     import pendulum
     from sqlalchemy.engine import Connection as SAConnection, Engine
@@ -114,13 +114,10 @@ if TYPE_CHECKING:
     from airflow.api_fastapi.execution_api.datamodels.asset import AssetProfile
     from airflow.models.dag import DagModel
     from airflow.models.dagrun import DagRun
-    from airflow.models.mappedoperator import MappedOperator
-    from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
     from airflow.serialization.definitions.dag import SerializedDAG
+    from airflow.serialization.definitions.mappedoperator import Operator
     from airflow.serialization.definitions.taskgroup import SerializedTaskGroup
     from airflow.utils.context import Context
-
-    Operator: TypeAlias = MappedOperator | SerializedBaseOperator
 
 
 PAST_DEPENDS_MET = "past_depends_met"
@@ -1660,7 +1657,6 @@ class TaskInstance(Base, LoggingMixin):
             session = settings.get_session()()
 
         from airflow.exceptions import NotMapped
-        from airflow.models.mappedoperator import get_mapped_ti_count
         from airflow.sdk.api.datamodels._generated import (
             DagRun as DagRunSDK,
             PrevSuccessfulDagRunResponse,
@@ -1669,6 +1665,7 @@ class TaskInstance(Base, LoggingMixin):
         from airflow.sdk.definitions.param import process_params
         from airflow.sdk.execution_time.context import InletEventsAccessors
         from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
+        from airflow.serialization.definitions.mappedoperator import get_mapped_ti_count
         from airflow.utils.context import (
             ConnectionAccessor,
             OutletEventAccessors,
@@ -2193,7 +2190,7 @@ def _find_common_ancestor_mapped_group(node1: Operator, node2: Operator) -> Seri
 
 def _is_further_mapped_inside(operator: Operator, container: SerializedTaskGroup) -> bool:
     """Whether given operator is *further* mapped inside a task group."""
-    from airflow.models.mappedoperator import is_mapped
+    from airflow.serialization.definitions.mappedoperator import is_mapped
 
     if is_mapped(operator):
         return True
@@ -2260,7 +2257,7 @@ def _get_relevant_map_indexes(
     :return: Specific map index or map indexes to pull, or ``None`` if we
         want to "whole" return value (i.e. no mapped task groups involved).
     """
-    from airflow.models.mappedoperator import get_mapped_ti_count
+    from airflow.serialization.definitions.mappedoperator import get_mapped_ti_count
 
     # This value should never be None since we already know the current task
     # is in a mapped task group, and should have been expanded, despite that,
@@ -2307,7 +2304,7 @@ def find_relevant_relatives(
     run_id: str,
     session: Session,
 ) -> Collection[str | tuple[str, int]]:
-    from airflow.models.mappedoperator import get_mapped_ti_count
+    from airflow.serialization.definitions.mappedoperator import get_mapped_ti_count
 
     visited: set[str | tuple[str, int]] = set()
 

--- a/airflow-core/src/airflow/models/taskmap.py
+++ b/airflow-core/src/airflow/models/taskmap.py
@@ -36,9 +36,8 @@ from airflow.utils.state import State, TaskInstanceState
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
-    from airflow.models.mappedoperator import MappedOperator
     from airflow.models.taskinstance import TaskInstance
-    from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
+    from airflow.serialization.definitions.mappedoperator import Operator
 
 
 class TaskMapVariant(enum.Enum):
@@ -126,7 +125,7 @@ class TaskMap(TaskInstanceDependencies):
     @classmethod
     def expand_mapped_task(
         cls,
-        task: SerializedBaseOperator | MappedOperator,
+        task: Operator,
         run_id: str,
         *,
         session: Session,
@@ -139,12 +138,15 @@ class TaskMap(TaskInstanceDependencies):
             order by map index, and the maximum map index value.
         """
         from airflow.models.expandinput import NotFullyPopulated
-        from airflow.models.mappedoperator import MappedOperator, get_mapped_ti_count
         from airflow.models.taskinstance import TaskInstance
         from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
+        from airflow.serialization.definitions.mappedoperator import (
+            SerializedMappedOperator,
+            get_mapped_ti_count,
+        )
         from airflow.settings import task_instance_mutation_hook
 
-        if not isinstance(task, (MappedOperator, SerializedBaseOperator)):
+        if not isinstance(task, (SerializedMappedOperator, SerializedBaseOperator)):
             raise RuntimeError(
                 f"cannot expand unrecognized operator type {type(task).__module__}.{type(task).__name__}"
             )

--- a/airflow-core/src/airflow/serialization/definitions/baseoperator.py
+++ b/airflow-core/src/airflow/serialization/definitions/baseoperator.py
@@ -38,10 +38,10 @@ from airflow.ti_deps.deps.trigger_rule_dep import TriggerRuleDep
 if TYPE_CHECKING:
     from collections.abc import Collection, Iterable, Iterator, Sequence
 
-    from airflow.models.mappedoperator import MappedOperator
     from airflow.models.taskinstance import TaskInstance
     from airflow.sdk import Context
     from airflow.serialization.definitions.dag import SerializedDAG
+    from airflow.serialization.definitions.mappedoperator import SerializedMappedOperator
     from airflow.serialization.definitions.operatorlink import XComOperatorLink
     from airflow.serialization.definitions.taskgroup import SerializedMappedTaskGroup, SerializedTaskGroup
     from airflow.task.trigger_rule import TriggerRule
@@ -286,8 +286,7 @@ class SerializedBaseOperator(DAGNode):
         link = self.operator_extra_link_dict.get(name) or self.global_operator_extra_link_dict.get(name)
         if not link:
             return None
-        # TODO: GH-52141 - BaseOperatorLink.get_link expects BaseOperator but receives SerializedBaseOperator.
-        return link.get_link(self, ti_key=ti.key)  # type: ignore[arg-type]
+        return link.get_link(self, ti_key=ti.key)
 
     @property
     def inherits_from_empty_operator(self) -> bool:
@@ -343,7 +342,7 @@ class SerializedBaseOperator(DAGNode):
         """
         return self.start_from_trigger
 
-    def _iter_all_mapped_downstreams(self) -> Iterator[MappedOperator | SerializedMappedTaskGroup]:
+    def _iter_all_mapped_downstreams(self) -> Iterator[SerializedMappedOperator | SerializedMappedTaskGroup]:
         """
         Return mapped nodes that are direct dependencies of the current task.
 
@@ -359,7 +358,7 @@ class SerializedBaseOperator(DAGNode):
         To get a list of tasks that uses the current task for task mapping, use
         :meth:`iter_mapped_dependants` instead.
         """
-        from airflow.models.mappedoperator import MappedOperator
+        from airflow.serialization.definitions.mappedoperator import SerializedMappedOperator
         from airflow.serialization.definitions.taskgroup import SerializedMappedTaskGroup, SerializedTaskGroup
 
         def _walk_group(group: SerializedTaskGroup) -> Iterable[tuple[str, DAGNode]]:
@@ -379,12 +378,12 @@ class SerializedBaseOperator(DAGNode):
         for key, child in _walk_group(dag.task_group):
             if key == self.node_id:
                 continue
-            if not isinstance(child, MappedOperator | SerializedMappedTaskGroup):
+            if not isinstance(child, SerializedMappedOperator | SerializedMappedTaskGroup):
                 continue
             if self.node_id in child.upstream_task_ids:
                 yield child
 
-    def iter_mapped_dependants(self) -> Iterator[MappedOperator | SerializedMappedTaskGroup]:
+    def iter_mapped_dependants(self) -> Iterator[SerializedMappedOperator | SerializedMappedTaskGroup]:
         """
         Return mapped nodes that depend on the current task the expansion.
 

--- a/airflow-core/src/airflow/serialization/definitions/dag.py
+++ b/airflow-core/src/airflow/serialization/definitions/dag.py
@@ -254,8 +254,8 @@ class SerializedDAG:
         include_direct_upstream: bool = False,
         exclude_original: bool = False,
     ):
-        from airflow.models.mappedoperator import MappedOperator as SerializedMappedOperator
         from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
+        from airflow.serialization.definitions.mappedoperator import SerializedMappedOperator
 
         def is_task(obj) -> TypeIs[SerializedOperator]:
             return isinstance(obj, (SerializedMappedOperator, SerializedBaseOperator))

--- a/airflow-core/src/airflow/serialization/definitions/node.py
+++ b/airflow-core/src/airflow/serialization/definitions/node.py
@@ -24,14 +24,10 @@ from airflow._shared.dagnode.node import GenericDAGNode
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-    from typing import TypeAlias
 
-    from airflow.models.mappedoperator import MappedOperator
-    from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
     from airflow.serialization.definitions.dag import SerializedDAG  # noqa: F401
+    from airflow.serialization.definitions.mappedoperator import Operator  # noqa: F401
     from airflow.serialization.definitions.taskgroup import SerializedTaskGroup  # noqa: F401
-
-    Operator: TypeAlias = SerializedBaseOperator | MappedOperator
 
 __all__ = ["DAGNode"]
 

--- a/airflow-core/src/airflow/serialization/definitions/operatorlink.py
+++ b/airflow-core/src/airflow/serialization/definitions/operatorlink.py
@@ -18,7 +18,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING
 
 import attrs
 
@@ -27,11 +27,8 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import create_session
 
 if TYPE_CHECKING:
-    from airflow.models.mappedoperator import MappedOperator as SerializedMappedOperator
     from airflow.models.taskinstancekey import TaskInstanceKey
-    from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
-
-    Operator: TypeAlias = "SerializedMappedOperator | SerializedBaseOperator"
+    from airflow.serialization.definitions.mappedoperator import Operator
 
 
 @attrs.define()

--- a/airflow-core/src/airflow/serialization/definitions/taskgroup.py
+++ b/airflow-core/src/airflow/serialization/definitions/taskgroup.py
@@ -185,13 +185,13 @@ class SerializedTaskGroup(DAGNode):
 
     def iter_tasks(self) -> Iterator[SerializedOperator]:
         """Return an iterator of the child tasks."""
-        from airflow.models.mappedoperator import MappedOperator
         from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
+        from airflow.serialization.definitions.mappedoperator import SerializedMappedOperator
 
         groups_to_visit = [self]
         while groups_to_visit:
             for child in groups_to_visit.pop(0).children.values():
-                if isinstance(child, (MappedOperator, SerializedBaseOperator)):
+                if isinstance(child, (SerializedMappedOperator, SerializedBaseOperator)):
                     yield child
                 elif isinstance(child, SerializedTaskGroup):
                     groups_to_visit.append(child)

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -32,7 +32,7 @@ from collections.abc import Collection, Iterable, Mapping
 from functools import cache, cached_property, lru_cache
 from inspect import signature
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple, TypeAlias, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple, TypeVar, cast, overload
 
 import attrs
 import lazy_object_proxy
@@ -107,16 +107,17 @@ if TYPE_CHECKING:
     from kubernetes.client import models as k8s  # noqa: TC004
 
     from airflow.models.expandinput import SchedulerExpandInput
-    from airflow.models.mappedoperator import MappedOperator as SerializedMappedOperator
     from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator  # noqa: TC004
     from airflow.sdk import BaseOperatorLink
     from airflow.sdk.definitions._internal.node import DAGNode as SDKDAGNode
+    from airflow.sdk.types import Operator as SdkOperator
+    from airflow.serialization.definitions.mappedoperator import (
+        Operator as SerializedOperator,
+        SerializedMappedOperator,
+    )
     from airflow.serialization.json_schema import Validator
     from airflow.timetables.base import DagRunInfo, Timetable
     from airflow.timetables.simple import PartitionMapper
-
-    SerializedOperator: TypeAlias = "SerializedMappedOperator | SerializedBaseOperator"
-    SdkOperator: TypeAlias = BaseOperator | MappedOperator
 
 log = logging.getLogger(__name__)
 
@@ -1344,7 +1345,7 @@ class OperatorSerialization(DAGNode, BaseSerialization):
         """Deserializes an operator from a JSON object."""
         op: SerializedOperator
         if encoded_op.get("_is_mapped", False):
-            from airflow.models.mappedoperator import MappedOperator as SerializedMappedOperator
+            from airflow.serialization.definitions.mappedoperator import SerializedMappedOperator
 
             try:
                 operator_name = encoded_op["_operator_name"]
@@ -2370,7 +2371,7 @@ def create_scheduler_operator(op: MappedOperator | SerializedMappedOperator) -> 
 
 
 def create_scheduler_operator(op: SdkOperator | SerializedOperator) -> SerializedOperator:
-    from airflow.models.mappedoperator import MappedOperator as SerializedMappedOperator
+    from airflow.serialization.definitions.mappedoperator import SerializedMappedOperator
 
     if isinstance(op, (SerializedBaseOperator, SerializedMappedOperator)):
         return op

--- a/airflow-core/src/airflow/ti_deps/deps/mapped_task_upstream_dep.py
+++ b/airflow-core/src/airflow/ti_deps/deps/mapped_task_upstream_dep.py
@@ -15,10 +15,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
 from __future__ import annotations
 
 from collections.abc import Iterator
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING
 
 from sqlalchemy import select
 
@@ -28,13 +29,9 @@ from airflow.utils.state import State, TaskInstanceState
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
-    from airflow.models.mappedoperator import MappedOperator
     from airflow.models.taskinstance import TaskInstance
-    from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
     from airflow.ti_deps.dep_context import DepContext
     from airflow.ti_deps.deps.base_ti_dep import TIDepStatus
-
-    Operator: TypeAlias = MappedOperator | SerializedBaseOperator
 
 
 class MappedTaskUpstreamDep(BaseTIDep):
@@ -55,8 +52,8 @@ class MappedTaskUpstreamDep(BaseTIDep):
         session: Session,
         dep_context: DepContext,
     ) -> Iterator[TIDepStatus]:
-        from airflow.models.mappedoperator import is_mapped
         from airflow.models.taskinstance import TaskInstance
+        from airflow.serialization.definitions.mappedoperator import is_mapped
 
         if ti.task is None:
             return

--- a/airflow-core/src/airflow/ti_deps/deps/prev_dagrun_dep.py
+++ b/airflow-core/src/airflow/ti_deps/deps/prev_dagrun_dep.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING
 
 from sqlalchemy import func, or_, select
 
@@ -32,10 +32,7 @@ from airflow.utils.state import TaskInstanceState
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
-    from airflow.models.mappedoperator import MappedOperator
-    from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
-
-    SchedulerOperator: TypeAlias = MappedOperator | SerializedBaseOperator
+    from airflow.serialization.definitions.mappedoperator import Operator
 
 _SUCCESSFUL_STATES = (TaskInstanceState.SKIPPED, TaskInstanceState.SUCCESS)
 
@@ -108,12 +105,7 @@ class PrevDagrunDep(BaseTIDep):
         return 0 if unsuccessful_tis_count is None else unsuccessful_tis_count
 
     @staticmethod
-    def _has_unsuccessful_dependants(
-        dagrun: DagRun,
-        task: SchedulerOperator,
-        *,
-        session: Session,
-    ) -> bool:
+    def _has_unsuccessful_dependants(dagrun: DagRun, task: Operator, *, session: Session) -> bool:
         """
         Check if any of the task's dependants are unsuccessful in a given run.
 

--- a/airflow-core/src/airflow/utils/dag_edges.py
+++ b/airflow-core/src/airflow/utils/dag_edges.py
@@ -16,17 +16,17 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeAlias, cast
+from typing import TYPE_CHECKING, cast
 
-from airflow.models.mappedoperator import MappedOperator
 from airflow.sdk.definitions._internal.abstractoperator import AbstractOperator
 from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
+from airflow.serialization.definitions.dag import SerializedDAG
+from airflow.serialization.definitions.mappedoperator import SerializedMappedOperator
 
 if TYPE_CHECKING:
     from airflow.sdk import DAG
     from airflow.serialization.definitions.dag import SerializedDAG
-
-    Operator: TypeAlias = MappedOperator | SerializedBaseOperator
+    from airflow.serialization.definitions.mappedoperator import Operator
 
 
 def dag_edges(dag: DAG | SerializedDAG):
@@ -64,7 +64,7 @@ def dag_edges(dag: DAG | SerializedDAG):
 
     def collect_edges(task_group):
         """Update edges_to_add and edges_to_skip according to TaskGroups."""
-        if isinstance(task_group, (AbstractOperator, SerializedBaseOperator, MappedOperator)):
+        if isinstance(task_group, (AbstractOperator, SerializedBaseOperator, SerializedMappedOperator)):
             return
 
         for target_id in task_group.downstream_group_ids:

--- a/airflow-core/src/airflow/utils/dot_renderer.py
+++ b/airflow-core/src/airflow/utils/dot_renderer.py
@@ -24,10 +24,10 @@ import warnings
 from typing import TYPE_CHECKING, Any
 
 from airflow.exceptions import AirflowException
-from airflow.models.mappedoperator import MappedOperator as SerializedMappedOperator
 from airflow.sdk import DAG, BaseOperator, TaskGroup
 from airflow.sdk.definitions.mappedoperator import MappedOperator
 from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
+from airflow.serialization.definitions.mappedoperator import SerializedMappedOperator
 from airflow.serialization.definitions.taskgroup import SerializedTaskGroup
 from airflow.utils.dag_edges import dag_edges
 from airflow.utils.state import State

--- a/airflow-core/tests/unit/serialization/test_dag_serialization.py
+++ b/airflow-core/tests/unit/serialization/test_dag_serialization.py
@@ -56,7 +56,6 @@ from airflow.exceptions import (
 )
 from airflow.models.asset import AssetModel
 from airflow.models.connection import Connection
-from airflow.models.mappedoperator import MappedOperator
 from airflow.models.taskinstance import TaskInstance as TI
 from airflow.models.xcom import XCOM_RETURN_KEY, XComModel
 from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator
@@ -71,6 +70,7 @@ from airflow.security import permissions
 from airflow.serialization.definitions.assets import SerializedAssetUniqueKey
 from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
 from airflow.serialization.definitions.dag import SerializedDAG
+from airflow.serialization.definitions.mappedoperator import SerializedMappedOperator
 from airflow.serialization.definitions.notset import NOTSET
 from airflow.serialization.definitions.operatorlink import XComOperatorLink
 from airflow.serialization.definitions.param import SerializedParam
@@ -764,7 +764,6 @@ class TestStringifiedDAGs:
         task,
     ):
         """Verify non-Airflow operators are casted to BaseOperator or MappedOperator."""
-        from airflow.models.mappedoperator import MappedOperator as SchedulerMappedOperator
         from airflow.sdk import BaseOperator
         from airflow.sdk.definitions.mappedoperator import MappedOperator
 
@@ -796,7 +795,7 @@ class TestStringifiedDAGs:
                 "_is_sensor",
             }
         else:  # Promised to be mapped by the assert above.
-            assert isinstance(serialized_task, SchedulerMappedOperator)
+            assert isinstance(serialized_task, SerializedMappedOperator)
             fields_to_check = {f.name for f in attrs.fields(MappedOperator)}
             fields_to_check -= {
                 "map_index_template",
@@ -1813,7 +1812,7 @@ class TestStringifiedDAGs:
         assert "outlets" not in serialized
 
         round_tripped = OperatorSerialization.deserialize_operator(serialized)
-        assert isinstance(round_tripped, MappedOperator)
+        assert isinstance(round_tripped, SerializedMappedOperator)
         assert round_tripped.inlets == []
         assert round_tripped.outlets == []
 
@@ -2646,7 +2645,7 @@ def test_operator_expand_serde():
     }
 
     op = BaseSerialization.deserialize(serialized)
-    assert isinstance(op, MappedOperator)
+    assert isinstance(op, SerializedMappedOperator)
 
     # operator_class now stores only minimal type information for memory efficiency
     assert op.operator_class == {
@@ -2900,7 +2899,7 @@ def test_taskflow_expand_serde():
     }
 
     deserialized = BaseSerialization.deserialize(serialized)
-    assert isinstance(deserialized, MappedOperator)
+    assert isinstance(deserialized, SerializedMappedOperator)
     assert deserialized.upstream_task_ids == set()
     assert deserialized.downstream_task_ids == set()
 
@@ -2992,7 +2991,7 @@ def test_taskflow_expand_kwargs_serde(strict):
     }
 
     deserialized = BaseSerialization.deserialize(serialized)
-    assert isinstance(deserialized, MappedOperator)
+    assert isinstance(deserialized, SerializedMappedOperator)
     assert deserialized._disallow_kwargs_override == strict
     assert deserialized.upstream_task_ids == set()
     assert deserialized.downstream_task_ids == set()
@@ -4237,9 +4236,7 @@ class TestMappedOperatorSerializationAndClientDefaults:
             deserialized_task = deserialized_dag.get_task("mapped_task")
 
             # Verify it's still a MappedOperator
-            from airflow.models.mappedoperator import MappedOperator as SchedulerMappedOperator
-
-            assert isinstance(deserialized_task, SchedulerMappedOperator)
+            assert isinstance(deserialized_task, SerializedMappedOperator)
 
             # Check that client_defaults values are applied (e.g., retry_delay from client_defaults)
             client_defaults = serialized_dag["client_defaults"]["tasks"]

--- a/devel-common/src/tests_common/test_utils/mapping.py
+++ b/devel-common/src/tests_common/test_utils/mapping.py
@@ -23,12 +23,11 @@ from airflow.models.taskmap import TaskMap
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
-    from airflow.models.mappedoperator import MappedOperator
-    from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
+    from airflow.serialization.definitions.mappedoperator import Operator
 
 
 def expand_mapped_task(
-    mapped: SerializedBaseOperator | MappedOperator,
+    mapped: Operator,
     run_id: str,
     upstream_task_id: str,
     length: int,

--- a/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
@@ -34,7 +34,6 @@ from airflow import __version__ as AIRFLOW_VERSION
 
 # TODO: move this maybe to Airflow's logic?
 from airflow.models import DagRun, TaskInstance, TaskReschedule
-from airflow.models.mappedoperator import MappedOperator as SerializedMappedOperator
 from airflow.providers.common.compat.assets import Asset
 from airflow.providers.common.compat.module_loading import import_string
 from airflow.providers.common.compat.sdk import DAG, BaseOperator, BaseSensorOperator, MappedOperator
@@ -58,6 +57,13 @@ from airflow.providers.openlineage.utils.selective_enable import (
 )
 from airflow.providers.openlineage.version_compat import AIRFLOW_V_3_0_PLUS, get_base_airflow_version_tuple
 from airflow.serialization.serialized_objects import SerializedBaseOperator, SerializedDAG
+
+try:
+    from airflow.serialization.definitions.mappedoperator import SerializedMappedOperator
+except ImportError:
+    from airflow.models.mappedoperator import (  # type: ignore[attr-defined,no-redef]
+        MappedOperator as SerializedMappedOperator,
+    )
 
 if not AIRFLOW_V_3_0_PLUS:
     from airflow.utils.session import NEW_SESSION, provide_session

--- a/providers/standard/tests/unit/standard/decorators/test_python.py
+++ b/providers/standard/tests/unit/standard/decorators/test_python.py
@@ -30,6 +30,7 @@ from tests_common.test_utils.version_compat import (
     AIRFLOW_V_3_0_1,
     AIRFLOW_V_3_0_PLUS,
     AIRFLOW_V_3_1_PLUS,
+    AIRFLOW_V_3_2_PLUS,
     XCOM_RETURN_KEY,
 )
 from unit.standard.operators.test_python import BasePythonTest
@@ -38,7 +39,6 @@ if AIRFLOW_V_3_0_PLUS:
     from airflow.sdk import DAG, BaseOperator, TaskGroup, XComArg, setup, task as task_decorator, teardown
     from airflow.sdk.bases.decorator import DecoratedMappedOperator
     from airflow.sdk.definitions._internal.expandinput import DictOfListsExpandInput
-    from airflow.sdk.definitions.mappedoperator import MappedOperator
 else:
     from airflow.decorators import (  # type: ignore[attr-defined,no-redef]
         setup,
@@ -49,7 +49,6 @@ else:
     from airflow.models.baseoperator import BaseOperator  # type: ignore[no-redef]
     from airflow.models.dag import DAG  # type: ignore[assignment,no-redef]
     from airflow.models.expandinput import DictOfListsExpandInput
-    from airflow.models.mappedoperator import MappedOperator  # type: ignore[assignment,no-redef]
     from airflow.models.xcom_arg import XComArg  # type: ignore[no-redef]
     from airflow.utils.task_group import TaskGroup  # type: ignore[no-redef]
 
@@ -58,6 +57,13 @@ if AIRFLOW_V_3_1_PLUS:
 else:
     from airflow.utils import timezone  # type: ignore[attr-defined,no-redef]
     from airflow.utils.trigger_rule import TriggerRule  # type: ignore[no-redef,attr-defined]
+
+if AIRFLOW_V_3_2_PLUS:
+    from airflow.serialization.definitions.mappedoperator import SerializedMappedOperator
+else:
+    from airflow.models.mappedoperator import (  # type: ignore[no-redef]
+        MappedOperator as SerializedMappedOperator,  # type: ignore[assignment,attr-defined]
+    )
 
 pytestmark = pytest.mark.db_test
 
@@ -819,6 +825,8 @@ def test_mapped_decorator_unmap_merge_op_kwargs(dag_maker, session):
 
 @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Different test for AF 2")
 def test_mapped_render_template_fields(dag_maker, session):
+    from airflow.sdk.definitions.mappedoperator import MappedOperator
+
     @task_decorator
     def fn(arg1, arg2): ...
 
@@ -884,7 +892,7 @@ def test_mapped_render_template_fields_af2(dag_maker, session):
 
         mapped_ti: TaskInstance = dr.get_task_instance(mapped.operator.task_id, session=session)
         mapped_ti.map_index = 0
-        assert isinstance(mapped_ti.task, MappedOperator)
+        assert isinstance(mapped_ti.task, SerializedMappedOperator)
         mapped.operator.render_template_fields(context=mapped_ti.get_template_context(session=session))
         assert isinstance(mapped_ti.task, BaseOperator)
 

--- a/providers/standard/tests/unit/standard/utils/test_skipmixin.py
+++ b/providers/standard/tests/unit/standard/utils/test_skipmixin.py
@@ -39,10 +39,8 @@ if AIRFLOW_V_3_0_PLUS:
     from airflow.providers.common.compat.sdk import DownstreamTasksSkipped
     from airflow.providers.standard.utils.skipmixin import SkipMixin
     from airflow.sdk import task, task_group
-    from airflow.sdk.definitions.mappedoperator import MappedOperator
 else:
     from airflow.decorators import task, task_group  # type: ignore[attr-defined,no-redef]
-    from airflow.models.mappedoperator import MappedOperator  # type: ignore[assignment]
     from airflow.models.skipmixin import SkipMixin
 
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)
@@ -108,23 +106,18 @@ class TestSkipMixin:
 
     @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Airflow 2 had a different implementation")
     def test_skip__only_mapped_operators_passed(self):
+        from airflow.sdk.definitions.mappedoperator import MappedOperator
+
         ti = Mock(map_index=2)
-        assert (
-            SkipMixin().skip(
-                ti=ti,
-                tasks=[MagicMock(spec=MappedOperator)],
-            )
-            is None
-        )
+        assert SkipMixin().skip(ti=ti, tasks=[MagicMock(spec=MappedOperator)]) is None
 
     @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Airflow 2 had a different implementation")
     def test_skip__only_none_mapped_operators_passed(self):
+        from airflow.sdk.definitions.mappedoperator import MappedOperator
+
         ti = Mock(map_index=-1)
         with pytest.raises(DownstreamTasksSkipped) as exc_info:
-            SkipMixin().skip(
-                ti=ti,
-                tasks=[MagicMock(spec=MappedOperator, task_id="task")],
-            )
+            SkipMixin().skip(ti=ti, tasks=[MagicMock(spec=MappedOperator, task_id="task")])
         assert exc_info.value.tasks == ["task"]
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Move Core MappedOperator to `airflow.serialization.definitions` and rename to SerializedMappedOperator. See #52141.