### PR TITLE
DagBag: use `Path.relative_to` for consistent cross-platform behavior

### DIFF
--- a/airflow-core/newsfragments/59785.significant.rst
+++ b/airflow-core/newsfragments/59785.significant.rst
@@ -1,0 +1,10 @@
+Modify the information returned by ``DagBag``
+
+**New behavior:**
+- ``DagBag`` now uses ``Path.relative_to`` for consistent cross-platform behavior.
+- ``FileLoadStat`` now has two additional nullable fields: ``bundle_path`` and ``bundle_name``.
+
+**Backward compatibility:**
+``FileLoadStat`` will no longer produce paths beginning with ``/`` with the meaning of "relative to the dags folder".
+This is a breaking change for any custom code that performs string-based path manipulations relying on this behavior.
+Users are advised to update such code to use ``pathlib.Path``.

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -225,8 +225,9 @@ class TestCliDags:
             dag_command.dag_report(args)
             out = temp_stdout.getvalue()
 
-        assert "airflow/example_dags/example_complex.py" in out
-        assert "example_complex" in out
+        data = json.loads(out)
+        assert any(item["file"].endswith("example_complex.py") for item in data)
+        assert any("example_complex" in item["dags"] for item in data)
 
     @conf_vars({("core", "load_examples"): "true"})
     def test_cli_get_dag_details(self, stdout_capture):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #45172

Verified on linux via the unit tests on on win11 by running the script below:
```python
# test_windows_path_fix.py
"""
Test script to verify the path normalization fix for Windows.
This tests the core logic without requiring a full Airflow installation.
"""
from pathlib import Path


def test_path_normalization():
    """
    Test that the fix correctly normalizes paths with mixed separators.
    
    This replicates the fix in airflow/dag_processing/dagbag.py:
        normalized_filepath = Path(filepath).as_posix()
        normalized_dags_folder = Path(settings.DAGS_FOLDER).as_posix()
        relative_file = normalized_filepath.replace(normalized_dags_folder, "")
    """
    test_cases = [
        # (dags_folder, filepath, expected_relative)
        # Windows backslash paths
        ("C:\\Users\\user\\dags", "C:\\Users\\user\\dags\\my_dag.py", "/my_dag.py"),
        # Mixed separators (the bug scenario from the issue)
        ("C:/Users/user/dags", "C:\\Users\\user\\dags\\my_dag.py", "/my_dag.py"),
        ("C:\\Users\\user/dags", "C:/Users/user/dags/my_dag.py", "/my_dag.py"),
        # Nested paths with mixed separators
        ("C:/Users/user/dags", "C:\\Users\\user\\dags\\subdir\\my_dag.py", "/subdir/my_dag.py"),
        # Forward slashes only (should still work)
        ("C:/Users/user/dags", "C:/Users/user/dags/my_dag.py", "/my_dag.py"),
    ]
    
    print("Testing path normalization fix...")
    print("-" * 60)
    
    all_passed = True
    for dags_folder, filepath, expected in test_cases:
        # This is the fix from dagbag.py
        normalized_filepath = Path(filepath).as_posix()
        normalized_dags_folder = Path(dags_folder).as_posix()
        relative_file = normalized_filepath.replace(normalized_dags_folder, "")
        
        passed = relative_file == expected
        status = "✓ PASS" if passed else "✗ FAIL"
        
        print(f"\n{status}")
        print(f"  DAGS_FOLDER: {dags_folder}")
        print(f"  filepath:    {filepath}")
        print(f"  Result:      {relative_file}")
        if not passed:
            print(f"  Expected:    {expected}")
            all_passed = False
    
    print("\n" + "-" * 60)
    
    # Also demonstrate what the OLD buggy code would have produced
    print("\nDemonstrating the OLD buggy behavior (without fix):")
    dags_folder = "C:/Users/user/dags"  # Forward slashes
    filepath = "C:\\Users\\user\\dags\\my_dag.py"  # Backslashes
    
    # Old code: simple string replace without normalization
    old_result = filepath.replace(dags_folder, "")
    print(f"  DAGS_FOLDER: {dags_folder}")
    print(f"  filepath:    {filepath}")
    print(f"  Old result:  {old_result}  <- BUG: absolute path returned!")
    
    # New code: normalize first
    new_result = Path(filepath).as_posix().replace(Path(dags_folder).as_posix(), "")
    print(f"  New result:  {new_result}  <- FIXED: relative path returned!")
    
    print("\n" + "=" * 60)
    if all_passed:
        print("✅ All tests passed! The fix works correctly on Windows.")
    else:
        print("❌ Some tests failed.")
    
    return all_passed


if __name__ == "__main__":
    success = test_path_normalization()
    exit(0 if success else 1)
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
