### PR TITLE
Clean up top-level SDK imports in Core

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/services/ui/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/ui/connections.py
@@ -27,7 +27,7 @@ from airflow.api_fastapi.core_api.datamodels.connections import (
     ConnectionHookMetaData,
     StandardHookFields,
 )
-from airflow.sdk import Param
+from airflow.serialization.definitions.param import SerializedParam
 
 if TYPE_CHECKING:
     from airflow.providers_manager import ConnectionFormWidgetInfo, HookInfo
@@ -79,7 +79,7 @@ class HookMetaService:
                 for v in validators:
                     if isinstance(v, HookMetaService.MockEnum):
                         enum = {"enum": v.allowed_values}
-            self.param = Param(
+            self.param = SerializedParam(
                 default=default,
                 title=label,
                 description=description or None,

--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -60,6 +60,7 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
     from airflow import DAG
+    from airflow.serialization.definitions.dag import SerializedDAG
     from airflow.timetables.base import DataInterval
 
 DAG_DETAIL_FIELDS = {*DAGResponse.model_fields, *DAGResponse.model_computed_fields}
@@ -656,7 +657,7 @@ def dag_test(args, dag: DAG | None = None, session: Session = NEW_SESSION) -> No
             )
         ).all()
 
-        dot_graph = render_dag(dag, tis=list(tis))
+        dot_graph = render_dag(cast("SerializedDAG", dag), tis=list(tis))
         print()
         if filename:
             _save_dot_to_file(dot_graph, filename)

--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -36,7 +36,6 @@ from airflow.configuration import ensure_secrets_loaded
 from airflow.exceptions import AirflowException, AirflowNotFoundException
 from airflow.models.base import ID_LEN, Base
 from airflow.models.crypto import get_fernet
-from airflow.sdk import SecretCache
 from airflow.utils.helpers import prune_dict
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import NEW_SESSION, provide_session
@@ -519,6 +518,8 @@ class Connection(Base, LoggingMixin):
 
         # check cache first
         # enabled only if SecretCache.init() has been called first
+        from airflow.sdk import SecretCache
+
         try:
             uri = SecretCache.get_connection_uri(conn_id)
             return Connection(conn_id=conn_id, uri=uri)

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -114,10 +114,10 @@ if TYPE_CHECKING:
     from airflow.api_fastapi.execution_api.datamodels.asset import AssetProfile
     from airflow.models.dag import DagModel
     from airflow.models.dagrun import DagRun
+    from airflow.sdk import Context
     from airflow.serialization.definitions.dag import SerializedDAG
     from airflow.serialization.definitions.mappedoperator import Operator
     from airflow.serialization.definitions.taskgroup import SerializedTaskGroup
-    from airflow.utils.context import Context
 
 
 PAST_DEPENDS_MET = "past_depends_met"

--- a/airflow-core/src/airflow/models/variable.py
+++ b/airflow-core/src/airflow/models/variable.py
@@ -32,7 +32,6 @@ from airflow._shared.secrets_masker import mask_secret
 from airflow.configuration import conf, ensure_secrets_loaded
 from airflow.models.base import ID_LEN, Base
 from airflow.models.crypto import get_fernet
-from airflow.sdk import SecretCache
 from airflow.secrets.metastore import MetastoreBackend
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import NEW_SESSION, create_session, provide_session
@@ -238,6 +237,8 @@ class Variable(Base, LoggingMixin):
             )
 
         # check if the secret exists in the custom secrets' backend.
+        from airflow.sdk import SecretCache
+
         Variable.check_for_write_conflict(key=key)
         if serialize_json:
             stored_value = json.dumps(value, indent=2)
@@ -428,6 +429,8 @@ class Variable(Base, LoggingMixin):
                 "Multi-team mode is not configured in the Airflow environment but the task trying to delete the variable belongs to a team"
             )
 
+        from airflow.sdk import SecretCache
+
         ctx: contextlib.AbstractContextManager
         if session is not None:
             ctx = contextlib.nullcontext(session)
@@ -494,6 +497,8 @@ class Variable(Base, LoggingMixin):
         :param team_name: Team name associated to the task trying to access the variable (if any)
         :return: Variable Value
         """
+        from airflow.sdk import SecretCache
+
         # Disable cache if the variable belongs to a team. We might enable it later
         if not team_name:
             # check cache first

--- a/airflow-core/src/airflow/serialization/definitions/mappedoperator.py
+++ b/airflow-core/src/airflow/serialization/definitions/mappedoperator.py
@@ -30,7 +30,6 @@ from sqlalchemy.orm import Session
 
 from airflow.exceptions import AirflowException, NotMapped
 from airflow.sdk import BaseOperator as TaskSDKBaseOperator
-from airflow.sdk.definitions._internal.abstractoperator import DEFAULT_RETRY_DELAY_MULTIPLIER
 from airflow.sdk.definitions.mappedoperator import MappedOperator as TaskSDKMappedOperator
 from airflow.serialization.definitions.baseoperator import DEFAULT_OPERATOR_DEPS, SerializedBaseOperator
 from airflow.serialization.definitions.node import DAGNode
@@ -287,10 +286,6 @@ class SerializedMappedOperator(DAGNode):
     @property
     def max_retry_delay(self) -> datetime.timedelta | float | None:
         return self._get_partial_kwargs_or_operator_default("max_retry_delay")
-
-    @property
-    def retry_delay_multiplier(self) -> float:
-        return float(self.partial_kwargs.get("retry_delay_multiplier", DEFAULT_RETRY_DELAY_MULTIPLIER))
 
     @property
     def weight_rule(self) -> PriorityWeightStrategy:

--- a/airflow-core/src/airflow/utils/cli.py
+++ b/airflow-core/src/airflow/utils/cli.py
@@ -37,7 +37,6 @@ from airflow import settings
 from airflow._shared.timezones import timezone
 from airflow.dag_processing.bundles.manager import DagBundlesManager
 from airflow.exceptions import AirflowException
-from airflow.sdk.definitions._internal.dag_parsing_context import _airflow_parsing_context_manager
 from airflow.utils import cli_action_loggers
 from airflow.utils.log.non_caching_file_handler import NonCachingFileHandler
 from airflow.utils.platform import getuser, is_terminal_support_colors
@@ -274,6 +273,7 @@ def get_bagged_dag(bundle_names: list | None, dag_id: str, dagfile_path: str | N
     dags folder.
     """
     from airflow.dag_processing.dagbag import DagBag, sync_bag_to_db
+    from airflow.sdk.definitions._internal.dag_parsing_context import _airflow_parsing_context_manager
 
     manager = DagBundlesManager()
     for bundle_name in bundle_names or ():

--- a/airflow-core/src/airflow/utils/context.py
+++ b/airflow-core/src/airflow/utils/context.py
@@ -19,22 +19,21 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+import warnings
+from typing import Any
 
 from sqlalchemy import select
 
 from airflow.models.asset import AssetModel
-from airflow.sdk import Asset, Context
+from airflow.sdk import Asset
 from airflow.sdk.execution_time.context import (
     ConnectionAccessor as ConnectionAccessorSDK,
     OutletEventAccessors as OutletEventAccessorsSDK,
     VariableAccessor as VariableAccessorSDK,
 )
 from airflow.serialization.definitions.notset import NOTSET, is_arg_set
+from airflow.utils.deprecation_tools import DeprecatedImportWarning
 from airflow.utils.session import create_session
-
-if TYPE_CHECKING:
-    from collections.abc import Container
 
 # NOTE: Please keep this in sync with the following:
 # * Context in task-sdk/src/airflow/sdk/definitions/context.py
@@ -141,30 +140,17 @@ class OutletEventAccessors(OutletEventAccessorsSDK):
         return Asset(name=asset.name, uri=asset.uri, group=asset.group, extra=asset.extra)
 
 
-def context_merge(context: Context, *args: Any, **kwargs: Any) -> None:
-    """
-    Merge parameters into an existing context.
+def __getattr__(name: str):
+    if name in ("Context", "context_copy_partial", "context_merge"):
+        warnings.warn(
+            "Importing Context from airflow.utils.context is deprecated and will "
+            "be removed in the future. Please import it from airflow.sdk instead.",
+            DeprecatedImportWarning,
+            stacklevel=2,
+        )
 
-    Like ``dict.update()`` , this take the same parameters, and updates
-    ``context`` in-place.
+        import airflow.sdk.definitions.context as sdk
 
-    This is implemented as a free function because the ``Context`` type is
-    "faked" as a ``TypedDict`` in ``context.pyi``, which cannot have custom
-    functions.
+        return getattr(sdk, name)
 
-    :meta private:
-    """
-    if not context:
-        context = Context()
-
-    context.update(*args, **kwargs)
-
-
-def context_copy_partial(source: Context, keys: Container[str]) -> Context:
-    """
-    Create a context by copying items under selected keys in ``source``.
-
-    :meta private:
-    """
-    new = {k: v for k, v in source.items() if k in keys}
-    return cast("Context", new)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/airflow-core/src/airflow/utils/dag_edges.py
+++ b/airflow-core/src/airflow/utils/dag_edges.py
@@ -16,20 +16,23 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any
 
