### PR TITLE
Fix sidebar visibility issue when main content exceeds viewport height

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/BaseLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/BaseLayout.tsx
@@ -53,7 +53,15 @@ export const BaseLayout = ({ children }: PropsWithChildren) => {
   return (
     <LocaleProvider locale={i18n.language || "en"}>
       <Nav />
-      <Box _ltr={{ ml: 20 }} _rtl={{ mr: 20 }} display="flex" flexDirection="column" h="100vh" p={3}>
+      <Box
+        _ltr={{ ml: 20 }}
+        _rtl={{ mr: 20 }}
+        display="flex"
+        flexDirection="column"
+        h="100vh"
+        overflowY="auto"
+        p={3}
+      >
         {children ?? <Outlet />}
       </Box>
     </LocaleProvider>


### PR DESCRIPTION
In responsive layouts, when the main content height exceeds the viewport height, users had to scroll the entire page to access bottom elements of the fixed sidebar, making navigation difficult.

## Change
The main content area in `BaseLayout.tsx` was set to h="100vh" without overflow handling.

Added `overflowY="auto"` to the main content container
--> Main content scrolls within its own container when it exceeds viewport height



## Before

https://github.com/user-attachments/assets/50897750-e6bb-46a1-afbf-fdb612c49017


## After

https://github.com/user-attachments/assets/f16c2968-6751-4444-9d88-7149ff43932b



<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
