### PR TITLE
Replace imports from airflow.security.permissions module in fab provider due to future deprecation of the module.

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/cli_commands/permissions_command.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/cli_commands/permissions_command.py
@@ -50,7 +50,11 @@ def cleanup_dag_permissions(dag_id: str, session: Session = NEW_SESSION) -> None
     from sqlalchemy import delete, select
 
     from airflow.providers.fab.auth_manager.models import Permission, Resource, assoc_permission_role
-    from airflow.security.permissions import RESOURCE_DAG_PREFIX, RESOURCE_DAG_RUN, RESOURCE_DETAILS_MAP
+    from airflow.providers.fab.www.security.permissions import (
+        RESOURCE_DAG_PREFIX,
+        RESOURCE_DAG_RUN,
+        RESOURCE_DETAILS_MAP,
+    )
 
     # Clean up specific DAG permissions
     dag_resources = session.scalars(
@@ -107,7 +111,7 @@ def permissions_cleanup(args):
     from airflow.models import DagModel
     from airflow.providers.fab.auth_manager.cli_commands.utils import get_application_builder
     from airflow.providers.fab.auth_manager.models import Resource
-    from airflow.security.permissions import (
+    from airflow.providers.fab.www.security.permissions import (
         RESOURCE_DAG_PREFIX,
         RESOURCE_DAG_RUN,
         RESOURCE_DETAILS_MAP,

--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -101,7 +101,6 @@ from airflow.providers.fab.version_compat import AIRFLOW_V_3_1_PLUS
 from airflow.providers.fab.www.security import permissions
 from airflow.providers.fab.www.security_manager import AirflowSecurityManagerV2
 from airflow.providers.fab.www.session import AirflowDatabaseSessionInterface
-from airflow.security.permissions import RESOURCE_BACKFILL
 
 if TYPE_CHECKING:
     from airflow.providers.fab.www.security.permissions import (
@@ -236,7 +235,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG_WARNING),
         (permissions.ACTION_CAN_READ, RESOURCE_ASSET),
         (permissions.ACTION_CAN_READ, RESOURCE_ASSET_ALIAS),
-        (permissions.ACTION_CAN_READ, RESOURCE_BACKFILL),
+        (permissions.ACTION_CAN_READ, permissions.RESOURCE_BACKFILL),
         (permissions.ACTION_CAN_READ, permissions.RESOURCE_CLUSTER_ACTIVITY),
         (permissions.ACTION_CAN_READ, permissions.RESOURCE_POOL),
         (permissions.ACTION_CAN_READ, permissions.RESOURCE_IMPORT_ERROR),
@@ -308,9 +307,9 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         (permissions.ACTION_CAN_DELETE, permissions.RESOURCE_XCOM),
         (permissions.ACTION_CAN_CREATE, RESOURCE_ASSET),
         (permissions.ACTION_CAN_DELETE, RESOURCE_ASSET),
-        (permissions.ACTION_CAN_CREATE, RESOURCE_BACKFILL),
-        (permissions.ACTION_CAN_EDIT, RESOURCE_BACKFILL),
-        (permissions.ACTION_CAN_DELETE, RESOURCE_BACKFILL),
+        (permissions.ACTION_CAN_CREATE, permissions.RESOURCE_BACKFILL),
+        (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_BACKFILL),
+        (permissions.ACTION_CAN_DELETE, permissions.RESOURCE_BACKFILL),
     ]
     # [END security_op_perms]
 

--- a/providers/fab/tests/unit/fab/auth_manager/cli_commands/test_permissions_command.py
+++ b/providers/fab/tests/unit/fab/auth_manager/cli_commands/test_permissions_command.py
@@ -256,7 +256,7 @@ class TestDagPermissions:
             cleanup_dag_permissions,
         )
         from airflow.providers.fab.auth_manager.models import Action, Permission, Resource
-        from airflow.security.permissions import RESOURCE_DAG_PREFIX
+        from airflow.providers.fab.www.security.permissions import RESOURCE_DAG_PREFIX
         from airflow.utils.session import create_session
 
         with create_session() as session:
@@ -309,7 +309,7 @@ class TestDagPermissions:
             cleanup_dag_permissions,
         )
         from airflow.providers.fab.auth_manager.models import Resource
-        from airflow.security.permissions import RESOURCE_DAG_PREFIX
+        from airflow.providers.fab.www.security.permissions import RESOURCE_DAG_PREFIX
         from airflow.utils.session import create_session
 
         with create_session() as session:
@@ -330,7 +330,7 @@ class TestDagPermissions:
             cleanup_dag_permissions,
         )
         from airflow.providers.fab.auth_manager.models import Resource
-        from airflow.security.permissions import RESOURCE_DAG_PREFIX
+        from airflow.providers.fab.www.security.permissions import RESOURCE_DAG_PREFIX
         from airflow.utils.session import create_session
 
         # Setup test data


### PR DESCRIPTION


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
