### PR TITLE
feat: add only_new to dag clear function

### DIFF
--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -227,7 +227,7 @@ def _recalculate_dagrun_queued_at_deadlines(
     # These changes are committed by the calling function.
 
 
-def get_new_tasks(
+def _get_new_tasks(
     dag_id: str,
     run_id: str,
     session: Session,

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -231,7 +231,7 @@ def get_new_tasks(
     dag_id: str,
     run_id: str,
     session: Session,
-) -> list[TaskInstance]:
+) -> Collection[str | tuple[str, int]]:
     """
     Get task instances for newly added tasks in the latest DAG version.
 
@@ -267,17 +267,7 @@ def get_new_tasks(
             dag_run.verify_integrity(session=session, dag_version_id=dag_version.id)
             session.flush()
 
-        from airflow.models.taskinstance import TaskInstance
-
-        new_tis = session.scalars(
-            select(TaskInstance).where(
-                TaskInstance.dag_id == dag_id,
-                TaskInstance.run_id == run_id,
-                TaskInstance.task_id.in_(new_task_ids),
-            )
-        ).all()
-        return list(new_tis)
-    return []
+    return list(new_task_ids)
 
 
 def clear_task_instances(

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -298,7 +298,11 @@ def _update_dagrun_to_latest_version(
     dag_run.bundle_version = dag_version.bundle_version
     dag_run.dag = latest_dag
 
+    for ti in dag_run.get_task_instances(session=session):
+        ti.dag_version_id = dag_version.id
+
     dag_run.verify_integrity(session=session, dag_version_id=dag_version.id)
+
     session.flush()
 
 

--- a/airflow-core/src/airflow/serialization/definitions/dag.py
+++ b/airflow-core/src/airflow/serialization/definitions/dag.py
@@ -936,7 +936,7 @@ class SerializedDAG:
         run_id: str,
         only_failed: bool = False,
         only_running: bool = False,
-        only_new: bool = False,
+        only_new: Literal[False] = False,
         dag_run_state: DagRunState = DagRunState.QUEUED,
         session: Session = NEW_SESSION,
         exclude_task_ids: frozenset[str] | frozenset[tuple[str, int]] | None = frozenset(),

--- a/airflow-core/src/airflow/serialization/definitions/dag.py
+++ b/airflow-core/src/airflow/serialization/definitions/dag.py
@@ -1022,27 +1022,27 @@ class SerializedDAG:
         if only_new:
             if not run_id:
                 raise ValueError("only_new requires run_id to be specified")
-            tis = get_new_tasks(self.dag_id, run_id, session)
-        else:
-            state: list[TaskInstanceState] = []
+            task_ids = get_new_tasks(self.dag_id, run_id, session)
 
-            if only_failed:
-                state += [TaskInstanceState.FAILED, TaskInstanceState.UPSTREAM_FAILED]
-            if only_running:
-                # Yes, having `+=` doesn't make sense, but this was the existing behaviour
-                state += [TaskInstanceState.RUNNING]
+        state: list[TaskInstanceState] = []
 
-            tis_result = self._get_task_instances(
-                task_ids=task_ids,
-                start_date=start_date,
-                end_date=end_date,
-                run_id=run_id,
-                state=state,
-                session=session,
-                exclude_task_ids=exclude_task_ids,
-                exclude_run_ids=exclude_run_ids,
-            )
-            tis = list(tis_result)
+        if only_failed:
+            state += [TaskInstanceState.FAILED, TaskInstanceState.UPSTREAM_FAILED]
+        if only_running:
+            # Yes, having `+=` doesn't make sense, but this was the existing behaviour
+            state += [TaskInstanceState.RUNNING]
+
+        tis_result = self._get_task_instances(
+            task_ids=task_ids,
+            start_date=start_date,
+            end_date=end_date,
+            run_id=run_id,
+            state=state,
+            session=session,
+            exclude_task_ids=exclude_task_ids,
+            exclude_run_ids=exclude_run_ids,
+        )
+        tis = list(tis_result)
 
         if dry_run:
             return list(tis)

--- a/airflow-core/src/airflow/serialization/definitions/dag.py
+++ b/airflow-core/src/airflow/serialization/definitions/dag.py
@@ -1042,10 +1042,11 @@ class SerializedDAG:
             exclude_task_ids=exclude_task_ids,
             exclude_run_ids=exclude_run_ids,
         )
-        tis = list(tis_result)
 
         if dry_run:
-            return list(tis)
+            return list(tis_result)
+
+        tis = list(tis_result)
 
         count = len(tis)
         if count == 0:

--- a/airflow-core/src/airflow/serialization/definitions/dag.py
+++ b/airflow-core/src/airflow/serialization/definitions/dag.py
@@ -919,6 +919,7 @@ class SerializedDAG:
         run_id: str,
         only_failed: bool = False,
         only_running: bool = False,
+        only_new: bool = False,
         dag_run_state: DagRunState = DagRunState.QUEUED,
         session: Session = NEW_SESSION,
         exclude_task_ids: frozenset[str] | frozenset[tuple[str, int]] | None = frozenset(),
@@ -934,6 +935,7 @@ class SerializedDAG:
         run_id: str,
         only_failed: bool = False,
         only_running: bool = False,
+        only_new: bool = False,
         dag_run_state: DagRunState = DagRunState.QUEUED,
         dry_run: Literal[False] = False,
         session: Session = NEW_SESSION,
@@ -952,6 +954,7 @@ class SerializedDAG:
         end_date: datetime.datetime | None = None,
         only_failed: bool = False,
         only_running: bool = False,
+        only_new: bool = False,
         dag_run_state: DagRunState = DagRunState.QUEUED,
         session: Session = NEW_SESSION,
         exclude_task_ids: frozenset[str] | frozenset[tuple[str, int]] | None = frozenset(),
@@ -968,6 +971,7 @@ class SerializedDAG:
         end_date: datetime.datetime | None = None,
         only_failed: bool = False,
         only_running: bool = False,
+        only_new: bool = False,
         dag_run_state: DagRunState = DagRunState.QUEUED,
         dry_run: Literal[False] = False,
         session: Session = NEW_SESSION,
@@ -986,6 +990,7 @@ class SerializedDAG:
         end_date: datetime.datetime | None = None,
         only_failed: bool = False,
         only_running: bool = False,
+        only_new: bool = False,
         dag_run_state: DagRunState = DagRunState.QUEUED,
         dry_run: bool = False,
         session: Session = NEW_SESSION,
@@ -1002,6 +1007,7 @@ class SerializedDAG:
         :param end_date: The maximum logical_date to clear
         :param only_failed: Only clear failed tasks
         :param only_running: Only clear running tasks.
+        :param only_new: Only newly added tasks in the latest version without clearing existing tasks
         :param dag_run_state: state to set DagRun to. If set to False, dagrun state will not
             be changed.
         :param dry_run: Find the tasks to clear but don't clear them.
@@ -1014,6 +1020,38 @@ class SerializedDAG:
         from airflow.models.taskinstance import clear_task_instances
 
         state: list[TaskInstanceState] = []
+
+        if only_new:
+            if not run_id:
+                raise ValueError("only_new requires run_id to be specified")
+
+            from airflow.models.dagbag import DBDagBag
+
+            dag_run = session.scalar(select(DagRun).filter_by(dag_id=self.dag_id, run_id=run_id))
+            if not dag_run:
+                raise ValueError(f"DagRun with run_id '{run_id}' not found")
+
+            dagbag = DBDagBag(load_op_links=False)
+            latest_dag = dagbag.get_latest_version_of_dag(self.dag_id, session=session)
+
+            if not latest_dag:
+                raise ValueError(f"Latest DAG version for '{self.dag_id}' not found")
+
+            current_dag = dagbag.get_dag_for_run(dag_run=dag_run, session=session)
+            new_task_ids = set(latest_dag.task_ids) - set(current_dag.task_ids) if current_dag else set()
+
+            # Update dag run to latest version
+            if new_task_ids:
+                dag_version = DagVersion.get_latest_version(self.dag_id, session=session)
+                if dag_version:
+                    dag_run.created_dag_version_id = dag_version.id
+                    dag_run.dag = latest_dag
+                    dag_run.verify_integrity(session=session, dag_version_id=dag_version.id)
+                    session.flush()
+
+                task_ids = list(new_task_ids)
+            else:
+                task_ids = []
         if only_failed:
             state += [TaskInstanceState.FAILED, TaskInstanceState.UPSTREAM_FAILED]
         if only_running:

--- a/airflow-core/src/airflow/serialization/definitions/dag.py
+++ b/airflow-core/src/airflow/serialization/definitions/dag.py
@@ -919,6 +919,23 @@ class SerializedDAG:
         run_id: str,
         only_failed: bool = False,
         only_running: bool = False,
+        only_new: Literal[True],
+        dag_run_state: DagRunState = DagRunState.QUEUED,
+        session: Session = NEW_SESSION,
+        exclude_task_ids: frozenset[str] | frozenset[tuple[str, int]] | None = frozenset(),
+        exclude_run_ids: frozenset[str] | None = frozenset(),
+        run_on_latest_version: bool = False,
+    ) -> set[str]: ...  # pragma: no cover
+
+    @overload
+    def clear(
+        self,
+        *,
+        dry_run: Literal[True],
+        task_ids: Collection[str | tuple[str, int]] | None = None,
+        run_id: str,
+        only_failed: bool = False,
+        only_running: bool = False,
         only_new: bool = False,
         dag_run_state: DagRunState = DagRunState.QUEUED,
         session: Session = NEW_SESSION,
@@ -1024,6 +1041,10 @@ class SerializedDAG:
         if only_new:
             if task_ids is not None:
                 raise ValueError("only_new and task_ids are mutually exclusive")
+            if only_failed:
+                raise ValueError("only_new and only_failed are mutually exclusive")
+            if only_running:
+                raise ValueError("only_new and only_running are mutually exclusive")
             if not run_id:
                 raise ValueError("only_new requires run_id to be specified")
             task_ids = _get_new_task_ids(self.dag_id, run_id, session)

--- a/airflow-core/src/airflow/serialization/definitions/dag.py
+++ b/airflow-core/src/airflow/serialization/definitions/dag.py
@@ -1017,12 +1017,12 @@ class SerializedDAG:
             tuples that should not be cleared
         :param exclude_run_ids: A set of ``run_id`` or (``run_id``)
         """
-        from airflow.models.taskinstance import clear_task_instances, get_new_tasks
+        from airflow.models.taskinstance import _get_new_tasks, clear_task_instances
 
         if only_new:
             if not run_id:
                 raise ValueError("only_new requires run_id to be specified")
-            task_ids = get_new_tasks(self.dag_id, run_id, session)
+            task_ids = _get_new_tasks(self.dag_id, run_id, session)
 
         state: list[TaskInstanceState] = []
         if only_failed:

--- a/airflow-core/src/airflow/serialization/definitions/dag.py
+++ b/airflow-core/src/airflow/serialization/definitions/dag.py
@@ -1025,7 +1025,6 @@ class SerializedDAG:
             task_ids = get_new_tasks(self.dag_id, run_id, session)
 
         state: list[TaskInstanceState] = []
-
         if only_failed:
             state += [TaskInstanceState.FAILED, TaskInstanceState.UPSTREAM_FAILED]
         if only_running:

--- a/airflow-core/src/airflow/serialization/definitions/dag.py
+++ b/airflow-core/src/airflow/serialization/definitions/dag.py
@@ -1022,6 +1022,8 @@ class SerializedDAG:
         )
 
         if only_new:
+            if task_ids is not None:
+                raise ValueError("only_new and task_ids are mutually exclusive")
             if not run_id:
                 raise ValueError("only_new requires run_id to be specified")
             task_ids = _get_new_task_ids(self.dag_id, run_id, session)

--- a/airflow-core/src/airflow/serialization/definitions/dag.py
+++ b/airflow-core/src/airflow/serialization/definitions/dag.py
@@ -1035,6 +1035,11 @@ class SerializedDAG:
 
                 scheduler_dagbag = DBDagBag(load_op_links=False)
                 latest_dag = scheduler_dagbag.get_latest_version_of_dag(self.dag_id, session=session)
+                if not latest_dag:
+                    raise AirflowException(
+                        f"Cannot clear new tasks for DAG {self.dag_id} because the latest version "
+                        "could not be loaded"
+                    )
                 dag_version = DagVersion.get_latest_version(self.dag_id, session=session)
 
                 tis = []

--- a/airflow-core/tests/unit/models/test_cleartasks.py
+++ b/airflow-core/tests/unit/models/test_cleartasks.py
@@ -748,7 +748,7 @@ class TestClearTasks:
             end_date=DEFAULT_DATE + datetime.timedelta(days=10),
             catchup=True,
             bundle_version="v1",
-        ):
+        ) as dag:
             task0 = EmptyOperator(task_id="0")
             task1 = EmptyOperator(task_id="1")
         dr = dag_maker.create_dagrun(
@@ -758,11 +758,11 @@ class TestClearTasks:
 
         old_dag_version = DagVersion.get_latest_version(dr.dag_id)
         ti0, ti1 = sorted(dr.task_instances, key=lambda ti: ti.task_id)
-        ti0.refresh_from_task(task0)
-        ti1.refresh_from_task(task1)
+        ti0.refresh_from_task(dag.get_task("0"))
+        ti1.refresh_from_task(dag.get_task("1"))
 
-        ti0.run()
-        ti1.run()
+        run_task_instance(ti0, task0)
+        run_task_instance(ti1, task1)
         dr.state = DagRunState.SUCCESS
         session.merge(dr)
         session.flush()
@@ -774,10 +774,10 @@ class TestClearTasks:
             catchup=True,
             bundle_version="v2",
         ) as dag:
