### PR TITLE
Fix Expand+Collapse Translation Key

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/ar/browse.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ar/browse.json
@@ -1,9 +1,5 @@
 {
   "auditLog": {
-    "actions": {
-      "collapseAllExtra": "طي جميع الJSON الإضافية",
-      "expandAllExtra": "توسيع جميع الJSON الإضافية"
-    },
     "columns": {
       "event": "اصل",
       "extra": "إضافي",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ar/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ar/common.json
@@ -37,6 +37,7 @@
     "requiredActions": "إجراءات مطلوبة",
     "xcoms": "(XComs) إكس كوم"
   },
+  "collapseAllExtra": "طي جميع الJSON الإضافية",
   "collapseDetailsPanel": "طي لوحة التفاصيل",
   "createdAssetEvent_few": "تم إنشاء واقعات أصل",
   "createdAssetEvent_many": "تم إنشاء واقعات أصل",
@@ -122,6 +123,7 @@
     "hotkey": "e",
     "tooltip": "اضغط {{hotkey}} للتوسيع"
   },
+  "expandAllExtra": "توسيع جميع الJSON الإضافية",
   "expression": {
     "all": "الكل",
     "and": "و",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ca/browse.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ca/browse.json
@@ -1,9 +1,5 @@
 {
   "auditLog": {
-    "actions": {
-      "collapseAllExtra": "Col·lapsar tots els camps extra json",
-      "expandAllExtra": "Expandir tots els camps extra json"
-    },
     "columns": {
       "event": "Esdeveniment",
       "extra": "Extra",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ca/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ca/common.json
@@ -25,6 +25,7 @@
     "requiredActions": "Accions requerides",
     "xcoms": "XComs"
   },
+  "collapseAllExtra": "Col·lapsar tots els camps extra json",
   "collapseDetailsPanel": "Col·lapsar el panell de detalls",
   "createdAssetEvent_one": "Esdeveniment d'Asset creat",
   "createdAssetEvent_other": "Esdeveniments d'Asset creats",
@@ -100,6 +101,7 @@
     "hotkey": "e",
     "tooltip": "Prem {{hotkey}} per alternar l'expansió"
   },
+  "expandAllExtra": "Expandir tots els camps extra json",
   "expression": {
     "all": "Tots",
     "and": "I",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/el/browse.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/el/browse.json
@@ -1,9 +1,5 @@
 {
   "auditLog": {
-    "actions": {
-      "collapseAllExtra": "Σύμπτυξη όλων των επιπλέον json",
-      "expandAllExtra": "Ανάπτυξη όλων των επιπλέον json"
-    },
     "columns": {
       "event": "Συμβάν",
       "extra": "Επιπλέον",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/el/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/el/common.json
@@ -25,6 +25,7 @@
     "requiredActions": "Απαιτούμενες Ενέργειες",
     "xcoms": "XComs"
   },
+  "collapseAllExtra": "Σύμπτυξη όλων των επιπλέον json",
   "collapseDetailsPanel": "Σύμπτυξη Πίνακα Λεπτομερειών",
   "createdAssetEvent_one": "Δημιουργήθηκε Συμβάν Οντότητας",
   "createdAssetEvent_other": "Δημιουργήθηκαν Συμβάντα Οντοτήτων",
@@ -93,6 +94,7 @@
     "hotkey": "e",
     "tooltip": "Πατήστε {{hotkey}} για εναλλαγή ανάπτυξης"
   },
+  "expandAllExtra": "Ανάπτυξη όλων των επιπλέον json",
   "expression": {
     "all": "Όλα",
     "and": "ΚΑΙ",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/es/browse.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/es/browse.json
@@ -1,9 +1,5 @@
 {
   "auditLog": {
-    "actions": {
-      "collapseAllExtra": "Colapsar todos los extra json",
-      "expandAllExtra": "Expandir todos los extra json"
-    },
     "columns": {
       "event": "Evento",
       "extra": "Extra",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/es/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/es/common.json
@@ -28,6 +28,7 @@
     "requiredActions": "Acciones Requeridas",
     "xcoms": "XComs"
   },
+  "collapseAllExtra": "Colapsar todos los extra json",
   "collapseDetailsPanel": "Colapsar Detalles del Panel",
   "createdAssetEvent_many": "Eventos de Asset Creados",
   "createdAssetEvent_one": "Evento de Asset Creado",
@@ -104,6 +105,7 @@
     "hotkey": "e",
     "tooltip": "Presiona {{hotkey}} para alternar expandir"
   },
+  "expandAllExtra": "Expandir todos los extra json",
   "expression": {
     "all": "Todos",
     "and": "Y",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/browse.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/browse.json
@@ -1,9 +1,5 @@
 {
   "auditLog": {
-    "actions": {
-      "collapseAllExtra": "Réduire tous les extra json",
-      "expandAllExtra": "Ouvrir tous les extra json"
-    },
     "columns": {
       "event": "Événement",
       "extra": "Extra",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/common.json
@@ -28,6 +28,7 @@
     "requiredActions": "Actions requises",
     "xcoms": "XComs"
   },
+  "collapseAllExtra": "Réduire tous les extra json",
   "collapseDetailsPanel": "Replier le panneau des détails",
   "createdAssetEvent_many": "Événements d'Asset créés",
   "createdAssetEvent_one": "Événement d'Asset créé",
@@ -99,6 +100,7 @@
     "hotkey": "e",
     "tooltip": "Appuyez sur {{hotkey}} pour développer/réduire"
   },
+  "expandAllExtra": "Ouvrir tous les extra json",
   "expression": {
     "all": "Tous",
     "and": "Et",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/hi/browse.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/hi/browse.json
@@ -1,9 +1,5 @@
 {
   "auditLog": {
-    "actions": {
-      "collapseAllExtra": "सभी अतिरिक्त JSON को संकुचित करें",
-      "expandAllExtra": "सभी अतिरिक्त JSON को विस्तृत करें"
-    },
     "columns": {
       "event": "इवेंट",
       "extra": "अतिरिक्त",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/hi/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/hi/common.json
@@ -18,6 +18,7 @@
     "requiredActions": "आवश्यक क्रियाएं",
     "xcoms": "XComs"
   },
+  "collapseAllExtra": "सभी अतिरिक्त JSON को संकुचित करें",
   "collapseDetailsPanel": "विवरण पैनल को छुपाएं",
   "createdAssetEvent_one": "बनाया गया एसेट इवेंट",
   "createdAssetEvent_other": "बनाए गए एसेट इवेंट्स",
@@ -85,6 +86,7 @@
     "hotkey": "e",
     "tooltip": "विस्तार को टॉगल करने के लिए {{hotkey}} दबाएं"
   },
+  "expandAllExtra": "सभी अतिरिक्त JSON को विस्तृत करें",
   "expression": {
     "all": "सभी",
     "and": "और",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/hu/browse.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/hu/browse.json
@@ -1,9 +1,5 @@
 {
   "auditLog": {
-    "actions": {
-      "collapseAllExtra": "Összes extra JSON összecsukása",
-      "expandAllExtra": "Összes extra JSON kibontása"
-    },
     "columns": {
       "event": "Esemény",
       "extra": "Extra",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/hu/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/hu/common.json
@@ -25,6 +25,7 @@
     "requiredActions": "Szükséges műveletek",
     "xcoms": "XComok"
   },
+  "collapseAllExtra": "Összes extra JSON összecsukása",
   "collapseDetailsPanel": "Részletek panel összecsukása",
   "createdAssetEvent_one": "Létrehozott adatkészlet esemény",
   "createdAssetEvent_other": "Létrehozott adatkészlet események",
@@ -98,6 +99,7 @@
     "hotkey": "e",
     "tooltip": "Nyomd meg a(z) {{hotkey}} gombot a kibontáshoz"
   },
+  "expandAllExtra": "Összes extra JSON kibontása",
   "expression": {
     "all": "Mind",
     "and": "ÉS",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/it/browse.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/it/browse.json
@@ -1,9 +1,5 @@
 {
   "auditLog": {
-    "actions": {
-      "collapseAllExtra": "Collassa tutti i json extra",
-      "expandAllExtra": "Espandi tutti i json extra"
-    },
     "columns": {
       "event": "Evento",
       "extra": "Extra",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/it/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/it/common.json
@@ -31,6 +31,7 @@
     "requiredActions": "Azioni Richieste",
     "xcoms": "XComs"
   },
+  "collapseAllExtra": "Collassa tutti i json extra",
   "collapseDetailsPanel": "Collassa i Dettagli",
   "createdAssetEvent_many": "Eventi Asset Creati",
   "createdAssetEvent_one": "Evento Asset Creato",
@@ -110,6 +111,7 @@
     "hotkey": "e",
     "tooltip": "Premi {{hotkey}} per attivare/disattivare espansione"
   },
+  "expandAllExtra": "Espandi tutti i json extra",
   "expression": {
     "all": "Tutti",
     "and": "E",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/nl/browse.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/nl/browse.json
@@ -1,9 +1,5 @@
 {
   "auditLog": {
-    "actions": {
-      "collapseAllExtra": "All extra JSON inklappen",
-      "expandAllExtra": "Alle extra JSON uitklappen"
-    },
     "columns": {
       "event": "Event",
       "extra": "Extra",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/nl/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/nl/common.json
@@ -25,6 +25,7 @@
     "requiredActions": "Vereiste acties",
     "xcoms": "XComs"
   },
+  "collapseAllExtra": "All extra JSON inklappen",
   "collapseDetailsPanel": "Details inklappen",
   "createdAssetEvent_one": "Asset Event aangemaakt",
   "createdAssetEvent_other": "Asset Events aangemaakt",
@@ -99,6 +100,7 @@
     "hotkey": "e",
     "tooltip": "Druk op {{hotkey}} op in- of uit te klappen"
   },
+  "expandAllExtra": "Alle extra JSON uitklappen",
   "expression": {
     "all": "Alles",
     "and": "En",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt/browse.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt/browse.json
@@ -1,9 +1,5 @@
 {
   "auditLog": {
-    "actions": {
-      "collapseAllExtra": "Recolher todos os extra json",
-      "expandAllExtra": "Expandir todos os extra json"
-    },
     "columns": {
       "event": "Evento",
       "extra": "Extra",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt/common.json
@@ -31,6 +31,7 @@
     "requiredActions": "Ações Necessárias",
     "xcoms": "XComs"
   },
+  "collapseAllExtra": "Recolher todos os extra json",
   "collapseDetailsPanel": "Recolher Painel de Detalhes",
   "createdAssetEvent_many": "Eventos de Asset Criados",
   "createdAssetEvent_one": "Evento de Asset Criado",
@@ -110,6 +111,7 @@
     "hotkey": "Pressione {{hotkey}} para expandir ou recolher",
     "tooltip": "Pressione {{hotkey}} para expandir ou recolher a secção"
   },
+  "expandAllExtra": "Expandir todos os extra json",
   "expression": {
     "all": "Todos",
     "and": "E",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/th/browse.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/th/browse.json
@@ -1,9 +1,5 @@
 {
   "auditLog": {
-    "actions": {
-      "collapseAllExtra": "ย่อข้อมูล JSON เพิ่มเติมทั้งหมด",
-      "expandAllExtra": "ขยายข้อมูล JSON เพิ่มเติมทั้งหมด"
-    },
     "columns": {
       "event": "อีเวนต์",
       "extra": "เพิ่มเติม",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/th/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/th/common.json
@@ -25,6 +25,7 @@
     "requiredActions": "การดำเนินการที่จำเป็น",
     "xcoms": "XComs"
   },
+  "collapseAllExtra": "ย่อข้อมูล JSON เพิ่มเติมทั้งหมด",
   "collapseDetailsPanel": "ย่อแผงรายละเอียด",
   "createdAssetEvent_one": "อีเวนต์ของ Asset ที่สร้างแล้ว",
   "createdAssetEvent_other": "อีเวนต์ของ Assets ที่สร้างแล้ว",
@@ -93,6 +94,7 @@
     "hotkey": "e",
     "tooltip": "กด {{hotkey}} เพื่อสลับการขยาย"
   },
+  "expandAllExtra": "ขยายข้อมูล JSON เพิ่มเติมทั้งหมด",
   "expression": {
     "all": "ทั้งหมด",
     "and": "และ",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/tr/browse.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/tr/browse.json
@@ -1,9 +1,5 @@
 {
   "auditLog": {
-    "actions": {
-      "collapseAllExtra": "Tüm ek JSON'ları daralt",
-      "expandAllExtra": "Tüm ek JSON'ları genişlet"
-    },
     "columns": {
       "event": "Etkinlik",
       "extra": "Ek Bilgi",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/tr/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/tr/common.json
@@ -25,6 +25,7 @@
     "requiredActions": "Gerekli Eylemler",
     "xcoms": "XCom'lar"
   },
+  "collapseAllExtra": "Tüm ek JSON'ları daralt",
   "collapseDetailsPanel": "Detay Panelini Daralt",
   "createdAssetEvent_one": "Oluşturulan Varlık Etkinliği",
   "createdAssetEvent_other": "Oluşturulan Varlık Etkinlikleri",
@@ -100,6 +101,7 @@
     "hotkey": "e",
     "tooltip": "{{hotkey}} tuşuna basarak genişletmeyi değiştir"
   },
+  "expandAllExtra": "Tüm ek JSON'ları genişlet",
   "expression": {
     "all": "Tümü",
     "and": "VE",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/browse.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/browse.json
@@ -1,9 +1,5 @@
 {
   "auditLog": {
-    "actions": {
-      "collapseAllExtra": "收起所有额外 JSON",
-      "expandAllExtra": "展开所有额外 JSON"
-    },
     "columns": {
       "event": "事件",
       "extra": "额外信息",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/common.json
@@ -25,6 +25,7 @@
     "requiredActions": "待响应的任务实例",
     "xcoms": "XComs"
   },
+  "collapseAllExtra": "收起所有额外 JSON",
   "collapseDetailsPanel": "收起详细信息",
   "createdAssetEvent_one": "已创建资源事件",
   "createdAssetEvent_other": "已创建资源事件",
@@ -93,6 +94,7 @@
     "hotkey": "e",
     "tooltip": "按下 {{hotkey}} 切换展开"
   },
+  "expandAllExtra": "展开所有额外 JSON",
   "expression": {
     "all": "全部",
     "and": "且",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/browse.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/browse.json
@@ -1,9 +1,5 @@
 {
   "auditLog": {
-    "actions": {
-      "collapseAllExtra": "收合所有額外 JSON",
-      "expandAllExtra": "展開所有額外 JSON"
-    },
     "columns": {
       "event": "事件",
       "extra": "額外資訊",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/common.json
@@ -25,6 +25,7 @@
     "requiredActions": "待回應的任務實例",
     "xcoms": "XComs"
   },
+  "collapseAllExtra": "收合所有額外 JSON",
   "collapseDetailsPanel": "收起詳細資訊",
   "createdAssetEvent_one": "已建立資源事件",
   "createdAssetEvent_other": "已建立資源事件",
@@ -100,6 +101,7 @@
     "hotkey": "e",
     "tooltip": "按下 {{hotkey}} 切換展開"
   },
+  "expandAllExtra": "展開所有額外 JSON",
   "expression": {
     "all": "全部",
     "and": "且",

--- a/airflow-core/src/airflow/ui/src/pages/Events/Events.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Events/Events.tsx
@@ -221,8 +221,8 @@ export const Events = () => {
       <Flex alignItems="center" justifyContent="space-between">
         <EventsFilters urlDagId={dagId} urlRunId={runId} urlTaskId={taskId} />
         <ExpandCollapseButtons
-          collapseLabel={translate("collapseAllExtra")}
-          expandLabel={translate("expandAllExtra")}
+          collapseLabel={translate("common:collapseAllExtra")}
+          expandLabel={translate("common:expandAllExtra")}
           onCollapse={onClose}
           onExpand={onOpen}
         />

--- a/airflow-core/src/airflow/ui/src/pages/XCom/XCom.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/XCom/XCom.tsx
@@ -210,8 +210,8 @@ export const XCom = () => {
             />
           ) : undefined}
           <ExpandCollapseButtons
-            collapseLabel={translate("collapseAllExtra")}
-            expandLabel={translate("expandAllExtra")}
+            collapseLabel={translate("common:collapseAllExtra")}
+            expandLabel={translate("common:expandAllExtra")}
             onCollapse={onClose}
             onExpand={onOpen}
           />


### PR DESCRIPTION
While testing #59671 I noticed that the movement of the translation key `collapseAllExtra` and `expandAllExtra` as a bit in-consistent, also all languages were not adjusted and did not move translation key. This PR fixes this and adjusts all (except German) translations to be correctly translated based on the previous key name. Label was "generic" in the past so I assume a re-translation is not needed.