### PR TITLE
Add and fix SIM107 and B012 Ruff rule

### DIFF
--- a/providers/celery/src/airflow/providers/celery/cli/celery_command.py
+++ b/providers/celery/src/airflow/providers/celery/cli/celery_command.py
@@ -132,10 +132,8 @@ def _run_stale_bundle_cleanup():
         )
     if not check_interval or check_interval <= 0 or not AIRFLOW_V_3_0_PLUS:
         # do not start bundle cleanup process
-        try:
+        with suppress(BaseException):
             yield
-        finally:
-            pass  # ignore any problems
         return
     from airflow.dag_processing.bundles.base import BundleUsageTrackingManager
 

--- a/providers/celery/src/airflow/providers/celery/cli/celery_command.py
+++ b/providers/celery/src/airflow/providers/celery/cli/celery_command.py
@@ -135,7 +135,8 @@ def _run_stale_bundle_cleanup():
         try:
             yield
         finally:
-            return
+            pass  # ignore any problems
+        return
     from airflow.dag_processing.bundles.base import BundleUsageTrackingManager
 
     log.info("starting stale bundle cleanup process")

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -1095,4 +1095,4 @@ class AsyncPodManager(LoggingMixin):
                     print(message_to_log)
                 else:
                     self.log.info("[%s] %s", container_name, message_to_log)
-            return now  # Return the current time as the last log time to ensure logs from the current second are read in the next fetch.
+        return now  # Return the current time as the last log time to ensure logs from the current second are read in the next fetch.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -629,11 +629,13 @@ extend-select = [
     "PGH004",  # Use specific rule codes when using noqa
     "PGH005", # Invalid unittest.mock.Mock methods/attributes/properties
     "S101", # Checks use `assert` outside the test cases, test cases should be added into the exclusions
+    "SIM107", # Don't use `return` in `try`-`except` and `finally`
     "SIM300", # Checks for conditions that position a constant on the left-hand side of the comparison
               # operator, rather than the right-hand side.
     "B004", # Checks for use of hasattr(x, "__call__") and replaces it with callable(x)
     "B006", # Checks for uses of mutable objects as function argument defaults.
     "B007", # Checks for unused variables in the loop
+    "B012", # Checks for `break`, `continue`, and `return` statements in `finally` blocks
     "B017", # Checks for pytest.raises context managers that catch Exception or BaseException.
     "B019", # Use of functools.lru_cache or functools.cache on methods can lead to memory leaks
     "B028", # No explicit stacklevel keyword argument found


### PR DESCRIPTION
As of comments from @johnslavik (Thanks!) in https://github.com/apache/airflow/pull/58488 detected a bad use of `return` in `finally` which should be prevented and PR #59019 did not make it on main this PR is a follow-up to prevent a regression on such problems.

Alongside two occurrences in Celery and CNCF.K8s provider are fixed, I assume for the good.