### PR TITLE
Docs: clarify serialization resolution order

### DIFF
--- a/airflow-core/docs/authoring-and-scheduling/serializers.rst
+++ b/airflow-core/docs/authoring-and-scheduling/serializers.rst
@@ -26,12 +26,23 @@ and efficiency.
 Serialization is a surprisingly hard job. Python out of the box only has support for serialization of primitives,
 like ``str`` and ``int`` and it loops over iterables. When things become more complex, custom serialization is required.
 
-Airflow out of the box supports three ways of custom serialization. Primitives are returned as is, without
-additional encoding, e.g. a ``str`` remains a ``str``. When it is not a primitive (or iterable thereof) Airflow
-looks for a registered serializer and deserializer in the namespace of ``airflow.sdk.serde.serializers``.
-If not found it will look in the class for a ``serialize()`` method or in case of deserialization a
-``deserialize(data, version: int)`` method. Finally, if the class is either decorated with ``@dataclass``
-or ``@attr.define`` it will use the public methods for those decorators.
+Serialization resolution order
+------------------------------
+
+Airflow resolves custom serialization in the following order:
+
+1. Primitive values (such as ``str`` or ``int``) and iterables of primitives
+   are returned as-is, without additional encoding.
+
+2. If the object is not a primitive, Airflow looks for a registered serializer
+   and deserializer in the ``airflow.sdk.serde.serializers`` namespace.
+
+3. If no registered serializer is found, Airflow checks whether the object
+   defines a ``serialize()`` method (and, for deserialization, a corresponding
+   ``deserialize(data, version: int)`` method).
+
+4. Finally, if the object is decorated with ``@dataclass`` or ``@attr.define``,
+   Airflow serializes the object using the public fields provided by those decorators.
 
 If you are looking to extend Airflow with a new serializer, it is good to know when to choose what way of serialization.
 Objects that are under the control of Airflow, i.e. residing under the namespace of ``airflow.*`` like


### PR DESCRIPTION
Reformats and clarifies the serialization resolution order into a dedicated
numbered list to improve readability, without changing behavior.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
