### PR TITLE
SQLA2 execution api (task_instances, test_dag_runs, test_variables, test_xcoms)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -424,6 +424,7 @@ repos:
             (?x)
             ^airflow-ctl.*\.py$|
             ^airflow-core/src/airflow/models/.*\.py$|
+            ^airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py$|
             ^airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py$|
             ^airflow-core/tests/unit/models/test_serialized_dag.py$|
             ^airflow-core/tests/unit/models/test_pool.py$|
@@ -439,7 +440,10 @@ repos:
             ^airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py$|
             ^airflow-core/tests/unit/cli/commands/test_task_command.py$|
             ^airflow-core/tests/unit/dag_processing/bundles/test_dag_bundle_manager.py$|
+            ^airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_dag_runs.py$|
             ^airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py$|
+            ^airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_variables.py$|
+            ^airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py$|
             ^airflow-core/tests/unit/models/test_deadline.py$|
             ^airflow-core/tests/unit/models/test_renderedtifields.py$|
             ^airflow-core/tests/unit/models/test_timestamp.py$|

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -248,11 +248,7 @@ def ti_run(
 
             xcom_keys = list(session.scalars(xcom_query))
         task_reschedule_count = (
-            session.query(
-                func.count(TaskReschedule.id)  # or any other primary key column
-            )
-            .filter(TaskReschedule.ti_id == ti_id_str)
-            .scalar()
+            session.scalar(select(func.count(TaskReschedule.id)).where(TaskReschedule.ti_id == ti_id_str))
             or 0
         )
 

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
@@ -24,6 +24,7 @@ import urllib.parse
 import httpx
 import pytest
 from fastapi import FastAPI, HTTPException, Path, Request, status
+from sqlalchemy import delete, select
 
 from airflow._shared.timezones import timezone
 from airflow.api_fastapi.execution_api.datamodels.xcom import XComResponse
@@ -41,8 +42,8 @@ pytestmark = pytest.mark.db_test
 def reset_db():
     """Reset XCom entries."""
     with create_session() as session:
-        session.query(DagRun).delete()
-        session.query(XComModel).delete()
+        session.execute(delete(DagRun))
+        session.execute(delete(XComModel))
 
 
 @pytest.fixture
@@ -354,9 +355,17 @@ class TestXComsSetEndpoint:
         assert response.status_code == 201
         assert response.json() == {"message": "XCom successfully set"}
 
-        xcom = session.query(XComModel).filter_by(task_id=ti.task_id, dag_id=ti.dag_id, key="xcom_1").first()
+        xcom = session.scalars(
+            select(XComModel).where(
+                XComModel.task_id == ti.task_id,
+                XComModel.dag_id == ti.dag_id,
+                XComModel.key == "xcom_1",
+            )
+        ).first()
         assert xcom.value == expected_value
-        task_map = session.query(TaskMap).filter_by(task_id=ti.task_id, dag_id=ti.dag_id).one_or_none()
+        task_map = session.scalars(
+            select(TaskMap).where(TaskMap.task_id == ti.task_id, TaskMap.dag_id == ti.dag_id)
+        ).one_or_none()
         assert task_map is None, "Should not be mapped"
 
     @pytest.mark.parametrize(
@@ -438,13 +447,18 @@ class TestXComsSetEndpoint:
         assert response.status_code == 201
         assert response.json() == {"message": "XCom successfully set"}
 
-        xcom = (
-            session.query(XComModel)
-            .filter_by(task_id=ti.task_id, dag_id=ti.dag_id, key="xcom_1", map_index=-1)
-            .first()
-        )
+        xcom = session.scalars(
+            select(XComModel).where(
+                XComModel.task_id == ti.task_id,
+                XComModel.dag_id == ti.dag_id,
+                XComModel.key == "xcom_1",
+                XComModel.map_index == -1,
+            )
+        ).first()
         assert xcom.value == "value1"
-        task_map = session.query(TaskMap).filter_by(task_id=ti.task_id, dag_id=ti.dag_id).one_or_none()
+        task_map = session.scalars(
+            select(TaskMap).where(TaskMap.task_id == ti.task_id, TaskMap.dag_id == ti.dag_id)
+        ).one_or_none()
         assert task_map is not None, "Should be mapped"
         assert task_map.dag_id == "dag"
         assert task_map.run_id == "test"
@@ -484,7 +498,9 @@ class TestXComsSetEndpoint:
             )
             response.raise_for_status()
 
-            task_map = session.query(TaskMap).filter_by(task_id=ti.task_id, dag_id=ti.dag_id).one_or_none()
+            task_map = session.scalars(
+                select(TaskMap).where(TaskMap.task_id == ti.task_id, TaskMap.dag_id == ti.dag_id)
+            ).one_or_none()
             assert task_map.length == length
 
     @pytest.mark.usefixtures("access_denied")
@@ -530,11 +546,13 @@ class TestXComsSetEndpoint:
             json=value,
         )
 
-        xcom = (
-            session.query(XComModel)
-            .filter_by(task_id=ti.task_id, dag_id=ti.dag_id, key="test_xcom_roundtrip")
-            .first()
-        )
+        xcom = session.scalars(
+            select(XComModel).where(
+                XComModel.task_id == ti.task_id,
+                XComModel.dag_id == ti.dag_id,
+                XComModel.key == "test_xcom_roundtrip",
+            )
+        ).first()
         assert xcom.value == expected_value
 
         response = client.get(f"/execution/xcoms/{ti.dag_id}/{ti.run_id}/{ti.task_id}/test_xcom_roundtrip")
@@ -553,7 +571,7 @@ class TestXComsDeleteEndpoint:
         ti1.xcom_push(key="xcom_1", value='"value2"', session=session)
         session.commit()
 
-        xcoms = session.query(XComModel).filter_by(key="xcom_1").all()
+        xcoms = session.scalars(select(XComModel).where(XComModel.key == "xcom_1")).all()
         assert xcoms is not None
         assert len(xcoms) == 2
 
@@ -562,12 +580,20 @@ class TestXComsDeleteEndpoint:
         assert response.status_code == 200
         assert response.json() == {"message": "XCom with key: xcom_1 successfully deleted."}
 
-        xcom_ti = (
-            session.query(XComModel).filter_by(task_id=ti.task_id, dag_id=ti.dag_id, key="xcom_1").first()
-        )
+        xcom_ti = session.scalars(
+            select(XComModel).where(
+                XComModel.task_id == ti.task_id,
+                XComModel.dag_id == ti.dag_id,
+                XComModel.key == "xcom_1",
+            )
+        ).first()
         assert xcom_ti is None
 
-        xcom_ti = (
-            session.query(XComModel).filter_by(task_id=ti1.task_id, dag_id=ti1.dag_id, key="xcom_1").first()
-        )
+        xcom_ti = session.scalars(
+            select(XComModel).where(
+                XComModel.task_id == ti1.task_id,
+                XComModel.dag_id == ti1.dag_id,
+                XComModel.key == "xcom_1",
+            )
+        ).first()
         assert xcom_ti is not None


### PR DESCRIPTION
Related: https://github.com/apache/airflow/pull/59218, https://github.com/apache/airflow/issues/59402

Passes mypy & pre-commit checks

airflow-core/src/airflow/api_fastapi
airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_dag_runs.py.
airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_variables.py
airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py