### PR TITLE
TaskInstance unused method cleanup

### DIFF
--- a/airflow-core/newsfragments/59835.significant.rst
+++ b/airflow-core/newsfragments/59835.significant.rst
@@ -1,0 +1,5 @@
+Methods removed from TaskInstance
+
+On class ``TaskInstance``, functions ``run()``, ``render_templates()``, and
+private members related to them have been removed. The class has been
+considered internal since 3.0, and should not be relied on in user code.

--- a/airflow-core/src/airflow/models/renderedtifields.py
+++ b/airflow-core/src/airflow/models/renderedtifields.py
@@ -163,7 +163,7 @@ class RenderedTaskInstanceFields(TaskInstanceDependencies):
         self.map_index = ti.map_index
         self.ti = ti
         if render_templates:
-            ti.render_templates()
+            raise ValueError("render_templates=True is no longer supported")
 
         if TYPE_CHECKING:
             assert isinstance(ti.task, SerializedBaseOperator)

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -1253,33 +1253,6 @@ class TaskInstance(Base, LoggingMixin):
         self.next_method = None
         self.next_kwargs = None
 
-    @provide_session
-    def _run_raw_task(
-        self,
-        mark_success: bool = False,
-        session: Session = NEW_SESSION,
-        **kwargs: Any,
-    ) -> None:
-        """Only kept for tests."""
-        from airflow.sdk.definitions.dag import _run_task
-
-        if mark_success:
-            self.set_state(TaskInstanceState.SUCCESS)
-            log.info("[DAG TEST] Marking success for %s ", self.task_id)
-            return None
-
-        # TODO (TaskSDK): This is the old ti execution path. The only usage is
-        # in TI.run(...), someone needs to analyse if it's still actually used
-        # somewhere and fix it, likely by rewriting TI.run(...) to use the same
-        # mechanism as Operator.test().
-        taskrun_result = _run_task(ti=self, task=self.task)  # type: ignore[arg-type]
-        if taskrun_result is None:
-            return None
-        if taskrun_result.error:
-            raise taskrun_result.error
-        self.task = taskrun_result.ti.task  # type: ignore[assignment]
-        return None
-
     @staticmethod
     @provide_session
     def register_asset_changes_in_db(
@@ -1459,55 +1432,6 @@ class TaskInstance(Base, LoggingMixin):
                 .where(TaskInstance.id == self.id)
                 .values(last_heartbeat_at=timezone.utcnow())
             )
-
-    @provide_session
-    def run(
-        self,
-        verbose: bool = True,
-        ignore_all_deps: bool = False,
-        ignore_depends_on_past: bool = False,
-        wait_for_past_depends_before_skipping: bool = False,
-        ignore_task_deps: bool = False,
-        ignore_ti_state: bool = False,
-        mark_success: bool = False,
-        test_mode: bool = False,
-        pool: str | None = None,
-        session: Session = NEW_SESSION,
-        raise_on_defer: bool = False,
-    ) -> None:
-        """Run TaskInstance (only kept for tests)."""
-        # This method is only used in ti.run and dag.test and task.test.
-        # So doing the s10n/de-s10n dance to operator on Serialized task for the scheduler dep check part.
-        from airflow.serialization.definitions.dag import SerializedDAG
-        from airflow.serialization.serialized_objects import DagSerialization
-
-        original_task = self.task
-        if TYPE_CHECKING:
-            assert original_task is not None
-            assert original_task.dag is not None
-
-        # We don't set up all tests well...
-        if not isinstance(original_task.dag, SerializedDAG):
-            serialized_dag = DagSerialization.from_dict(DagSerialization.to_dict(original_task.dag))
-            self.task = serialized_dag.get_task(original_task.task_id)
-
-        res = self.check_and_change_state_before_execution(
-            verbose=verbose,
-            ignore_all_deps=ignore_all_deps,
-            ignore_depends_on_past=ignore_depends_on_past,
-            wait_for_past_depends_before_skipping=wait_for_past_depends_before_skipping,
-            ignore_task_deps=ignore_task_deps,
-            ignore_ti_state=ignore_ti_state,
-            mark_success=mark_success,
-            test_mode=test_mode,
-            pool=pool,
-            session=session,
-        )
-        self.task = original_task
-        if not res:
-            return
-
-        self._run_raw_task(mark_success=mark_success)
 
     @classmethod
     def fetch_handle_failure_context(

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -1718,32 +1718,6 @@ class TaskInstance(Base, LoggingMixin):
 
         return context
 
-    # TODO (GH-52141): We should remove this entire function (only makes sense at runtime).
-    # This is intentionally left untyped so Mypy complains less about this dead code.
-    def render_templates(self, context=None, jinja_env=None):
-        """
-        Render templates in the operator fields.
-
-        If the task was originally mapped, this may replace ``self.task`` with
-        the unmapped, fully rendered BaseOperator. The original ``self.task``
-        before replacement is returned.
-        """
-        from airflow.sdk.definitions.mappedoperator import MappedOperator
-
-        if not context:
-            context = self.get_template_context()
-        original_task = self.task
-
-        # If self.task is mapped, this call replaces self.task to point to the
-        # unmapped BaseOperator created by this function! This is because the
-        # MappedOperator is useless for template rendering, and we need to be
-        # able to access the unmapped task instead.
-        original_task.render_template_fields(context, jinja_env)
-        if isinstance(self.task, MappedOperator):
-            self.task = context["ti"].task
-
-        return original_task
-
     def set_duration(self) -> None:
         """Set task instance duration."""
         if self.end_date and self.start_date:

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -54,6 +54,7 @@ from tests_common.test_utils.db import (
 )
 from tests_common.test_utils.logs import check_last_log
 from tests_common.test_utils.mock_operators import MockOperator
+from tests_common.test_utils.taskinstance import create_task_instance
 
 if TYPE_CHECKING:
     from tests_common.pytest_plugin import CreateTaskInstance
@@ -673,7 +674,7 @@ class TestGetMappedTaskInstances:
                     itertools.repeat(TaskInstanceState.RUNNING, dag["running"]),
                 )
             ):
-                ti = TaskInstance(
+                ti = create_task_instance(
                     mapped, run_id=dr.run_id, map_index=index, state=state, dag_version_id=dag_version.id
                 )
                 setattr(ti, "start_date", DEFAULT_DATETIME_1)

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_xcom.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_xcom.py
@@ -26,7 +26,6 @@ from airflow.api_fastapi.core_api.datamodels.xcom import XComCreateBody
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagbundle import DagBundleModel
 from airflow.models.dagrun import DagRun
-from airflow.models.taskinstance import TaskInstance
 from airflow.models.xcom import XComModel
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.sdk import DAG, AssetAlias
@@ -40,6 +39,8 @@ from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.db import clear_db_dag_bundles, clear_db_dags, clear_db_runs, clear_db_xcom
 from tests_common.test_utils.logs import check_last_log
+from tests_common.test_utils.mock_operators import MockOperator
+from tests_common.test_utils.taskinstance import create_task_instance
 
 pytestmark = pytest.mark.db_test
 
@@ -436,7 +437,11 @@ class TestGetXComEntries(TestXComEndpoint):
         session.merge(orm_dag_bundle)
         session.flush()
 
-        dag = DAG(dag_id=dag_id)
+        with DAG(dag_id=dag_id) as dag:
+            if mapped_ti:
+                task = MockOperator.partial(task_id=task_id).expand(arg1=[0, 1])
+            else:
+                task = EmptyOperator(task_id=task_id)
         sync_dag_to_db(dag)
         dagrun = DagRun(
             dag_id=dag_id,
@@ -449,14 +454,10 @@ class TestGetXComEntries(TestXComEndpoint):
         dag_version = DagVersion.get_latest_version(dag.dag_id)
         if mapped_ti:
             for i in [0, 1]:
-                ti = TaskInstance(
-                    EmptyOperator(task_id=task_id), run_id=run_id, map_index=i, dag_version_id=dag_version.id
-                )
-                ti.dag_id = dag_id
+                ti = create_task_instance(task, run_id=run_id, map_index=i, dag_version_id=dag_version.id)
                 session.add(ti)
         else:
-            ti = TaskInstance(EmptyOperator(task_id=task_id), run_id=run_id, dag_version_id=dag_version.id)
-            ti.dag_id = dag_id
+            ti = create_task_instance(task, run_id=run_id, dag_version_id=dag_version.id)
             session.add(ti)
         session.commit()
 

--- a/airflow-core/tests/unit/callbacks/test_callback_requests.py
+++ b/airflow-core/tests/unit/callbacks/test_callback_requests.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
 
 import pytest
 from pydantic import TypeAdapter
@@ -35,9 +34,8 @@ from airflow.callbacks.callback_requests import (
     EmailRequest,
     TaskCallbackRequest,
 )
-from airflow.models.dag import DAG
 from airflow.models.taskinstance import TaskInstance
-from airflow.providers.standard.operators.bash import BashOperator
+from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
 from airflow.utils.state import State, TaskInstanceState
 
 pytestmark = pytest.mark.db_test
@@ -67,12 +65,7 @@ class TestCallbackRequest:
     def test_from_json(self, input, request_class):
         if input is None:
             ti = TaskInstance(
-                task=BashOperator(
-                    task_id="test",
-                    bash_command="true",
-                    start_date=datetime.now(),
-                    dag=DAG(dag_id="id", schedule=None),
-                ),
+                task=SerializedBaseOperator(task_id="test"),
                 run_id="fake_run",
                 state=State.RUNNING,
                 dag_version_id=uuid.uuid4(),

--- a/airflow-core/tests/unit/cli/commands/test_task_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_task_command.py
@@ -353,8 +353,8 @@ class TestCliTasks:
 
         SerializedDagModel.write_dag(lazy_deserialized_dag2, bundle_name="testing")
 
-        task2 = dag2.get_task(task_id="print_the_context")
         dag2 = DagSerialization.from_dict(lazy_deserialized_dag2.data)
+        task2 = dag2.get_task(task_id="print_the_context")
 
         default_date2 = timezone.datetime(2016, 1, 9)
         dag2.clear()

--- a/airflow-core/tests/unit/core/test_core.py
+++ b/airflow-core/tests/unit/core/test_core.py
@@ -22,8 +22,8 @@ from datetime import timedelta
 import pytest
 
 from airflow._shared.timezones.timezone import datetime
-from airflow.models.baseoperator import BaseOperator
 from airflow.providers.standard.operators.empty import EmptyOperator
+from airflow.sdk import BaseOperator
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.db import clear_db_dags, clear_db_runs

--- a/airflow-core/tests/unit/executors/test_base_executor.py
+++ b/airflow-core/tests/unit/executors/test_base_executor.py
@@ -36,6 +36,7 @@ from airflow.executors.base_executor import BaseExecutor, RunningRetryAttemptTyp
 from airflow.executors.local_executor import LocalExecutor
 from airflow.models.taskinstance import TaskInstance, TaskInstanceKey
 from airflow.sdk import BaseOperator
+from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
 from airflow.utils.state import State, TaskInstanceState
 
 from tests_common.test_utils.markers import skip_if_force_lowest_dependencies_marker
@@ -60,7 +61,7 @@ def test_invalid_slotspool():
 
 def test_get_task_log():
     executor = BaseExecutor()
-    ti = TaskInstance(task=BaseOperator(task_id="dummy"), dag_version_id=mock.MagicMock(spec=UUID))
+    ti = TaskInstance(task=SerializedBaseOperator(task_id="dummy"), dag_version_id=mock.MagicMock(spec=UUID))
     assert executor.get_task_log(ti=ti, try_number=1) == ([], [])
 
 

--- a/airflow-core/tests/unit/models/test_cleartasks.py
+++ b/airflow-core/tests/unit/models/test_cleartasks.py
@@ -605,7 +605,7 @@ class TestClearTasks:
             )
             ti = dr.task_instances[0]
             ti.task = task
-            dags.append(dag_maker.serialized_model.dag)
+            dags.append(dag_maker.serialized_dag)
             tis.append(ti)
 
         # test clear all dags

--- a/airflow-core/tests/unit/models/test_cleartasks.py
+++ b/airflow-core/tests/unit/models/test_cleartasks.py
@@ -37,6 +37,7 @@ from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 from tests_common.test_utils import db
 from tests_common.test_utils.dag import sync_dag_to_db
+from tests_common.test_utils.taskinstance import run_task_instance
 from unit.models import DEFAULT_DATE
 
 pytestmark = [pytest.mark.db_test, pytest.mark.need_serialized_dag]
@@ -61,19 +62,15 @@ class TestClearTasks:
             end_date=DEFAULT_DATE + datetime.timedelta(days=10),
             catchup=True,
         ) as dag:
-            task0 = EmptyOperator(task_id="0")
-            task1 = EmptyOperator(task_id="1", retries=2)
+            EmptyOperator(task_id="0")
+            EmptyOperator(task_id="1", retries=2)
 
         dr = dag_maker.create_dagrun(
             state=State.RUNNING,
             run_type=DagRunType.SCHEDULED,
         )
-        ti0, ti1 = sorted(dr.task_instances, key=lambda ti: ti.task_id)
-        ti0.refresh_from_task(task0)
-        ti1.refresh_from_task(task1)
-
-        ti0.run()
-        ti1.run()
+        ti0 = dag_maker.run_ti("0", dr)
+        ti1 = dag_maker.run_ti("1", dr)
 
         with create_session() as session:
             # do the incrementing of try_number ordinarily handled by scheduler
@@ -303,8 +300,8 @@ class TestClearTasks:
         When clearing a TI, if the best available serdag for that task doesn't have the
         task anymore, then it has different logic re setting max tries."""
         with dag_maker("test_clear_task_instances_without_task") as dag:
-            task0 = EmptyOperator(task_id="task0")
-            task1 = EmptyOperator(task_id="task1", retries=2)
+            EmptyOperator(task_id="task0")
+            EmptyOperator(task_id="task1", retries=2)
 
         dr = dag_maker.create_dagrun(
             state=State.RUNNING,
@@ -312,8 +309,8 @@ class TestClearTasks:
         )
 
         ti0, ti1 = sorted(dr.task_instances, key=lambda ti: ti.task_id)
-        ti0.refresh_from_task(task0)
-        ti1.refresh_from_task(task1)
+        ti0.refresh_from_task(dag.get_task("task0"))
+        ti1.refresh_from_task(dag.get_task("task1"))
 
         # simulate running this task
         # do the incrementing of try_number ordinarily handled by scheduler
@@ -376,8 +373,8 @@ class TestClearTasks:
         )
 
         ti0, ti1 = sorted(dr.task_instances, key=lambda ti: ti.task_id)
-        ti0.refresh_from_task(task0)
-        ti1.refresh_from_task(task1)
+        ti0.refresh_from_task(dag.get_task("task0"))
+        ti1.refresh_from_task(dag.get_task("task1"))
 
         with create_session() as session:
             # do the incrementing of try_number ordinarily handled by scheduler
@@ -387,8 +384,8 @@ class TestClearTasks:
             session.merge(ti1)
             session.commit()
 
-        ti0.run(session=session)
-        ti1.run(session=session)
+        run_task_instance(ti0, task0)
+        run_task_instance(ti1, task1)
 
         # we use order_by(task_id) here because for the test DAG structure of ours
         # this is equivalent to topological sort. It would not work in general case
@@ -460,8 +457,8 @@ class TestClearTasks:
         )
 
         ti0, ti1 = sorted(dr.task_instances, key=lambda ti: ti.task_id)
-        ti0.refresh_from_task(task0)
-        ti1.refresh_from_task(task1)
+        ti0.refresh_from_task(dag.get_task("0"))
+        ti1.refresh_from_task(dag.get_task("1"))
 
         with create_session() as session:
             # do the incrementing of try_number ordinarily handled by scheduler
@@ -471,8 +468,8 @@ class TestClearTasks:
             session.merge(ti1)
             session.commit()
 
-        ti0.run()
-        ti1.run()
+        run_task_instance(ti0, task0)
+        run_task_instance(ti1, task1)
 
         with create_session() as session:
 
@@ -581,7 +578,7 @@ class TestClearTasks:
         assert ti0.max_tries == 1
 
     def test_dags_clear(self, dag_maker, session):
-        dags, tis = [], []
+        sdk_dags, ser_dags, tis = [], [], []
         num_of_dags = 5
         for i in range(num_of_dags):
             with dag_maker(
@@ -591,7 +588,7 @@ class TestClearTasks:
                 start_date=DEFAULT_DATE,
                 end_date=DEFAULT_DATE + datetime.timedelta(days=10),
             ):
-                task = EmptyOperator(task_id=f"test_task_clear_{i}", owner="test")
+                EmptyOperator(task_id=f"test_task_clear_{i}", owner="test")
 
             dr = dag_maker.create_dagrun(
                 run_id=f"scheduled_{i}",
@@ -603,19 +600,19 @@ class TestClearTasks:
                 run_after=DEFAULT_DATE,
                 triggered_by=DagRunTriggeredByType.TEST,
             )
-            ti = dr.task_instances[0]
-            ti.task = task
-            dags.append(dag_maker.serialized_dag)
+            sdk_dags.append(dag_maker.dag)
+            ser_dags.append(serialized_dag := dag_maker.serialized_dag)
+            (ti := dr.task_instances[0]).refresh_from_task(serialized_dag.get_task(ti.task_id))
             tis.append(ti)
 
         # test clear all dags
-        for i in range(num_of_dags):
-            session.get(TaskInstance, tis[i].id).try_number += 1
+        for dag, ti in zip(sdk_dags, tis):
+            session.get(TaskInstance, ti.id).try_number += 1
             session.commit()
-            tis[i].run()
-            assert tis[i].state == State.SUCCESS
-            assert tis[i].try_number == 1
-            assert tis[i].max_tries == 0
+            run_task_instance(ti, dag.get_task(ti.task_id))
+            assert ti.state == State.SUCCESS
+            assert ti.try_number == 1
+            assert ti.max_tries == 0
         session.commit()
 
         def _get_ti(old_ti):
@@ -628,7 +625,7 @@ class TestClearTasks:
                 )
             )
 
-        SerializedDAG.clear_dags(dags)
+        SerializedDAG.clear_dags(ser_dags)
         session.commit()
         for i in range(num_of_dags):
             ti = _get_ti(tis[i])
@@ -637,7 +634,7 @@ class TestClearTasks:
             assert ti.max_tries == 1
 
         # test dry_run
-        for i, dag in enumerate(dags):
+        for i, dag in enumerate(ser_dags):
             ti = _get_ti(tis[i])
             ti.try_number += 1
             session.commit()
@@ -649,7 +646,7 @@ class TestClearTasks:
             assert ti.try_number == 2
             assert ti.max_tries == 1
         session.commit()
-        SerializedDAG.clear_dags(dags, dry_run=True)
+        SerializedDAG.clear_dags(ser_dags, dry_run=True)
         session.commit()
         for i in range(num_of_dags):
             ti = _get_ti(tis[i])
@@ -663,7 +660,7 @@ class TestClearTasks:
         ti_fail.state = State.FAILED
         session.commit()
 
-        SerializedDAG.clear_dags(dags, only_failed=True)
+        SerializedDAG.clear_dags(ser_dags, only_failed=True)
 
         for ti_in in tis:
             ti = _get_ti(ti_in)
@@ -685,7 +682,7 @@ class TestClearTasks:
             end_date=DEFAULT_DATE + datetime.timedelta(days=10),
             catchup=True,
             bundle_version="v1",
-        ):
+        ) as dag:
             task0 = EmptyOperator(task_id="0")
             task1 = EmptyOperator(task_id="1", retries=2)
         dr = dag_maker.create_dagrun(
@@ -695,11 +692,11 @@ class TestClearTasks:
 
         old_dag_version = DagVersion.get_latest_version(dr.dag_id)
         ti0, ti1 = sorted(dr.task_instances, key=lambda ti: ti.task_id)
-        ti0.refresh_from_task(task0)
-        ti1.refresh_from_task(task1)
+        ti0.refresh_from_task(dag.get_task("0"))
+        ti1.refresh_from_task(dag.get_task("1"))
 
-        ti0.run()
-        ti1.run()
+        run_task_instance(ti0, task0)
+        run_task_instance(ti1, task1)
         dr.state = DagRunState.SUCCESS
         session.merge(dr)
         session.flush()

--- a/airflow-core/tests/unit/models/test_dagrun.py
+++ b/airflow-core/tests/unit/models/test_dagrun.py
@@ -1456,7 +1456,7 @@ def test_mapped_literal_verify_integrity(dag_maker, session):
         task_2.expand(arg2=[1, 2])
 
     # Update it to use the new serialized DAG
-    dr.dag = dag_maker.serialized_model.dag
+    dr.dag = dag_maker.serialized_dag
     dag_version_id = DagVersion.get_latest_version(dag_id=dr.dag_id, session=session).id
     dr.verify_integrity(dag_version_id=dag_version_id, session=session)
 
@@ -1479,7 +1479,7 @@ def test_mapped_literal_to_xcom_arg_verify_integrity(dag_maker, session):
         t1 = BaseOperator(task_id="task_1")
         task_2.expand(arg2=t1.output)
 
-    dr.dag = dag_maker.serialized_model.dag
+    dr.dag = dag_maker.serialized_dag
     dag_version_id = DagVersion.get_latest_version(dag_id=dr.dag_id, session=session).id
     dr.verify_integrity(dag_version_id=dag_version_id, session=session)
 
@@ -1525,7 +1525,7 @@ def test_mapped_literal_length_increase_adds_additional_ti(dag_maker, session):
     with dag_maker(session=session, serialized=True):
         task_2.expand(arg2=[1, 2, 3, 4, 5])
 
-    dr.dag = dag_maker.serialized_model.dag
+    dr.dag = dag_maker.serialized_dag
     # Every mapped task is revised at task_instance_scheduling_decision
     dr.task_instance_scheduling_decisions()
 
@@ -1565,7 +1565,7 @@ def test_mapped_literal_length_reduction_adds_removed_state(dag_maker, session):
     with dag_maker(session=session):
         task_2.expand(arg2=[1, 2])
 
-    dr.dag = dag_maker.serialized_model.dag
+    dr.dag = dag_maker.serialized_dag
     # Since we change the literal on the dag file itself, the dag_hash will
     # change which will have the scheduler verify the dr integrity
     dag_version_id = DagVersion.get_latest_version(dag_id=dr.dag_id, session=session).id

--- a/airflow-core/tests/unit/models/test_mappedoperator.py
+++ b/airflow-core/tests/unit/models/test_mappedoperator.py
@@ -41,6 +41,7 @@ from airflow.utils.state import TaskInstanceState
 from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.mapping import expand_mapped_task
 from tests_common.test_utils.mock_operators import MockOperator
+from tests_common.test_utils.taskinstance import run_task_instance
 from unit.models import DEFAULT_DATE
 
 pytestmark = pytest.mark.db_test
@@ -138,7 +139,7 @@ def test_expand_mapped_task_instance(dag_maker, session, num_existing_tis, expec
     for index in range(num_existing_tis):
         # Give the existing TIs a state to make sure we don't change them
         ti = TaskInstance(
-            mapped,
+            mapped_deser,
             run_id=dr.run_id,
             map_index=index,
             state=TaskInstanceState.SUCCESS,
@@ -190,7 +191,7 @@ def test_expand_mapped_task_failed_state_in_db(dag_maker, session):
     for index in range(2):
         # Give the existing TIs a state to make sure we don't change them
         ti = TaskInstance(
-            mapped,
+            mapped_deser,
             run_id=dr.run_id,
             map_index=index,
             state=TaskInstanceState.SUCCESS,
@@ -303,7 +304,7 @@ def test_expand_kwargs_mapped_task_instance(dag_maker, session, num_existing_tis
     for index in range(num_existing_tis):
         # Give the existing TIs a state to make sure we don't change them
         ti = TaskInstance(
-            mapped,
+            dag.get_task(mapped.task_id),
             run_id=dr.run_id,
             map_index=index,
             state=TaskInstanceState.SUCCESS,
@@ -455,7 +456,7 @@ def test_expand_mapped_task_instance_with_named_index(
     dr = dag_maker.create_dagrun(session=session)
     tis = dr.get_task_instances(session=session)
     for ti in tis:
-        ti.run()
+        run_task_instance(ti, dag_maker.dag.get_task(ti.task_id))
     session.flush()
 
     indices = session.scalars(
@@ -1595,7 +1596,7 @@ def test_mapped_tasks_in_mapped_task_group_waits_for_upstreams_to_complete(dag_m
 
     dr = dag_maker.create_dagrun()
     ti = dr.get_task_instance(task_id="t1")
-    ti.run()
+    run_task_instance(ti, dag.get_task(ti.task_id))
     dr.task_instance_scheduling_decisions()
     ti3 = dr.get_task_instance(task_id="tg1.t3")
     assert not ti3.state

--- a/airflow-core/tests/unit/models/test_pool.py
+++ b/airflow-core/tests/unit/models/test_pool.py
@@ -27,7 +27,6 @@ from airflow import settings
 from airflow.exceptions import AirflowException, PoolNotFound
 from airflow.models.dag_version import DagVersion
 from airflow.models.pool import Pool
-from airflow.models.taskinstance import TaskInstance as TI
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.utils.session import create_session
 from airflow.utils.state import State
@@ -38,6 +37,7 @@ from tests_common.test_utils.db import (
     clear_db_runs,
     set_default_pool_slots,
 )
+from tests_common.test_utils.taskinstance import create_task_instance
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -188,9 +188,9 @@ class TestPool:
 
         dr = dag_maker.create_dagrun()
         dag_version = DagVersion.get_latest_version(dr.dag_id)
-        ti1 = TI(task=op1, run_id=dr.run_id, dag_version_id=dag_version.id)
+        ti1 = create_task_instance(task=op1, run_id=dr.run_id, dag_version_id=dag_version.id)
         ti1.refresh_from_db()
-        ti2 = TI(task=op2, run_id=dr.run_id, dag_version_id=dag_version.id)
+        ti2 = create_task_instance(task=op2, run_id=dr.run_id, dag_version_id=dag_version.id)
         ti2.refresh_from_db()
         ti1.state = State.RUNNING
         ti2.state = State.QUEUED
@@ -238,9 +238,9 @@ class TestPool:
 
         dr = dag_maker.create_dagrun()
         dag_version = DagVersion.get_latest_version(dr.dag_id)
-        ti1 = TI(task=op1, run_id=dr.run_id, dag_version_id=dag_version.id)
-        ti2 = TI(task=op2, run_id=dr.run_id, dag_version_id=dag_version.id)
-        ti3 = TI(task=op3, run_id=dr.run_id, dag_version_id=dag_version.id)
+        ti1 = create_task_instance(task=op1, run_id=dr.run_id, dag_version_id=dag_version.id)
+        ti2 = create_task_instance(task=op2, run_id=dr.run_id, dag_version_id=dag_version.id)
+        ti3 = create_task_instance(task=op3, run_id=dr.run_id, dag_version_id=dag_version.id)
         ti1.refresh_from_db()
         ti1.state = State.RUNNING
         ti2.refresh_from_db()

--- a/airflow-core/tests/unit/models/test_renderedtifields.py
+++ b/airflow-core/tests/unit/models/test_renderedtifields.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import os
 from collections import Counter
-from collections.abc import Sequence
 from datetime import date, timedelta
 from typing import TYPE_CHECKING
 from unittest import mock
@@ -33,8 +32,7 @@ from sqlalchemy import select
 from airflow import settings
 from airflow._shared.timezones.timezone import datetime
 from airflow.configuration import conf
-from airflow.models import DagRun, Variable
-from airflow.models.baseoperator import BaseOperator
+from airflow.models import DagRun
 from airflow.models.renderedtifields import RenderedTaskInstanceFields as RTIF
 from airflow.models.taskmap import TaskMap
 from airflow.providers.standard.operators.bash import BashOperator
@@ -116,34 +114,8 @@ class TestRenderedTaskInstanceFields:
             pytest.param({"foo": "bar"}, {"foo": "bar"}, id="dict"),
             pytest.param(("foo", "bar"), ["foo", "bar"], id="tuple"),
             pytest.param({"foo"}, "{'foo'}", id="set"),
-            pytest.param("{{ task.task_id }}", "test", id="templated_string"),
             (date(2018, 12, 6), "2018-12-06"),
             pytest.param(datetime(2018, 12, 6, 10, 55), "2018-12-06 10:55:00+00:00", id="datetime"),
-            pytest.param(
-                ClassWithCustomAttributes(
-                    att1="{{ task.task_id }}", att2="{{ task.task_id }}", template_fields=["att1"]
-                ),
-                "ClassWithCustomAttributes({'att1': 'test', 'att2': '{{ task.task_id }}', "
-                "'template_fields': ['att1']})",
-                id="class_with_custom_attributes",
-            ),
-            pytest.param(
-                ClassWithCustomAttributes(
-                    nested1=ClassWithCustomAttributes(
-                        att1="{{ task.task_id }}", att2="{{ task.task_id }}", template_fields=["att1"]
-                    ),
-                    nested2=ClassWithCustomAttributes(
-                        att3="{{ task.task_id }}", att4="{{ task.task_id }}", template_fields=["att3"]
-                    ),
-                    template_fields=["nested1"],
-                ),
-                "ClassWithCustomAttributes({'nested1': ClassWithCustomAttributes("
-                "{'att1': 'test', 'att2': '{{ task.task_id }}', 'template_fields': ['att1']}), "
-                "'nested2': ClassWithCustomAttributes("
-                "{'att3': '{{ task.task_id }}', 'att4': '{{ task.task_id }}', 'template_fields': ['att3']}), "
-                "'template_fields': ['nested1']})",
-                id="nested_class_with_custom_attributes",
-            ),
             pytest.param(
                 "a" * 5000,
                 f"Truncated. You can change this behaviour in [core]max_templated_field_length. {('a' * 5000)[: max_length - 79]!r}... ",
@@ -151,7 +123,8 @@ class TestRenderedTaskInstanceFields:
             ),
             pytest.param(
                 LargeStrObject(),
-                f"Truncated. You can change this behaviour in [core]max_templated_field_length. {str(LargeStrObject())[: max_length - 79]!r}... ",
+                f"Truncated. You can change this behaviour in "
+                f"[core]max_templated_field_length. {str(LargeStrObject())[: max_length - 79]!r}... ",
                 id="large_object",
             ),
         ],
@@ -171,7 +144,7 @@ class TestRenderedTaskInstanceFields:
         ti, ti2 = dr.task_instances
         ti.task = task
         ti2.task = task_2
-        rtif = RTIF(ti=ti)
+        rtif = RTIF(ti=ti, render_templates=False)
 
         assert ti.dag_id == rtif.dag_id
         assert ti.task_id == rtif.task_id
@@ -190,23 +163,6 @@ class TestRenderedTaskInstanceFields:
         # i.e. for the TIs that are not stored in RTIF table
         # Fetching them will return None
         assert RTIF.get_templated_fields(ti=ti2) is None
-
-    @pytest.mark.enable_redact
-    def test_secrets_are_masked_when_large_string(self, dag_maker):
-        """
-        Test that secrets are masked when the templated field is a large string
-        """
-        Variable.set(
-            key="api_key",
-            value="test api key are still masked" * 5000,
-        )
-        with dag_maker("test_serialized_rendered_fields"):
-            task = BashOperator(task_id="test", bash_command="echo {{ var.value.api_key }}")
-        dr = dag_maker.create_dagrun()
-        ti = dr.task_instances[0]
-        ti.task = task
-        rtif = RTIF(ti=ti)
-        assert "***" in rtif.rendered_fields.get("bash_command")
 
     @mock.patch("airflow.models.BaseOperator.render_template")
     def test_pandas_dataframes_works_with_the_string_compare(self, render_mock, dag_maker):
@@ -228,7 +184,7 @@ class TestRenderedTaskInstanceFields:
 
         dr = dag_maker.create_dagrun()
         ti, ti2 = dr.task_instances
-        rtif = RTIF(ti=ti2)
+        rtif = RTIF(ti=ti2, render_templates=False)
         rtif.write()
 
     @pytest.mark.parametrize(
@@ -256,7 +212,7 @@ class TestRenderedTaskInstanceFields:
             dr = dag_maker.create_dagrun(run_id=str(num), logical_date=dag.start_date + timedelta(days=num))
             ti = dr.task_instances[0]
             ti.task = task
-            rtif_list.append(RTIF(ti))
+            rtif_list.append(RTIF(ti, render_templates=False))
 
         session.add_all(rtif_list)
         session.flush()
@@ -302,8 +258,8 @@ class TestRenderedTaskInstanceFields:
             TaskMap.expand_mapped_task(dag.task_dict[mapped.task_id], dr.run_id, session=dag_maker.session)
             session.refresh(dr)
             for ti in dr.task_instances:
-                ti.task = mapped
-                session.add(RTIF(ti))
+                ti.task = dag_maker.serialized_dag.get_task(ti.task_id)
+                session.add(RTIF(ti, render_templates=False))
         session.flush()
 
         result = session.scalars(select(RTIF).where(RTIF.dag_id == dag.dag_id)).all()
@@ -325,20 +281,18 @@ class TestRenderedTaskInstanceFields:
         """
         Test records can be written and overwritten
         """
-        Variable.set(key="test_key", value="test_val")
-
         session = settings.Session()
         result = session.scalars(select(RTIF)).all()
         assert result == []
 
         with dag_maker("test_write"):
-            task = BashOperator(task_id="test", bash_command="echo {{ var.value.test_key }}")
+            task = BashOperator(task_id="test", bash_command="echo test_val")
 
         dr = dag_maker.create_dagrun()
         ti = dr.task_instances[0]
         ti.task = task
 
-        rtif = RTIF(ti)
+        rtif = RTIF(ti, render_templates=False)
         rtif.write()
         result = session.execute(
             select(RTIF.dag_id, RTIF.task_id, RTIF.rendered_fields).where(
@@ -350,15 +304,13 @@ class TestRenderedTaskInstanceFields:
         assert result == ("test_write", "test", {"bash_command": "echo test_val", "env": None, "cwd": None})
 
         # Test that overwrite saves new values to the DB
-        Variable.delete("test_key")
-        Variable.set(key="test_key", value="test_val_updated")
         self.clean_db()
         with dag_maker("test_write"):
-            updated_task = BashOperator(task_id="test", bash_command="echo {{ var.value.test_key }}")
+            updated_task = BashOperator(task_id="test", bash_command="echo test_val_updated")
         dr = dag_maker.create_dagrun()
         ti = dr.task_instances[0]
         ti.task = updated_task
-        rtif_updated = RTIF(ti)
+        rtif_updated = RTIF(ti, render_templates=False)
         rtif_updated.write()
 
         result_updated = session.execute(
@@ -380,7 +332,7 @@ class TestRenderedTaskInstanceFields:
             with dag_maker("test_ritf_redact", serialized=True):
                 task = BashOperator(
                     task_id="test",
-                    bash_command="echo {{ var.value.api_key }}",
+                    bash_command="echo secret",
                     env={"foo": "secret", "other_api_key": "masked based on key name"},
                 )
             dr = dag_maker.create_dagrun()
@@ -393,7 +345,7 @@ class TestRenderedTaskInstanceFields:
 
             ti = dr.task_instances[0]
             ti.task = task
-            rtif = RTIF(ti=ti)
+            rtif = RTIF(ti=ti, render_templates=False)
             assert rtif.rendered_fields == {
                 "bash_command": "val 1",
                 "env": "val 2",
@@ -405,28 +357,22 @@ class TestRenderedTaskInstanceFields:
         Here we verify bad behavior.  When we rerun a task whose RTIF
         will get removed, we get a stale data error.
         """
-        with dag_maker(dag_id="test_retry_handling"):
+        with dag_maker(dag_id="test_retry_handling", session=session) as dag:
             task = PythonOperator(
                 task_id="test_retry_handling_op",
-                python_callable=lambda a, b: print(f"{a}\n{b}\n"),
-                op_args=[
-                    "dag {{dag.dag_id}};",
-                    "try_number {{ti.try_number}};yo",
-                ],
+                python_callable=lambda a: print(f"{a}\n"),
+                op_args=[f"dag {dag.dag_id};"],
             )
 
         def popuate_rtif(date):
             run_id = f"abc_{date.to_date_string()}"
-            dr = session.scalar(select(DagRun).where(DagRun.logical_date == date, DagRun.run_id == run_id))
-            if not dr:
-                dr = dag_maker.create_dagrun(logical_date=date, run_id=run_id)
-            ti: TaskInstance = dr.task_instances[0]
+            dag_run = dag_maker.create_dagrun(logical_date=date, run_id=run_id)
+            ti = dag_run.task_instances[0]
             ti.state = TaskInstanceState.SUCCESS
 
             rtif = RTIF(ti=ti, render_templates=False, rendered_fields={"a": "1"})
             session.merge(rtif)
-            session.flush()
-            return dr
+            return dag_run
 
         base_date = pendulum.datetime(2021, 1, 1)
         exec_dates = [base_date.add(days=x) for x in range(40)]
@@ -441,75 +387,5 @@ class TestRenderedTaskInstanceFields:
         assert dr
         ti: TaskInstance = dr.task_instances[0]
         ti.state = None
-        session.flush()
-        # rerun the old run. this will shouldn't fail
-        ti.task = task
-        ti.run()
-
-    def test_nested_dictionary_template_field_rendering(self, dag_maker):
-        """
-        Test that nested dictionary items in template fields are properly rendered
-        when using template_fields_renderers with dot-separated paths.
-
-        This test verifies the fix for rendering dictionary items in templates.
-        Before the fix, nested dictionary items specified in template_fields_renderers
-        (e.g., "configuration.query.sql") would not be rendered. After the fix,
-        these nested items are properly extracted and rendered.
-        """
-
-        # Create a custom operator with a dictionary template field
-        class MyConfigOperator(BaseOperator):
-            template_fields: Sequence[str] = ("configuration",)
-            template_fields_renderers = {
-                "configuration": "json",
-                "configuration.query.sql": "sql",
-            }
-
-            def __init__(self, configuration: dict, **kwargs):
-                super().__init__(**kwargs)
-                self.configuration = configuration
-
-        # Create a configuration dictionary with nested structure
-        configuration = {
-            "query": {
-                "job_id": "123",
-                "sql": "select * from my_table where date = '{{ ds }}'",
-            }
-        }
-
-        with dag_maker("test_nested_dict_rendering"):
-            task = MyConfigOperator(task_id="test_config", configuration=configuration)
-        dr = dag_maker.create_dagrun()
-
-        session = dag_maker.session
-        ti = dr.task_instances[0]
-        ti.task = task
-        rtif = RTIF(ti=ti)
-
-        # Verify that the base configuration field is rendered
-        assert "configuration" in rtif.rendered_fields
-        rendered_config = rtif.rendered_fields["configuration"]
-        assert isinstance(rendered_config, dict)
-        assert rendered_config["query"]["job_id"] == "123"
-        # The SQL should be templated (ds should be replaced with actual date)
-        assert "select * from my_table where date = '" in rendered_config["query"]["sql"]
-        assert rendered_config["query"]["sql"] != configuration["query"]["sql"]
-
-        # Verify that the nested dictionary item is also rendered
-        # This is the key test - before the fix, this would not exist
-        assert "configuration.query.sql" in rtif.rendered_fields
-        rendered_sql = rtif.rendered_fields["configuration.query.sql"]
-        assert isinstance(rendered_sql, str)
-        assert "select * from my_table where date = '" in rendered_sql
-        # The template should be rendered (ds should be replaced)
-        assert "{{ ds }}" not in rendered_sql
-
-        # Store in database and verify retrieval
-        session.add(rtif)
-        session.flush()
-
-        retrieved_fields = RTIF.get_templated_fields(ti=ti, session=session)
-        assert retrieved_fields is not None
-        assert "configuration" in retrieved_fields
-        assert "configuration.query.sql" in retrieved_fields
-        assert retrieved_fields["configuration.query.sql"] == rendered_sql
+        # rerun the old run. this shouldn't fail
+        dag_maker.run_ti(task.task_id, dr)

--- a/airflow-core/tests/unit/models/test_taskinstance.py
+++ b/airflow-core/tests/unit/models/test_taskinstance.py
@@ -47,7 +47,6 @@ from airflow.models.asset import (
     AssetPartitionDagRun,
     PartitionedAssetKeyLog,
 )
-from airflow.models.connection import Connection
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagrun import DagRun
 from airflow.models.hitl_history import HITLDetailHistory
@@ -63,7 +62,6 @@ from airflow.models.taskinstance import (
 from airflow.models.taskinstancehistory import TaskInstanceHistory
 from airflow.models.taskmap import TaskMap
 from airflow.models.taskreschedule import TaskReschedule
-from airflow.models.variable import Variable
 from airflow.models.xcom import XComModel
 from airflow.observability.stats import Stats
 from airflow.providers.standard.operators.bash import BashOperator
@@ -80,6 +78,7 @@ from airflow.sdk.definitions.param import process_params
 from airflow.sdk.definitions.taskgroup import TaskGroup
 from airflow.sdk.execution_time.comms import AssetEventsResult
 from airflow.serialization.definitions.assets import SerializedAsset
+from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
 from airflow.serialization.definitions.dag import SerializedDAG
 from airflow.serialization.encoders import ensure_serialized_asset
 from airflow.serialization.serialized_objects import OperatorSerialization
@@ -90,15 +89,18 @@ from airflow.ti_deps.deps.base_ti_dep import TIDepStatus
 from airflow.ti_deps.deps.ready_to_reschedule import ReadyToRescheduleDep
 from airflow.ti_deps.deps.trigger_rule_dep import TriggerRuleDep, _UpstreamTIStates
 from airflow.timetables.simple import IdentityMapper, PartitionedAssetTimetable
-from airflow.utils.db import merge_conn
 from airflow.utils.session import create_session, provide_session
 from airflow.utils.span_status import SpanStatus
 from airflow.utils.state import DagRunState, State, TaskInstanceState
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 from tests_common.test_utils import db
-from tests_common.test_utils.db import clear_db_connections, clear_db_runs
+from tests_common.test_utils.db import clear_db_runs
 from tests_common.test_utils.mock_operators import MockOperator
+from tests_common.test_utils.taskinstance import (
+    create_task_instance as _create_task_instance,
+    run_task_instance,
+)
 from unit.models import DEFAULT_DATE
 
 if TYPE_CHECKING:
@@ -352,11 +354,9 @@ class TestTaskInstance:
                 pool="test_pool",
             )
         ti = dag_maker.create_dagrun(logical_date=timezone.utcnow()).task_instances[0]
-        ti.task = task
         ti.state = State.QUEUED
         with create_session() as session:
             session.add(ti)
-            session.commit()
 
         all_deps = RUNNING_DEPS | {ReadyToRescheduleDep()}
         all_non_requeueable_deps = all_deps - REQUEUEABLE_DEPS
@@ -370,7 +370,7 @@ class TestTaskInstance:
 
         for class_name, (dep_patch, method_patch) in patch_dict.items():
             method_patch.return_value = iter([TIDepStatus("mock_" + class_name, False, "mock")])
-            ti.run()
+            run_task_instance(ti, task)
             assert ti.state == State.QUEUED
             dep_patch.return_value = TIDepStatus("mock_" + class_name, True, "mock")
 
@@ -422,7 +422,7 @@ class TestTaskInstance:
             )
 
     @provide_session
