### PR TITLE
Remove global from listener

### DIFF
--- a/airflow-core/tests/unit/listeners/class_listener.py
+++ b/airflow-core/tests/unit/listeners/class_listener.py
@@ -34,8 +34,7 @@ class ClassBasedListener:
 
     @hookimpl
     def before_stopping(self, component):
-        global stopped_component
-        stopped_component = component
+        self.stopped_component = component
         self.state.append(DagRunState.SUCCESS)
 
     @hookimpl


### PR DESCRIPTION
Another small increment to remove global statements for PR https://github.com/apache/airflow/pull/58116

This removes global statement from some listener pytest.
Actually I am not sure how and where this is used, could not find any reference. Let's see if tests just turn green

`global` is evil. Also in pytests :-D