### PR TITLE
SQLA2: Address assorted mypy violations in airflow-core

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2188,7 +2188,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 ):
                     dag_model.calculate_dagrun_date_fields(dag, get_run_data_interval(dag.timetable, dag_run))
 
-                dag_run = session.scalar(
+                dag_run_reloaded = session.scalar(
                     select(DagRun)
                     .where(DagRun.id == dag_run.id)
                     .options(
@@ -2196,6 +2196,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                         selectinload(DagRun.consumed_asset_events).selectinload(AssetEvent.source_aliases),
                     )
                 )
+                if dag_run_reloaded is None:
+                    # This should never happen since we just had the dag_run
+                    self.log.error("DagRun %s was deleted unexpectedly", dag_run.id)
+                    return None
+                dag_run = dag_run_reloaded
                 callback_to_execute = DagCallbackRequest(
                     filepath=dag_model.relative_fileloc or "",
                     dag_id=dag.dag_id,

--- a/shared/configuration/src/airflow_shared/configuration/parser.py
+++ b/shared/configuration/src/airflow_shared/configuration/parser.py
@@ -282,12 +282,6 @@ class AirflowConfigParser(ConfigParser):
         sensitive.update(depr_section, depr_option)
         return sensitive
 
-    @overload  # type: ignore[override]
-    def get(self, section: str, key: str, fallback: str = ..., **kwargs) -> str: ...
-
-    @overload
-    def get(self, section: str, key: str, **kwargs) -> str | None: ...
-
     def _update_defaults_from_string(self, config_string: str) -> None:
         """
         Update the defaults in _default_values based on values in config_string ("ini" format).

--- a/shared/configuration/src/airflow_shared/configuration/parser.py
+++ b/shared/configuration/src/airflow_shared/configuration/parser.py
@@ -248,7 +248,7 @@ class AirflowConfigParser(ConfigParser):
         self.configuration_description = configuration_description
         self._default_values = _default_values
         self._suppress_future_warnings = False
-        self.upgraded_values = {}
+        self.upgraded_values: dict[tuple[str, str], str] = {}
 
     @functools.cached_property
     def inversed_deprecated_options(self):

--- a/shared/observability/src/airflow_shared/observability/metrics/datadog_logger.py
+++ b/shared/observability/src/airflow_shared/observability/metrics/datadog_logger.py
@@ -175,12 +175,16 @@ def get_dogstatsd_logger(
     """Get DataDog StatsD logger."""
     from datadog import DogStatsd
 
-    dogstatsd = DogStatsd(
-        host,
-        port,
-        namespace,
-        constant_tags=cls.get_constant_tags(),
-    )
+    dogstatsd_kwargs: dict[str, str | int | list[str]] = {
+        "constant_tags": cls.get_constant_tags(),
+    }
+    if host is not None:
+        dogstatsd_kwargs["host"] = host
+    if port is not None:
+        dogstatsd_kwargs["port"] = port
+    if namespace is not None:
+        dogstatsd_kwargs["namespace"] = namespace
+    dogstatsd = DogStatsd(**dogstatsd_kwargs)
     metric_tags_validator = PatternBlockListValidator(statsd_disabled_tags)
     validator = get_validator(metrics_allow_list, metrics_block_list)
     return SafeDogStatsdLogger(

--- a/shared/observability/src/airflow_shared/observability/metrics/otel_logger.py
+++ b/shared/observability/src/airflow_shared/observability/metrics/otel_logger.py
@@ -388,7 +388,9 @@ def get_otel_logger(
     stat_name_handler: Callable[[str], str] | None = None,
     statsd_influxdb_enabled: bool = False,
 ) -> SafeOtelLogger:
-    resource = Resource.create(attributes={SERVICE_NAME: service_name})
+    effective_service_name: str = service_name or "airflow"
+    effective_prefix: str = prefix or DEFAULT_METRIC_NAME_PREFIX
+    resource = Resource.create(attributes={SERVICE_NAME: effective_service_name})
     protocol = "https" if ssl_active else "http"
     # Allow transparent support for standard OpenTelemetry SDK environment variables.
     # https://opentelemetry.io/docs/specs/otel/protocol/exporter/#configuration-options
@@ -420,5 +422,5 @@ def get_otel_logger(
     validator = get_validator(metrics_allow_list, metrics_block_list)
 
     return SafeOtelLogger(
-        metrics.get_meter_provider(), prefix, validator, stat_name_handler, statsd_influxdb_enabled
+        metrics.get_meter_provider(), effective_prefix, validator, stat_name_handler, statsd_influxdb_enabled
     )

--- a/shared/observability/src/airflow_shared/observability/traces/otel_tracer.py
+++ b/shared/observability/src/airflow_shared/observability/traces/otel_tracer.py
@@ -77,7 +77,7 @@ class OtelTrace:
             log.info("(otel_tracer.__init__) - [BatchSpanProcessor] is being used")
             self.span_processor = BatchSpanProcessor(self.span_exporter)
         self.tag_string = tag_string
-        self.otel_service = otel_service
+        self.otel_service: str = otel_service or "airflow"
         self.resource = Resource.create(attributes={SERVICE_NAME: self.otel_service})
         self.debug = debug
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Related: https://github.com/apache/airflow/pull/59218

The 22 addressed violations:
```none
airflow-core/src/airflow/_shared/configuration/parser.py:251: error: Need type annotation for "upgraded_values" (hint:
"upgraded_values: dict[<type>, <type>] = ...")  [var-annotated]
            self.upgraded_values = {}
            ^~~~~~~~~~~~~~~~~~~~
airflow-core/src/airflow/_shared/configuration/parser.py:285: error: An overloaded function outside a stub file must have an
implementation  [no-overload-impl]
        @overload  # type: ignore[override]
         ^
airflow-core/src/airflow/_shared/configuration/parser.py:285: note: Error code "no-overload-impl" not covered by "type: ignore" comment
airflow-core/src/airflow/_shared/configuration/parser.py:980: error: Name "get" already defined on line 285  [no-redef]
        @overload  # type: ignore[override]
         ^
airflow-core/src/airflow/_shared/configuration/parser.py:980: note: Error code "no-redef" not covered by "type: ignore" comment
airflow-core/src/airflow/_shared/observability/metrics/datadog_logger.py:179: error: Argument 1 to "DogStatsd" has incompatible type
"str | None"; expected "str"  [arg-type]
            host,
            ^~~~
airflow-core/src/airflow/_shared/observability/metrics/datadog_logger.py:180: error: Argument 2 to "DogStatsd" has incompatible type
"int | None"; expected "int"  [arg-type]
            port,
            ^~~~
airflow-core/src/airflow/_shared/observability/metrics/datadog_logger.py:181: error: Argument 3 to "DogStatsd" has incompatible type
"str | None"; expected "None"  [arg-type]
            namespace,
            ^~~~~~~~~
airflow-core/src/airflow/_shared/observability/traces/otel_tracer.py:81: error: Dict entry 0 has incompatible type "str": "str | None";
expected "str": "int | float | Sequence[str] | Sequence[int] | Sequence[float]"  [dict-item]
            self.resource = Resource.create(attributes={SERVICE_NAME: self.otel_service})
                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
airflow-core/src/airflow/_shared/observability/traces/otel_tracer.py:150: error: Argument "component" to "get_tracer" of "OtelTrace"
has incompatible type "str | None"; expected "str"  [arg-type]
            tracer = self.get_tracer(component=component, trace_id=trace_id, span_id=span_id)
                                               ^~~~~~~~~
airflow-core/src/airflow/_shared/observability/traces/otel_tracer.py:259: error: Argument "component" to "get_tracer" of "OtelTrace"
has incompatible type "str | None"; expected "str"  [arg-type]
            tracer = self.get_tracer(component=component)
                                               ^~~~~~~~~
airflow-core/src/airflow/_shared/observability/metrics/otel_logger.py:391: error: Dict entry 0 has incompatible type "str":
"str | None"; expected "str": "int | float | Sequence[str] | Sequence[int] | Sequence[float]"  [dict-item]
        resource = Resource.create(attributes={SERVICE_NAME: service_name})
                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~
airflow-core/src/airflow/_shared/observability/metrics/otel_logger.py:423: error: Argument 2 to "SafeOtelLogger" has incompatible type
"str | None"; expected "str"  [arg-type]
            metrics.get_meter_provider(), prefix, validator, stat_name_handler, statsd_influxdb_enabled
                                          ^~~~~~
airflow-core/src/airflow/_shared/logging/structlog.py:99: error: Incompatible types in assignment (expression has type
"Mapping[Any, Any]", variable has type "tuple[Any, ...]")  [assignment]
                    args = args[0]
                           ^~~~~~~
airflow-core/src/airflow/_shared/logging/structlog.py:289: error: Incompatible types in assignment (expression has type
"tuple[Module, Module, Module]", variable has type "tuple[Module, Module]")  [assignment]
            suppress += (httpcore,)
            ^~~~~~~~~~~~~~~~~~~~~~~
airflow-core/src/airflow/_shared/logging/structlog.py:295: error: Incompatible types in assignment (expression has type
"tuple[Module, Module, Module]", variable has type "tuple[Module, Module]")  [assignment]
            suppress += (httpx,)
            ^~~~~~~~~~~~~~~~~~~~
airflow-core/src/airflow/_shared/logging/structlog.py:323: error: Item "str" of "str | bytes" has no attribute "decode"  [union-attr]
                return json(logger, method_name, event_dict).decode("utf-8")
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
airflow-core/src/airflow/_shared/logging/structlog.py:346: error: Incompatible types in assignment (expression has type
"Callable[[TextIO, tuple[type[BaseException], BaseException, TracebackType | None]], None]", variable has type "RichTracebackFormatter")
 [assignment]
            exc_formatter = structlog.dev.plain_traceback
                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
airflow-core/src/airflow/_shared/logging/structlog.py:372: error: Incompatible types in assignment (expression has type
"ConsoleRenderer", variable has type "PercentFormatRender")  [assignment]
            console = structlog.dev.ConsoleRenderer(
                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
airflow-core/src/airflow/_shared/logging/structlog.py:482: error: Argument 1 to "LoggerFactory" has incompatible type
"type[NamedBytesLogger]"; expected "Callable[[str | None, LogOutputType | None], Any]"  [arg-type]
            logger_factory = LoggerFactory(NamedBytesLogger, io=output)
                                           ^~~~~~~~~~~~~~~~
airflow-core/src/airflow/_shared/logging/structlog.py:489: error: Value of type variable "_BufferT_co" of "TextIOWrapper" cannot be
"LogOutputType"  [type-var]
                output = io.TextIOWrapper(output, line_buffering=True)
                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
airflow-core/src/airflow/_shared/logging/structlog.py:489: error: Incompatible types in assignment (expression has type
"TextIOWrapper[LogOutputType]", variable has type "LogOutputType | None")  [assignment]
                output = io.TextIOWrapper(output, line_buffering=True)
                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
airflow-core/src/airflow/_shared/logging/structlog.py:490: error: Argument 1 to "LoggerFactory" has incompatible type
"type[NamedWriteLogger]"; expected "Callable[[str | None, LogOutputType | None], Any]"  [arg-type]
            logger_factory = LoggerFactory(NamedWriteLogger, io=output)
                                           ^~~~~~~~~~~~~~~~
airflow-core/src/airflow/jobs/scheduler_job_runner.py:2191: error: Incompatible types in assignment (expression has type
"DagRun | None", variable has type "DagRun")  [assignment]
                    dag_run = session.scalar(
                              ^~~~~~~~~~~~~~~
Found 22 errors in 6 files (checked 1078 source files)
```


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