-from airflow.sdk.definitions._internal.abstractoperator import AbstractOperator
-from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
-from airflow.serialization.definitions.dag import SerializedDAG
-from airflow.serialization.definitions.mappedoperator import SerializedMappedOperator
+from airflow.serialization.definitions.taskgroup import SerializedTaskGroup
+
+# Also support SDK types if possible.
+try:
+    from airflow.sdk import TaskGroup
+except ImportError:
+    TaskGroup = SerializedTaskGroup  # type: ignore[misc]
 
 if TYPE_CHECKING:
-    from airflow.sdk import DAG
     from airflow.serialization.definitions.dag import SerializedDAG
     from airflow.serialization.definitions.mappedoperator import Operator
+    from airflow.serialization.definitions.node import DAGNode
 
 
-def dag_edges(dag: DAG | SerializedDAG):
+def dag_edges(dag: SerializedDAG):
     """
     Create the list of edges needed to construct the Graph view.
 
@@ -62,9 +65,10 @@ def dag_edges(dag: DAG | SerializedDAG):
 
     task_group_map = dag.task_group.get_task_group_dict()
 
-    def collect_edges(task_group):
+    def collect_edges(task_group: DAGNode) -> None:
         """Update edges_to_add and edges_to_skip according to TaskGroups."""
-        if isinstance(task_group, (AbstractOperator, SerializedBaseOperator, SerializedMappedOperator)):
+        child: DAGNode
+        if not isinstance(task_group, (TaskGroup, SerializedTaskGroup)):
             return
 
         for target_id in task_group.downstream_group_ids:
@@ -111,9 +115,7 @@ def dag_edges(dag: DAG | SerializedDAG):
     edges = set()
     setup_teardown_edges = set()
 
-    # TODO (GH-52141): 'roots' in scheduler needs to return scheduler types
-    # instead, but currently it inherits SDK's DAG.
-    tasks_to_trace = cast("list[Operator]", dag.roots)
+    tasks_to_trace = dag.roots
     while tasks_to_trace:
         tasks_to_trace_next: list[Operator] = []
         for task in tasks_to_trace:
@@ -130,7 +132,7 @@ def dag_edges(dag: DAG | SerializedDAG):
     # Build result dicts with the two ends of the edge, plus any extra metadata
     # if we have it.
     for source_id, target_id in sorted(edges.union(edges_to_add) - edges_to_skip):
-        record = {"source_id": source_id, "target_id": target_id}
+        record: dict[str, Any] = {"source_id": source_id, "target_id": target_id}
         label = dag.get_edge_info(source_id, target_id).get("label")
         if (source_id, target_id) in setup_teardown_edges:
             record["is_setup_teardown"] = True

--- a/airflow-core/src/airflow/utils/dot_renderer.py
+++ b/airflow-core/src/airflow/utils/dot_renderer.py
@@ -24,13 +24,25 @@ import warnings
 from typing import TYPE_CHECKING, Any
 
 from airflow.exceptions import AirflowException
-from airflow.sdk import DAG, BaseOperator, TaskGroup
-from airflow.sdk.definitions.mappedoperator import MappedOperator
 from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
 from airflow.serialization.definitions.mappedoperator import SerializedMappedOperator
 from airflow.serialization.definitions.taskgroup import SerializedTaskGroup
 from airflow.utils.dag_edges import dag_edges
 from airflow.utils.state import State
+
+# Also support SDK types if possible.
+try:
+    from airflow.sdk import BaseOperator
+except ImportError:
+    BaseOperator = SerializedBaseOperator  # type: ignore[assignment,misc]
+try:
+    from airflow.sdk.definitions.mappedoperator import MappedOperator
+except ImportError:
+    MappedOperator = SerializedMappedOperator  # type: ignore[assignment,misc]
+try:
+    from airflow.sdk import TaskGroup
+except ImportError:
+    TaskGroup = SerializedTaskGroup  # type: ignore[assignment,misc]
 
 if TYPE_CHECKING:
     import graphviz
@@ -38,6 +50,8 @@ if TYPE_CHECKING:
     from airflow.models import TaskInstance
     from airflow.serialization.dag_dependency import DagDependency
     from airflow.serialization.definitions.dag import SerializedDAG
+    from airflow.serialization.definitions.mappedoperator import Operator
+    from airflow.serialization.definitions.node import DAGNode
 else:
     try:
         import graphviz
@@ -70,7 +84,7 @@ def _refine_color(color: str):
 
 
 def _draw_task(
-    task: BaseOperator | MappedOperator | SerializedBaseOperator | SerializedMappedOperator,
+    task: Operator,
     parent_graph: graphviz.Digraph,
     states_by_task_id: dict[Any, Any] | None,
 ) -> None:
@@ -96,7 +110,7 @@ def _draw_task(
 
 
 def _draw_task_group(
-    task_group: TaskGroup | SerializedTaskGroup,
+    task_group: SerializedTaskGroup,
     parent_graph: graphviz.Digraph,
     states_by_task_id: dict[str, str | None] | None,
 ) -> None:
@@ -136,29 +150,27 @@ def _draw_task_group(
 
 
 def _draw_nodes(
-    node: object, parent_graph: graphviz.Digraph, states_by_task_id: dict[str, str | None] | None
+    node: DAGNode, parent_graph: graphviz.Digraph, states_by_task_id: dict[str, str | None] | None
 ) -> None:
     """Draw the node and its children on the given parent_graph recursively."""
     if isinstance(node, (BaseOperator, MappedOperator, SerializedBaseOperator, SerializedMappedOperator)):
         _draw_task(node, parent_graph, states_by_task_id)
+    elif not isinstance(node, (TaskGroup, SerializedTaskGroup)):
+        raise AirflowException(f"The node {node} should be TaskGroup and is not")
+    elif node.is_root:
+        # No need to draw background for root TaskGroup.
+        _draw_task_group(node, parent_graph, states_by_task_id)
     else:
-        if not isinstance(node, (SerializedTaskGroup, TaskGroup)):
-            raise AirflowException(f"The node {node} should be TaskGroup and is not")
-        # Draw TaskGroup
-        if node.is_root:
-            # No need to draw background for root TaskGroup.
-            _draw_task_group(node, parent_graph, states_by_task_id)
-        else:
-            with parent_graph.subgraph(name=f"cluster_{node.group_id}") as sub:
-                sub.attr(
-                    shape="rectangle",
-                    style="filled",
-                    color=_refine_color(node.ui_fgcolor),
-                    # Partially transparent CornflowerBlue
-                    fillcolor="#6495ed7f",
-                    label=node.label,
-                )
-                _draw_task_group(node, sub, states_by_task_id)
+        with parent_graph.subgraph(name=f"cluster_{node.group_id}") as sub:
+            sub.attr(
+                shape="rectangle",
+                style="filled",
+                color=_refine_color(node.ui_fgcolor),
+                # Partially transparent CornflowerBlue
+                fillcolor="#6495ed7f",
+                label=node.label,
+            )
+            _draw_task_group(node, sub, states_by_task_id)
 
 
 def render_dag_dependencies(deps: dict[str, list[DagDependency]]) -> graphviz.Digraph:
@@ -194,7 +206,7 @@ def render_dag_dependencies(deps: dict[str, list[DagDependency]]) -> graphviz.Di
     return dot
 
 
-def render_dag(dag: DAG | SerializedDAG, tis: list[TaskInstance] | None = None) -> graphviz.Digraph:
+def render_dag(dag: SerializedDAG, tis: list[TaskInstance] | None = None) -> graphviz.Digraph:
     """
     Render the DAG object to the DOT object.
 

--- a/devel-common/src/tests_common/test_utils/compat.py
+++ b/devel-common/src/tests_common/test_utils/compat.py
@@ -82,6 +82,11 @@ except ImportError:
     from airflow.utils import timezone  # type: ignore[no-redef,attr-defined]
 
 try:
+    from airflow.sdk import Context
+except ImportError:
+    from airflow.utils.context import Context  # type: ignore[no-redef,attr-defined]
+
+try:
     from airflow.sdk import TriggerRule
 except ImportError:
     # Compatibility for Airflow < 3.1

--- a/devel-common/src/tests_common/test_utils/mock_context.py
+++ b/devel-common/src/tests_common/test_utils/mock_context.py
@@ -21,7 +21,7 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 from unittest import mock
 
-from airflow.utils.context import Context
+from tests_common.test_utils.compat import Context
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session

--- a/providers/alibaba/src/airflow/providers/alibaba/cloud/links/maxcompute.py
+++ b/providers/alibaba/src/airflow/providers/alibaba/cloud/links/maxcompute.py
@@ -23,7 +23,7 @@ from airflow.providers.common.compat.sdk import BaseOperatorLink, XCom
 if TYPE_CHECKING:
     from airflow.models.taskinstancekey import TaskInstanceKey
     from airflow.providers.common.compat.sdk import BaseOperator
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class MaxComputeLogViewLink(BaseOperatorLink):