-            task0 = EmptyOperator(task_id="0")
-            task1 = EmptyOperator(task_id="1")
-            task1 = EmptyOperator(task_id="2")
-            task1 = EmptyOperator(task_id="3")
+            EmptyOperator(task_id="0")
+            EmptyOperator(task_id="1")
+            EmptyOperator(task_id="2")
+            EmptyOperator(task_id="3")
 
         new_dag_version = DagVersion.get_latest_version(dag.dag_id)
 
@@ -803,7 +803,7 @@ class TestClearTasks:
             end_date=DEFAULT_DATE + datetime.timedelta(days=10),
             catchup=True,
             bundle_version="v1",
-        ):
+        ) as dag:
             task0 = EmptyOperator(task_id="0")
             task1 = EmptyOperator(task_id="1")
         dr = dag_maker.create_dagrun(
@@ -813,11 +813,11 @@ class TestClearTasks:
 
         old_dag_version = DagVersion.get_latest_version(dr.dag_id)
         ti0, ti1 = sorted(dr.task_instances, key=lambda ti: ti.task_id)
-        ti0.refresh_from_task(task0)
-        ti1.refresh_from_task(task1)
+        ti0.refresh_from_task(dag.get_task("0"))
+        ti1.refresh_from_task(dag.get_task("1"))
 
-        ti0.run()
-        ti1.run()
+        run_task_instance(ti0, task0)
+        run_task_instance(ti1, task1)
         dr.state = DagRunState.SUCCESS
         session.merge(dr)
         session.flush()
@@ -829,10 +829,10 @@ class TestClearTasks:
             catchup=True,
             bundle_version="v2",
         ) as dag:
