### PR TITLE
Switch to `pip check` compliant pagefind

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -997,11 +997,8 @@ function install_airflow_and_providers_from_docker_context_files(){
         "${install_airflow_distribution[@]}" "${install_airflow_core_distribution[@]}" "${airflow_distributions[@]}"
     set +x
     common::install_packaging_tools
-    # Here we should use `pip check` not `uv pip check` to detect any incompatibilities that might happen
-    # between `pip` and `uv` installations
-    # However, in the current version of `pip` there is a bug that incorrectly detects `pagefind-bin` as unsupported
-    # https://github.com/pypa/pip/issues/13709 -> once this is fixed, we should bring `pip check` back.
-    uv pip check
+    # We use pip check here to make sure that whatever `uv` installs, is also "correct" according to `pip`
+    pip check
 }
 
 function install_all_other_distributions_from_docker_context_files() {
@@ -1241,11 +1238,8 @@ function install_airflow_when_building_images() {
     echo
     echo "${COLOR_BLUE}Running 'pip check'${COLOR_RESET}"
     echo
-    # Here we should use `pip check` not `uv pip check` to detect any incompatibilities that might happen
-    # between `pip` and `uv` installations
-    # However, in the current version of `pip` there is a bug that incorrectly detects `pagefind-bin` as unsupported
-    # https://github.com/pypa/pip/issues/13709 -> once this is fixed, we should bring `pip check` back.
-    uv pip check
+    # We use pip check here to make sure that whatever `uv` installs, is also "correct" according to `pip`
+    pip check
 }
 
 common::get_colors
@@ -1280,11 +1274,8 @@ function install_additional_dependencies() {
         echo
         echo "${COLOR_BLUE}Running 'pip check'${COLOR_RESET}"
         echo
-        # Here we should use `pip check` not `uv pip check` to detect any incompatibilities that might happen
-        # between `pip` and `uv` installations
-        # However, in the current version of `pip` there is a bug that incorrectly detects `pagefind-bin` as unsupported
-        # https://github.com/pypa/pip/issues/13709 -> once this is fixed, we should bring `pip check` back.
-        uv pip check
+        # We use pip check here to make sure that whatever `uv` installs, is also "correct" according to `pip`
+        pip check
     else
         echo
         echo "${COLOR_BLUE}Installing additional dependencies upgrading only if needed${COLOR_RESET}"
@@ -1298,11 +1289,8 @@ function install_additional_dependencies() {
         echo
         echo "${COLOR_BLUE}Running 'pip check'${COLOR_RESET}"
         echo
-        # Here we should use `pip check` not `uv pip check` to detect any incompatibilities that might happen
-        # between `pip` and `uv` installations
-        # However, in the current version of `pip` there is a bug that incorrectly detects `pagefind-bin` as unsupported
-        # https://github.com/pypa/pip/issues/13709 -> once this is fixed, we should bring `pip check` back.
-        uv pip check
+        # We use pip check here to make sure that whatever `uv` installs, is also "correct" according to `pip`
+        pip check
     fi
 }
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -990,11 +990,8 @@ function install_airflow_when_building_images() {
     echo
     echo "${COLOR_BLUE}Running 'pip check'${COLOR_RESET}"
     echo
-    # Here we should use `pip check` not `uv pip check` to detect any incompatibilities that might happen
-    # between `pip` and `uv` installations
-    # However, in the current version of `pip` there is a bug that incorrectly detects `pagefind-bin` as unsupported
-    # https://github.com/pypa/pip/issues/13709 -> once this is fixed, we should bring `pip check` back.
-    uv pip check
+    # We use pip check here to make sure that whatever `uv` installs, is also "correct" according to `pip`
+    pip check
 }
 
 common::get_colors
@@ -1029,11 +1026,8 @@ function install_additional_dependencies() {
         echo
         echo "${COLOR_BLUE}Running 'pip check'${COLOR_RESET}"
         echo
-        # Here we should use `pip check` not `uv pip check` to detect any incompatibilities that might happen
-        # between `pip` and `uv` installations
-        # However, in the current version of `pip` there is a bug that incorrectly detects `pagefind-bin` as unsupported
-        # https://github.com/pypa/pip/issues/13709 -> once this is fixed, we should bring `pip check` back.
-        uv pip check
+        # We use pip check here to make sure that whatever `uv` installs, is also "correct" according to `pip`
+        pip check
     else
         echo
         echo "${COLOR_BLUE}Installing additional dependencies upgrading only if needed${COLOR_RESET}"
@@ -1047,11 +1041,8 @@ function install_additional_dependencies() {
         echo
         echo "${COLOR_BLUE}Running 'pip check'${COLOR_RESET}"
         echo
-        # Here we should use `pip check` not `uv pip check` to detect any incompatibilities that might happen
-        # between `pip` and `uv` installations
-        # However, in the current version of `pip` there is a bug that incorrectly detects `pagefind-bin` as unsupported
-        # https://github.com/pypa/pip/issues/13709 -> once this is fixed, we should bring `pip check` back.
-        uv pip check
+        # We use pip check here to make sure that whatever `uv` installs, is also "correct" according to `pip`
+        pip check
     fi
 }
 
@@ -1370,11 +1361,8 @@ function check_downgrade_sqlalchemy() {
     echo
     echo "${COLOR_BLUE}Running 'pip check'${COLOR_RESET}"
     echo
-    # Here we should use `pip check` not `uv pip check` to detect any incompatibilities that might happen
-    # between `pip` and `uv` installations
-    # However, in the current version of `pip` there is a bug that incorrectly detects `pagefind-bin` as unsupported
-    # https://github.com/pypa/pip/issues/13709 -> once this is fixed, we should bring `pip check` back.
-    uv pip check
+    # We use pip check here to make sure that whatever `uv` installs, is also "correct" according to `pip`
+    pip check
 }
 
 function check_downgrade_pendulum() {
@@ -1391,11 +1379,8 @@ function check_downgrade_pendulum() {
     echo
     echo "${COLOR_BLUE}Running 'pip check'${COLOR_RESET}"
     echo
-    # Here we should use `pip check` not `uv pip check` to detect any incompatibilities that might happen
-    # between `pip` and `uv` installations
-    # However, in the current version of `pip` there is a bug that incorrectly detects `pagefind-bin` as unsupported
-    # https://github.com/pypa/pip/issues/13709 -> once this is fixed, we should bring `pip check` back.
-    uv pip check
+    # We use pip check here to make sure that whatever `uv` installs, is also "correct" according to `pip`
+    pip check
 }
 
 function check_run_tests() {

--- a/devel-common/pyproject.toml
+++ b/devel-common/pyproject.toml
@@ -76,7 +76,10 @@ dependencies = [
     "rich-click>=1.7.1",
     "click>=8.1.8",
     "docutils>=0.21",
-    "pagefind[bin]",
+    # TODO: replace with "pagefind[bin]>=1.5.0" when released - you need to have "release" version to get
+    # the new pagefind-bin installed
+    "pagefind>=1.5.0a3",
+    "pagefind-bin>=1.5.0a3",
     "sphinx-airflow-theme@https://github.com/apache/airflow-site/releases/download/0.3.0/sphinx_airflow_theme-0.3.0-py3-none-any.whl",
     "sphinx-argparse>=0.4.0",
     "sphinx-autoapi>=3",

--- a/scripts/docker/entrypoint_ci.sh
+++ b/scripts/docker/entrypoint_ci.sh
@@ -340,11 +340,8 @@ function check_downgrade_sqlalchemy() {
     echo
     echo "${COLOR_BLUE}Running 'pip check'${COLOR_RESET}"
     echo
-    # Here we should use `pip check` not `uv pip check` to detect any incompatibilities that might happen
-    # between `pip` and `uv` installations
-    # However, in the current version of `pip` there is a bug that incorrectly detects `pagefind-bin` as unsupported
-    # https://github.com/pypa/pip/issues/13709 -> once this is fixed, we should bring `pip check` back.
-    uv pip check
+    # We use pip check here to make sure that whatever `uv` installs, is also "correct" according to `pip`
+    pip check
 }
 
 # Download minimum supported version of pendulum to run tests with it
@@ -362,11 +359,8 @@ function check_downgrade_pendulum() {
     echo
     echo "${COLOR_BLUE}Running 'pip check'${COLOR_RESET}"
     echo
-    # Here we should use `pip check` not `uv pip check` to detect any incompatibilities that might happen
-    # between `pip` and `uv` installations
-    # However, in the current version of `pip` there is a bug that incorrectly detects `pagefind-bin` as unsupported
-    # https://github.com/pypa/pip/issues/13709 -> once this is fixed, we should bring `pip check` back.
-    uv pip check
+    # We use pip check here to make sure that whatever `uv` installs, is also "correct" according to `pip`
+    pip check
 }
 
 # Check if we should run tests and run them if needed

--- a/scripts/docker/install_additional_dependencies.sh
+++ b/scripts/docker/install_additional_dependencies.sh
@@ -38,11 +38,8 @@ function install_additional_dependencies() {
         echo
         echo "${COLOR_BLUE}Running 'pip check'${COLOR_RESET}"
         echo
-        # Here we should use `pip check` not `uv pip check` to detect any incompatibilities that might happen
-        # between `pip` and `uv` installations
-        # However, in the current version of `pip` there is a bug that incorrectly detects `pagefind-bin` as unsupported
-        # https://github.com/pypa/pip/issues/13709 -> once this is fixed, we should bring `pip check` back.
-        uv pip check
+        # We use pip check here to make sure that whatever `uv` installs, is also "correct" according to `pip`
+        pip check
     else
         echo
         echo "${COLOR_BLUE}Installing additional dependencies upgrading only if needed${COLOR_RESET}"
@@ -56,11 +53,8 @@ function install_additional_dependencies() {
         echo
         echo "${COLOR_BLUE}Running 'pip check'${COLOR_RESET}"
         echo
-        # Here we should use `pip check` not `uv pip check` to detect any incompatibilities that might happen
-        # between `pip` and `uv` installations
-        # However, in the current version of `pip` there is a bug that incorrectly detects `pagefind-bin` as unsupported
-        # https://github.com/pypa/pip/issues/13709 -> once this is fixed, we should bring `pip check` back.
-        uv pip check
+        # We use pip check here to make sure that whatever `uv` installs, is also "correct" according to `pip`
+        pip check
     fi
 }
 

--- a/scripts/docker/install_airflow_when_building_images.sh
+++ b/scripts/docker/install_airflow_when_building_images.sh
@@ -203,11 +203,8 @@ function install_airflow_when_building_images() {
     echo
     echo "${COLOR_BLUE}Running 'pip check'${COLOR_RESET}"
     echo
-    # Here we should use `pip check` not `uv pip check` to detect any incompatibilities that might happen
-    # between `pip` and `uv` installations
-    # However, in the current version of `pip` there is a bug that incorrectly detects `pagefind-bin` as unsupported
-    # https://github.com/pypa/pip/issues/13709 -> once this is fixed, we should bring `pip check` back.
-    uv pip check
+    # We use pip check here to make sure that whatever `uv` installs, is also "correct" according to `pip`
+    pip check
 }
 
 common::get_colors

--- a/scripts/docker/install_from_docker_context_files.sh
+++ b/scripts/docker/install_from_docker_context_files.sh
@@ -122,11 +122,8 @@ function install_airflow_and_providers_from_docker_context_files(){
         "${install_airflow_distribution[@]}" "${install_airflow_core_distribution[@]}" "${airflow_distributions[@]}"
     set +x
     common::install_packaging_tools
-    # Here we should use `pip check` not `uv pip check` to detect any incompatibilities that might happen
-    # between `pip` and `uv` installations
-    # However, in the current version of `pip` there is a bug that incorrectly detects `pagefind-bin` as unsupported
-    # https://github.com/pypa/pip/issues/13709 -> once this is fixed, we should bring `pip check` back.
-    uv pip check
+    # We use pip check here to make sure that whatever `uv` installs, is also "correct" according to `pip`
+    pip check
 }
 
 # Simply install all other (non-apache-airflow) distributions placed in docker-context files


### PR DESCRIPTION
The pagefind before 1.5.0 had multiple tags published in a way that broke `pip check`.

This has been tracked in https://github.com/pypa/pip/issues/13709

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
