### PR TITLE
Update prek documentation to show uninstall is optional

### DIFF
--- a/contributing-docs/03_contributors_quick_start.rst
+++ b/contributing-docs/03_contributors_quick_start.rst
@@ -357,7 +357,7 @@ It will run prek hooks automatically before committing and stops the commit on f
 
 .. code-block:: bash
 
-https://apache-airflow.slack.com/archives/CQ9QHSFQX/p1765778581290659  cd ~/Projects/airflow
+  cd ~/Projects/airflow
   prek uninstall
 
 - For more information on this visit |08_static_code_checks.rst|

--- a/contributing-docs/03_contributors_quick_start.rst
+++ b/contributing-docs/03_contributors_quick_start.rst
@@ -58,8 +58,6 @@ If you do not work in a remote development environment, you will need these prer
 The below setup describes `Ubuntu installation <https://docs.docker.com/engine/install/ubuntu/>`_.
 It might be slightly different on different machines.
 
-For Windows, from Start button, type WSL and press enter to get into Linux OS (instead of Windows OS).
-
 Docker Community Edition
 ------------------------
 
@@ -355,11 +353,11 @@ It will run prek hooks automatically before committing and stops the commit on f
   prek install
   git commit -m "Added xyz"
 
-8. To disable prek hooks
+8. If you want to disable prek hooks
 
 .. code-block:: bash
 
-  cd ~/Projects/airflow
+https://apache-airflow.slack.com/archives/CQ9QHSFQX/p1765778581290659  cd ~/Projects/airflow
   prek uninstall
 
 - For more information on this visit |08_static_code_checks.rst|
@@ -467,7 +465,7 @@ see in CI in your local environment.
       breeze --python 3.10 --backend postgres
 
 
-5. When you enter the Breeze environment you should see a prompt similar to ``[Breeze:3.10.19] root@e4756f6ac886:/opt/airflow#``. This
+5. When you enter the Breeze environment you should see a prompt similar to ``root@e4756f6ac886:/opt/airflow#``. This
    means that you are inside the Breeze container and ready to run most of the development tasks. You can leave
    the environment with ``exit`` and re-enter it with just ``breeze`` command
 

--- a/contributing-docs/03_contributors_quick_start.rst
+++ b/contributing-docs/03_contributors_quick_start.rst
@@ -58,6 +58,8 @@ If you do not work in a remote development environment, you will need these prer
 The below setup describes `Ubuntu installation <https://docs.docker.com/engine/install/ubuntu/>`_.
 It might be slightly different on different machines.
 
+For Windows, from Start button, type WSL and press enter to get into Linux OS (instead of Windows OS).
+
 Docker Community Edition
 ------------------------
 
@@ -465,7 +467,7 @@ see in CI in your local environment.
       breeze --python 3.10 --backend postgres
 
 
-5. When you enter the Breeze environment you should see a prompt similar to ``root@e4756f6ac886:/opt/airflow#``. This
+5. When you enter the Breeze environment you should see a prompt similar to ``[Breeze:3.10.19] root@e4756f6ac886:/opt/airflow#``. This
    means that you are inside the Breeze container and ready to run most of the development tasks. You can leave
    the environment with ``exit`` and re-enter it with just ``breeze`` command
 


### PR DESCRIPTION
This PR is to update documentation to reflect uninstall is not mandatory. It can be used to disable prek hooks.
Slack conversation thread: [here](https://apache-airflow.slack.com/archives/CQ9QHSFQX/p1765778581290659)