### PR TITLE
Clean up SDK references in airflow.models.expandinput

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -64,11 +64,11 @@ from airflow.exceptions import TaskNotFound
 from airflow.models.asset import AssetActive
 from airflow.models.dag import DagModel
 from airflow.models.dagrun import DagRun as DR
+from airflow.models.expandinput import NotFullyPopulated
 from airflow.models.taskinstance import TaskInstance as TI, _stop_remaining_tasks
 from airflow.models.taskreschedule import TaskReschedule
 from airflow.models.trigger import Trigger
 from airflow.models.xcom import XComModel
-from airflow.sdk.definitions._internal.expandinput import NotFullyPopulated
 from airflow.serialization.definitions.assets import SerializedAsset, SerializedAssetUniqueKey
 from airflow.serialization.definitions.dag import SerializedDAG
 from airflow.task.trigger_rule import TriggerRule

--- a/airflow-core/src/airflow/models/expandinput.py
+++ b/airflow-core/src/airflow/models/expandinput.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 import attrs
 
-from airflow.sdk.definitions._internal.expandinput import MappedArgument, NotFullyPopulated
+from airflow.sdk.definitions._internal.expandinput import MappedArgument
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -39,10 +39,27 @@ if TYPE_CHECKING:
 
 
 __all__ = [
+    "NotFullyPopulated",
     "SchedulerDictOfListsExpandInput",
     "SchedulerListOfDictsExpandInput",
-    "NotFullyPopulated",
 ]
+
+
+class NotFullyPopulated(RuntimeError):
+    """
+    Raise when mapped length cannot be calculated due to incomplete metadata.
+
+    This is generally due to not all upstream tasks have been completed (or in
+    parse-time length calculations, when any upstream has runtime dependencies
+    on mapped length) when the function is called.
+    """
+
+    def __init__(self, missing: set[str]) -> None:
+        self.missing = missing
+
+    def __str__(self) -> str:
+        keys = ", ".join(repr(k) for k in sorted(self.missing))
+        return f"Failed to populate all mapping metadata; missing: {keys}"
 
 
 def _needs_run_time_resolution(v: OperatorExpandArgument) -> TypeGuard[MappedArgument | SchedulerXComArg]:

--- a/airflow-core/src/airflow/models/expandinput.py
+++ b/airflow-core/src/airflow/models/expandinput.py
@@ -24,33 +24,24 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 import attrs
 
-from airflow.sdk.definitions._internal.expandinput import (
-    DictOfListsExpandInput,
-    ListOfDictsExpandInput,
-    MappedArgument,
-    NotFullyPopulated,
-    OperatorExpandArgument,
-    OperatorExpandKwargsArgument,
-    is_mappable,
-)
+from airflow.sdk.definitions._internal.expandinput import MappedArgument, NotFullyPopulated
 
 if TYPE_CHECKING:
-    from typing import TypeGuard
+    from collections.abc import Sequence
+    from typing import TypeAlias, TypeGuard
 
     from sqlalchemy.orm import Session
 
     from airflow.serialization.definitions.mappedoperator import Operator
     from airflow.serialization.definitions.xcom_arg import SchedulerXComArg
 
+    OperatorExpandArgument: TypeAlias = MappedArgument | SchedulerXComArg | Sequence | dict[str, Any]
+
 
 __all__ = [
-    "DictOfListsExpandInput",
-    "ListOfDictsExpandInput",
-    "MappedArgument",
+    "SchedulerDictOfListsExpandInput",
+    "SchedulerListOfDictsExpandInput",
     "NotFullyPopulated",
-    "OperatorExpandArgument",
-    "OperatorExpandKwargsArgument",
-    "is_mappable",
 ]
 
 
