### PR TITLE
Add ability to get previous TI on ``RuntimeTaskInstance``

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
@@ -350,6 +350,21 @@ class PrevSuccessfulDagRunResponse(BaseModel):
     end_date: UtcDateTime | None = None
 
 
+class PreviousTIResponse(BaseModel):
+    """Schema for response with previous TaskInstance information."""
+
+    task_id: str
+    dag_id: str
+    run_id: str
+    logical_date: UtcDateTime | None = None
+    start_date: UtcDateTime | None = None
+    end_date: UtcDateTime | None = None
+    state: str | None = None
+    try_number: int
+    map_index: int | None = -1
+    duration: float | None = None
+
+
 class TaskStatesResponse(BaseModel):
     """Response for task states with run_id, task and state."""
 

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -44,6 +44,7 @@ from airflow.api_fastapi.common.types import UtcDateTime
 from airflow.api_fastapi.compat import HTTP_422_UNPROCESSABLE_CONTENT
 from airflow.api_fastapi.execution_api.datamodels.taskinstance import (
     InactiveAssetsResponse,
+    PreviousTIResponse,
     PrevSuccessfulDagRunResponse,
     TaskBreadcrumbsResponse,
     TaskStatesResponse,
@@ -870,6 +871,61 @@ def get_task_instance_count(
 
     count = session.scalar(query)
     return count or 0
+
+
+@router.get("/previous/{dag_id}/{task_id}", status_code=status.HTTP_200_OK)
+def get_previous_task_instance(
+    dag_id: str,
+    task_id: str,
+    session: SessionDep,
+    logical_date: Annotated[UtcDateTime | None, Query()] = None,
+    run_id: Annotated[str | None, Query()] = None,
+    state: Annotated[TaskInstanceState | None, Query()] = None,
+) -> PreviousTIResponse | None:
+    """
+    Get the previous task instance matching the given criteria.
+
+    :param dag_id: DAG ID (from path)
+    :param task_id: Task ID (from path)
+    :param logical_date: If provided, finds TI with logical_date < this value (before filter)
+    :param run_id: If provided, filters by run_id
+    :param state: If provided, filters by TaskInstance state
+    """
+    query = (
+        select(TI)
+        .join(DR, (TI.dag_id == DR.dag_id) & (TI.run_id == DR.run_id))
+        .options(joinedload(TI.dag_run))
+        .where(TI.dag_id == dag_id, TI.task_id == task_id)
+        .order_by(DR.logical_date.desc())
+    )
+
+    if logical_date:
+        # Find TI with logical_date BEFORE the provided date (previous)
+        query = query.where(DR.logical_date < logical_date)
+
+    if run_id:
+        query = query.where(TI.run_id == run_id)
+
+    if state:
+        query = query.where(TI.state == state)
+
+    ti = session.scalars(query).first()
+
+    if not ti:
+        return None
+
+    return PreviousTIResponse(
+        task_id=ti.task_id,
+        dag_id=ti.dag_id,
+        run_id=ti.run_id,
+        logical_date=ti.dag_run.logical_date,
+        start_date=ti.start_date,
+        end_date=ti.end_date,
+        state=ti.state,
+        try_number=ti.try_number,
+        map_index=ti.map_index,
+        duration=ti.duration,
+    )
 
 
 @router.get("/states", status_code=status.HTTP_200_OK)

--- a/airflow-core/src/airflow/dag_processing/processor.py
+++ b/airflow-core/src/airflow/dag_processing/processor.py
@@ -44,6 +44,7 @@ from airflow.sdk.execution_time.comms import (
     ErrorResponse,
     GetConnection,
     GetPreviousDagRun,
+    GetPreviousTI,
     GetPrevSuccessfulDagRun,
     GetTaskStates,
     GetTICount,
@@ -55,6 +56,7 @@ from airflow.sdk.execution_time.comms import (
     MaskSecret,
     OKResponse,
     PreviousDagRunResult,
+    PreviousTIResult,
     PrevSuccessfulDagRunResult,
     PutVariable,
     TaskStatesResult,
@@ -127,6 +129,7 @@ ToManager = Annotated[
     | DeleteVariable
     | GetPrevSuccessfulDagRun
     | GetPreviousDagRun
+    | GetPreviousTI
     | GetXCom
     | GetXComCount
     | GetXComSequenceItem
@@ -141,6 +144,7 @@ ToDagProcessor = Annotated[
     | VariableResult
     | TaskStatesResult
     | PreviousDagRunResult
+    | PreviousTIResult
     | PrevSuccessfulDagRunResult
     | ErrorResponse
     | OKResponse
@@ -632,6 +636,14 @@ class DagFileProcessorProcess(WatchedSubprocess):
                 resp = TaskStatesResult.from_api_response(task_states_map)
             else:
                 resp = task_states_map
+        elif isinstance(msg, GetPreviousTI):
+            resp = self.client.task_instances.get_previous(
+                dag_id=msg.dag_id,
+                task_id=msg.task_id,
+                logical_date=msg.logical_date,
+                map_index=msg.map_index,
+                state=msg.state,
+            )
         else:
             log.error("Unhandled request", msg=msg)
             self.send_msg(

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -60,6 +60,7 @@ from airflow.sdk.execution_time.comms import (
     GetDagRunState,
     GetDRCount,
     GetHITLDetailResponse,
+    GetPreviousTI,
     GetTaskStates,
     GetTICount,
     GetVariable,
@@ -269,6 +270,7 @@ ToTriggerSupervisor = Annotated[
     | GetTaskStates
     | GetDagRunState
     | GetDRCount
+    | GetPreviousTI
     | GetHITLDetailResponse
     | UpdateHITLDetail
     | MaskSecret,
@@ -498,6 +500,14 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
                 resp = TaskStatesResult.from_api_response(run_id_task_state_map)
             else:
                 resp = run_id_task_state_map
+        elif isinstance(msg, GetPreviousTI):
+            resp = self.client.task_instances.get_previous(
+                dag_id=msg.dag_id,
+                task_id=msg.task_id,
+                logical_date=msg.logical_date,
+                map_index=msg.map_index,
+                state=msg.state,
+            )
         elif isinstance(msg, UpdateHITLDetail):
             api_resp = self.client.hitl.update_response(
                 ti_id=msg.ti_id,

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -2138,6 +2138,174 @@ class TestGetCount:
         assert response.json() == expected_count
 
 
+class TestGetPreviousTI:
+    def setup_method(self):
+        clear_db_runs()
+
+    def teardown_method(self):
+        clear_db_runs()
+
+    def test_get_previous_ti_basic(self, client, session, create_task_instance):
+        """Test basic get_previous_ti without filters."""
+        # Create TIs with different logical dates
+        create_task_instance(
+            task_id="test_task",
+            state=State.SUCCESS,
+            logical_date=timezone.datetime(2025, 1, 1),
+            run_id="run1",
+        )
+        create_task_instance(
+            task_id="test_task",
+            state=State.SUCCESS,
+            logical_date=timezone.datetime(2025, 1, 2),
+            run_id="run2",
+        )
+        session.commit()
+
+        response = client.get(
+            "/execution/task-instances/previous/dag/test_task",
+            params={
+                "logical_date": "2025-01-02T00:00:00Z",
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["task_id"] == "test_task"
+        assert data["dag_id"] == "dag"
+        assert data["run_id"] == "run1"
+        assert data["state"] == State.SUCCESS
+
+    def test_get_previous_ti_with_state_filter(self, client, session, create_task_instance):
+        """Test get_previous_ti with state filter."""
+        # Create TIs with different states
+        create_task_instance(
+            task_id="test_task",
+            state=State.FAILED,
+            logical_date=timezone.datetime(2025, 1, 1),
+            run_id="run1",
+        )
+        create_task_instance(
+            task_id="test_task",
+            state=State.SUCCESS,
+            logical_date=timezone.datetime(2025, 1, 2),
+            run_id="run2",
+        )
+        create_task_instance(
+            task_id="test_task",
+            state=State.FAILED,
+            logical_date=timezone.datetime(2025, 1, 3),
+            run_id="run3",
+        )
+        session.commit()
+
+        # Query for previous successful TI before 2025-01-03
+        response = client.get(
+            "/execution/task-instances/previous/dag/test_task",
+            params={
+                "logical_date": "2025-01-03T00:00:00Z",
+                "state": State.SUCCESS,
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["task_id"] == "test_task"
+        assert data["run_id"] == "run2"
+        assert data["state"] == State.SUCCESS
+
+    def test_get_previous_ti_with_run_id_filter(self, client, session, create_task_instance):
+        """Test get_previous_ti with run_id filter."""
+        create_task_instance(
+            task_id="test_task",
+            state=State.SUCCESS,
+            logical_date=timezone.datetime(2025, 1, 1),
+            run_id="specific_run",
+        )
+        create_task_instance(
+            task_id="test_task",
+            state=State.SUCCESS,
+            logical_date=timezone.datetime(2025, 1, 2),
+            run_id="other_run",
+        )
+        session.commit()
+
+        response = client.get(
+            "/execution/task-instances/previous/dag/test_task",
+            params={
+                "run_id": "specific_run",
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["run_id"] == "specific_run"
+
+    def test_get_previous_ti_not_found(self, client, session):
+        """Test get_previous_ti when no previous TI exists."""
+        response = client.get(
+            "/execution/task-instances/previous/dag/test_task",
+        )
+        assert response.status_code == 200
+        assert response.json() is None
+
+    def test_get_previous_ti_returns_most_recent(self, client, session, create_task_instance):
+        """Test that get_previous_ti returns the most recent matching TI."""
+        # Create multiple TIs
+        for i in range(5):
+            create_task_instance(
+                task_id="test_task",
+                state=State.SUCCESS,
+                logical_date=timezone.datetime(2025, 1, i + 1),
+                run_id=f"run{i + 1}",
+            )
+        session.commit()
+
+        # Query for TI before 2025-01-05
+        response = client.get(
+            "/execution/task-instances/previous/dag/test_task",
+            params={
+                "logical_date": "2025-01-05T00:00:00Z",
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        # Should return the most recent one (2025-01-04)
+        assert data["run_id"] == "run4"
+
+    def test_get_previous_ti_with_all_filters(self, client, session, create_task_instance):
+        """Test get_previous_ti with all filters combined."""
+        create_task_instance(
+            task_id="test_task",
+            state=State.SUCCESS,
+            logical_date=timezone.datetime(2025, 1, 1),
+            run_id="target_run_1",
+        )
+        create_task_instance(
+            task_id="test_task",
+            state=State.FAILED,
+            logical_date=timezone.datetime(2025, 1, 2),
+            run_id="target_run_2",
+        )
+        create_task_instance(
+            task_id="test_task",
+            state=State.SUCCESS,
+            logical_date=timezone.datetime(2025, 1, 3),
+            run_id="target_run_3",
+        )
+        session.commit()
+
+        # Query for previous successful TI before 2025-01-03 with run_id filter
+        response = client.get(
+            "/execution/task-instances/previous/dag/test_task",
+            params={
+                "logical_date": "2025-01-03T00:00:00Z",
+                "state": State.SUCCESS,
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["run_id"] == "target_run_1"
+        assert data["state"] == State.SUCCESS
+
+
 class TestGetTaskStates:
     def setup_method(self):
         clear_db_runs()

--- a/airflow-core/tests/unit/dag_processing/test_processor.py
+++ b/airflow-core/tests/unit/dag_processing/test_processor.py
@@ -1847,7 +1847,6 @@ class TestDagProcessingMessageTypes:
             "GetDagRun",
             "GetDagRunState",
             "GetDRCount",
-            "GetPreviousTI",
             "GetTaskBreadcrumbs",
             "GetTaskRescheduleStartDate",
             "GetTICount",
@@ -1882,7 +1881,6 @@ class TestDagProcessingMessageTypes:
             "TaskStatesResult",
             "InactiveAssetsResult",
             "CreateHITLDetailPayload",
-            "PreviousTIResult",
             "HITLDetailRequestResult",
         }
 

--- a/airflow-core/tests/unit/dag_processing/test_processor.py
+++ b/airflow-core/tests/unit/dag_processing/test_processor.py
@@ -1847,6 +1847,7 @@ class TestDagProcessingMessageTypes:
             "GetDagRun",
             "GetDagRunState",
             "GetDRCount",
+            "GetPreviousTI",
             "GetTaskBreadcrumbs",
             "GetTaskRescheduleStartDate",
             "GetTICount",
@@ -1881,6 +1882,7 @@ class TestDagProcessingMessageTypes:
             "TaskStatesResult",
             "InactiveAssetsResult",
             "CreateHITLDetailPayload",
+            "PreviousTIResult",
             "HITLDetailRequestResult",
         }
 

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -1203,6 +1203,7 @@ class TestTriggererMessageTypes:
             "GetDagRun",
             "GetPrevSuccessfulDagRun",
             "GetPreviousDagRun",
+            "GetPreviousTI",
             "GetTaskBreadcrumbs",
             "GetTaskRescheduleStartDate",
             "GetXComCount",
@@ -1236,6 +1237,7 @@ class TestTriggererMessageTypes:
             "XComSequenceIndexResult",
             "XComSequenceSliceResult",
             "PreviousDagRunResult",
+            "PreviousTIResult",
             "HITLDetailRequestResult",
         }
 

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -1203,7 +1203,6 @@ class TestTriggererMessageTypes:
             "GetDagRun",
             "GetPrevSuccessfulDagRun",
             "GetPreviousDagRun",
-            "GetPreviousTI",
             "GetTaskBreadcrumbs",
             "GetTaskRescheduleStartDate",
             "GetXComCount",

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -328,7 +328,7 @@ class TaskInstanceOperations:
         dag_id: str,
         task_id: str,
         logical_date: datetime | None = None,
-        run_id: str | None = None,
+        map_index: int = -1,
         state: TaskInstanceState | str | None = None,
     ) -> PreviousTIResult:
         """
@@ -337,14 +337,12 @@ class TaskInstanceOperations:
         :param dag_id: DAG ID
         :param task_id: Task ID
         :param logical_date: If provided, finds TI with logical_date < this value (before filter)
-        :param run_id: If provided, filters by run_id
+        :param map_index: Map index to filter by (defaults to -1 for non-mapped tasks)
         :param state: If provided, filters by TaskInstance state
         """
-        params = {}
+        params: dict[str, Any] = {"map_index": map_index}
         if logical_date:
             params["logical_date"] = logical_date.isoformat()
-        if run_id:
-            params["run_id"] = run_id
         if state:
             params["state"] = state.value if isinstance(state, TaskInstanceState) else state
 

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -171,6 +171,23 @@ class PrevSuccessfulDagRunResponse(BaseModel):
     end_date: Annotated[AwareDatetime | None, Field(title="End Date")] = None
 
 
+class PreviousTIResponse(BaseModel):
+    """
+    Schema for response with previous TaskInstance information.
+    """
+
+    task_id: Annotated[str, Field(title="Task Id")]
+    dag_id: Annotated[str, Field(title="Dag Id")]
+    run_id: Annotated[str, Field(title="Run Id")]
+    logical_date: Annotated[AwareDatetime | None, Field(title="Logical Date")] = None
+    start_date: Annotated[AwareDatetime | None, Field(title="Start Date")] = None
+    end_date: Annotated[AwareDatetime | None, Field(title="End Date")] = None
+    state: Annotated[str | None, Field(title="State")] = None
+    try_number: Annotated[int, Field(title="Try Number")]
+    map_index: Annotated[int | None, Field(title="Map Index")] = -1
+    duration: Annotated[float | None, Field(title="Duration")] = None
+
+
 class TIDeferredStatePayload(BaseModel):
     """
     Schema for updating TaskInstance to a deferred state.
@@ -284,6 +301,27 @@ class TaskBreadcrumbsResponse(BaseModel):
     """
 
     breadcrumbs: Annotated[list[dict[str, Any]], Field(title="Breadcrumbs")]
+
+
+class TaskInstanceState(str, Enum):
+    """
+    All possible states that a Task Instance can be in.
+
+    Note that None is also allowed, so always use this in a type hint with Optional.
+    """
+
+    REMOVED = "removed"
+    SCHEDULED = "scheduled"
+    QUEUED = "queued"
+    RUNNING = "running"
+    SUCCESS = "success"
+    RESTARTING = "restarting"
+    FAILED = "failed"
+    UP_FOR_RETRY = "up_for_retry"
+    UP_FOR_RESCHEDULE = "up_for_reschedule"
+    UPSTREAM_FAILED = "upstream_failed"
+    SKIPPED = "skipped"
+    DEFERRED = "deferred"
 
 
 class TaskStatesResponse(BaseModel):
@@ -422,21 +460,6 @@ class TerminalTIState(str, Enum):
     SKIPPED = "skipped"
     UPSTREAM_FAILED = "upstream_failed"
     REMOVED = "removed"
-
-
-class TaskInstanceState(str, Enum):
-    REMOVED = "removed"
-    SCHEDULED = "scheduled"
-    QUEUED = "queued"
-    RUNNING = "running"
-    SUCCESS = "success"
-    RESTARTING = "restarting"
-    FAILED = "failed"
-    UP_FOR_RETRY = "up_for_retry"
-    UP_FOR_RESCHEDULE = "up_for_reschedule"
-    UPSTREAM_FAILED = "upstream_failed"
-    SKIPPED = "skipped"
-    DEFERRED = "deferred"
 
 
 class WeightRule(str, Enum):

--- a/task-sdk/src/airflow/sdk/execution_time/comms.py
+++ b/task-sdk/src/airflow/sdk/execution_time/comms.py
@@ -73,6 +73,7 @@ from airflow.sdk.api.datamodels._generated import (
     DagRunStateResponse,
     HITLDetailRequest,
     InactiveAssetsResponse,
+    PreviousTIResponse,
     PrevSuccessfulDagRunResponse,
     TaskBreadcrumbsResponse,
     TaskInstance,
@@ -542,6 +543,13 @@ class PreviousDagRunResult(BaseModel):
     type: Literal["PreviousDagRunResult"] = "PreviousDagRunResult"
 
 
+class PreviousTIResult(BaseModel):
+    """Response containing previous task instance data."""
+
+    task_instance: PreviousTIResponse | None = None
+    type: Literal["PreviousTIResult"] = "PreviousTIResult"
+
+
 class PrevSuccessfulDagRunResult(PrevSuccessfulDagRunResponse):
     type: Literal["PrevSuccessfulDagRunResult"] = "PrevSuccessfulDagRunResult"
 
@@ -655,6 +663,7 @@ ToTask = Annotated[
     | DRCount
     | ErrorResponse
     | PrevSuccessfulDagRunResult
+    | PreviousTIResult
     | SentFDs
     | StartupDetails
     | TaskRescheduleStartDate
@@ -866,6 +875,17 @@ class GetPreviousDagRun(BaseModel):
     type: Literal["GetPreviousDagRun"] = "GetPreviousDagRun"
 
 
+class GetPreviousTI(BaseModel):
+    """Request to get previous task instance."""
+
+    dag_id: str
+    task_id: str
+    logical_date: AwareDatetime | None = None
+    run_id: str | None = None
+    state: TaskInstanceState | None = None
+    type: Literal["GetPreviousTI"] = "GetPreviousTI"
+
+
 class GetAssetByName(BaseModel):
     name: str
     type: Literal["GetAssetByName"] = "GetAssetByName"
@@ -984,6 +1004,7 @@ ToSupervisor = Annotated[
     | GetDRCount
     | GetPrevSuccessfulDagRun
     | GetPreviousDagRun
+    | GetPreviousTI
     | GetTaskRescheduleStartDate
     | GetTICount
     | GetTaskBreadcrumbs

--- a/task-sdk/src/airflow/sdk/execution_time/comms.py
+++ b/task-sdk/src/airflow/sdk/execution_time/comms.py
@@ -881,7 +881,7 @@ class GetPreviousTI(BaseModel):
     dag_id: str
     task_id: str
     logical_date: AwareDatetime | None = None
-    run_id: str | None = None
+    map_index: int = -1
     state: TaskInstanceState | None = None
     type: Literal["GetPreviousTI"] = "GetPreviousTI"
 

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -1424,7 +1424,7 @@ class ActivitySubprocess(WatchedSubprocess):
                 dag_id=msg.dag_id,
                 task_id=msg.task_id,
                 logical_date=msg.logical_date,
-                run_id=msg.run_id,
+                map_index=msg.map_index,
                 state=msg.state,
             )
         elif isinstance(msg, DeleteVariable):

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -88,6 +88,7 @@ from airflow.sdk.execution_time.comms import (
     GetDagRunState,
     GetDRCount,
     GetPreviousDagRun,
+    GetPreviousTI,
     GetPrevSuccessfulDagRun,
     GetTaskBreadcrumbs,
     GetTaskRescheduleStartDate,
@@ -1416,6 +1417,14 @@ class ActivitySubprocess(WatchedSubprocess):
             resp = self.client.dag_runs.get_previous(
                 dag_id=msg.dag_id,
                 logical_date=msg.logical_date,
+                state=msg.state,
+            )
+        elif isinstance(msg, GetPreviousTI):
+            resp = self.client.task_instances.get_previous(
+                dag_id=msg.dag_id,
+                task_id=msg.task_id,
+                logical_date=msg.logical_date,
+                run_id=msg.run_id,
                 state=msg.state,
             )
         elif isinstance(msg, DeleteVariable):

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -45,6 +45,7 @@ from airflow.sdk.api.client import get_hostname, getuser
 from airflow.sdk.api.datamodels._generated import (
     AssetProfile,
     DagRun,
+    PreviousTIResponse,
     TaskInstance,
     TaskInstanceState,
     TIRunContext,
@@ -76,12 +77,14 @@ from airflow.sdk.execution_time.comms import (
     GetDagRunState,
     GetDRCount,
     GetPreviousDagRun,
+    GetPreviousTI,
     GetTaskBreadcrumbs,
     GetTaskRescheduleStartDate,
     GetTaskStates,
     GetTICount,
     InactiveAssetsResult,
     PreviousDagRunResult,
+    PreviousTIResult,
     RescheduleTask,
     ResendLoggingFD,
     RetryTask,
@@ -480,6 +483,46 @@ class RuntimeTaskInstance(TaskInstance):
             assert isinstance(response, PreviousDagRunResult)
 
         return response.dag_run
+
+    def get_previous_ti(
+        self,
+        state: TaskInstanceState | None = None,
+        logical_date: AwareDatetime | None = None,
+        run_id: str | None = None,
+    ) -> PreviousTIResponse | None:
+        """
+        Return the previous task instance matching the given criteria.
+
+        :param state: Filter by TaskInstance state
+        :param logical_date: Filter by logical date (returns TI before this date)
+        :param run_id: Filter by run_id
+        :return: Previous task instance or None if not found
+        """
+        context = self.get_template_context()
+        dag_run = context.get("dag_run")
+
+        log = structlog.get_logger(logger_name="task")
+        log.debug("Getting previous task instance", task_id=self.task_id, state=state)
+
+        # Use current dag run's logical_date if not provided
+        effective_logical_date = logical_date
+        if effective_logical_date is None and dag_run and dag_run.logical_date:
+            effective_logical_date = dag_run.logical_date
+
+        response = SUPERVISOR_COMMS.send(
+            msg=GetPreviousTI(
+                dag_id=self.dag_id,
+                task_id=self.task_id,
+                logical_date=effective_logical_date,
+                run_id=run_id,
+                state=state,
+            )
+        )
+
+        if TYPE_CHECKING:
+            assert isinstance(response, PreviousTIResult)
+
+        return response.task_instance
 
     @staticmethod
     def get_ti_count(

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -488,14 +488,14 @@ class RuntimeTaskInstance(TaskInstance):
         self,
         state: TaskInstanceState | None = None,
         logical_date: AwareDatetime | None = None,
-        run_id: str | None = None,
+        map_index: int = -1,
     ) -> PreviousTIResponse | None:
         """
         Return the previous task instance matching the given criteria.
 
         :param state: Filter by TaskInstance state
         :param logical_date: Filter by logical date (returns TI before this date)
-        :param run_id: Filter by run_id
+        :param map_index: Filter by map_index (defaults to -1 for non-mapped tasks)
         :return: Previous task instance or None if not found
         """
         context = self.get_template_context()
@@ -514,7 +514,7 @@ class RuntimeTaskInstance(TaskInstance):
                 dag_id=self.dag_id,
                 task_id=self.task_id,
                 logical_date=effective_logical_date,
-                run_id=run_id,
+                map_index=map_index,
                 state=state,
             )
         )

--- a/task-sdk/src/airflow/sdk/types.py
+++ b/task-sdk/src/airflow/sdk/types.py
@@ -96,7 +96,7 @@ class RuntimeTaskInstanceProtocol(Protocol):
         self,
         state: TaskInstanceState | None = None,
         logical_date: AwareDatetime | None = None,
-        run_id: str | None = None,
+        map_index: int = -1,
     ) -> PreviousTIResponse | None: ...
 
     @staticmethod

--- a/task-sdk/src/airflow/sdk/types.py
+++ b/task-sdk/src/airflow/sdk/types.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from pydantic import AwareDatetime, JsonValue
 
     from airflow.sdk._shared.logging.types import Logger as Logger
-    from airflow.sdk.api.datamodels._generated import TaskInstanceState
+    from airflow.sdk.api.datamodels._generated import PreviousTIResponse, TaskInstanceState
     from airflow.sdk.bases.operator import BaseOperator
     from airflow.sdk.definitions.asset import Asset, AssetAlias, AssetAliasEvent, AssetRef, BaseAssetUniqueKey
     from airflow.sdk.definitions.context import Context
@@ -91,6 +91,13 @@ class RuntimeTaskInstanceProtocol(Protocol):
     def get_first_reschedule_date(self, first_try_number) -> AwareDatetime | None: ...
 
     def get_previous_dagrun(self, state: str | None = None) -> DagRunProtocol | None: ...
+
+    def get_previous_ti(
+        self,
+        state: TaskInstanceState | None = None,
+        logical_date: AwareDatetime | None = None,
+        run_id: str | None = None,
+    ) -> PreviousTIResponse | None: ...
 
     @staticmethod
     def get_ti_count(

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -564,6 +564,7 @@ class TestTaskInstanceOperations:
             if request.url.path == "/task-instances/previous/test_dag/test_task":
                 assert request.url.params == httpx.QueryParams(
                     logical_date=logical_date.isoformat(),
+                    map_index="-1",
                 )
                 # Return complete TI data
                 return httpx.Response(
@@ -602,6 +603,7 @@ class TestTaskInstanceOperations:
             if request.url.path == "/task-instances/previous/test_dag/test_task":
                 assert request.url.params == httpx.QueryParams(
                     logical_date=logical_date.isoformat(),
+                    map_index="-1",
                     state="success",
                 )
                 return httpx.Response(
@@ -628,37 +630,35 @@ class TestTaskInstanceOperations:
 
         assert result.task_instance.state == "success"
 
-    def test_get_previous_with_run_id_filter(self):
-        """Test get_previous functionality with run_id filtering."""
+    def test_get_previous_with_map_index_filter(self):
+        """Test get_previous functionality with map_index filtering."""
 
         def handle_request(request: httpx.Request) -> httpx.Response:
             if request.url.path == "/task-instances/previous/test_dag/test_task":
                 assert request.url.params == httpx.QueryParams(
-                    run_id="specific_run",
+                    map_index="0",
                 )
                 return httpx.Response(
                     status_code=200,
                     json={
                         "task_id": "test_task",
                         "dag_id": "test_dag",
-                        "run_id": "specific_run",
+                        "run_id": "prev_run",
                         "logical_date": "2024-01-14T12:00:00+00:00",
                         "start_date": "2024-01-14T12:05:00+00:00",
                         "end_date": "2024-01-14T12:10:00+00:00",
                         "state": "success",
                         "try_number": 1,
-                        "map_index": -1,
+                        "map_index": 0,
                         "duration": 300.0,
                     },
                 )
             return httpx.Response(status_code=422)
 
         client = make_client(transport=httpx.MockTransport(handle_request))
-        result = client.task_instances.get_previous(
-            dag_id="test_dag", task_id="test_task", run_id="specific_run"
-        )
+        result = client.task_instances.get_previous(dag_id="test_dag", task_id="test_task", map_index=0)
 
-        assert result.task_instance.run_id == "specific_run"
+        assert result.task_instance.map_index == 0
 
     def test_get_previous_not_found(self):
         """Test get_previous when no previous TI exists returns None."""

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -52,6 +52,7 @@ from airflow.sdk.execution_time.comms import (
     ErrorResponse,
     OKResponse,
     PreviousDagRunResult,
+    PreviousTIResult,
     RescheduleTask,
     TaskRescheduleStartDate,
 )
@@ -554,6 +555,125 @@ class TestTaskInstanceOperations:
             logical_dates=logical_dates,
         )
         assert result.task_states == {"run_id": {"group1.task1": "success", "group1.task2": "failed"}}
+
+    def test_get_previous_basic(self):
+        """Test basic get_previous functionality."""
+        logical_date = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/task-instances/previous/test_dag/test_task":
+                assert request.url.params == httpx.QueryParams(
+                    logical_date=logical_date.isoformat(),
+                )
+                # Return complete TI data
+                return httpx.Response(
+                    status_code=200,
+                    json={
+                        "task_id": "test_task",
+                        "dag_id": "test_dag",
+                        "run_id": "prev_run",
+                        "logical_date": "2024-01-14T12:00:00+00:00",
+                        "start_date": "2024-01-14T12:05:00+00:00",
+                        "end_date": "2024-01-14T12:10:00+00:00",
+                        "state": "success",
+                        "try_number": 1,
+                        "map_index": -1,
+                        "duration": 300.0,
+                    },
+                )
+            return httpx.Response(status_code=422)
+
+        client = make_client(transport=httpx.MockTransport(handle_request))
+        result = client.task_instances.get_previous(
+            dag_id="test_dag", task_id="test_task", logical_date=logical_date
+        )
+
+        assert isinstance(result, PreviousTIResult)
+        assert result.task_instance.task_id == "test_task"
+        assert result.task_instance.dag_id == "test_dag"
+        assert result.task_instance.run_id == "prev_run"
+        assert result.task_instance.state == "success"
+
+    def test_get_previous_with_state_filter(self):
+        """Test get_previous functionality with state filtering."""
+        logical_date = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/task-instances/previous/test_dag/test_task":
+                assert request.url.params == httpx.QueryParams(
+                    logical_date=logical_date.isoformat(),
+                    state="success",
+                )
+                return httpx.Response(
+                    status_code=200,
+                    json={
+                        "task_id": "test_task",
+                        "dag_id": "test_dag",
+                        "run_id": "prev_run",
+                        "logical_date": "2024-01-14T12:00:00+00:00",
+                        "start_date": "2024-01-14T12:05:00+00:00",
+                        "end_date": "2024-01-14T12:10:00+00:00",
+                        "state": "success",
+                        "try_number": 1,
+                        "map_index": -1,
+                        "duration": 300.0,
+                    },
+                )
+            return httpx.Response(status_code=422)
+
+        client = make_client(transport=httpx.MockTransport(handle_request))
+        result = client.task_instances.get_previous(
+            dag_id="test_dag", task_id="test_task", logical_date=logical_date, state="success"
+        )
+
+        assert result.task_instance.state == "success"
+
+    def test_get_previous_with_run_id_filter(self):
+        """Test get_previous functionality with run_id filtering."""
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/task-instances/previous/test_dag/test_task":
+                assert request.url.params == httpx.QueryParams(
+                    run_id="specific_run",
+                )
+                return httpx.Response(
+                    status_code=200,
+                    json={
+                        "task_id": "test_task",
+                        "dag_id": "test_dag",
+                        "run_id": "specific_run",
+                        "logical_date": "2024-01-14T12:00:00+00:00",
+                        "start_date": "2024-01-14T12:05:00+00:00",
+                        "end_date": "2024-01-14T12:10:00+00:00",
+                        "state": "success",
+                        "try_number": 1,
+                        "map_index": -1,
+                        "duration": 300.0,
+                    },
+                )
+            return httpx.Response(status_code=422)
+
+        client = make_client(transport=httpx.MockTransport(handle_request))
+        result = client.task_instances.get_previous(
+            dag_id="test_dag", task_id="test_task", run_id="specific_run"
+        )
+
+        assert result.task_instance.run_id == "specific_run"
+
+    def test_get_previous_not_found(self):
+        """Test get_previous when no previous TI exists returns None."""
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/task-instances/previous/test_dag/test_task":
+                # Return None (null) when no previous TI found
+                return httpx.Response(status_code=200, content="null")
+            return httpx.Response(status_code=422)
+
+        client = make_client(transport=httpx.MockTransport(handle_request))
+        result = client.task_instances.get_previous(dag_id="test_dag", task_id="test_task")
+
+        assert isinstance(result, PreviousTIResult)
+        assert result.task_instance is None
 
 
 class TestVariableOperations:

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -2175,6 +2175,7 @@ REQUEST_TEST_CASES = [
             dag_id="test_dag",
             task_id="test_task",
             logical_date=timezone.parse("2024-01-15T12:00:00Z"),
+            map_index=0,
             state=TaskInstanceState.SUCCESS,
         ),
         expected_body={
@@ -2187,7 +2188,7 @@ REQUEST_TEST_CASES = [
                 "end_date": timezone.parse("2024-01-14T12:10:00Z"),
                 "state": "success",
                 "try_number": 1,
-                "map_index": -1,
+                "map_index": 0,
                 "duration": 300.0,
             },
             "type": "PreviousTIResult",
@@ -2198,8 +2199,8 @@ REQUEST_TEST_CASES = [
                 "dag_id": "test_dag",
                 "task_id": "test_task",
                 "logical_date": timezone.parse("2024-01-15T12:00:00Z"),
+                "map_index": 0,
                 "state": TaskInstanceState.SUCCESS,
-                "run_id": None,
             },
             response=PreviousTIResult(
                 task_instance=PreviousTIResponse(
@@ -2211,7 +2212,7 @@ REQUEST_TEST_CASES = [
                     end_date=timezone.parse("2024-01-14T12:10:00Z"),
                     state="success",
                     try_number=1,
-                    map_index=-1,
+                    map_index=0,
                     duration=300.0,
                 )
             ),

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -59,6 +59,7 @@ from airflow.sdk.api.datamodels._generated import (
     DagRun,
     DagRunState,
     DagRunType,
+    PreviousTIResponse,
     TaskInstance,
     TaskInstanceState,
 )
@@ -87,6 +88,7 @@ from airflow.sdk.execution_time.comms import (
     GetDRCount,
     GetHITLDetailResponse,
     GetPreviousDagRun,
+    GetPreviousTI,
     GetPrevSuccessfulDagRun,
     GetTaskBreadcrumbs,
     GetTaskRescheduleStartDate,
@@ -102,6 +104,7 @@ from airflow.sdk.execution_time.comms import (
     MaskSecret,
     OKResponse,
     PreviousDagRunResult,
+    PreviousTIResult,
     PrevSuccessfulDagRunResult,
     PutVariable,
     RescheduleTask,
@@ -2166,6 +2169,54 @@ REQUEST_TEST_CASES = [
             response=PreviousDagRunResult(dag_run=None),
         ),
         test_id="get_previous_dagrun_with_state",
+    ),
+    RequestTestCase(
+        message=GetPreviousTI(
+            dag_id="test_dag",
+            task_id="test_task",
+            logical_date=timezone.parse("2024-01-15T12:00:00Z"),
+            state=TaskInstanceState.SUCCESS,
+        ),
+        expected_body={
+            "task_instance": {
+                "task_id": "test_task",
+                "dag_id": "test_dag",
+                "run_id": "prev_run",
+                "logical_date": timezone.parse("2024-01-14T12:00:00Z"),
+                "start_date": timezone.parse("2024-01-14T12:05:00Z"),
+                "end_date": timezone.parse("2024-01-14T12:10:00Z"),
+                "state": "success",
+                "try_number": 1,
+                "map_index": -1,
+                "duration": 300.0,
+            },
+            "type": "PreviousTIResult",
+        },
+        client_mock=ClientMock(
+            method_path="task_instances.get_previous",
+            kwargs={
+                "dag_id": "test_dag",
+                "task_id": "test_task",
+                "logical_date": timezone.parse("2024-01-15T12:00:00Z"),
+                "state": TaskInstanceState.SUCCESS,
+                "run_id": None,
+            },
+            response=PreviousTIResult(
+                task_instance=PreviousTIResponse(
+                    task_id="test_task",
+                    dag_id="test_dag",
+                    run_id="prev_run",
+                    logical_date=timezone.parse("2024-01-14T12:00:00Z"),
+                    start_date=timezone.parse("2024-01-14T12:05:00Z"),
+                    end_date=timezone.parse("2024-01-14T12:10:00Z"),
+                    state="success",
+                    try_number=1,
+                    map_index=-1,
+                    duration=300.0,
+                )
+            ),
+        ),
+        test_id="get_previous_ti",
     ),
     RequestTestCase(
         message=GetTaskRescheduleStartDate(ti_id=TI_ID),


### PR DESCRIPTION
Fixes #59609

Add `get_previous_ti()` method to `RuntimeTaskInstance` for retrieving previous task instance executions. Supports filtering by state, logical_date, and run_id. 

This will help users migrating from Airflow 2.x since they were able to do `prev_ti = ti.get_previous_ti(state='success')` in Airflow 2 as described in the GitHub issue.

<img width="1434" height="623" alt="image" src="https://github.com/user-attachments/assets/c339a8c2-5285-4c4d-993c-df7488205628" />

<img width="1718" height="718" alt="image" src="https://github.com/user-attachments/assets/1d05304e-4e44-4f0b-80c5-d569f2a350f5" />


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
