### PR TITLE
Port over custom serializer tests from airflow core to task sdk

### DIFF
--- a/airflow-core/tests/unit/serialization/test_dag_serialization.py
+++ b/airflow-core/tests/unit/serialization/test_dag_serialization.py
@@ -4102,6 +4102,18 @@ class TestSchemaDefaults:
         overlap = optional_fields & required_fields
         assert not overlap, f"Optional fields should not overlap with required fields: {overlap}"
 
+    def test_json_schema_load_dag_schema_dict(self, monkeypatch):
+        """Test error handling when schema file is missing."""
+        from airflow.exceptions import AirflowException
+
+        monkeypatch.setattr(
+            "airflow.serialization.json_schema.pkgutil.get_data", lambda __name__, fname: None
+        )
+
+        with pytest.raises(AirflowException) as ctx:
+            load_dag_schema_dict()
+        assert "Schema file schema.json does not exists" in str(ctx.value)
+
 
 class TestDeserializationDefaultsResolution:
     """Test defaults resolution during deserialization."""

--- a/task-sdk/tests/conftest.py
+++ b/task-sdk/tests/conftest.py
@@ -23,6 +23,8 @@ from typing import TYPE_CHECKING, Any, NoReturn, Protocol
 
 import pytest
 
+from tests_common.test_utils.config import conf_vars
+
 pytest_plugins = "tests_common.pytest_plugin"
 
 # Task SDK does not need access to the Airflow database
@@ -335,3 +337,14 @@ def make_ti_context_dict(make_ti_context: MakeTIContextCallable) -> MakeTIContex
         return context.model_dump(exclude_unset=True, mode="json")
 
     return _make_context_dict
+
+
+@pytest.fixture(scope="class", autouse=True)
+def allow_test_classes_deserialization():
+    """
+    Allow test classes and airflow SDK classes to be deserialized. In airflow-core tests, this is provided by
+    unit_tests.cfg which sets allowed_deserialization_classes = airflow.* tests.*
+    SDK tests may not inherit that configuration, so we explicitly allow airflow.sdk.* and tests.* here.
+    """
+    with conf_vars({("core", "allowed_deserialization_classes"): "airflow.sdk.* tests.*"}):
+        yield

--- a/task-sdk/tests/task_sdk/serde/test_serde.py
+++ b/task-sdk/tests/task_sdk/serde/test_serde.py
@@ -196,17 +196,6 @@ class C:
         return None
 
 
-@pytest.fixture(scope="class", autouse=True)
-def allow_test_classes_deserialization():
-    """
-    Allow test classes and airflow SDK classes to be deserialized. In airflow-core tests, this is provided by
-    unit_tests.cfg which sets allowed_deserialization_classes = airflow.* tests.*
-    SDK tests may not inherit that configuration, so we explicitly allow airflow.sdk.* and tests.* here.
-    """
-    with conf_vars({("core", "allowed_deserialization_classes"): "airflow.sdk.* tests.*"}):
-        yield
-
-
 @pytest.mark.usefixtures("recalculate_patterns")
 class TestSerDe:
     def test_ser_primitives(self):

--- a/task-sdk/tests/task_sdk/serde/test_serializers.py
+++ b/task-sdk/tests/task_sdk/serde/test_serializers.py
@@ -36,10 +36,10 @@ from pendulum.tz.timezone import FixedTimezone, Timezone
 from pydantic import BaseModel, Field
 from pydantic.dataclasses import dataclass as pydantic_dataclass
 
-from airflow._shared.module_loading import qualname
+from airflow.sdk._shared.module_loading import qualname
 from airflow.sdk.definitions.param import Param, ParamsDict
 from airflow.sdk.serde import CLASSNAME, DATA, VERSION, decode, deserialize, serialize
-from airflow.serialization.serializers import builtin
+from airflow.sdk.serde.serializers import builtin
 
 from tests_common.test_utils.markers import skip_if_force_lowest_dependencies_marker
 
@@ -170,12 +170,12 @@ class TestSerializers:
         }
 
     def test_bignum_serialize_non_decimal(self):
-        from airflow.serialization.serializers.bignum import serialize
+        from airflow.sdk.serde.serializers.bignum import serialize
 
         assert serialize(12345) == ("", "", 0, False)
 
     def test_bignum_deserialize_decimal(self):
-        from airflow.serialization.serializers.bignum import deserialize
+        from airflow.sdk.serde.serializers.bignum import deserialize
 
         res = deserialize(decimal.Decimal, 1, decimal.Decimal(12345))
         assert res == decimal.Decimal(12345)
@@ -198,7 +198,7 @@ class TestSerializers:
         ],
     )
     def test_bignum_deserialize_errors(self, klass, version, payload, msg):
-        from airflow.serialization.serializers.bignum import deserialize
+        from airflow.sdk.serde.serializers.bignum import deserialize
 
         with pytest.raises(TypeError, match=msg):
             deserialize(klass, version, payload)
@@ -221,7 +221,7 @@ class TestSerializers:
         assert type(value) is type(d)
 
     def test_numpy_serializers(self):
-        from airflow.serialization.serializers.numpy import serialize
+        from airflow.sdk.serde.serializers.numpy import serialize
 
         numpy_version = metadata.version("numpy")
         is_numpy_2 = version.parse(numpy_version).major == 2
