### PR TITLE
SQLA2 public tests (test_backfills, test_connections, test_pools)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -426,6 +426,9 @@ repos:
             ^airflow-core/src/airflow/models/.*\.py$|
             ^airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py$|
             ^airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py$|
+            ^airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_backfills.py$|
+            ^airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py$|
+            ^airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py$|
             ^airflow-core/tests/unit/models/test_serialized_dag.py$|
             ^airflow-core/tests/unit/models/test_pool.py$|
             ^airflow-core/tests/unit/models/test_trigger.py$|

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_backfills.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_backfills.py
@@ -205,7 +205,7 @@ class TestCreateBackfill(TestBackfillEndpoint):
     def test_create_backfill(self, repro_act, repro_exp, session, dag_maker, test_client):
         with dag_maker(session=session, dag_id="TEST_DAG_1", schedule="0 * * * *") as dag:
             EmptyOperator(task_id="mytask")
-        session.query(DagModel).all()
+        session.scalars(select(DagModel)).all()
         session.commit()
         from_date = pendulum.parse("2024-01-01")
         from_date_iso = to_iso(from_date)
@@ -244,7 +244,7 @@ class TestCreateBackfill(TestBackfillEndpoint):
         check_last_log(session, dag_id="TEST_DAG_1", event="create_backfill", logical_date=None)
 
     def test_dag_not_exist(self, session, test_client):
-        session.query(DagModel).all()
+        session.scalars(select(DagModel)).all()
         session.commit()
         from_date = pendulum.parse("2024-01-01")
         from_date_iso = to_iso(from_date)
@@ -270,7 +270,7 @@ class TestCreateBackfill(TestBackfillEndpoint):
     def test_no_schedule_dag(self, session, dag_maker, test_client):
         with dag_maker(session=session, dag_id="TEST_DAG_1", schedule="None") as dag:
             EmptyOperator(task_id="mytask")
-        session.query(DagModel).all()
+        session.scalars(select(DagModel)).all()
         session.commit()
         from_date = pendulum.parse("2024-01-01")
         from_date_iso = to_iso(from_date)
@@ -306,7 +306,7 @@ class TestCreateBackfill(TestBackfillEndpoint):
     ):
         with dag_maker(session=session, dag_id="TEST_DAG_1", schedule="0 * * * *") as dag:
             EmptyOperator(task_id="mytask", depends_on_past=True)
-        session.query(DagModel).all()
+        session.scalars(select(DagModel)).all()
         session.commit()
         from_date = pendulum.parse("2024-01-01")
         from_date_iso = to_iso(from_date)
@@ -350,7 +350,7 @@ class TestCreateBackfill(TestBackfillEndpoint):
     def test_create_backfill_future_dates(self, session, dag_maker, test_client, run_backwards):
         with dag_maker(session=session, dag_id="TEST_DAG_1", schedule="0 * * * *") as dag:
             EmptyOperator(task_id="mytask")
-        session.query(DagModel).all()
+        session.scalars(select(DagModel)).all()
         session.commit()
         from_date = timezone.utcnow() + timedelta(days=1)
         to_date = timezone.utcnow() + timedelta(days=1)
@@ -381,7 +381,7 @@ class TestCreateBackfill(TestBackfillEndpoint):
     def test_create_backfill_past_future_dates(self, session, dag_maker, test_client, run_backwards):
         with dag_maker(session=session, dag_id="TEST_DAG_1", schedule="@daily") as dag:
             EmptyOperator(task_id="mytask")
-        session.query(DagModel).all()
+        session.scalars(select(DagModel)).all()
         session.commit()
         from_date = timezone.utcnow() - timedelta(days=2)
         to_date = timezone.utcnow() + timedelta(days=1)
@@ -543,7 +543,7 @@ class TestCreateBackfill(TestBackfillEndpoint):
     def test_should_respond_401(self, unauthenticated_test_client, dag_maker, session):
         with dag_maker(session=session, dag_id="TEST_DAG_1", schedule="0 * * * *") as dag:
             EmptyOperator(task_id="mytask")
-        session.query(DagModel).all()
+        session.scalars(select(DagModel)).all()
         session.commit()
         from_date = pendulum.parse("2024-01-01")
         from_date_iso = to_iso(from_date)
@@ -564,7 +564,7 @@ class TestCreateBackfill(TestBackfillEndpoint):
     def test_should_respond_403(self, unauthorized_test_client, dag_maker, session):
         with dag_maker(session=session, dag_id="TEST_DAG_1", schedule="0 * * * *") as dag:
             EmptyOperator(task_id="mytask")
-        session.query(DagModel).all()
+        session.scalars(select(DagModel)).all()
         session.commit()
         from_date = pendulum.parse("2024-01-01")
         from_date_iso = to_iso(from_date)
@@ -682,7 +682,7 @@ class TestCreateBackfillDryRun(TestBackfillEndpoint):
     ):
         with dag_maker(session=session, dag_id="TEST_DAG_1", schedule="0 * * * *") as dag:
             EmptyOperator(task_id="mytask", depends_on_past=True)
-        session.query(DagModel).all()
+        session.scalars(select(DagModel)).all()
         session.commit()
         from_date = pendulum.parse("2024-01-01")
         from_date_iso = to_iso(from_date)

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py
@@ -991,7 +991,7 @@ class TestBulkPools(TestPoolsEndpoint):
         assert response_data["update"]["success"] == ["pool1"]
 
         # Assert: fetch from DB and check only masked field changed
-        updated_pool = session.scalars(select(Pool).where(Pool.pool == "pool1")).one()
+        updated_pool = session.execute(select(Pool).where(Pool.pool == "pool1")).scalar_one()
         assert updated_pool.slots == 50  # updated
         assert updated_pool.description is None  # unchanged
         assert updated_pool.include_deferred is True  # unchanged


### PR DESCRIPTION
Related: https://github.com/apache/airflow/pull/59218, https://github.com/apache/airflow/issues/59402

Passes mypy & pre-commit checks

airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_backfills.py
airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py