### PR TITLE
Remove alias for schema field in Connection response

### DIFF
--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -86,8 +86,7 @@ dependencies = [
     "deprecated>=1.2.13",
     "dill>=0.2.2",
     # limited due to changes needed https://github.com/fastapi/fastapi/pull/14434
-    # and the bug in fastapi 0.126.0 https://github.com/fastapi/fastapi/pull/14575#issuecomment-3678581316
-    "fastapi[standard-no-fastapi-cloud-cli]>=0.121.0, !=0.123.5, !=0.126.0",
+    "fastapi[standard-no-fastapi-cloud-cli]>=0.121.0, !=0.123.5",
     "uvicorn>=0.37.0",
     "starlette>=0.45.0",
     "httpx>=0.25.0",

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
@@ -37,7 +37,7 @@ class ConnectionResponse(BaseModel):
     description: str | None
     host: str | None
     login: str | None
-    schema_: str | None = Field(alias="schema")
+    schema: str | None
     port: int | None
     password: str | None
     extra: str | None


### PR DESCRIPTION
The alias and cadwyn does not play well together, and since
Pydantic v2 does not use the `schema` any more, we can get rid of
the alias.

This caused the issue with 0.126.0 version of fastapi:

https://github.com/fastapi/fastapi/pull/14575#issuecomment-3678581316

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
