### PR TITLE
Fix task logging level regression in Airflow 3.1.5

### DIFF
--- a/shared/logging/src/airflow_shared/logging/structlog.py
+++ b/shared/logging/src/airflow_shared/logging/structlog.py
@@ -547,7 +547,7 @@ def configure_logging(
     )
     config["root"] = {
         "handlers": ["default"],
-        "level": "INFO",
+        "level": log_level.upper(),
         "propagate": True,
     }
 


### PR DESCRIPTION
The root logger level was hardcoded to INFO instead of respecting the configured logging_level setting. This caused user task code using logging.getLogger(__name__).info() to not show up in task logs unless the log level was artificially high (e.g. level 55).

Changes:

- Set root logger level to log_level.upper() instead of hardcoded INFO

- Add tests verifying root logger respects configured log level

- Add test for INFO level filtering (DEBUG messages not shown)

This restores the behavior from Airflow 2.x where logger.info() worked as documented.





