### PR TITLE
Add workers.celery.replicas field

### DIFF
--- a/chart/newsfragments/59730.significant.rst
+++ b/chart/newsfragments/59730.significant.rst
@@ -1,0 +1,3 @@
+``workers.replicas`` command is now deprecated in favor of ``workers.celery.replicas``.
+
+Along the upgrade of Helm Chart version, change the configuration of ``workers.replicas`` to ``workers.celery.replicas`` or unset ``workers.celery.replicas`` to preserve previous behaviour of the Helm Chart.

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -188,6 +188,14 @@ DEPRECATION WARNING:
 
 {{- end }}
 
+{{- if ne (int .Values.workers.replicas) 1 }}
+
+ DEPRECATION WARNING:
+    `workers.replicas` has been renamed to `workers.celery.replicas`.
+    Please change your values as support for the old name will be dropped in a future release.
+
+{{- end }}
+
 {{ if (semverCompare ">=3.0.0" .Values.airflowVersion) }}
 #####################################################
 #  WARNING: You should set a static API secret key  #

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -62,7 +62,11 @@ spec:
   serviceName: {{ include "airflow.fullname" . }}-worker
   {{- end }}
   {{- if and (not $keda) (not $hpa) }}
+  {{- if ne (int .Values.workers.celery.replicas) 1 }}
+  replicas: {{ .Values.workers.celery.replicas }}
+  {{- else }}
   replicas: {{ .Values.workers.replicas }}
+  {{- end }}
   {{- end }}
   {{- if $revisionHistoryLimit }}
   revisionHistoryLimit: {{ $revisionHistoryLimit }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -62,11 +62,7 @@ spec:
   serviceName: {{ include "airflow.fullname" . }}-worker
   {{- end }}
   {{- if and (not $keda) (not $hpa) }}
-  {{- if ne (int .Values.workers.celery.replicas) 1 }}
-  replicas: {{ .Values.workers.celery.replicas }}
-  {{- else }}
-  replicas: {{ .Values.workers.replicas }}
-  {{- end }}
+  replicas: {{ .Values.workers.celery.replicas | default .Values.workers.replicas }}
   {{- end }}
   {{- if $revisionHistoryLimit }}
   revisionHistoryLimit: {{ $revisionHistoryLimit }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1635,7 +1635,7 @@
             "additionalProperties": false,
             "properties": {
                 "replicas": {
-                    "description": "Number of Airflow Celery workers.",
+                    "description": "Number of Airflow Celery workers (deprecated, use `workers.celery.replicas` instead).",
                     "type": "integer",
                     "default": 1
                 },
@@ -2608,6 +2608,11 @@
                     "type": "object",
                     "x-docsSection": "Workers",
                     "properties": {
+                        "replicas": {
+                            "description": "Number of Airflow Celery workers.",
+                            "type": "integer",
+                            "default": 1
+                        },
                         "serviceAccount": {
                             "description": "Create ServiceAccount.",
                             "type": "object",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -637,7 +637,7 @@ kerberos:
 
 # Airflow Worker Config
 workers:
-  # Number of Airflow Celery workers
+  # Number of Airflow Celery workers (deprecated, use `workers.celery.replicas` instead)
   replicas: 1
 
   # Max number of old Airflow Celery workers ReplicaSets to retain
@@ -1011,6 +1011,9 @@ workers:
   useWorkerDedicatedServiceAccounts: false
 
   celery:
+    # Number of Airflow Celery workers
+    replicas: 1
+
     # Create ServiceAccount for Airflow Celery workers
     serviceAccount:
       # default value is true

--- a/helm-tests/tests/helm_tests/airflow_core/test_worker.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_worker.py
@@ -1053,6 +1053,7 @@ class TestWorker:
             ({"celery": {"replicas": 2}}, 2),
             ({"celery": {"replicas": None}}, 1),
             ({"replicas": 2, "celery": {"replicas": 3}}, 3),
+            ({"replicas": 2, "celery": {"replicas": None}}, 2),
         ],
     )
     def test_workers_replicas(self, workers_values, expected):

--- a/helm-tests/tests/helm_tests/airflow_core/test_worker.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_worker.py
@@ -1049,8 +1049,9 @@ class TestWorker:
     @pytest.mark.parametrize(
         ("workers_values", "expected"),
         [
-            ({"replicas": 2}, 2),
+            ({"replicas": 2}, 1),
             ({"celery": {"replicas": 2}}, 2),
+            ({"celery": {"replicas": None}}, 1),
             ({"replicas": 2, "celery": {"replicas": 3}}, 3),
         ],
     )

--- a/helm-tests/tests/helm_tests/airflow_core/test_worker.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_worker.py
@@ -1046,6 +1046,22 @@ class TestWorker:
             == "release-name-storage-class"
         )
 
+    @pytest.mark.parametrize(
+        ("workers_values", "expected"),
+        [
+            ({"replicas": 2}, 2),
+            ({"celery": {"replicas": 2}}, 2),
+            ({"replicas": 2, "celery": {"replicas": 3}}, 3),
+        ],
+    )
+    def test_workers_replicas(self, workers_values, expected):
+        docs = render_chart(
+            values={"workers": workers_values},
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+
+        assert expected == jmespath.search("spec.replicas", docs[0])
+
 
 class TestWorkerLogGroomer(LogGroomerTestBase):
     """Worker groomer."""


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
related: https://github.com/apache/airflow/issues/28880

This PR introduces a new `workers.celery.replicas` command and deprecates the old `workers.replicas` command (as it was only applicable to Celery workers).

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