@@ -62,6 +53,13 @@ def _needs_run_time_resolution(v: OperatorExpandArgument) -> TypeGuard[MappedArg
 
 @attrs.define
 class SchedulerDictOfListsExpandInput:
+    """
+    Serialized storage of a mapped operator's mapped kwargs.
+
+    This corresponds to SDK's ``DictOfListsExpandInput``, which was created by
+    calling ``expand(**kwargs)`` on an operator type.
+    """
+
     value: dict
 
     EXPAND_INPUT_TYPE: ClassVar[str] = "dict-of-lists"
@@ -123,6 +121,13 @@ class SchedulerDictOfListsExpandInput:
 
 @attrs.define
 class SchedulerListOfDictsExpandInput:
+    """
+    Serialized storage of a mapped operator's mapped kwargs.
+
+    This corresponds to SDK's ``ListOfDictsExpandInput``, which was created by
+    calling ``expand_kwargs(xcom_arg)`` on an operator type.
+    """
+
     value: list
 
     EXPAND_INPUT_TYPE: ClassVar[str] = "list-of-dicts"

--- a/airflow-core/src/airflow/serialization/encoders.py
+++ b/airflow-core/src/airflow/serialization/encoders.py
@@ -59,10 +59,17 @@ from airflow.utils.docs import get_docs_url
 if TYPE_CHECKING:
     from dateutil.relativedelta import relativedelta
 
+    from airflow.sdk.definitions._internal.expandinput import ExpandInput
     from airflow.sdk.definitions.asset import BaseAsset
     from airflow.triggers.base import BaseEventTrigger
 
     T = TypeVar("T")
+
+
+def encode_expand_input(var: ExpandInput) -> dict[str, Any]:
+    from airflow.serialization.serialized_objects import BaseSerialization
+
+    return {"type": var.EXPAND_INPUT_TYPE, "value": BaseSerialization.serialize(var.value)}
 
 
 def encode_relativedelta(var: relativedelta) -> dict[str, Any]:

--- a/airflow-core/src/airflow/serialization/enums.py
+++ b/airflow-core/src/airflow/serialization/enums.py
@@ -69,3 +69,4 @@ class DagAttributeTypes(str, Enum):
     DAG_CALLBACK_REQUEST = "dag_callback_request"
     TASK_INSTANCE_KEY = "task_instance_key"
     DEADLINE_ALERT = "deadline_alert"
+    MAPPED_ARGUMENT = "mapped_argument"

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -46,10 +46,11 @@ from airflow._shared.timezones.timezone import from_timestamp, parse_timezone, u
 from airflow.callbacks.callback_requests import DagCallbackRequest, TaskCallbackRequest
 from airflow.exceptions import AirflowException, DeserializationError, SerializationError
 from airflow.models.connection import Connection
-from airflow.models.expandinput import create_expand_input
+from airflow.models.expandinput import SchedulerMappedArgument, create_expand_input
 from airflow.models.taskinstancekey import TaskInstanceKey
 from airflow.sdk import DAG, Asset, AssetAlias, BaseOperator, XComArg
 from airflow.sdk.bases.operator import OPERATOR_DEFAULTS  # TODO: Copy this into the scheduler?
+from airflow.sdk.definitions._internal.expandinput import MappedArgument
 from airflow.sdk.definitions.asset import (
     AssetAliasEvent,
     AssetAliasUniqueKey,
@@ -81,6 +82,7 @@ from airflow.serialization.definitions.xcom_arg import SchedulerXComArg, deseria
 from airflow.serialization.encoders import (
     coerce_to_core_timetable,
     encode_asset_like,
+    encode_expand_input,
     encode_relativedelta,
     encode_timetable,
     encode_timezone,
@@ -653,6 +655,9 @@ class BaseSerialization:
             return cls._encode(var.to_json(), type_=DAT.TASK_CALLBACK_REQUEST)
         elif isinstance(var, DagCallbackRequest):
             return cls._encode(var.to_json(), type_=DAT.DAG_CALLBACK_REQUEST)
+        elif isinstance(var, MappedArgument):
+            data = {"input": encode_expand_input(var._input), "key": var._key}
+            return cls._encode(data, type_=DAT.MAPPED_ARGUMENT)
         elif var.__class__ == Context:
             d = {}
             for k, v in var.items():
@@ -762,6 +767,9 @@ class BaseSerialization:
             return DagCallbackRequest.from_json(var)
         elif type_ == DAT.TASK_INSTANCE_KEY:
             return TaskInstanceKey(**var)
+        elif type_ == DAT.MAPPED_ARGUMENT:
+            expand_input = create_expand_input(var["input"]["type"], var["input"]["value"])
+            return SchedulerMappedArgument(input=expand_input, key=var["key"])
         elif type_ == DAT.ARG_NOT_SET:
             from airflow.serialization.definitions.notset import NOTSET
 
@@ -1032,10 +1040,7 @@ class OperatorSerialization(DAGNode, BaseSerialization):
         expansion_kwargs = op._get_specified_expand_input()
         if TYPE_CHECKING:  # Let Mypy check the input type for us!
             _ExpandInputRef.validate_expand_input_value(expansion_kwargs.value)
-        serialized_op[op._expand_input_attr] = {
-            "type": type(expansion_kwargs).EXPAND_INPUT_TYPE,
-            "value": cls.serialize(expansion_kwargs.value),
-        }
+        serialized_op[op._expand_input_attr] = encode_expand_input(expansion_kwargs)
 
         if op.partial_kwargs:
             serialized_op["partial_kwargs"] = {}
@@ -2178,11 +2183,7 @@ class TaskGroupSerialization(BaseSerialization):
         }
 
         if isinstance(task_group, MappedTaskGroup):
-            expand_input = task_group._expand_input
-            encoded["expand_input"] = {
-                "type": expand_input.EXPAND_INPUT_TYPE,
-                "value": cls.serialize(expand_input.value),
-            }
+            encoded["expand_input"] = encode_expand_input(task_group._expand_input)
             encoded["is_mapped"] = True
 
         return encoded

--- a/airflow-core/tests/unit/models/test_dagrun.py
+++ b/airflow-core/tests/unit/models/test_dagrun.py
@@ -1456,7 +1456,7 @@ def test_mapped_literal_verify_integrity(dag_maker, session):
         task_2.expand(arg2=[1, 2])
 
     # Update it to use the new serialized DAG
-    dr.dag = dag_maker.dag
+    dr.dag = dag_maker.serialized_model.dag
     dag_version_id = DagVersion.get_latest_version(dag_id=dr.dag_id, session=session).id
     dr.verify_integrity(dag_version_id=dag_version_id, session=session)
 
@@ -1479,7 +1479,7 @@ def test_mapped_literal_to_xcom_arg_verify_integrity(dag_maker, session):
         t1 = BaseOperator(task_id="task_1")
         task_2.expand(arg2=t1.output)
 
-    dr.dag = dag_maker.dag
+    dr.dag = dag_maker.serialized_model.dag
     dag_version_id = DagVersion.get_latest_version(dag_id=dr.dag_id, session=session).id
     dr.verify_integrity(dag_version_id=dag_version_id, session=session)
 
@@ -1522,10 +1522,10 @@ def test_mapped_literal_length_increase_adds_additional_ti(dag_maker, session):
     ]
 
     # Now "increase" the length of literal
-    with dag_maker(session=session, serialized=True) as dag:
+    with dag_maker(session=session, serialized=True):
         task_2.expand(arg2=[1, 2, 3, 4, 5])
 
-    dr.dag = dag
+    dr.dag = dag_maker.serialized_model.dag
     # Every mapped task is revised at task_instance_scheduling_decision
     dr.task_instance_scheduling_decisions()
 
@@ -1565,7 +1565,7 @@ def test_mapped_literal_length_reduction_adds_removed_state(dag_maker, session):
     with dag_maker(session=session):
         task_2.expand(arg2=[1, 2])
 
-    dr.dag = dag_maker.dag
+    dr.dag = dag_maker.serialized_model.dag
     # Since we change the literal on the dag file itself, the dag_hash will
     # change which will have the scheduler verify the dr integrity
     dag_version_id = DagVersion.get_latest_version(dag_id=dr.dag_id, session=session).id

--- a/providers/standard/tests/unit/standard/decorators/test_python.py
+++ b/providers/standard/tests/unit/standard/decorators/test_python.py
@@ -48,7 +48,7 @@ else:
     from airflow.decorators.base import DecoratedMappedOperator  # type: ignore[no-redef]
     from airflow.models.baseoperator import BaseOperator  # type: ignore[no-redef]
     from airflow.models.dag import DAG  # type: ignore[assignment,no-redef]
-    from airflow.models.expandinput import DictOfListsExpandInput
+    from airflow.models.expandinput import DictOfListsExpandInput  # type: ignore[attr-defined,no-redef]
     from airflow.models.xcom_arg import XComArg  # type: ignore[no-redef]
     from airflow.utils.task_group import TaskGroup  # type: ignore[no-redef]
 

--- a/task-sdk/src/airflow/sdk/definitions/_internal/abstractoperator.py
+++ b/task-sdk/src/airflow/sdk/definitions/_internal/abstractoperator.py
@@ -28,8 +28,6 @@ from collections.abc import (
 )
 from typing import TYPE_CHECKING, Any, ClassVar, TypeAlias
 
-import methodtools
-
 from airflow.sdk import TriggerRule, WeightRule
 from airflow.sdk.configuration import conf
 from airflow.sdk.definitions._internal.mixins import DependencyMixin
@@ -81,10 +79,6 @@ DEFAULT_TASK_EXECUTION_TIMEOUT: datetime.timedelta | None = conf.gettimedelta(
 )
 
 log = logging.getLogger(__name__)
-
-
-class NotMapped(Exception):
-    """Raise if a task is neither mapped nor has any parent mapped groups."""
 
 
 class AbstractOperator(Templater, DAGNode):
@@ -408,21 +402,3 @@ class AbstractOperator(Templater, DAGNode):
             else:
                 self._needs_expansion = False
         return self._needs_expansion
-
-    @methodtools.lru_cache(maxsize=None)
-    def get_parse_time_mapped_ti_count(self) -> int:
-        """
-        Return the number of mapped task instances that can be created on Dag run creation.
-
-        This only considers literal mapped arguments, and would return *None*
-        when any non-literal values are used for mapping.
-
-        :raise NotFullyPopulated: If non-literal mapped arguments are encountered.
-        :raise NotMapped: If the operator is neither mapped, nor has any parent
-            mapped task groups.
-        :return: Total number of mapped TIs this task should have.
-        """
-        group = self.get_closest_mapped_task_group()
-        if group is None:
-            raise NotMapped()
-        return group.get_parse_time_mapped_ti_count()

--- a/task-sdk/src/airflow/sdk/definitions/_internal/expandinput.py
+++ b/task-sdk/src/airflow/sdk/definitions/_internal/expandinput.py
@@ -17,8 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import functools
-import operator
 from collections.abc import Iterable, Mapping, Sequence, Sized
 from typing import TYPE_CHECKING, Any, ClassVar, Union
 
@@ -123,15 +121,6 @@ class DictOfListsExpandInput(ResolveMixin):
         """Generate kwargs with values available on parse-time."""
         return ((k, v) for k, v in self.value.items() if _is_parse_time_mappable(v))
 
-    def get_parse_time_mapped_ti_count(self) -> int:
-        if not self.value:
-            return 0
-        literal_values = [len(v) for _, v in self._iter_parse_time_resolved_kwargs()]
-        if len(literal_values) != len(self.value):
-            literal_keys = (k for k, _ in self._iter_parse_time_resolved_kwargs())
-            raise NotFullyPopulated(set(self.value).difference(literal_keys))
-        return functools.reduce(operator.mul, literal_values, 1)
-
     def _get_map_lengths(
         self, resolved_vals: dict[str, Sized], upstream_map_indexes: dict[str, int]
     ) -> dict[str, int]:
@@ -235,11 +224,6 @@ class ListOfDictsExpandInput(ResolveMixin):
     value: OperatorExpandKwargsArgument
 
     EXPAND_INPUT_TYPE: ClassVar[str] = "list-of-dicts"
-
-    def get_parse_time_mapped_ti_count(self) -> int:
-        if isinstance(self.value, Sized):
-            return len(self.value)
-        raise NotFullyPopulated({"expand_kwargs() argument"})
 
     def iter_references(self) -> Iterable[tuple[Operator, str]]:
         from airflow.sdk.definitions.xcom_arg import XComArg

--- a/task-sdk/src/airflow/sdk/definitions/mappedoperator.py
+++ b/task-sdk/src/airflow/sdk/definitions/mappedoperator.py
@@ -42,7 +42,6 @@ from airflow.sdk.definitions._internal.abstractoperator import (
     DEFAULT_WAIT_FOR_PAST_DEPENDS_BEFORE_SKIPPING,
     DEFAULT_WEIGHT_RULE,
     AbstractOperator,
-    NotMapped,
     TaskStateChangeCallbackAttrType,
 )
 from airflow.sdk.definitions._internal.expandinput import (
@@ -795,16 +794,6 @@ class MappedOperator(AbstractOperator):
 
         for operator, _ in XComArg.iter_xcom_references(self._get_specified_expand_input()):
             yield operator
-
-    @methodtools.lru_cache(maxsize=None)
-    def get_parse_time_mapped_ti_count(self) -> int:
-        current_count = self._get_specified_expand_input().get_parse_time_mapped_ti_count()
-        try:
-            # The use of `methodtools` interferes with the zero-arg super
-            parent_count = super(MappedOperator, self).get_parse_time_mapped_ti_count()  # noqa: UP008
-        except NotMapped:
-            return current_count
-        return parent_count * current_count
 
     def render_template_fields(
         self,

--- a/task-sdk/src/airflow/sdk/definitions/mappedoperator.py
+++ b/task-sdk/src/airflow/sdk/definitions/mappedoperator.py
@@ -59,12 +59,12 @@ if TYPE_CHECKING:
     import jinja2  # Slow import.
     import pendulum
 
-    from airflow.models.expandinput import (
+    from airflow.sdk import DAG, BaseOperator, BaseOperatorLink, Context, TaskGroup, TriggerRule, XComArg
+    from airflow.sdk.definitions._internal.expandinput import (
+        ExpandInput,
         OperatorExpandArgument,
         OperatorExpandKwargsArgument,
     )
-    from airflow.sdk import DAG, BaseOperator, BaseOperatorLink, Context, TaskGroup, TriggerRule, XComArg
-    from airflow.sdk.definitions._internal.expandinput import ExpandInput
     from airflow.sdk.definitions.operator_resources import Resources
     from airflow.sdk.definitions.param import ParamsDict
     from airflow.triggers.base import StartTriggerArgs

--- a/task-sdk/src/airflow/sdk/definitions/taskgroup.py
+++ b/task-sdk/src/airflow/sdk/definitions/taskgroup.py
@@ -20,15 +20,12 @@
 from __future__ import annotations
 
 import copy
-import functools
-import operator
 import re
 import weakref
 from collections.abc import Generator, Iterator, Sequence
 from typing import TYPE_CHECKING, Any
 
 import attrs
-import methodtools
 
 from airflow.sdk import TriggerRule
 from airflow.sdk.definitions._internal.node import DAGNode, validate_group_key
@@ -628,27 +625,6 @@ class MappedTaskGroup(TaskGroup):
                     "allowed with trigger rule 'always'"
                 )
             yield from self._iter_child(child)
-
-    @methodtools.lru_cache(maxsize=None)
-    def get_parse_time_mapped_ti_count(self) -> int:
-        """
-        Return the Number of instances a task in this group should be mapped to, when a Dag run is created.
-
-        This only considers literal mapped arguments, and would return *None*
-        when any non-literal values are used for mapping.
-
-        If this group is inside mapped task groups, all the nested counts are
-        multiplied and accounted.
-
-        :meta private:
-
-        :raise NotFullyPopulated: If any non-literal mapped arguments are encountered.
-        :return: The total number of mapped instances each task should have.
-        """
-        return functools.reduce(
-            operator.mul,
-            (g._expand_input.get_parse_time_mapped_ti_count() for g in self.iter_mapped_task_groups()),
-        )
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         for op, _ in self._expand_input.iter_references():


### PR DESCRIPTION
Most of these are not used anymore after the Greate Split. The one remaining class (not actually used in scheduler logic currently) is also now properly encoded.

See #52141.