### PR TITLE
Add BigQueryTableStreamingBufferEmptySensor for safe DML operations

### DIFF
--- a/example_bigquery_streaming_buffer.py
+++ b/example_bigquery_streaming_buffer.py
@@ -1,0 +1,68 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Example DAG demonstrating BigQueryTableStreamingBufferEmptySensor usage.
+
+This example shows how to safely perform DML operations on BigQuery tables
+that receive streaming inserts.
+"""
+
+from datetime import datetime
+
+from airflow import DAG
+from airflow.providers.google.cloud.operators.bigquery import BigQueryInsertJobOperator
+from airflow.providers.google.cloud.sensors.bigquery import BigQueryTableStreamingBufferEmptySensor
+
+PROJECT_ID = "your-project-id"
+DATASET_ID = "your_dataset"
+TABLE_ID = "your_streaming_table"
+
+with DAG(
+    dag_id="example_bigquery_streaming_buffer_sensor",
+    start_date=datetime(2024, 1, 1),
+    schedule=None,
+    catchup=False,
+    tags=["example", "bigquery", "streaming"],
+) as dag:
+    # Wait for streaming buffer to be empty before running DML
+    wait_for_buffer_empty = BigQueryTableStreamingBufferEmptySensor(
+        task_id="wait_for_streaming_buffer_empty",
+        project_id=PROJECT_ID,
+        dataset_id=DATASET_ID,
+        table_id=TABLE_ID,
+        poke_interval=60,  # Check every 60 seconds
+        timeout=3600,  # Timeout after 1 hour
+        mode="reschedule",  # Free up worker slots while waiting
+    )
+
+    # Run DML operation once buffer is empty
+    run_dml = BigQueryInsertJobOperator(
+        task_id="run_dml_operation",
+        configuration={
+            "query": {
+                "query": f"""
+                    UPDATE `{PROJECT_ID}.{DATASET_ID}.{TABLE_ID}`
+                    SET status = 'processed'
+                    WHERE status = 'pending'
+                """,
+                "useLegacySql": False,
+            }
+        },
+    )
+
+    wait_for_buffer_empty >> run_dml


### PR DESCRIPTION
This sensor checks if a BigQuery table's streaming buffer is empty before allowing DML operations (UPDATE, DELETE, MERGE) to proceed.

Solves the issue where DML statements fail with 'would affect rows in the streaming buffer' error when tables receive continuous streaming inserts.

Added comprehensive tests and example DAG demonstrating usage.
## Description

This PR adds `BigQueryTableStreamingBufferEmptySensor` to solve a critical issue affecting users who run DML operations on BigQuery tables populated via streaming inserts.


### User Impact

When Apache Airflow DAGs execute DML statements (UPDATE, DELETE, MERGE) on BigQuery tables that receive continuous streaming inserts (via Dataflow, CDC pipelines, BigQuery Storage Write API, or `tabledata.insertAll`), tasks fail with:

**This causes:**
- ❌ Pipeline failures requiring manual intervention
- ❌ Wasted compute resources on repeated retries
- ❌ Delayed data processing (hours of retry attempts)
- ❌ SLA violations in production environments
- ❌ Fragile pipelines requiring workarounds (sleep commands, external scripts)

### Root Cause

**BigQuery's documented limitation:** DML operations cannot modify rows still residing in the streaming buffer. The buffer typically flushes within minutes but can take up to 90 minutes under certain conditions.

**Airflow's current behavior:** Operators like `BigQueryInsertJobOperator` immediately execute DML statements without checking buffer state, causing:
1. Job fails with streaming buffer error
2. Airflow retries the task (same error)
3. Repeated failures until buffer happens to be empty
4. No visibility into why failures occur or when it's safe to retry

### Why This Matters

This issue is **increasingly common** because:
- Modern data pipelines heavily use streaming ingestion (real-time CDC, event streams, IoT data)
- BigQuery recommends streaming API for high-throughput ingestion
- Users need to run incremental DML operations (deduplication, status updates, soft deletes) on the same tables
- Google Cloud Composer users report this as a frequent pain point

## Solution

### What This PR Adds

A new sensor `BigQueryTableStreamingBufferEmptySensor` that:

1. **Checks streaming buffer state** via BigQuery Tables API
2. **Waits until buffer is empty** before allowing downstream DML operations
3. **Provides visibility** through logging (estimated rows in buffer)
4. **Follows Airflow patterns** (poke_interval, timeout, mode='reschedule')
5. **Non-blocking** when using `mode='reschedule'` (frees worker slots)

### Implementation Details

```python
class BigQueryTableStreamingBufferEmptySensor(BaseSensorOperator):
    """
    Checks if a BigQuery table's streaming buffer is empty.
    
    The sensor queries table metadata and checks the streamingBuffer field:
    - If streamingBuffer is None → buffer empty → sensor succeeds
    - If streamingBuffer exists → checks estimated_rows → waits
    """

closes **59408