--- a/providers/alibaba/src/airflow/providers/alibaba/cloud/operators/analyticdb_spark.py
+++ b/providers/alibaba/src/airflow/providers/alibaba/cloud/operators/analyticdb_spark.py
@@ -26,7 +26,7 @@ from airflow.providers.alibaba.cloud.hooks.analyticdb_spark import AnalyticDBSpa
 from airflow.providers.common.compat.sdk import AirflowException, BaseOperator
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class AnalyticDBSparkBaseOperator(BaseOperator):

--- a/providers/alibaba/src/airflow/providers/alibaba/cloud/operators/maxcompute.py
+++ b/providers/alibaba/src/airflow/providers/alibaba/cloud/operators/maxcompute.py
@@ -29,7 +29,7 @@ from airflow.providers.common.compat.sdk import BaseOperator
 if TYPE_CHECKING:
     from odps.models import Instance
 
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class MaxComputeSQLOperator(BaseOperator):

--- a/providers/alibaba/src/airflow/providers/alibaba/cloud/operators/oss.py
+++ b/providers/alibaba/src/airflow/providers/alibaba/cloud/operators/oss.py
@@ -25,7 +25,7 @@ from airflow.providers.alibaba.cloud.hooks.oss import OSSHook
 from airflow.providers.common.compat.sdk import BaseOperator
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class OSSCreateBucketOperator(BaseOperator):

--- a/providers/alibaba/src/airflow/providers/alibaba/cloud/sensors/analyticdb_spark.py
+++ b/providers/alibaba/src/airflow/providers/alibaba/cloud/sensors/analyticdb_spark.py
@@ -25,7 +25,7 @@ from airflow.providers.alibaba.cloud.hooks.analyticdb_spark import AnalyticDBSpa
 from airflow.providers.common.compat.sdk import BaseSensorOperator
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class AnalyticDBSparkSensor(BaseSensorOperator):

--- a/providers/alibaba/src/airflow/providers/alibaba/cloud/sensors/oss_key.py
+++ b/providers/alibaba/src/airflow/providers/alibaba/cloud/sensors/oss_key.py
@@ -29,7 +29,7 @@ from airflow.providers.alibaba.cloud.hooks.oss import OSSHook
 from airflow.providers.common.compat.sdk import AirflowException, BaseSensorOperator
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class OSSKeySensor(BaseSensorOperator):

--- a/providers/amazon/src/airflow/providers/amazon/aws/links/base_aws.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/links/base_aws.py
@@ -25,7 +25,7 @@ from airflow.providers.common.compat.sdk import BaseOperatorLink, XCom
 if TYPE_CHECKING:
     from airflow.models import BaseOperator
     from airflow.models.taskinstancekey import TaskInstanceKey
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 BASE_AWS_CONSOLE_LINK = "https://console.{aws_domain}"

