### PR TITLE
Force uninstall edge provider for Breeze start-airflow cmd on Airflow 2

### DIFF
--- a/scripts/in_container/install_airflow_and_providers.py
+++ b/scripts/in_container/install_airflow_and_providers.py
@@ -997,9 +997,8 @@ def install_airflow_and_providers(
                 "apache-airflow-providers-keycloak",
                 "apache-airflow-providers-common-messaging",
                 "apache-airflow-providers-git",
+                "apache-airflow-providers-edge3",
             ]
-            if version.minor < 10:
-                providers_to_uninstall_for_airflow_2.append("apache-airflow-providers-edge3")
             run_command(
                 ["uv", "pip", "uninstall", *providers_to_uninstall_for_airflow_2],
                 github_actions=github_actions,


### PR DESCRIPTION
## Why

When running ‎`breeze start-airflow --backend postgres --mount-sources providers-and-tests --use-airflow-version 2.11.0`, we will hit an error because the Edge provider now requires Airflow 3.0.0 or later.

```
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/opt/airflow/providers/edge3/src/airflow/providers/edge3/__init__.py", line 37, in <module>
    raise RuntimeError(
RuntimeError: The package `apache-airflow-providers-edge3:2.0.0` needs Apache Airflow 3.0.0+

Error: check_environment returned 1. Exiting.
```

<details>
<summary>Full Traceback</summary>

```
This could be because you are installing old airflow version
Attempting to run deprecated 'airflow db init' instead.
/usr/python/lib/python3.10/site-packages/google/api_core/_python_version_support.py:266 FutureWarning: You are using a Python version (3.10.19) which Google will stop supporting in new releases of google.api_core once it reaches its end of life (2026-10-04). Please upgrade to the latest Python version, or at least Python 3.11, to continue receiving updates for google.api_core past that date.
/usr/python/lib/python3.10/site-packages/airflow/metrics/base_stats_logger.py:22 RemovedInAirflow3Warning: Timer and timing metrics publish in seconds were deprecated. It is enabled by default from Airflow 3 onwards. Enable timer_unit_consistency to publish all the timer and timing metrics in milliseconds.
/usr/python/lib/python3.10/site-packages/airflow/triggers/base.py:27 RemovedInAirflow3Warning: Timer and timing metrics publish in seconds were deprecated. It is enabled by default from Airflow 3 onwards. Enable timer_unit_consistency to publish all the timer and timing metrics in milliseconds.
Traceback (most recent call last):
  File "/usr/python/bin/airflow", line 10, in <module>
    sys.exit(main())
  File "/usr/python/lib/python3.10/site-packages/airflow/__main__.py", line 62, in main
    args.func(args)
  File "/usr/python/lib/python3.10/site-packages/airflow/cli/cli_config.py", line 49, in command
    return func(*args, **kwargs)
  File "/usr/python/lib/python3.10/site-packages/airflow/utils/providers_configuration_loader.py", line 54, in wrapped_function
    ProvidersManager().initialize_providers_configuration()
  File "/usr/python/lib/python3.10/site-packages/airflow/providers_manager.py", line 384, in wrapped_function
    func(*args, **kwargs)
  File "/usr/python/lib/python3.10/site-packages/airflow/providers_manager.py", line 579, in initialize_providers_configuration
    self._initialize_providers_configuration()
  File "/usr/python/lib/python3.10/site-packages/airflow/providers_manager.py", line 592, in _initialize_providers_configuration
    self.initialize_providers_list()
  File "/usr/python/lib/python3.10/site-packages/airflow/providers_manager.py", line 384, in wrapped_function
    func(*args, **kwargs)
  File "/usr/python/lib/python3.10/site-packages/airflow/providers_manager.py", line 495, in initialize_providers_list
    self._discover_all_providers_from_packages()
  File "/usr/python/lib/python3.10/site-packages/airflow/providers_manager.py", line 627, in _discover_all_providers_from_packages
    provider_info = entry_point.load()()
  File "/usr/python/lib/python3.10/site-packages/importlib_metadata/__init__.py", line 211, in load
    module = import_module(match.group('module'))
  File "/usr/python/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 992, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/opt/airflow/providers/edge3/src/airflow/providers/edge3/__init__.py", line 37, in <module>
    raise RuntimeError(
RuntimeError: The package `apache-airflow-providers-edge3:2.0.0` needs Apache Airflow 3.0.0+

Error: check_environment returned 1. Exiting.
```


</details>

## What

When running the ‎`breeze start-airflow` command with Airflow 2, we should now force uninstall the Edge provider.
