### PR TITLE
Upgrade fallback instance type to ml.m6i.xlarge

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/sagemaker_unified_studio.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/sagemaker_unified_studio.py
@@ -123,7 +123,7 @@ class SageMakerNotebookHook(BaseHook):
         if self.compute:
             start_execution_params["compute"] = self.compute
         else:
-            start_execution_params["compute"] = {"instance_type": "ml.m4.xlarge"}
+            start_execution_params["compute"] = {"instance_type": "ml.m6i.xlarge"}
 
         print(start_execution_params)
         return self._sagemaker_studio.execution_client.start_execution(**start_execution_params)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

**Description**

SMUS Workflows canary tests are failing because of the hard-coded fallback instance type of `ml.m4.xlarge` that currently exists in the Airflow package. The m4 instance type is not available in all AWS regions, and specifically it doesn't exist in eu-north-1/ARN (EC2 doesn’t have m4 instance types in ARN). This causes failures when the operator runs in those regions without an explicitly specified compute configuration.

Our solution is to request an upgrade for this instance type to `ml.m6i.xlarge`, which is already being used in the SDK and has broader region availability.

**Description of added unit tests**

Two unit tests were added to add coverage for the new fallback instance type: 

- They verify that when no custom `compute` is passed, the hook falls back to the `ml.m6i.xlarge` instance type. 
- When it is provided, the custom `compute` config is used instead.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
