### PR TITLE
Fix duplicate HTTP requests on initial DAG page load

### DIFF
--- a/airflow-core/src/airflow/ui/src/queries/useRefreshOnNewDagRuns.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useRefreshOnNewDagRuns.ts
@@ -45,7 +45,13 @@ export const useRefreshOnNewDagRuns = (dagId: string, hasPendingRuns: boolean | 
   useEffect(() => {
     const latestDagRunId = latestDagRun?.run_id;
 
-    if ((latestDagRunId ?? "") && previousDagRunIdRef.current !== latestDagRunId) {
+    if (latestDagRunId !== undefined && previousDagRunIdRef.current !== latestDagRunId) {
+      // On initial load, just set the ref without invalidating queries
+      if (previousDagRunIdRef.current === undefined) {
+        previousDagRunIdRef.current = latestDagRunId;
+        return;
+      }
+
       previousDagRunIdRef.current = latestDagRunId;
 
       const queryKeys = [


### PR DESCRIPTION
Prevent unnecessary cache invalidation when the DAG run ID is first loaded. Previously, when a page was initially loaded, the cache would be cleared and queries re-fetched even though the data hadn't changed, resulting in duplicate HTTP requests visible in the network tab.

The fix checks if this is the first time the DAG run ID is being set (previousDagRunIdRef.current === undefined) and if so, sets the ref without invalidating the query cache. Cache invalidation now only occurs when there is an actual new DAG run, which is the intended behavior.

Fixes duplicate requests for /ui/grid/runs, /ui/grid/structure, and other API endpoints on pages like http://localhost:8000/dags/example_branch_labels
Fix duplicate HTTP requests on initial DAG page load

This PR resolves an issue where the UI was making duplicate HTTP requests on initial page load, causing unnecessary network traffic and potential performance degradation.

**Problem:**
When loading a DAG page (e.g., `http://localhost:8000/dags/example_branch_labels`), the `useRefreshOnNewDagRuns` hook was incorrectly invalidating the query cache on the first render. This occurred because:

- `previousDagRunIdRef.current` is initialized as `undefined`
- When `latestDagRunId` is fetched for the first time, it differs from `undefined`
- The condition `previousDagRunIdRef.current !== latestDagRunId` triggers cache invalidation
- All queries are refetched, resulting in duplicate requests for endpoints like `/ui/grid/runs`, `/ui/grid/structure`, etc.

**Solution:**
Added an early return when `previousDagRunIdRef.current` is `undefined` (initial load). The ref is set without invalidating queries, ensuring cache invalidation only occurs when a genuinely new DAG run appears:

```typescript
if (previousDagRunIdRef.current === undefined) {
  previousDagRunIdRef.current = latestDagRunId;
  return;
}
```

**Impact:**
- Eliminates duplicate HTTP requests on initial page load
- Reduces unnecessary network traffic and improves page load performance
- Preserves the intended behavior of refreshing data when new DAG runs occur

**Testing:**
1. Navigate to any DAG page with existing runs
2. Open browser DevTools Network tab
3. Verify each API endpoint is called only once on initial load
4. Confirm cache invalidation still works correctly when a new DAG run completes

