### PR TITLE
Add Content-Type to Request Header in Task SDK calls, fix logic

### DIFF
--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -914,7 +914,9 @@ class Client(httpx.Client):
     def request(self, *args, **kwargs):
         """Implement a convenience for httpx.Client.request with a retry layer."""
         # Set content type as convenience if not already set
-        if "content" in kwargs and "headers" not in kwargs:
+        if kwargs.get("content", None) is not None and "content-type" not in (
+            kwargs.get("headers", {}) or {}
+        ):
             kwargs["headers"] = {"content-type": "application/json"}
 
         return super().request(*args, **kwargs)


### PR DESCRIPTION
After we deployed Airflow 3.1.5 to our environment @AutomationDev85 and me noticed that still the WAF rules hit the deployment and debugging one level deeper revealed a logic problem of the fix applied in #57377:

The call from base class `patch()` to the extended `Client` from TaskSDK uses actually (empty) kwargs for content and header (e.g. passing `content=None` and `header=None` which then made the header not applied. See also https://github.com/encode/httpx/blob/master/httpx/_client.py#L1221

This PR corrects the logic to check for "if any content is to be submitted" and "No header for content type set". With this the content-type header is now consistently applied making our WAF happy.