### PR TITLE
Expose literal and ParamsDict at SDK top level

### DIFF
--- a/task-sdk/docs/api.rst
+++ b/task-sdk/docs/api.rst
@@ -72,8 +72,6 @@ Bases
 
 .. autoapiclass:: airflow.sdk.BaseXCom
 
-.. autoapiclass:: airflow.sdk.XComArg
-
 .. autoapiclass:: airflow.sdk.PokeReturnValue
 
 .. autoapiclass:: airflow.sdk.BaseHook
@@ -88,13 +86,19 @@ Tasks & Operators
 -----------------
 .. autoapiclass:: airflow.sdk.TaskGroup
 
-.. autoapifunction:: airflow.sdk.get_current_context
+.. autoapiclass:: airflow.sdk.XComArg
 
-.. autoapifunction:: airflow.sdk.get_parsing_context
+.. autoapifunction:: airflow.sdk.literal
 
 .. autoapiclass:: airflow.sdk.Param
 
+.. autoclass:: airflow.sdk.ParamsDict
+
 .. autoclass:: airflow.sdk.TriggerRule
+
+.. autoapifunction:: airflow.sdk.get_current_context
+
+.. autoapifunction:: airflow.sdk.get_parsing_context
 
 State Enums
 -----------
@@ -111,8 +115,6 @@ Setting Dependencies
 .. autoapifunction:: airflow.sdk.chain_linear
 
 .. autoapifunction:: airflow.sdk.cross_downstream
-
-.. autoapifunction:: airflow.sdk.literal
 
 Edges & Labels
 ~~~~~~~~~~~~~~

--- a/task-sdk/src/airflow/sdk/__init__.py
+++ b/task-sdk/src/airflow/sdk/__init__.py
@@ -46,6 +46,7 @@ __all__ = [
     "MultipleCronTriggerTimetable",
     "ObjectStoragePath",
     "Param",
+    "ParamsDict",
     "PokeReturnValue",
     "TaskGroup",
     "TaskInstanceState",
@@ -71,8 +72,6 @@ __all__ = [
 
 __version__ = "1.2.0"
 
-from airflow.sdk.observability.trace import Trace
-
 if TYPE_CHECKING:
     from airflow.sdk.api.datamodels._generated import DagRunState, TaskInstanceState, TriggerRule, WeightRule
     from airflow.sdk.bases.hook import BaseHook
@@ -90,7 +89,7 @@ if TYPE_CHECKING:
     from airflow.sdk.definitions.decorators import setup, task, teardown
     from airflow.sdk.definitions.decorators.task_group import task_group
     from airflow.sdk.definitions.edges import EdgeModifier, Label
-    from airflow.sdk.definitions.param import Param
+    from airflow.sdk.definitions.param import Param, ParamsDict
     from airflow.sdk.definitions.taskgroup import TaskGroup
     from airflow.sdk.definitions.template import literal
     from airflow.sdk.definitions.timetables.assets import AssetOrTimeSchedule
@@ -107,6 +106,7 @@ if TYPE_CHECKING:
     from airflow.sdk.definitions.variable import Variable
     from airflow.sdk.definitions.xcom_arg import XComArg
     from airflow.sdk.io.path import ObjectStoragePath
+    from airflow.sdk.observability.trace import Trace
 
     conf: AirflowSDKConfigParser
 
@@ -137,6 +137,7 @@ __lazy_imports: dict[str, str] = {
     "MultipleCronTriggerTimetable": ".definitions.timetables.trigger",
     "ObjectStoragePath": ".io.path",
     "Param": ".definitions.param",
+    "ParamsDict": ".definitions.param",
     "PokeReturnValue": ".bases.sensor",
     "SecretCache": ".execution_time.cache",
     "TaskGroup": ".definitions.taskgroup",
@@ -154,6 +155,7 @@ __lazy_imports: dict[str, str] = {
     "dag": ".definitions.dag",
     "get_current_context": ".definitions.context",
     "get_parsing_context": ".definitions.context",
+    "literal": ".definitions.template",
     "setup": ".definitions.decorators",
     "task": ".definitions.decorators",
     "task_group": ".definitions.decorators",

--- a/task-sdk/tests/task_sdk/docs/test_public_api.py
+++ b/task-sdk/tests/task_sdk/docs/test_public_api.py
@@ -72,7 +72,7 @@ def test_lazy_imports_match_public_api():
     import airflow.sdk as sdk
 
     lazy = getattr(sdk, "__lazy_imports", {})
-    expected = set(getattr(sdk, "__all__", [])) - {"__version__", "literal"}
+    expected = set(getattr(sdk, "__all__", [])) - {"__version__"}
     ignore = {"SecretCache"}
     actual = set(lazy.keys())
     missing = expected - actual


### PR DESCRIPTION
`literal` was actually declared (both in typing and `__all__`) but missed in the implementation. `ParamsDict` is used in too many places I feel it’s valuable.