### PR TITLE
Fix upstream map index resolution after placeholder expansion

### DIFF
--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -2383,6 +2383,14 @@ def _get_relevant_map_indexes(
     # and "ti_count == ancestor_ti_count" does not work, since the further
     # expansion may be of length 1.
     if not _is_further_mapped_inside(relative, common_ancestor):
+        placeholder_index = _resolve_placeholder_map_index(
+            task=task, relative=relative, map_index=ancestor_map_index, run_id=run_id, session=session
+        )
+        # Handle cases where an upstream mapped placeholder (map_index = -1) has already
+        # been expanded and replaced by its successor (map_index = 0) at evaluation time.
+        if placeholder_index is not None:
+            return placeholder_index
+
         return ancestor_map_index
 
     # Otherwise we need a partial aggregation for values from selected task
@@ -2455,6 +2463,54 @@ def find_relevant_relatives(
     _visit_relevant_relatives_for_normal(normal_tasks)
     _visit_relevant_relatives_for_mapped(mapped_tasks)
     return visited
+
+
+def _resolve_placeholder_map_index(
+    *,
+    task: Operator,
+    relative: Operator,
+    map_index: int,
+    run_id: str,
+    session: Session,
+) -> int | None:
+    """
+    Resolve the correct map_index for upstream dependency evaluation.
+
+    This handles the transition from map_index = -1 (pre-expansion placeholder)
+    to map_index = 0 (post-expansion placeholder successor).
+
+    Returns:
+        - 0 if the placeholder has transitioned from -1 to 0
+        - None if no override should be applied
+    """
+    if map_index != -1:
+        return None
+
+    rows = session.execute(
+        select(TaskInstance.task_id, TaskInstance.map_index).where(
+            TaskInstance.dag_id == relative.dag_id,
+            TaskInstance.run_id == run_id,
+            TaskInstance.task_id.in_([task.task_id, relative.task_id]),
+            TaskInstance.map_index.in_([-1, 0]),
+        )
+    ).all()
+
+    task_to_map_indexes: dict[str, list[int]] = defaultdict(list)
+    for task_id, mi in rows:
+        task_to_map_indexes[task_id].append(mi)
+
+    # We only rewrite when:
+    # 1) the current task is still using the placeholder (-1)
+    # 2) the upstream placeholder (-1) no longer exists
+    # 3) the post-expansion placeholder (0) does exist
+    if (
+        -1 in task_to_map_indexes.get(task.task_id, [])
+        and -1 not in task_to_map_indexes.get(relative.task_id, [])
+        and 0 in task_to_map_indexes.get(relative.task_id, [])
+    ):
+        return 0
+
+    return None
 
 
 class TaskInstanceNote(Base):

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -2383,15 +2383,19 @@ def _get_relevant_map_indexes(
     # and "ti_count == ancestor_ti_count" does not work, since the further
     # expansion may be of length 1.
     if not _is_further_mapped_inside(relative, common_ancestor):
-        placeholder_index = _resolve_placeholder_map_index(
-            task=task, relative=relative, map_index=ancestor_map_index, run_id=run_id, session=session
+        # During mapped task group expansion, upstream placeholder task instances
+        # (map_index = -1) may already have been replaced by their first expanded
+        # successor (map_index = 0) while downstream task instances are still
+        # unexpanded and continue resolving dependencies against the placeholder index.
+        resolved_map_index = (
+            0
+            if _should_use_post_expansion_placeholder(
+                task=task, relative=relative, map_index=ancestor_map_index, run_id=run_id, session=session
+            )
+            else ancestor_map_index
         )
-        # Handle cases where an upstream mapped placeholder (map_index = -1) has already
-        # been expanded and replaced by its successor (map_index = 0) at evaluation time.
-        if placeholder_index is not None:
-            return placeholder_index
 
-        return ancestor_map_index
+        return resolved_map_index
 
     # Otherwise we need a partial aggregation for values from selected task
     # instances in the ancestor's expansion context.
@@ -2465,26 +2469,23 @@ def find_relevant_relatives(
     return visited
 
 
-def _resolve_placeholder_map_index(
+def _should_use_post_expansion_placeholder(
     *,
     task: Operator,
     relative: Operator,
     map_index: int,
     run_id: str,
     session: Session,
-) -> int | None:
+) -> bool:
     """
-    Resolve the correct map_index for upstream dependency evaluation.
+    Determine whether upstream dependency resolution should use map_index = 0.
 
-    This handles the transition from map_index = -1 (pre-expansion placeholder)
-    to map_index = 0 (post-expansion placeholder successor).
-
-    Returns:
-        - 0 if the placeholder has transitioned from -1 to 0
-        - None if no override should be applied
+    Returns True when the upstream placeholder task instance
+    (map_index = -1) has already been replaced by its post-expansion
+    successor (map_index = 0).
     """
     if map_index != -1:
-        return None
+        return False
 
     rows = session.execute(
         select(TaskInstance.task_id, TaskInstance.map_index).where(
@@ -2495,22 +2496,19 @@ def _resolve_placeholder_map_index(
         )
     ).all()
 
-    task_to_map_indexes: dict[str, list[int]] = defaultdict(list)
+    task_to_map_indexes: dict[str, set[int]] = defaultdict(set)
     for task_id, mi in rows:
-        task_to_map_indexes[task_id].append(mi)
+        task_to_map_indexes[task_id].add(mi)
 
     # We only rewrite when:
     # 1) the current task is still using the placeholder (-1)
     # 2) the upstream placeholder (-1) no longer exists
     # 3) the post-expansion placeholder (0) does exist
-    if (
-        -1 in task_to_map_indexes.get(task.task_id, [])
-        and -1 not in task_to_map_indexes.get(relative.task_id, [])
-        and 0 in task_to_map_indexes.get(relative.task_id, [])
-    ):
-        return 0
-
-    return None
+    return (
+        -1 in task_to_map_indexes[task.task_id]
+        and -1 not in task_to_map_indexes[relative.task_id]
+        and 0 in task_to_map_indexes[relative.task_id]
+    )
 
 
 class TaskInstanceNote(Base):

--- a/airflow-core/tests/unit/models/test_taskinstance.py
+++ b/airflow-core/tests/unit/models/test_taskinstance.py
@@ -3434,9 +3434,10 @@ def test_downstream_placeholder_handles_upstream_post_expansion(dag_maker, sessi
     (map_index = -1) has been replaced by the first expanded task
     (map_index = 0).
 
-    This verifies that trigger rule evaluation correctly resolves relevant
-    upstream map indexes both when referencing the original placeholder
-    and when referencing the first expanded task instance.
+    This verifies that downstream mapped dependency resolution:
+    - preserves placeholder behavior before upstream expansion
+    - correctly resolves the post-expansion transition
+    - preserves normal expanded task behavior afterwards
     """
 
     with dag_maker(session=session) as dag:
@@ -3472,6 +3473,23 @@ def test_downstream_placeholder_handles_upstream_post_expansion(dag_maker, sessi
 
     dag_maker.run_ti("get_mapping_source", map_index=-1, dag_run=dr, session=session)
 
+    upstream_task = dag.get_task("mapped_task")
+    downstream_task = dag.get_task("downstream")
+
+    # Before upstream expansion occurs, mapped dependency resolution
+    # should retain the existing placeholder semantics since no concrete
+    # upstream/downstream map index pairing exists yet.
+    downstream_ti = dr.get_task_instance(task_id="downstream", map_index=-1, session=session)
+    downstream_ti.refresh_from_task(downstream_task)
+
+    result = downstream_ti.get_relevant_upstream_map_indexes(
+        upstream=upstream_task,
+        ti_count=1,
+        session=session,
+    )
+
+    assert result == -3
+
     # Force expansion of the upstream mapped task.
     upstream_task = dag.get_task("mapped_task")
     _, max_index = TaskMap.expand_mapped_task(
@@ -3479,7 +3497,7 @@ def test_downstream_placeholder_handles_upstream_post_expansion(dag_maker, sessi
         dr.run_id,
         session=session,
     )
-    expanded_ti_count = max_index + 1
+    upstream_expanded_ti_count = max_index + 1
 
     downstream_task = dag.get_task("downstream")
 
@@ -3489,7 +3507,7 @@ def test_downstream_placeholder_handles_upstream_post_expansion(dag_maker, sessi
 
     result = downstream_ti.get_relevant_upstream_map_indexes(
         upstream=upstream_task,
-        ti_count=expanded_ti_count,
+        ti_count=upstream_expanded_ti_count,
         session=session,
     )
 
@@ -3502,20 +3520,20 @@ def test_downstream_placeholder_handles_upstream_post_expansion(dag_maker, sessi
         dr.run_id,
         session=session,
     )
-    expanded_ti_count = max_index + 1
+    downstream_expanded_ti_count = max_index + 1
 
-    # Grab the first expanded downstream task. Behavior is the same for all cases where map_index >= 0.
+    # Grab the first expanded downstream task instance (map_index = 0).
     downstream_ti = dr.get_task_instance(task_id="downstream", map_index=0, session=session)
     downstream_ti.refresh_from_task(downstream_task)
 
     result = downstream_ti.get_relevant_upstream_map_indexes(
         upstream=upstream_task,
-        ti_count=expanded_ti_count,
+        ti_count=downstream_expanded_ti_count,
         session=session,
     )
 
-    # Verify behavior remains unchanged once the downstream task itself
-    # has expanded (map_index >= 0).
+    # Verify behavior remains unchanged once the downstream task
+    # itself has expanded.
     assert result == 0
 
 

--- a/airflow-core/tests/unit/models/test_taskinstance.py
+++ b/airflow-core/tests/unit/models/test_taskinstance.py
@@ -3428,6 +3428,97 @@ def test_find_relevant_relatives(dag_maker, session, normal_tasks, mapped_tasks,
     assert result == expected
 
 
+def test_downstream_placeholder_handles_upstream_post_expansion(dag_maker, session):
+    """
+    Test dynamic task mapping behavior when an upstream placeholder task
+    (map_index = -1) has been replaced by the first expanded task
+    (map_index = 0).
+
+    This verifies that trigger rule evaluation correctly resolves relevant
+    upstream map indexes both when referencing the original placeholder
+    and when referencing the first expanded task instance.
+    """
+
+    with dag_maker(session=session) as dag:
+
+        @task
+        def get_mapping_source():
+            return ["one", "two", "three"]
+
+        @task
+        def mapped_task(x):
+            output = f"{x}"
+            return output
+
+        @task_group(prefix_group_id=False)
+        def the_task_group(x):
+            start = MockOperator(task_id="start")
+            upstream = mapped_task(x)
+
+            # Downstream task inside the task group that does not directly
+            # consume the expand input, but is still mapped via the mapped
+            # task group context.
+            downstream = MockOperator(task_id="downstream")
+
+            start >> upstream >> downstream
+
+        mapping_source = get_mapping_source()
+        mapped_tg = the_task_group.expand(x=mapping_source)
+
+        mapping_source >> mapped_tg
+
+    # Create DAG run and execute prerequisites.
+    dr = dag_maker.create_dagrun()
+
+    dag_maker.run_ti("get_mapping_source", map_index=-1, dag_run=dr, session=session)
+
+    # Force expansion of the upstream mapped task.
+    upstream_task = dag.get_task("mapped_task")
+    _, max_index = TaskMap.expand_mapped_task(
+        upstream_task,
+        dr.run_id,
+        session=session,
+    )
+    expanded_ti_count = max_index + 1
+
+    downstream_task = dag.get_task("downstream")
+
+    # Grab the downstream placeholder TI.
+    downstream_ti = dr.get_task_instance(task_id="downstream", map_index=-1, session=session)
+    downstream_ti.refresh_from_task(downstream_task)
+
+    result = downstream_ti.get_relevant_upstream_map_indexes(
+        upstream=upstream_task,
+        ti_count=expanded_ti_count,
+        session=session,
+    )
+
+    assert result == 0
+
+    # Now do the same for downstream expanded (map_index = 0) to ensure existing behavior is not broken.
+    # Force expansion of the downstream mapped task.
+    _, max_index = TaskMap.expand_mapped_task(
+        downstream_task,
+        dr.run_id,
+        session=session,
+    )
+    expanded_ti_count = max_index + 1
+
+    # Grab the first expanded downstream task. Behavior is the same for all cases where map_index >= 0.
+    downstream_ti = dr.get_task_instance(task_id="downstream", map_index=0, session=session)
+    downstream_ti.refresh_from_task(downstream_task)
+
+    result = downstream_ti.get_relevant_upstream_map_indexes(
+        upstream=upstream_task,
+        ti_count=expanded_ti_count,
+        session=session,
+    )
+
+    # Verify behavior remains unchanged once the downstream task itself
+    # has expanded (map_index >= 0).
+    assert result == 0
+
+
 def test_find_relevant_relatives_with_non_mapped_task_as_tuple(dag_maker, session):
     """Test that specifying a non-mapped task as a tuple doesn't raise NotMapped exception."""
     # t1 -> t2 (non-mapped) -> t3


### PR DESCRIPTION
**Description**

Fix upstream map index resolution for dynamically mapped task groups when placeholder task instances are replaced during expansion.

After expansion, the upstream placeholder (`map_index = -1`) is replaced by the first expanded task instance (`map_index = 0`). Downstream task instances that are still unexpanded may continue to reference the placeholder, causing incorrect upstream dependency resolution.

This change introduces a small helper (`_should_use_post_expansion_placeholder`) that is invoked during upstream map index resolution to correctly handle this transition, while preserving existing behavior for already-expanded downstream tasks.

**Rationale**

Placeholder task instances are a temporary pre-expansion representation. Once expansion occurs, they are no longer valid references, but downstream resolution logic may still encounter them. Handling this transition explicitly prevents downstream tasks from treating completed upstream work as unresolved.

This could cause implicit dependencies to be skipped during DAG evaluation under certain trigger rules (such as `NONE_FAILED_MIN_ONE_SUCCESS`), particularly when multiple parallel task streams within the `MappedTaskGroup `converge on a single downstream task outside the group. As a result, DAG runs could be incorrectly marked as failed or skipped despite valid upstream execution.

Please refer to issue https://github.com/apache/airflow/issues/59289 for more context. This PR was opened in response to that. The author of the issue reported the bug in Airflow 3.0.6 but I can confirm that the same issue is present in Airflow 3.1.5 (as well as the main branch at the time this PR was last updated).

**Tests**

Added a test covering the post-expansion state where:

- The upstream placeholder has been expanded.
- The downstream task instance is either unexpanded or expanded.

The test asserts that `get_relevant_upstream_map_indexes` returns the correct upstream map index in both cases.

Closes: https://github.com/apache/airflow/issues/59289
