### PR TITLE
Upper-bind FastAPI until Cadwyn is adapted to FastAPI 0.126.0+

### DIFF
--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -85,9 +85,12 @@ dependencies = [
     "cryptography>=41.0.0,<46.0.0",
     "deprecated>=1.2.13",
     "dill>=0.2.2",
-    # limited due to changes needed https://github.com/fastapi/fastapi/pull/14434
-    # and the bug in fastapi 0.126.0 https://github.com/fastapi/fastapi/pull/14575#issuecomment-3678581316
-    "fastapi[standard-no-fastapi-cloud-cli]>=0.121.0, !=0.123.5, !=0.126.0, !=0.127.0",
+    # Limited due to backwards incompatible (but deliberate) changes in FastAPI 0.126.0
+    # which break Cadwyn way of copying classes and break serialization. As explained
+    # in https://github.com/fastapi/fastapi/pull/14582#issuecomment-3682792249, Cadwyn
+    # needs to adapt to those changes and we cannot move to newer version of FastAPI
+    # This is tracked in Cadwyn in https://github.com/zmievsa/cadwyn/issues/314
+    "fastapi[standard-no-fastapi-cloud-cli]>=0.121.0, <0.126.0",
     "uvicorn>=0.37.0",
     "starlette>=0.45.0",
     "httpx>=0.25.0",


### PR DESCRIPTION
Limited due to backwards incompatible (but deliberate) changes in FastAPI 0.126.0 which break Cadwyn way of copying classes and break serialization. As explained in
https://github.com/fastapi/fastapi/pull/14582#issuecomment-3682792249, Cadwyn needs to adapt to those changes and we cannot move to newer version of FastAPI This is tracked in Cadwyn in https://github.com/zmievsa/cadwyn/issues/314

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
