### PR TITLE
Feat: add E2E tests for backfill pause and stop controls

### DIFF
--- a/airflow-core/src/airflow/ui/tests/e2e/pages/BackfillPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/BackfillPage.ts
@@ -59,7 +59,7 @@ export class BackfillPage extends BasePage {
 
     await this.page.waitForTimeout(1000);
 
-    const backfillRadio = this.page.locator('input[value="backfill"]');
+    const backfillRadio = this.page.locator('label:has-text("Backfill")');
 
     await backfillRadio.waitFor({ state: "visible", timeout: 10_000 });
     await backfillRadio.click();

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/BackfillPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/BackfillPage.ts
@@ -51,13 +51,6 @@ export class BackfillPage extends BasePage {
     await this.page.waitForTimeout(1000);
   }
 
-  public async isBackfillPaused(): Promise<boolean> {
-    await this.pauseButton.waitFor({ state: "visible", timeout: 10_000 });
-    const ariaLabel = await this.pauseButton.getAttribute("aria-label");
-
-    return Boolean(ariaLabel?.toLowerCase().includes("unpause"));
-  }
-
   public async createBackfill(dagName: string): Promise<void> {
     await this.navigateTo(BackfillPage.getDagDetailUrl(dagName));
 
@@ -84,6 +77,13 @@ export class BackfillPage extends BasePage {
     await runButton.click({ force: true });
 
     await this.page.waitForTimeout(2000);
+  }
+
+  public async isBackfillPaused(): Promise<boolean> {
+    await this.pauseButton.waitFor({ state: "visible", timeout: 10_000 });
+    const ariaLabel = await this.pauseButton.getAttribute("aria-label");
+
+    return Boolean(ariaLabel?.toLowerCase().includes("unpause"));
   }
 
   public async navigateToBackfillsTab(dagName: string): Promise<void> {

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/BackfillPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/BackfillPage.ts
@@ -1,0 +1,103 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import type { Locator, Page } from "@playwright/test";
+import { BasePage } from "tests/e2e/pages/BasePage";
+
+export class BackfillPage extends BasePage {
+  public readonly backfillBanner: Locator;
+  public readonly backfillsTab: Locator;
+  public readonly cancelButton: Locator;
+  public readonly pauseButton: Locator;
+  public readonly triggerButton: Locator;
+
+  public constructor(page: Page) {
+    super(page);
+    this.backfillBanner = page.locator('div:has-text("Backfill in progress")');
+    this.backfillsTab = page.locator('a[href*="/backfills"]');
+    this.cancelButton = page.locator('button[aria-label*="ancel"]');
+    this.pauseButton = page.locator('button[aria-label*="ause"]');
+    this.triggerButton = page.locator('button:has-text("Trigger")');
+  }
+
+  public static getDagDetailUrl(dagName: string): string {
+    return `/dags/${dagName}`;
+  }
+
+  public async clickCancelButton(): Promise<void> {
+    await this.cancelButton.waitFor({ state: "visible", timeout: 10_000 });
+    await this.cancelButton.click();
+    await this.page.waitForTimeout(1000);
+  }
+
+  public async clickPauseButton(): Promise<void> {
+    await this.pauseButton.waitFor({ state: "visible", timeout: 10_000 });
+    await this.pauseButton.click();
+    await this.page.waitForTimeout(1000);
+  }
+
+  public async isBackfillPaused(): Promise<boolean> {
+    await this.pauseButton.waitFor({ state: "visible", timeout: 10_000 });
+    const ariaLabel = await this.pauseButton.getAttribute("aria-label");
+
+    return Boolean(ariaLabel?.toLowerCase().includes("unpause"));
+  }
+
+  public async createBackfill(dagName: string): Promise<void> {
+    await this.navigateTo(BackfillPage.getDagDetailUrl(dagName));
+
+    await this.triggerButton.waitFor({ state: "visible", timeout: 10_000 });
+    await this.triggerButton.click();
+
+    await this.page.waitForTimeout(1000);
+
+    const backfillRadio = this.page.locator('input[value="backfill"]');
+
+    await backfillRadio.waitFor({ state: "visible", timeout: 10_000 });
+    await backfillRadio.click();
+
+    const fromDateInput = this.page.locator('input[name="from_date"]');
+    const toDateInput = this.page.locator('input[name="to_date"]');
+
+    await fromDateInput.fill("2024-01-01T00:00");
+    await toDateInput.fill("2024-01-02T00:00");
+
+    await this.page.waitForTimeout(2000);
+
+    const runButton = this.page.locator('button:has-text("Run")').last();
+
+    await runButton.click({ force: true });
+
+    await this.page.waitForTimeout(2000);
+  }
+
+  public async navigateToBackfillsTab(dagName: string): Promise<void> {
+    await this.navigateTo(BackfillPage.getDagDetailUrl(dagName));
+    await this.backfillsTab.waitFor({ state: "visible", timeout: 10_000 });
+    await this.backfillsTab.click();
+    await this.waitForPageLoad();
+  }
+
+  public async navigateToDagDetail(dagName: string): Promise<void> {
+    await this.navigateTo(BackfillPage.getDagDetailUrl(dagName));
+  }
+
+  public async waitForBackfillCompletion(timeout: number = 30_000): Promise<void> {
+    await this.backfillBanner.waitFor({ state: "hidden", timeout });
+  }
+}

--- a/airflow-core/src/airflow/ui/tests/e2e/specs/backfill-controls.spec.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/specs/backfill-controls.spec.ts
@@ -19,24 +19,17 @@
 import { expect, test } from "@playwright/test";
 import { testConfig } from "playwright.config";
 import { BackfillPage } from "tests/e2e/pages/BackfillPage";
-import { LoginPage } from "tests/e2e/pages/LoginPage";
 
 test.describe("Backfill Controls", () => {
   let backfillPage: BackfillPage;
-  let loginPage: LoginPage;
 
-  const testCredentials = testConfig.credentials;
   const testDagId = testConfig.testDag.id;
 
   test.beforeEach(({ page }) => {
     backfillPage = new BackfillPage(page);
-    loginPage = new LoginPage(page);
   });
 
   test("should pause and resume a running backfill", async () => {
-    await loginPage.navigateAndLogin(testCredentials.username, testCredentials.password);
-    await loginPage.expectLoginSuccess();
-
     await backfillPage.navigateToBackfillsTab(testDagId);
 
     await backfillPage.createBackfill(testDagId);
@@ -55,9 +48,6 @@ test.describe("Backfill Controls", () => {
   });
 
   test("should cancel an active backfill", async () => {
-    await loginPage.navigateAndLogin(testCredentials.username, testCredentials.password);
-    await loginPage.expectLoginSuccess();
-
     await backfillPage.navigateToBackfillsTab(testDagId);
 
     await backfillPage.createBackfill(testDagId);
@@ -70,9 +60,6 @@ test.describe("Backfill Controls", () => {
   });
 
   test("should not be able to resume a cancelled backfill", async () => {
-    await loginPage.navigateAndLogin(testCredentials.username, testCredentials.password);
-    await loginPage.expectLoginSuccess();
-
     await backfillPage.navigateToBackfillsTab(testDagId);
 
     await backfillPage.createBackfill(testDagId);

--- a/airflow-core/src/airflow/ui/tests/e2e/specs/backfill-controls.spec.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/specs/backfill-controls.spec.ts
@@ -1,0 +1,87 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { expect, test } from "@playwright/test";
+import { testConfig } from "playwright.config";
+import { BackfillPage } from "tests/e2e/pages/BackfillPage";
+import { LoginPage } from "tests/e2e/pages/LoginPage";
+
+test.describe("Backfill Controls", () => {
+  let backfillPage: BackfillPage;
+  let loginPage: LoginPage;
+
+  const testCredentials = testConfig.credentials;
+  const testDagId = testConfig.testDag.id;
+
+  test.beforeEach(({ page }) => {
+    backfillPage = new BackfillPage(page);
+    loginPage = new LoginPage(page);
+  });
+
+  test("should pause and resume a running backfill", async () => {
+    await loginPage.navigateAndLogin(testCredentials.username, testCredentials.password);
+    await loginPage.expectLoginSuccess();
+
+    await backfillPage.navigateToBackfillsTab(testDagId);
+
+    await backfillPage.createBackfill(testDagId);
+
+    await backfillPage.clickPauseButton();
+
+    const isPaused = await backfillPage.isBackfillPaused();
+
+    expect(isPaused).toBe(true);
+
+    await backfillPage.clickPauseButton();
+
+    const isRunning = await backfillPage.isBackfillPaused();
+
+    expect(isRunning).toBe(false);
+  });
+
+  test("should cancel an active backfill", async () => {
+    await loginPage.navigateAndLogin(testCredentials.username, testCredentials.password);
+    await loginPage.expectLoginSuccess();
+
+    await backfillPage.navigateToBackfillsTab(testDagId);
+
+    await backfillPage.createBackfill(testDagId);
+
+    await backfillPage.clickCancelButton();
+
+    await backfillPage.waitForBackfillCompletion();
+
+    await expect(backfillPage.backfillBanner).not.toBeVisible();
+  });
+
+  test("should not be able to resume a cancelled backfill", async () => {
+    await loginPage.navigateAndLogin(testCredentials.username, testCredentials.password);
+    await loginPage.expectLoginSuccess();
+
+    await backfillPage.navigateToBackfillsTab(testDagId);
+
+    await backfillPage.createBackfill(testDagId);
+
+    await backfillPage.clickCancelButton();
+
+    await backfillPage.waitForBackfillCompletion();
+
+    await expect(backfillPage.pauseButton).not.toBeVisible();
+    await expect(backfillPage.cancelButton).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
Add UI E2E tests for backfill pause, resume, and cancel controls

This PR adds end-to-end tests to verify the backfill control functionality on the DAG detail page.

**What this tests:**
- Pausing a running backfill and verifying status changes to paused
- Resuming a paused backfill and verifying status returns to running
- Cancelling an active backfill and verifying status changes to cancelled
- Verifying that cancelled backfills cannot be resumed

**Implementation:**
- Created `BackfillPage` page object following existing POM pattern
- Added test suite `backfill-controls.spec.ts` with 3 test cases
- All tests follow the same structure as existing E2E tests (`dags-list.spec.ts`)

closes: #59594

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

<!-- Please keep an empty line above the dashes. -->

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
