### PR TITLE
De-obfuscate scheduler dag run creation "continue" logic

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -1788,6 +1788,19 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         )
 
         for dag_model in dag_models:
+            if dag_model.next_dagrun is None:
+                self.log.error(
+                    "dag_model.next_dagrun is None; expected datetime",
+                    dag_id=dag_model.dag_id,
+                )
+                continue
+            if dag_model.next_dagrun_create_after is None:
+                self.log.error(
+                    "dag_model.next_dagrun_create_after is None; expected datetime",
+                    dag_id=dag_model.dag_id,
+                )
+                continue
+
             serdag = _get_current_dag(dag_id=dag_model.dag_id, session=session)
             if not serdag:
                 self.log.error("DAG '%s' not found in serialized_dag table", dag_model.dag_id)
@@ -1804,38 +1817,35 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             # instead of falling in a loop of IntegrityError.
             if (serdag.dag_id, dag_model.next_dagrun) not in existing_dagruns:
                 try:
-                    if dag_model.next_dagrun is not None and dag_model.next_dagrun_create_after is not None:
-                        serdag.create_dagrun(
-                            run_id=serdag.timetable.generate_run_id(
-                                run_type=DagRunType.SCHEDULED,
-                                run_after=timezone.coerce_datetime(dag_model.next_dagrun),
-                                data_interval=data_interval,
-                            ),
-                            logical_date=dag_model.next_dagrun,
-                            data_interval=data_interval,
-                            run_after=dag_model.next_dagrun_create_after,
+                    serdag.create_dagrun(
+                        run_id=serdag.timetable.generate_run_id(
                             run_type=DagRunType.SCHEDULED,
-                            triggered_by=DagRunTriggeredByType.TIMETABLE,
-                            state=DagRunState.QUEUED,
-                            creating_job_id=self.job.id,
-                            session=session,
-                        )
-                        active_runs_of_dags[serdag.dag_id] += 1
-                    else:
-                        if dag_model.next_dagrun is None:
-                            raise ValueError("dag_model.next_dagrun is None; expected datetime")
-                        raise ValueError("dag_model.next_dagrun_create_after is None; expected datetime")
+                            run_after=timezone.coerce_datetime(dag_model.next_dagrun),
+                            data_interval=data_interval,
+                        ),
+                        logical_date=dag_model.next_dagrun,
+                        data_interval=data_interval,
+                        run_after=dag_model.next_dagrun_create_after,
+                        run_type=DagRunType.SCHEDULED,
+                        triggered_by=DagRunTriggeredByType.TIMETABLE,
+                        state=DagRunState.QUEUED,
+                        creating_job_id=self.job.id,
+                        session=session,
+                    )
+                    active_runs_of_dags[serdag.dag_id] += 1
+
                 # Exceptions like ValueError, ParamValidationError, etc. are raised by
                 # DagModel.create_dagrun() when dag is misconfigured. The scheduler should not
                 # crash due to misconfigured dags. We should log any exception encountered
                 # and continue to the next serdag.
                 except Exception:
                     self.log.exception("Failed creating DagRun for %s", serdag.dag_id)
-                    # todo: continuing here does not work because session needs rollback
-                    #  but you need either to make smaller transactions and commit after every dag run
-                    #  or to use savepoints.
+                    # todo: if you get a database error here, continuing does not work because
+                    #  session needs rollback. you need either to make smaller transactions and
+                    #  commit after every dag run or use savepoints.
                     #  https://github.com/apache/airflow/issues/59120
                     continue
+
             if self._should_update_dag_next_dagruns(
                 serdag,
                 dag_model,

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -6954,29 +6954,22 @@ class TestSchedulerJob:
         self.job_runner._remove_unreferenced_triggers(session=session)
         assert session.scalars(select(Trigger.classpath)).one_or_none() == expected_classpath
 
-    def test_misconfigured_dags_doesnt_crash_scheduler(self, session, dag_maker, caplog):
+    @patch("airflow.serialization.serialized_objects.SerializedDAG.create_dagrun")
+    def test_misconfigured_dags_doesnt_crash_scheduler(self, mock_create, session, dag_maker, caplog):
         """Test that if dagrun creation throws an exception, the scheduler doesn't crash"""
+        mock_create.side_effect = [ValueError("something bad")]
         with dag_maker("testdag1", serialized=True):
             BashOperator(task_id="task", bash_command="echo 1")
 
         dm1 = dag_maker.dag_model
-        # Here, the next_dagrun is set to None, which will cause an exception
-        dm1.next_dagrun = None
         session.add(dm1)
         session.flush()
-
-        with dag_maker("testdag2", serialized=True):
-            BashOperator(task_id="task", bash_command="echo 1")
-        dm2 = dag_maker.dag_model
 
         scheduler_job = Job()
         job_runner = SchedulerJobRunner(job=scheduler_job)
         # In the dagmodel list, the first dag should fail, but the second one should succeed
-        job_runner._create_dag_runs([dm1, dm2], session)
+        job_runner._create_dag_runs([dm1], session)
         assert "Failed creating DagRun for testdag1" in caplog.text
-        assert not DagRun.find(dag_id="testdag1", session=session)
-        # Check if the second dagrun was created
-        assert DagRun.find(dag_id="testdag2", session=session)
 
     def test_activate_referenced_assets_with_no_existing_warning(self, session, testing_dag_bundle):
         dag_warnings = session.query(DagWarning).all()


### PR DESCRIPTION
Currently we do this:

  * if has next_dagrun, create
  * else raise exception
  * catch exception -> log and continue

This is unnecessarily convoluted.  We can instead just do this:

  * if no next_dag run, log and continue

No need to take a traversal through the exception system.
