### PR TITLE
Fix Breeze compatibility test uri hint

### DIFF
--- a/scripts/in_container/run_ci_tests.sh
+++ b/scripts/in_container/run_ci_tests.sh
@@ -64,7 +64,7 @@ if [[ ${CI:="false"} == "true" && ${RES} != "0" && ${USE_AIRFLOW_VERSION=} != ""
     echo "${COLOR_YELLOW}Failing compatibility test of providers for for ${USE_AIRFLOW_VERSION} Airflow and you need to make sure it passes for it as well or deal with compatibility.${COLOR_RESET}"
     echo
     echo "${COLOR_BLUE}Read more on how to run the test locally and how to deal with Provider's compatibility with older Airflow versions at:${COLOR_RESET}"
-    echo "https://github.com/apache/airflow/blob/main/contributing-docs/testing/unit_tests.rst#running-provider-compatibility-tests"
+    echo "https://github.com/apache/airflow/blob/main/contributing-docs/testing/unit_tests.rst#compatibility-provider-unit-tests-against-older-airflow-releases"
     echo
 fi
 


### PR DESCRIPTION

The correct section hook should be `#compatibility-provider-unit-tests-against-older-airflow-releases` instead of `#running-provider-compatibility-tests` for the hint.