### PR TITLE
Improve CLI date argument help text documentation

### DIFF
--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -167,8 +167,24 @@ ARG_BUNDLE_NAME = Arg(
     default=None,
     action="append",
 )
-ARG_START_DATE = Arg(("-s", "--start-date"), help="Override start_date YYYY-MM-DD", type=parsedate)
-ARG_END_DATE = Arg(("-e", "--end-date"), help="Override end_date YYYY-MM-DD", type=parsedate)
+ARG_START_DATE = Arg(
+    ("-s", "--start-date"),
+    help=(
+        "Override start_date. Accepts multiple datetime formats including: "
+        "YYYY-MM-DD, YYYY-MM-DDTHH:MM:SS, YYYY-MM-DDTHH:MM:SS±HH:MM (ISO 8601), "
+        "and other formats supported by pendulum.parse()"
+    ),
+    type=parsedate,
+)
+ARG_END_DATE = Arg(
+    ("-e", "--end-date"),
+    help=(
+        "Override end_date. Accepts multiple datetime formats including: "
+        "YYYY-MM-DD, YYYY-MM-DDTHH:MM:SS, YYYY-MM-DDTHH:MM:SS±HH:MM (ISO 8601), "
+        "and other formats supported by pendulum.parse()"
+    ),
+    type=parsedate,
+)
 ARG_OUTPUT_PATH = Arg(
     (
         "-o",


### PR DESCRIPTION
The help text for --start-date and --end-date arguments only documented the YYYY-MM-DD format, but the actual implementation uses pendulum.parse() which accepts a much wider variety of formats.

This commit updates the help text to accurately document the commonly used formats:
- YYYY-MM-DD (date only)
- YYYY-MM-DDTHH:MM:SS (datetime)
- YYYY-MM-DDTHH:MM:SSHH:MM (datetime with timezone, ISO 8601)

The help text also references pendulum.parse() to indicate that additional formats are supported, improving clarity for users.

Fixes: Incomplete documentation of date format options

Improves the CLI help text documentation for `--start-date` and `--end-date` arguments to accurately reflect the supported datetime formats.

## Problem
The help text for date arguments only documented `YYYY-MM-DD` format, but the actual implementation uses `pendulum.parse()` which accepts many more formats including ISO 8601, RFC 3339, and others.

## Solution
Updated the help text to document commonly used formats and reference `pendulum.parse()` for complete format support.

## Testing
Run `airflow dags backfill --help` to verify the updated help text displays correctly.