-    def test_ti_updates_with_task(self, create_task_instance, session):
+    def test_ti_updates_with_task(self, dag_maker, create_task_instance, session):
         """
         test that updating the executor_config propagates to the TaskInstance DB
         """
@@ -431,7 +431,6 @@ class TestTaskInstance:
             task_id="test_run_pooling_task_op",
             executor_config={"foo": "bar"},
         )
-        dag = ti.task.dag
 
         ti.run(session=session)
         executor_configs = session.scalars(
@@ -443,13 +442,13 @@ class TestTaskInstance:
             task_id="test_run_pooling_task_op2",
             executor_config={"bar": "baz"},
             start_date=timezone.datetime(2016, 2, 1, 0, 0, 0),
-            dag=dag,
+            dag=dag_maker.dag,
         )
-        ti2 = TI(task=task2, run_id=ti.run_id, dag_version_id=ti.dag_version_id)
+        ti2 = _create_task_instance(task=task2, run_id=ti.run_id, dag_version_id=ti.dag_version_id)
         session.add(ti2)
         session.flush()
 
-        ti2.run(session=session)
+        run_task_instance(ti2, task2, session=session)
         # Ensure it's reloaded
         ti2.executor_config = None
         ti2.refresh_from_db(session)
@@ -486,10 +485,7 @@ class TestTaskInstance:
                 python_callable=raise_skip_exception,
             )
 
-        dr = dag_maker.create_dagrun(logical_date=timezone.utcnow())
-        ti = dr.task_instances[0]
-        ti.task = task
-        ti.run()
+        ti = dag_maker.run_ti(task.task_id, dag_run_kwargs={"logical_date": timezone.utcnow()})
         assert ti.state == State.SKIPPED
 
     def test_retry_delay(self, dag_maker, time_machine):
@@ -497,21 +493,21 @@ class TestTaskInstance:
         Test that retry delays are respected
         """
         time_machine.move_to("2021-09-19 04:56:35", tick=False)
-        with dag_maker(dag_id="test_retry_handling"):
-            task = BashOperator(
-                task_id="test_retry_handling_op",
+        with dag_maker():
+            BashOperator(
+                task_id="op",
                 bash_command="exit 1",
                 retries=1,
                 retry_delay=datetime.timedelta(seconds=3),
             )
 
         def run_with_error(ti):
-            orig_task, ti.task = ti.task, task
             with contextlib.suppress(AirflowException):
-                ti.run()
-            ti.task = orig_task
+                dag_maker.run_ti(ti.task_id, ti.dag_run)
+            ti.refresh_from_db(session)
 
         ti = dag_maker.create_dagrun(logical_date=timezone.utcnow()).task_instances[0]
+        ti.task = dag_maker.serialized_dag.get_task(ti.task_id)
         with create_session() as session:
             session.get(TaskInstance, ti.id).try_number += 1
 
@@ -548,19 +544,18 @@ class TestTaskInstance:
             "cwd": None,
         }
 
-        with dag_maker(dag_id="test_retry_handling", serialized=True) as dag:
-            task = BashOperator(
-                task_id="test_retry_handling_op",
+        with dag_maker(dag_id="test_retry_handling", session=session) as dag:
+            BashOperator(
+                task_id="op",
                 bash_command="echo {{dag.dag_id}}; exit 1",
                 retries=1,
                 retry_delay=datetime.timedelta(seconds=0),
             )
 
         def run_with_error(ti):
-            orig_task, ti.task = ti.task, task
             with contextlib.suppress(AirflowException):
-                ti.run()
-            ti.task = orig_task
+                dag_maker.run_ti(ti.task_id, ti.dag_run)
+            ti.refresh_from_db(session)
 
         ti = dag_maker.create_dagrun(logical_date=timezone.utcnow()).task_instances[0]
         assert ti.try_number == 0
@@ -742,7 +737,6 @@ class TestTaskInstance:
                 pool="test_pool",
             ).expand(poke_interval=[0])
         ti = dag_maker.create_dagrun(logical_date=timezone.utcnow()).task_instances[0]
-        ti.task = task
 
         def run_ti_and_assert(
             run_date,
@@ -753,10 +747,9 @@ class TestTaskInstance:
             expected_try_number,
             expected_task_reschedule_count,
         ):
-            ti.refresh_from_task(task)
             with time_machine.travel(run_date, tick=False):
                 try:
-                    ti.run()
+                    run_task_instance(ti, task)
                 except AirflowException:
                     if not fail:
                         raise
@@ -806,7 +799,6 @@ class TestTaskInstance:
                 pool="test_pool",
             )
         ti = dag_maker.create_dagrun(logical_date=timezone.utcnow()).task_instances[0]
-        ti.task = task
         assert ti.try_number == 0
 
         def run_ti_and_assert(
@@ -820,7 +812,7 @@ class TestTaskInstance:
         ):
             with time_machine.travel(run_date, tick=False):
                 try:
-                    ti.run()
+                    run_task_instance(ti, task)
                 except AirflowException:
                     if not fail:
                         raise
@@ -850,10 +842,7 @@ class TestTaskInstance:
             def execute(self, context): ...
 
         with dag_maker(dag_id="test_depends_on_past", serialized=True, catchup=True):
-            task = CustomOp(
-                task_id="test_dop_task",
-                depends_on_past=True,
-            )
+            task = CustomOp(task_id="test_dop_task", depends_on_past=True)
         dag_maker.create_dagrun(
             state=State.FAILED,
             run_type=DagRunType.SCHEDULED,
@@ -866,17 +855,12 @@ class TestTaskInstance:
             run_type=DagRunType.SCHEDULED,
         )
 
-        ti = dr.task_instances[0]
-        ti.task = task
-
         # depends_on_past prevents the run
-        dag_maker.run_ti(task.task_id, dr, ignore_depends_on_past=False)
-        ti.refresh_from_db()
+        ti = dag_maker.run_ti(task.task_id, dr, ignore_depends_on_past=False)
         assert ti.state is None
 
         # ignore first depends_on_past to allow the run
-        dag_maker.run_ti(task.task_id, dr, ignore_depends_on_past=True)
-        ti.refresh_from_db()
+        ti = dag_maker.run_ti(task.task_id, dr, ignore_depends_on_past=True)
         assert ti.state == State.SUCCESS
 
     def test_depends_on_past_catchup_false(self, dag_maker):
@@ -1355,18 +1339,23 @@ class TestTaskInstance:
     )
     @provide_session
     def test_are_dependents_done(
-        self, downstream_ti_state, expected_are_dependents_done, create_task_instance, session
+        self,
+        downstream_ti_state,
+        expected_are_dependents_done,
+        dag_maker,
+        session,
     ):
-        ti = create_task_instance(session=session)
-        dag = ti.task.dag
-        downstream_task = EmptyOperator(task_id="downstream_task", dag=dag)
-        ti.task >> downstream_task
+        with dag_maker():
+            EmptyOperator(task_id="0") >> EmptyOperator(task_id="downstream_task")
 
-        downstream_ti = TI(downstream_task, run_id=ti.run_id, dag_version_id=ti.dag_version_id)
+        dr = dag_maker.create_dagrun()
+        downstream_ti = dr.get_task_instance("downstream_task", session=session)
 
         downstream_ti.set_state(downstream_ti_state, session)
         session.flush()
-        assert ti.are_dependents_done(session) == expected_are_dependents_done
+
+        ti0 = dr.get_task_instance(task_id="0", session=session)
+        assert ti0.are_dependents_done(session) == expected_are_dependents_done
 
     def test_xcom_push_flag(self, dag_maker):
         """
@@ -1377,14 +1366,12 @@ class TestTaskInstance:
 
         with dag_maker(dag_id="test_xcom", serialized=True):
             # nothing saved to XCom
