### PR TITLE
Don't poll HITL details when no pending dagrun on Dag page

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Dag/Dag.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Dag.tsx
@@ -106,10 +106,7 @@ export const Dag = () => {
 
   const { tabs: processedTabs } = useRequiredActionTabs({ dagId }, tabs, {
     refetchInterval:
-      
-      (dag?.active_runs_count ?? 0) > 0 ||
-      (latestRun && isStatePending(latestRun.state))
-
+      (dag?.active_runs_count ?? 0) > 0 || (latestRun && isStatePending(latestRun.state))
         ? refetchInterval
         : false,
   });

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Dag.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Dag.tsx
@@ -106,7 +106,10 @@ export const Dag = () => {
 
   const { tabs: processedTabs } = useRequiredActionTabs({ dagId }, tabs, {
     refetchInterval:
-      (dag?.active_runs_count ?? 0) > 0 || isStatePending(latestRun?.state)
+      
+      (dag?.active_runs_count ?? 0) > 0 ||
+      (latestRun && isStatePending(latestRun.state))
+
         ? refetchInterval
         : false,
   });

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Dag.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Dag.tsx
@@ -105,7 +105,10 @@ export const Dag = () => {
   );
 
   const { tabs: processedTabs } = useRequiredActionTabs({ dagId }, tabs, {
-    refetchInterval,
+    refetchInterval:
+      (dag?.active_runs_count ?? 0) > 0 || isStatePending(latestRun?.state)
+        ? refetchInterval
+        : false,
   });
 
   const displayTabs = processedTabs.filter((tab) => {


### PR DESCRIPTION
Fixes #59760

This PR prevents polling the HITL details API on the DAG page when there are
no active or pending DAG runs, reducing unnecessary API calls and load.
