### PR TITLE
Fix flaky test_reading_from_pipes on Python 3.13 with pytest-xdist

### DIFF
--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -910,7 +910,8 @@ class Client(httpx.Client):
             kwargs.setdefault("base_url", "dry-run://server")
         else:
             kwargs["base_url"] = base_url
-            kwargs["verify"] = self._get_ssl_context_cached(certifi.where(), API_SSL_CERT_PATH)
+            # Call via the class to avoid binding lru_cache wires to this instance.
+            kwargs["verify"] = type(self)._get_ssl_context_cached(certifi.where(), API_SSL_CERT_PATH)
 
         # Set timeout if not explicitly provided
         kwargs.setdefault("timeout", API_TIMEOUT)

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -36,14 +36,7 @@ from contextlib import contextmanager, suppress
 from datetime import datetime, timezone
 from http import HTTPStatus
 from socket import socket, socketpair
-from typing import (
-    TYPE_CHECKING,
-    BinaryIO,
-    ClassVar,
-    NoReturn,
-    TextIO,
-    cast,
-)
+from typing import TYPE_CHECKING, BinaryIO, ClassVar, NoReturn, TextIO, cast
 from urllib.parse import urlparse
 from uuid import UUID
 
@@ -911,27 +904,39 @@ def _remote_logging_conn(client: Client):
     # Fetch connection details on-demand without caching the entire API client instance
     conn = _fetch_remote_logging_conn(conn_id, client)
 
-    if conn:
-        key = f"AIRFLOW_CONN_{conn_id.upper()}"
-        old_conn = os.getenv(key)
-        old_context = os.getenv("_AIRFLOW_PROCESS_CONTEXT")
-
-        os.environ[key] = conn.get_uri()
-        # Set process context to "client" so that Connection deserialization uses SDK Connection class
-        # which has from_uri() method, instead of core Connection class
-        os.environ["_AIRFLOW_PROCESS_CONTEXT"] = "client"
+    if not conn:
         try:
             yield
         finally:
-            if old_conn is None:
-                del os.environ[key]
-            else:
-                os.environ[key] = old_conn
+            # Ensure we don't leak the caller's client when no connection was fetched.
+            del conn
+            del client
+        return
 
-            if old_context is None:
-                del os.environ["_AIRFLOW_PROCESS_CONTEXT"]
-            else:
-                os.environ["_AIRFLOW_PROCESS_CONTEXT"] = old_context
+    key = f"AIRFLOW_CONN_{conn_id.upper()}"
+    old_conn = os.getenv(key)
+    old_context = os.getenv("_AIRFLOW_PROCESS_CONTEXT")
+
+    os.environ[key] = conn.get_uri()
+    # Set process context to "client" so that Connection deserialization uses SDK Connection class
+    # which has from_uri() method, instead of core Connection class
+    os.environ["_AIRFLOW_PROCESS_CONTEXT"] = "client"
+    try:
+        yield
+    finally:
+        if old_conn is None:
+            del os.environ[key]
+        else:
+            os.environ[key] = old_conn
+
+        if old_context is None:
+            del os.environ["_AIRFLOW_PROCESS_CONTEXT"]
+        else:
+            os.environ["_AIRFLOW_PROCESS_CONTEXT"] = old_context
+
+        # Explicitly drop local references so the caller's client can be garbage collected.
+        del conn
+        del client
 
 
 @attrs.define(kw_only=True)


### PR DESCRIPTION
## Summary

This PR fixes the flaky `test_reading_from_pipes` test on Python 3.13 with pytest-xdist through two complementary fixes.

### Fix 1: Defensive improvements

These changes address the symptom pathway where inherited mocks in forked processes could trigger warnings:

1. **context.py**: Changed `hasattr()` to `getattr()` to avoid triggering coroutine creation when checking for async methods on AsyncMock objects
2. **test_supervisor.py**: Added `use_real_secrets_backends` fixture to ensure real backend instances are used in subprocess tests, preventing inheritance of mocked backends across fork boundaries
3. **supervisor.py**: Fixed resource cleanup in `_remote_logging_conn()` with explicit `del` statements to prevent leaking client references
4. **client.py**: Fixed lru_cache binding by calling via `type(self)` instead of `self` to avoid carrying stale cache state across forked processes

### Fix 2: Root cause fix

The actual source of the unawaited coroutine was in `test_runtime_error_triggers_greenback_fallback` in `test_secrets.py`:

1. The test mocked `greenback.await_` to return a value directly without actually awaiting anything
2. When `backend.get_connection()` executed `greenback.await_(self.aget_connection(conn_id))`, a real coroutine was created
3. The mocked `greenback.await_` returned immediately without awaiting that coroutine
4. When the orphaned coroutine was garbage collected, Python 3.13 raised `RuntimeWarning: coroutine 'ExecutionAPISecretsBackend.aget_connection' was never awaited`
5. When tests ran in parallel with pytest-xdist, this warning appeared in `captured_logs` of other tests, causing assertion failures

**The fix**: Modified the test to mock `greenback.await_` with a `side_effect` that actually awaits the coroutine, and mock `aget_connection` to return the expected connection directly.

Both fixes together make the codebase more robust against async-related test flakiness on Python 3.13.


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