@@ -240,7 +240,7 @@ class TestSerializers:
         ],
     )
     def test_numpy_deserialize_errors(self, klass, ver, value, msg):
-        from airflow.serialization.serializers.numpy import deserialize
+        from airflow.sdk.serde.serializers.numpy import deserialize
 
         with pytest.raises(TypeError, match=msg):
             deserialize(klass, ver, value)
@@ -260,7 +260,7 @@ class TestSerializers:
         assert i.equals(d)
 
     def test_pandas_serializers(self):
-        from airflow.serialization.serializers.pandas import serialize
+        from airflow.sdk.serde.serializers.pandas import serialize
 
         assert serialize(123) == ("", "", 0, False)
 
@@ -278,7 +278,7 @@ class TestSerializers:
         ],
     )
     def test_pandas_deserialize_errors(self, klass, version, data, msg):
-        from airflow.serialization.serializers.pandas import deserialize
+        from airflow.sdk.serde.serializers.pandas import deserialize
 
         with pytest.raises(TypeError, match=msg):
             deserialize(klass, version, data)
@@ -337,7 +337,7 @@ class TestSerializers:
             assert d._storage_options is None
 
     def test_deltalake_serialize_deserialize(self):
-        from airflow.serialization.serializers.deltalake import serialize
+        from airflow.sdk.serde.serializers.deltalake import serialize
 
         assert serialize(object()) == ("", "", 0, False)
 
@@ -359,14 +359,14 @@ class TestSerializers:
         ],
     )
     def test_deltalake_deserialize_errors(self, klass, version, payload, msg):
-        from airflow.serialization.serializers.deltalake import deserialize
+        from airflow.sdk.serde.serializers.deltalake import deserialize
 
         with pytest.raises(TypeError, match=msg):
             deserialize(klass, version, payload)
 
     def test_kubernetes_serializer(self, monkeypatch):
         from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator
-        from airflow.serialization.serializers.kubernetes import serialize
+        from airflow.sdk.serde.serializers.kubernetes import serialize
 
         pod = k8s.V1Pod(metadata=k8s.V1ObjectMeta(name="foo"))
         monkeypatch.setattr(PodGenerator, "serialize_pod", lambda o: (_ for _ in ()).throw(Exception("fail")))
@@ -394,7 +394,7 @@ class TestSerializers:
         ],
     )
     def test_pydantic_deserialize_errors(self, klass, version, data, msg):
-        from airflow.serialization.serializers.pydantic import deserialize
+        from airflow.sdk.serde.serializers.pydantic import deserialize
 
         with pytest.raises(TypeError, match=msg):
             deserialize(klass, version, data)
@@ -560,17 +560,17 @@ class TestSerializers:
         assert deserialize(ser_value) == expected
 
     def test_timezone_serialize_fixed(self):
-        from airflow.serialization.serializers.timezone import serialize
+        from airflow.sdk.serde.serializers.timezone import serialize
 
         assert serialize(FixedTimezone(0)) == ("UTC", "pendulum.tz.timezone.FixedTimezone", 1, True)
 
     def test_timezone_serialize_no_name(self):
-        from airflow.serialization.serializers.timezone import serialize
+        from airflow.sdk.serde.serializers.timezone import serialize
 
         assert serialize(NoNameTZ()) == ("", "", 0, False)
 
     def test_timezone_deserialize_zoneinfo(self):
-        from airflow.serialization.serializers.timezone import deserialize
+        from airflow.sdk.serde.serializers.timezone import deserialize
 
         zi = deserialize(ZoneInfo, 1, "Asia/Taipei")
         assert isinstance(zi, ZoneInfo)
@@ -584,7 +584,7 @@ class TestSerializers:
         ],
     )
     def test_timezone_deserialize_errors(self, klass, version, data, msg):
-        from airflow.serialization.serializers.timezone import deserialize
+        from airflow.sdk.serde.serializers.timezone import deserialize
 
         with pytest.raises(TypeError, match=msg):
             deserialize(klass, version, data)
@@ -598,21 +598,9 @@ class TestSerializers:
         ],
     )
     def test_timezone_get_tzinfo_name(self, tz_obj, expected):
-        from airflow.serialization.serializers.timezone import _get_tzinfo_name
+        from airflow.sdk.serde.serializers.timezone import _get_tzinfo_name
 
         assert _get_tzinfo_name(tz_obj) == expected
-
-    def test_json_schema_load_dag_schema_dict(self, monkeypatch):
-        from airflow.exceptions import AirflowException
-        from airflow.serialization.json_schema import load_dag_schema_dict
-
-        monkeypatch.setattr(
-            "airflow.serialization.json_schema.pkgutil.get_data", lambda __name__, fname: None
-        )
-
-        with pytest.raises(AirflowException) as ctx:
-            load_dag_schema_dict()
-        assert "Schema file schema.json does not exists" in str(ctx.value)
 
     @pytest.mark.parametrize(
         ("klass", "version", "data"),


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Realised via: https://github.com/apache/airflow/actions/runs/20363972474/job/58515372873?pr=59631 that this is needed as a precursor to #59631. 

Moving over the tests from airflow core over to task sdk now that task sdk contains all things serde + custom serializers.

Also realised that `test_json_schema_load_dag_schema_dict` didnt belong in there as it tests json schema, more appropriate for dag serialisation tests.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