-            task0 = EmptyOperator(task_id="0")
-            task1 = EmptyOperator(task_id="1")
-            task1 = EmptyOperator(task_id="2")
-            task1 = EmptyOperator(task_id="3")
+            EmptyOperator(task_id="0")
+            EmptyOperator(task_id="1")
+            EmptyOperator(task_id="2")
+            EmptyOperator(task_id="3")
 
         new_dag_version = DagVersion.get_latest_version(dag.dag_id)
 
@@ -866,7 +866,7 @@ class TestClearTasks:
             end_date=DEFAULT_DATE + datetime.timedelta(days=10),
             catchup=True,
             bundle_version="v1",
-        ):
+        ) as dag:
             task0 = EmptyOperator(task_id="0")
             task1 = EmptyOperator(task_id="1")
         dr = dag_maker.create_dagrun(
@@ -876,11 +876,11 @@ class TestClearTasks:
 
         old_dag_version = DagVersion.get_latest_version(dr.dag_id)
         ti0, ti1 = sorted(dr.task_instances, key=lambda ti: ti.task_id)
-        ti0.refresh_from_task(task0)
-        ti1.refresh_from_task(task1)
+        ti0.refresh_from_task(dag.get_task("0"))
+        ti1.refresh_from_task(dag.get_task("1"))
 
-        ti0.run()
-        ti1.run()
+        run_task_instance(ti0, task0)
+        run_task_instance(ti1, task1)
         dr.state = DagRunState.SUCCESS
         session.merge(dr)
         session.flush()
@@ -892,8 +892,8 @@ class TestClearTasks:
             catchup=True,
             bundle_version="v2",
         ) as dag:
-            task0 = EmptyOperator(task_id="0")
-            task1 = EmptyOperator(task_id="1")
+            EmptyOperator(task_id="0")
+            EmptyOperator(task_id="1")
 
         new_dag_version = DagVersion.get_latest_version(dag.dag_id)
 

--- a/airflow-core/tests/unit/models/test_cleartasks.py
+++ b/airflow-core/tests/unit/models/test_cleartasks.py
@@ -852,8 +852,7 @@ class TestClearTasks:
         )
 
         assert len(new_tis) == 2
-        assert [new_tis[0].task_id, new_tis[1].task_id] == ["2", "3"]
-        assert [new_tis[0].state, new_tis[1].state] == [None, None]
+        assert sorted(new_tis) == ["2", "3"]
 
         session.rollback()
         dr.refresh_from_db(session)

--- a/airflow-core/tests/unit/models/test_cleartasks.py
+++ b/airflow-core/tests/unit/models/test_cleartasks.py
@@ -808,9 +808,6 @@ class TestClearTasks:
         """Test that only_new with dry_run returns new tasks and changes can be rolled back."""
         with dag_maker(
             "test_clear_new_task_instances_dry_run",
-            start_date=DEFAULT_DATE,
-            end_date=DEFAULT_DATE + datetime.timedelta(days=10),
-            catchup=True,
             bundle_version="v1",
         ) as dag:
             task0 = EmptyOperator(task_id="0")
