### PR TITLE
Convert remaining `pip check` commands to `uv pip check`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -997,7 +997,11 @@ function install_airflow_and_providers_from_docker_context_files(){
         "${install_airflow_distribution[@]}" "${install_airflow_core_distribution[@]}" "${airflow_distributions[@]}"
     set +x
     common::install_packaging_tools
-    pip check
+    # Here we should use `pip check` not `uv pip check` to detect any incompatibilities that might happen
+    # between `pip` and `uv` installations
+    # However, in the current version of `pip` there is a bug that incorrectly detects `pagefind-bin` as unsupported
+    # https://github.com/pypa/pip/issues/13709 -> once this is fixed, we should bring `pip check` back.
+    uv pip check
 }
 
 function install_all_other_distributions_from_docker_context_files() {
@@ -1235,7 +1239,7 @@ function install_airflow_when_building_images() {
     set +x
     common::install_packaging_tools
     echo
-    echo "${COLOR_BLUE}Running 'uv pip check'${COLOR_RESET}"
+    echo "${COLOR_BLUE}Running 'pip check'${COLOR_RESET}"
     echo
     # Here we should use `pip check` not `uv pip check` to detect any incompatibilities that might happen
     # between `pip` and `uv` installations
@@ -1276,7 +1280,11 @@ function install_additional_dependencies() {
         echo
         echo "${COLOR_BLUE}Running 'pip check'${COLOR_RESET}"
         echo
-        pip check
+        # Here we should use `pip check` not `uv pip check` to detect any incompatibilities that might happen
+        # between `pip` and `uv` installations
+        # However, in the current version of `pip` there is a bug that incorrectly detects `pagefind-bin` as unsupported
+        # https://github.com/pypa/pip/issues/13709 -> once this is fixed, we should bring `pip check` back.
+        uv pip check
     else
         echo
         echo "${COLOR_BLUE}Installing additional dependencies upgrading only if needed${COLOR_RESET}"
@@ -1290,7 +1298,11 @@ function install_additional_dependencies() {
         echo
         echo "${COLOR_BLUE}Running 'pip check'${COLOR_RESET}"
         echo
-        pip check
+        # Here we should use `pip check` not `uv pip check` to detect any incompatibilities that might happen
+        # between `pip` and `uv` installations
+        # However, in the current version of `pip` there is a bug that incorrectly detects `pagefind-bin` as unsupported
+        # https://github.com/pypa/pip/issues/13709 -> once this is fixed, we should bring `pip check` back.
+        uv pip check
     fi
 }
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -988,7 +988,7 @@ function install_airflow_when_building_images() {
     set +x
     common::install_packaging_tools
     echo
-    echo "${COLOR_BLUE}Running 'uv pip check'${COLOR_RESET}"
+    echo "${COLOR_BLUE}Running 'pip check'${COLOR_RESET}"
     echo
     # Here we should use `pip check` not `uv pip check` to detect any incompatibilities that might happen
     # between `pip` and `uv` installations
@@ -1029,7 +1029,11 @@ function install_additional_dependencies() {
         echo
         echo "${COLOR_BLUE}Running 'pip check'${COLOR_RESET}"
         echo
-        pip check
+        # Here we should use `pip check` not `uv pip check` to detect any incompatibilities that might happen
+        # between `pip` and `uv` installations
+        # However, in the current version of `pip` there is a bug that incorrectly detects `pagefind-bin` as unsupported
+        # https://github.com/pypa/pip/issues/13709 -> once this is fixed, we should bring `pip check` back.
+        uv pip check
     else
         echo
         echo "${COLOR_BLUE}Installing additional dependencies upgrading only if needed${COLOR_RESET}"
@@ -1043,7 +1047,11 @@ function install_additional_dependencies() {
         echo
         echo "${COLOR_BLUE}Running 'pip check'${COLOR_RESET}"
         echo
-        pip check
+        # Here we should use `pip check` not `uv pip check` to detect any incompatibilities that might happen
+        # between `pip` and `uv` installations
+        # However, in the current version of `pip` there is a bug that incorrectly detects `pagefind-bin` as unsupported
+        # https://github.com/pypa/pip/issues/13709 -> once this is fixed, we should bring `pip check` back.
+        uv pip check
     fi
 }
 
@@ -1359,7 +1367,14 @@ function check_downgrade_sqlalchemy() {
     echo
     # shellcheck disable=SC2086
     ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} "sqlalchemy[asyncio]==${min_sqlalchemy_version}"
-    pip check
+    echo
+    echo "${COLOR_BLUE}Running 'pip check'${COLOR_RESET}"
+    echo
+    # Here we should use `pip check` not `uv pip check` to detect any incompatibilities that might happen
+    # between `pip` and `uv` installations
+    # However, in the current version of `pip` there is a bug that incorrectly detects `pagefind-bin` as unsupported
+    # https://github.com/pypa/pip/issues/13709 -> once this is fixed, we should bring `pip check` back.
+    uv pip check
 }
 
 function check_downgrade_pendulum() {
@@ -1373,7 +1388,14 @@ function check_downgrade_pendulum() {
     echo
     # shellcheck disable=SC2086
     ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} "pendulum==${min_pendulum_version}"
-    pip check
+    echo
+    echo "${COLOR_BLUE}Running 'pip check'${COLOR_RESET}"
+    echo
+    # Here we should use `pip check` not `uv pip check` to detect any incompatibilities that might happen
+    # between `pip` and `uv` installations
+    # However, in the current version of `pip` there is a bug that incorrectly detects `pagefind-bin` as unsupported
+    # https://github.com/pypa/pip/issues/13709 -> once this is fixed, we should bring `pip check` back.
+    uv pip check
 }
 
 function check_run_tests() {

--- a/scripts/docker/entrypoint_ci.sh
+++ b/scripts/docker/entrypoint_ci.sh
@@ -337,7 +337,14 @@ function check_downgrade_sqlalchemy() {
     echo
     # shellcheck disable=SC2086
     ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} "sqlalchemy[asyncio]==${min_sqlalchemy_version}"
-    pip check
+    echo
+    echo "${COLOR_BLUE}Running 'pip check'${COLOR_RESET}"
+    echo
+    # Here we should use `pip check` not `uv pip check` to detect any incompatibilities that might happen
+    # between `pip` and `uv` installations
+    # However, in the current version of `pip` there is a bug that incorrectly detects `pagefind-bin` as unsupported
+    # https://github.com/pypa/pip/issues/13709 -> once this is fixed, we should bring `pip check` back.
+    uv pip check
 }
 
 # Download minimum supported version of pendulum to run tests with it
@@ -352,7 +359,14 @@ function check_downgrade_pendulum() {
     echo
     # shellcheck disable=SC2086
     ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} "pendulum==${min_pendulum_version}"
-    pip check
+    echo
+    echo "${COLOR_BLUE}Running 'pip check'${COLOR_RESET}"
+    echo
+    # Here we should use `pip check` not `uv pip check` to detect any incompatibilities that might happen
+    # between `pip` and `uv` installations
+    # However, in the current version of `pip` there is a bug that incorrectly detects `pagefind-bin` as unsupported
+    # https://github.com/pypa/pip/issues/13709 -> once this is fixed, we should bring `pip check` back.
+    uv pip check
 }
 
 # Check if we should run tests and run them if needed

--- a/scripts/docker/install_additional_dependencies.sh
+++ b/scripts/docker/install_additional_dependencies.sh
@@ -38,7 +38,11 @@ function install_additional_dependencies() {
         echo
         echo "${COLOR_BLUE}Running 'pip check'${COLOR_RESET}"
         echo
-        pip check
+        # Here we should use `pip check` not `uv pip check` to detect any incompatibilities that might happen
+        # between `pip` and `uv` installations
+        # However, in the current version of `pip` there is a bug that incorrectly detects `pagefind-bin` as unsupported
+        # https://github.com/pypa/pip/issues/13709 -> once this is fixed, we should bring `pip check` back.
+        uv pip check
     else
         echo
         echo "${COLOR_BLUE}Installing additional dependencies upgrading only if needed${COLOR_RESET}"
@@ -52,7 +56,11 @@ function install_additional_dependencies() {
         echo
         echo "${COLOR_BLUE}Running 'pip check'${COLOR_RESET}"
         echo
-        pip check
+        # Here we should use `pip check` not `uv pip check` to detect any incompatibilities that might happen
+        # between `pip` and `uv` installations
+        # However, in the current version of `pip` there is a bug that incorrectly detects `pagefind-bin` as unsupported
+        # https://github.com/pypa/pip/issues/13709 -> once this is fixed, we should bring `pip check` back.
+        uv pip check
     fi
 }
 

--- a/scripts/docker/install_airflow_when_building_images.sh
+++ b/scripts/docker/install_airflow_when_building_images.sh
@@ -201,7 +201,7 @@ function install_airflow_when_building_images() {
     set +x
     common::install_packaging_tools
     echo
-    echo "${COLOR_BLUE}Running 'uv pip check'${COLOR_RESET}"
+    echo "${COLOR_BLUE}Running 'pip check'${COLOR_RESET}"
     echo
     # Here we should use `pip check` not `uv pip check` to detect any incompatibilities that might happen
     # between `pip` and `uv` installations

--- a/scripts/docker/install_from_docker_context_files.sh
+++ b/scripts/docker/install_from_docker_context_files.sh
@@ -122,7 +122,11 @@ function install_airflow_and_providers_from_docker_context_files(){
         "${install_airflow_distribution[@]}" "${install_airflow_core_distribution[@]}" "${airflow_distributions[@]}"
     set +x
     common::install_packaging_tools
-    pip check
+    # Here we should use `pip check` not `uv pip check` to detect any incompatibilities that might happen
+    # between `pip` and `uv` installations
+    # However, in the current version of `pip` there is a bug that incorrectly detects `pagefind-bin` as unsupported
+    # https://github.com/pypa/pip/issues/13709 -> once this is fixed, we should bring `pip check` back.
+    uv pip check
 }
 
 # Simply install all other (non-apache-airflow) distributions placed in docker-context files


### PR DESCRIPTION
Follow up after #59658 - there are few more places where canary builds used `pip check` and until the `pip` inconsistent behaviour is fixed (https://github.com/pypa/pip/issues/13709) we should use `uv pip check` instead.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
