### PR TITLE
Add deferrable support to AzureBatchOperator

### DIFF
--- a/providers/microsoft/azure/provider.yaml
+++ b/providers/microsoft/azure/provider.yaml
@@ -289,6 +289,9 @@ hooks:
       - airflow.providers.microsoft.azure.hooks.powerbi
 
 triggers:
+  - integration-name: Microsoft Azure Batch
+    python-modules:
+      - airflow.providers.microsoft.azure.triggers.batch
   - integration-name: Microsoft Azure Data Factory
     python-modules:
       - airflow.providers.microsoft.azure.triggers.data_factory

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/batch.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/batch.py
@@ -25,6 +25,7 @@ from azure.batch import models as batch_models
 
 from airflow.providers.common.compat.sdk import AirflowException, BaseOperator
 from airflow.providers.microsoft.azure.hooks.batch import AzureBatchHook
+from airflow.providers.microsoft.azure.triggers.batch import AzureBatchJobTrigger
 
 if TYPE_CHECKING:
     from airflow.sdk import Context
@@ -91,6 +92,7 @@ class AzureBatchOperator(BaseOperator):
     :param timeout: The amount of time to wait for the job to complete in minutes. Default is 25
     :param should_delete_job: Whether to delete job after execution. Default is False
     :param should_delete_pool: Whether to delete pool after execution of jobs. Default is False
