### PR TITLE
Draft: Provider documentation URL handling for custom providers

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Providers.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Providers.tsx
@@ -16,6 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
+// TODO: Allow providers to define custom documentation URLs
+
 import { Box, Heading, Link } from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
 import type { TFunction } from "i18next";

--- a/airflow-core/src/airflow/ui/src/pages/Providers.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Providers.tsx
@@ -33,22 +33,29 @@ import { ErrorAlert } from "src/components/ErrorAlert";
 import { urlRegex } from "src/constants/urlRegex";
 
 const createColumns = (translate: TFunction): Array<ColumnDef<ProviderResponse>> => [
-  {
-    accessorKey: "package_name",
-    cell: ({ row: { original } }) => (
+{
+  accessorKey: "package_name",
+  cell: ({ row: { original } }) => {
+    const documentationUrl =
+      original?.project_urls?.documentation ??
+      `https://airflow.apache.org/docs/${original.package_name}/${original.version}/`;
+
+    return (
       <Link
         aria-label={original.package_name}
         color="fg.info"
-        href={`https://airflow.apache.org/docs/${original.package_name}/${original.version}/`}
+        href={documentationUrl}
         rel="noopener noreferrer"
         target="_blank"
       >
         {original.package_name}
       </Link>
-    ),
-    enableSorting: false,
-    header: translate("providers.columns.packageName"),
+    );
   },
+  enableSorting: false,
+  header: translate("providers.columns.packageName"),
+},
+
   {
     accessorKey: "version",
     cell: ({ row: { original } }) => original.version,


### PR DESCRIPTION
Draft PR to start work on allowing custom providers to define their own documentation URLs.

Related issue: #59576

This PR currently only adds a TODO marker in the UI code to highlight where
provider-specific documentation URLs should be handled.

No functional changes yet. This draft is meant for coordination and early feedback.


---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