@@ -833,9 +830,6 @@ class TestClearTasks:
 
         with dag_maker(
             "test_clear_new_task_instances_dry_run",
-            start_date=DEFAULT_DATE,
-            end_date=DEFAULT_DATE + datetime.timedelta(days=10),
-            catchup=True,
             bundle_version="v2",
         ) as dag:
             EmptyOperator(task_id="0")
@@ -868,9 +862,6 @@ class TestClearTasks:
         """Test that only_new returns 0 when no new tasks are added."""
         with dag_maker(
             "test_clear_no_new_task_instances",
-            start_date=DEFAULT_DATE,
-            end_date=DEFAULT_DATE + datetime.timedelta(days=10),
-            catchup=True,
             bundle_version="v1",
         ) as dag:
             task0 = EmptyOperator(task_id="0")
@@ -893,9 +884,6 @@ class TestClearTasks:
 
         with dag_maker(
             "test_clear_no_new_task_instances",
-            start_date=DEFAULT_DATE,
-            end_date=DEFAULT_DATE + datetime.timedelta(days=10),
-            catchup=True,
             bundle_version="v2",
         ) as dag:
             EmptyOperator(task_id="0")

--- a/airflow-core/tests/unit/models/test_cleartasks.py
+++ b/airflow-core/tests/unit/models/test_cleartasks.py
@@ -785,12 +785,15 @@ class TestClearTasks:
         assert count == 2
 
         session.flush()
