### PR TITLE
Updated _DAG_HASH_ATTRS to use timetable instead of schedule

### DIFF
--- a/airflow-core/src/airflow/timetables/base.py
+++ b/airflow-core/src/airflow/timetables/base.py
@@ -216,6 +216,16 @@ class Timetable(Protocol):
         """
         return {}
 
+    def __repr__(self) -> str:
+        """
+        Represent the timetable as a string.
+
+        This is useful for Dag hashing. Custom subclasses can also implement
+        their own logic. (See also :func:`~airflow.sdk.DAG.__hash__`.)
+        """
+        attrs = [f"{k}={v}" for k, v in self.serialize().items()]
+        return f"{self.__class__.__name__}({', '.join(attrs)})"
+
     def validate(self) -> None:
         """
         Validate the timetable is correctly specified.

--- a/task-sdk/src/airflow/sdk/definitions/dag.py
+++ b/task-sdk/src/airflow/sdk/definitions/dag.py
@@ -110,9 +110,7 @@ _DAG_HASH_ATTRS = frozenset(
         "fileloc",
         "template_searchpath",
         "last_loaded",
-        "schedule",
-        # TODO: Task-SDK: we should be hashing on timetable now, not schedule!
-        # "timetable",
+        "timetable",
     }
 )
 

--- a/task-sdk/src/airflow/sdk/definitions/timetables/simple.py
+++ b/task-sdk/src/airflow/sdk/definitions/timetables/simple.py
@@ -18,7 +18,9 @@
 from __future__ import annotations
 
 import attrs
+
 from airflow.sdk.bases.timetable import BaseTimetable
+
 
 @attrs.define
 class NullTimetable(BaseTimetable):
@@ -30,6 +32,7 @@ class NullTimetable(BaseTimetable):
 
     can_be_scheduled = False
 
+
 @attrs.define
 class OnceTimetable(BaseTimetable):
     """
@@ -37,6 +40,7 @@ class OnceTimetable(BaseTimetable):
 
     This corresponds to ``schedule="@once"``.
     """
+
 
 @attrs.define
 class ContinuousTimetable(BaseTimetable):

--- a/task-sdk/src/airflow/sdk/definitions/timetables/simple.py
+++ b/task-sdk/src/airflow/sdk/definitions/timetables/simple.py
@@ -17,9 +17,10 @@
 
 from __future__ import annotations
 
+import attrs
 from airflow.sdk.bases.timetable import BaseTimetable
 
-
+@attrs.define
 class NullTimetable(BaseTimetable):
     """
     Timetable that never schedules anything.
@@ -29,7 +30,7 @@ class NullTimetable(BaseTimetable):
 
     can_be_scheduled = False
 
-
+@attrs.define
 class OnceTimetable(BaseTimetable):
     """
     Timetable that schedules the execution once as soon as possible.
@@ -37,7 +38,7 @@ class OnceTimetable(BaseTimetable):
     This corresponds to ``schedule="@once"``.
     """
 
-
+@attrs.define
 class ContinuousTimetable(BaseTimetable):
     """
     Timetable that schedules continually, while still respecting start_date and end_date.


### PR DESCRIPTION
Updated `_DAG_HASH_ATTRS` to use `timetable` instead of `schedule` . As noted in the TODO, for the Task-SDK we should be hashing on `timetable` now, not `schedule`.

I verified the existing unit tests passed. I wasn't sure if this needed any tests since it's swapping functionally equivalent attributes. Happy to add some if needed. 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
