### PR TITLE
Don't clear query cache when the initial ref is empty string and compared against latest run leading to duplicate requests.

### DIFF
--- a/airflow-core/src/airflow/ui/src/queries/useRefreshOnNewDagRuns.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useRefreshOnNewDagRuns.ts
@@ -45,7 +45,17 @@ export const useRefreshOnNewDagRuns = (dagId: string, hasPendingRuns: boolean | 
   useEffect(() => {
     const latestDagRunId = latestDagRun?.run_id;
 
-    if (latestDagRunId !== undefined && previousDagRunIdRef.current !== latestDagRunId) {
+    if (latestDagRunId !== undefined && previousDagRunIdRef.current === "") {
+      previousDagRunIdRef.current = latestDagRunId;
+
+      return;
+    }
+
+    if (
+      latestDagRunId !== undefined &&
+      previousDagRunIdRef.current !== "" &&
+      previousDagRunIdRef.current !== latestDagRunId
+    ) {
       previousDagRunIdRef.current = latestDagRunId;
 
       const queryKeys = [


### PR DESCRIPTION
On the initial load `previousDagRunIdRef.current` is "" and compared against `latestDagRunId` to clear cache causing the http requests to be initiated again. Initially when previousDagRunIdRef.current is empty set it to latestDagRunId and check only when there is a new run in the next loop. Duplicate requests like "/ui/grid/runs", "/ui/grid/structure" etc. are not made with this check reducing the overall load on the webserver on page load.

In main loading a dag page with one run and no pending run

/ui - 11 requests
/api - 16 requests

After PR

/ui - 9 requests
/api - 11 requests

Closes #59757 