### PR TITLE
[v3-1-test] Upper-bind FastAPI until Cadwyn is adapted to FastAPI 0.1…

### DIFF
--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -41,7 +41,7 @@ license-files = ["LICENSE", "NOTICE"]
 # proactively. This way we also have a chance to test it with Python 3.14 and bump the upper binding
 # and manually mark providers that do not support it yet with !-3.14 - until they support it - which will
 # also exclude resolving uv workspace dependencies for those providers.
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10,!=3.14"
 authors = [
     { name = "Apache Software Foundation", email = "dev@airflow.apache.org" },
 ]
@@ -77,14 +77,20 @@ dependencies = [
     "argcomplete>=1.10",
     "asgiref>=2.3.0",
     "attrs>=22.1.0, !=25.2.0",
-    "cadwyn>=5.2.1",
+    "cadwyn>=5.6.1",
     "colorlog>=6.8.2",
     "cron-descriptor>=1.2.24",
     "croniter>=2.0.2",
-    "cryptography>=41.0.0",
+    # TODO(potiuk): We should bump cryptography to >=46.0.0 when sqlalchemy>=2.0 is required
+    "cryptography>=41.0.0,<46.0.0",
     "deprecated>=1.2.13",
     "dill>=0.2.2",
-    "fastapi[standard-no-fastapi-cloud-cli]>=0.116.0,<0.118.0",
+    # Limited due to backwards incompatible (but deliberate) changes in FastAPI 0.126.0
+    # which break Cadwyn way of copying classes and break serialization. As explained
+    # in https://github.com/fastapi/fastapi/pull/14582#issuecomment-3682792249, Cadwyn
+    # needs to adapt to those changes and we cannot move to newer version of FastAPI
+    # This is tracked in Cadwyn in https://github.com/zmievsa/cadwyn/issues/314
+    "fastapi[standard-no-fastapi-cloud-cli]>=0.121.0, <0.126.0",
     "uvicorn>=0.37.0",
     "starlette>=0.45.0",
     "httpx>=0.25.0",


### PR DESCRIPTION
…26.0+ (#59726)

Limited due to backwards incompatible (but deliberate) changes in FastAPI 0.126.0 which break Cadwyn way of copying classes and break serialization. As explained in
https://github.com/fastapi/fastapi/pull/14582#issuecomment-3682792249, Cadwyn needs to adapt to those changes and we cannot move to newer version of FastAPI This is tracked in Cadwyn in https://github.com/zmievsa/cadwyn/issues/314 (cherry picked from commit 3bf0ed824f390f994146e01be703484835dd47f1)

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