+    :param deferrable: Run operator in deferrable mode. Default is False
     """
 
     template_fields: Sequence[str] = (
@@ -139,6 +141,7 @@ class AzureBatchOperator(BaseOperator):
         timeout: int = 25,
         should_delete_job: bool = False,
         should_delete_pool: bool = False,
+        deferrable: bool = False,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -176,6 +179,8 @@ class AzureBatchOperator(BaseOperator):
         self.timeout = timeout
         self.should_delete_job = should_delete_job
         self.should_delete_pool = should_delete_pool
+        self.deferrable = deferrable
+        self._cleanup_done = False
 
     @cached_property
     def hook(self) -> AzureBatchHook:
@@ -265,15 +270,16 @@ class AzureBatchOperator(BaseOperator):
             start_task=self.batch_start_task,
         )
         self.hook.create_pool(pool)
-        # Wait for nodes to reach complete state
-        self.hook.wait_for_all_node_state(
-            self.batch_pool_id,
-            {
-                batch_models.ComputeNodeState.start_task_failed,
-                batch_models.ComputeNodeState.unusable,
-                batch_models.ComputeNodeState.idle,
-            },
-        )
+        # Wait for nodes to reach complete state (skipped in deferrable mode)
+        if not self.deferrable:
+            self.hook.wait_for_all_node_state(
+                self.batch_pool_id,
+                {
+                    batch_models.ComputeNodeState.start_task_failed,
+                    batch_models.ComputeNodeState.unusable,
+                    batch_models.ComputeNodeState.idle,
+                },
+            )
         # Create job if not already exist
         job = self.hook.configure_job(
             job_id=self.batch_job_id,
@@ -296,23 +302,76 @@ class AzureBatchOperator(BaseOperator):
         )
         # Add task to job
         self.hook.add_single_task_to_job(job_id=self.batch_job_id, task=task)
-        # Wait for tasks to complete
-        fail_tasks = self.hook.wait_for_job_tasks_to_complete(job_id=self.batch_job_id, timeout=self.timeout)
-        # Clean up
-        if self.should_delete_job:
-            # delete job first
-            self.clean_up(job_id=self.batch_job_id)
-        if self.should_delete_pool:
-            self.clean_up(self.batch_pool_id)
-        # raise exception if any task fail
-        if fail_tasks:
-            raise AirflowException(f"Job fail. The failed task are: {fail_tasks}")
+        if self.deferrable:
+            # Verify pool and nodes are in terminal state before deferral
+            pool = self.hook.connection.pool.get(self.batch_pool_id)
+            nodes = list(self.hook.connection.compute_node.list(self.batch_pool_id))
+            if pool.resize_errors:
+                raise AirflowException(f"Pool resize errors: {pool.resize_errors}")
+            self.log.debug("Deferral pre-check: %d nodes present in pool %s", len(nodes), self.batch_pool_id)
+
+            self.defer(
+                timeout=self.execution_timeout,
+                trigger=AzureBatchJobTrigger(
+                    job_id=self.batch_job_id,
+                    azure_batch_conn_id=self.azure_batch_conn_id,
+                    timeout=self.timeout,
+                ),
+                method_name="execute_complete",
+            )
+            return
+
+        # Wait for tasks to complete (synchronous path) with guaranteed cleanup on failure
+        sync_failed = False
+        try:
+            fail_tasks = self.hook.wait_for_job_tasks_to_complete(
+                job_id=self.batch_job_id, timeout=self.timeout
+            )
+            if fail_tasks:
+                sync_failed = True
+                raise AirflowException(f"Job fail. The failed task are: {fail_tasks}")
+        finally:
+            if sync_failed:
+                # Ensure cleanup runs before exception propagates (historical behavior)
+                if self.should_delete_job:
+                    self.clean_up(job_id=self.batch_job_id)
+                if self.should_delete_pool:
+                    self.clean_up(self.batch_pool_id)
+                self._cleanup_done = True
+
+    def execute_complete(self, context: Context, event: dict[str, Any] | None = None) -> str:
+        if not event:
+            raise AirflowException("No event received in trigger callback")
+
+        status = event.get("status")
+        fail_task_ids = event.get("fail_task_ids", [])
+
+        if status == "timeout":
+            raise TimeoutError(event.get("message", "Timed out waiting for tasks to complete"))
+        if status == "error":
+            raise AirflowException(event.get("message", "Unknown error while waiting for tasks"))
+        if status == "failure" or fail_task_ids:
+            raise AirflowException(f"Job failed. Failed tasks: {fail_task_ids}")
+        if status != "success":
+            raise AirflowException(f"Unexpected event status: {event}")
+
+        return self.batch_job_id
 
     def on_kill(self) -> None:
         response = self.hook.connection.job.terminate(
             job_id=self.batch_job_id, terminate_reason="Job killed by user"
         )
         self.log.info("Azure Batch job (%s) terminated: %s", self.batch_job_id, response)
+
+    def post_execute(self, context: Context, result: Any | None = None) -> None:  # type: ignore[override]
+        """Perform cleanup after task completion in both deferrable and non-deferrable modes."""
+        if getattr(self, "_cleanup_done", False):
+            return
+        if self.should_delete_job:
+            self.clean_up(job_id=self.batch_job_id)
+        if self.should_delete_pool:
+            self.clean_up(self.batch_pool_id)
+        self._cleanup_done = True
 
     def clean_up(self, pool_id: str | None = None, job_id: str | None = None) -> None:
         """

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/triggers/batch.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/triggers/batch.py
@@ -1,0 +1,95 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from datetime import timedelta
+from typing import Any
+
+from azure.batch import models as batch_models
+
+from airflow.providers.microsoft.azure.hooks.batch import AzureBatchHook
+from airflow.triggers.base import BaseTrigger, TriggerEvent
+from airflow.utils import timezone
+
+
+class AzureBatchJobTrigger(BaseTrigger):
+    """
+    Poll Azure Batch for task completion for a given job.
+
+    :param job_id: The Azure Batch job identifier to poll.
+    :param azure_batch_conn_id: Connection id for Azure Batch.
+    :param timeout: Maximum wait time in minutes.
+    :param poll_interval: Seconds to sleep between polls.
+    """
+
+    def __init__(
+        self,
+        job_id: str,
+        azure_batch_conn_id: str = "azure_batch_default",
+        timeout: int = 25,
+        poll_interval: int = 15,
+    ) -> None:
+        super().__init__()
+        self.job_id = job_id
+        self.azure_batch_conn_id = azure_batch_conn_id
+        self.timeout = timeout
+        self.poll_interval = poll_interval
+
+    def serialize(self) -> tuple[str, dict[str, Any]]:
+        """Serialize trigger configuration."""
+        return (
+            "airflow.providers.microsoft.azure.triggers.batch.AzureBatchJobTrigger",
+            {
+                "job_id": self.job_id,
+                "azure_batch_conn_id": self.azure_batch_conn_id,
+                "timeout": self.timeout,
+                "poll_interval": self.poll_interval,
+            },
+        )
+
+    async def run(self) -> AsyncIterator[TriggerEvent]:
+        hook = AzureBatchHook(self.azure_batch_conn_id)
+        timeout_time = timezone.utcnow() + timedelta(minutes=self.timeout)
+
+        try:
+            while timezone.utcnow() < timeout_time:
+                tasks = await asyncio.to_thread(lambda: list(hook.connection.task.list(self.job_id)))
+                incomplete_tasks = [task for task in tasks if task.state != batch_models.TaskState.completed]
+
+                if not incomplete_tasks:
+                    fail_task_ids = [
+                        task.id
+                        for task in tasks
+                        if task.execution_info
+                        and task.execution_info.result == batch_models.TaskExecutionResult.failure
+                    ]
+                    status = "success" if not fail_task_ids else "failure"
+                    yield TriggerEvent({"status": status, "fail_task_ids": fail_task_ids})
+                    return
+
+                await asyncio.sleep(self.poll_interval)
+
+            yield TriggerEvent(
+                {
+                    "status": "timeout",
+                    "message": "Timed out waiting for tasks to complete",
+                }
+            )
+        except Exception as exc:
+            yield TriggerEvent({"status": "error", "message": str(exc)})

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/triggers/batch.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/triggers/batch.py
@@ -69,7 +69,7 @@ class AzureBatchJobTrigger(BaseTrigger):
 
         try:
             while timezone.utcnow() < timeout_time:
-                tasks = await asyncio.to_thread(lambda: list(hook.connection.task.list(self.job_id)))
+                tasks = await asyncio.to_thread(list, hook.connection.task.list(self.job_id))
                 incomplete_tasks = [task for task in tasks if task.state != batch_models.TaskState.completed]
 
                 if not incomplete_tasks:

--- a/providers/microsoft/azure/tests/system/microsoft/azure/example_azure_batch_operator.py
+++ b/providers/microsoft/azure/tests/system/microsoft/azure/example_azure_batch_operator.py
@@ -57,6 +57,24 @@ with DAG(
     )
     # [END howto_azure_batch_operator]
 
+    # [START howto_azure_batch_operator_deferrable]
+    azure_batch_operator_deferrable = AzureBatchOperator(
+        task_id="azure_batch_deferrable",
+        batch_pool_id=f"{POOL_ID}-deferrable",
+        batch_pool_vm_size="standard_d2s_v3",
+        batch_job_id="example-job-deferrable",
+        batch_task_command_line="/bin/bash -c 'set -e; set -o pipefail; echo hello from deferrable!; wait'",
+        batch_task_id="example-task-deferrable",
+        vm_node_agent_sku_id="batch.node.ubuntu 22.04",
+        vm_publisher="Canonical",
+        vm_offer="0001-com-ubuntu-server-jammy",
+        vm_sku="22_04-lts-gen2",
+        target_dedicated_nodes=1,
+        deferrable=True,
+        poll_interval=30,  # Check every 30 seconds
+    )
+    # [END howto_azure_batch_operator_deferrable]
+
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
 # Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/triggers/test_batch.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/triggers/test_batch.py
