### PR TITLE
Improve error message for inconsistent data interval state

### DIFF
--- a/airflow-core/docs/authoring-and-scheduling/serializers.rst
+++ b/airflow-core/docs/authoring-and-scheduling/serializers.rst
@@ -28,18 +28,19 @@ like ``str`` and ``int`` and it loops over iterables. When things become more co
 
 Airflow supports custom serialization using a well-defined resolution order:
 
-First, primitive values (such as ``str`` or ``int``) and iterables of primitives
-are returned as-is, without additional encoding.
+1. Primitive values (such as ``str`` or ``int``) and iterables of primitives
+   are returned as-is, without additional encoding.
 
-If the object is not a primitive, Airflow looks for a registered serializer and
-deserializer in the ``airflow.sdk.serde.serializers`` namespace.
+2. If the object is not a primitive, Airflow looks for a registered serializer
+   and deserializer in the ``airflow.sdk.serde.serializers`` namespace.
 
-If no registered serializer is found, Airflow then checks whether the object
-defines a ``serialize()`` method (and, for deserialization, a corresponding
-``deserialize(data, version: int)`` method).
+3. If no registered serializer is found, Airflow then checks whether the object
+   defines a ``serialize()`` method (and, for deserialization, a corresponding
+   ``deserialize(data, version: int)`` method).
 
-Finally, if the object is decorated with ``@dataclass`` or ``@attr.define``,
-Airflow serializes the object using the public fields provided by those decorators.
+4. Finally, if the object is decorated with ``@dataclass`` or ``@attr.define``,
+   Airflow serializes the object using the public fields provided by those
+   decorators.
 
 If you are looking to extend Airflow with a new serializer, it is good to know when to choose what way of serialization.
 Objects that are under the control of Airflow, i.e. residing under the namespace of ``airflow.*`` like

--- a/airflow-core/docs/authoring-and-scheduling/serializers.rst
+++ b/airflow-core/docs/authoring-and-scheduling/serializers.rst
@@ -26,12 +26,20 @@ and efficiency.
 Serialization is a surprisingly hard job. Python out of the box only has support for serialization of primitives,
 like ``str`` and ``int`` and it loops over iterables. When things become more complex, custom serialization is required.
 
-Airflow out of the box supports three ways of custom serialization. Primitives are returned as is, without
-additional encoding, e.g. a ``str`` remains a ``str``. When it is not a primitive (or iterable thereof) Airflow
-looks for a registered serializer and deserializer in the namespace of ``airflow.sdk.serde.serializers``.
-If not found it will look in the class for a ``serialize()`` method or in case of deserialization a
-``deserialize(data, version: int)`` method. Finally, if the class is either decorated with ``@dataclass``
-or ``@attr.define`` it will use the public methods for those decorators.
+Airflow supports custom serialization using a well-defined resolution order:
+
+First, primitive values (such as ``str`` or ``int``) and iterables of primitives
+are returned as-is, without additional encoding.
+
+If the object is not a primitive, Airflow looks for a registered serializer and
+deserializer in the ``airflow.sdk.serde.serializers`` namespace.
+
+If no registered serializer is found, Airflow then checks whether the object
+defines a ``serialize()`` method (and, for deserialization, a corresponding
+``deserialize(data, version: int)`` method).
+
+Finally, if the object is decorated with ``@dataclass`` or ``@attr.define``,
+Airflow serializes the object using the public fields provided by those decorators.
 
 If you are looking to extend Airflow with a new serializer, it is good to know when to choose what way of serialization.
 Objects that are under the control of Airflow, i.e. residing under the namespace of ``airflow.*`` like

--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -191,13 +191,15 @@ class InconsistentDataInterval(AirflowException):
     prior to AIP-39), or both be datetime (for runs scheduled after AIP-39 is
     implemented). This is raised if exactly one of the fields is None.
     """
-
     _template = (
-    "Inconsistent {cls} data interval detected: "
-    "{start[0]}={start[1]!r}, {end[0]}={end[1]!r}. "
-    "Both fields must be either None (pre-AIP-39 runs) or datetime. "
-    "This can occur due to mixed DAG run metadata or an invalid timetable configuration."
-)
+        "Inconsistent {cls} data interval detected: "
+        "{start[0]}={start[1]!r}, {end[0]}={end[1]!r}. "
+        "Both fields must be either None (pre-AIP-39 runs) or datetime. "
+        "This can occur due to mixed DAG run metadata or an invalid timetable "
+        "configuration."
+    )
+
+
     def __init__(self, instance: Any, start_field_name: str, end_field_name: str) -> None:
         self._class_name = type(instance).__name__
         self._start_field = (start_field_name, getattr(instance, start_field_name))

--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -193,10 +193,11 @@ class InconsistentDataInterval(AirflowException):
     """
 
     _template = (
-        "Inconsistent {cls}: {start[0]}={start[1]!r}, {end[0]}={end[1]!r}, "
-        "they must be either both None or both datetime"
-    )
-
+    "Inconsistent {cls} data interval detected: "
+    "{start[0]}={start[1]!r}, {end[0]}={end[1]!r}. "
+    "Both fields must be either None (pre-AIP-39 runs) or datetime. "
+    "This can occur due to mixed DAG run metadata or an invalid timetable configuration."
+)
     def __init__(self, instance: Any, start_field_name: str, end_field_name: str) -> None:
         self._class_name = type(instance).__name__
         self._start_field = (start_field_name, getattr(instance, start_field_name))

--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -191,6 +191,7 @@ class InconsistentDataInterval(AirflowException):
     prior to AIP-39), or both be datetime (for runs scheduled after AIP-39 is
     implemented). This is raised if exactly one of the fields is None.
     """
+
     _template = (
         "Inconsistent {cls} data interval detected: "
         "{start[0]}={start[1]!r}, {end[0]}={end[1]!r}. "
@@ -198,7 +199,6 @@ class InconsistentDataInterval(AirflowException):
         "This can occur due to mixed DAG run metadata or an invalid timetable "
         "configuration."
     )
-
 
     def __init__(self, instance: Any, start_field_name: str, end_field_name: str) -> None:
         self._class_name = type(instance).__name__


### PR DESCRIPTION
This PR improves the error message raised when a model has an inconsistent
data interval state (only one of start/end set).

The updated message provides additional context about common causes such as
pre-AIP-39 DAG runs or invalid timetable configuration.

No functional changes.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
