### PR TITLE
Don't issue warning if memray_trace_components was not set

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -2682,7 +2682,7 @@ profiling:
         memray flamegraph $AIRFLOW_HOME/<component>_memory.bin
         ```
         This is an expensive operation and generally should not be used except for debugging purposes.
-      version_added: 3.1.2
+      version_added: 3.2.0
       type: string
       example: "scheduler,api,dag_processor"
-      default: ""
+      default: ~

--- a/shared/configuration/src/airflow_shared/configuration/parser.py
+++ b/shared/configuration/src/airflow_shared/configuration/parser.py
@@ -1081,7 +1081,8 @@ class AirflowConfigParser(ConfigParser):
         val = self.get(section, key, **kwargs)
 
         if isinstance(val, list) or val is None:
-            # Given a fallback that was already a list, don't try to parse it
+            # `get` will always return a (possibly-empty) string, so the only way we can
+            # have these types is with `fallback=` was specified. So just return it.
             return val
 
         if val == "":

--- a/shared/configuration/src/airflow_shared/configuration/parser.py
+++ b/shared/configuration/src/airflow_shared/configuration/parser.py
@@ -1079,13 +1079,14 @@ class AirflowConfigParser(ConfigParser):
     def getlist(self, section: str, key: str, delimiter=",", **kwargs):
         """Get config value as list."""
         val = self.get(section, key, **kwargs)
-        if val is None:
-            if "fallback" in kwargs:
-                return kwargs["fallback"]
-            raise AirflowConfigException(
-                f"Failed to convert value None to list. "
-                f'Please check "{key}" key in "{section}" section is set.'
-            )
+
+        if isinstance(val, list) or val is None:
+            # Given a fallback that was already a list, don't try to parse it
+            return val
+
+        if val == "":
+            return []
+
         try:
             return [item.strip() for item in val.split(delimiter)]
         except Exception:
@@ -1119,7 +1120,9 @@ class AirflowConfigParser(ConfigParser):
 
     def getenumlist(self, section: str, key: str, enum_class: type[E], delimiter=",", **kwargs) -> list[E]:
         """Get config value as list of enums."""
+        kwargs.setdefault("fallback", [])
         string_list = self.getlist(section, key, delimiter, **kwargs)
+
         enum_names = [enum_item.name for enum_item in enum_class]
         enum_list = []
 
@@ -1128,8 +1131,9 @@ class AirflowConfigParser(ConfigParser):
                 enum_list.append(enum_class[val])
             except KeyError:
                 log.warning(
-                    "Failed to convert value. Please check %s key in %s section. "
+                    "Failed to convert value %r. Please check %s key in %s section. "
                     "it must be one of %s, if not the value is ignored",
+                    val,
                     key,
                     section,
                     ", ".join(enum_names),

--- a/shared/configuration/tests/configuration/test_parser.py
+++ b/shared/configuration/tests/configuration/test_parser.py
@@ -154,11 +154,9 @@ key2 = 1.23
     def test_getlist(self):
         """Test AirflowConfigParser.getlist"""
         test_config = """
-[empty]
-key0 = willbereplacedbymock
-
 [single]
 key1 = str
+empty =
 
 [many]
 key2 = one,two,three
@@ -168,19 +166,19 @@ key3 = one;two;three
 """
         test_conf = AirflowConfigParser(default_config=test_config)
         single = test_conf.getlist("single", "key1")
-        assert isinstance(single, list)
-        assert len(single) == 1
+        assert single == ["str"]
+
+        empty = test_conf.getlist("single", "empty")
+        assert empty == []
+
         many = test_conf.getlist("many", "key2")
-        assert isinstance(many, list)
-        assert len(many) == 3
+        assert many == ["one", "two", "three"]
+
         semicolon = test_conf.getlist("diffdelimiter", "key3", delimiter=";")
-        assert isinstance(semicolon, list)
-        assert len(semicolon) == 3
-        with patch.object(test_conf, "get", return_value=None):
-            with pytest.raises(
-                AirflowConfigException, match=re.escape("Failed to convert value None to list.")
-            ):
-                test_conf.getlist("empty", "key0")
+        assert semicolon == ["one", "two", "three"]
+
+        assert test_conf.getlist("empty", "key0", fallback=None) is None
+        assert test_conf.getlist("empty", "key0", fallback=[]) == []
 
     @pytest.mark.parametrize(
         ("config_str", "expected"),


### PR DESCRIPTION
Previously this was giving a warning like this:

> [warning  ] Failed to convert value. Please check memray_trace_components
> key in profiling section. it must be one of scheduler, dag_processor, api, if
> not the value is ignored [airflow._shared.configuration.parser]
> loc=parser.py:1128

This was because the default was set to `""` (when none/not set is a better
default) and also getlist wasn't handling this case correctly -- it returned
it as [""].

I have also removed the special "Failed to convert value None" as there is no
way None can be set other than via a `fallback` option, so there is no way
that exception could be hit other than via the mocking done in tests.

Finally, I noticed that the version added was wrong, as this was never
included in any of the point releases in 3.1.x

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
