### PR TITLE
Fix `priority_weight` NOT NULL constraint in provider tests

### DIFF
--- a/devel-common/src/tests_common/test_utils/compat.py
+++ b/devel-common/src/tests_common/test_utils/compat.py
@@ -53,6 +53,14 @@ except ImportError:
     OperatorSerialization = SerializedBaseOperator  # type: ignore[assignment,misc,no-redef]
 
 try:
+    from airflow.serialization.serialized_objects import create_scheduler_operator
+except ImportError:
+    # Compatibility for Airflow < 3.1
+    def create_scheduler_operator(op):  # type: ignore[no-redef]
+        return op
+
+
+try:
     from airflow.providers.common.sql.operators.generic_transfer import GenericTransfer
     from airflow.providers.standard.operators.bash import BashOperator
     from airflow.providers.standard.operators.empty import EmptyOperator

--- a/providers/apache/kylin/tests/unit/apache/kylin/operators/test_kylin_cube.py
+++ b/providers/apache/kylin/tests/unit/apache/kylin/operators/test_kylin_cube.py
@@ -178,6 +178,8 @@ class TestKylinCubeOperator:
             sync_dag_to_db(self.dag)
             dag_version = DagVersion.get_latest_version(operator.dag_id)
             ti = TaskInstance(operator, run_id="kylin_test", dag_version_id=dag_version.id)
+            # Set priority_weight explicitly as SDK operators have string weight_rule
+            ti.priority_weight = operator.priority_weight
             ti.dag_run = DagRun(
                 dag_id=self.dag.dag_id,
                 run_id="kylin_test",

--- a/providers/apache/spark/tests/unit/apache/spark/operators/test_spark_submit.py
+++ b/providers/apache/spark/tests/unit/apache/spark/operators/test_spark_submit.py
@@ -205,6 +205,8 @@ class TestSparkSubmitOperator:
             sync_dag_to_db(self.dag)
             dag_version = DagVersion.get_latest_version(operator.dag_id)
             ti = TaskInstance(operator, run_id="spark_test", dag_version_id=dag_version.id)
+            # Set priority_weight explicitly as SDK operators have string weight_rule
+            ti.priority_weight = operator.priority_weight
             ti.dag_run = DagRun(
                 dag_id=self.dag.dag_id,
                 run_id="spark_test",

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -141,6 +141,9 @@ def create_context(task, persist_to_db=False, map_index=None):
                 session.commit()
                 session.refresh(dag_version)
         task_instance = TaskInstance(task=task, run_id=dag_run.run_id, dag_version_id=dag_version.id)
+        # Set priority_weight explicitly as SDK operators have string weight_rule
+        if persist_to_db:
+            task_instance.priority_weight = task.priority_weight
     else:
         task_instance = TaskInstance(task=task, run_id=dag_run.run_id)
     task_instance.dag_run = dag_run


### PR DESCRIPTION
After commit 60b4ed48e1 ("Remove PriorityWeightStrategy reference in SDK"), SDK operators store weight_rule as a string instead of a PriorityWeightStrategy object. When TaskInstance.refresh_from_task() calls task.weight_rule.get_weight(), it fails silently due to contextlib.suppress(Exception), leaving priority_weight unset.

Fix by wrapping SDK operators with create_scheduler_operator() before passing to TaskInstance, matching the pattern used in core tests.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
