### PR TITLE
Support uuid ser/deser in task sdk serde

### DIFF
--- a/task-sdk/src/airflow/sdk/serde/serializers/uuid.py
+++ b/task-sdk/src/airflow/sdk/serde/serializers/uuid.py
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from airflow.sdk.module_loading import qualname
+
+if TYPE_CHECKING:
+    import uuid
+
+    from airflow.sdk.serde import U
+
+__version__ = 1
+
+serializers = ["uuid.UUID"]
+deserializers = serializers
+
+
+def serialize(o: object) -> tuple[U, str, int, bool]:
+    """Serialize a UUID object to a string representation."""
+    import uuid
+
+    if isinstance(o, uuid.UUID):
+        return str(o), qualname(o), __version__, True
+    return "", "", 0, False
+
+
+def deserialize(cls: type, version: int, data: str) -> uuid.UUID:
+    """Deserialize a string back to a UUID object."""
+    import uuid
+
+    if cls is uuid.UUID and isinstance(data, str):
+        return uuid.UUID(data)
+    raise TypeError(f"cannot deserialize {qualname(cls)} from {type(data)}")

--- a/task-sdk/tests/task_sdk/serde/test_serializers.py
+++ b/task-sdk/tests/task_sdk/serde/test_serializers.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import datetime
 import decimal
+import uuid
 from importlib import metadata
 from typing import ClassVar
 from unittest.mock import patch
@@ -661,3 +662,16 @@ class TestSerializers:
         bad = {CLASSNAME: "", VERSION: 1, DATA: {}}
         with pytest.raises(TypeError, match="classname cannot be empty"):
             deserialize(bad)
+
+    @pytest.mark.parametrize(
+        "uuid_value",
+        [
+            pytest.param(uuid.uuid4(), id="uuid4"),
+            pytest.param(uuid.uuid1(), id="uuid1"),
+        ],
+    )
+    def test_uuid_roundtrip(self, uuid_value):
+        serialized = serialize(uuid_value)
+        deserialized = deserialize(serialized)
+        assert isinstance(deserialized, uuid.UUID)
+        assert uuid_value == deserialized


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

While working on: https://github.com/apache/airflow/pull/59711, realised that serde doesn't support serialisation and deserialisation of uuid objects, which initially was done by `BaseSerialialisation`.

`BaseSerialization` just did a stringify on uuid / objects it didnt know about: https://github.com/astronomer/airflow/blob/main/airflow-core/src/airflow/serialization/serialized_objects.py#L685-L689

This would lead to loss of type on deserialization / round trip would be affected.

```python
PyDev console: using IPython 9.8.0
Python 3.13.3 (main, Apr  8 2025, 13:54:08) [Clang 17.0.0 (clang-1700.0.13.3)] on darwin
import uuid
u = uuid.uuid4()
from airflow.serialization.serialized_objects import BaseSerialization
BaseSerialization.serialize(u)
Out[9]: '901190bc-6633-4b2b-aa0d-dab01e40415a'
BaseSerialization.deserialize(BaseSerialization.serialize(u))
Out[10]: '901190bc-6633-4b2b-aa0d-dab01e40415a'
BaseSerialization.deserialize(BaseSerialization.serialize(u)) == u
Out[11]: False
```

I decided to write a serde serializer for this which would do it better. We stringify, yes, but we maintain the type info and deserialize better now.

```python
u = uuid.uuid4()
from airflow.sdk.serde import serialize, deserialize
serialize(u)
Out[5]: 
{'__classname__': 'uuid.UUID',
 '__version__': 1,
 '__data__': '901190bc-6633-4b2b-aa0d-dab01e40415a'}
deserialize(serialize(u))
Out[6]: UUID('901190bc-6633-4b2b-aa0d-dab01e40415a')
u
Out[7]: UUID('901190bc-6633-4b2b-aa0d-dab01e40415a')
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