-            task = PythonOperator(
+            PythonOperator(
                 task_id=task_id,
                 python_callable=lambda: value,
                 do_xcom_push=False,
             )
-        ti = dag_maker.create_dagrun(logical_date=timezone.utcnow()).task_instances[0]
-        ti.task = task
-        ti.run()
+        ti = dag_maker.run_ti(task_id, dag_run_kwargs={"logical_date": timezone.utcnow()})
         assert ti.xcom_pull(task_ids=task_id) is None
 
     def test_check_and_change_state_before_execution(self, create_task_instance, testing_dag_bundle):
@@ -1644,8 +1631,8 @@ class TestTaskInstance:
         regular_task = BashOperator(task_id="regular", bash_command="echo test", dag=dag)
         mapped_task = BashOperator.partial(task_id="mapped", dag=dag).expand(bash_command=["echo 1"])
 
-        regular_ti = TaskInstance(task=regular_task, dag_version_id=mock.MagicMock())
-        mapped_ti = TaskInstance(task=mapped_task, dag_version_id=mock.MagicMock())
+        regular_ti = _create_task_instance(task=regular_task, dag_version_id=mock.MagicMock())
+        mapped_ti = _create_task_instance(task=mapped_task, dag_version_id=mock.MagicMock())
 
         assert regular_ti.is_schedulable
         assert mapped_ti.is_schedulable
@@ -1683,7 +1670,7 @@ class TestTaskInstance:
 
     def test_set_duration(self):
         task = EmptyOperator(task_id="op", email="test@test.test")
-        ti = TI(task=task, dag_version_id=mock.MagicMock())
+        ti = _create_task_instance(task=task, dag_version_id=mock.MagicMock())
         ti.start_date = datetime.datetime(2018, 10, 1, 1)
         ti.end_date = datetime.datetime(2018, 10, 1, 2)
         ti.set_duration()
@@ -1691,7 +1678,7 @@ class TestTaskInstance:
 
     def test_set_duration_empty_dates(self):
         task = EmptyOperator(task_id="op", email="test@test.test")
-        ti = TI(task=task, dag_version_id=mock.MagicMock())
+        ti = _create_task_instance(task=task, dag_version_id=mock.MagicMock())
         ti.set_duration()
         assert ti.duration is None
 
@@ -1723,7 +1710,7 @@ class TestTaskInstance:
 
         dr: DagRun = dag_maker.create_dagrun()
         for ti in dr.get_task_instances(session=session):
-            ti.run(session=session)
+            run_task_instance(ti, dag_maker.dag.get_task(ti.task_id), session=session)
 
         events = dict((tuple(row)) for row in session.execute(select(AssetEvent.source_task_id, AssetEvent)))
         assert set(events) == {"write1", "write2"}
@@ -1752,12 +1739,11 @@ class TestTaskInstance:
 
             write()
 
-        dr: DagRun = dag_maker.create_dagrun()
-        dr.get_task_instance("write").run(session=session)
+        ti = dag_maker.run_ti("write")
 
         event = session.scalars(select(AssetEvent)).one()
-        assert event.source_dag_id == dr.dag_id
-        assert event.source_run_id == dr.run_id
+        assert event.source_dag_id == ti.dag_id
+        assert event.source_run_id == ti.run_id
         assert event.source_task_id == "write"
         assert event.extra == {"one": 1}
 
@@ -1782,7 +1768,7 @@ class TestTaskInstance:
         dr: DagRun = dag_maker.create_dagrun()
 
         for ti in dr.get_task_instances(session=session):
-            ti.run(session=session)
+            run_task_instance(ti, dag_maker.dag.get_task(ti.task_id), session=session)
 
         producer_events = session.execute(
             select(AssetEvent).where(AssetEvent.source_task_id == "producer")
@@ -1839,7 +1825,7 @@ class TestTaskInstance:
         dr: DagRun = dag_maker.create_dagrun()
 
         for ti in dr.get_task_instances(session=session):
-            ti.run(session=session)
+            run_task_instance(ti, dag_maker.dag.get_task(ti.task_id), session=session)
 
         producer_events = session.execute(
             select(AssetEvent).where(AssetEvent.source_task_id == "producer")
@@ -1899,7 +1885,7 @@ class TestTaskInstance:
         dr: DagRun = dag_maker.create_dagrun()
 
         for ti in dr.get_task_instances(session=session):
-            ti.run(session=session)
+            run_task_instance(ti, dag_maker.dag.get_task(ti.task_id), session=session)
 
         producer_event = session.scalar(select(AssetEvent).where(AssetEvent.source_task_id == "producer"))
 
@@ -1939,8 +1925,7 @@ class TestTaskInstance:
 
             producer()
 
-        (ti,) = dag_maker.create_dagrun().get_task_instances(session=session)
-        ti.run(session=session)
+        dag_maker.run_ti("producer")
 
         asset_model = session.scalars(asset_model_chheck_stmt).one()
         assert asset_model.uri == asset_uri
@@ -1969,9 +1954,9 @@ class TestTaskInstance:
 
             producer_without_inactive() >> producer_with_inactive()
 
-        tis = {ti.task_id: ti for ti in dag_maker.create_dagrun().task_instances}
-        tis["producer_without_inactive"].run(session=session)
-        tis["producer_with_inactive"].run(session=session)
+        dagrun = dag_maker.create_dagrun(session=session)
+        dag_maker.run_ti("producer_without_inactive", dagrun, session=session)
+        dag_maker.run_ti("producer_with_inactive", dagrun, session=session)
 
         producer_events = {
             e.source_task_id: e
@@ -2069,16 +2054,12 @@ class TestTaskInstance:
         # Run "write1", "write2", and "write3" (in this order).
         decision = dr.task_instance_scheduling_decisions(session=session)
         for ti in sorted(decision.schedulable_tis, key=operator.attrgetter("task_id")):
-            # TODO: TaskSDK #45549
-            ti.task = dag_maker.dag.get_task(ti.task_id)
-            ti.run(session=session)
+            run_task_instance(ti, dag_maker.dag.get_task(ti.task_id), session=session)
 
         # Run "read".
         decision = dr.task_instance_scheduling_decisions(session=session)
         for ti in decision.schedulable_tis:
-            # TODO: TaskSDK #45549
-            ti.task = dag_maker.dag.get_task(ti.task_id)
-            ti.run(session=session)
+            run_task_instance(ti, dag_maker.dag.get_task(ti.task_id), session=session)
 
         # Should be done.
         assert not dr.task_instance_scheduling_decisions(session=session).schedulable_tis
@@ -2103,9 +2084,7 @@ class TestTaskInstance:
 
         dr: DagRun = dag_maker.create_dagrun()
         for ti in dr.get_task_instances(session=session):
-            # TODO: TaskSDK #45549
-            ti.task = dag_maker.dag.get_task(ti.task_id)
-            ti.run(session=session)
+            run_task_instance(ti, dag_maker.dag.get_task(ti.task_id), session=session)
 
         # Should be done.
         assert not dr.task_instance_scheduling_decisions(session=session).schedulable_tis
@@ -2137,7 +2116,8 @@ class TestTaskInstance:
             test_task2()
 
         ti = dr1.get_task_instance(task_id="test_task1")
-        ti.run()
+        run_task_instance(ti, dag1.get_task(ti.task_id))
+
         # Change the asset.
         with dag_maker(dag_id="testdag", schedule=[Asset("test2/1")], serialized=True):
 
@@ -2215,196 +2195,6 @@ class TestTaskInstance:
         assert ti_list[3].get_previous_ti(state=State.SUCCESS).run_id == ti_list[1].run_id
 
         assert ti_list[3].get_previous_ti(state=State.SUCCESS).run_id != ti_list[2].run_id
-
-    def test_context_triggering_asset_events_none(self, session, create_task_instance):
-        ti = create_task_instance()
-        template_context = ti.get_template_context()
-
-        assert ti in session
-        session.expunge_all()
-
-        assert template_context["triggering_asset_events"] == {}
-
-    def test_context_triggering_asset_events(self, create_dummy_dag, session):
-        ds1 = AssetModel(id=1, uri="one")
-        ds2 = AssetModel(id=2, uri="two")
-        session.add_all([ds1, ds2])
-        session.commit()
-
-        logical_date = timezone.utcnow()
-        # it's easier to fake a manual run here
-        dag, task1 = create_dummy_dag(
-            dag_id="test_triggering_asset_events",
-            schedule=None,
-            start_date=DEFAULT_DATE,
-            task_id="test_context",
-            with_dagrun_type=DagRunType.MANUAL,
-            session=session,
-        )
-        dr = dag.create_dagrun(
-            run_id="test2",
-            run_type=DagRunType.ASSET_TRIGGERED,
-            logical_date=logical_date,
-            state=DagRunState.RUNNING,
-            session=session,
-            data_interval=(logical_date, logical_date),
-            run_after=logical_date,
-            triggered_by=DagRunTriggeredByType.TEST,
-        )
-        ds1_event = AssetEvent(asset_id=1)
-        ds2_event_1 = AssetEvent(asset_id=2)
-        ds2_event_2 = AssetEvent(asset_id=2)
-        dr.consumed_asset_events.append(ds1_event)
-        dr.consumed_asset_events.append(ds2_event_1)
-        dr.consumed_asset_events.append(ds2_event_2)
-        session.commit()
-
-        ti = dr.get_task_instance(task1.task_id, session=session)
-        ti.refresh_from_task(task1)
-
-        # Check we run this in the same context as the actual task at runtime!
-        assert ti in session
-        session.expunge(ti)
-        session.expunge(dr)
-
-        template_context = ti.get_template_context()
-
-        assert template_context["triggering_asset_events"] == {
-            "one": [ds1_event],
-            "two": [ds2_event_1, ds2_event_2],
-        }
-
-    def test_pendulum_template_dates(self, create_task_instance):
-        ti = create_task_instance(
-            dag_id="test_pendulum_template_dates",
-            task_id="test_pendulum_template_dates_task",
-            schedule="0 12 * * *",
-            serialized=True,
-        )
-
-        template_context = ti.get_template_context()
-
-        assert isinstance(template_context["data_interval_start"], pendulum.DateTime)
-        assert isinstance(template_context["data_interval_end"], pendulum.DateTime)
-
-    def test_template_render(self, create_task_instance, session):
-        ti = create_task_instance(
-            dag_id="test_template_render",
-            task_id="test_template_render_task",
-            schedule="0 12 * * *",
-        )
-        session.add(ti)
-        session.commit()
-        template_context = ti.get_template_context()
-        result = ti.task.render_template("Task: {{ dag.dag_id }} -> {{ task.task_id }}", template_context)
-        assert result == "Task: test_template_render -> test_template_render_task"
-
-    @pytest.mark.parametrize(
-        ("content", "expected_output"),
-        [
-            ('{{ conn.get("a_connection").host }}', "hostvalue"),
-            ('{{ conn.get("a_connection", "unused_fallback").host }}', "hostvalue"),
-            ('{{ conn.get("missing_connection", {"host": "fallback_host"}).host }}', "fallback_host"),
-            ("{{ conn.a_connection.host }}", "hostvalue"),
-            ("{{ conn.a_connection.login }}", "loginvalue"),
-            ("{{ conn.a_connection.password }}", "passwordvalue"),
-            ('{{ conn.a_connection.extra_dejson["extra__asana__workspace"] }}', "extra1"),
-            ("{{ conn.a_connection.extra_dejson.extra__asana__workspace }}", "extra1"),
-        ],
-    )
-    def test_template_with_connection(self, content, expected_output, create_task_instance, session):
-        """
-        Test the availability of variables in templates
-        """
-        with create_session() as session:
-            clear_db_connections(add_default_connections_back=False)
-            merge_conn(
-                Connection(
-                    conn_id="a_connection",
-                    conn_type="a_type",
-                    description="a_conn_description",
-                    host="hostvalue",
-                    login="loginvalue",
-                    password="passwordvalue",
-                    schema="schemavalues",
-                    extra={
-                        "extra__asana__workspace": "extra1",
-                    },
-                ),
-                session,
-            )
-
-        ti = create_task_instance()
-        session.add(ti)
-        session.commit()
-
-        context = ti.get_template_context()
-        result = ti.task.render_template(content, context)
-        assert result == expected_output
-
-    @pytest.mark.parametrize(
-        ("content", "expected_output"),
-        [
-            ("{{ var.value.a_variable }}", "a test value"),
-            ('{{ var.value.get("a_variable") }}', "a test value"),
-            ('{{ var.value.get("a_variable", "unused_fallback") }}', "a test value"),
-            ('{{ var.value.get("missing_variable", "fallback") }}', "fallback"),
-        ],
-    )
-    def test_template_with_variable(self, content, expected_output, create_task_instance, session):
-        """
-        Test the availability of variables in templates
-        """
-        Variable.set("a_variable", "a test value")
-
-        ti = create_task_instance()
-        session.add(ti)
-        session.commit()
-        context = ti.get_template_context()
-        result = ti.task.render_template(content, context)
-        assert result == expected_output
-
-    def test_template_with_variable_missing(self, create_task_instance, session):
-        """
-        Test the availability of variables in templates
-        """
-        ti = create_task_instance()
-        session.add(ti)
-        session.commit()
-        context = ti.get_template_context()
-        with pytest.raises(KeyError):
-            ti.task.render_template('{{ var.value.get("missing_variable") }}', context)
-
-    @pytest.mark.parametrize(
-        ("content", "expected_output"),
-        [
-            ("{{ var.value.a_variable }}", '{\n  "a": {\n    "test": "value"\n  }\n}'),
-            ('{{ var.json.a_variable["a"]["test"] }}', "value"),
-            ('{{ var.json.get("a_variable")["a"]["test"] }}', "value"),
-            ('{{ var.json.get("a_variable", {"a": {"test": "unused_fallback"}})["a"]["test"] }}', "value"),
-            ('{{ var.json.get("missing_variable", {"a": {"test": "fallback"}})["a"]["test"] }}', "fallback"),
-        ],
-    )
-    def test_template_with_json_variable(self, content, expected_output, create_task_instance, session):
-        """
-        Test the availability of variables in templates
-        """
-        Variable.set("a_variable", {"a": {"test": "value"}}, serialize_json=True)
-
-        ti = create_task_instance()
-        session.add(ti)
-        session.commit()
-        context = ti.get_template_context()
-        result = ti.task.render_template(content, context)
-        assert result == expected_output
-
-    def test_template_with_json_variable_missing(self, create_task_instance, session):
-        ti = create_task_instance()
-        session.add(ti)
-        session.commit()
-        context = ti.get_template_context()
-        with pytest.raises(KeyError):
-            ti.task.render_template('{{ var.json.get("missing_variable") }}', context)
 
     @provide_session
     def test_handle_failure_calls_listener(self, dag_maker, session):
@@ -2570,9 +2360,8 @@ class TestTaskInstance:
                 retries=1,
             )
         ti = dag_maker.create_dagrun(logical_date=timezone.utcnow()).task_instances[0]
-        ti.task = task
         with contextlib.suppress(AirflowException):
-            ti.run()
+            run_task_instance(ti, task)
         assert ti.state == State.UP_FOR_RETRY
 
     def _env_var_check_callback(self):
@@ -2659,7 +2448,7 @@ class TestTaskInstance:
             session.merge(ti)
             session.commit()
 
-        mock_task = mock.MagicMock()
+        mock_task = mock.MagicMock(spec=SerializedBaseOperator)
         mock_task.task_id = expected_values["task_id"]
         mock_task.dag_id = expected_values["dag_id"]
 
@@ -2696,7 +2485,7 @@ class TestTaskInstance:
         session.merge(ti)
         session.commit()
         for table in [RenderedTaskInstanceFields]:
-            session.add(table(ti))
+            session.add(table(ti, render_templates=False))
         XComModel.set(key="key", value="value", task_id=ti.task_id, dag_id=ti.dag_id, run_id=ti.run_id)
         session.commit()
         for table in tables:
@@ -2734,8 +2523,7 @@ class TestTaskInstance:
             )
         dr = dag_maker.create_dagrun(logical_date=timezone.utcnow())
         ti = dr.task_instances[0]
-        ti.task = task
-        ti.run()
+        run_task_instance(ti, task)
         assert ti.state == State.SKIPPED
         on_skipped_callback_function.assert_called_once()
         on_success_callback_function.assert_not_called()
@@ -2751,10 +2539,9 @@ class TestTaskInstance:
 
         dr = dag_maker.create_dagrun()
         ti = dr.task_instances[0]
-        ti.task = task
         try_id = ti.id
         with pytest.raises(AirflowException):
-            ti.run()
+            run_task_instance(ti, task)
         ti = session.scalar(select(TaskInstance))
         # the ti.id should be different from the previous one
         assert ti.id != try_id
@@ -2782,10 +2569,9 @@ class TestTaskInstance:
 
         dr = dag_maker.create_dagrun()
         ti = dr.task_instances[0]
-        ti.task = task
         try_id = ti.id
         with pytest.raises(TypeError):
-            ti.run()
+            run_task_instance(ti, task)
         ti = session.scalar(select(TaskInstance))
         assert ti is not None
         # the ti.id should be different from the previous one
@@ -2867,7 +2653,7 @@ class TestTaskInstanceRecordTaskMapXComPush:
             push_something()
 
         ti = next(ti for ti in dag_maker.create_dagrun().task_instances if ti.task_id == "push_something")
-        ti.run()
+        run_task_instance(ti, dag.get_task(ti.task_id))
 
         assert dag_maker.session.scalar(select(func.count()).select_from(TaskMap)) == 0
 
@@ -2887,7 +2673,7 @@ class TestTaskInstanceRecordTaskMapXComPush:
             push_something() >> completely_different()
 
         ti = next(ti for ti in dag_maker.create_dagrun().task_instances if ti.task_id == "push_something")
-        ti.run()
+        run_task_instance(ti, dag.get_task(ti.task_id))
 
         assert dag_maker.session.scalar(select(func.count()).select_from(TaskMap)) == 0
 
@@ -2925,18 +2711,18 @@ class TestTaskInstanceRecordTaskMapXComPush:
             show.partial(arg1=push_1()).expand(arg2=push_2())
             tg.expand(arg=push_4())
 
-        tis = {ti.task_id: ti for ti in dag_maker.create_dagrun().task_instances}
+        dr = dag_maker.create_dagrun()
 
-        tis["push_1"].run()
+        dag_maker.run_ti("push_1", dr)
         assert dag_maker.session.scalar(select(func.count()).select_from(TaskMap)) == 0
 
-        tis["push_2"].run()
+        dag_maker.run_ti("push_2", dr)
         assert dag_maker.session.scalar(select(func.count()).select_from(TaskMap)) == 1
 
-        tis["push_3"].run()
+        dag_maker.run_ti("push_3", dr)
         assert dag_maker.session.scalar(select(func.count()).select_from(TaskMap)) == 1
 
-        tis["push_4"].run()
+        dag_maker.run_ti("push_4", dr)
         assert dag_maker.session.scalar(select(func.count()).select_from(TaskMap)) == 2
 
 
@@ -2957,7 +2743,7 @@ class TestMappedTaskInstanceReceiveValue:
             def show(value):
                 outputs.append(value)
 
-            show_task = show.expand(value=literal).operator
+            show.expand(value=literal)
 
         dag_run = dag_maker.create_dagrun()
         mapped_tis = session.scalars(
@@ -2968,8 +2754,8 @@ class TestMappedTaskInstanceReceiveValue:
         assert len(mapped_tis) == len(literal)
 
         for ti in sorted(mapped_tis, key=operator.attrgetter("map_index")):
-            ti.refresh_from_task(show_task)
-            ti.run()
+            ti.refresh_from_task(dag_maker.serialized_dag.get_task("show"))
+            run_task_instance(ti, dag_maker.dag.get_task("show"))
         assert outputs == expected_outputs
 
     @pytest.mark.parametrize(
@@ -2996,13 +2782,11 @@ class TestMappedTaskInstanceReceiveValue:
 
         dag_run = dag_maker.create_dagrun()
         emit_ti = dag_run.get_task_instance("emit", session=session)
-        emit_ti.refresh_from_task(dag_maker.dag.get_task("emit"))
+        emit_ti.refresh_from_task(dag_maker.serialized_dag.get_task("emit"))
         dag_maker.run_ti(emit_ti.task_id, dag_run=dag_run, session=session)
 
-        show_task = dag.get_task("show")
-        mapped_tis, max_map_index = TaskMap.expand_mapped_task(
-            dag.task_dict[show_task.task_id], dag_run.run_id, session=session
-        )
+        show_task = dag_maker.serialized_dag.get_task("show")
+        mapped_tis, max_map_index = TaskMap.expand_mapped_task(show_task, dag_run.run_id, session=session)
         assert max_map_index + 1 == len(mapped_tis) == len(upstream_return)
 
         for ti in sorted(mapped_tis, key=operator.attrgetter("map_index")):

--- a/airflow-core/tests/unit/models/test_taskmap.py
+++ b/airflow-core/tests/unit/models/test_taskmap.py
@@ -21,16 +21,17 @@ from unittest import mock
 
 import pytest
 
-from airflow.models.taskinstance import TaskInstance
 from airflow.models.taskmap import TaskMap, TaskMapVariant
 from airflow.providers.standard.operators.empty import EmptyOperator
+
+from tests_common.test_utils.taskinstance import create_task_instance
 
 pytestmark = pytest.mark.db_test
 
 
 def test_task_map_from_task_instance_xcom():
     task = EmptyOperator(task_id="test_task")
-    ti = TaskInstance(task=task, run_id="test_run", map_index=0, dag_version_id=mock.MagicMock())
+    ti = create_task_instance(task=task, run_id="test_run", map_index=0, dag_version_id=mock.MagicMock())
     ti.dag_id = "test_dag"
     value = {"key1": "value1", "key2": "value2"}
 
@@ -51,7 +52,7 @@ def test_task_map_from_task_instance_xcom():
 
 def test_task_map_with_invalid_task_instance():
     task = EmptyOperator(task_id="test_task")
-    ti = TaskInstance(task=task, run_id=None, map_index=0, dag_version_id=mock.MagicMock())
+    ti = create_task_instance(task=task, run_id=None, map_index=0, dag_version_id=mock.MagicMock())
     ti.dag_id = "test_dag"
 
     # Define some arbitrary XCom-like value data

--- a/airflow-core/tests/unit/ti_deps/deps/test_dag_ti_slots_available_dep.py
+++ b/airflow-core/tests/unit/ti_deps/deps/test_dag_ti_slots_available_dep.py
@@ -23,6 +23,7 @@ from unittest.mock import Mock
 import pytest
 
 from airflow.models import TaskInstance
+from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
 from airflow.ti_deps.deps.dag_ti_slots_available_dep import DagTISlotsAvailableDep
 
 pytestmark = pytest.mark.db_test
@@ -34,7 +35,9 @@ class TestDagTISlotsAvailableDep:
         Test max_active_tasks reached should fail dep
         """
         dag = Mock(concurrency=1, get_concurrency_reached=Mock(return_value=True))
-        task = Mock(dag=dag, pool_slots=1)
+        task = SerializedBaseOperator(task_id="op")
+        task.dag = dag
+        task.pool_slots = 1
         ti = TaskInstance(task, dag_version_id=mock.MagicMock())
 
         assert not DagTISlotsAvailableDep().is_met(ti=ti)
@@ -44,7 +47,9 @@ class TestDagTISlotsAvailableDep:
         Test all conditions met should pass dep
         """
         dag = Mock(concurrency=1, get_concurrency_reached=Mock(return_value=False))
-        task = Mock(dag=dag, pool_slots=1)
+        task = SerializedBaseOperator(task_id="op")
+        task.dag = dag
+        task.pool_slots = 1
         ti = TaskInstance(task, dag_version_id=mock.MagicMock())
 
         assert DagTISlotsAvailableDep().is_met(ti=ti)

--- a/airflow-core/tests/unit/ti_deps/deps/test_dag_unpaused_dep.py
+++ b/airflow-core/tests/unit/ti_deps/deps/test_dag_unpaused_dep.py
@@ -22,6 +22,7 @@ from unittest import mock
 import pytest
 
 from airflow.models import TaskInstance
+from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
 from airflow.ti_deps.deps.dag_unpaused_dep import DagUnpausedDep
 
 pytestmark = pytest.mark.db_test
@@ -34,7 +35,7 @@ class TestDagUnpausedDep:
         Test paused DAG should fail dependency
         """
         mock_is_dag_paused.return_value = True
-        task = mock.Mock()
+        task = SerializedBaseOperator(task_id="op")
         ti = TaskInstance(task=task, dag_version_id=mock.MagicMock())
 
         assert not DagUnpausedDep().is_met(ti=ti)
@@ -44,7 +45,7 @@ class TestDagUnpausedDep:
         Test all conditions met should pass dep
         """
         mock_is_dag_paused.return_value = False
-        task = mock.Mock()
+        task = SerializedBaseOperator(task_id="op")
         ti = TaskInstance(task=task, dag_version_id=mock.MagicMock())
 
         assert DagUnpausedDep().is_met(ti=ti)

--- a/airflow-core/tests/unit/ti_deps/deps/test_not_in_retry_period_dep.py
+++ b/airflow-core/tests/unit/ti_deps/deps/test_not_in_retry_period_dep.py
@@ -19,13 +19,13 @@ from __future__ import annotations
 
 from datetime import timedelta
 from unittest import mock
-from unittest.mock import Mock
 
 import pytest
 import time_machine
 
 from airflow._shared.timezones.timezone import datetime
 from airflow.models import TaskInstance
+from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
 from airflow.ti_deps.deps.not_in_retry_period_dep import NotInRetryPeriodDep
 from airflow.utils.state import State
 
@@ -34,7 +34,9 @@ pytestmark = pytest.mark.db_test
 
 class TestNotInRetryPeriodDep:
     def _get_task_instance(self, state, end_date=None, retry_delay=timedelta(minutes=15)):
-        task = Mock(retry_delay=retry_delay, retry_exponential_backoff=0)
+        task = SerializedBaseOperator(task_id="fake")
+        task.retry_delay = retry_delay
+        task.retry_exponential_backoff = 0
         ti = TaskInstance(task=task, state=state, dag_version_id=mock.MagicMock())
         ti.end_date = end_date
         return ti

--- a/airflow-core/tests/unit/utils/log/test_log_reader.py
+++ b/airflow-core/tests/unit/utils/log/test_log_reader.py
@@ -309,7 +309,7 @@ class TestLogView:
         def echo_run_type(dag_run: DagRun, **kwargs):
             print(dag_run.run_type)
 
-        with dag_maker(dag_id, start_date=self.DEFAULT_DATE, schedule="@daily") as dag:
+        with dag_maker(dag_id, start_date=self.DEFAULT_DATE, schedule="@daily"):
             PythonOperator(task_id=task_id, python_callable=echo_run_type)
 
         start = pendulum.datetime(2021, 1, 1)
@@ -334,8 +334,8 @@ class TestLogView:
         assert scheduled_ti is not None
         assert manual_ti is not None
 
-        scheduled_ti.refresh_from_task(dag.get_task(task_id))
-        manual_ti.refresh_from_task(dag.get_task(task_id))
+        scheduled_ti.refresh_from_task(dag_maker.serialized_dag.get_task(task_id))
+        manual_ti.refresh_from_task(dag_maker.serialized_dag.get_task(task_id))
 
         reader = TaskLogReader()
         assert reader.render_log_filename(scheduled_ti, 1) != reader.render_log_filename(manual_ti, 1)

--- a/airflow-core/tests/unit/utils/test_db_cleanup.py
+++ b/airflow-core/tests/unit/utils/test_db_cleanup.py
@@ -676,6 +676,8 @@ class TestDBCleanup:
 
 
 def create_tis(base_date, num_tis, run_type=DagRunType.SCHEDULED):
+    from tests_common.test_utils.taskinstance import create_task_instance
+
     with create_session() as session:
         bundle_name = "testing"
         session.add(DagBundleModel(name=bundle_name))
@@ -695,7 +697,7 @@ def create_tis(base_date, num_tis, run_type=DagRunType.SCHEDULED):
                 run_type=run_type,
                 start_date=start_date,
             )
-            ti = TaskInstance(
+            ti = create_task_instance(
                 PythonOperator(task_id="dummy-task", python_callable=print),
                 run_id=dag_run.run_id,
                 dag_version_id=dag_version.id,

--- a/airflow-core/tests/unit/utils/test_log_handlers.py
+++ b/airflow-core/tests/unit/utils/test_log_handlers.py
@@ -43,7 +43,6 @@ from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONF
 from airflow.executors import executor_constants, executor_loader
 from airflow.jobs.job import Job
 from airflow.jobs.triggerer_job_runner import TriggererJobRunner
-from airflow.models.dag_version import DagVersion
 from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance
 from airflow.models.taskinstancehistory import TaskInstanceHistory
@@ -124,14 +123,13 @@ class TestFileTaskLogHandler:
             ti.log.info("test")
 
         with dag_maker("dag_for_testing_file_task_handler", schedule=None):
-            task = PythonOperator(
+            PythonOperator(
                 task_id="task_for_testing_file_log_handler",
                 python_callable=task_callable,
             )
 
         dagrun = dag_maker.create_dagrun()
-        dag_version = DagVersion.get_latest_version(dagrun.dag_id)
-        ti = TaskInstance(task=task, run_id=dagrun.run_id, dag_version_id=dag_version.id)
+        ti = dagrun.task_instances[0]
 
         logger = ti.log
         ti.log.disabled = False
@@ -172,13 +170,12 @@ class TestFileTaskLogHandler:
             ti.log.info("test")
 
         with dag_maker("dag_for_testing_file_task_handler", schedule=None):
-            task = PythonOperator(
+            PythonOperator(
                 task_id="task_for_testing_file_log_handler",
                 python_callable=task_callable,
             )
         dagrun = dag_maker.create_dagrun()
-        dag_version = DagVersion.get_latest_version(dagrun.dag_id)
-        ti = TaskInstance(task=task, run_id=dagrun.run_id, dag_version_id=dag_version.id)
+        ti = dagrun.task_instances[0]
 
         ti.try_number = 0
         ti.state = ti_state
@@ -344,13 +341,12 @@ class TestFileTaskLogHandler:
             ti.log.info("test")
 
         with dag_maker("dag_for_testing_file_task_handler", schedule=None):
-            task = PythonOperator(
+            PythonOperator(
                 task_id="task_for_testing_file_log_handler",
                 python_callable=task_callable,
             )
         dagrun = dag_maker.create_dagrun()
-        dag_version = DagVersion.get_latest_version(dagrun.dag_id)
-        ti = TaskInstance(task=task, run_id=dagrun.run_id, dag_version_id=dag_version.id)
+        ti = dagrun.task_instances[0]
 
         ti.try_number = 2
         ti.state = State.RUNNING
@@ -396,13 +392,12 @@ class TestFileTaskLogHandler:
         update_conf = {"handlers": {"task": {"max_bytes": max_bytes_size, "backup_count": 1}}}
         reset_log_config(update_conf)
         with dag_maker("dag_for_testing_file_task_handler_rotate_size_limit"):
-            task = PythonOperator(
+            PythonOperator(
                 task_id="task_for_testing_file_log_handler_rotate_size_limit",
                 python_callable=task_callable,
             )
         dagrun = dag_maker.create_dagrun()
-        dag_version = DagVersion.get_latest_version(dagrun.dag_id)
-        ti = TaskInstance(task=task, run_id=dagrun.run_id, dag_version_id=dag_version.id)
+        ti = dagrun.task_instances[0]
 
         ti.try_number = 1
         ti.state = State.RUNNING

--- a/devel-common/src/tests_common/pytest_plugin.py
+++ b/devel-common/src/tests_common/pytest_plugin.py
@@ -1124,7 +1124,7 @@ def dag_maker(request) -> Generator[DagMaker, None, None]:
             self.dag_run = dag.create_dagrun(**kwargs)
             for ti in self.dag_run.task_instances:
                 # This need to always operate on the _real_ dag
-                ti.refresh_from_task(self.dag.get_task(ti.task_id))
+                ti.refresh_from_task(self._serialized_dag().get_task(ti.task_id))
             self.session.commit()
             return self.dag_run
 
@@ -1167,7 +1167,7 @@ def dag_maker(request) -> Generator[DagMaker, None, None]:
                     f"Task instance with task_id '{task_id}' not found in dag run. "
                     f"Available task_ids: {available_task_ids}"
                 )
-            task = self.dag.get_task(ti.task_id)
+            task = self._serialized_dag().get_task(ti.task_id)
 
             if not AIRFLOW_V_3_1_PLUS:
                 # Airflow <3.1 has a bug for DecoratedOperator has an unused signature for

--- a/devel-common/src/tests_common/test_utils/compat.py
+++ b/devel-common/src/tests_common/test_utils/compat.py
@@ -40,10 +40,15 @@ except ImportError:
     from airflow.models.baseoperator import BaseOperatorLink  # type: ignore[no-redef]
 
 try:
+    from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
     from airflow.serialization.definitions.dag import SerializedDAG
+    from airflow.serialization.definitions.mappedoperator import SerializedMappedOperator
     from airflow.serialization.serialized_objects import DagSerialization, OperatorSerialization
 except ImportError:
     # Compatibility for Airflow < 3.2.*
+    from airflow.models.mappedoperator import (  # type: ignore[no-redef]
+        MappedOperator as SerializedMappedOperator,
+    )
     from airflow.serialization.serialized_objects import (  # type: ignore[no-redef]
         SerializedBaseOperator,
         SerializedDAG,

--- a/devel-common/src/tests_common/test_utils/mock_context.py
+++ b/devel-common/src/tests_common/test_utils/mock_context.py
@@ -16,12 +16,12 @@
 # under the License.
 from __future__ import annotations
 
-import inspect
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 from unittest import mock
 
 from tests_common.test_utils.compat import Context
+from tests_common.test_utils.taskinstance import create_task_instance
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -30,37 +30,14 @@ if TYPE_CHECKING:
 def mock_context(task) -> Context:
     from airflow.models import TaskInstance
     from airflow.utils.session import NEW_SESSION
-    from airflow.utils.state import TaskInstanceState
 
     from tests_common.test_utils.compat import XCOM_RETURN_KEY
 
     values: dict[str, Any] = {}
 
     class MockedTaskInstance(TaskInstance):
-        def __init__(
-            self,
-            task,
-            run_id: str | None = "run_id",
-            state: str | None = TaskInstanceState.RUNNING,
-            map_index: int = -1,
-        ):
-            # Inspect the parameters of TaskInstance.__init__
-            init_sig = inspect.signature(super().__init__)
-            if "dag_version_id" in init_sig.parameters:
-                super().__init__(
-                    task=task,
-                    run_id=run_id,
-                    state=state,
-                    map_index=map_index,
-                    dag_version_id=mock.MagicMock(),
-                )
-            else:
-                super().__init__(
-                    task=task,
-                    run_id=run_id,
-                    state=state,
-                    map_index=map_index,
-                )  # type: ignore[call-arg]
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
             self.values: dict[str, Any] = {}
 
         def xcom_pull(
@@ -86,7 +63,7 @@ def mock_context(task) -> Context:
                 key += f"_{self.map_index}"
             values[key] = value
 
-    values["ti"] = MockedTaskInstance(task=task)
+    values["ti"] = create_task_instance(task, dag_version_id=mock.MagicMock(), ti_type=MockedTaskInstance)
 
     # See https://github.com/python/mypy/issues/8890 - mypy does not support passing typed dict to TypedDict
     return Context(values)  # type: ignore[misc]

--- a/devel-common/src/tests_common/test_utils/taskinstance.py
+++ b/devel-common/src/tests_common/test_utils/taskinstance.py
@@ -1,0 +1,84 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from airflow.models.taskinstance import TaskInstance
+from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
+from airflow.serialization.definitions.mappedoperator import SerializedMappedOperator
+from airflow.serialization.serialized_objects import create_scheduler_operator
+
+from tests_common.test_utils.dag import create_scheduler_dag
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from airflow.sdk.types import Operator as SdkOperator
+    from airflow.serialization.definitions.mappedoperator import Operator as SerializedOperator
+
+__all__ = ["create_task_instance", "run_task_instance"]
+
+
+def create_task_instance(
+    task: SdkOperator | SerializedOperator,
+    *,
+    dag_version_id: UUID,
+    run_id: str | None = None,
+    state: str | None = None,
+    map_index: int = -1,
+) -> TaskInstance:
+    if isinstance(task, (SerializedBaseOperator, SerializedMappedOperator)):
+        serialized_task = task
+    elif sdk_dag := task.get_dag():
+        serialized_task = create_scheduler_dag(sdk_dag).get_task(task.task_id)
+    else:
+        serialized_task = create_scheduler_operator(task)
+    return TaskInstance(
+        serialized_task,
+        dag_version_id=dag_version_id,
+        run_id=run_id,
+        state=state,
+        map_index=map_index,
+    )
+
+
+def run_task_instance(
+    ti: TaskInstance,
+    task: SdkOperator,
+    *,
+    ignore_depends_on_past: bool = False,
+    ignore_ti_state: bool = False,
+    mark_success: bool = False,
+    session=None,
+) -> None:
+    kwargs = {"session": session} if session else {}
+    if not ti.check_and_change_state_before_execution(
+        ignore_depends_on_past=ignore_depends_on_past,
+        ignore_ti_state=ignore_ti_state,
+        mark_success=mark_success,
+        **kwargs,
+    ):
+        return
+
+    from airflow.sdk.definitions.dag import _run_task
+
+    if (taskrun_result := _run_task(ti=ti, task=task)) and (error := taskrun_result.error):
+        raise error from error
+    return

--- a/kubernetes-tests/tests/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes-tests/tests/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -37,7 +37,6 @@ from airflow.exceptions import AirflowException, AirflowSkipException
 from airflow.models.connection import Connection
 from airflow.models.dag import DAG
 from airflow.models.dagrun import DagRun
-from airflow.models.taskinstance import TaskInstance
 from airflow.providers.cncf.kubernetes.hooks.kubernetes import KubernetesHook
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from airflow.providers.cncf.kubernetes.utils.pod_manager import OnFinishAction, PodManager
@@ -46,6 +45,8 @@ from airflow.utils import timezone
 from airflow.utils.types import DagRunType
 from airflow.version import version as airflow_version
 from kubernetes_tests.test_base import BaseK8STest, StringContainingId
+
+from tests_common.test_utils.taskinstance import create_task_instance
 
 HOOK_CLASS = "airflow.providers.cncf.kubernetes.operators.pod.KubernetesHook"
 POD_MANAGER_CLASS = "airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager"
@@ -76,10 +77,7 @@ def create_context(task) -> Context:
                 logical_date=logical_date,
             ),
         )
-    if AIRFLOW_V_3_0_PLUS:
-        task_instance = TaskInstance(task=task, run_id=dag_run.run_id, dag_version_id=mock.MagicMock())
-    else:
-        task_instance = TaskInstance(task=task)
+    task_instance = create_task_instance(task=task, run_id=dag_run.run_id, dag_version_id=mock.MagicMock())
     task_instance.dag_run = dag_run
     task_instance.dag_id = dag.dag_id
     task_instance.try_number = 1

--- a/providers/amazon/tests/unit/amazon/aws/log/test_cloudwatch_task_handler.py
+++ b/providers/amazon/tests/unit/amazon/aws/log/test_cloudwatch_task_handler.py
@@ -46,6 +46,7 @@ from tests_common.test_utils.compat import EmptyOperator
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.db import clear_db_dag_bundles, clear_db_dags, clear_db_runs
+from tests_common.test_utils.taskinstance import create_task_instance
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_2_PLUS
 
 
@@ -221,7 +222,7 @@ class TestCloudwatchTaskHandler:
             from airflow.models.dag_version import DagVersion
 
             dag_version = DagVersion.get_latest_version(self.dag.dag_id, session=session)
-            self.ti = TaskInstance(task=task, run_id=dag_run.run_id, dag_version_id=dag_version.id)
+            self.ti = create_task_instance(task=task, run_id=dag_run.run_id, dag_version_id=dag_version.id)
         else:
             self.ti = TaskInstance(task=task, run_id=dag_run.run_id)
         self.ti.dag_run = dag_run

--- a/providers/amazon/tests/unit/amazon/aws/log/test_s3_task_handler.py
+++ b/providers/amazon/tests/unit/amazon/aws/log/test_s3_task_handler.py
@@ -37,6 +37,7 @@ from tests_common.test_utils.compat import EmptyOperator
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.db import clear_db_dag_bundles, clear_db_dags, clear_db_runs
+from tests_common.test_utils.taskinstance import create_task_instance
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 try:
@@ -98,7 +99,7 @@ class TestS3RemoteLogIO:
             from airflow.models.dag_version import DagVersion
 
             dag_version = DagVersion.get_latest_version(self.dag.dag_id)
-            self.ti = TaskInstance(task=task, dag_version_id=dag_version.id)
+            self.ti = create_task_instance(task=task, dag_version_id=dag_version.id)
         else:
             self.ti = TaskInstance(task=task, run_id=dag_run.run_id)
         self.ti.dag_run = dag_run
@@ -240,7 +241,7 @@ class TestS3TaskHandler:
             from airflow.models.dag_version import DagVersion
 
             dag_version = DagVersion.get_latest_version(self.dag.dag_id)
-            self.ti = TaskInstance(task=task, run_id=dag_run.run_id, dag_version_id=dag_version.id)
+            self.ti = create_task_instance(task=task, run_id=dag_run.run_id, dag_version_id=dag_version.id)
         else:
             self.ti = TaskInstance(task=task, run_id=dag_run.run_id)
         self.ti.dag_run = dag_run

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_athena.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_athena.py
@@ -42,6 +42,7 @@ from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.dag import sync_dag_to_db
+from tests_common.test_utils.taskinstance import create_task_instance
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 from unit.amazon.aws.utils.test_template_fields import validate_template_fields
 
@@ -251,7 +252,7 @@ class TestAthenaOperator:
 
             sync_dag_to_db(self.dag)
             dag_version = DagVersion.get_latest_version(self.dag.dag_id)
-            ti = TaskInstance(task=self.athena, dag_version_id=dag_version.id)
+            ti = create_task_instance(task=self.athena, dag_version_id=dag_version.id)
             dag_run = DagRun(
                 dag_id=self.dag.dag_id,
                 logical_date=timezone.utcnow(),

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_base_aws.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_base_aws.py
@@ -24,11 +24,6 @@ from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from airflow.providers.amazon.aws.operators.base_aws import AwsBaseOperator
 from airflow.providers.common.compat.sdk import BaseHook
 
-try:
-    from airflow.sdk import timezone
-except ImportError:
-    from airflow.utils import timezone  # type: ignore[attr-defined,no-redef]
-
 TEST_CONN = "aws_test_conn"
 
 
@@ -120,9 +115,7 @@ class TestAwsBaseOperator:
         with dag_maker("test_aws_base_operator", serialized=True):
             FakeS3Operator(task_id="fake-task-id", **op_kwargs)
 
-        dagrun = dag_maker.create_dagrun(logical_date=timezone.utcnow())
-        tis = {ti.task_id: ti for ti in dagrun.task_instances}
-        tis["fake-task-id"].run()
+        dag_maker.run_ti("fake-task-id")
 
     def test_no_aws_hook_class_attr(self):
         class NoAwsHookClassOperator(AwsBaseOperator): ...

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_datasync.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_datasync.py
@@ -31,6 +31,7 @@ from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.dag import sync_dag_to_db
+from tests_common.test_utils.taskinstance import create_task_instance
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 from unit.amazon.aws.utils.test_template_fields import validate_template_fields
 
@@ -372,7 +373,7 @@ class TestDataSyncOperatorCreate(DataSyncTestCaseBase):
                 run_type=DagRunType.MANUAL,
                 state=DagRunState.RUNNING,
             )
-            ti = TaskInstance(task=self.datasync, dag_version_id=dag_version.id)
+            ti = create_task_instance(task=self.datasync, dag_version_id=dag_version.id)
         else:
             dag_run = DagRun(
                 dag_id=self.dag.dag_id,
@@ -586,7 +587,7 @@ class TestDataSyncOperatorGetTasks(DataSyncTestCaseBase):
 
             sync_dag_to_db(self.dag)
             dag_version = DagVersion.get_latest_version(self.dag.dag_id)
-            ti = TaskInstance(task=self.datasync, dag_version_id=dag_version.id)
+            ti = create_task_instance(task=self.datasync, dag_version_id=dag_version.id)
             dag_run = DagRun(
                 dag_id=self.dag.dag_id,
                 logical_date=timezone.utcnow(),
@@ -709,7 +710,7 @@ class TestDataSyncOperatorUpdate(DataSyncTestCaseBase):
 
             sync_dag_to_db(self.dag)
             dag_version = DagVersion.get_latest_version(self.dag.dag_id)
-            ti = TaskInstance(task=self.datasync, dag_version_id=dag_version.id)
+            ti = create_task_instance(task=self.datasync, dag_version_id=dag_version.id)
             dag_run = DagRun(
                 dag_id=self.dag.dag_id,
                 logical_date=timezone.utcnow(),
@@ -925,7 +926,7 @@ class TestDataSyncOperator(DataSyncTestCaseBase):
 
             sync_dag_to_db(self.dag)
             dag_version = DagVersion.get_latest_version(self.dag.dag_id)
-            ti = TaskInstance(task=self.datasync, dag_version_id=dag_version.id)
+            ti = create_task_instance(task=self.datasync, dag_version_id=dag_version.id)
             dag_run = DagRun(
                 dag_id=self.dag.dag_id,
                 logical_date=timezone.utcnow(),
@@ -1044,7 +1045,7 @@ class TestDataSyncOperatorDelete(DataSyncTestCaseBase):
 
             sync_dag_to_db(self.dag)
             dag_version = DagVersion.get_latest_version(self.dag.dag_id)
-            ti = TaskInstance(task=self.datasync, dag_version_id=dag_version.id)
+            ti = create_task_instance(task=self.datasync, dag_version_id=dag_version.id)
             dag_run = DagRun(
                 dag_id=self.dag.dag_id,
                 logical_date=timezone.utcnow(),

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_emr_add_steps.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_emr_add_steps.py
@@ -29,15 +29,12 @@ from airflow.models import DAG, DagRun, TaskInstance
 from airflow.providers.amazon.aws.operators.emr import EmrAddStepsOperator
 from airflow.providers.amazon.aws.triggers.emr import EmrAddStepsTrigger
 from airflow.providers.common.compat.sdk import AirflowException, TaskDeferred
-
-try:
-    from airflow.sdk import timezone
-except ImportError:
-    from airflow.utils import timezone  # type: ignore[attr-defined,no-redef]
 from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunType
 
+from tests_common.test_utils.compat import timezone
 from tests_common.test_utils.dag import sync_dag_to_db
+from tests_common.test_utils.taskinstance import create_task_instance, render_template_fields
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 from unit.amazon.aws.utils.test_template_fields import validate_template_fields
 
@@ -110,13 +107,14 @@ class TestEmrAddStepsOperator:
 
             sync_dag_to_db(self.operator.dag)
             dag_version = DagVersion.get_latest_version(self.operator.dag.dag_id)
-            ti = TaskInstance(task=self.operator, dag_version_id=dag_version.id)
+            ti = create_task_instance(task=self.operator, dag_version_id=dag_version.id)
             dag_run = DagRun(
                 dag_id=self.operator.dag.dag_id,
                 logical_date=DEFAULT_DATE,
                 run_id="test",
                 run_type=DagRunType.MANUAL,
                 state=DagRunState.RUNNING,
+                run_after=timezone.utcnow(),
             )
         else:
             dag_run = DagRun(
@@ -128,9 +126,7 @@ class TestEmrAddStepsOperator:
             )
             ti = TaskInstance(task=self.operator)
         ti.dag_run = dag_run
-        session.add(ti)
-        session.commit()
-        ti.render_templates()
+        render_template_fields(ti, self.operator)
 
         expected_args = [
             {
@@ -184,13 +180,14 @@ class TestEmrAddStepsOperator:
 
             sync_dag_to_db(dag)
             dag_version = DagVersion.get_latest_version(dag.dag_id)
-            ti = TaskInstance(task=test_task, dag_version_id=dag_version.id)
+            ti = create_task_instance(task=test_task, dag_version_id=dag_version.id)
             dag_run = DagRun(
                 dag_id=dag.dag_id,
                 logical_date=timezone.utcnow(),
                 run_id="test",
                 run_type=DagRunType.MANUAL,
                 state=DagRunState.RUNNING,
+                run_after=timezone.utcnow(),
             )
         else:
             dag_run = DagRun(
@@ -202,9 +199,7 @@ class TestEmrAddStepsOperator:
             )
             ti = TaskInstance(task=test_task)
         ti.dag_run = dag_run
-        session.add(ti)
-        session.commit()
-        ti.render_templates()
+        render_template_fields(ti, test_task)
 
         assert json.loads(test_task.steps) == file_steps
 

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_emr_create_job_flow.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_emr_create_job_flow.py
@@ -36,6 +36,7 @@ from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.dag import sync_dag_to_db
+from tests_common.test_utils.taskinstance import create_task_instance, render_template_fields
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 from unit.amazon.aws.utils.test_template_fields import validate_template_fields
 from unit.amazon.aws.utils.test_waiter import assert_expected_waiter_type
@@ -110,13 +111,14 @@ class TestEmrCreateJobFlowOperator:
 
             sync_dag_to_db(self.operator.dag)
             dag_version = DagVersion.get_latest_version(self.operator.dag.dag_id)
-            ti = TaskInstance(task=self.operator, dag_version_id=dag_version.id)
+            ti = create_task_instance(task=self.operator, dag_version_id=dag_version.id)
             dag_run = DagRun(
                 dag_id=self.operator.dag_id,
                 logical_date=DEFAULT_DATE,
                 run_id="test",
                 run_type=DagRunType.MANUAL,
                 state=DagRunState.RUNNING,
+                run_after=timezone.utcnow(),
             )
         else:
             dag_run = DagRun(
@@ -128,9 +130,7 @@ class TestEmrCreateJobFlowOperator:
             )
             ti = TaskInstance(task=self.operator)
         ti.dag_run = dag_run
-        session.add(ti)
-        session.commit()
-        ti.render_templates()
+        render_template_fields(ti, self.operator)
 
         expected_args = {
             "Name": "test_job_flow",
@@ -165,13 +165,14 @@ class TestEmrCreateJobFlowOperator:
 
             sync_dag_to_db(self.operator.dag)
             dag_version = DagVersion.get_latest_version(self.operator.dag.dag_id)
-            ti = TaskInstance(task=self.operator, dag_version_id=dag_version.id)
+            ti = create_task_instance(task=self.operator, dag_version_id=dag_version.id)
             dag_run = DagRun(
                 dag_id=self.operator.dag_id,
                 logical_date=DEFAULT_DATE,
                 run_id="test",
                 run_type=DagRunType.MANUAL,
                 state=DagRunState.RUNNING,
+                run_after=timezone.utcnow(),
             )
         else:
             dag_run = DagRun(
@@ -183,9 +184,7 @@ class TestEmrCreateJobFlowOperator:
             )
             ti = TaskInstance(task=self.operator)
         ti.dag_run = dag_run
-        session.add(ti)
-        session.commit()
-        ti.render_templates()
+        render_template_fields(ti, self.operator)
 
         mocked_hook_client.run_job_flow.return_value = RUN_JOB_FLOW_SUCCESS_RETURN
 

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_sagemaker_base.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_sagemaker_base.py
@@ -34,6 +34,7 @@ from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.dag import sync_dag_to_db
+from tests_common.test_utils.taskinstance import create_task_instance, render_template_fields
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 from unit.amazon.aws.utils.test_template_fields import validate_template_fields
 
@@ -220,13 +221,14 @@ class TestSageMakerExperimentOperator:
 
             sync_dag_to_db(dag)
             dag_version = DagVersion.get_latest_version(dag.dag_id)
-            ti = TaskInstance(task=op, dag_version_id=dag_version.id)
+            ti = create_task_instance(task=op, dag_version_id=dag_version.id)
             dag_run = DagRun(
                 dag_id=dag.dag_id,
                 logical_date=logical_date,
                 run_id="test",
                 run_type=DagRunType.MANUAL,
                 state=DagRunState.RUNNING,
+                run_after=timezone.utcnow(),
             )
         else:
             dag_run = DagRun(
@@ -238,12 +240,9 @@ class TestSageMakerExperimentOperator:
             )
             ti = TaskInstance(task=op)
         ti.dag_run = dag_run
-        session.add(ti)
-        session.commit()
-        context = ti.get_template_context()
-        ti.render_templates(context)
+        rendered = render_template_fields(ti, op)
 
-        ret = op.execute(None)
+        ret = rendered.execute(None)
 
         assert ret == "abcdef"
         conn_mock().create_experiment.assert_called_once_with(

--- a/providers/amazon/tests/unit/amazon/aws/sensors/test_base_aws.py
+++ b/providers/amazon/tests/unit/amazon/aws/sensors/test_base_aws.py
@@ -24,11 +24,6 @@ from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from airflow.providers.amazon.aws.sensors.base_aws import AwsBaseSensor
 from airflow.providers.common.compat.sdk import BaseHook
 
-try:
-    from airflow.sdk import timezone
-except ImportError:
-    from airflow.utils import timezone  # type: ignore[attr-defined,no-redef]
-
 TEST_CONN = "aws_test_conn"
 
 
@@ -121,10 +116,7 @@ class TestAwsBaseSensor:
     def test_execute(self, dag_maker, op_kwargs):
         with dag_maker("test_aws_base_sensor", serialized=True):
             FakeDynamoDBSensor(task_id="fake-task-id", **op_kwargs, poke_interval=1)
-
-        dagrun = dag_maker.create_dagrun(logical_date=timezone.utcnow())
-        tis = {ti.task_id: ti for ti in dagrun.task_instances}
-        tis["fake-task-id"].run()
+        dag_maker.run_ti("fake-task-id")
 
     def test_no_aws_hook_class_attr(self):
         class NoAwsHookClassSensor(AwsBaseSensor): ...

--- a/providers/amazon/tests/unit/amazon/aws/sensors/test_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/sensors/test_s3.py
@@ -33,6 +33,7 @@ from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.dag import sync_dag_to_db
+from tests_common.test_utils.taskinstance import create_task_instance, render_template_fields
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 try:
@@ -146,8 +147,9 @@ class TestS3KeySensor:
                 run_id="test",
                 run_type=DagRunType.MANUAL,
                 state=DagRunState.RUNNING,
+                run_after=timezone.utcnow(),
             )
-            ti = TaskInstance(task=op, dag_version_id=dag_version.id)
+            ti = create_task_instance(task=op, dag_version_id=dag_version.id)
         else:
             dag_run = DagRun(
                 dag_id=dag.dag_id,
@@ -158,11 +160,8 @@ class TestS3KeySensor:
             )
             ti = TaskInstance(task=op)
         ti.dag_run = dag_run
-        session.add(ti)
-        session.commit()
-        context = ti.get_template_context(session)
-        ti.render_templates(context)
-        op.poke(None)
+        rendered = render_template_fields(ti, op)
+        rendered.poke(None)
 
         mock_head_object.assert_called_once_with("key", "bucket")
 
@@ -205,14 +204,12 @@ class TestS3KeySensor:
                 run_id="test",
                 run_type=DagRunType.MANUAL,
                 state=DagRunState.RUNNING,
+                run_after=timezone.utcnow(),
             )
-            ti = TaskInstance(task=op, dag_version_id=dag_version.id)
+            ti = create_task_instance(task=op, dag_version_id=dag_version.id)
         ti.dag_run = dag_run
-        session.add(ti)
-        session.commit()
-        context = ti.get_template_context(session)
-        ti.render_templates(context)
-        op.poke(None)
+        rendered = render_template_fields(ti, op)
+        rendered.poke(None)
 
         mock_head_object.assert_any_call("file1", "bucket")
         mock_head_object.assert_any_call("file2", "bucket")

--- a/providers/amazon/tests/unit/amazon/aws/transfers/test_dynamodb_to_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/transfers/test_dynamodb_to_s3.py
@@ -27,15 +27,12 @@ import pytest
 from airflow import DAG
 from airflow.models import DagRun, TaskInstance
 from airflow.providers.amazon.aws.transfers.dynamodb_to_s3 import DynamoDBToS3Operator, JSONEncoder
-
-try:
-    from airflow.sdk import timezone
-except ImportError:
-    from airflow.utils import timezone  # type: ignore[attr-defined,no-redef]
 from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunType
 
+from tests_common.test_utils.compat import timezone
 from tests_common.test_utils.dag import sync_dag_to_db
+from tests_common.test_utils.taskinstance import create_task_instance, render_template_fields
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 
@@ -282,7 +279,7 @@ class TestDynamodbToS3:
 
             sync_dag_to_db(dag)
             dag_version = DagVersion.get_latest_version(dag.dag_id)
-            ti = TaskInstance(operator, run_id="something", dag_version_id=dag_version.id)
+            ti = create_task_instance(operator, run_id="something", dag_version_id=dag_version.id)
             ti.dag_run = DagRun(
                 dag_id=dag.dag_id,
                 run_id="something",
@@ -301,7 +298,7 @@ class TestDynamodbToS3:
             )
         session.add(ti)
         session.commit()
-        ti.render_templates()
+        render_template_fields(ti, operator)
         assert getattr(operator, "source_aws_conn_id") == "2020-01-01"
         assert getattr(operator, "dest_aws_conn_id") == "2020-01-01"
         assert getattr(operator, "s3_bucket_name") == "2020-01-01"

--- a/providers/amazon/tests/unit/amazon/aws/transfers/test_mongo_to_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/transfers/test_mongo_to_s3.py
@@ -26,13 +26,10 @@ from airflow.providers.amazon.aws.transfers.mongo_to_s3 import MongoToS3Operator
 from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunType
 
+from tests_common.test_utils.compat import timezone
 from tests_common.test_utils.dag import sync_dag_to_db
+from tests_common.test_utils.taskinstance import create_task_instance, render_template_fields
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
-
-try:
-    from airflow.sdk import timezone
-except ImportError:
-    from airflow.utils import timezone  # type: ignore[attr-defined,no-redef]
 
 TASK_ID = "test_mongo_to_s3_operator"
 MONGO_CONN_ID = "default_mongo"
@@ -93,13 +90,14 @@ class TestMongoToS3Operator:
 
             sync_dag_to_db(self.dag)
             dag_version = DagVersion.get_latest_version(self.mock_operator.dag_id)
-            ti = TaskInstance(self.mock_operator, dag_version_id=dag_version.id)
+            ti = create_task_instance(self.mock_operator, dag_version_id=dag_version.id)
             dag_run = DagRun(
                 dag_id=self.mock_operator.dag_id,
                 logical_date=DEFAULT_DATE,
                 run_id="test",
                 run_type=DagRunType.MANUAL,
                 state=DagRunState.RUNNING,
+                run_after=timezone.utcnow(),
             )
         else:
             dag_run = DagRun(
@@ -111,12 +109,8 @@ class TestMongoToS3Operator:
             )
             ti = TaskInstance(task=self.mock_operator)
         ti.dag_run = dag_run
-        session.add(ti)
-        session.commit()
-        ti.render_templates()
-
+        render_template_fields(ti, self.mock_operator)
         expected_rendered_template = {"$lt": "2017-01-01T00:00:00+00:00Z"}
-
         assert expected_rendered_template == getattr(self.mock_operator, "mongo_query")
 
     @mock.patch("airflow.providers.amazon.aws.transfers.mongo_to_s3.MongoHook")

--- a/providers/apache/druid/tests/unit/apache/druid/operators/test_druid.py
+++ b/providers/apache/druid/tests/unit/apache/druid/operators/test_druid.py
@@ -65,10 +65,8 @@ def test_render_template(dag_maker):
             params={"index_type": "index_hadoop", "datasource": "datasource_prd"},
         )
 
-    dag_run = dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED)
-    dag_maker.session.add(dag_run.task_instances[0])
-    dag_maker.session.commit()
-    dag_run.task_instances[0].render_templates()
+    ti = dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED).task_instances[0]
+    operator.render_template_fields(ti.get_template_context())
     assert json.loads(operator.json_index_file) == RENDERED_INDEX
 
 
@@ -91,7 +89,8 @@ def test_render_template_from_file(tmp_path, dag_maker):
             params={"index_type": "index_hadoop", "datasource": "datasource_prd"},
         )
 
-    dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED).task_instances[0].render_templates()
+    ti = dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED).task_instances[0]
+    operator.render_template_fields(ti.get_template_context())
     assert json.loads(operator.json_index_file) == RENDERED_INDEX
 
 

--- a/providers/apache/kylin/tests/unit/apache/kylin/operators/test_kylin_cube.py
+++ b/providers/apache/kylin/tests/unit/apache/kylin/operators/test_kylin_cube.py
@@ -30,6 +30,7 @@ from airflow.utils import state, timezone
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.dag import sync_dag_to_db
+from tests_common.test_utils.taskinstance import create_task_instance, render_template_fields
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 DEFAULT_DATE = timezone.datetime(2020, 1, 1)
@@ -177,7 +178,7 @@ class TestKylinCubeOperator:
 
             sync_dag_to_db(self.dag)
             dag_version = DagVersion.get_latest_version(operator.dag_id)
-            ti = TaskInstance(operator, run_id="kylin_test", dag_version_id=dag_version.id)
+            ti = create_task_instance(operator, run_id="kylin_test", dag_version_id=dag_version.id)
             ti.dag_run = DagRun(
                 dag_id=self.dag.dag_id,
                 run_id="kylin_test",
@@ -198,7 +199,7 @@ class TestKylinCubeOperator:
             )
         session.add(ti)
         session.commit()
-        ti.render_templates()
+        render_template_fields(ti, operator)
         assert getattr(operator, "project") == "learn_kylin"
         assert getattr(operator, "cube") == "kylin_sales_cube"
         assert getattr(operator, "command") == "build"

--- a/providers/apache/livy/tests/unit/apache/livy/operators/test_livy.py
+++ b/providers/apache/livy/tests/unit/apache/livy/operators/test_livy.py
@@ -588,8 +588,7 @@ def test_spark_params_templating(create_task_instance_of_operator, session):
     )
     session.add(ti)
     session.commit()
-    ti.render_templates()
-    task: LivyOperator = ti.task
+    task = ti.render_templates()
     assert task.spark_params == {
         "archives": "literal-archives",
         "args": "literal-args",

--- a/providers/apache/spark/tests/unit/apache/spark/decorators/test_pyspark.py
+++ b/providers/apache/spark/tests/unit/apache/spark/decorators/test_pyspark.py
@@ -110,9 +110,7 @@ class TestPysparkDecorator:
         with dag_maker():
             f()
 
-        dr = dag_maker.create_dagrun()
-        ti = dr.get_task_instances()[0]
-        ti.run()
+        ti = dag_maker.run_ti("f")
         assert len(ti.xcom_pull()) == 100
         assert config.get("spark.master") == "spark://none"
         assert config.get("spark.executor.memory") == "2g"
@@ -137,9 +135,7 @@ class TestPysparkDecorator:
         with dag_maker():
             f()
 
-        dr = dag_maker.create_dagrun()
-        ti = dr.get_task_instances()[0]
-        ti.run()
+        ti = dag_maker.run_ti("f")
         assert ti.xcom_pull() == e
         assert config.get("spark.master") == "local[*]"
         spark_mock.builder.config.assert_called_once_with(conf=conf_mock())
@@ -161,9 +157,7 @@ class TestPysparkDecorator:
         with dag_maker():
             f()
 
-        dr = dag_maker.create_dagrun()
-        ti = dr.get_task_instances()[0]
-        ti.run()
+        ti = dag_maker.run_ti("f")
         assert ti.xcom_pull()
         assert config.get("spark.remote") == "sc://localhost"
         assert config.get("spark.master") is None
@@ -187,9 +181,7 @@ class TestPysparkDecorator:
         with dag_maker():
             f()
 
-        dr = dag_maker.create_dagrun()
-        ti = dr.get_task_instances()[0]
-        ti.run()
+        ti = dag_maker.run_ti("f")
         assert ti.xcom_pull()
         assert config.get("spark.remote") == "sc://localhost/;user_id=connect;token=1234;use_ssl=True"
         assert config.get("spark.master") is None

--- a/providers/apache/spark/tests/unit/apache/spark/operators/test_spark_jdbc.py
+++ b/providers/apache/spark/tests/unit/apache/spark/operators/test_spark_jdbc.py
@@ -158,8 +158,7 @@ class TestSparkJDBCOperator:
         )
         session.add(ti)
         session.commit()
-        ti.render_templates()
-        task: SparkJDBCOperator = ti.task
+        task = ti.render_templates()
         assert task.application == "application"
         assert task.conf == "conf"
         assert task.files == "files"

--- a/providers/apache/spark/tests/unit/apache/spark/operators/test_spark_sql.py
+++ b/providers/apache/spark/tests/unit/apache/spark/operators/test_spark_sql.py
@@ -78,6 +78,5 @@ class TestSparkSqlOperator:
         )
         session.add(ti)
         session.commit()
-        ti.render_templates()
-        task: SparkSqlOperator = ti.task
+        task = ti.render_templates()
         assert task.sql == "sql"

--- a/providers/apache/spark/tests/unit/apache/spark/operators/test_spark_submit.py
+++ b/providers/apache/spark/tests/unit/apache/spark/operators/test_spark_submit.py
@@ -31,6 +31,7 @@ from airflow.utils import timezone
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.dag import sync_dag_to_db
+from tests_common.test_utils.taskinstance import create_task_instance, render_template_fields
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 DEFAULT_DATE = timezone.datetime(2017, 1, 1)
@@ -204,7 +205,7 @@ class TestSparkSubmitOperator:
 
             sync_dag_to_db(self.dag)
             dag_version = DagVersion.get_latest_version(operator.dag_id)
-            ti = TaskInstance(operator, run_id="spark_test", dag_version_id=dag_version.id)
+            ti = create_task_instance(operator, run_id="spark_test", dag_version_id=dag_version.id)
             ti.dag_run = DagRun(
                 dag_id=self.dag.dag_id,
                 run_id="spark_test",
@@ -227,7 +228,7 @@ class TestSparkSubmitOperator:
         session.add(ti)
         session.commit()
         # When
-        ti.render_templates()
+        render_template_fields(ti, operator)
 
         # Then
         expected_application_args = [
@@ -274,8 +275,7 @@ class TestSparkSubmitOperator:
         )
         session.add(ti)
         session.commit()
-        ti.render_templates()
-        task: SparkSubmitOperator = ti.task
+        task = ti.render_templates()
         assert task.application == "application"
         assert task.conf == "conf"
         assert task.files == "files"

--- a/providers/celery/tests/unit/celery/executors/test_celery_executor.py
+++ b/providers/celery/tests/unit/celery/executors/test_celery_executor.py
@@ -44,6 +44,7 @@ from airflow.utils.state import State
 from tests_common.test_utils import db
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.dag import sync_dag_to_db
+from tests_common.test_utils.taskinstance import create_task_instance
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS, AIRFLOW_V_3_2_PLUS
 
 if AIRFLOW_V_3_0_PLUS:
@@ -229,7 +230,7 @@ class TestCeleryExecutor:
         if AIRFLOW_V_3_0_PLUS:
             sync_dag_to_db(dag)
             dag_version = DagVersion.get_latest_version(dag.dag_id)
-            key1 = TaskInstance(task=task_1, run_id=None, dag_version_id=dag_version.id)
+            key1 = create_task_instance(task=task_1, run_id=None, dag_version_id=dag_version.id)
         else:
             key1 = TaskInstance(task=task_1, run_id=None)
         tis = [key1]
@@ -250,8 +251,8 @@ class TestCeleryExecutor:
         if AIRFLOW_V_3_0_PLUS:
             sync_dag_to_db(dag)
             dag_version = DagVersion.get_latest_version(dag.dag_id)
-            ti1 = TaskInstance(task=task_1, run_id=None, dag_version_id=dag_version.id)
-            ti2 = TaskInstance(task=task_2, run_id=None, dag_version_id=dag_version.id)
+            ti1 = create_task_instance(task=task_1, run_id=None, dag_version_id=dag_version.id)
+            ti2 = create_task_instance(task=task_2, run_id=None, dag_version_id=dag_version.id)
         else:
             ti1 = TaskInstance(task=task_1, run_id=None)
             ti2 = TaskInstance(task=task_2, run_id=None)
@@ -294,7 +295,7 @@ class TestCeleryExecutor:
         if AIRFLOW_V_3_0_PLUS:
             sync_dag_to_db(dag)
             dag_version = DagVersion.get_latest_version(task.dag.dag_id)
-            ti = TaskInstance(task=task, run_id=None, dag_version_id=dag_version.id)
+            ti = create_task_instance(task=task, run_id=None, dag_version_id=dag_version.id)
         else:
             ti = TaskInstance(task=task, run_id=None)
         ti.external_executor_id = "231"
@@ -328,7 +329,7 @@ class TestCeleryExecutor:
         if AIRFLOW_V_3_0_PLUS:
             sync_dag_to_db(dag)
             dag_version = DagVersion.get_latest_version(task.dag.dag_id)
-            ti = TaskInstance(task=task, run_id=None, dag_version_id=dag_version.id)
+            ti = create_task_instance(task=task, run_id=None, dag_version_id=dag_version.id)
         else:
             ti = TaskInstance(task=task, run_id=None)
         ti.external_executor_id = "231"

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/decorators/kubernetes_cmd.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/decorators/kubernetes_cmd.py
@@ -79,7 +79,7 @@ class _KubernetesCmdDecoratedOperator(DecoratedOperator, KubernetesPodOperator):
         else:
             self.cmds = generated
             self.arguments = []
-        context["ti"].render_templates()  # type: ignore[attr-defined]
+        self.render_template_fields(context)
         return super().execute(context)
 
     def _generate_cmds(self, context: Context) -> list[str]:

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/log_handlers/test_log_handlers.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/log_handlers/test_log_handlers.py
@@ -41,6 +41,7 @@ from tests_common.test_utils.compat import PythonOperator
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.db import clear_db_dag_bundles, clear_db_dags, clear_db_runs
+from tests_common.test_utils.taskinstance import create_task_instance, run_task_instance
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS
 
 if AIRFLOW_V_3_0_PLUS:
@@ -145,7 +146,11 @@ class TestFileTaskLogHandler:
             **dagrun_kwargs,
         )
         if AIRFLOW_V_3_0_PLUS:
-            ti = TaskInstance(task=task, run_id=dagrun.run_id, dag_version_id=dagrun.created_dag_version_id)
+            ti = create_task_instance(
+                task=task,
+                run_id=dagrun.run_id,
+                dag_version_id=dagrun.created_dag_version_id,
+            )
         else:
             ti = TaskInstance(task=task, run_id=dagrun.run_id)
         ti.try_number = 3
@@ -156,7 +161,7 @@ class TestFileTaskLogHandler:
 
         file_handler = TaskLogReader().log_handler
         set_context(logger, ti)
-        ti.run(ignore_ti_state=True)
+        run_task_instance(ti, task, ignore_ti_state=True)
         ti.state = TaskInstanceState.RUNNING
         # clear executor_instances cache
         file_handler.executor_instances = {}

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_job.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_job.py
@@ -39,6 +39,7 @@ from airflow.utils.session import create_session
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.dag import sync_dag_to_db
+from tests_common.test_utils.taskinstance import create_task_instance
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 DEFAULT_DATE = timezone.datetime(2016, 1, 1, 1, 0, 0)
@@ -81,7 +82,7 @@ def create_context(task, persist_to_db=False, map_index=None):
         from airflow.models.dag_version import DagVersion
 
         dag_version = DagVersion.get_latest_version(dag.dag_id)
-        task_instance = TaskInstance(task=task, run_id=dag_run.run_id, dag_version_id=dag_version.id)
+        task_instance = create_task_instance(task=task, run_id=dag_run.run_id, dag_version_id=dag_version.id)
     else:
         task_instance = TaskInstance(task=task, run_id=dag_run.run_id)
     task_instance.dag_run = dag_run
@@ -156,14 +157,14 @@ class TestKubernetesJobOperator:
         assert dag_id == rendered.container_resources.requests["cpu"]
         assert dag_id == rendered.volume_mounts[0].name
         assert dag_id == rendered.volume_mounts[0].sub_path
-        assert dag_id == ti.task.image
-        assert dag_id == ti.task.cmds
-        assert dag_id == ti.task.namespace
-        assert dag_id == ti.task.config_file
-        assert dag_id == ti.task.labels
-        assert dag_id == ti.task.job_template_file
-        assert dag_id == ti.task.arguments
-        assert dag_id == ti.task.env_vars[0]
+        assert dag_id == rendered.image
+        assert dag_id == rendered.cmds
+        assert dag_id == rendered.namespace
+        assert dag_id == rendered.config_file
+        assert dag_id == rendered.labels
+        assert dag_id == rendered.job_template_file
+        assert dag_id == rendered.arguments
+        assert dag_id == rendered.env_vars[0]
         assert dag_id == rendered.annotations["dag-id"]
 
     def sanitize_for_serialization(self, obj):

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -51,6 +51,7 @@ from airflow.utils.types import DagRunType
 
 from tests_common.test_utils import db
 from tests_common.test_utils.dag import sync_dag_to_db
+from tests_common.test_utils.taskinstance import create_task_instance
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS
 
 if AIRFLOW_V_3_0_PLUS or AIRFLOW_V_3_1_PLUS:
@@ -140,7 +141,7 @@ def create_context(task, persist_to_db=False, map_index=None):
                 session.add(dag_version)
                 session.commit()
                 session.refresh(dag_version)
-        task_instance = TaskInstance(task=task, run_id=dag_run.run_id, dag_version_id=dag_version.id)
+        task_instance = create_task_instance(task=task, run_id=dag_run.run_id, dag_version_id=dag_version.id)
     else:
         task_instance = TaskInstance(task=task, run_id=dag_run.run_id)
     task_instance.dag_run = dag_run
@@ -234,19 +235,19 @@ class TestKubernetesPodOperator:
         assert dag_id == rendered.container_resources.requests["cpu"]
         assert dag_id == rendered.volume_mounts[0].name
         assert dag_id == rendered.volume_mounts[0].sub_path
-        assert dag_id == ti.task.image
-        assert dag_id == ti.task.cmds
-        assert dag_id == ti.task.name
-        assert dag_id == ti.task.hostname
-        assert dag_id == ti.task.base_container_name
-        assert dag_id == ti.task.namespace
-        assert dag_id == ti.task.config_file
-        assert dag_id == ti.task.labels
-        assert dag_id == ti.task.pod_template_file
-        assert dag_id == ti.task.arguments
-        assert dag_id == ti.task.env_vars[0]
+        assert dag_id == rendered.image
+        assert dag_id == rendered.cmds
+        assert dag_id == rendered.name
+        assert dag_id == rendered.hostname
+        assert dag_id == rendered.base_container_name
+        assert dag_id == rendered.namespace
+        assert dag_id == rendered.config_file
+        assert dag_id == rendered.labels
+        assert dag_id == rendered.pod_template_file
+        assert dag_id == rendered.arguments
+        assert dag_id == rendered.env_vars[0]
         assert dag_id == rendered.annotations["dag-id"]
-        assert dag_id == ti.task.env_from[0].config_map_ref.name
+        assert dag_id == rendered.env_from[0].config_map_ref.name
         assert dag_id == rendered.volumes[0].name
         assert dag_id == rendered.volumes[0].config_map.name
 

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/test_template_rendering.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/test_template_rendering.py
@@ -215,7 +215,7 @@ def test_get_k8s_pod_yaml(render_k8s_pod_yaml, dag_maker, session):
 
     render_k8s_pod_yaml.return_value = {"I'm a": "pod", "secret": "password123"}
 
-    rtif = RTIF(ti=ti)
+    rtif = RTIF(ti=ti, render_templates=False)
 
     assert ti.dag_id == rtif.dag_id
     assert ti.task_id == rtif.task_id

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks_copy.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks_copy.py
@@ -257,8 +257,7 @@ def test_templating(create_task_instance_of_operator, session):
     )
     session.add(ti)
     session.commit()
-    ti.render_templates()
-    task: DatabricksCopyIntoOperator = ti.task
+    task = ti.render_templates()
     assert task.file_location == "file-location"
     assert task.files == "files"
     assert task.table_name == "table-name"

--- a/providers/dbt/cloud/tests/unit/dbt/cloud/operators/test_dbt.py
+++ b/providers/dbt/cloud/tests/unit/dbt/cloud/operators/test_dbt.py
@@ -647,7 +647,7 @@ class TestDbtCloudRunJobOperator:
     )
     @pytest.mark.db_test
     def test_run_job_operator_link(
-        self, conn_id, account_id, create_task_instance_of_operator, request, mock_supervisor_comms
+        self, conn_id, account_id, dag_maker, create_task_instance_of_operator, request, mock_supervisor_comms
     ):
         ti = create_task_instance_of_operator(
             DbtCloudRunJobOperator,
@@ -674,7 +674,9 @@ class TestDbtCloudRunJobOperator:
                     run_id=_run_response["data"]["id"],
                 ),
             )
-        url = ti.task.operator_extra_links[0].get_link(operator=ti.task, ti_key=ti.key)
+
+        task = dag_maker.dag.get_task(ti.task_id)
+        url = task.operator_extra_links[0].get_link(operator=ti.task, ti_key=ti.key)
 
         assert url == (
             EXPECTED_JOB_RUN_OP_EXTRA_LINK.format(

--- a/providers/docker/tests/unit/docker/decorators/test_docker.py
+++ b/providers/docker/tests/unit/docker/decorators/test_docker.py
@@ -25,6 +25,7 @@ from airflow.providers.common.compat.sdk import AirflowException
 from airflow.utils.state import TaskInstanceState
 
 from tests_common.test_utils.markers import skip_if_force_lowest_dependencies_marker
+from tests_common.test_utils.taskinstance import create_task_instance, render_template_fields
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS
 
 if AIRFLOW_V_3_0_PLUS:
@@ -100,10 +101,14 @@ class TestDockerDecorator:
 
         dr = dag_maker.create_dagrun()
         if AIRFLOW_V_3_0_PLUS:
-            ti = TaskInstance(task=ret.operator, run_id=dr.run_id, dag_version_id=dr.created_dag_version_id)
+            ti = create_task_instance(
+                task=ret.operator,
+                run_id=dr.run_id,
+                dag_version_id=dr.created_dag_version_id,
+            )
         else:
             ti = TaskInstance(task=ret.operator, run_id=dr.run_id)
-        rendered = ti.render_templates()
+        rendered = render_template_fields(ti, ret.operator)
         assert rendered.container_name == f"python_{dr.dag_id}"
         assert rendered.mounts[0]["Target"] == f"/{ti.run_id}"
 

--- a/providers/docker/tests/unit/docker/operators/test_docker.py
+++ b/providers/docker/tests/unit/docker/operators/test_docker.py
@@ -808,20 +808,17 @@ class TestDockerOperator:
         assert labels == self.client_mock.create_container.call_args.kwargs["labels"]
 
     @pytest.mark.db_test
-    def test_basic_docker_operator_with_template_fields(self, dag_maker):
+    def test_basic_docker_operator_with_template_fields(self, create_task_instance_of_operator):
         from docker.types import Mount
 
-        with dag_maker():
-            operator = DockerOperator(
-                task_id="test",
-                image="test",
-                container_name="python_{{dag_run.dag_id}}",
-                mounts=[Mount(source="workspace", target="/{{task_instance.run_id}}")],
-            )
-            operator.execute({})
-
-        dr = dag_maker.create_dagrun()
-        ti = dr.task_instances[0]
+        ti = create_task_instance_of_operator(
+            operator_class=DockerOperator,
+            dag_id="test",
+            task_id="test",
+            image="test",
+            container_name="python_{{dag_run.dag_id}}",
+            mounts=[Mount(source="workspace", target="/{{task_instance.run_id}}")],
+        )
         rendered = ti.render_templates()
-        assert rendered.container_name == f"python_{dr.dag_id}"
+        assert rendered.container_name == f"python_{ti.dag_id}"
         assert rendered.mounts[0]["Target"] == f"/{ti.run_id}"

--- a/providers/google/tests/unit/google/cloud/links/test_base_link.py
+++ b/providers/google/tests/unit/google/cloud/links/test_base_link.py
@@ -105,7 +105,7 @@ class MyOperator(GoogleCloudBaseOperator):
 
 class TestOperatorWithBaseGoogleLink:
     @pytest.mark.db_test
-    def test_get_link(self, create_task_instance_of_operator, session, mock_supervisor_comms):
+    def test_get_link(self, dag_maker, create_task_instance_of_operator, session, mock_supervisor_comms):
         expected_url = EXPECTED_GOOGLE_LINK
         link = GoogleLink()
         ti = create_task_instance_of_operator(
@@ -116,19 +116,18 @@ class TestOperatorWithBaseGoogleLink:
             cluster_id=TEST_CLUSTER_ID,
             project_id=TEST_PROJECT_ID,
         )
-        session.add(ti)
-        session.commit()
+        task = dag_maker.dag.get_task(ti.task_id)
 
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
             mock_supervisor_comms.send.return_value = XComResult(
                 key="key",
                 value={
-                    "cluster_id": ti.task.cluster_id,
-                    "location": ti.task.location,
-                    "project_id": ti.task.project_id,
+                    "cluster_id": task.cluster_id,
+                    "location": task.location,
+                    "project_id": task.project_id,
                 },
             )
-        actual_url = link.get_link(operator=ti.task, ti_key=ti.key)
+        actual_url = link.get_link(operator=task, ti_key=ti.key)
         assert actual_url == expected_url
 
     @pytest.mark.db_test
@@ -136,6 +135,7 @@ class TestOperatorWithBaseGoogleLink:
     def test_get_link_uses_xcom_url_and_skips_get_config(
         self,
         mock_get_value,
+        dag_maker,
         create_task_instance_of_operator,
         session,
     ):
@@ -151,11 +151,9 @@ class TestOperatorWithBaseGoogleLink:
             cluster_id=TEST_CLUSTER_ID,
             project_id=TEST_PROJECT_ID,
         )
-        session.add(ti)
-        session.commit()
 
         with mock.patch.object(GoogleLink, "get_config", autospec=True) as m_get_config:
-            actual_url = link.get_link(operator=ti.task, ti_key=ti.key)
+            actual_url = link.get_link(operator=dag_maker.dag.get_task(ti.task_id), ti_key=ti.key)
 
         assert actual_url == xcom_url
         m_get_config.assert_not_called()
@@ -165,6 +163,7 @@ class TestOperatorWithBaseGoogleLink:
     def test_get_link_falls_back_to_get_config_when_xcom_not_http(
         self,
         mock_get_value,
+        dag_maker,
         create_task_instance_of_operator,
         session,
     ):
@@ -179,8 +178,7 @@ class TestOperatorWithBaseGoogleLink:
             cluster_id=TEST_CLUSTER_ID,
             project_id=TEST_PROJECT_ID,
         )
-        session.add(ti)
-        session.commit()
+        task = dag_maker.dag.get_task(ti.task_id)
 
         expected_formatted = "https://console.cloud.google.com/expected/link?project=test-proj"
         with (
@@ -188,14 +186,14 @@ class TestOperatorWithBaseGoogleLink:
                 GoogleLink,
                 "get_config",
                 return_value={
-                    "project_id": ti.task.project_id,
-                    "location": ti.task.location,
-                    "cluster_id": ti.task.cluster_id,
+                    "project_id": task.project_id,
+                    "location": task.location,
+                    "cluster_id": task.cluster_id,
                 },
             ) as m_get_config,
             mock.patch.object(GoogleLink, "_format_link", return_value=expected_formatted) as m_fmt,
         ):
-            actual_url = link.get_link(operator=ti.task, ti_key=ti.key)
+            actual_url = link.get_link(operator=task, ti_key=ti.key)
 
         assert actual_url == expected_formatted
         m_get_config.assert_called_once()

--- a/providers/google/tests/unit/google/cloud/links/test_dataplex.py
+++ b/providers/google/tests/unit/google/cloud/links/test_dataplex.py
@@ -106,7 +106,7 @@ EXPECTED_DATAPLEX_CATALOG_ENTRY_LINK = (
 
 class TestDataplexTaskLink:
     @pytest.mark.db_test
-    def test_get_link(self, create_task_instance_of_operator, session, mock_supervisor_comms):
+    def test_get_link(self, dag_maker, create_task_instance_of_operator, session, mock_supervisor_comms):
         expected_url = EXPECTED_DATAPLEX_TASK_LINK
         link = DataplexTaskLink()
         ti = create_task_instance_of_operator(
@@ -119,26 +119,25 @@ class TestDataplexTaskLink:
             body=TEST_LAKE_BODY,
             dataplex_task_id=TEST_TASK_ID,
         )
-        session.add(ti)
-        session.commit()
+        task = dag_maker.dag.get_task(ti.task_id)
 
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
             mock_supervisor_comms.send.return_value = XComResult(
                 key="key",
                 value={
-                    "lake_id": ti.task.lake_id,
-                    "task_id": ti.task.dataplex_task_id,
-                    "region": ti.task.region,
-                    "project_id": ti.task.project_id,
+                    "lake_id": task.lake_id,
+                    "task_id": task.dataplex_task_id,
+                    "region": task.region,
+                    "project_id": task.project_id,
                 },
             )
-        actual_url = link.get_link(operator=ti.task, ti_key=ti.key)
+        actual_url = link.get_link(operator=task, ti_key=ti.key)
         assert actual_url == expected_url
 
 
 class TestDataplexTasksLink:
     @pytest.mark.db_test
-    def test_get_link(self, create_task_instance_of_operator, session, mock_supervisor_comms):
+    def test_get_link(self, dag_maker, create_task_instance_of_operator, session, mock_supervisor_comms):
         expected_url = EXPECTED_DATAPLEX_TASKS_LINK
         link = DataplexTasksLink()
         ti = create_task_instance_of_operator(
@@ -149,27 +148,26 @@ class TestDataplexTasksLink:
             lake_id=TEST_LAKE_ID,
             project_id=TEST_PROJECT_ID,
         )
-        session.add(ti)
-        session.commit()
+        task = dag_maker.dag.get_task(ti.task_id)
 
-        link.persist(context={"ti": ti, "task": ti.task})
+        link.persist(context={"ti": ti, "task": task})
 
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
             mock_supervisor_comms.send.return_value = XComResult(
                 key="key",
                 value={
-                    "project_id": ti.task.project_id,
-                    "lake_id": ti.task.lake_id,
-                    "region": ti.task.region,
+                    "project_id": task.project_id,
+                    "lake_id": task.lake_id,
+                    "region": task.region,
                 },
             )
-        actual_url = link.get_link(operator=ti.task, ti_key=ti.key)
+        actual_url = link.get_link(operator=task, ti_key=ti.key)
         assert actual_url == expected_url
 
 
 class TestDataplexLakeLink:
     @pytest.mark.db_test
-    def test_get_link(self, create_task_instance_of_operator, session, mock_supervisor_comms):
+    def test_get_link(self, dag_maker, create_task_instance_of_operator, session, mock_supervisor_comms):
         expected_url = DATAPLEX_LAKE_LINK
         link = DataplexLakeLink()
         ti = create_task_instance_of_operator(
@@ -181,25 +179,24 @@ class TestDataplexLakeLink:
             project_id=TEST_PROJECT_ID,
             body={},
         )
-        session.add(ti)
-        session.commit()
+        task = dag_maker.dag.get_task(ti.task_id)
 
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
             mock_supervisor_comms.send.return_value = XComResult(
                 key="key",
                 value={
-                    "lake_id": ti.task.lake_id,
-                    "region": ti.task.region,
-                    "project_id": ti.task.project_id,
+                    "lake_id": task.lake_id,
+                    "region": task.region,
+                    "project_id": task.project_id,
                 },
             )
-        actual_url = link.get_link(operator=ti.task, ti_key=ti.key)
+        actual_url = link.get_link(operator=task, ti_key=ti.key)
         assert actual_url == expected_url
 
 
 class TestDataplexCatalogEntryGroupLink:
     @pytest.mark.db_test
-    def test_get_link(self, create_task_instance_of_operator, session, mock_supervisor_comms):
+    def test_get_link(self, dag_maker, create_task_instance_of_operator, session, mock_supervisor_comms):
         expected_url = EXPECTED_DATAPLEX_CATALOG_ENTRY_GROUP_LINK
         link = DataplexCatalogEntryGroupLink()
         ti = create_task_instance_of_operator(
@@ -210,27 +207,26 @@ class TestDataplexCatalogEntryGroupLink:
             entry_group_id=TEST_ENTRY_GROUP_ID,
             project_id=TEST_PROJECT_ID,
         )
-        session.add(ti)
-        session.commit()
+        task = dag_maker.dag.get_task(ti.task_id)
 
-        link.persist(context={"ti": ti, "task": ti.task})
+        link.persist(context={"ti": ti, "task": task})
 
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
             mock_supervisor_comms.send.return_value = XComResult(
                 key="key",
                 value={
-                    "entry_group_id": ti.task.entry_group_id,
-                    "location": ti.task.location,
-                    "project_id": ti.task.project_id,
+                    "entry_group_id": task.entry_group_id,
+                    "location": task.location,
+                    "project_id": task.project_id,
                 },
             )
-        actual_url = link.get_link(operator=ti.task, ti_key=ti.key)
+        actual_url = link.get_link(operator=task, ti_key=ti.key)
         assert actual_url == expected_url
 
 
 class TestDataplexCatalogEntryGroupsLink:
     @pytest.mark.db_test
-    def test_get_link(self, create_task_instance_of_operator, session, mock_supervisor_comms):
+    def test_get_link(self, dag_maker, create_task_instance_of_operator, session, mock_supervisor_comms):
         expected_url = EXPECTED_DATAPLEX_CATALOG_ENTRY_GROUPS_LINK
         link = DataplexCatalogEntryGroupsLink()
         ti = create_task_instance_of_operator(
@@ -242,24 +238,23 @@ class TestDataplexCatalogEntryGroupsLink:
             entry_group_configuration=TEST_ENTRY_GROUP_ID_BODY,
             project_id=TEST_PROJECT_ID,
         )
-        session.add(ti)
-        session.commit()
+        task = dag_maker.dag.get_task(ti.task_id)
 
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
             mock_supervisor_comms.send.return_value = XComResult(
                 key="key",
                 value={
-                    "location": ti.task.location,
-                    "project_id": ti.task.project_id,
+                    "location": task.location,
+                    "project_id": task.project_id,
                 },
             )
-        actual_url = link.get_link(operator=ti.task, ti_key=ti.key)
+        actual_url = link.get_link(operator=task, ti_key=ti.key)
         assert actual_url == expected_url
 
 
 class TestDataplexCatalogEntryTypeLink:
     @pytest.mark.db_test
-    def test_get_link(self, create_task_instance_of_operator, session, mock_supervisor_comms):
+    def test_get_link(self, dag_maker, create_task_instance_of_operator, session, mock_supervisor_comms):
         expected_url = EXPECTED_DATAPLEX_CATALOG_ENTRY_TYPE_LINK
         link = DataplexCatalogEntryTypeLink()
         ti = create_task_instance_of_operator(
@@ -270,25 +265,24 @@ class TestDataplexCatalogEntryTypeLink:
             entry_type_id=TEST_ENTRY_TYPE_ID,
             project_id=TEST_PROJECT_ID,
         )
-        session.add(ti)
-        session.commit()
+        task = dag_maker.dag.get_task(ti.task_id)
 
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
             mock_supervisor_comms.send.return_value = XComResult(
                 key="key",
                 value={
-                    "entry_type_id": ti.task.entry_type_id,
-                    "location": ti.task.location,
-                    "project_id": ti.task.project_id,
+                    "entry_type_id": task.entry_type_id,
+                    "location": task.location,
+                    "project_id": task.project_id,
                 },
             )
-        actual_url = link.get_link(operator=ti.task, ti_key=ti.key)
+        actual_url = link.get_link(operator=task, ti_key=ti.key)
         assert actual_url == expected_url
 
 
 class TestDataplexCatalogEntryTypesLink:
     @pytest.mark.db_test
-    def test_get_link(self, create_task_instance_of_operator, session, mock_supervisor_comms):
+    def test_get_link(self, dag_maker, create_task_instance_of_operator, session, mock_supervisor_comms):
         expected_url = EXPECTED_DATAPLEX_CATALOG_ENTRY_TYPES_LINK
         link = DataplexCatalogEntryTypesLink()
         ti = create_task_instance_of_operator(
@@ -300,24 +294,23 @@ class TestDataplexCatalogEntryTypesLink:
             entry_type_configuration=TEST_ENTRY_TYPE_ID_BODY,
             project_id=TEST_PROJECT_ID,
         )
-        session.add(ti)
-        session.commit()
+        task = dag_maker.dag.get_task(ti.task_id)
 
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
             mock_supervisor_comms.send.return_value = XComResult(
                 key="key",
                 value={
-                    "location": ti.task.location,
-                    "project_id": ti.task.project_id,
+                    "location": task.location,
+                    "project_id": task.project_id,
                 },
             )
-        actual_url = link.get_link(operator=ti.task, ti_key=ti.key)
+        actual_url = link.get_link(operator=task, ti_key=ti.key)
         assert actual_url == expected_url
 
 
 class TestDataplexCatalogAspectTypeLink:
     @pytest.mark.db_test
-    def test_get_link(self, create_task_instance_of_operator, session, mock_supervisor_comms):
+    def test_get_link(self, dag_maker, create_task_instance_of_operator, session, mock_supervisor_comms):
         expected_url = EXPECTED_DATAPLEX_CATALOG_ASPECT_TYPE_LINK
         link = DataplexCatalogAspectTypeLink()
         ti = create_task_instance_of_operator(
@@ -328,25 +321,24 @@ class TestDataplexCatalogAspectTypeLink:
             aspect_type_id=TEST_ASPECT_TYPE_ID,
             project_id=TEST_PROJECT_ID,
         )
-        session.add(ti)
-        session.commit()
+        task = dag_maker.dag.get_task(ti.task_id)
 
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
             mock_supervisor_comms.send.return_value = XComResult(
                 key="key",
                 value={
-                    "aspect_type_id": ti.task.aspect_type_id,
-                    "location": ti.task.location,
-                    "project_id": ti.task.project_id,
+                    "aspect_type_id": task.aspect_type_id,
+                    "location": task.location,
+                    "project_id": task.project_id,
                 },
             )
-        actual_url = link.get_link(operator=ti.task, ti_key=ti.key)
+        actual_url = link.get_link(operator=task, ti_key=ti.key)
         assert actual_url == expected_url
 
 
 class TestDataplexCatalogAspectTypesLink:
     @pytest.mark.db_test
-    def test_get_link(self, create_task_instance_of_operator, session, mock_supervisor_comms):
+    def test_get_link(self, dag_maker, create_task_instance_of_operator, session, mock_supervisor_comms):
         expected_url = EXPECTED_DATAPLEX_CATALOG_ASPECT_TYPES_LINK
         link = DataplexCatalogAspectTypesLink()
         ti = create_task_instance_of_operator(
@@ -358,24 +350,23 @@ class TestDataplexCatalogAspectTypesLink:
             aspect_type_configuration=TEST_ASPECT_TYPE_ID_BODY,
             project_id=TEST_PROJECT_ID,
         )
-        session.add(ti)
-        session.commit()
+        task = dag_maker.dag.get_task(ti.task_id)
 
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
             mock_supervisor_comms.send.return_value = XComResult(
                 key="key",
                 value={
-                    "location": ti.task.location,
-                    "project_id": ti.task.project_id,
+                    "location": task.location,
+                    "project_id": task.project_id,
                 },
             )
-        actual_url = link.get_link(operator=ti.task, ti_key=ti.key)
+        actual_url = link.get_link(operator=task, ti_key=ti.key)
         assert actual_url == expected_url
 
 
 class TestDataplexCatalogEntryLink:
     @pytest.mark.db_test
-    def test_get_link(self, create_task_instance_of_operator, session, mock_supervisor_comms):
+    def test_get_link(self, dag_maker, create_task_instance_of_operator, session, mock_supervisor_comms):
         expected_url = EXPECTED_DATAPLEX_CATALOG_ENTRY_LINK
         link = DataplexCatalogEntryLink()
         ti = create_task_instance_of_operator(
@@ -387,18 +378,17 @@ class TestDataplexCatalogEntryLink:
             entry_group_id=TEST_ENTRY_GROUP_ID,
             project_id=TEST_PROJECT_ID,
         )
-        session.add(ti)
-        session.commit()
+        task = dag_maker.dag.get_task(ti.task_id)
 
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
             mock_supervisor_comms.send.return_value = XComResult(
                 key="key",
                 value={
-                    "entry_id": ti.task.entry_id,
-                    "entry_group_id": ti.task.entry_group_id,
-                    "location": ti.task.location,
-                    "project_id": ti.task.project_id,
+                    "entry_id": task.entry_id,
+                    "entry_group_id": task.entry_group_id,
+                    "location": task.location,
+                    "project_id": task.project_id,
                 },
             )
-        actual_url = link.get_link(operator=ti.task, ti_key=ti.key)
+        actual_url = link.get_link(operator=task, ti_key=ti.key)
         assert actual_url == expected_url

--- a/providers/google/tests/unit/google/cloud/operators/test_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_bigquery.py
@@ -695,16 +695,12 @@ class TestBigQueryGetDataOperator:
 
     @pytest.mark.db_test
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
-    def test_bigquery_get_data_operator_async_with_selected_fields(
-        self, mock_hook, create_task_instance_of_operator
-    ):
+    def test_bigquery_get_data_operator_async_with_selected_fields(self, mock_hook):
         """
         Asserts that a task is deferred and a BigQuerygetDataTrigger will be fired
         when the BigQueryGetDataOperator is executed with deferrable=True.
         """
-        ti = create_task_instance_of_operator(
-            BigQueryGetDataOperator,
-            dag_id="dag_id",
+        operator = BigQueryGetDataOperator(
             task_id="get_data_from_bq",
             dataset_id=TEST_DATASET,
             table_id=TEST_TABLE_ID,
@@ -716,7 +712,7 @@ class TestBigQueryGetDataOperator:
         )
 
         with pytest.raises(TaskDeferred) as exc:
-            ti.task.execute(MagicMock())
+            operator.execute(MagicMock())
 
         assert isinstance(exc.value.trigger, BigQueryGetDataTrigger), (
             "Trigger is not a BigQueryGetDataTrigger"
@@ -725,16 +721,12 @@ class TestBigQueryGetDataOperator:
     @pytest.mark.db_test
     @pytest.mark.parametrize("as_dict", [True, False])
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
-    def test_bigquery_get_data_operator_async_without_selected_fields(
-        self, mock_hook, create_task_instance_of_operator, as_dict
-    ):
+    def test_bigquery_get_data_operator_async_without_selected_fields(self, mock_hook, as_dict):
         """
         Asserts that a task is deferred and a BigQueryGetDataTrigger will be fired
         when the BigQueryGetDataOperator is executed with deferrable=True.
         """
-        ti = create_task_instance_of_operator(
-            BigQueryGetDataOperator,
-            dag_id="dag_id",
+        operator = BigQueryGetDataOperator(
             task_id="get_data_from_bq",
             dataset_id=TEST_DATASET,
             table_id=TEST_TABLE_ID,
@@ -746,7 +738,7 @@ class TestBigQueryGetDataOperator:
         )
 
         with pytest.raises(TaskDeferred) as exc:
-            ti.task.execute(MagicMock())
+            operator.execute(MagicMock())
 
         assert isinstance(exc.value.trigger, BigQueryGetDataTrigger), (
             "Trigger is not a BigQueryGetDataTrigger"
@@ -1392,7 +1384,7 @@ class TestBigQueryInsertJobOperator:
 
     @pytest.mark.db_test
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
-    def test_bigquery_insert_job_operator_async(self, mock_hook, create_task_instance_of_operator):
+    def test_bigquery_insert_job_operator_async(self, mock_hook):
         """
         Asserts that a task is deferred and a BigQueryInsertJobTrigger will be fired
         when the BigQueryInsertJobOperator is executed with deferrable=True.
@@ -1409,9 +1401,7 @@ class TestBigQueryInsertJobOperator:
         }
         mock_hook.return_value.insert_job.return_value = MagicMock(job_id=real_job_id, error_result=False)
 
-        ti = create_task_instance_of_operator(
-            BigQueryInsertJobOperator,
-            dag_id="dag_id",
+        operator = BigQueryInsertJobOperator(
             task_id="insert_query_job",
             configuration=configuration,
             location=TEST_DATASET_LOCATION,
@@ -1421,7 +1411,7 @@ class TestBigQueryInsertJobOperator:
         )
 
         with pytest.raises(TaskDeferred) as exc:
-            ti.task.execute(MagicMock())
+            operator.execute(MagicMock())
 
         assert isinstance(exc.value.trigger, BigQueryInsertJobTrigger), (
             "Trigger is not a BigQueryInsertJobTrigger"
@@ -1429,9 +1419,7 @@ class TestBigQueryInsertJobOperator:
 
     @pytest.mark.db_test
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
-    def test_bigquery_insert_job_operator_async_inherits_hook_project_id_when_non_given(
-        self, mock_hook, create_task_instance_of_operator
-    ):
+    def test_bigquery_insert_job_operator_async_inherits_hook_project_id_when_non_given(self, mock_hook):
         """
         Asserts that a deferred task of type BigQueryInsertJobTrigger will assume the project_id
         of the hook that is used within the BigQueryInsertJobOperator when there is no
@@ -1447,9 +1435,7 @@ class TestBigQueryInsertJobOperator:
         }
         mock_hook.return_value.project_id = TEST_GCP_PROJECT_ID
 
-        ti = create_task_instance_of_operator(
-            BigQueryInsertJobOperator,
-            dag_id="dag_id",
+        operator = BigQueryInsertJobOperator(
             task_id="insert_query_job",
             configuration=configuration,
             location=TEST_DATASET_LOCATION,
@@ -1459,7 +1445,7 @@ class TestBigQueryInsertJobOperator:
         )
 
         with pytest.raises(TaskDeferred) as exc:
-            ti.task.execute(MagicMock())
+            operator.execute(MagicMock())
 
         assert isinstance(exc.value.trigger, BigQueryInsertJobTrigger), (
             "Trigger is not a BigQueryInsertJobTrigger"
@@ -1492,7 +1478,7 @@ class TestBigQueryInsertJobOperator:
             )
 
     @pytest.mark.db_test
-    def test_bigquery_insert_job_operator_execute_complete(self, create_task_instance_of_operator):
+    def test_bigquery_insert_job_operator_execute_complete(self):
         """Asserts that logging occurs as expected"""
         configuration = {
             "query": {
@@ -1502,9 +1488,7 @@ class TestBigQueryInsertJobOperator:
         }
         job_id = "123456"
 
-        ti = create_task_instance_of_operator(
-            BigQueryInsertJobOperator,
-            dag_id="dag_id",
+        operator = BigQueryInsertJobOperator(
             task_id="insert_query_job",
             configuration=configuration,
             location=TEST_DATASET_LOCATION,
@@ -1512,7 +1496,6 @@ class TestBigQueryInsertJobOperator:
             project_id=TEST_GCP_PROJECT_ID,
             deferrable=True,
         )
-        operator = ti.task
         with mock.patch.object(operator.log, "info") as mock_log_info:
             operator.execute_complete(
                 context=MagicMock(),
@@ -1553,9 +1536,7 @@ class TestBigQueryInsertJobOperator:
         "airflow.providers.google.cloud.operators.bigquery.BigQueryInsertJobOperator._handle_job_error"
     )
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
-    def test_bigquery_insert_job_operator_with_job_id_generate(
-        self, mock_hook, _handle_job_error, create_task_instance_of_operator
-    ):
+    def test_bigquery_insert_job_operator_with_job_id_generate(self, mock_hook, _handle_job_error):
         job_id = "123456"
         hash_ = "hash"
         real_job_id = f"{job_id}_{hash_}"
@@ -1576,9 +1557,7 @@ class TestBigQueryInsertJobOperator:
         )
         mock_hook.return_value.get_job.return_value = job
 
-        ti = create_task_instance_of_operator(
-            BigQueryInsertJobOperator,
-            dag_id="adhoc_airflow",
+        operator = BigQueryInsertJobOperator(
             task_id="insert_query_job",
             configuration=configuration,
             location=TEST_DATASET_LOCATION,
@@ -1589,7 +1568,7 @@ class TestBigQueryInsertJobOperator:
         )
 
         with pytest.raises(TaskDeferred):
-            ti.task.execute(MagicMock())
+            operator.execute(MagicMock())
 
         mock_hook.return_value.generate_job_id.assert_called_once_with(
             job_id=job_id,
@@ -1684,7 +1663,7 @@ class TestBigQueryInsertJobOperator:
 
     @pytest.mark.db_test
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
-    def test_execute_force_rerun_async(self, mock_hook, create_task_instance_of_operator):
+    def test_execute_force_rerun_async(self, mock_hook):
         job_id = "123456"
         hash_ = "hash"
         real_job_id = f"{job_id}_{hash_}"
@@ -1706,9 +1685,7 @@ class TestBigQueryInsertJobOperator:
         )
         mock_hook.return_value.get_job.return_value = job
 
-        ti = create_task_instance_of_operator(
-            BigQueryInsertJobOperator,
-            dag_id="dag_id",
+        operator = BigQueryInsertJobOperator(
             task_id="insert_query_job",
             configuration=configuration,
             location=TEST_DATASET_LOCATION,
@@ -1719,7 +1696,7 @@ class TestBigQueryInsertJobOperator:
         )
 
         with pytest.raises(AirflowException) as exc:
-            ti.task.execute(MagicMock())
+            operator.execute(MagicMock())
 
         expected_exception_msg = (
             f"Job with id: {real_job_id} already exists and is in {job.state} state. "
@@ -2071,7 +2048,7 @@ class TestBigQueryIntervalCheckOperator:
 
     @pytest.mark.db_test
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
-    def test_bigquery_interval_check_operator_async(self, mock_hook, create_task_instance_of_operator):
+    def test_bigquery_interval_check_operator_async(self, mock_hook):
         """
         Asserts that a task is deferred and a BigQueryIntervalCheckTrigger will be fired
         when the BigQueryIntervalCheckOperator is executed with deferrable=True.
@@ -2082,9 +2059,7 @@ class TestBigQueryIntervalCheckOperator:
 
         mock_hook.return_value.insert_job.return_value = MagicMock(job_id=real_job_id, error_result=False)
 
-        ti = create_task_instance_of_operator(
-            BigQueryIntervalCheckOperator,
-            dag_id="dag_id",
+        operator = BigQueryIntervalCheckOperator(
             task_id="bq_interval_check_operator_execute_complete",
             table="test_table",
             metrics_thresholds={"COUNT(*)": 1.5},
@@ -2093,7 +2068,7 @@ class TestBigQueryIntervalCheckOperator:
         )
 
         with pytest.raises(TaskDeferred) as exc:
-            ti.task.execute(MagicMock())
+            operator.execute(MagicMock())
 
         assert isinstance(exc.value.trigger, BigQueryIntervalCheckTrigger), (
             "Trigger is not a BigQueryIntervalCheckTrigger"
@@ -2101,9 +2076,7 @@ class TestBigQueryIntervalCheckOperator:
 
     @pytest.mark.db_test
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
-    def test_bigquery_interval_check_operator_with_project_id(
-        self, mock_hook, create_task_instance_of_operator
-    ):
+    def test_bigquery_interval_check_operator_with_project_id(self, mock_hook):
         """
         Test BigQueryIntervalCheckOperator with a specified project_id.
         Ensure that the bq_project_id is passed correctly when submitting the job.
@@ -2113,9 +2086,7 @@ class TestBigQueryIntervalCheckOperator:
         real_job_id = f"{job_id}_{hash_}"
 
         project_id = "test-project-id"
-        ti = create_task_instance_of_operator(
-            BigQueryIntervalCheckOperator,
-            dag_id="dag_id",
+        operator = BigQueryIntervalCheckOperator(
             task_id="bq_interval_check_operator_with_project_id",
             table="test_table",
             metrics_thresholds={"COUNT(*)": 1.5},
@@ -2127,7 +2098,7 @@ class TestBigQueryIntervalCheckOperator:
         mock_hook.return_value.insert_job.return_value = MagicMock(job_id=real_job_id, error_result=False)
 
         with pytest.raises(TaskDeferred):
-            ti.task.execute(MagicMock())
+            operator.execute(MagicMock())
 
         mock_hook.return_value.insert_job.assert_called_with(
             configuration=mock.ANY,
@@ -2139,9 +2110,7 @@ class TestBigQueryIntervalCheckOperator:
 
     @pytest.mark.db_test
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
-    def test_bigquery_interval_check_operator_without_project_id(
-        self, mock_hook, create_task_instance_of_operator
-    ):
+    def test_bigquery_interval_check_operator_without_project_id(self, mock_hook):
         """
         Test BigQueryIntervalCheckOperator without a specified project_id.
         Ensure that the project_id falls back to the hook.project_id as previously implemented.
@@ -2151,9 +2120,7 @@ class TestBigQueryIntervalCheckOperator:
         real_job_id = f"{job_id}_{hash_}"
 
         project_id = "test-project-id"
-        ti = create_task_instance_of_operator(
-            BigQueryIntervalCheckOperator,
-            dag_id="dag_id",
+        operator = BigQueryIntervalCheckOperator(
             task_id="bq_interval_check_operator_without_project_id",
             table="test_table",
             metrics_thresholds={"COUNT(*)": 1.5},
@@ -2165,7 +2132,7 @@ class TestBigQueryIntervalCheckOperator:
         mock_hook.return_value.insert_job.return_value = MagicMock(job_id=real_job_id, error_result=False)
 
         with pytest.raises(TaskDeferred):
-            ti.task.execute(MagicMock())
+            operator.execute(MagicMock())
 
         mock_hook.return_value.insert_job.assert_called_with(
             configuration=mock.ANY,
@@ -2216,7 +2183,7 @@ class TestBigQueryCheckOperator:
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryCheckOperator.defer")
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
     def test_bigquery_check_operator_async_finish_before_deferred(
-        self, mock_hook, mock_defer, mock_validate_records, create_task_instance_of_operator
+        self, mock_hook, mock_defer, mock_validate_records
     ):
         job_id = "123456"
         hash_ = "hash"
@@ -2227,25 +2194,21 @@ class TestBigQueryCheckOperator:
         mock_hook.return_value.insert_job.return_value = mocked_job
         mock_hook.return_value.insert_job.return_value.running.return_value = False
 
-        ti = create_task_instance_of_operator(
-            BigQueryCheckOperator,
-            dag_id="dag_id",
+        operator = BigQueryCheckOperator(
             task_id="bq_check_operator_job",
             sql="SELECT * FROM any",
             location=TEST_DATASET_LOCATION,
             deferrable=True,
         )
 
-        ti.task.execute(MagicMock())
+        operator.execute(MagicMock())
         mock_defer.assert_not_called()
         mock_validate_records.assert_called_once_with((1, 2, 3))
 
     @pytest.mark.db_test
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryCheckOperator._validate_records")
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
-    def test_bigquery_check_operator_query_parameters_passing(
-        self, mock_hook, mock_validate_records, create_task_instance_of_operator
-    ):
+    def test_bigquery_check_operator_query_parameters_passing(self, mock_hook, mock_validate_records):
         job_id = "123456"
         hash_ = "hash"
         real_job_id = f"{job_id}_{hash_}"
@@ -2256,9 +2219,7 @@ class TestBigQueryCheckOperator:
         mock_hook.return_value.insert_job.return_value = mocked_job
         mock_hook.return_value.insert_job.return_value.running.return_value = False
 
-        ti = create_task_instance_of_operator(
-            BigQueryCheckOperator,
-            dag_id="dag_id",
+        operator = BigQueryCheckOperator(
             task_id="bq_check_operator_query_params_job",
             sql="SELECT * FROM any WHERE test_param = @test_param",
             location=TEST_DATASET_LOCATION,
@@ -2266,14 +2227,12 @@ class TestBigQueryCheckOperator:
             query_params=query_params,
         )
 
-        ti.task.execute(MagicMock())
+        operator.execute(MagicMock())
         mock_validate_records.assert_called_once_with((1, 2, 3))
 
     @pytest.mark.db_test
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
-    def test_bigquery_check_operator_async_finish_with_error_before_deferred(
-        self, mock_hook, create_task_instance_of_operator
-    ):
+    def test_bigquery_check_operator_async_finish_with_error_before_deferred(self, mock_hook):
         job_id = "123456"
         hash_ = "hash"
         real_job_id = f"{job_id}_{hash_}"
@@ -2281,9 +2240,7 @@ class TestBigQueryCheckOperator:
         mock_hook.return_value.insert_job.return_value = MagicMock(job_id=real_job_id, error_result=True)
         mock_hook.return_value.insert_job.return_value.running.return_value = False
 
-        ti = create_task_instance_of_operator(
-            BigQueryCheckOperator,
-            dag_id="dag_id",
+        operator = BigQueryCheckOperator(
             task_id="bq_check_operator_job",
             sql="SELECT * FROM any",
             location=TEST_DATASET_LOCATION,
@@ -2291,13 +2248,13 @@ class TestBigQueryCheckOperator:
         )
 
         with pytest.raises(AirflowException) as exc:
-            ti.task.execute(MagicMock())
+            operator.execute(MagicMock())
 
         assert str(exc.value) == f"BigQuery job {real_job_id} failed: True"
 
     @pytest.mark.db_test
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
-    def test_bigquery_check_operator_async(self, mock_hook, create_task_instance_of_operator):
+    def test_bigquery_check_operator_async(self, mock_hook):
         """
         Asserts that a task is deferred and a BigQueryCheckTrigger will be fired
         when the BigQueryCheckOperator is executed with deferrable=True.
@@ -2308,9 +2265,7 @@ class TestBigQueryCheckOperator:
 
         mock_hook.return_value.insert_job.return_value = MagicMock(job_id=real_job_id, error_result=False)
 
-        ti = create_task_instance_of_operator(
-            BigQueryCheckOperator,
-            dag_id="dag_id",
+        operator = BigQueryCheckOperator(
             task_id="bq_check_operator_job",
             sql="SELECT * FROM any",
             location=TEST_DATASET_LOCATION,
@@ -2318,7 +2273,7 @@ class TestBigQueryCheckOperator:
         )
 
         with pytest.raises(TaskDeferred) as exc:
-            ti.task.execute(MagicMock())
+            operator.execute(MagicMock())
 
         assert isinstance(exc.value.trigger, BigQueryCheckTrigger), "Trigger is not a BigQueryCheckTrigger"
 
@@ -2397,14 +2352,12 @@ class TestBigQueryCheckOperator:
 class TestBigQueryValueCheckOperator:
     @pytest.mark.db_test
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
-    def test_bigquery_value_check_async(self, mock_hook, create_task_instance_of_operator):
+    def test_bigquery_value_check_async(self, mock_hook):
         """
         Asserts that a task is deferred and a BigQueryValueCheckTrigger will be fired
         when the BigQueryValueCheckOperator with deferrable=True is executed.
         """
-        ti = create_task_instance_of_operator(
-            BigQueryValueCheckOperator,
-            dag_id="dag_id",
+        operator = BigQueryValueCheckOperator(
             task_id="check_value",
             sql="SELECT COUNT(*) FROM Any",
             pass_value=2,
@@ -2416,7 +2369,7 @@ class TestBigQueryValueCheckOperator:
         real_job_id = f"{job_id}_{hash_}"
         mock_hook.return_value.insert_job.return_value = MagicMock(job_id=real_job_id, error_result=False)
         with pytest.raises(TaskDeferred) as exc:
-            ti.task.execute(MagicMock())
+            operator.execute(MagicMock())
 
         assert isinstance(exc.value.trigger, BigQueryValueCheckTrigger), (
             "Trigger is not a BigQueryValueCheckTrigger"
@@ -2427,7 +2380,7 @@ class TestBigQueryValueCheckOperator:
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryValueCheckOperator.check_value")
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
     def test_bigquery_value_check_operator_async_finish_before_deferred(
-        self, mock_hook, mock_check_value, mock_defer, create_task_instance_of_operator
+        self, mock_hook, mock_check_value, mock_defer
     ):
         job_id = "123456"
         hash_ = "hash"
@@ -2438,9 +2391,7 @@ class TestBigQueryValueCheckOperator:
         mock_hook.return_value.insert_job.return_value = mocked_job
         mock_hook.return_value.insert_job.return_value.running.return_value = False
 
-        ti = create_task_instance_of_operator(
-            BigQueryValueCheckOperator,
-            dag_id="dag_id",
+        operator = BigQueryValueCheckOperator(
             task_id="check_value",
             sql="SELECT COUNT(*) FROM Any",
             pass_value=2,
@@ -2448,15 +2399,13 @@ class TestBigQueryValueCheckOperator:
             deferrable=True,
         )
 
-        ti.task.execute(MagicMock())
+        operator.execute(MagicMock())
         assert not mock_defer.called
         mock_check_value.assert_called_once_with((1, 2, 3))
 
     @pytest.mark.db_test
     @mock.patch("airflow.providers.google.cloud.operators.bigquery.BigQueryHook")
-    def test_bigquery_value_check_operator_async_finish_with_error_before_deferred(
-        self, mock_hook, create_task_instance_of_operator
-    ):
+    def test_bigquery_value_check_operator_async_finish_with_error_before_deferred(self, mock_hook):
         job_id = "123456"
         hash_ = "hash"
         real_job_id = f"{job_id}_{hash_}"
@@ -2464,9 +2413,7 @@ class TestBigQueryValueCheckOperator:
         mock_hook.return_value.insert_job.return_value = MagicMock(job_id=real_job_id, error_result=True)
         mock_hook.return_value.insert_job.return_value.running.return_value = False
 
-        ti = create_task_instance_of_operator(
-            BigQueryValueCheckOperator,
-            dag_id="dag_id",
+        operator = BigQueryValueCheckOperator(
             task_id="check_value",
             sql="SELECT COUNT(*) FROM Any",
             pass_value=2,
@@ -2475,7 +2422,7 @@ class TestBigQueryValueCheckOperator:
         )
 
         with pytest.raises(AirflowException) as exc:
-            ti.task.execute(MagicMock())
+            operator.execute(MagicMock())
 
         assert str(exc.value) == f"BigQuery job {real_job_id} failed: True"
 
@@ -2605,16 +2552,14 @@ class TestBigQueryColumnCheckOperator:
     @mock.patch("airflow.providers.google.cloud.operators.bigquery._BigQueryHookWithFlexibleProjectId")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryJob")
     def test_bigquery_column_check_operator_succeeds(
-        self, mock_job, mock_hook, check_type, check_value, check_result, create_task_instance_of_operator
+        self, mock_job, mock_hook, check_type, check_value, check_result
     ):
         mock_job.result.return_value.to_dataframe.return_value = pd.DataFrame(
             {"col_name": ["col1"], "check_type": ["min"], "check_result": [check_result]}
         )
         mock_hook.return_value.insert_job.return_value = mock_job
 
-        ti = create_task_instance_of_operator(
-            BigQueryColumnCheckOperator,
-            dag_id="dag_id",
+        operator = BigQueryColumnCheckOperator(
             task_id="check_column_succeeds",
             table=TEST_TABLE_ID,
             use_legacy_sql=False,
@@ -2622,7 +2567,7 @@ class TestBigQueryColumnCheckOperator:
                 "col1": {"min": {check_type: check_value}},
             },
         )
-        ti.task.execute(MagicMock())
+        operator.execute(MagicMock())
 
     @pytest.mark.parametrize(
         ("check_type", "check_value", "check_result"),
@@ -2637,16 +2582,14 @@ class TestBigQueryColumnCheckOperator:
     @mock.patch("airflow.providers.google.cloud.operators.bigquery._BigQueryHookWithFlexibleProjectId")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryJob")
     def test_bigquery_column_check_operator_fails(
-        self, mock_job, mock_hook, check_type, check_value, check_result, create_task_instance_of_operator
+        self, mock_job, mock_hook, check_type, check_value, check_result
     ):
         mock_job.result.return_value.to_dataframe.return_value = pd.DataFrame(
             {"col_name": ["col1"], "check_type": ["min"], "check_result": [check_result]}
         )
         mock_hook.return_value.insert_job.return_value = mock_job
 
-        ti = create_task_instance_of_operator(
-            BigQueryColumnCheckOperator,
-            dag_id="dag_id",
+        operator = BigQueryColumnCheckOperator(
             task_id="check_column_fails",
             table=TEST_TABLE_ID,
             use_legacy_sql=False,
@@ -2655,7 +2598,7 @@ class TestBigQueryColumnCheckOperator:
             },
         )
         with pytest.raises(AirflowException):
-            ti.task.execute(MagicMock())
+            operator.execute(MagicMock())
 
     @pytest.mark.parametrize(
         ("check_type", "check_value", "check_result"),

--- a/providers/google/tests/unit/google/cloud/operators/test_cloud_build.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_cloud_build.py
@@ -413,7 +413,7 @@ def set_execute_complete(session, ti, **next_kwargs):
 @pytest.mark.db_test
 @mock.patch(CLOUD_BUILD_HOOK_PATH)
 def test_async_create_build_fires_correct_trigger_should_execute_successfully(
-    mock_hook, create_task_instance_of_operator, session
+    mock_hook, dag_maker, create_task_instance_of_operator, session
 ):
     mock_hook.return_value.create_build_without_waiting_for_result.return_value = (BUILD, BUILD_ID)
 
@@ -426,7 +426,7 @@ def test_async_create_build_fires_correct_trigger_should_execute_successfully(
     )
 
     with pytest.raises(TaskDeferred) as exc:
-        ti.task.execute({"ti": ti, "task_instance": ti})
+        dag_maker.dag.get_task(ti.task_id).execute({"ti": ti, "task_instance": ti})
 
     assert isinstance(exc.value.trigger, CloudBuildCreateBuildTrigger), (
         "Trigger is not a CloudBuildCreateBuildTrigger"
@@ -457,7 +457,7 @@ def test_async_create_build_without_wait_should_execute_successfully(mock_hook):
 @pytest.mark.db_test
 @mock.patch(CLOUD_BUILD_HOOK_PATH)
 def test_async_create_build_correct_logging_should_execute_successfully(
-    mock_hook, create_task_instance_of_operator, session
+    mock_hook, dag_maker, create_task_instance_of_operator, session
 ):
     mock_hook.return_value.create_build_without_waiting_for_result.return_value = (BUILD, BUILD_ID)
     mock_hook.return_value.get_build.return_value = Build()
@@ -470,8 +470,9 @@ def test_async_create_build_correct_logging_should_execute_successfully(
         dag_id="cloud_build_create_build_logging",
     )
 
-    with mock.patch.object(ti.task.log, "info") as mock_log_info:
-        ti.task.execute_complete(
+    task = dag_maker.dag.get_task(ti.task_id)
+    with mock.patch.object(task.log, "info") as mock_log_info:
+        task.execute_complete(
             context={"ti": ti, "task": ti.task},
             event={
                 "instance": TEST_BUILD_INSTANCE,

--- a/providers/google/tests/unit/google/cloud/operators/test_cloud_storage_transfer_service.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_cloud_storage_transfer_service.py
@@ -403,12 +403,10 @@ class TestGcpStorageTransferJobCreateOperator:
             aws_conn_id="{{ dag.dag_id }}",
             task_id="task-id",
         )
-        session.add(ti)
-        session.commit()
-        ti.render_templates()
-        assert excepted == getattr(ti.task, "body")
-        assert dag_id == getattr(ti.task, "gcp_conn_id")
-        assert dag_id == getattr(ti.task, "aws_conn_id")
+        rendered = ti.render_templates()
+        assert excepted == getattr(rendered, "body")
+        assert dag_id == getattr(rendered, "gcp_conn_id")
+        assert dag_id == getattr(rendered, "aws_conn_id")
 
 
 class TestGcpStorageTransferJobUpdateOperator:
@@ -451,11 +449,9 @@ class TestGcpStorageTransferJobUpdateOperator:
             body={"transferJob": {"name": "{{ dag.dag_id }}"}},
             task_id="task-id",
         )
-        session.add(ti)
-        session.commit()
-        ti.render_templates()
-        assert dag_id == getattr(ti.task, "body")["transferJob"]["name"]
-        assert dag_id == getattr(ti.task, "job_name")
+        rendered = ti.render_templates()
+        assert dag_id == getattr(rendered, "body")["transferJob"]["name"]
+        assert dag_id == getattr(rendered, "job_name")
 
 
 class TestGcpStorageTransferJobDeleteOperator:
@@ -496,12 +492,10 @@ class TestGcpStorageTransferJobDeleteOperator:
             api_version="{{ dag.dag_id }}",
             task_id=TASK_ID,
         )
-        session.add(ti)
-        session.commit()
-        ti.render_templates()
-        assert dag_id == ti.task.job_name
-        assert dag_id == ti.task.gcp_conn_id
-        assert dag_id == ti.task.api_version
+        rendered = ti.render_templates()
+        assert dag_id == rendered.job_name
+        assert dag_id == rendered.gcp_conn_id
+        assert dag_id == rendered.api_version
 
     def test_job_delete_should_throw_ex_when_name_none(self):
         with pytest.raises(AirflowException, match="The required parameter 'job_name' is empty or None"):
@@ -550,14 +544,12 @@ class TestGcpStorageTransferJobRunOperator:
             google_impersonation_chain="{{ dag.dag_id }}",
             task_id=TASK_ID,
         )
-        session.add(ti)
-        session.commit()
-        ti.render_templates()
-        assert dag_id == ti.task.job_name
-        assert dag_id == ti.task.project_id
-        assert dag_id == ti.task.gcp_conn_id
-        assert dag_id == ti.task.api_version
-        assert dag_id == ti.task.google_impersonation_chain
+        rendered = ti.render_templates()
+        assert dag_id == rendered.job_name
+        assert dag_id == rendered.project_id
+        assert dag_id == rendered.gcp_conn_id
+        assert dag_id == rendered.api_version
+        assert dag_id == rendered.google_impersonation_chain
 
     def test_job_run_should_throw_ex_when_name_none(self):
         op = CloudDataTransferServiceRunJobOperator(job_name="", task_id="task-id")
@@ -600,10 +592,8 @@ class TestGpcStorageTransferOperationsGetOperator:
             operation_name="{{ dag.dag_id }}",
             task_id="task-id",
         )
-        session.add(ti)
-        session.commit()
-        ti.render_templates()
-        assert dag_id == ti.task.operation_name
+        rendered = ti.render_templates()
+        assert dag_id == rendered.operation_name
 
     def test_operation_get_should_throw_ex_when_operation_name_none(self):
         with pytest.raises(
@@ -648,12 +638,10 @@ class TestGcpStorageTransferOperationListOperator:
             gcp_conn_id="{{ dag.dag_id }}",
             task_id="task-id",
         )
-        session.add(ti)
-        session.commit()
-        ti.render_templates()
+        rendered = ti.render_templates()
 
-        assert dag_id == ti.task.request_filter["job_names"][0]
-        assert dag_id == ti.task.gcp_conn_id
+        assert dag_id == rendered.request_filter["job_names"][0]
+        assert dag_id == rendered.gcp_conn_id
 
 
 class TestGcpStorageTransferOperationsPauseOperator:
@@ -691,12 +679,10 @@ class TestGcpStorageTransferOperationsPauseOperator:
             api_version="{{ dag.dag_id }}",
             task_id=TASK_ID,
         )
-        session.add(ti)
-        session.commit()
-        ti.render_templates()
-        assert dag_id == ti.task.operation_name
-        assert dag_id == ti.task.gcp_conn_id
-        assert dag_id == ti.task.api_version
+        rendered = ti.render_templates()
+        assert dag_id == rendered.operation_name
+        assert dag_id == rendered.gcp_conn_id
+        assert dag_id == rendered.api_version
 
     def test_operation_pause_should_throw_ex_when_name_none(self):
         with pytest.raises(
@@ -743,12 +729,10 @@ class TestGcpStorageTransferOperationsResumeOperator:
             api_version="{{ dag.dag_id }}",
             task_id=TASK_ID,
         )
-        session.add(ti)
-        session.commit()
-        ti.render_templates()
-        assert dag_id == ti.task.operation_name
-        assert dag_id == ti.task.gcp_conn_id
-        assert dag_id == ti.task.api_version
+        rendered = ti.render_templates()
+        assert dag_id == rendered.operation_name
+        assert dag_id == rendered.gcp_conn_id
+        assert dag_id == rendered.api_version
 
     @mock.patch(
         "airflow.providers.google.cloud.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook"
@@ -798,12 +782,10 @@ class TestGcpStorageTransferOperationsCancelOperator:
             api_version="{{ dag.dag_id }}",
             task_id=TASK_ID,
         )
-        session.add(ti)
-        session.commit()
-        ti.render_templates()
-        assert dag_id == ti.task.operation_name
-        assert dag_id == ti.task.gcp_conn_id
-        assert dag_id == ti.task.api_version
+        rendered = ti.render_templates()
+        assert dag_id == rendered.operation_name
+        assert dag_id == rendered.gcp_conn_id
+        assert dag_id == rendered.api_version
 
     @mock.patch(
         "airflow.providers.google.cloud.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook"
@@ -852,14 +834,12 @@ class TestS3ToGoogleCloudStorageTransferOperator:
             gcp_conn_id="{{ dag.dag_id }}",
             task_id=TASK_ID,
         )
-        session.add(ti)
-        session.commit()
-        ti.render_templates()
-        assert dag_id == ti.task.s3_bucket
-        assert dag_id == ti.task.gcs_bucket
-        assert dag_id == ti.task.description
-        assert dag_id == ti.task.object_conditions["exclude_prefixes"][0]
-        assert dag_id == ti.task.gcp_conn_id
+        rendered = ti.render_templates()
+        assert dag_id == rendered.s3_bucket
+        assert dag_id == rendered.gcs_bucket
+        assert dag_id == rendered.description
+        assert dag_id == rendered.object_conditions["exclude_prefixes"][0]
+        assert dag_id == rendered.gcp_conn_id
 
     @mock.patch(
         "airflow.providers.google.cloud.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook"
@@ -1215,14 +1195,12 @@ class TestGoogleCloudStorageToGoogleCloudStorageTransferOperator:
             gcp_conn_id="{{ dag.dag_id }}",
             task_id=TASK_ID,
         )
-        session.add(ti)
-        session.commit()
-        ti.render_templates()
-        assert dag_id == ti.task.source_bucket
-        assert dag_id == ti.task.destination_bucket
-        assert dag_id == ti.task.description
-        assert dag_id == ti.task.object_conditions["exclude_prefixes"][0]
-        assert dag_id == ti.task.gcp_conn_id
+        rendered = ti.render_templates()
+        assert dag_id == rendered.source_bucket
+        assert dag_id == rendered.destination_bucket
+        assert dag_id == rendered.description
+        assert dag_id == rendered.object_conditions["exclude_prefixes"][0]
+        assert dag_id == rendered.gcp_conn_id
 
     @mock.patch(
         "airflow.providers.google.cloud.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook"

--- a/providers/google/tests/unit/google/cloud/operators/test_compute.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_compute.py
@@ -502,14 +502,12 @@ class TestGceInstanceStart:
             api_version="{{ dag.dag_id }}",
             task_id="id",
         )
-        session.add(ti)
-        session.commit()
-        ti.render_templates()
-        assert dag_id == ti.task.project_id
-        assert dag_id == ti.task.zone
-        assert dag_id == ti.task.resource_id
-        assert dag_id == ti.task.gcp_conn_id
-        assert dag_id == ti.task.api_version
+        rendered = ti.render_templates()
+        assert dag_id == rendered.project_id
+        assert dag_id == rendered.zone
+        assert dag_id == rendered.resource_id
+        assert dag_id == rendered.gcp_conn_id
+        assert dag_id == rendered.api_version
 
     def test_instance_start_should_throw_ex_when_missing_project_id(self):
         with pytest.raises(AirflowException, match=r"The required parameter 'project_id' is missing"):
@@ -595,14 +593,12 @@ class TestGceInstanceStop:
             api_version="{{ dag.dag_id }}",
             task_id="id",
         )
-        session.add(ti)
-        session.commit()
-        ti.render_templates()
-        assert dag_id == ti.task.project_id
-        assert dag_id == ti.task.zone
-        assert dag_id == ti.task.resource_id
-        assert dag_id == ti.task.gcp_conn_id
-        assert dag_id == ti.task.api_version
+        rendered = ti.render_templates()
+        assert dag_id == rendered.project_id
+        assert dag_id == rendered.zone
+        assert dag_id == rendered.resource_id
+        assert dag_id == rendered.gcp_conn_id
+        assert dag_id == rendered.api_version
 
     def test_instance_stop_should_throw_ex_when_missing_project_id(self):
         with pytest.raises(AirflowException, match=r"The required parameter 'project_id' is missing"):
@@ -679,14 +675,12 @@ class TestGceInstanceSetMachineType:
             api_version="{{ dag.dag_id }}",
             task_id="id",
         )
-        session.add(ti)
-        session.commit()
-        ti.render_templates()
-        assert dag_id == ti.task.project_id
-        assert dag_id == ti.task.zone
-        assert dag_id == ti.task.resource_id
-        assert dag_id == ti.task.gcp_conn_id
-        assert dag_id == ti.task.api_version
+        rendered = ti.render_templates()
+        assert dag_id == rendered.project_id
+        assert dag_id == rendered.zone
+        assert dag_id == rendered.resource_id
+        assert dag_id == rendered.gcp_conn_id
+        assert dag_id == rendered.api_version
 
     def test_machine_type_set_should_throw_ex_when_missing_project_id(self):
         with pytest.raises(AirflowException, match=r"The required parameter 'project_id' is missing"):

--- a/providers/google/tests/unit/google/cloud/operators/test_dataprep.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_dataprep.py
@@ -184,13 +184,11 @@ class TestDataprepCopyFlowOperatorTest:
             name="{{ dag.dag_id }}",
             description="{{ dag.dag_id }}",
         )
-        session.add(ti)
-        session.commit()
-        ti.render_templates()
-        assert dag_id == ti.task.project_id
-        assert dag_id == ti.task.flow_id
-        assert dag_id == ti.task.name
-        assert dag_id == ti.task.description
+        task = ti.render_templates()
+        assert dag_id == task.project_id
+        assert dag_id == task.flow_id
+        assert dag_id == task.name
+        assert dag_id == task.description
 
     @mock.patch("airflow.providers.google.cloud.operators.dataprep.GoogleDataprepHook")
     @mock.patch("airflow.providers.google.cloud.operators.dataprep.DataprepFlowLink")
@@ -256,10 +254,8 @@ class TestDataprepDeleteFlowOperator:
             task_id=TASK_ID,
             flow_id="{{ dag.dag_id }}",
         )
-        session.add(ti)
-        session.commit()
-        ti.render_templates()
-        assert dag_id == ti.task.flow_id
+        task = ti.render_templates()
+        assert dag_id == task.flow_id
 
 
 class TestDataprepRunFlowOperator:
@@ -291,9 +287,7 @@ class TestDataprepRunFlowOperator:
             flow_id="{{ dag.dag_id }}",
             body_request={},
         )
-        session.add(ti)
-        session.commit()
-        ti.render_templates()
+        task = ti.render_templates()
 
-        assert dag_id == ti.task.project_id
-        assert dag_id == ti.task.flow_id
+        assert dag_id == task.project_id
+        assert dag_id == task.flow_id

--- a/providers/google/tests/unit/google/cloud/operators/test_dataproc.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_dataproc.py
@@ -1133,7 +1133,7 @@ def test_create_cluster_operator_extra_links(
         delete_on_error=True,
         gcp_conn_id=GCP_CONN_ID,
     )
-
+    task = dag_maker.dag.get_task(ti.task_id)
     serialized_dag = dag_maker.get_serialized_data()
     # Assert operator links for serialized DAG
     deserialized_dag = DagSerialization.deserialize_dag(serialized_dag["dag"])
@@ -1146,7 +1146,7 @@ def test_create_cluster_operator_extra_links(
             value="",
         )
     # Assert operator link is empty when no XCom push occurred
-    assert ti.task.operator_extra_links[0].get_link(operator=ti.task, ti_key=ti.key) == ""
+    assert task.operator_extra_links[0].get_link(operator=task, ti_key=ti.key) == ""
 
     ti.xcom_push(key="dataproc_cluster", value=DATAPROC_CLUSTER_EXPECTED)
 
@@ -1157,8 +1157,7 @@ def test_create_cluster_operator_extra_links(
         )
     # Assert operator links after execution
     assert (
-        ti.task.operator_extra_links[0].get_link(operator=ti.task, ti_key=ti.key)
-        == DATAPROC_CLUSTER_LINK_EXPECTED
+        task.operator_extra_links[0].get_link(operator=task, ti_key=ti.key) == DATAPROC_CLUSTER_LINK_EXPECTED
     )
 
 
@@ -2015,7 +2014,7 @@ def test_submit_job_operator_extra_links(
         job={},
         gcp_conn_id=GCP_CONN_ID,
     )
-
+    task = dag_maker.dag.get_task(ti.task_id)
     serialized_dag = dag_maker.get_serialized_data()
 
     # Assert operator links for serialized DAG
@@ -2030,7 +2029,7 @@ def test_submit_job_operator_extra_links(
         )
 
     # Assert operator link is empty when no XCom push occurred
-    assert ti.task.operator_extra_links[0].get_link(operator=ti.task, ti_key=ti.key) == ""
+    assert task.operator_extra_links[0].get_link(operator=task, ti_key=ti.key) == ""
 
     ti.xcom_push(key="dataproc_job", value=DATAPROC_JOB_EXPECTED)
 
@@ -2041,10 +2040,7 @@ def test_submit_job_operator_extra_links(
         )
 
     # Assert operator links after execution
-    assert (
-        ti.task.operator_extra_links[0].get_link(operator=ti.task, ti_key=ti.key)
-        == DATAPROC_JOB_LINK_EXPECTED
-    )
+    assert task.operator_extra_links[0].get_link(operator=task, ti_key=ti.key) == DATAPROC_JOB_LINK_EXPECTED
 
 
 class TestDataprocUpdateClusterOperator(DataprocClusterTestBase):
@@ -2224,7 +2220,7 @@ def test_update_cluster_operator_extra_links(
         project_id=GCP_PROJECT,
         gcp_conn_id=GCP_CONN_ID,
     )
-
+    task = dag_maker.dag.get_task(ti.task_id)
     serialized_dag = dag_maker.get_serialized_data()
 
     # Assert operator links for serialized DAG
@@ -2238,7 +2234,7 @@ def test_update_cluster_operator_extra_links(
             value="",
         )
     # Assert operator link is empty when no XCom push occurred
-    assert ti.task.operator_extra_links[0].get_link(operator=ti.task, ti_key=ti.key) == ""
+    assert task.operator_extra_links[0].get_link(operator=task, ti_key=ti.key) == ""
 
     ti.xcom_push(key="dataproc_cluster", value=DATAPROC_CLUSTER_EXPECTED)
 
@@ -2250,8 +2246,7 @@ def test_update_cluster_operator_extra_links(
 
     # Assert operator links after execution
     assert (
-        ti.task.operator_extra_links[0].get_link(operator=ti.task, ti_key=ti.key)
-        == DATAPROC_CLUSTER_LINK_EXPECTED
+        task.operator_extra_links[0].get_link(operator=task, ti_key=ti.key) == DATAPROC_CLUSTER_LINK_EXPECTED
     )
 
 
@@ -2451,6 +2446,7 @@ def test_instantiate_workflow_operator_extra_links(
         template_id=TEMPLATE_ID,
         gcp_conn_id=GCP_CONN_ID,
     )
+    task = dag_maker.dag.get_task(ti.task_id)
     serialized_dag = dag_maker.get_serialized_data()
 
     # Assert operator links for serialized DAG
@@ -2464,7 +2460,7 @@ def test_instantiate_workflow_operator_extra_links(
             value="",
         )
     # Assert operator link is empty when no XCom push occurred
-    assert ti.task.operator_extra_links[0].get_link(operator=ti.task, ti_key=ti.key) == ""
+    assert task.operator_extra_links[0].get_link(operator=task, ti_key=ti.key) == ""
 
     ti.xcom_push(key="dataproc_workflow", value=DATAPROC_WORKFLOW_EXPECTED)
     if AIRFLOW_V_3_0_PLUS:
@@ -2474,8 +2470,7 @@ def test_instantiate_workflow_operator_extra_links(
         )
     # Assert operator links after execution
     assert (
-        ti.task.operator_extra_links[0].get_link(operator=ti.task, ti_key=ti.key)
-        == DATAPROC_WORKFLOW_LINK_EXPECTED
+        task.operator_extra_links[0].get_link(operator=task, ti_key=ti.key) == DATAPROC_WORKFLOW_LINK_EXPECTED
     )
 
 
@@ -3145,6 +3140,7 @@ def test_instantiate_inline_workflow_operator_extra_links(
         template={},
         gcp_conn_id=GCP_CONN_ID,
     )
+    task = dag_maker.dag.get_task(ti.task_id)
     serialized_dag = dag_maker.get_serialized_data()
 
     # Assert operator links for serialized DAG
@@ -3157,7 +3153,7 @@ def test_instantiate_inline_workflow_operator_extra_links(
             value="",
         )
     # Assert operator link is empty when no XCom push occurred
-    assert ti.task.operator_extra_links[0].get_link(operator=ti.task, ti_key=ti.key) == ""
+    assert task.operator_extra_links[0].get_link(operator=task, ti_key=ti.key) == ""
 
     ti.xcom_push(key="dataproc_workflow", value=DATAPROC_WORKFLOW_EXPECTED)
     if AIRFLOW_V_3_0_PLUS:
@@ -3167,8 +3163,7 @@ def test_instantiate_inline_workflow_operator_extra_links(
 
     # Assert operator links after execution
     assert (
-        ti.task.operator_extra_links[0].get_link(operator=ti.task, ti_key=ti.key)
-        == DATAPROC_WORKFLOW_LINK_EXPECTED
+        task.operator_extra_links[0].get_link(operator=task, ti_key=ti.key) == DATAPROC_WORKFLOW_LINK_EXPECTED
     )
 
 

--- a/providers/google/tests/unit/google/cloud/operators/test_pubsub.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_pubsub.py
@@ -514,21 +514,19 @@ class TestPubSubPullOperator:
 
     @pytest.mark.db_test
     @mock.patch("airflow.providers.google.cloud.operators.pubsub.PubSubHook")
-    def test_execute_deferred(self, mock_hook, create_task_instance_of_operator):
+    def test_execute_deferred(self, mock_hook):
         """
         Asserts that a task is deferred and a PubSubPullOperator will be fired
         when the PubSubPullOperator is executed with deferrable=True.
         """
-        ti = create_task_instance_of_operator(
-            PubSubPullOperator,
-            dag_id="dag_id",
+        task = PubSubPullOperator(
             task_id=TASK_ID,
             project_id=TEST_PROJECT,
             subscription=TEST_SUBSCRIPTION,
             deferrable=True,
         )
         with pytest.raises(TaskDeferred) as _:
-            ti.task.execute(mock.MagicMock())
+            task.execute(mock.MagicMock())
 
     @mock.patch("airflow.providers.google.cloud.operators.pubsub.PubSubHook")
     def test_get_openlineage_facets(self, mock_hook):

--- a/providers/google/tests/unit/google/cloud/operators/test_vertex_ai.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_vertex_ai.py
@@ -1237,10 +1237,7 @@ class TestVertexAIDeleteCustomTrainingJobOperator:
             dag_id="test_template_body_templating_dag",
             task_id="test_template_body_templating_task",
         )
-        session.add(ti)
-        session.commit()
-        ti.render_templates()
-        task: DeleteCustomTrainingJobOperator = ti.task
+        task = ti.render_templates()
         assert task.training_pipeline_id == "training-pipeline-id"
         assert task.custom_job_id == "custom_job_id"
         assert task.region == "region"
@@ -1991,10 +1988,7 @@ class TestVertexAIDeleteAutoMLTrainingJobOperator:
             dag_id="test_template_body_templating_dag",
             task_id="test_template_body_templating_task",
         )
-        session.add(ti)
-        session.commit()
-        ti.render_templates()
-        task: DeleteAutoMLTrainingJobOperator = ti.task
+        task = ti.render_templates()
         assert task.training_pipeline_id == "training-pipeline-id"
         assert task.region == "region"
         assert task.project_id == "project-id"

--- a/providers/google/tests/unit/google/marketing_platform/operators/test_campaign_manager.py
+++ b/providers/google/tests/unit/google/marketing_platform/operators/test_campaign_manager.py
@@ -35,6 +35,8 @@ from airflow.providers.google.marketing_platform.operators.campaign_manager impo
 from airflow.utils import timezone
 from airflow.utils.session import create_session
 
+from tests_common.test_utils.taskinstance import run_task_instance
+
 API_VERSION = "v4"
 GCP_CONN_ID = "google_cloud_default"
 
@@ -198,7 +200,7 @@ class TestGoogleCampaignManagerDownloadReportOperator:
         dr = dag_maker.create_dagrun()
 
         for ti in dr.get_task_instances():
-            ti.run()
+            run_task_instance(ti, dag_maker.dag.get_task(ti.task_id))
 
         gcs_hook_mock.return_value.upload.assert_called_once_with(
             bucket_name=BUCKET_NAME,

--- a/providers/http/tests/unit/http/sensors/test_http.py
+++ b/providers/http/tests/unit/http/sensors/test_http.py
@@ -151,7 +151,7 @@ class TestHttpSensor:
         assert prep_request.method, received_request.method
 
     @patch("airflow.providers.http.hooks.http.Session.send")
-    def test_poke_context(self, mock_session_send, create_task_instance_of_operator):
+    def test_poke_context(self, mock_session_send, dag_maker, create_task_instance_of_operator):
         response = requests.Response()
         response.status_code = 200
         mock_session_send.return_value = response
@@ -172,7 +172,7 @@ class TestHttpSensor:
             poke_interval=1,
         )
 
-        task_instance.task.execute(task_instance.get_template_context())
+        dag_maker.dag.get_task(task_instance.task_id).execute(task_instance.get_template_context())
 
     @patch("airflow.providers.http.hooks.http.Session.send")
     def test_logging_head_error_request(self, mock_session_send, create_task_of_operator):

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_data_factory.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_data_factory.py
@@ -38,13 +38,14 @@ from airflow.providers.microsoft.azure.triggers.data_factory import AzureDataFac
 from airflow.utils import timezone
 from airflow.utils.types import DagRunType
 
+from tests_common.test_utils.taskinstance import create_task_instance as _create_task_instance
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
-
-if TYPE_CHECKING:
-    from airflow.models.baseoperator import BaseOperator
 
 if AIRFLOW_V_3_0_PLUS:
     from airflow.sdk.execution_time.comms import XComResult
+
+if TYPE_CHECKING:
+    from airflow.models.baseoperator import BaseOperator
 
 DEFAULT_DATE = timezone.datetime(2021, 1, 1)
 SUBSCRIPTION_ID = "my-subscription-id"
@@ -239,7 +240,7 @@ class TestAzureDataFactoryRunPipelineOperator:
         ],
     )
     def test_run_pipeline_operator_link(
-        self, resource_group, factory, create_task_instance_of_operator, mock_supervisor_comms
+        self, resource_group, factory, dag_maker, create_task_instance_of_operator, mock_supervisor_comms
     ):
         ti = create_task_instance_of_operator(
             AzureDataFactoryRunPipelineOperator,
@@ -258,7 +259,8 @@ class TestAzureDataFactoryRunPipelineOperator:
                 value=PIPELINE_RUN_RESPONSE["run_id"],
             )
 
-        url = ti.task.operator_extra_links[0].get_link(operator=ti.task, ti_key=ti.key)
+        task = dag_maker.dag.get_task(ti.task_id)
+        url = task.operator_extra_links[0].get_link(operator=task, ti_key=ti.key)
         EXPECTED_PIPELINE_RUN_OP_EXTRA_LINK = (
             "https://adf.azure.com/en-us/monitoring/pipelineruns/{run_id}"
             "?factory=/subscriptions/{subscription_id}/"
@@ -295,7 +297,7 @@ def create_task_instance(create_task_instance_of_operator, session):
 
 class TestAzureDataFactoryRunPipelineOperatorWithDeferrable:
     @pytest.fixture(autouse=True)
-    def setup_operator(self, create_task_instance):
+    def setup_operator(self, dag_maker, create_task_instance):
         """Fixture to set up the operator using create_task_instance."""
         self.ti = create_task_instance(
             operator_class=AzureDataFactoryRunPipelineOperator,
@@ -306,6 +308,7 @@ class TestAzureDataFactoryRunPipelineOperatorWithDeferrable:
             parameters={"myParam": "value"},
             deferrable=True,
         )
+        self.task = dag_maker.dag.get_task(self.ti.task_id)
 
     def get_dag_run(self, dag_id: str = "test_dag_id", run_id: str = "test_dag_id") -> DagRun:
         if AIRFLOW_V_3_0_PLUS:
@@ -320,7 +323,11 @@ class TestAzureDataFactoryRunPipelineOperatorWithDeferrable:
 
     def get_task_instance(self, task: BaseOperator) -> TaskInstance:
         if AIRFLOW_V_3_0_PLUS:
-            return TaskInstance(task, run_id=timezone.datetime(2022, 1, 1), dag_version_id=mock.MagicMock())
+            return _create_task_instance(
+                task,
+                run_id=timezone.datetime(2022, 1, 1).isoformat(),
+                dag_version_id=mock.MagicMock(),
+            )
         return TaskInstance(task, timezone.datetime(2022, 1, 1))
 
     def get_conn(
@@ -351,7 +358,7 @@ class TestAzureDataFactoryRunPipelineOperatorWithDeferrable:
                 run_id=DagRun.generate_run_id(DagRunType.MANUAL, logical_date),
             )
         if AIRFLOW_V_3_0_PLUS:
-            task_instance = TaskInstance(task=task, dag_version_id=mock.MagicMock())
+            task_instance = _create_task_instance(task=task, dag_version_id=mock.MagicMock())
         else:
             task_instance = TaskInstance(task=task)
         task_instance.dag_run = dag_run
@@ -387,7 +394,7 @@ class TestAzureDataFactoryRunPipelineOperatorWithDeferrable:
         CreateRunResponse.run_id = AZ_PIPELINE_RUN_ID
         mock_run_pipeline.return_value = CreateRunResponse
 
-        self.ti.task.execute(context=self.create_context(self.ti.task))
+        self.task.execute(context=self.create_context(self.task))
         assert not mock_defer.called
 
     @pytest.mark.db_test
@@ -411,7 +418,7 @@ class TestAzureDataFactoryRunPipelineOperatorWithDeferrable:
         mock_run_pipeline.return_value = CreateRunResponse
 
         with pytest.raises(AzureDataFactoryPipelineRunException):
-            self.ti.task.execute(context=self.create_context(self.ti.task))
+            self.task.execute(context=self.create_context(self.task))
         assert not mock_defer.called
 
     @pytest.mark.db_test
@@ -430,7 +437,7 @@ class TestAzureDataFactoryRunPipelineOperatorWithDeferrable:
         mock_run_pipeline.return_value = CreateRunResponse
 
         with pytest.raises(TaskDeferred) as exc:
-            self.ti.task.execute(context=self.create_context(self.ti.task))
+            self.task.execute(context=self.create_context(self.task))
 
         assert isinstance(exc.value.trigger, AzureDataFactoryTrigger), (
             "Trigger is not a AzureDataFactoryTrigger"
@@ -439,9 +446,8 @@ class TestAzureDataFactoryRunPipelineOperatorWithDeferrable:
     @pytest.mark.db_test
     def test_azure_data_factory_run_pipeline_operator_async_execute_complete_success(self):
         """Assert that execute_complete log success message"""
-
-        with mock.patch.object(self.ti.task.log, "info") as mock_log_info:
-            self.ti.task.execute_complete(
+        with mock.patch.object(self.task.log, "info") as mock_log_info:
+            self.task.execute_complete(
                 context={},
                 event={"status": "success", "message": "success", "run_id": AZ_PIPELINE_RUN_ID},
             )
@@ -450,9 +456,8 @@ class TestAzureDataFactoryRunPipelineOperatorWithDeferrable:
     @pytest.mark.db_test
     def test_azure_data_factory_run_pipeline_operator_async_execute_complete_fail(self):
         """Assert that execute_complete raise exception on error"""
-
         with pytest.raises(AirflowException):
-            self.ti.task.execute_complete(
+            self.task.execute_complete(
                 context={},
                 event={"status": "error", "message": "error", "run_id": AZ_PIPELINE_RUN_ID},
             )

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_powerbi.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_powerbi.py
@@ -192,7 +192,7 @@ class TestPowerBIDatasetRefreshOperator:
         assert context["ti"].xcom_push.call_count == 0
 
     @pytest.mark.db_test
-    def test_powerbi_link(self, create_task_instance_of_operator):
+    def test_powerbi_link(self, dag_maker, create_task_instance_of_operator):
         """Assert Power BI Extra link matches the expected URL."""
         ti = create_task_instance_of_operator(
             PowerBIDatasetRefreshOperator,
@@ -206,7 +206,8 @@ class TestPowerBIDatasetRefreshOperator:
         )
 
         ti.xcom_push(key="powerbi_dataset_refresh_id", value=NEW_REFRESH_REQUEST_ID)
-        url = ti.task.operator_extra_links[0].get_link(operator=ti.task, ti_key=ti.key)
+        task = dag_maker.dag.get_task(ti.task_id)
+        url = task.operator_extra_links[0].get_link(operator=task, ti_key=ti.key)
         EXPECTED_ITEM_RUN_OP_EXTRA_LINK = (
             f"https://app.powerbi.com/groups/{GROUP_ID}/datasets/{DATASET_ID}/details?experience=power-bi"
         )

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_synapse.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_synapse.py
@@ -281,7 +281,12 @@ class TestAzureSynapseRunPipelineOperator:
             mock_get_pipeline_run.assert_not_called()
 
     @pytest.mark.db_test
-    def test_run_pipeline_operator_link(self, create_task_instance_of_operator, mock_supervisor_comms):
+    def test_run_pipeline_operator_link(
+        self,
+        dag_maker,
+        create_task_instance_of_operator,
+        mock_supervisor_comms,
+    ):
         ti = create_task_instance_of_operator(
             AzureSynapseRunPipelineOperator,
             dag_id="test_synapse_run_pipeline_op_link",
@@ -298,7 +303,8 @@ class TestAzureSynapseRunPipelineOperator:
                 value=PIPELINE_RUN_RESPONSE["run_id"],
             )
 
-        url = ti.task.operator_extra_links[0].get_link(operator=ti.task, ti_key=ti.key)
+        task = dag_maker.dag.get_task(ti.task_id)
+        url = task.operator_extra_links[0].get_link(operator=task, ti_key=ti.key)
 
         EXPECTED_PIPELINE_RUN_OP_EXTRA_LINK = (
             "https://ms.web.azuresynapse.net/en/monitoring/pipelineruns/{run_id}"

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/sensors/test_wasb.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/sensors/test_wasb.py
@@ -34,6 +34,7 @@ from airflow.providers.microsoft.azure.triggers.wasb import WasbBlobSensorTrigge
 from airflow.utils import timezone
 from airflow.utils.types import DagRunType
 
+from tests_common.test_utils.taskinstance import create_task_instance
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 if TYPE_CHECKING:
@@ -128,7 +129,7 @@ class TestWasbBlobAsyncSensor:
                 ),
             )
         if AIRFLOW_V_3_0_PLUS:
-            task_instance = TaskInstance(task=task, dag_version_id=mock.MagicMock())
+            task_instance = create_task_instance(task=task, dag_version_id=mock.MagicMock())
         else:
             task_instance = TaskInstance(task=task)
         task_instance.dag_run = dag_run
@@ -277,7 +278,7 @@ class TestWasbPrefixAsyncSensor:
                 ),
             )
         if AIRFLOW_V_3_0_PLUS:
-            task_instance = TaskInstance(task=task, dag_version_id=mock.MagicMock())
+            task_instance = create_task_instance(task=task, dag_version_id=mock.MagicMock())
         else:
             task_instance = TaskInstance(task=task)
         task_instance.dag_run = dag_run

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_adapter.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_adapter.py
@@ -57,6 +57,7 @@ from airflow.utils.types import DagRunType
 from tests_common.test_utils.compat import BashOperator
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.markers import skip_if_force_lowest_dependencies_marker
+from tests_common.test_utils.taskinstance import create_task_instance
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 
@@ -870,14 +871,14 @@ def test_emit_dag_complete_event(
     dag_run._state = DagRunState.SUCCESS
     dag_run.end_date = event_time
     if AIRFLOW_V_3_0_PLUS:
-        ti0 = TaskInstance(
+        ti0 = create_task_instance(
             task=task_0, run_id=run_id, state=TaskInstanceState.SUCCESS, dag_version_id=mock.MagicMock()
         )
-        ti1 = TaskInstance(
+        ti1 = create_task_instance(
             task=task_1, run_id=run_id, state=TaskInstanceState.SKIPPED, dag_version_id=mock.MagicMock()
         )
 
-        ti2 = TaskInstance(
+        ti2 = create_task_instance(
             task=task_2, run_id=run_id, state=TaskInstanceState.FAILED, dag_version_id=mock.MagicMock()
         )
     else:
@@ -1035,14 +1036,14 @@ def test_emit_dag_failed_event(
     dag_run.end_date = event_time
 
     if AIRFLOW_V_3_0_PLUS:
-        ti0 = TaskInstance(
+        ti0 = create_task_instance(
             task=task_0, run_id=run_id, state=TaskInstanceState.SUCCESS, dag_version_id=mock.MagicMock()
         )
-        ti1 = TaskInstance(
+        ti1 = create_task_instance(
             task=task_1, run_id=run_id, state=TaskInstanceState.SKIPPED, dag_version_id=mock.MagicMock()
         )
 
-        ti2 = TaskInstance(
+        ti2 = create_task_instance(
             task=task_2, run_id=run_id, state=TaskInstanceState.FAILED, dag_version_id=mock.MagicMock()
         )
     else:

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
@@ -34,6 +34,7 @@ from openlineage.client.transport.console import ConsoleConfig
 from uuid6 import uuid7
 
 from airflow.models import DAG, DagRun, TaskInstance
+from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.providers.openlineage.extractors.base import OperatorLineage
 from airflow.providers.openlineage.plugins.adapter import OpenLineageAdapter
 from airflow.providers.openlineage.plugins.listener import OpenLineageListener
@@ -45,14 +46,13 @@ from tests_common.test_utils.compat import EmptyOperator, PythonOperator
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.dag import create_scheduler_dag
 from tests_common.test_utils.db import clear_db_runs
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS
+from tests_common.test_utils.taskinstance import create_task_instance
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS, AIRFLOW_V_3_2_PLUS
 
 if AIRFLOW_V_3_1_PLUS:
     from airflow._shared.timezones import timezone
 else:
     from airflow.utils import timezone  # type: ignore[attr-defined,no-redef]
-
-from airflow.providers.common.compat.sdk import BaseOperator
 
 EXPECTED_TRY_NUMBER_1 = 1
 
@@ -204,17 +204,9 @@ class TestOpenLineageListenerAirflow2:
             state=DagRunState.RUNNING,
             execution_date=date,  # type: ignore
         )
-        if AIRFLOW_V_3_1_PLUS:
-            from airflow.serialization.serialized_objects import create_scheduler_operator
-
-            task_instance = TaskInstance(
-                create_scheduler_operator(t),
-                run_id=run_id,
-                dag_version_id=dagrun.created_dag_version_id,
-            )
-        elif AIRFLOW_V_3_0_PLUS:
-            task_instance = TaskInstance(
-                t,  # type: ignore[arg-type]
+        if AIRFLOW_V_3_0_PLUS:
+            task_instance = create_task_instance(
+                t,
                 run_id=run_id,
                 dag_version_id=dagrun.created_dag_version_id,
             )
@@ -257,7 +249,14 @@ class TestOpenLineageListenerAirflow2:
         adapter.fail_task = mock.Mock()
         adapter.complete_task = mock.Mock()
         listener.adapter = adapter
-        if AIRFLOW_V_3_0_PLUS:
+        if AIRFLOW_V_3_2_PLUS:
+            from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
+
+            task_instance = TaskInstance(
+                task=SerializedBaseOperator(task_id="task_id_from_task_and_not_ti"),
+                dag_version_id=mock.MagicMock(),
+            )
+        elif AIRFLOW_V_3_0_PLUS:
             task_instance = TaskInstance(task=mock.Mock(), dag_version_id=mock.MagicMock())
         else:
             task_instance = TaskInstance(task=mock.Mock())  # type: ignore
@@ -1089,7 +1088,15 @@ class TestOpenLineageListenerAirflow3:
 
         if not runtime_ti:
             # TaskInstance is used when on API server (when listener gets called about manual state change)
-            task_instance = TaskInstance(task=MagicMock(), dag_version_id=uuid7())
+            if AIRFLOW_V_3_2_PLUS:
+                from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
+
+                task_instance = TaskInstance(
+                    task=SerializedBaseOperator(task_id="task_id"),
+                    dag_version_id=uuid7(),
+                )
+            else:
+                task_instance = TaskInstance(task=MagicMock(), dag_version_id=uuid7())
             task_instance.dag_run = DagRun()
             task_instance.dag_run.dag_id = "dag_id_from_dagrun_and_not_ti"
             task_instance.dag_run.run_id = "dag_run_run_id"

--- a/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
+++ b/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
@@ -70,6 +70,7 @@ from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.compat import BashOperator, OperatorSerialization, PythonOperator
 from tests_common.test_utils.mock_operators import MockOperator
+from tests_common.test_utils.taskinstance import create_task_instance
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_3_PLUS, AIRFLOW_V_3_0_PLUS
 
 BASH_OPERATOR_PATH = "airflow.providers.standard.operators.bash"
@@ -1439,7 +1440,7 @@ def test_get_task_groups_details_no_task_groups():
 @patch("airflow.providers.openlineage.conf.custom_run_facets", return_value=set())
 def test_get_user_provided_run_facets_with_no_function_definition(mock_custom_facet_funcs):
     if AIRFLOW_V_3_0_PLUS:
-        sample_ti = TaskInstance(
+        sample_ti = create_task_instance(
             task=EmptyOperator(
                 task_id="test-task",
                 dag=DAG("test-dag", schedule=None, start_date=datetime.datetime(2024, 7, 1)),
@@ -1465,7 +1466,7 @@ def test_get_user_provided_run_facets_with_no_function_definition(mock_custom_fa
 )
 def test_get_user_provided_run_facets_with_function_definition(mock_custom_facet_funcs):
     if AIRFLOW_V_3_0_PLUS:
-        sample_ti = TaskInstance(
+        sample_ti = create_task_instance(
             task=EmptyOperator(
                 task_id="test-task",
                 dag=DAG("test-dag", schedule=None, start_date=datetime.datetime(2024, 7, 1)),
@@ -1495,7 +1496,7 @@ def test_get_user_provided_run_facets_with_function_definition(mock_custom_facet
 )
 def test_get_user_provided_run_facets_with_return_value_as_none(mock_custom_facet_funcs):
     if AIRFLOW_V_3_0_PLUS:
-        sample_ti = TaskInstance(
+        sample_ti = create_task_instance(
             task=BashOperator(
                 task_id="test-task",
                 bash_command="exit 0;",
@@ -1528,7 +1529,7 @@ def test_get_user_provided_run_facets_with_return_value_as_none(mock_custom_face
 )
 def test_get_user_provided_run_facets_with_multiple_function_definition(mock_custom_facet_funcs):
     if AIRFLOW_V_3_0_PLUS:
-        sample_ti = TaskInstance(
+        sample_ti = create_task_instance(
             task=EmptyOperator(
                 task_id="test-task",
                 dag=DAG("test-dag", schedule=None, start_date=datetime.datetime(2024, 7, 1)),
@@ -1560,7 +1561,7 @@ def test_get_user_provided_run_facets_with_multiple_function_definition(mock_cus
 )
 def test_get_user_provided_run_facets_with_duplicate_facet_keys(mock_custom_facet_funcs):
     if AIRFLOW_V_3_0_PLUS:
-        sample_ti = TaskInstance(
+        sample_ti = create_task_instance(
             task=EmptyOperator(
                 task_id="test-task",
                 dag=DAG("test-dag", schedule=None, start_date=datetime.datetime(2024, 7, 1)),
@@ -1588,7 +1589,7 @@ def test_get_user_provided_run_facets_with_duplicate_facet_keys(mock_custom_face
 )
 def test_get_user_provided_run_facets_with_invalid_function_definition(mock_custom_facet_funcs):
     if AIRFLOW_V_3_0_PLUS:
-        sample_ti = TaskInstance(
+        sample_ti = create_task_instance(
             task=EmptyOperator(
                 task_id="test-task",
                 dag=DAG("test-dag", schedule=None, start_date=datetime.datetime(2024, 7, 1)),
@@ -1614,7 +1615,7 @@ def test_get_user_provided_run_facets_with_invalid_function_definition(mock_cust
 )
 def test_get_user_provided_run_facets_with_wrong_return_type_function(mock_custom_facet_funcs):
     if AIRFLOW_V_3_0_PLUS:
-        sample_ti = TaskInstance(
+        sample_ti = create_task_instance(
             task=EmptyOperator(
                 task_id="test-task",
                 dag=DAG("test-dag", schedule=None, start_date=datetime.datetime(2024, 7, 1)),
@@ -1640,7 +1641,7 @@ def test_get_user_provided_run_facets_with_wrong_return_type_function(mock_custo
 )
 def test_get_user_provided_run_facets_with_exception(mock_custom_facet_funcs):
     if AIRFLOW_V_3_0_PLUS:
-        sample_ti = TaskInstance(
+        sample_ti = create_task_instance(
             task=EmptyOperator(
                 task_id="test-task",
                 dag=DAG("test-dag", schedule=None, start_date=datetime.datetime(2024, 7, 1)),

--- a/providers/redis/tests/unit/redis/log/test_redis_task_handler.py
+++ b/providers/redis/tests/unit/redis/log/test_redis_task_handler.py
@@ -33,6 +33,7 @@ from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.db import clear_db_dag_bundles, clear_db_dags, clear_db_runs
 from tests_common.test_utils.file_task_handler import extract_events
+from tests_common.test_utils.taskinstance import create_task_instance
 from tests_common.test_utils.version_compat import (
     AIRFLOW_V_3_0_PLUS,
     AIRFLOW_V_3_1_PLUS,
@@ -98,7 +99,7 @@ class TestRedisTaskHandler:
             from airflow.models.dag_version import DagVersion
 
             dag_version = DagVersion.get_latest_version(dag.dag_id)
-            ti = TaskInstance(task=task, run_id=dag_run.run_id, dag_version_id=dag_version.id)
+            ti = create_task_instance(task=task, run_id=dag_run.run_id, dag_version_id=dag_version.id)
         else:
             ti = TaskInstance(task=task, run_id=dag_run.run_id)
         ti.dag_run = dag_run

--- a/providers/snowflake/tests/unit/snowflake/operators/test_snowflake.py
+++ b/providers/snowflake/tests/unit/snowflake/operators/test_snowflake.py
@@ -40,6 +40,7 @@ from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.db import clear_db_dag_bundles, clear_db_dags, clear_db_runs
+from tests_common.test_utils.taskinstance import create_task_instance
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, timezone
 
 DEFAULT_DATE = timezone.datetime(2015, 1, 1)
@@ -239,7 +240,7 @@ def create_context(task, dag=None):
 
         sync_dag_to_db(dag)
         dag_version = DagVersion.get_latest_version(dag.dag_id)
-        task_instance = TaskInstance(task=task, run_id="test_run_id", dag_version_id=dag_version.id)
+        task_instance = create_task_instance(task=task, run_id="test_run_id", dag_version_id=dag_version.id)
         dag_run = DagRun(
             dag_id=dag.dag_id,
             logical_date=logical_date,

--- a/providers/ssh/tests/unit/ssh/operators/test_ssh.py
+++ b/providers/ssh/tests/unit/ssh/operators/test_ssh.py
@@ -37,6 +37,7 @@ from airflow.providers.ssh.operators.ssh import SSHOperator
 
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.dag import sync_dag_to_db
+from tests_common.test_utils.taskinstance import create_task_instance
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, NOTSET
 
 datetime = timezone.datetime
@@ -279,7 +280,7 @@ class TestSSHOperator:
         if AIRFLOW_V_3_0_PLUS:
             sync_dag_to_db(dag)
             dag_version = DagVersion.get_latest_version(dag.dag_id)
-            ti = TaskInstance(task=task, run_id=dr.run_id, dag_version_id=dag_version.id)
+            ti = create_task_instance(task=task, run_id=dr.run_id, dag_version_id=dag_version.id)
         else:
             ti = TaskInstance(task=task, run_id=dr.run_id)
         with pytest.raises(AirflowException, match=f"SSH operator error: exit status = {ssh_exit_code}"):

--- a/providers/standard/src/airflow/providers/standard/decorators/bash.py
+++ b/providers/standard/src/airflow/providers/standard/decorators/bash.py
@@ -89,8 +89,7 @@ class _BashDecoratedOperator(DecoratedOperator, BashOperator):
             raise TypeError("The returned value from the TaskFlow callable must be a non-empty string.")
 
         self._is_inline_cmd = self._is_inline_command(bash_command=self.bash_command)
-        context["ti"].render_templates()  # type: ignore[attr-defined]
-
+        self.render_template_fields(context)
         return super().execute(context)
 
 

--- a/providers/standard/tests/unit/standard/decorators/test_external_python.py
+++ b/providers/standard/tests/unit/standard/decorators/test_external_python.py
@@ -26,6 +26,7 @@ from subprocess import CalledProcessError
 
 import pytest
 
+from tests_common.test_utils.taskinstance import run_task_instance
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 if AIRFLOW_V_3_0_PLUS:
@@ -90,11 +91,11 @@ class TestExternalPythonDecorator:
             import dill  # noqa: F401
 
         with dag_maker(serialized=True):
-            f()
+            v = f()
 
         dr = dag_maker.create_dagrun()
         ti = dr.get_task_instances()[0]
-        ti.run()
+        run_task_instance(ti, v.operator)
 
     @pytest.mark.parametrize(
         "serializer",
@@ -116,10 +117,10 @@ class TestExternalPythonDecorator:
             import dill  # noqa: F401
 
         with dag_maker(serialized=True):
-            f()
+            v = f()
         dr = dag_maker.create_dagrun()
         ti = dr.get_task_instances()[0]
-        ti.run()
+        run_task_instance(ti, v.operator)
 
     @pytest.mark.parametrize(
         "serializer",
@@ -134,12 +135,12 @@ class TestExternalPythonDecorator:
             pass
 
         with dag_maker(serialized=True):
-            f()
+            v = f()
         dr = dag_maker.create_dagrun()
         ti = dr.get_task_instances()[0]
 
         with pytest.raises(CalledProcessError):
-            ti.run()
+            run_task_instance(ti, v.operator)
 
     def test_exception_raises_error(self, dag_maker, venv_python):
         @task.external_python(python=venv_python)
@@ -147,12 +148,12 @@ class TestExternalPythonDecorator:
             raise Exception
 
         with dag_maker(serialized=True):
-            f()
+            v = f()
         dr = dag_maker.create_dagrun()
         ti = dr.get_task_instances()[0]
 
         with pytest.raises(CalledProcessError):
-            ti.run()
+            run_task_instance(ti, v.operator)
 
     @pytest.mark.parametrize(
         "serializer",
@@ -171,10 +172,10 @@ class TestExternalPythonDecorator:
             raise Exception
 
         with dag_maker(serialized=True):
-            f(0, 1, c=True)
+            v = f(0, 1, c=True)
         dr = dag_maker.create_dagrun()
         ti = dr.get_task_instances()[0]
-        ti.run()
+        run_task_instance(ti, v.operator)
 
     @pytest.mark.parametrize(
         "serializer",
@@ -191,11 +192,11 @@ class TestExternalPythonDecorator:
             return None
 
         with dag_maker(serialized=True):
-            f()
+            v = f()
 
         dr = dag_maker.create_dagrun()
         ti = dr.get_task_instances()[0]
-        ti.run()
+        run_task_instance(ti, v.operator)
 
     @pytest.mark.parametrize(
         "serializer",
@@ -212,11 +213,11 @@ class TestExternalPythonDecorator:
             return None
 
         with dag_maker(serialized=True):
-            f(datetime.datetime.now(tz=datetime.timezone.utc))
+            v = f(datetime.datetime.now(tz=datetime.timezone.utc))
 
         dr = dag_maker.create_dagrun()
         ti = dr.get_task_instances()[0]
-        ti.run()
+        run_task_instance(ti, v.operator)
 
     @pytest.mark.parametrize(
         "serializer",
@@ -236,14 +237,14 @@ class TestExternalPythonDecorator:
             return 1
 
         with dag_maker(serialized=True) as dag:
-            f()
+            v = f()
         dr = dag_maker.create_dagrun()
 
         assert len(dag.task_group.children) == 1
         setup_task = dag.task_group.children["f"]
         assert setup_task.is_setup
         ti = dr.get_task_instances()[0]
-        ti.run()
+        run_task_instance(ti, v.operator)
 
     @pytest.mark.parametrize(
         "serializer",
@@ -263,14 +264,14 @@ class TestExternalPythonDecorator:
             return 1
 
         with dag_maker(serialized=True) as dag:
-            f()
+            v = f()
         dr = dag_maker.create_dagrun()
 
         assert len(dag.task_group.children) == 1
         teardown_task = dag.task_group.children["f"]
         assert teardown_task.is_teardown
         ti = dr.get_task_instances()[0]
-        ti.run()
+        run_task_instance(ti, v.operator)
 
     @pytest.mark.parametrize(
         "serializer",
@@ -291,7 +292,7 @@ class TestExternalPythonDecorator:
             return 1
 
         with dag_maker(serialized=True) as dag:
-            f()
+            v = f()
         dr = dag_maker.create_dagrun()
 
         assert len(dag.task_group.children) == 1
@@ -299,4 +300,4 @@ class TestExternalPythonDecorator:
         assert teardown_task.is_teardown
         assert teardown_task.on_failure_fail_dagrun is on_failure_fail_dagrun
         ti = dr.get_task_instances()[0]
-        ti.run()
+        run_task_instance(ti, v.operator)

--- a/providers/standard/tests/unit/standard/operators/test_bash.py
+++ b/providers/standard/tests/unit/standard/operators/test_bash.py
@@ -23,7 +23,6 @@ import signal
 from datetime import datetime, timedelta
 from pathlib import Path
 from time import sleep
-from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
@@ -35,9 +34,6 @@ from airflow.utils.state import State
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
-
-if TYPE_CHECKING:
-    from airflow.models import TaskInstance
 
 DEFAULT_DATE = datetime(2016, 1, 1, tzinfo=timezone.utc)
 END_DATE = datetime(2016, 1, 2, tzinfo=timezone.utc)
@@ -264,7 +260,7 @@ class TestBashOperator:
                 pytest.fail("BashOperator's subprocess still running after stopping on timeout!")
 
     @pytest.mark.db_test
-    def test_templated_fields(self, create_task_instance_of_operator):
+    def test_templated_fields(self, dag_maker, create_task_instance_of_operator):
         ti = create_task_instance_of_operator(
             BashOperator,
             # Templated fields
@@ -275,13 +271,19 @@ class TestBashOperator:
             dag_id="test_templated_fields_dag",
             task_id="test_templated_fields_task",
         )
-        ti.render_templates()
-        task: BashOperator = ti.task
+        context = {
+            "dag": dag_maker.dag,
+            "dag_run": ti.dag_run,
+            "ds": "~whatever~",
+            "task": dag_maker.dag.get_task(ti.task_id),
+            "ti": ti,
+        }
+        task = ti.render_templates(context=context)
         assert task.bash_command == 'echo "test_templated_fields_dag"'
         assert task.cwd == Path(__file__).absolute().parent.as_posix()
 
     @pytest.mark.db_test
-    def test_templated_bash_script(self, dag_maker, tmp_path, session):
+    def test_templated_bash_script(self, dag_maker, create_task_instance_of_operator, tmp_path, session):
         """
         Creates a .sh script with Jinja template.
         Pass it to the BashOperator and ensure it gets correctly rendered and executed.
@@ -290,16 +292,14 @@ class TestBashOperator:
         path: Path = tmp_path / bash_script
         path.write_text('echo "{{ ti.task_id }}"')
 
-        with dag_maker(
-            dag_id="test_templated_bash_script", session=session, template_searchpath=os.fspath(path.parent)
-        ):
-            BashOperator(task_id="test_templated_fields_task", bash_command=bash_script)
-        ti: TaskInstance = dag_maker.create_dagrun().task_instances[0]
-        session.add(ti)
-        session.commit()
-        context = ti.get_template_context(session=session)
-        ti.render_templates(context=context)
-
-        task: BashOperator = ti.task
+        ti = create_task_instance_of_operator(
+            BashOperator,
+            dag_id="test_templated_bash_script",
+            template_searchpath=os.fspath(path.parent),
+            task_id="test_templated_fields_task",
+            bash_command=bash_script,
+        )
+        context = {"dag": dag_maker.dag, "ti": ti}
+        task = ti.render_templates(context=context)
         result = task.execute(context=context)
         assert result == "test_templated_fields_task"

--- a/providers/standard/tests/unit/standard/operators/test_python.py
+++ b/providers/standard/tests/unit/standard/operators/test_python.py
@@ -63,6 +63,7 @@ from airflow.utils.state import DagRunState, State, TaskInstanceState
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.db import clear_db_runs
+from tests_common.test_utils.taskinstance import run_task_instance
 from tests_common.test_utils.version_compat import (
     AIRFLOW_V_3_0_1,
     AIRFLOW_V_3_0_PLUS,
@@ -606,27 +607,22 @@ class TestBranchOperator(BasePythonTest):
             task1 >> join
 
         dr = self.dag_maker.create_dagrun()
-        task_ids = [self.task_id, "task1", "join"]
-        tis = {ti.task_id: ti for ti in dr.task_instances}
 
-        for task_id in task_ids:  # Mimic the specific order the scheduling would run the tests.
-            task_instance = tis[task_id]
-            task_instance.refresh_from_task(self.dag_maker.dag.get_task(task_id))
+        def _run_task(task_id: str):
             if AIRFLOW_V_3_0_1:
                 from airflow.providers.common.compat.sdk import DownstreamTasksSkipped
 
                 try:
-                    task_instance.run()
+                    task_instance = self.dag_maker.run_ti(task_id, dr)
                 except DownstreamTasksSkipped:
                     task_instance.set_state(State.SUCCESS)
             else:
-                task_instance.run()
+                task_instance = self.dag_maker.run_ti(task_id, dr)
+            return task_instance.state
 
-        def get_state(ti):
-            ti.refresh_from_db()
-            return ti.state
-
-        assert [get_state(tis[task_id]) for task_id in task_ids] == expected_states
+        # Mimic the specific order the scheduling would run the tests.
+        states = [_run_task(task_id) for task_id in [self.task_id, "task1", "join"]]
+        assert states == expected_states
 
 
 class TestShortCircuitOperator(BasePythonTest):
@@ -2386,7 +2382,7 @@ class TestShortCircuitWithTeardown:
         dagrun = dag_maker.create_dagrun()
         tis = dagrun.get_task_instances()
         ti: TaskInstance = next(x for x in tis if x.task_id == "op1")
-        ti._run_raw_task()
+        run_task_instance(ti, op1)
         if should_skip:
             # we can't use assert_called_with because it's a set and therefore not ordered
             actual_skipped = set(x.task_id for x in op1.skip.call_args.kwargs["tasks"])
@@ -2412,13 +2408,9 @@ class TestShortCircuitWithTeardown:
                 s1 >> op1 >> s2 >> op2 >> t2 >> t1
             else:
                 raise ValueError("unexpected")
-            op1.skip = MagicMock()
-        dagrun = dag_maker.create_dagrun()
-        tis = dagrun.get_task_instances()
-        ti: TaskInstance = next(x for x in tis if x.task_id == "op1")
-        ti._run_raw_task()
-        # we can't use assert_called_with because it's a set and therefore not ordered
-        actual_skipped = set(op1.skip.call_args.kwargs["tasks"])
+        with mock.patch.object(ShortCircuitOperator, "skip", create=True) as mock_skip:
+            dag_maker.run_ti("op1", ignore_task_deps=True)
+        actual_skipped = set(mock_skip.call_args.kwargs["tasks"])
         assert actual_skipped == {s2, op2}
 
     def test_short_circuit_with_teardowns_complicated_2(self, dag_maker):
@@ -2439,14 +2431,10 @@ class TestShortCircuitWithTeardown:
             # this is the weird, maybe nonsensical part
             # in this case we don't want to skip t2 since it should run
             op1 >> t2
-            op1.skip = MagicMock()
-        dagrun = dag_maker.create_dagrun()
-        tis = dagrun.get_task_instances()
-        ti: TaskInstance = next(x for x in tis if x.task_id == "op1")
-        ti._run_raw_task()
-        # we can't use assert_called_with because it's a set and therefore not ordered
-        actual_kwargs = op1.skip.call_args.kwargs
-        actual_skipped = set(actual_kwargs["tasks"])
+
+        with mock.patch.object(ShortCircuitOperator, "skip", create=True) as mock_skip:
+            dag_maker.run_ti("op1", ignore_task_deps=True)
+        actual_skipped = set(mock_skip.call_args.kwargs["tasks"])
         assert actual_skipped == {op3}
 
     @pytest.mark.parametrize("level", [logging.DEBUG, logging.INFO])
@@ -2472,18 +2460,18 @@ class TestShortCircuitWithTeardown:
             # this is the weird, maybe nonsensical part
             # in this case we don't want to skip t2 since it should run
             op1 >> t2
-            op1.skip = MagicMock()
-        dagrun = dag_maker.create_dagrun()
-        tis = dagrun.get_task_instances()
-        ti: TaskInstance = next(x for x in tis if x.task_id == "op1")
 
-        with caplog.at_level(level):
-            if hasattr(ti.task.log, "setLevel"):
-                # Compat with Pre Airflow 3.1
-                ti.task.log.setLevel(level)
-            ti._run_raw_task()
+        # Compat with Pre Airflow 3.1
+        if hasattr(op1.log, "setLevel"):
+            op1.log.setLevel(level)
+
+        with (
+            caplog.at_level(level),
+            mock.patch.object(ShortCircuitOperator, "skip", create=True) as mock_skip,
+        ):
+            dag_maker.run_ti("op1", ignore_task_deps=True)
         # we can't use assert_called_with because it's a set and therefore not ordered
-        actual_kwargs = op1.skip.call_args.kwargs
+        actual_kwargs = mock_skip.call_args.kwargs
         actual_skipped = actual_kwargs["tasks"]
         if level <= logging.DEBUG:
             assert isinstance(actual_skipped, list)

--- a/providers/standard/tests/unit/standard/operators/test_python.py
+++ b/providers/standard/tests/unit/standard/operators/test_python.py
@@ -123,12 +123,12 @@ class BasePythonTest:
     default_date: datetime = DEFAULT_DATE
 
     @pytest.fixture(autouse=True)
-    def base_tests_setup(self, request, create_serialized_task_instance_of_operator, dag_maker):
+    def base_tests_setup(self, request, create_task_instance_of_operator, dag_maker):
         self.dag_id = f"dag_{slugify(request.cls.__name__)}"
         self.task_id = f"task_{slugify(request.node.name, max_length=40)}"
         self.run_id = f"run_{slugify(request.node.name, max_length=40)}"
         self.ds_templated = self.default_date.date().isoformat()
-        self.ti_maker = create_serialized_task_instance_of_operator
+        self.ti_maker = create_task_instance_of_operator
 
         self.dag_maker = dag_maker
         self.dag_non_serialized = self.dag_maker(self.dag_id, template_searchpath=TEMPLATE_SEARCHPATH).dag

--- a/providers/standard/tests/unit/standard/sensors/test_external_task_sensor.py
+++ b/providers/standard/tests/unit/standard/sensors/test_external_task_sensor.py
@@ -1579,13 +1579,13 @@ def test_external_task_sensor_extra_link(
         external_dag_id=external_dag_id,
         external_task_id=external_task_id,
     )
-    ti.render_templates()
+    task = ti.render_templates()
 
-    assert ti.task.external_dag_id == expected_external_dag_id
-    assert ti.task.external_task_id == expected_external_task_id
-    assert ti.task.external_task_ids == [expected_external_task_id]
+    assert task.external_dag_id == expected_external_dag_id
+    assert task.external_task_id == expected_external_task_id
+    assert task.external_task_ids == [expected_external_task_id]
 
-    url = ti.task.operator_extra_links[0].get_link(operator=ti.task, ti_key=ti.key)
+    url = task.operator_extra_links[0].get_link(operator=task, ti_key=ti.key)
 
     assert f"/dags/{expected_external_dag_id}/runs" in url
 

--- a/providers/standard/tests/unit/standard/utils/test_skipmixin.py
+++ b/providers/standard/tests/unit/standard/utils/test_skipmixin.py
@@ -30,6 +30,7 @@ from airflow.utils.state import State
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.db import clear_db_dags, clear_db_runs
+from tests_common.test_utils.taskinstance import create_task_instance
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 pytestmark = pytest.mark.db_test
@@ -39,6 +40,7 @@ if AIRFLOW_V_3_0_PLUS:
     from airflow.providers.common.compat.sdk import DownstreamTasksSkipped
     from airflow.providers.standard.utils.skipmixin import SkipMixin
     from airflow.sdk import task, task_group
+    from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
 else:
     from airflow.decorators import task, task_group  # type: ignore[attr-defined,no-redef]
     from airflow.models.skipmixin import SkipMixin
@@ -134,7 +136,7 @@ class TestSkipMixin:
         with dag_maker(
             "dag_test_skip_all_except",
             serialized=True,
-        ) as dag:
+        ):
             task1 = EmptyOperator(task_id="task1")
             task2 = EmptyOperator(task_id="task2")
             task3 = EmptyOperator(task_id="task3")
@@ -142,8 +144,13 @@ class TestSkipMixin:
             task1 >> [task2, task3]
         dag_maker.create_dagrun(run_id=DEFAULT_DAG_RUN_ID)
         if AIRFLOW_V_3_0_PLUS:
-            dag_version = DagVersion.get_latest_version(dag.dag_id)
-            ti1 = TI(task1, run_id=DEFAULT_DAG_RUN_ID, dag_version_id=dag_version.id)
+            ti1 = RuntimeTaskInstance.model_construct(
+                dag_id=task1.dag_id,
+                task_id=task1.task_id,
+                task=task1,
+                run_id=DEFAULT_DAG_RUN_ID,
+            )
+            ti1.__dict__["xcom_push"] = MagicMock()
         else:
             ti1 = TI(task1, run_id=DEFAULT_DAG_RUN_ID)
 
@@ -189,8 +196,13 @@ class TestSkipMixin:
             task1 >> [task2, task3]
         dag_maker.create_dagrun(run_id=DEFAULT_DAG_RUN_ID)
         if AIRFLOW_V_3_0_PLUS:
-            dag_version = DagVersion.get_latest_version(task1.dag_id)
-            ti1 = TI(task1, run_id=DEFAULT_DAG_RUN_ID, dag_version_id=dag_version.id)
+            ti1 = RuntimeTaskInstance.model_construct(
+                dag_id=task1.dag_id,
+                task_id=task1.task_id,
+                task=task1,
+                run_id=DEFAULT_DAG_RUN_ID,
+            )
+            ti1.__dict__["xcom_push"] = MagicMock()
         else:
             ti1 = TI(task1, run_id=DEFAULT_DAG_RUN_ID)
 
@@ -218,7 +230,6 @@ class TestSkipMixin:
     @pytest.mark.skipif(
         AIRFLOW_V_3_0_PLUS, reason="In Airflow 3, `NotPreviouslySkippedDep` is used for this case"
     )
-    @pytest.mark.need_serialized_dag
     def test_mapped_tasks_skip_all_except(self, dag_maker):
         with dag_maker("dag_test_skip_all_except") as dag:
 
@@ -233,56 +244,27 @@ class TestSkipMixin:
 
             task_group_op.expand(k=[0, 1])
 
+        def _create_task_instance(task_id, map_index):
+            task = dag.get_task(task_id)
+            if not AIRFLOW_V_3_0_PLUS:
+                return TI(task, run_id=DEFAULT_DAG_RUN_ID, map_index=map_index)
+            ti = RuntimeTaskInstance.model_construct(
+                dag_id=dag.dag_id,
+                task_id=task_id,
+                task=task,
+                run_id=DEFAULT_DAG_RUN_ID,
+                map_index=map_index,
+            )
+            ti.__dict__["xcom_push"] = MagicMock()
+            return ti
+
         dag_maker.create_dagrun(run_id=DEFAULT_DAG_RUN_ID)
-        if AIRFLOW_V_3_0_PLUS:
-            dag_version = DagVersion.get_latest_version(dag.dag_id)
-            branch_op_ti_0 = TI(
-                dag.get_task("task_group_op.branch_op"),
-                run_id=DEFAULT_DAG_RUN_ID,
-                map_index=0,
-                dag_version_id=dag_version.id,
-            )
-            branch_op_ti_1 = TI(
-                dag.get_task("task_group_op.branch_op"),
-                run_id=DEFAULT_DAG_RUN_ID,
-                map_index=1,
-                dag_version_id=dag_version.id,
-            )
-            branch_a_ti_0 = TI(
-                dag.get_task("task_group_op.branch_a"),
-                run_id=DEFAULT_DAG_RUN_ID,
-                map_index=0,
-                dag_version_id=dag_version.id,
-            )
-            branch_a_ti_1 = TI(
-                dag.get_task("task_group_op.branch_a"),
-                run_id=DEFAULT_DAG_RUN_ID,
-                map_index=1,
-                dag_version_id=dag_version.id,
-            )
-            branch_b_ti_0 = TI(
-                dag.get_task("task_group_op.branch_b"),
-                run_id=DEFAULT_DAG_RUN_ID,
-                map_index=0,
-                dag_version_id=dag_version.id,
-            )
-            branch_b_ti_1 = TI(
-                dag.get_task("task_group_op.branch_b"),
-                run_id=DEFAULT_DAG_RUN_ID,
-                map_index=1,
-                dag_version_id=dag_version.id,
-            )
-        else:
-            branch_op_ti_0 = TI(
-                dag.get_task("task_group_op.branch_op"), run_id=DEFAULT_DAG_RUN_ID, map_index=0
-            )
-            branch_op_ti_1 = TI(
-                dag.get_task("task_group_op.branch_op"), run_id=DEFAULT_DAG_RUN_ID, map_index=1
-            )
-            branch_a_ti_0 = TI(dag.get_task("task_group_op.branch_a"), run_id=DEFAULT_DAG_RUN_ID, map_index=0)
-            branch_a_ti_1 = TI(dag.get_task("task_group_op.branch_a"), run_id=DEFAULT_DAG_RUN_ID, map_index=1)
-            branch_b_ti_0 = TI(dag.get_task("task_group_op.branch_b"), run_id=DEFAULT_DAG_RUN_ID, map_index=0)
-            branch_b_ti_1 = TI(dag.get_task("task_group_op.branch_b"), run_id=DEFAULT_DAG_RUN_ID, map_index=1)
+        branch_op_ti_0 = _create_task_instance("task_group_op.branch_op", map_index=0)
+        branch_op_ti_1 = _create_task_instance("task_group_op.branch_op", map_index=1)
+        branch_a_ti_0 = _create_task_instance("task_group_op.branch_a", map_index=0)
+        branch_a_ti_1 = _create_task_instance("task_group_op.branch_a", map_index=1)
+        branch_b_ti_0 = _create_task_instance("task_group_op.branch_b", map_index=0)
+        branch_b_ti_1 = _create_task_instance("task_group_op.branch_b", map_index=1)
 
         SkipMixin().skip_all_except(ti=branch_op_ti_0, branch_task_ids="task_group_op.branch_a")
         SkipMixin().skip_all_except(ti=branch_op_ti_1, branch_task_ids="task_group_op.branch_b")
@@ -302,7 +284,7 @@ class TestSkipMixin:
         dag_maker.create_dagrun(run_id=DEFAULT_DAG_RUN_ID)
         if AIRFLOW_V_3_0_PLUS:
             dag_version = DagVersion.get_latest_version(task.dag_id)
-            ti1 = TI(task, run_id=DEFAULT_DAG_RUN_ID, dag_version_id=dag_version.id)
+            ti1 = create_task_instance(task, run_id=DEFAULT_DAG_RUN_ID, dag_version_id=dag_version.id)
         else:
             ti1 = TI(task, run_id=DEFAULT_DAG_RUN_ID)
         error_message = (
@@ -317,7 +299,7 @@ class TestSkipMixin:
         dag_maker.create_dagrun(run_id=DEFAULT_DAG_RUN_ID)
         if AIRFLOW_V_3_0_PLUS:
             dag_version = DagVersion.get_latest_version(task.dag_id)
-            ti1 = TI(task, run_id=DEFAULT_DAG_RUN_ID, dag_version_id=dag_version.id)
+            ti1 = create_task_instance(task, run_id=DEFAULT_DAG_RUN_ID, dag_version_id=dag_version.id)
         else:
             ti1 = TI(task, run_id=DEFAULT_DAG_RUN_ID)
 
@@ -356,7 +338,7 @@ class TestSkipMixin:
         dag_maker.create_dagrun(run_id=DEFAULT_DAG_RUN_ID)
         if AIRFLOW_V_3_0_PLUS:
             dag_version = DagVersion.get_latest_version(task1.dag_id)
-            ti1 = TI(task1, run_id=DEFAULT_DAG_RUN_ID, dag_version_id=dag_version.id)
+            ti1 = create_task_instance(task1, run_id=DEFAULT_DAG_RUN_ID, dag_version_id=dag_version.id)
         else:
             ti1 = TI(task1, run_id=DEFAULT_DAG_RUN_ID)
 
@@ -418,7 +400,7 @@ class TestSkipMixin:
             def poke(self, context):
                 return True
 
-        with dag_maker("dag_test_branch_sensor_skipping"):
+        with dag_maker("dag_test_branch_sensor_skipping") as dag:
             branch_task = EmptyOperator(task_id="branch_task")
             regular_task = EmptyOperator(task_id="regular_task")
             sensor_task = DummySensor(task_id="sensor_task")
@@ -426,8 +408,13 @@ class TestSkipMixin:
 
         dag_maker.create_dagrun(run_id=DEFAULT_DAG_RUN_ID)
 
-        dag_version = DagVersion.get_latest_version(branch_task.dag_id)
-        ti_branch = TI(branch_task, run_id=DEFAULT_DAG_RUN_ID, dag_version_id=dag_version.id)
+        ti_branch = RuntimeTaskInstance.model_construct(
+            dag_id=dag.dag_id,
+            task_id="branch_task",
+            task=branch_task,
+            run_id=DEFAULT_DAG_RUN_ID,
+        )
+        ti_branch.__dict__["xcom_push"] = MagicMock()
 
         # Test skipping the sensor (follow regular_task branch)
         with pytest.raises(DownstreamTasksSkipped) as exc_info:

--- a/providers/weaviate/tests/unit/weaviate/operators/test_weaviate.py
+++ b/providers/weaviate/tests/unit/weaviate/operators/test_weaviate.py
@@ -27,6 +27,8 @@ from airflow.providers.weaviate.operators.weaviate import (
     WeaviateIngestOperator,
 )
 
+from tests_common.test_utils.taskinstance import render_template_fields
+
 
 class TestWeaviateIngestOperator:
     @pytest.fixture
@@ -69,14 +71,13 @@ class TestWeaviateIngestOperator:
             collection_name="my_collection",
             input_data="{{ dag.dag_id }}",
         )
-        ti.render_templates()
-
-        assert dag_id == ti.task.input_data
+        task = ti.render_templates()
+        assert dag_id == task.input_data
 
     @pytest.mark.db_test
     def test_partial_batch_hook_params(self, dag_maker, session):
         with dag_maker(dag_id="test_partial_batch_hook_params", session=session):
-            WeaviateIngestOperator.partial(
+            task = WeaviateIngestOperator.partial(
                 task_id="fake-task-id",
                 conn_id="weaviate_conn",
                 collection_name="FooBar",
@@ -86,8 +87,8 @@ class TestWeaviateIngestOperator:
         dr = dag_maker.create_dagrun()
         tis = dr.get_task_instances(session=session)
         for ti in tis:
-            ti.render_templates()
-            assert ti.task.hook_params == {"baz": "biz"}
+            rendered = render_template_fields(ti, task.unmap({"input_data": {}}))
+            assert rendered.hook_params == {"baz": "biz"}
 
 
 class TestWeaviateDocumentIngestOperator:
@@ -134,7 +135,7 @@ class TestWeaviateDocumentIngestOperator:
     @pytest.mark.db_test
     def test_partial_hook_params(self, dag_maker, session):
         with dag_maker(dag_id="test_partial_hook_params", session=session):
-            WeaviateDocumentIngestOperator.partial(
+            task = WeaviateDocumentIngestOperator.partial(
                 task_id="fake-task-id",
                 conn_id="weaviate_conn",
                 collection_name="FooBar",
@@ -145,5 +146,5 @@ class TestWeaviateDocumentIngestOperator:
         dr = dag_maker.create_dagrun()
         tis = dr.get_task_instances(session=session)
         for ti in tis:
-            ti.render_templates()
-            assert ti.task.hook_params == {"baz": "biz"}
+            rendered = render_template_fields(ti, task.unmap({"input_data": {}}))
+            assert rendered.hook_params == {"baz": "biz"}

--- a/providers/ydb/tests/unit/ydb/operators/test_ydb.py
+++ b/providers/ydb/tests/unit/ydb/operators/test_ydb.py
@@ -49,8 +49,7 @@ def test_sql_templating(create_task_instance_of_operator):
         dag_id="test_template_body_templating_dag",
         task_id="test_template_body_templating_task",
     )
-    ti.render_templates()
-    task: YDBExecuteQueryOperator = ti.task
+    task = ti.render_templates()
     assert task.sql == "SELECT * FROM pet WHERE birth_date BETWEEN '2020-01-01' AND '2020-12-31'"
 
 


### PR DESCRIPTION
I started out trying to fix #59780 but ended up doing a big operation planned for later.

The original intention was to find a way to make #59780 pass all version combinations, but the provider tests have so many leftover quirks from before 3.0, I decided to take apart all of those instead, to keep the compat layer simpler and easier to understand. This also allows us to do a couple of long-waited cleanups in Core:

1. RenderedTaskInstanceField no longer contains template rendering logic. After the 3.0 task runner implementation, this logic is no longer used anywhere (rendering is now done in the worker and sent via execution API to be stored literally instead). I removed the feature entirely, deleted a bunch of tests on it, and rewrote a number of provider tests so they render things properly.
2. TaskInstance.render_templates() and TaskInstance.run() are removed. These are also never used in 3.x (they are re-implemented in the SDK on RuntimeTaskInstance), but a bunch of tests rely heavily on them. I created a helper module (`test_utils.taskinstance`) with free functions that implement a compat layer to be used in providers instead. This contributes to most changes in this PR.

This is a very big one, but should not be logically difficult to review. Just the same changes over and over again across all providers.

I want to also remove TaskInstance.get_template_context() after this is removed. That one is also never used in 3.x.