### PR TITLE
Remove global from shared airflow code

### DIFF
--- a/shared/secrets_masker/src/airflow_shared/secrets_masker/secrets_masker.py
+++ b/shared/secrets_masker/src/airflow_shared/secrets_masker/secrets_masker.py
@@ -127,9 +127,7 @@ def merge(
     return _secrets_masker().merge(new_value, old_value, name, max_depth)
 
 
-_global_secrets_masker: SecretsMasker | None = None
-
-
+@cache
 def _secrets_masker() -> SecretsMasker:
     """
     Get or create the module-level secrets masker instance.
@@ -139,10 +137,7 @@ def _secrets_masker() -> SecretsMasker:
     airflow.sdk._shared) will have separate global variables and thus separate
     masker instances.
     """
-    global _global_secrets_masker
-    if _global_secrets_masker is None:
-        _global_secrets_masker = SecretsMasker()
-    return _global_secrets_masker
+    return SecretsMasker()
 
 
 def reset_secrets_masker() -> None:


### PR DESCRIPTION
Another small increment to remove global statements for PR https://github.com/apache/airflow/pull/58116

This removes global statement from shared code. One is using a static field in a class the other can be prevented with a @cache annotation.

`global` is evil. Especially in shared code :-D