@@ -1,0 +1,267 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest import mock
+
+import pytest
+from azure.batch import models as batch_models
+
+from airflow.providers.microsoft.azure.triggers.batch import AzureBatchJobTrigger
+from airflow.triggers.base import TriggerEvent
+
+
+def test_azure_batch_job_trigger_serialize():
+    trigger = AzureBatchJobTrigger(
+        job_id="job-123",
+        azure_batch_conn_id="azure_batch_conn",
+        timeout=42,
+        poll_interval=9,
+    )
+
+    class_path, payload = trigger.serialize()
+
+    assert class_path == "airflow.providers.microsoft.azure.triggers.batch.AzureBatchJobTrigger"
+    assert set(payload.keys()) == {"job_id", "azure_batch_conn_id", "timeout", "poll_interval"}
+    assert payload["job_id"] == "job-123"
+    assert payload["azure_batch_conn_id"] == "azure_batch_conn"
+    assert payload["timeout"] == 42
+    assert payload["poll_interval"] == 9
+    json.dumps(payload)
+    assert all(isinstance(value, (str, int, float, bool, type(None))) for value in payload.values())
+
+
+@pytest.mark.asyncio
+async def test_trigger_run_success_all_tasks_completed():
+    """Test trigger emits success when all tasks complete successfully."""
+    trigger = AzureBatchJobTrigger(
+        job_id="test-job",
+        azure_batch_conn_id="azure_batch_default",
+        timeout=1,  # 1 minute
+        poll_interval=1,  # 1 second
+    )
+
+    # Mock task with completed state and success result
+    mock_task1 = mock.MagicMock()
+    mock_task1.id = "task1"
+    mock_task1.state = batch_models.TaskState.completed
+    mock_task1.execution_info = mock.MagicMock()
+    mock_task1.execution_info.result = batch_models.TaskExecutionResult.success
+
+    mock_task2 = mock.MagicMock()
+    mock_task2.id = "task2"
+    mock_task2.state = batch_models.TaskState.completed
+    mock_task2.execution_info = mock.MagicMock()
+    mock_task2.execution_info.result = batch_models.TaskExecutionResult.success
+
+    with mock.patch("airflow.providers.microsoft.azure.triggers.batch.AzureBatchHook") as mock_hook_class:
+        mock_hook = mock_hook_class.return_value
+        mock_hook.connection.task.list.return_value = [mock_task1, mock_task2]
+
+        events = []
+        async for event in trigger.run():
+            events.append(event)
+
+        assert len(events) == 1
+        assert events[0].payload["status"] == "success"
+        assert events[0].payload["fail_task_ids"] == []
+
+
+@pytest.mark.asyncio
+async def test_trigger_run_failure_some_tasks_failed():
+    """Test trigger emits failure when some tasks fail."""
+    trigger = AzureBatchJobTrigger(
+        job_id="test-job",
+        azure_batch_conn_id="azure_batch_default",
+        timeout=1,
+        poll_interval=1,
+    )
+
+    # Mock tasks with mixed results
+    mock_task1 = mock.MagicMock()
+    mock_task1.id = "task1"
+    mock_task1.state = batch_models.TaskState.completed
+    mock_task1.execution_info = mock.MagicMock()
+    mock_task1.execution_info.result = batch_models.TaskExecutionResult.success
+
+    mock_task2 = mock.MagicMock()
+    mock_task2.id = "task2"
+    mock_task2.state = batch_models.TaskState.completed
+    mock_task2.execution_info = mock.MagicMock()
+    mock_task2.execution_info.result = batch_models.TaskExecutionResult.failure
+
+    mock_task3 = mock.MagicMock()
+    mock_task3.id = "task3"
+    mock_task3.state = batch_models.TaskState.completed
+    mock_task3.execution_info = mock.MagicMock()
+    mock_task3.execution_info.result = batch_models.TaskExecutionResult.failure
+
+    with mock.patch("airflow.providers.microsoft.azure.triggers.batch.AzureBatchHook") as mock_hook_class:
+        mock_hook = mock_hook_class.return_value
+        mock_hook.connection.task.list.return_value = [mock_task1, mock_task2, mock_task3]
+
+        events = []
+        async for event in trigger.run():
+            events.append(event)
+
+        assert len(events) == 1
+        assert events[0].payload["status"] == "failure"
+        assert set(events[0].payload["fail_task_ids"]) == {"task2", "task3"}
+
+
+@pytest.mark.asyncio
+async def test_trigger_run_timeout():
+    """Test trigger emits timeout when polling exceeds timeout."""
+    trigger = AzureBatchJobTrigger(
+        job_id="test-job",
+        azure_batch_conn_id="azure_batch_default",
+        timeout=0.001,  # Very short timeout (0.001 minutes = 0.06 seconds)
+        poll_interval=1,
+    )
+
+    # Mock task that never completes
+    mock_task = mock.MagicMock()
+    mock_task.id = "task1"
+    mock_task.state = batch_models.TaskState.running
+
+    with mock.patch("airflow.providers.microsoft.azure.triggers.batch.AzureBatchHook") as mock_hook_class:
+        mock_hook = mock_hook_class.return_value
+        mock_hook.connection.task.list.return_value = [mock_task]
+
+        # Advance time to trigger timeout
+        with mock.patch("airflow.providers.microsoft.azure.triggers.batch.timezone") as mock_timezone:
+            from datetime import datetime, timedelta
+
+            start_time = datetime(2024, 1, 1, 0, 0, 0)
+            mock_timezone.utcnow.side_effect = [
+                start_time,  # Initial time
+                start_time + timedelta(minutes=1),  # After timeout
+            ]
+
+            events = []
+            async for event in trigger.run():
+                events.append(event)
+
+            assert len(events) == 1
+            assert events[0].payload["status"] == "timeout"
+            assert "Timed out waiting for tasks to complete" in events[0].payload["message"]
+
+
+@pytest.mark.asyncio
+async def test_trigger_run_error_exception():
+    """Test trigger emits error when Azure client raises exception."""
+    trigger = AzureBatchJobTrigger(
+        job_id="test-job",
+        azure_batch_conn_id="azure_batch_default",
+        timeout=1,
+        poll_interval=1,
+    )
+
+    with mock.patch("airflow.providers.microsoft.azure.triggers.batch.AzureBatchHook") as mock_hook_class:
+        mock_hook = mock_hook_class.return_value
+        mock_hook.connection.task.list.side_effect = Exception("Azure API error")
+
+        events = []
+        async for event in trigger.run():
+            events.append(event)
+
+        assert len(events) == 1
+        assert events[0].payload["status"] == "error"
+        assert "Azure API error" in events[0].payload["message"]
+
+
+@pytest.mark.asyncio
+async def test_trigger_poll_interval_respected():
+    """Test trigger respects poll_interval between checks."""
+    trigger = AzureBatchJobTrigger(
+        job_id="test-job",
+        azure_batch_conn_id="azure_batch_default",
+        timeout=1,
+        poll_interval=5,  # 5 seconds
+    )
+
+    # Mock task that completes after one poll
+    mock_task = mock.MagicMock()
+    mock_task.id = "task1"
+    mock_task.state = batch_models.TaskState.running
+
+    mock_completed_task = mock.MagicMock()
+    mock_completed_task.id = "task1"
+    mock_completed_task.state = batch_models.TaskState.completed
+    mock_completed_task.execution_info = mock.MagicMock()
+    mock_completed_task.execution_info.result = batch_models.TaskExecutionResult.success
+
+    call_count = 0
+
+    def task_list_side_effect(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return [mock_task]  # First call: running
+        return [mock_completed_task]  # Second call: completed
+
+    with mock.patch("airflow.providers.microsoft.azure.triggers.batch.AzureBatchHook") as mock_hook_class:
+        mock_hook = mock_hook_class.return_value
+        mock_hook.connection.task.list.side_effect = task_list_side_effect
+
+        with mock.patch("airflow.providers.microsoft.azure.triggers.batch.asyncio.sleep") as mock_sleep:
+            mock_sleep.return_value = None
+
+            events = []
+            async for event in trigger.run():
+                events.append(event)
+
+            # Verify sleep was called with correct interval
+            mock_sleep.assert_called_once_with(5)
+
+            assert len(events) == 1
+            assert events[0].payload["status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_trigger_exits_after_first_terminal_event():
+    """Test trigger exits immediately after emitting first terminal event."""
+    trigger = AzureBatchJobTrigger(
+        job_id="test-job",
+        azure_batch_conn_id="azure_batch_default",
+        timeout=10,
+        poll_interval=1,
+    )
+
+    mock_task = mock.MagicMock()
+    mock_task.id = "task1"
+    mock_task.state = batch_models.TaskState.completed
+    mock_task.execution_info = mock.MagicMock()
+    mock_task.execution_info.result = batch_models.TaskExecutionResult.success
+
+    with mock.patch("airflow.providers.microsoft.azure.triggers.batch.AzureBatchHook") as mock_hook_class:
+        mock_hook = mock_hook_class.return_value
+        # This should only be called once before trigger exits
+        mock_hook.connection.task.list.return_value = [mock_task]
+
+        events = []
+        async for event in trigger.run():
+            events.append(event)
+
+        # Should emit exactly one event and stop
+        assert len(events) == 1
+        assert events[0].payload["status"] == "success"
+
+        # Verify list was only called once
+        assert mock_hook.connection.task.list.call_count == 1

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/triggers/test_batch.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/triggers/test_batch.py
@@ -27,241 +27,236 @@ from airflow.providers.microsoft.azure.triggers.batch import AzureBatchJobTrigge
 from airflow.triggers.base import TriggerEvent
 
 
-def test_azure_batch_job_trigger_serialize():
-    trigger = AzureBatchJobTrigger(
-        job_id="job-123",
-        azure_batch_conn_id="azure_batch_conn",
-        timeout=42,
-        poll_interval=9,
-    )
+class TestAzureBatchJobTrigger:
+    def test_azure_batch_job_trigger_serialize(self):
+        trigger = AzureBatchJobTrigger(
+            job_id="job-123",
+            azure_batch_conn_id="azure_batch_conn",
+            timeout=42,
+            poll_interval=9,
+        )
 
-    class_path, payload = trigger.serialize()
+        class_path, payload = trigger.serialize()
 
-    assert class_path == "airflow.providers.microsoft.azure.triggers.batch.AzureBatchJobTrigger"
-    assert set(payload.keys()) == {"job_id", "azure_batch_conn_id", "timeout", "poll_interval"}
-    assert payload["job_id"] == "job-123"
-    assert payload["azure_batch_conn_id"] == "azure_batch_conn"
-    assert payload["timeout"] == 42
-    assert payload["poll_interval"] == 9
-    json.dumps(payload)
-    assert all(isinstance(value, (str, int, float, bool, type(None))) for value in payload.values())
+        assert class_path == "airflow.providers.microsoft.azure.triggers.batch.AzureBatchJobTrigger"
+        assert set(payload.keys()) == {"job_id", "azure_batch_conn_id", "timeout", "poll_interval"}
+        assert payload["job_id"] == "job-123"
+        assert payload["azure_batch_conn_id"] == "azure_batch_conn"
+        assert payload["timeout"] == 42
+        assert payload["poll_interval"] == 9
+        json.dumps(payload)
+        assert all(isinstance(value, (str, int, float, bool, type(None))) for value in payload.values())
 
+    @pytest.mark.asyncio
+    async def test_trigger_run_success_all_tasks_completed(self):
+        """Test trigger emits success when all tasks complete successfully."""
+        trigger = AzureBatchJobTrigger(
+            job_id="test-job",
+            azure_batch_conn_id="azure_batch_default",
+            timeout=1,  # 1 minute
+            poll_interval=1,  # 1 second
+        )
 
-@pytest.mark.asyncio
-async def test_trigger_run_success_all_tasks_completed():
-    """Test trigger emits success when all tasks complete successfully."""
-    trigger = AzureBatchJobTrigger(
-        job_id="test-job",
-        azure_batch_conn_id="azure_batch_default",
-        timeout=1,  # 1 minute
-        poll_interval=1,  # 1 second
-    )
+        # Mock task with completed state and success result
+        mock_task1 = mock.MagicMock()
+        mock_task1.id = "task1"
+        mock_task1.state = batch_models.TaskState.completed
+        mock_task1.execution_info = mock.MagicMock()
+        mock_task1.execution_info.result = batch_models.TaskExecutionResult.success
 
-    # Mock task with completed state and success result
-    mock_task1 = mock.MagicMock()
-    mock_task1.id = "task1"
-    mock_task1.state = batch_models.TaskState.completed
-    mock_task1.execution_info = mock.MagicMock()
-    mock_task1.execution_info.result = batch_models.TaskExecutionResult.success
+        mock_task2 = mock.MagicMock()
+        mock_task2.id = "task2"
+        mock_task2.state = batch_models.TaskState.completed
+        mock_task2.execution_info = mock.MagicMock()
+        mock_task2.execution_info.result = batch_models.TaskExecutionResult.success
 
-    mock_task2 = mock.MagicMock()
-    mock_task2.id = "task2"
-    mock_task2.state = batch_models.TaskState.completed
-    mock_task2.execution_info = mock.MagicMock()
-    mock_task2.execution_info.result = batch_models.TaskExecutionResult.success
-
-    with mock.patch("airflow.providers.microsoft.azure.triggers.batch.AzureBatchHook") as mock_hook_class:
-        mock_hook = mock_hook_class.return_value
-        mock_hook.connection.task.list.return_value = [mock_task1, mock_task2]
-
-        events = []
-        async for event in trigger.run():
-            events.append(event)
-
-        assert len(events) == 1
-        assert events[0].payload["status"] == "success"
-        assert events[0].payload["fail_task_ids"] == []
-
-
-@pytest.mark.asyncio
-async def test_trigger_run_failure_some_tasks_failed():
-    """Test trigger emits failure when some tasks fail."""
-    trigger = AzureBatchJobTrigger(
-        job_id="test-job",
-        azure_batch_conn_id="azure_batch_default",
-        timeout=1,
-        poll_interval=1,
-    )
-
-    # Mock tasks with mixed results
-    mock_task1 = mock.MagicMock()
-    mock_task1.id = "task1"
-    mock_task1.state = batch_models.TaskState.completed
-    mock_task1.execution_info = mock.MagicMock()
-    mock_task1.execution_info.result = batch_models.TaskExecutionResult.success
-
-    mock_task2 = mock.MagicMock()
-    mock_task2.id = "task2"
-    mock_task2.state = batch_models.TaskState.completed
-    mock_task2.execution_info = mock.MagicMock()
-    mock_task2.execution_info.result = batch_models.TaskExecutionResult.failure
-
-    mock_task3 = mock.MagicMock()
-    mock_task3.id = "task3"
-    mock_task3.state = batch_models.TaskState.completed
-    mock_task3.execution_info = mock.MagicMock()
-    mock_task3.execution_info.result = batch_models.TaskExecutionResult.failure
-
-    with mock.patch("airflow.providers.microsoft.azure.triggers.batch.AzureBatchHook") as mock_hook_class:
-        mock_hook = mock_hook_class.return_value
-        mock_hook.connection.task.list.return_value = [mock_task1, mock_task2, mock_task3]
-
-        events = []
-        async for event in trigger.run():
-            events.append(event)
-
-        assert len(events) == 1
-        assert events[0].payload["status"] == "failure"
-        assert set(events[0].payload["fail_task_ids"]) == {"task2", "task3"}
-
-
-@pytest.mark.asyncio
-async def test_trigger_run_timeout():
-    """Test trigger emits timeout when polling exceeds timeout."""
-    trigger = AzureBatchJobTrigger(
-        job_id="test-job",
-        azure_batch_conn_id="azure_batch_default",
-        timeout=0.001,  # Very short timeout (0.001 minutes = 0.06 seconds)
-        poll_interval=1,
-    )
-
-    # Mock task that never completes
-    mock_task = mock.MagicMock()
-    mock_task.id = "task1"
-    mock_task.state = batch_models.TaskState.running
-
-    with mock.patch("airflow.providers.microsoft.azure.triggers.batch.AzureBatchHook") as mock_hook_class:
-        mock_hook = mock_hook_class.return_value
-        mock_hook.connection.task.list.return_value = [mock_task]
-
-        # Advance time to trigger timeout
-        with mock.patch("airflow.providers.microsoft.azure.triggers.batch.timezone") as mock_timezone:
-            from datetime import datetime, timedelta
-
-            start_time = datetime(2024, 1, 1, 0, 0, 0)
-            mock_timezone.utcnow.side_effect = [
-                start_time,  # Initial time
-                start_time + timedelta(minutes=1),  # After timeout
-            ]
+        with mock.patch("airflow.providers.microsoft.azure.triggers.batch.AzureBatchHook") as mock_hook_class:
+            mock_hook = mock_hook_class.return_value
+            mock_hook.connection.task.list.return_value = [mock_task1, mock_task2]
 
             events = []
             async for event in trigger.run():
                 events.append(event)
-
-            assert len(events) == 1
-            assert events[0].payload["status"] == "timeout"
-            assert "Timed out waiting for tasks to complete" in events[0].payload["message"]
-
-
-@pytest.mark.asyncio
-async def test_trigger_run_error_exception():
-    """Test trigger emits error when Azure client raises exception."""
-    trigger = AzureBatchJobTrigger(
-        job_id="test-job",
-        azure_batch_conn_id="azure_batch_default",
-        timeout=1,
-        poll_interval=1,
-    )
-
-    with mock.patch("airflow.providers.microsoft.azure.triggers.batch.AzureBatchHook") as mock_hook_class:
-        mock_hook = mock_hook_class.return_value
-        mock_hook.connection.task.list.side_effect = Exception("Azure API error")
-
-        events = []
-        async for event in trigger.run():
-            events.append(event)
-
-        assert len(events) == 1
-        assert events[0].payload["status"] == "error"
-        assert "Azure API error" in events[0].payload["message"]
-
-
-@pytest.mark.asyncio
-async def test_trigger_poll_interval_respected():
-    """Test trigger respects poll_interval between checks."""
-    trigger = AzureBatchJobTrigger(
-        job_id="test-job",
-        azure_batch_conn_id="azure_batch_default",
-        timeout=1,
-        poll_interval=5,  # 5 seconds
-    )
-
-    # Mock task that completes after one poll
-    mock_task = mock.MagicMock()
-    mock_task.id = "task1"
-    mock_task.state = batch_models.TaskState.running
-
-    mock_completed_task = mock.MagicMock()
-    mock_completed_task.id = "task1"
-    mock_completed_task.state = batch_models.TaskState.completed
-    mock_completed_task.execution_info = mock.MagicMock()
-    mock_completed_task.execution_info.result = batch_models.TaskExecutionResult.success
-
-    call_count = 0
-
-    def task_list_side_effect(*args, **kwargs):
-        nonlocal call_count
-        call_count += 1
-        if call_count == 1:
-            return [mock_task]  # First call: running
-        return [mock_completed_task]  # Second call: completed
-
-    with mock.patch("airflow.providers.microsoft.azure.triggers.batch.AzureBatchHook") as mock_hook_class:
-        mock_hook = mock_hook_class.return_value
-        mock_hook.connection.task.list.side_effect = task_list_side_effect
-
-        with mock.patch("airflow.providers.microsoft.azure.triggers.batch.asyncio.sleep") as mock_sleep:
-            mock_sleep.return_value = None
-
-            events = []
-            async for event in trigger.run():
-                events.append(event)
-
-            # Verify sleep was called with correct interval
-            mock_sleep.assert_called_once_with(5)
 
             assert len(events) == 1
             assert events[0].payload["status"] == "success"
+            assert events[0].payload["fail_task_ids"] == []
 
+    @pytest.mark.asyncio
+    async def test_trigger_run_failure_some_tasks_failed(self):
+        """Test trigger emits failure when some tasks fail."""
+        trigger = AzureBatchJobTrigger(
+            job_id="test-job",
+            azure_batch_conn_id="azure_batch_default",
+            timeout=1,
+            poll_interval=1,
+        )
 
-@pytest.mark.asyncio
-async def test_trigger_exits_after_first_terminal_event():
-    """Test trigger exits immediately after emitting first terminal event."""
-    trigger = AzureBatchJobTrigger(
-        job_id="test-job",
-        azure_batch_conn_id="azure_batch_default",
-        timeout=10,
-        poll_interval=1,
-    )
+        # Mock tasks with mixed results
+        mock_task1 = mock.MagicMock()
+        mock_task1.id = "task1"
+        mock_task1.state = batch_models.TaskState.completed
+        mock_task1.execution_info = mock.MagicMock()
+        mock_task1.execution_info.result = batch_models.TaskExecutionResult.success
 
-    mock_task = mock.MagicMock()
-    mock_task.id = "task1"
-    mock_task.state = batch_models.TaskState.completed
-    mock_task.execution_info = mock.MagicMock()
-    mock_task.execution_info.result = batch_models.TaskExecutionResult.success
+        mock_task2 = mock.MagicMock()
+        mock_task2.id = "task2"
+        mock_task2.state = batch_models.TaskState.completed
+        mock_task2.execution_info = mock.MagicMock()
+        mock_task2.execution_info.result = batch_models.TaskExecutionResult.failure
 
-    with mock.patch("airflow.providers.microsoft.azure.triggers.batch.AzureBatchHook") as mock_hook_class:
-        mock_hook = mock_hook_class.return_value
-        # This should only be called once before trigger exits
-        mock_hook.connection.task.list.return_value = [mock_task]
+        mock_task3 = mock.MagicMock()
+        mock_task3.id = "task3"
+        mock_task3.state = batch_models.TaskState.completed
+        mock_task3.execution_info = mock.MagicMock()
+        mock_task3.execution_info.result = batch_models.TaskExecutionResult.failure
 
-        events = []
-        async for event in trigger.run():
-            events.append(event)
+        with mock.patch("airflow.providers.microsoft.azure.triggers.batch.AzureBatchHook") as mock_hook_class:
+            mock_hook = mock_hook_class.return_value
+            mock_hook.connection.task.list.return_value = [mock_task1, mock_task2, mock_task3]
 
-        # Should emit exactly one event and stop
-        assert len(events) == 1
-        assert events[0].payload["status"] == "success"
+            events = []
+            async for event in trigger.run():
+                events.append(event)
 
-        # Verify list was only called once
-        assert mock_hook.connection.task.list.call_count == 1
+            assert len(events) == 1
+            assert events[0].payload["status"] == "failure"
+            assert set(events[0].payload["fail_task_ids"]) == {"task2", "task3"}
+
+    @pytest.mark.asyncio
+    async def test_trigger_run_timeout(self):
+        """Test trigger emits timeout when polling exceeds timeout."""
+        trigger = AzureBatchJobTrigger(
+            job_id="test-job",
+            azure_batch_conn_id="azure_batch_default",
+            timeout=0.001,  # Very short timeout (0.001 minutes = 0.06 seconds)
+            poll_interval=1,
+        )
+
+        # Mock task that never completes
+        mock_task = mock.MagicMock()
+        mock_task.id = "task1"
+        mock_task.state = batch_models.TaskState.running
+
+        with mock.patch("airflow.providers.microsoft.azure.triggers.batch.AzureBatchHook") as mock_hook_class:
+            mock_hook = mock_hook_class.return_value
+            mock_hook.connection.task.list.return_value = [mock_task]
+
+            # Advance time to trigger timeout
+            with mock.patch("airflow.providers.microsoft.azure.triggers.batch.timezone") as mock_timezone:
+                from datetime import datetime, timedelta
+
+                start_time = datetime(2024, 1, 1, 0, 0, 0)
+                mock_timezone.utcnow.side_effect = [
+                    start_time,  # Initial time
+                    start_time + timedelta(minutes=1),  # After timeout
+                ]
+
+                events = []
+                async for event in trigger.run():
+                    events.append(event)
+
+                assert len(events) == 1
+                assert events[0].payload["status"] == "timeout"
+                assert "Timed out waiting for tasks to complete" in events[0].payload["message"]
+
+    @pytest.mark.asyncio
+    async def test_trigger_run_error_exception(self):
+        """Test trigger emits error when Azure client raises exception."""
+        trigger = AzureBatchJobTrigger(
+            job_id="test-job",
+            azure_batch_conn_id="azure_batch_default",
+            timeout=1,
+            poll_interval=1,
+        )
+
+        with mock.patch("airflow.providers.microsoft.azure.triggers.batch.AzureBatchHook") as mock_hook_class:
+            mock_hook = mock_hook_class.return_value
+            mock_hook.connection.task.list.side_effect = Exception("Azure API error")
+
+            events = []
+            async for event in trigger.run():
+                events.append(event)
+
+            assert len(events) == 1
+            assert events[0].payload["status"] == "error"
+            assert "Azure API error" in events[0].payload["message"]
+
+    @pytest.mark.asyncio
+    async def test_trigger_poll_interval_respected(self):
+        """Test trigger respects poll_interval between checks."""
+        trigger = AzureBatchJobTrigger(
+            job_id="test-job",
+            azure_batch_conn_id="azure_batch_default",
+            timeout=1,
+            poll_interval=5,  # 5 seconds
+        )
+
+        # Mock task that completes after one poll
+        mock_task = mock.MagicMock()
+        mock_task.id = "task1"
+        mock_task.state = batch_models.TaskState.running
+
+        mock_completed_task = mock.MagicMock()
+        mock_completed_task.id = "task1"
+        mock_completed_task.state = batch_models.TaskState.completed
+        mock_completed_task.execution_info = mock.MagicMock()
+        mock_completed_task.execution_info.result = batch_models.TaskExecutionResult.success
+
+        call_count = 0
+
+        def task_list_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return [mock_task]  # First call: running
+            return [mock_completed_task]  # Second call: completed
+
+        with mock.patch("airflow.providers.microsoft.azure.triggers.batch.AzureBatchHook") as mock_hook_class:
+            mock_hook = mock_hook_class.return_value
+            mock_hook.connection.task.list.side_effect = task_list_side_effect
+
+            with mock.patch("airflow.providers.microsoft.azure.triggers.batch.asyncio.sleep") as mock_sleep:
+                mock_sleep.return_value = None
+
+                events = []
+                async for event in trigger.run():
+                    events.append(event)
+
+                # Verify sleep was called with correct interval
+                mock_sleep.assert_called_once_with(5)
+
+                assert len(events) == 1
+                assert events[0].payload["status"] == "success"
+
+    @pytest.mark.asyncio
+    async def test_trigger_exits_after_first_terminal_event(self):
+        """Test trigger exits immediately after emitting first terminal event."""
+        trigger = AzureBatchJobTrigger(
+            job_id="test-job",
+            azure_batch_conn_id="azure_batch_default",
+            timeout=10,
+            poll_interval=1,
+        )
+
+        mock_task = mock.MagicMock()
+        mock_task.id = "task1"
+        mock_task.state = batch_models.TaskState.completed
+        mock_task.execution_info = mock.MagicMock()
+        mock_task.execution_info.result = batch_models.TaskExecutionResult.success
+
+        with mock.patch("airflow.providers.microsoft.azure.triggers.batch.AzureBatchHook") as mock_hook_class:
+            mock_hook = mock_hook_class.return_value
+            # This should only be called once before trigger exits
+            mock_hook.connection.task.list.return_value = [mock_task]
+
+            events = []
+            async for event in trigger.run():
+                events.append(event)
+
+            # Should emit exactly one event and stop
+            assert len(events) == 1
+            assert events[0].payload["status"] == "success"
+
+            # Verify list was only called once
+            assert mock_hook.connection.task.list.call_count == 1


### PR DESCRIPTION
This PR adds an opt-in deferrable mode to `AzureBatchOperator`.

**What this changes**

- Adds a `deferrable` flag (default: `False`).
- When `deferrable=True`, the operator:
  - submits the Azure Batch pool/job/task
  - immediately defers
  - moves all waiting and polling to a trigger
- The worker no longer blocks on sleep-based polling in deferrable mode.

**What stays the same**

- Default behavior is unchanged.
- With `deferrable=False`, the operator still runs exactly as before:
  - same polling logic
  - same exceptions
  - same cleanup behavior on both success and failure
- Existing DAGs are not affected unless `deferrable=True` is explicitly enabled.

**Cleanup behavior**

Cleanup semantics are preserved:

- Cleanup runs on both success and failure, matching historical behavior.
- Cleanup does not run inside `execute_complete()`.
- Cleanup runs exactly once in all paths (sync, deferrable, failure, timeout).

**Why this is needed**

Previously, the operator blocked a worker while polling Azure Batch using sleep-based loops.  
This change aligns the Azure Batch operator with existing deferrable patterns and reduces unnecessary worker usage.

Related issue: #59779