--- a/providers/amazon/src/airflow/providers/amazon/aws/notifications/chime.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/notifications/chime.py
@@ -24,7 +24,7 @@ from airflow.providers.amazon.aws.hooks.chime import ChimeWebhookHook
 from airflow.providers.common.compat.notifier import BaseNotifier
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class ChimeNotifier(BaseNotifier):

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/appflow.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/appflow.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
         TaskTypeDef,
     )
 
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 SUPPORTED_SOURCES = {"salesforce", "zendesk"}
 MANDATORY_FILTER_DATE_MSG = "The filter_date argument is mandatory for {entity}!"

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/athena.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/athena.py
@@ -33,7 +33,7 @@ from airflow.providers.common.compat.sdk import AirflowException
 if TYPE_CHECKING:
     from airflow.providers.common.compat.openlineage.facet import BaseFacet, Dataset, DatasetFacet
     from airflow.providers.openlineage.extractors.base import OperatorLineage
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class AthenaOperator(AwsBaseOperator[AthenaHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/batch.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/batch.py
@@ -49,7 +49,7 @@ from airflow.providers.amazon.aws.utils.task_log_fetcher import AwsTaskLogFetche
 from airflow.providers.common.compat.sdk import AirflowException
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class BatchOperator(AwsBaseOperator[BatchClientHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/bedrock.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/bedrock.py
@@ -40,12 +40,11 @@ from airflow.providers.amazon.aws.triggers.bedrock import (
 )
 from airflow.providers.amazon.aws.utils import validate_execute_complete_event
 from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
-from airflow.providers.common.compat.sdk import AirflowException
+from airflow.providers.common.compat.sdk import AirflowException, timezone
 from airflow.utils.helpers import prune_dict
-from airflow.utils.timezone import utcnow
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class BedrockInvokeModelOperator(AwsBaseOperator[BedrockRuntimeHook]):
@@ -237,7 +236,7 @@ class BedrockCustomizeModelOperator(AwsBaseOperator[BedrockHook]):
                 if not self.ensure_unique_job_name:
                     raise error
                 retry = True
-                self.job_name = f"{self.job_name}-{int(utcnow().timestamp())}"
+                self.job_name = f"{self.job_name}-{int(timezone.utcnow().timestamp())}"
                 self.log.info("Changed job name to '%s' to avoid collision.", self.job_name)
 
         if response["ResponseMetadata"]["HTTPStatusCode"] != 201:

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/cloud_formation.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/cloud_formation.py
@@ -27,7 +27,7 @@ from airflow.providers.amazon.aws.operators.base_aws import AwsBaseOperator
 from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class CloudFormationCreateStackOperator(AwsBaseOperator[CloudFormationHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/comprehend.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/comprehend.py
@@ -33,13 +33,12 @@ from airflow.providers.amazon.aws.triggers.comprehend import (
 )
 from airflow.providers.amazon.aws.utils import validate_execute_complete_event
 from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
-from airflow.providers.common.compat.sdk import AirflowException
-from airflow.utils.timezone import utcnow
+from airflow.providers.common.compat.sdk import AirflowException, timezone
 
 if TYPE_CHECKING:
     import boto3
 
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class ComprehendBaseOperator(AwsBaseOperator[ComprehendHook]):
@@ -157,7 +156,7 @@ class ComprehendStartPiiEntitiesDetectionJobOperator(ComprehendBaseOperator):
     def execute(self, context: Context) -> str:
         if self.start_pii_entities_kwargs.get("JobName", None) is None:
             self.start_pii_entities_kwargs["JobName"] = (
-                f"start_pii_entities_detection_job-{int(utcnow().timestamp())}"
+                f"start_pii_entities_detection_job-{int(timezone.utcnow().timestamp())}"
             )
 
         self.log.info(

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/datasync.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/datasync.py
@@ -30,7 +30,7 @@ from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 from airflow.providers.common.compat.sdk import AirflowException, AirflowTaskTimeout
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class DataSyncOperator(AwsBaseOperator[DataSyncHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/dms.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/dms.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import Any, ClassVar
 
 from airflow.configuration import conf
 from airflow.providers.amazon.aws.hooks.dms import DmsHook
@@ -32,11 +32,7 @@ from airflow.providers.amazon.aws.triggers.dms import (
     DmsReplicationTerminalStatusTrigger,
 )
 from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
-from airflow.providers.common.compat.sdk import AirflowException
-from airflow.utils.context import Context
-
-if TYPE_CHECKING:
-    from airflow.utils.context import Context
+from airflow.providers.common.compat.sdk import AirflowException, Context
 
 
 class DmsCreateTaskOperator(AwsBaseOperator[DmsHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/ec2.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/ec2.py
@@ -30,7 +30,7 @@ from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 from airflow.providers.common.compat.sdk import AirflowException
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class EC2StartInstanceOperator(AwsBaseOperator[EC2Hook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/ecs.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/ecs.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
     import boto3
 
     from airflow.models import TaskInstance
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class EcsBaseOperator(AwsBaseOperator[EcsHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/eks.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/eks.py
@@ -54,7 +54,7 @@ except ImportError:
     )
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 CHECK_INTERVAL_SECONDS = 15

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/emr.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/emr.py
@@ -62,7 +62,7 @@ from airflow.providers.common.compat.sdk import AirflowException
 from airflow.utils.helpers import exactly_one, prune_dict
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class EmrAddStepsOperator(AwsBaseOperator[EmrHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/eventbridge.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/eventbridge.py
@@ -26,7 +26,7 @@ from airflow.providers.common.compat.sdk import AirflowException
 from airflow.utils.helpers import prune_dict
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class EventBridgePutEventsOperator(AwsBaseOperator[EventBridgeHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/glacier.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/glacier.py
@@ -25,7 +25,7 @@ from airflow.providers.amazon.aws.operators.base_aws import AwsBaseOperator
 from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class GlacierCreateJobOperator(AwsBaseOperator[GlacierHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/glue.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/glue.py
@@ -39,7 +39,7 @@ from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 from airflow.providers.common.compat.sdk import AirflowException
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class GlueJobOperator(AwsBaseOperator[GlueJobHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/glue_crawler.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/glue_crawler.py
@@ -21,6 +21,7 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 from airflow.configuration import conf
+from airflow.providers.amazon.aws.hooks.glue_crawler import GlueCrawlerHook
 from airflow.providers.amazon.aws.operators.base_aws import AwsBaseOperator
 from airflow.providers.amazon.aws.triggers.glue_crawler import GlueCrawlerCompleteTrigger
 from airflow.providers.amazon.aws.utils import validate_execute_complete_event
@@ -28,9 +29,7 @@ from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 from airflow.providers.common.compat.sdk import AirflowException
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
-
-from airflow.providers.amazon.aws.hooks.glue_crawler import GlueCrawlerHook
+    from airflow.sdk import Context
 
 
 class GlueCrawlerOperator(AwsBaseOperator[GlueCrawlerHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/glue_databrew.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/glue_databrew.py
@@ -29,7 +29,7 @@ from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 from airflow.providers.common.compat.sdk import AirflowException
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class GlueDataBrewStartJobOperator(AwsBaseOperator[GlueDataBrewHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/kinesis_analytics.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/kinesis_analytics.py
@@ -32,7 +32,7 @@ from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 from airflow.providers.common.compat.sdk import AirflowException
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class KinesisAnalyticsV2CreateApplicationOperator(AwsBaseOperator[KinesisAnalyticsV2Hook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/lambda_function.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/lambda_function.py
@@ -31,7 +31,7 @@ from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 from airflow.providers.common.compat.sdk import AirflowException
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class LambdaCreateFunctionOperator(AwsBaseOperator[LambdaHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/mwaa.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/mwaa.py
@@ -30,7 +30,7 @@ from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 from airflow.providers.common.compat.sdk import AirflowException
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class MwaaTriggerDagRunOperator(AwsBaseOperator[MwaaHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/neptune.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/neptune.py
@@ -34,7 +34,7 @@ from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 from airflow.providers.common.compat.sdk import AirflowException
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 def handle_waitable_exception(

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/quicksight.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/quicksight.py
@@ -24,7 +24,7 @@ from airflow.providers.amazon.aws.operators.base_aws import AwsBaseOperator
 from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class QuickSightCreateIngestionOperator(AwsBaseOperator[QuickSightHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/rds.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/rds.py
@@ -41,7 +41,7 @@ from airflow.utils.helpers import prune_dict
 if TYPE_CHECKING:
     from mypy_boto3_rds.type_defs import TagTypeDef
 
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class RdsBaseOperator(AwsBaseOperator[RdsHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/redshift_cluster.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/redshift_cluster.py
@@ -37,7 +37,7 @@ from airflow.providers.common.compat.sdk import AirflowException
 from airflow.utils.helpers import prune_dict
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class RedshiftCreateClusterOperator(AwsBaseOperator[RedshiftHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/redshift_data.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/redshift_data.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
         GetStatementResultResponseTypeDef,
     )
 
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class RedshiftDataOperator(AwsBaseOperator[RedshiftDataHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/s3.py
@@ -37,7 +37,7 @@ from airflow.utils.helpers import exactly_one
 if TYPE_CHECKING:
     from datetime import datetime
 
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 BUCKET_DOES_NOT_EXIST_MSG = "Bucket with name: %s doesn't exist"
 

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/sagemaker.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/sagemaker.py
@@ -48,7 +48,7 @@ from airflow.utils.helpers import prune_dict
 if TYPE_CHECKING:
     from airflow.providers.common.compat.openlineage.facet import Dataset
     from airflow.providers.openlineage.extractors.base import OperatorLineage
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 # DEFAULT_CONN_ID: str = "aws_default"
 CHECK_INTERVAL_SECOND: int = 30

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/sagemaker_unified_studio.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/sagemaker_unified_studio.py
@@ -35,7 +35,7 @@ from airflow.providers.amazon.aws.triggers.sagemaker_unified_studio import (
 from airflow.providers.common.compat.sdk import AirflowException, BaseOperator
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class SageMakerNotebookOperator(BaseOperator):

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/sns.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/sns.py
@@ -27,7 +27,7 @@ from airflow.providers.amazon.aws.operators.base_aws import AwsBaseOperator
 from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class SnsPublishOperator(AwsBaseOperator[SnsHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/sqs.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/sqs.py
@@ -26,7 +26,7 @@ from airflow.providers.amazon.aws.operators.base_aws import AwsBaseOperator
 from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class SqsPublishOperator(AwsBaseOperator[SqsHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/ssm.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/ssm.py
@@ -27,7 +27,7 @@ from airflow.providers.amazon.aws.utils import validate_execute_complete_event
 from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class SsmRunCommandOperator(AwsBaseOperator[SsmHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/step_function.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/step_function.py
@@ -34,7 +34,7 @@ from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 from airflow.providers.common.compat.sdk import AirflowException
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class StepFunctionStartExecutionOperator(AwsBaseOperator[StepFunctionHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/athena.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/athena.py
@@ -20,14 +20,13 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
+from airflow.providers.amazon.aws.hooks.athena import AthenaHook
 from airflow.providers.amazon.aws.sensors.base_aws import AwsBaseSensor
 from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
+from airflow.providers.common.compat.sdk import AirflowException
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
-
-from airflow.providers.amazon.aws.hooks.athena import AthenaHook
-from airflow.providers.common.compat.sdk import AirflowException
+    from airflow.sdk import Context
 
 
 class AthenaSensor(AwsBaseSensor[AthenaHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/batch.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/batch.py
@@ -28,7 +28,7 @@ from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 from airflow.providers.common.compat.sdk import AirflowException
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class BatchSensor(AwsBaseSensor[BatchClientHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/bedrock.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/bedrock.py
@@ -37,7 +37,7 @@ from airflow.providers.common.compat.sdk import AirflowException
 
 if TYPE_CHECKING:
     from airflow.providers.amazon.aws.triggers.bedrock import BedrockBaseBatchInferenceTrigger
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 _GenericBedrockHook = TypeVar("_GenericBedrockHook", BedrockAgentHook, BedrockHook)

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/cloud_formation.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/cloud_formation.py
@@ -22,13 +22,12 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
+from airflow.providers.amazon.aws.hooks.cloud_formation import CloudFormationHook
 from airflow.providers.amazon.aws.sensors.base_aws import AwsBaseSensor
 from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
-
-from airflow.providers.amazon.aws.hooks.cloud_formation import CloudFormationHook
+    from airflow.sdk import Context
 
 
 class CloudFormationCreateStackSensor(AwsBaseSensor[CloudFormationHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/comprehend.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/comprehend.py
@@ -31,7 +31,7 @@ from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 from airflow.providers.common.compat.sdk import AirflowException
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class ComprehendBaseSensor(AwsBaseSensor[ComprehendHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/dms.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/dms.py
@@ -26,7 +26,7 @@ from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 from airflow.providers.common.compat.sdk import AirflowException
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class DmsTaskBaseSensor(AwsBaseSensor[DmsHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/dynamodb.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/dynamodb.py
@@ -26,7 +26,7 @@ from airflow.providers.amazon.aws.sensors.base_aws import AwsBaseSensor
 from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class DynamoDBValueSensor(AwsBaseSensor[DynamoDBHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/ec2.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/ec2.py
@@ -29,7 +29,7 @@ from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 from airflow.providers.common.compat.sdk import AirflowException
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class EC2InstanceStateSensor(AwsBaseSensor[EC2Hook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/ecs.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/ecs.py
@@ -33,7 +33,7 @@ from airflow.providers.common.compat.sdk import AirflowException
 if TYPE_CHECKING:
     import boto3
 
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 def _check_failed(current_state, target_state, failure_states) -> None:

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/eks.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/eks.py
@@ -35,7 +35,7 @@ from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 from airflow.providers.common.compat.sdk import AirflowException
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 DEFAULT_CONN_ID = "aws_default"

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/emr.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/emr.py
@@ -35,7 +35,7 @@ from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 from airflow.providers.common.compat.sdk import AirflowException
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class EmrBaseSensor(AwsBaseSensor[EmrHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/glacier.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/glacier.py
@@ -27,7 +27,7 @@ from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 from airflow.providers.common.compat.sdk import AirflowException
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class JobStatus(Enum):

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/glue.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/glue.py
@@ -33,7 +33,7 @@ from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 from airflow.providers.common.compat.sdk import AirflowException
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class GlueJobSensor(AwsBaseSensor[GlueJobHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/glue_catalog_partition.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/glue_catalog_partition.py
@@ -30,7 +30,7 @@ from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 from airflow.providers.common.compat.sdk import AirflowException
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class GlueCatalogPartitionSensor(AwsBaseSensor[GlueCatalogHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/glue_crawler.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/glue_crawler.py
@@ -26,7 +26,7 @@ from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 from airflow.providers.common.compat.sdk import AirflowException
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class GlueCrawlerSensor(AwsBaseSensor[GlueCrawlerHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/kinesis_analytics.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/kinesis_analytics.py
@@ -29,7 +29,7 @@ from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 from airflow.providers.common.compat.sdk import AirflowException
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class KinesisAnalyticsV2BaseSensor(AwsBaseSensor[KinesisAnalyticsV2Hook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/lambda_function.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/lambda_function.py
@@ -27,7 +27,7 @@ from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 from airflow.providers.common.compat.sdk import AirflowException
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class LambdaFunctionStateSensor(AwsBaseSensor[LambdaHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/mwaa.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/mwaa.py
@@ -29,7 +29,7 @@ from airflow.providers.common.compat.sdk import AirflowException
 from airflow.utils.state import DagRunState, TaskInstanceState
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class MwaaDagRunSensor(AwsBaseSensor[MwaaHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/opensearch_serverless.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/opensearch_serverless.py
@@ -30,7 +30,7 @@ from airflow.providers.common.compat.sdk import AirflowException
 from airflow.utils.helpers import exactly_one
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class OpenSearchServerlessCollectionActiveSensor(AwsBaseSensor[OpenSearchServerlessHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/quicksight.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/quicksight.py
@@ -25,7 +25,7 @@ from airflow.providers.amazon.aws.sensors.base_aws import AwsBaseSensor
 from airflow.providers.common.compat.sdk import AirflowException
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class QuickSightSensor(AwsBaseSensor[QuickSightHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/rds.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/rds.py
@@ -26,7 +26,7 @@ from airflow.providers.amazon.aws.utils.rds import RdsDbType
 from airflow.providers.common.compat.sdk import AirflowException, AirflowNotFoundException
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class RdsBaseSensor(AwsBaseSensor[RdsHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/redshift_cluster.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/redshift_cluster.py
@@ -29,7 +29,7 @@ from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 from airflow.providers.common.compat.sdk import AirflowException
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class RedshiftClusterSensor(AwsBaseSensor[RedshiftHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/s3.py
@@ -26,16 +26,15 @@ from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, cast
 
 from airflow.configuration import conf
-from airflow.providers.amazon.aws.utils import validate_execute_complete_event
-
-if TYPE_CHECKING:
-    from airflow.utils.context import Context
-
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.amazon.aws.sensors.base_aws import AwsBaseSensor
 from airflow.providers.amazon.aws.triggers.s3 import S3KeysUnchangedTrigger, S3KeyTrigger
+from airflow.providers.amazon.aws.utils import validate_execute_complete_event
 from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 from airflow.providers.common.compat.sdk import AirflowException, poke_mode_only
+
+if TYPE_CHECKING:
+    from airflow.sdk import Context
 
 
 class S3KeySensor(AwsBaseSensor[S3Hook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/sagemaker.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/sagemaker.py
@@ -26,7 +26,7 @@ from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 from airflow.providers.common.compat.sdk import AirflowException
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class SageMakerBaseSensor(AwsBaseSensor[SageMakerHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/sagemaker_unified_studio.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/sagemaker_unified_studio.py
@@ -27,7 +27,7 @@ from airflow.providers.amazon.aws.hooks.sagemaker_unified_studio import (
 from airflow.providers.common.compat.sdk import AirflowException, BaseSensorOperator
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class SageMakerNotebookSensor(BaseSensorOperator):

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/sqs.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/sqs.py
@@ -35,7 +35,7 @@ from airflow.providers.common.compat.sdk import AirflowException
 if TYPE_CHECKING:
     from airflow.providers.amazon.aws.hooks.base_aws import BaseAwsConnection
     from airflow.providers.amazon.aws.utils.sqs import MessageFilteringType
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class SqsSensor(AwsBaseSensor[SqsHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/ssm.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/ssm.py
@@ -28,7 +28,7 @@ from airflow.providers.amazon.aws.utils import validate_execute_complete_event
 from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class SsmRunCommandCompletedSensor(AwsBaseSensor[SsmHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/step_function.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/step_function.py
@@ -26,7 +26,7 @@ from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
 from airflow.providers.common.compat.sdk import AirflowException
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class StepFunctionExecutionSensor(AwsBaseSensor[StepFunctionHook]):

--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/azure_blob_to_s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/azure_blob_to_s3.py
@@ -33,7 +33,7 @@ except ModuleNotFoundError as e:
     raise AirflowOptionalProviderFeatureException(e)
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class AzureBlobStorageToS3Operator(BaseOperator):

--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/exasol_to_s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/exasol_to_s3.py
@@ -28,7 +28,7 @@ from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.providers.exasol.hooks.exasol import ExasolHook
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class ExasolToS3Operator(BaseOperator):

--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/ftp_to_s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/ftp_to_s3.py
@@ -26,7 +26,7 @@ from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.providers.ftp.hooks.ftp import FTPHook
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class FTPToS3Operator(BaseOperator):

--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/gcs_to_s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/gcs_to_s3.py
@@ -31,7 +31,7 @@ from airflow.providers.google.cloud.hooks.gcs import GCSHook
 
 if TYPE_CHECKING:
     from airflow.providers.openlineage.extractors import OperatorLineage
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class GCSToS3Operator(BaseOperator):

--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/glacier_to_gcs.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/glacier_to_gcs.py
@@ -26,7 +26,7 @@ from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class GlacierToGCSOperator(BaseOperator):

--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/google_api_to_s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/google_api_to_s3.py
@@ -31,7 +31,7 @@ from airflow.providers.google.common.hooks.discovery_api import GoogleDiscoveryA
 
 if TYPE_CHECKING:
     from airflow.providers.common.compat.sdk import RuntimeTaskInstanceProtocol
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 # MAX XCOM Size is 48KB
 # https://github.com/apache/airflow/pull/1618#discussion_r68249677

--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/hive_to_dynamodb.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/hive_to_dynamodb.py
@@ -28,7 +28,7 @@ from airflow.providers.apache.hive.hooks.hive import HiveServer2Hook
 from airflow.providers.common.compat.sdk import BaseOperator
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class HiveToDynamoDBOperator(BaseOperator):

--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/http_to_s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/http_to_s3.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
     from requests.auth import AuthBase
 
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class HttpToS3Operator(BaseOperator):

--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/imap_attachment_to_s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/imap_attachment_to_s3.py
@@ -27,7 +27,7 @@ from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.providers.imap.hooks.imap import ImapHook
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class ImapAttachmentToS3Operator(BaseOperator):

--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/local_to_s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/local_to_s3.py
@@ -24,7 +24,7 @@ from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.common.compat.sdk import BaseOperator
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class LocalFilesystemToS3Operator(BaseOperator):

--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/mongo_to_s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/mongo_to_s3.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     from pymongo.command_cursor import CommandCursor
     from pymongo.cursor import Cursor
 
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class MongoToS3Operator(BaseOperator):

--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/redshift_to_s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/redshift_to_s3.py
@@ -31,7 +31,7 @@ from airflow.providers.amazon.version_compat import NOTSET, ArgNotSet, is_arg_se
 from airflow.providers.common.compat.sdk import AirflowException, BaseOperator
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class RedshiftToS3Operator(BaseOperator):

--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/s3_to_dynamodb.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/s3_to_dynamodb.py
@@ -26,7 +26,7 @@ from airflow.providers.amazon.aws.hooks.dynamodb import DynamoDBHook
 from airflow.providers.common.compat.sdk import AirflowException, BaseOperator
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class AttributeDefinition(TypedDict):

--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/s3_to_ftp.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/s3_to_ftp.py
@@ -26,7 +26,7 @@ from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.providers.ftp.hooks.ftp import FTPHook
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class S3ToFTPOperator(BaseOperator):

--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
@@ -27,7 +27,7 @@ from airflow.providers.amazon.version_compat import NOTSET, ArgNotSet, is_arg_se
 from airflow.providers.common.compat.sdk import AirflowException, BaseOperator
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 AVAILABLE_METHODS = ["APPEND", "REPLACE", "UPSERT"]
 

--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/s3_to_sftp.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/s3_to_sftp.py
@@ -27,7 +27,7 @@ from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.providers.ssh.hooks.ssh import SSHHook
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class S3ToSFTPOperator(BaseOperator):

--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/s3_to_sql.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/s3_to_sql.py
@@ -25,7 +25,7 @@ from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.common.compat.sdk import AirflowException, BaseHook, BaseOperator
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class S3ToSqlOperator(BaseOperator):

--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/salesforce_to_s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/salesforce_to_s3.py
@@ -26,7 +26,7 @@ from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.providers.salesforce.hooks.salesforce import SalesforceHook
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class SalesforceToS3Operator(BaseOperator):

--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/sftp_to_s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/sftp_to_s3.py
@@ -27,7 +27,7 @@ from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.providers.ssh.hooks.ssh import SSHHook
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class SFTPToS3Operator(BaseOperator):

--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/sql_to_s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/sql_to_s3.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     import polars as pl
 
     from airflow.providers.common.sql.hooks.sql import DbApiHook
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class FILE_FORMAT(enum.Enum):

--- a/providers/amazon/tests/unit/amazon/aws/sensors/test_emr_base.py
+++ b/providers/amazon/tests/unit/amazon/aws/sensors/test_emr_base.py
@@ -25,11 +25,7 @@ from airflow.providers.amazon.aws.sensors.emr import EmrBaseSensor
 from airflow.providers.common.compat.sdk import AirflowException
 
 if TYPE_CHECKING:
-    try:
-        from airflow.sdk.definitions.context import Context
-    except ImportError:
-        # TODO: Remove once provider drops support for Airflow 2
-        from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 TARGET_STATE = "TARGET_STATE"
 FAILED_STATE = "FAILED_STATE"

--- a/providers/amazon/tests/unit/amazon/aws/sensors/test_sagemaker_unified_studio.py
+++ b/providers/amazon/tests/unit/amazon/aws/sensors/test_sagemaker_unified_studio.py
@@ -20,11 +20,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from airflow.providers.amazon.aws.sensors.sagemaker_unified_studio import (
-    SageMakerNotebookSensor,
-)
-from airflow.providers.common.compat.sdk import AirflowException
-from airflow.utils.context import Context
+from airflow.providers.amazon.aws.sensors.sagemaker_unified_studio import SageMakerNotebookSensor
+from airflow.providers.common.compat.sdk import AirflowException, Context
 
 
 class TestSageMakerNotebookSensor:

--- a/providers/celery/src/airflow/providers/celery/sensors/celery_queue.py
+++ b/providers/celery/src/airflow/providers/celery/sensors/celery_queue.py
@@ -29,11 +29,7 @@ else:
     from airflow.sensors.base import BaseSensorOperator  # type: ignore[no-redef]
 
 if TYPE_CHECKING:
-    try:
-        from airflow.sdk.definitions.context import Context
-    except ImportError:
-        # TODO: Remove once provider drops support for Airflow 2
-        from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class CeleryQueueSensor(BaseSensorOperator):

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/callbacks.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/callbacks.py
@@ -24,7 +24,7 @@ import kubernetes_asyncio.client as async_k8s
 
 if TYPE_CHECKING:
     from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 client_type: TypeAlias = k8s.CoreV1Api | async_k8s.CoreV1Api
 

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/decorators/kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/decorators/kubernetes.py
@@ -38,7 +38,7 @@ from airflow.providers.common.compat.sdk import (
 )
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 _PYTHON_SCRIPT_ENV = "__PYTHON_SCRIPT"
 _PYTHON_INPUT_ENV = "__PYTHON_INPUT"

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/decorators/kubernetes_cmd.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/decorators/kubernetes_cmd.py
@@ -30,7 +30,7 @@ from airflow.providers.common.compat.sdk import (
 from airflow.utils.operator_helpers import determine_kwargs
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class _KubernetesCmdDecoratedOperator(DecoratedOperator, KubernetesPodOperator):

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/job.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/job.py
@@ -45,16 +45,15 @@ from airflow.providers.cncf.kubernetes.triggers.job import KubernetesJobTrigger
 from airflow.providers.cncf.kubernetes.utils.pod_manager import EMPTY_XCOM_RESULT, PodNotFoundException
 from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_1_PLUS
 from airflow.providers.common.compat.sdk import AirflowException
+from airflow.utils import yaml
 
 if AIRFLOW_V_3_1_PLUS:
     from airflow.sdk import BaseOperator
 else:
     from airflow.models import BaseOperator
-from airflow.utils import yaml
-from airflow.utils.context import Context
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 log = logging.getLogger(__name__)
 

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -98,12 +98,7 @@ if TYPE_CHECKING:
 
     from airflow.providers.cncf.kubernetes.hooks.kubernetes import PodOperatorHookProtocol
     from airflow.providers.cncf.kubernetes.secret import Secret
-
-    try:
-        from airflow.sdk.definitions.context import Context
-    except ImportError:
-        # TODO: Remove once provider drops support for Airflow 2
-        from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 alphanum_lower = string.ascii_lowercase + string.digits
 

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py
@@ -36,11 +36,7 @@ from airflow.utils.helpers import prune_dict
 if TYPE_CHECKING:
     import jinja2
 
-    try:
-        from airflow.sdk.definitions.context import Context
-    except ImportError:
-        # TODO: Remove once provider drops support for Airflow 2
-        from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class SparkKubernetesOperator(KubernetesPodOperator):

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/sensors/spark_kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/sensors/spark_kubernetes.py
@@ -27,7 +27,7 @@ from airflow.providers.cncf.kubernetes.hooks.kubernetes import KubernetesHook
 from airflow.providers.common.compat.sdk import AirflowException, BaseSensorOperator
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class SparkKubernetesSensor(BaseSensorOperator):

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -59,7 +59,7 @@ else:
     from airflow.models.xcom import XCom  # type: ignore[no-redef]
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 pytestmark = pytest.mark.db_test
 

--- a/providers/common/sql/src/airflow/providers/common/sql/operators/generic_transfer.pyi
+++ b/providers/common/sql/src/airflow/providers/common/sql/operators/generic_transfer.pyi
@@ -38,7 +38,7 @@ from _typeshed import Incomplete as Incomplete
 
 from airflow.models import BaseOperator
 from airflow.providers.common.sql.hooks.sql import DbApiHook as DbApiHook
-from airflow.utils.context import Context as Context
+from airflow.sdk import Context
 
 class GenericTransfer(BaseOperator):
     template_fields: Sequence[str]

--- a/providers/common/sql/src/airflow/providers/common/sql/sensors/sql.pyi
+++ b/providers/common/sql/src/airflow/providers/common/sql/sensors/sql.pyi
@@ -38,7 +38,7 @@ from typing import Any
 from _typeshed import Incomplete as Incomplete
 
 from airflow.providers.common.compat.sdk import BaseSensorOperator
-from airflow.utils.context import Context as Context
+from airflow.sdk import Context
 
 class SqlSensor(BaseSensorOperator):
     template_fields: Sequence[str]

--- a/providers/databricks/src/airflow/providers/databricks/utils/mixins.py
+++ b/providers/databricks/src/airflow/providers/databricks/utils/mixins.py
@@ -20,18 +20,14 @@ from __future__ import annotations
 
 import time
 from logging import Logger
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Protocol,
-)
+from typing import TYPE_CHECKING, Any, Protocol
 
 from airflow.providers.common.compat.sdk import AirflowException
 from airflow.providers.databricks.hooks.databricks import DatabricksHook, SQLStatementState
 from airflow.providers.databricks.triggers.databricks import DatabricksSQLStatementExecutionTrigger
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class GetHookHasFields(Protocol):

--- a/providers/dbt/cloud/src/airflow/providers/dbt/cloud/operators/dbt.py
+++ b/providers/dbt/cloud/src/airflow/providers/dbt/cloud/operators/dbt.py
@@ -36,7 +36,7 @@ from airflow.providers.dbt.cloud.utils.openlineage import generate_openlineage_e
 
 if TYPE_CHECKING:
     from airflow.providers.openlineage.extractors import OperatorLineage
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class DbtCloudRunJobOperatorLink(BaseOperatorLink):

--- a/providers/dbt/cloud/src/airflow/providers/dbt/cloud/sensors/dbt.py
+++ b/providers/dbt/cloud/src/airflow/providers/dbt/cloud/sensors/dbt.py
@@ -28,7 +28,7 @@ from airflow.providers.dbt.cloud.utils.openlineage import generate_openlineage_e
 
 if TYPE_CHECKING:
     from airflow.providers.openlineage.extractors import OperatorLineage
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class DbtCloudJobRunSensor(BaseSensorOperator):

--- a/providers/edge3/src/airflow/providers/edge3/example_dags/win_notepad.py
+++ b/providers/edge3/src/airflow/providers/edge3/example_dags/win_notepad.py
@@ -37,7 +37,7 @@ from airflow.models.dag import DAG
 from airflow.sdk import Param
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class NotepadOperator(BaseOperator):

--- a/providers/grpc/src/airflow/providers/grpc/operators/grpc.py
+++ b/providers/grpc/src/airflow/providers/grpc/operators/grpc.py
@@ -24,11 +24,7 @@ from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.providers.grpc.hooks.grpc import GrpcHook
 
 if TYPE_CHECKING:
-    try:
-        from airflow.sdk.definitions.context import Context
-    except ImportError:
-        # TODO: Remove once provider drops support for Airflow 2
-        from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class GrpcOperator(BaseOperator):

--- a/providers/http/src/airflow/providers/http/operators/http.py
+++ b/providers/http/src/airflow/providers/http/operators/http.py
@@ -34,12 +34,7 @@ if TYPE_CHECKING:
     from requests.auth import AuthBase
 
     from airflow.providers.http.hooks.http import HttpHook
-
-    try:
-        from airflow.sdk.definitions.context import Context
-    except ImportError:
-        # TODO: Remove once provider drops support for Airflow 2
-        from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class HttpOperator(BaseOperator):

--- a/providers/http/src/airflow/providers/http/sensors/http.py
+++ b/providers/http/src/airflow/providers/http/sensors/http.py
@@ -27,18 +27,7 @@ from airflow.providers.http.hooks.http import HttpHook
 from airflow.providers.http.triggers.http import HttpSensorTrigger
 
 if TYPE_CHECKING:
-    from airflow.providers.common.compat.version_compat import AIRFLOW_V_3_0_PLUS
-
-    try:
-        from airflow.sdk.definitions.context import Context
-
-        if AIRFLOW_V_3_0_PLUS:
-            from airflow.sdk import PokeReturnValue
-        else:
-            from airflow.sensors.base import PokeReturnValue  # type: ignore[no-redef]
-    except ImportError:
-        # TODO: Remove once provider drops support for Airflow 2
-        from airflow.utils.context import Context
+    from airflow.sdk import Context, PokeReturnValue
 
 
 class HttpSensor(BaseSensorOperator):

--- a/providers/imap/src/airflow/providers/imap/sensors/imap_attachment.py
+++ b/providers/imap/src/airflow/providers/imap/sensors/imap_attachment.py
@@ -26,11 +26,7 @@ from airflow.providers.common.compat.sdk import BaseSensorOperator
 from airflow.providers.imap.hooks.imap import ImapHook
 
 if TYPE_CHECKING:
-    try:
-        from airflow.sdk.definitions.context import Context
-    except ImportError:
-        # TODO: Remove once provider drops support for Airflow 2
-        from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class ImapAttachmentSensor(BaseSensorOperator):

--- a/providers/influxdb/src/airflow/providers/influxdb/operators/influxdb.py
+++ b/providers/influxdb/src/airflow/providers/influxdb/operators/influxdb.py
@@ -24,11 +24,7 @@ from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.providers.influxdb.hooks.influxdb import InfluxDBHook
 
 if TYPE_CHECKING:
-    try:
-        from airflow.sdk.definitions.context import Context
-    except ImportError:
-        # TODO: Remove once provider drops support for Airflow 2
-        from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class InfluxDBOperator(BaseOperator):

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/asb.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/asb.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 
     from azure.identity import DefaultAzureCredential
 
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
     MessageCallback = Callable[[ServiceBusMessage, Context], None]
 

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/adls.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/adls.py
@@ -23,7 +23,7 @@ from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.providers.microsoft.azure.hooks.data_lake import AzureDataLakeHook, AzureDataLakeStorageV2Hook
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 DEFAULT_AZURE_DATA_LAKE_CONN_ID = "azure_data_lake_default"
 

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/adx.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/adx.py
@@ -30,7 +30,7 @@ from airflow.providers.microsoft.azure.hooks.adx import AzureDataExplorerHook
 if TYPE_CHECKING:
     from azure.kusto.data._models import KustoResultTable
 
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class AzureDataExplorerQueryOperator(BaseOperator):

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/asb.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/asb.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from azure.servicebus import ServiceBusMessage
     from azure.servicebus.management import AuthorizationRule, CorrelationRuleFilter, SqlRuleFilter
 
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
     MessageCallback = Callable[[ServiceBusMessage, Context], None]
 

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/batch.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/batch.py
@@ -27,7 +27,7 @@ from airflow.providers.common.compat.sdk import AirflowException, BaseOperator
 from airflow.providers.microsoft.azure.hooks.batch import AzureBatchHook
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class AzureBatchOperator(BaseOperator):

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/container_instances.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/container_instances.py
@@ -48,7 +48,7 @@ from airflow.providers.microsoft.azure.hooks.container_registry import AzureCont
 from airflow.providers.microsoft.azure.hooks.container_volume import AzureContainerVolumeHook
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 Volume = namedtuple(
     "Volume",

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/cosmos.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/cosmos.py
@@ -24,7 +24,7 @@ from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.providers.microsoft.azure.hooks.cosmos import AzureCosmosDBHook
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class AzureCosmosInsertDocumentOperator(BaseOperator):

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/data_factory.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/data_factory.py
@@ -41,7 +41,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 
 if TYPE_CHECKING:
     from airflow.models.taskinstancekey import TaskInstanceKey
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class AzureDataFactoryPipelineRunLink(LoggingMixin, BaseOperatorLink):

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/msgraph.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/msgraph.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 
     from msgraph_core import APIVersion
 
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 def default_event_handler(event: dict[Any, Any] | None = None, **context) -> Any:

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/powerbi.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/powerbi.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from msgraph_core import APIVersion
 
     from airflow.models.taskinstancekey import TaskInstanceKey
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class PowerBILink(BaseOperatorLink):

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/synapse.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/synapse.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
     from azure.synapse.spark.models import SparkBatchJobOptions
 
     from airflow.models.taskinstancekey import TaskInstanceKey
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class AzureSynapseRunSparkBatchOperator(BaseOperator):

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/wasb_delete_blob.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/wasb_delete_blob.py
@@ -24,7 +24,7 @@ from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class WasbDeleteBlobOperator(BaseOperator):

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/sensors/cosmos.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/sensors/cosmos.py
@@ -24,7 +24,7 @@ from airflow.providers.common.compat.sdk import BaseSensorOperator
 from airflow.providers.microsoft.azure.hooks.cosmos import AzureCosmosDBHook
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class AzureCosmosDocumentSensor(BaseSensorOperator):

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/sensors/data_factory.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/sensors/data_factory.py
@@ -31,7 +31,7 @@ from airflow.providers.microsoft.azure.hooks.data_factory import (
 from airflow.providers.microsoft.azure.triggers.data_factory import ADFPipelineRunStatusSensorTrigger
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class AzureDataFactoryPipelineRunStatusSensor(BaseSensorOperator):

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/sensors/msgraph.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/sensors/msgraph.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 
     from msgraph_core import APIVersion
 
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class MSGraphSensor(BaseSensorOperator):

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/sensors/wasb.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/sensors/wasb.py
@@ -27,7 +27,7 @@ from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
 from airflow.providers.microsoft.azure.triggers.wasb import WasbBlobSensorTrigger, WasbPrefixSensorTrigger
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class WasbBlobSensor(BaseSensorOperator):

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/transfers/local_to_adls.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/transfers/local_to_adls.py
@@ -23,7 +23,7 @@ from airflow.providers.common.compat.sdk import AirflowException, BaseOperator
 from airflow.providers.microsoft.azure.hooks.data_lake import AzureDataLakeHook
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class LocalFilesystemToADLSOperator(BaseOperator):

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/transfers/local_to_wasb.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/transfers/local_to_wasb.py
@@ -24,7 +24,7 @@ from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class LocalFilesystemToWasbOperator(BaseOperator):

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/transfers/oracle_to_azure_data_lake.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/transfers/oracle_to_azure_data_lake.py
@@ -28,7 +28,7 @@ from airflow.providers.microsoft.azure.hooks.data_lake import AzureDataLakeHook
 from airflow.providers.oracle.hooks.oracle import OracleHook
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class OracleToAzureDataLakeOperator(BaseOperator):

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/transfers/s3_to_wasb.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/transfers/s3_to_wasb.py
@@ -27,7 +27,7 @@ from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 # Create three custom exception that are

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/transfers/sftp_to_wasb.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/transfers/sftp_to_wasb.py
@@ -26,13 +26,13 @@ from functools import cached_property
 from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from airflow.utils.context import Context
-
 from airflow.providers.common.compat.sdk import AirflowException, BaseOperator
 from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
 from airflow.providers.microsoft.azure.version_compat import AIRFLOW_V_3_0_PLUS
 from airflow.providers.sftp.hooks.sftp import SFTPHook
+
+if TYPE_CHECKING:
+    from airflow.sdk import Context
 
 WILDCARD = "*"
 SftpFile = namedtuple("SftpFile", "sftp_file_path, blob_name")

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_asb.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_asb.py
@@ -34,11 +34,7 @@ except ImportError:
 from airflow.models import Connection
 from airflow.providers.microsoft.azure.hooks.asb import AdminClientHook, MessageHook
 
-try:
-    from airflow.sdk.definitions.context import Context
-except ImportError:
-    # TODO: Remove once provider drops support for Airflow 2
-    from airflow.utils.context import Context
+from tests_common.test_utils.compat import Context
 
 MESSAGE = "Test Message"
 MESSAGE_LIST = [f"{MESSAGE} {n}" for n in range(10)]

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_asb.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_asb.py
@@ -39,11 +39,7 @@ from airflow.providers.microsoft.azure.operators.asb import (
     AzureServiceBusUpdateSubscriptionOperator,
 )
 
-try:
-    from airflow.sdk.definitions.context import Context
-except ImportError:
-    # TODO: Remove once provider drops support for Airflow 2
-    from airflow.utils.context import Context
+from tests_common.test_utils.compat import Context
 
 QUEUE_NAME = "test_queue"
 MESSAGE = "Test Message"

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_container_instances.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_container_instances.py
@@ -35,11 +35,7 @@ from azure.mgmt.containerinstance.models import (
 from airflow.providers.common.compat.sdk import AirflowException
 from airflow.providers.microsoft.azure.operators.container_instances import AzureContainerInstancesOperator
 
-try:
-    from airflow.sdk.definitions.context import Context
-except ImportError:
-    # TODO: Remove once provider drops support for Airflow 2
-    from airflow.utils.context import Context
+from tests_common.test_utils.compat import Context
 
 
 def make_mock_cg(container_state, events=None):

--- a/providers/microsoft/psrp/src/airflow/providers/microsoft/psrp/operators/psrp.py
+++ b/providers/microsoft/psrp/src/airflow/providers/microsoft/psrp/operators/psrp.py
@@ -32,7 +32,7 @@ from airflow.utils.helpers import exactly_one
 if TYPE_CHECKING:
     from pypsrp.powershell import Command
 
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class PsrpOperator(BaseOperator):

--- a/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/operators/winrm.py
+++ b/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/operators/winrm.py
@@ -27,7 +27,7 @@ from airflow.providers.common.compat.sdk import AirflowException, BaseOperator
 from airflow.providers.microsoft.winrm.hooks.winrm import WinRMHook
 
 if TYPE_CHECKING:
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 # Hide the following error message in urllib3 when making WinRM connections:
 # requests.packages.urllib3.exceptions.HeaderParsingError: [StartBoundaryNotFoundDefect(),

--- a/providers/mongo/src/airflow/providers/mongo/sensors/mongo.py
+++ b/providers/mongo/src/airflow/providers/mongo/sensors/mongo.py
@@ -24,11 +24,7 @@ from airflow.providers.common.compat.sdk import BaseSensorOperator
 from airflow.providers.mongo.hooks.mongo import MongoHook
 
 if TYPE_CHECKING:
-    try:
-        from airflow.sdk.definitions.context import Context
-    except ImportError:
-        # TODO: Remove once provider drops support for Airflow 2
-        from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class MongoSensor(BaseSensorOperator):

--- a/providers/mongo/tests/unit/mongo/sensors/test_mongo.py
+++ b/providers/mongo/tests/unit/mongo/sensors/test_mongo.py
@@ -24,11 +24,7 @@ from airflow.providers.mongo.hooks.mongo import MongoHook
 from airflow.providers.mongo.sensors.mongo import MongoSensor
 from airflow.utils import timezone
 
-try:
-    from airflow.sdk.definitions.context import Context
-except ImportError:
-    # TODO: Remove once provider drops support for Airflow 2
-    from airflow.utils.context import Context
+from tests_common.test_utils.compat import Context
 
 DEFAULT_DATE = timezone.datetime(2017, 1, 1)
 

--- a/providers/neo4j/src/airflow/providers/neo4j/operators/neo4j.py
+++ b/providers/neo4j/src/airflow/providers/neo4j/operators/neo4j.py
@@ -24,11 +24,7 @@ from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.providers.neo4j.hooks.neo4j import Neo4jHook
 
 if TYPE_CHECKING:
-    try:
-        from airflow.sdk.definitions.context import Context
-    except ImportError:
-        # TODO: Remove once provider drops support for Airflow 2
-        from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class Neo4jOperator(BaseOperator):

--- a/providers/neo4j/src/airflow/providers/neo4j/sensors/neo4j.py
+++ b/providers/neo4j/src/airflow/providers/neo4j/sensors/neo4j.py
@@ -24,10 +24,7 @@ from airflow.providers.common.compat.sdk import AirflowException, BaseSensorOper
 from airflow.providers.neo4j.hooks.neo4j import Neo4jHook
 
 if TYPE_CHECKING:
-    try:
-        from airflow.sdk.definitions.context import Context
-    except ImportError:
-        from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class Neo4jSensor(BaseSensorOperator):

--- a/providers/opensearch/src/airflow/providers/opensearch/operators/opensearch.py
+++ b/providers/opensearch/src/airflow/providers/opensearch/operators/opensearch.py
@@ -30,11 +30,7 @@ from airflow.providers.opensearch.hooks.opensearch import OpenSearchHook
 if TYPE_CHECKING:
     from opensearchpy import Connection as OpenSearchConnectionClass
 
-    try:
-        from airflow.sdk.definitions.context import Context
-    except ImportError:
-        # TODO: Remove once provider drops support for Airflow 2
-        from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class OpenSearchQueryOperator(BaseOperator):

--- a/providers/pinecone/src/airflow/providers/pinecone/operators/pinecone.py
+++ b/providers/pinecone/src/airflow/providers/pinecone/operators/pinecone.py
@@ -27,10 +27,7 @@ from airflow.providers.pinecone.hooks.pinecone import PineconeHook
 if TYPE_CHECKING:
     from pinecone import Vector
 
-    try:
-        from airflow.sdk.definitions.context import Context
-    except ImportError:
-        from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class PineconeIngestOperator(BaseOperator):

--- a/providers/presto/src/airflow/providers/presto/transfers/gcs_to_presto.py
+++ b/providers/presto/src/airflow/providers/presto/transfers/gcs_to_presto.py
@@ -30,11 +30,7 @@ from airflow.providers.google.cloud.hooks.gcs import GCSHook
 from airflow.providers.presto.hooks.presto import PrestoHook
 
 if TYPE_CHECKING:
-    try:
-        from airflow.sdk.definitions.context import Context
-    except ImportError:
-        # TODO: Remove once provider drops support for Airflow 2
-        from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class GCSToPrestoOperator(BaseOperator):

--- a/providers/qdrant/src/airflow/providers/qdrant/operators/qdrant.py
+++ b/providers/qdrant/src/airflow/providers/qdrant/operators/qdrant.py
@@ -27,11 +27,7 @@ from airflow.providers.qdrant.hooks.qdrant import QdrantHook
 if TYPE_CHECKING:
     from qdrant_client.models import VectorStruct
 
-    try:
-        from airflow.sdk.definitions.context import Context
-    except ImportError:
-        # TODO: Remove once provider drops support for Airflow 2
-        from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 
 class QdrantIngestOperator(BaseOperator):

--- a/providers/standard/tests/unit/standard/operators/test_python.py
+++ b/providers/standard/tests/unit/standard/operators/test_python.py
@@ -91,7 +91,7 @@ except ImportError:
 if TYPE_CHECKING:
     from airflow.models.dag import DAG
     from airflow.models.dagrun import DagRun
-    from airflow.utils.context import Context
+    from airflow.sdk import Context
 
 pytestmark = [pytest.mark.db_test, pytest.mark.need_serialized_dag]
 

--- a/providers/teradata/src/airflow/providers/teradata/operators/tpt.py
+++ b/providers/teradata/src/airflow/providers/teradata/operators/tpt.py
@@ -19,6 +19,10 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from airflow.models import BaseOperator
+from airflow.providers.ssh.hooks.ssh import SSHHook
+from airflow.providers.teradata.hooks.teradata import TeradataHook
+from airflow.providers.teradata.hooks.tpt import TptHook
 from airflow.providers.teradata.utils.tpt_util import (
     get_remote_temp_directory,
     is_valid_file,
@@ -29,16 +33,9 @@ from airflow.providers.teradata.utils.tpt_util import (
 )
 
 if TYPE_CHECKING:
-    try:
-        from airflow.sdk.definitions.context import Context
-    except ImportError:
-        from airflow.utils.context import Context
     from paramiko import SSHClient
 
-from airflow.models import BaseOperator
-from airflow.providers.ssh.hooks.ssh import SSHHook
-from airflow.providers.teradata.hooks.teradata import TeradataHook
-from airflow.providers.teradata.hooks.tpt import TptHook
+    from airflow.sdk import Context
 
 
 class DdlOperator(BaseOperator):

--- a/shared/dagnode/src/airflow_shared/dagnode/node.py
+++ b/shared/dagnode/src/airflow_shared/dagnode/node.py
@@ -40,6 +40,7 @@ class GenericDAGNode(Generic[Dag, Task, TaskGroup]):
 
     dag: Dag | None
     task_group: TaskGroup | None
+    downstream_group_ids: set[str | None]
     upstream_task_ids: set[str]
     downstream_task_ids: set[str]
 

--- a/task-sdk/src/airflow/sdk/definitions/_internal/abstractoperator.py
+++ b/task-sdk/src/airflow/sdk/definitions/_internal/abstractoperator.py
@@ -66,7 +66,6 @@ DEFAULT_RETRIES: int = conf.getint("core", "default_task_retries", fallback=0)
 DEFAULT_RETRY_DELAY: datetime.timedelta = datetime.timedelta(
     seconds=conf.getint("core", "default_task_retry_delay", fallback=300)
 )
-DEFAULT_RETRY_DELAY_MULTIPLIER: float = 2.0
 MAX_RETRY_DELAY: int = conf.getint("core", "max_task_retry_delay", fallback=24 * 60 * 60)
 
 # TODO: Task-SDK -- these defaults should be overridable from the Airflow config


### PR DESCRIPTION
Some more cleanups

1. The `airflow.utils.context` module has been cleaned up. Old names are redirected to `airflow.sdk` with a warning.
2. `from airflow.utils.context import Context` for typing (mostly in providers) are all unconditionally changed to `from airflow.sdk import Context` since they should only matter for our Mypy checks in CI.
3. A compat layer is made in devel-commons for imports of `Context` in provider tests.
4. SDK imports to keep old Core functions working are now made locally instead.

Most of the Core modules are now SDK-free (aside from typing). Exceptions are

* Partitions
* DeadlineAlert
* Template-rendering things

The two are on old as mentioned in #52141. I plan to tackle the third next. That’s a bit complicated.