### PR TITLE
Update API auth. instructions in Docker running docs (#59830)

### DIFF
--- a/airflow-core/docs/howto/docker-compose/index.rst
+++ b/airflow-core/docs/howto/docker-compose/index.rst
@@ -295,9 +295,14 @@ Here is a sample ``curl`` command, which sends a request to retrieve a pool list
 .. code-block:: bash
 
     ENDPOINT_URL="http://localhost:8080"
-    curl -X GET  \
-        --user "airflow:airflow" \
-        "${ENDPOINT_URL}/api/v1/pools"
+    JWT_TOKEN=$(curl -s -X POST ${ENDPOINT_URL}/auth/token \
+                     -H "Content-Type: application/json" \
+                     -d '{"username": "airflow", "password": "airflow"}' |\
+                jq -r '.access_token' \
+              )
+    curl -X GET \
+        "${ENDPOINT_URL}/api/v2/pools" \
+        -H "Authorization: Bearer ${JWT_TOKEN}"
 
 Cleaning up
 ===========


### PR DESCRIPTION
I followed this guide, but example to test API is no longer working as "v1" API is deprecated and system requires to use "v2" instead. More importantly, I was unable to authenticate using username and password. It seems that JWT token is the only valid authentication asset. I prepared therefore alternative example which is correcting both issues. Hope it is not too complicated. Cheers, Tomas.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