-        dr.refresh_from_db(session)
 
-        assert dr.created_dag_version_id == new_dag_version.id
-        assert dr.bundle_version == new_dag_version.bundle_version
+        updated_dr = session.scalar(
+            select(DagRun).where(DagRun.dag_id == dr.dag_id, DagRun.run_id == dr.run_id)
+        )
 
-        all_tis = sorted(dr.task_instances, key=lambda ti: ti.task_id)
+        assert updated_dr.created_dag_version_id == new_dag_version.id
+        assert updated_dr.bundle_version == new_dag_version.bundle_version
+
+        all_tis = sorted(updated_dr.task_instances, key=lambda ti: ti.task_id)
         assert len(all_tis) == 4
         assert [ti.task_id for ti in all_tis] == ["0", "1", "2", "3"]
 

--- a/airflow-core/tests/unit/models/test_cleartasks.py
+++ b/airflow-core/tests/unit/models/test_cleartasks.py
@@ -738,3 +738,172 @@ class TestClearTasks:
             assert TaskInstanceState.REMOVED not in [ti.state for ti in dr.task_instances]
             for ti in dr.task_instances:
                 assert ti.dag_version_id == old_dag_version.id
+
+    def test_clear_only_new_tasks(self, dag_maker, session):
+        """Test that only_new queues only newly added tasks without clearing existing ones."""
+
+        with dag_maker(
+            "test_clear_new_task_instances",
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=10),
+            catchup=True,
+            bundle_version="v1",
+        ):
+            task0 = EmptyOperator(task_id="0")
+            task1 = EmptyOperator(task_id="1")
+        dr = dag_maker.create_dagrun(
+            state=State.RUNNING,
+            run_type=DagRunType.SCHEDULED,
+        )
+
+        old_dag_version = DagVersion.get_latest_version(dr.dag_id)
+        ti0, ti1 = sorted(dr.task_instances, key=lambda ti: ti.task_id)
+        ti0.refresh_from_task(task0)
+        ti1.refresh_from_task(task1)
+
+        ti0.run()
+        ti1.run()
+        dr.state = DagRunState.SUCCESS
+        session.merge(dr)
+        session.flush()
+
+        with dag_maker(
+            "test_clear_new_task_instances",
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=10),
+            catchup=True,
+            bundle_version="v2",
+        ) as dag:
+            task0 = EmptyOperator(task_id="0")
+            task1 = EmptyOperator(task_id="1")
+            task1 = EmptyOperator(task_id="2")
+            task1 = EmptyOperator(task_id="3")
+
+        new_dag_version = DagVersion.get_latest_version(dag.dag_id)
+
+        assert old_dag_version.id != new_dag_version.id
+
+        count = dag.clear(
+            run_id=dr.run_id,
+            only_new=True,
+            session=session,
+        )
+
+        session.flush()
+        dr.refresh_from_db(session)
+
+        # Should return 2 new tasks
+        assert count == 2
+
+    def test_clear_only_new_tasks_dry_run(self, dag_maker, session):
+        """Test that only_new with dry_run returns new tasks without making changes."""
+        with dag_maker(
+            "test_clear_new_task_instances_dry_run",
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=10),
+            catchup=True,
+            bundle_version="v1",
+        ):
+            task0 = EmptyOperator(task_id="0")
+            task1 = EmptyOperator(task_id="1")
+        dr = dag_maker.create_dagrun(
+            state=State.RUNNING,
+            run_type=DagRunType.SCHEDULED,
+        )
+
+        old_dag_version = DagVersion.get_latest_version(dr.dag_id)
+        ti0, ti1 = sorted(dr.task_instances, key=lambda ti: ti.task_id)
+        ti0.refresh_from_task(task0)
+        ti1.refresh_from_task(task1)
+
+        ti0.run()
+        ti1.run()
+        dr.state = DagRunState.SUCCESS
+        session.merge(dr)
+        session.flush()
+
+        with dag_maker(
+            "test_clear_new_task_instances_dry_run",
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=10),
+            catchup=True,
+            bundle_version="v2",
+        ) as dag:
+            task0 = EmptyOperator(task_id="0")
+            task1 = EmptyOperator(task_id="1")
+            task1 = EmptyOperator(task_id="2")
+            task1 = EmptyOperator(task_id="3")
+
+        new_dag_version = DagVersion.get_latest_version(dag.dag_id)
+
+        assert old_dag_version.id != new_dag_version.id
+
+        # Dry run - should return list of new tasks without making changes
+        new_tis = dag.clear(
+            run_id=dr.run_id,
+            only_new=True,
+            dry_run=True,
+            session=session,
+        )
+
+        session.flush()
+        dr.refresh_from_db(session)
+
+        # Check if correct tasks are returned
+        assert len(new_tis) == 2
+        assert [new_tis[0].task_id, new_tis[1].task_id] == ["2", "3"]
+        assert [new_tis[0].state, new_tis[1].state] == [None, None]
+
+        # Verify no changes were made to the database
+        assert dr.created_dag_version_id == old_dag_version.id
+        assert len(dr.task_instances) == 2  # should be only the 2 earlier tasks
+
+    def test_clear_only_new_no_new_tasks(self, dag_maker, session):
+        """Test that only_new returns 0 when no new tasks are added."""
+        with dag_maker(
+            "test_clear_no_new_task_instances",
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=10),
+            catchup=True,
+            bundle_version="v1",
+        ):
+            task0 = EmptyOperator(task_id="0")
+            task1 = EmptyOperator(task_id="1")
+        dr = dag_maker.create_dagrun(
+            state=State.RUNNING,
+            run_type=DagRunType.SCHEDULED,
+        )
+
+        old_dag_version = DagVersion.get_latest_version(dr.dag_id)
+        ti0, ti1 = sorted(dr.task_instances, key=lambda ti: ti.task_id)
+        ti0.refresh_from_task(task0)
+        ti1.refresh_from_task(task1)
+
+        ti0.run()
+        ti1.run()
+        dr.state = DagRunState.SUCCESS
+        session.merge(dr)
+        session.flush()
+
+        with dag_maker(
+            "test_clear_no_new_task_instances",
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=10),
+            catchup=True,
+            bundle_version="v2",
+        ) as dag:
+            task0 = EmptyOperator(task_id="0")
+            task1 = EmptyOperator(task_id="1")
+
+        new_dag_version = DagVersion.get_latest_version(dag.dag_id)
+
+        assert old_dag_version.id != new_dag_version.id
+
+        # Clear with only_new should return 0
+        count = dag.clear(
+            run_id=dr.run_id,
+            only_new=True,
+            session=session,
+        )
+
+        assert count == 0


### PR DESCRIPTION
## Context
The ability to clear newly introduced tasks in an already existing DAG run seems not to have been added to Airflow 3 yet.

<img width="886" height="356" alt="image" src="https://github.com/user-attachments/assets/947719bb-4f8f-4a83-8bea-6aa10f67cd72" />
 
The button in the UI is disabled at all times.

## Implementation

In this PR I try to start with the basic requirement, which is to add functionality to the `dag.clear()` function that ensures only newly added tasks are cleared. 

## Questions to Reviewer

- I'm not sure if the use of DagBag is appropriate here. It works, but I am not as familiar with best practices in Airflow as I would like to be yet. I'm also not fully aware of how this was implemented in Airflow 2, and since I'm touching core Airflow things here, please let me know if there's anything off about my approach. Would love to learn more!
- Are there any existing plans to add this back that we can align on? I see there is an argument `run_on_latest_version`, but I am unsure of its purpose. I've seen it's experimental and I wonder if it is at all involved with the issue attached to this PR. 

## Issue
See below the related issues.

related: #57051
related: #56250


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
