### PR TITLE
Chart: add custom envs to database cleanup

### DIFF
--- a/chart/templates/database-cleanup/database-cleanup-cronjob.yaml
+++ b/chart/templates/database-cleanup/database-cleanup-cronjob.yaml
@@ -98,9 +98,14 @@ spec:
               {{- if .Values.databaseCleanup.args }}
               args: {{ tpl (toYaml .Values.databaseCleanup.args) . | nindent 16 }}
               {{- end }}
+              {{- if .Values.databaseCleanup.applyCustomEnv }}
+              envFrom: {{- include "custom_airflow_environment_from" . | default "\n  []" | indent 14 }}
+              env: {{- include "custom_airflow_environment" . | indent 14 }}
+              {{- else }}
               env:
-                {{- include "standard_airflow_environment" . | indent 12 }}
-                {{- include "container_extra_envs" (list . .Values.databaseCleanup.env) | indent 12 }}
+              {{- end }}
+                {{- include "standard_airflow_environment" . | indent 14 }}
+                {{- include "container_extra_envs" (list . .Values.databaseCleanup.env) | indent 14 }}
               volumeMounts:
                 {{- include "airflow_config_mount" . | nindent 16 }}
                 {{- if .Values.volumeMounts }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -9084,6 +9084,11 @@
                     "type": "boolean",
                     "default": false
                 },
+                "applyCustomEnv": {
+                    "description": "Specify if you want additional configured env vars applied to database cleanup job",
+                    "type": "boolean",
+                    "default": true
+                },
                 "schedule": {
                     "description": "Database cleanup schedule (templated).",
                     "type": "string",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2943,6 +2943,7 @@ cleanup:
 # This runs as a CronJob to cleanup database for old entries.
 databaseCleanup:
   enabled: false
+  applyCustomEnv: true
   # Run every week on Sunday at midnight (templated).
   schedule: "0 0 * * 0"
   # Command to use when running the database cleanup cronjob (templated).

--- a/helm-tests/tests/helm_tests/airflow_aux/test_extra_env_env_from.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_extra_env_env_from.py
@@ -37,6 +37,10 @@ PARAMS = [
         ("spec.template.spec.containers[0]",),
     ),
     (
+        ("CronJob", f"{RELEASE_NAME}-database-cleanup"),
+        ("spec.jobTemplate.spec.template.spec.containers[0]",),
+    ),
+    (
         ("Deployment", f"{RELEASE_NAME}-scheduler"),
         (
             "spec.template.spec.initContainers[0]",
@@ -82,6 +86,9 @@ class TestExtraEnvEnvFrom:
         values_str = textwrap.dedent(
             """
             airflowVersion: "2.6.0"
+            databaseCleanup:
+              enabled: true
+              applyCustomEnv: true
             flower:
               enabled: true
             extraEnvFrom: |


### PR DESCRIPTION
Added possibility to pass custom envs to database-cleanup cronjob as it is done for [create-user-job](https://github.com/apache/airflow/blob/main/chart/templates/jobs/create-user-job.yaml#L108). Custom envs can affect configuration and since databaseCleanup container runs `airflow ...` command, I think it would be useful to have custom envs in databaseCleanup container too.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
