### PR TITLE
Add compat deprecation handling for [webserver/base_url]

### DIFF
--- a/airflow-core/docs/administration-and-deployment/production-deployment.rst
+++ b/airflow-core/docs/administration-and-deployment/production-deployment.rst
@@ -90,7 +90,7 @@ e.g. metadata DB, password, etc. You can accomplish this using the format :envva
 .. code-block:: bash
 
  AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=my_conn_id
- AIRFLOW__WEBSERVER__BASE_URL=http://host:port
+ AIRFLOW__API__BASE_URL=http://host:port
 
 Some configurations such as the Airflow Backend connection URI can be derived from bash commands as well:
 

--- a/shared/configuration/src/airflow_shared/configuration/parser.py
+++ b/shared/configuration/src/airflow_shared/configuration/parser.py
@@ -129,6 +129,7 @@ class AirflowConfigParser(ConfigParser):
     # DeprecationWarning will be issued and the old option will be used instead
     deprecated_options: dict[tuple[str, str], tuple[str, str, str]] = {
         ("dag_processor", "refresh_interval"): ("scheduler", "dag_dir_list_interval", "3.0"),
+        ("api", "base_url"): ("webserver", "base_url", "3.0"),
         ("api", "host"): ("webserver", "web_server_host", "3.0"),
         ("api", "port"): ("webserver", "web_server_port", "3.0"),
         ("api", "workers"): ("webserver", "workers", "3.0"),


### PR DESCRIPTION
related: https://github.com/apache/airflow/pull/55704#pullrequestreview-3596607981

## Why 

As the above comment pointed out, we didn't handle `[webserver/base_url]` to `[api/base_url]` config properly. If user still using `AIRFLOW__WEBSERVER__BASE_URL` env, the redirection of API Server will not work.

## What

- Add `[webserver/base_url]` to `[api/base_url]` pair in `deprecated_options`
- Fix outdated `AIRFLOW__API__BASE_URL` in the doc