### PR TITLE
Fix K8s Tests in Python 3.13 after PR 59767

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
@@ -1052,7 +1052,7 @@ def _deploy_helm_chart(
         if multi_namespace_mode:
             helm_command.extend(["--set", "multiNamespaceMode=true"])
         if not use_flask_appbuilder:
-            helm_command.extend(["--set", "createUserJob.defaultUser.enabled=false"])
+            helm_command.extend(["--set", "createUserJob.enabled=false"])
         if upgrade:
             # force upgrade
             helm_command.append("--force")

--- a/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
@@ -1052,7 +1052,7 @@ def _deploy_helm_chart(
         if multi_namespace_mode:
             helm_command.extend(["--set", "multiNamespaceMode=true"])
         if not use_flask_appbuilder:
-            helm_command.extend(["--set", "webserver.defaultUser.enabled=false"])
+            helm_command.extend(["--set", "createUserJob.defaultUser.enabled=false"])
         if upgrade:
             # force upgrade
             helm_command.append("--force")


### PR DESCRIPTION
PR #59767 removed a key which seems to be used still in all K8s tests, changing the used key int he test config.

See https://github.com/apache/airflow/actions/runs/20498501525/job/58903274791

```
Error: INSTALLATION FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
airflow:
- webserver: Additional property defaultUser is not allowed
```

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
