### PR TITLE
Refactor models tests to use SQLA2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -433,6 +433,11 @@ repos:
             ^airflow-core/tests/unit/models/test_cleartasks.py$|
             ^airflow-core/tests/unit/models/test_xcom.py$|
             ^airflow-core/tests/unit/models/test_dagrun.py$|
+            ^airflow-core/tests/unit/models/test_dag\.py$|
+            ^airflow-core/tests/unit/models/test_dagcode\.py$|
+            ^airflow-core/tests/unit/models/test_mappedoperator\.py$|
+            ^airflow-core/tests/unit/models/test_taskinstance\.py$|
+            ^airflow-core/tests/unit/models/test_variable\.py$|
             ^airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_sources.py$|
             ^airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_hitl.py$|
             ^airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_assets.py$|

--- a/airflow-core/tests/unit/models/test_dagcode.py
+++ b/airflow-core/tests/unit/models/test_dagcode.py
@@ -21,6 +21,7 @@ from unittest.mock import patch
 
 import pendulum
 import pytest
+from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 
 import airflow.example_dags as example_dags_module
@@ -49,7 +50,12 @@ def make_example_dags(module):
     from airflow.utils.session import create_session
 
     with create_session() as session:
-        if session.query(DagBundleModel).filter(DagBundleModel.name == "testing").count() == 0:
+        if (
+            session.scalar(
+                select(func.count()).select_from(DagBundleModel).where(DagBundleModel.name == "testing")
+            )
+            == 0
+        ):
             testing = DagBundleModel(name="testing")
             session.add(testing)
 
@@ -110,13 +116,12 @@ class TestDagCode:
         with create_session() as session:
             for dag in example_dags.values():
                 assert DagCode.has_dag(dag.dag_id)
-                result = (
-                    session.query(DagCode.fileloc, DagCode.dag_id, DagCode.source_code)
-                    .filter(DagCode.dag_id == dag.dag_id)
+                result = session.execute(
+                    select(DagCode.fileloc, DagCode.dag_id, DagCode.source_code)
+                    .where(DagCode.dag_id == dag.dag_id)
                     .order_by(DagCode.last_updated.desc())
                     .limit(1)
-                    .one()
-                )
+                ).one()
 
                 assert result.fileloc == dag.fileloc
                 with open_maybe_zipped(dag.fileloc, "r") as source:
@@ -149,13 +154,12 @@ class TestDagCode:
             triggered_by=DagRunTriggeredByType.TEST,
             run_type=DagRunType.MANUAL,
         )
-        result = (
-            session.query(DagCode)
-            .filter(DagCode.fileloc == example_dag.fileloc)
+        result = session.scalars(
+            select(DagCode)
+            .where(DagCode.fileloc == example_dag.fileloc)
             .order_by(DagCode.last_updated.desc())
             .limit(1)
-            .one()
-        )
+        ).one()
 
         assert result.source_code is not None
 
@@ -164,17 +168,16 @@ class TestDagCode:
             mock_code.return_value = "# dummy code"
             sync_dag_to_db(example_dag, session=session)
 
-        new_result = (
-            session.query(DagCode)
-            .filter(DagCode.fileloc == example_dag.fileloc)
+        new_result = session.scalars(
+            select(DagCode)
+            .where(DagCode.fileloc == example_dag.fileloc)
             .order_by(DagCode.last_updated.desc())
             .limit(1)
-            .one()
-        )
+        ).one()
 
         assert new_result.source_code != result.source_code
         assert new_result.last_updated > result.last_updated
-        assert session.query(DagCode).count() == 2
+        assert session.scalar(select(func.count()).select_from(DagCode)) == 2
 
     def test_has_dag(self, dag_maker):
         """Test has_dag method."""

--- a/airflow-core/tests/unit/models/test_mappedoperator.py
+++ b/airflow-core/tests/unit/models/test_mappedoperator.py
@@ -25,7 +25,7 @@ from unittest import mock
 from unittest.mock import patch
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import delete, select
 
 from airflow.exceptions import AirflowSkipException
 from airflow.models.dag_version import DagVersion
@@ -125,11 +125,13 @@ def test_expand_mapped_task_instance(dag_maker, session, num_existing_tis, expec
 
     if num_existing_tis:
         # Remove the map_index=-1 TI when we're creating other TIs
-        session.query(TaskInstance).filter(
-            TaskInstance.dag_id == mapped.dag_id,
-            TaskInstance.task_id == mapped.task_id,
-            TaskInstance.run_id == dr.run_id,
-        ).delete()
+        session.execute(
+            delete(TaskInstance).where(
+                TaskInstance.dag_id == mapped.dag_id,
+                TaskInstance.task_id == mapped.task_id,
+                TaskInstance.run_id == dr.run_id,
+            )
+        )
 
     dag_version = DagVersion.get_latest_version(dr.dag_id)
 
@@ -147,12 +149,15 @@ def test_expand_mapped_task_instance(dag_maker, session, num_existing_tis, expec
 
     TaskMap.expand_mapped_task(mapped_deser, dr.run_id, session=session)
 
-    indices = (
-        session.query(TaskInstance.map_index, TaskInstance.state)
-        .filter_by(task_id=mapped.task_id, dag_id=mapped.dag_id, run_id=dr.run_id)
+    indices = session.execute(
+        select(TaskInstance.map_index, TaskInstance.state)
+        .where(
+            TaskInstance.task_id == mapped.task_id,
+            TaskInstance.dag_id == mapped.dag_id,
+            TaskInstance.run_id == dr.run_id,
+        )
         .order_by(TaskInstance.map_index)
-        .all()
-    )
+    ).all()
 
     assert indices == expected
 
@@ -194,23 +199,29 @@ def test_expand_mapped_task_failed_state_in_db(dag_maker, session):
         session.add(ti)
     session.flush()
 
-    indices = (
-        session.query(TaskInstance.map_index, TaskInstance.state)
-        .filter_by(task_id=mapped.task_id, dag_id=mapped.dag_id, run_id=dr.run_id)
+    indices = session.execute(
+        select(TaskInstance.map_index, TaskInstance.state)
+        .where(
+            TaskInstance.task_id == mapped.task_id,
+            TaskInstance.dag_id == mapped.dag_id,
+            TaskInstance.run_id == dr.run_id,
+        )
         .order_by(TaskInstance.map_index)
-        .all()
-    )
+    ).all()
     # Make sure we have the faulty state in the database
     assert indices == [(-1, None), (0, "success"), (1, "success")]
 
     TaskMap.expand_mapped_task(mapped_deser, dr.run_id, session=session)
 
-    indices = (
-        session.query(TaskInstance.map_index, TaskInstance.state)
-        .filter_by(task_id=mapped.task_id, dag_id=mapped.dag_id, run_id=dr.run_id)
+    indices = session.execute(
+        select(TaskInstance.map_index, TaskInstance.state)
+        .where(
+            TaskInstance.task_id == mapped.task_id,
+            TaskInstance.dag_id == mapped.dag_id,
+            TaskInstance.run_id == dr.run_id,
+        )
         .order_by(TaskInstance.map_index)
-        .all()
-    )
+    ).all()
     # The -1 index should be cleaned up
     assert indices == [(0, "success"), (1, "success")]
 
@@ -224,12 +235,15 @@ def test_expand_mapped_task_instance_skipped_on_zero(dag_maker, session):
 
     expand_mapped_task(dag.task_dict[mapped.task_id], dr.run_id, task1.task_id, length=0, session=session)
 
-    indices = (
-        session.query(TaskInstance.map_index, TaskInstance.state)
-        .filter_by(task_id=mapped.task_id, dag_id=mapped.dag_id, run_id=dr.run_id)
+    indices = session.execute(
+        select(TaskInstance.map_index, TaskInstance.state)
+        .where(
+            TaskInstance.task_id == mapped.task_id,
+            TaskInstance.dag_id == mapped.dag_id,
+            TaskInstance.run_id == dr.run_id,
+        )
         .order_by(TaskInstance.map_index)
-        .all()
-    )
+    ).all()
 
     assert indices == [(-1, TaskInstanceState.SKIPPED)]
 
@@ -277,11 +291,13 @@ def test_expand_kwargs_mapped_task_instance(dag_maker, session, num_existing_tis
 
     if num_existing_tis:
         # Remove the map_index=-1 TI when we're creating other TIs
-        session.query(TaskInstance).filter(
-            TaskInstance.dag_id == mapped.dag_id,
-            TaskInstance.task_id == mapped.task_id,
-            TaskInstance.run_id == dr.run_id,
-        ).delete()
+        session.execute(
+            delete(TaskInstance).where(
+                TaskInstance.dag_id == mapped.dag_id,
+                TaskInstance.task_id == mapped.task_id,
+                TaskInstance.run_id == dr.run_id,
+            )
+        )
     dag_version = DagVersion.get_latest_version(dr.dag_id)
 
     for index in range(num_existing_tis):
@@ -298,12 +314,15 @@ def test_expand_kwargs_mapped_task_instance(dag_maker, session, num_existing_tis
 
     TaskMap.expand_mapped_task(dag.task_dict[mapped.task_id], dr.run_id, session=session)
 
-    indices = (
-        session.query(TaskInstance.map_index, TaskInstance.state)
-        .filter_by(task_id=mapped.task_id, dag_id=mapped.dag_id, run_id=dr.run_id)
+    indices = session.execute(
+        select(TaskInstance.map_index, TaskInstance.state)
+        .where(
+            TaskInstance.task_id == mapped.task_id,
+            TaskInstance.dag_id == mapped.dag_id,
+            TaskInstance.run_id == dr.run_id,
+        )
         .order_by(TaskInstance.map_index)
-        .all()
-    )
+    ).all()
 
     assert indices == expected
 

--- a/airflow-core/tests/unit/models/test_taskinstance.py
+++ b/airflow-core/tests/unit/models/test_taskinstance.py
@@ -30,7 +30,7 @@ import pendulum
 import pytest
 import time_machine
 import uuid6
-from sqlalchemy import select
+from sqlalchemy import delete, func, select
 from sqlalchemy.exc import IntegrityError
 
 from airflow import settings
@@ -2700,16 +2700,16 @@ class TestTaskInstance:
         XComModel.set(key="key", value="value", task_id=ti.task_id, dag_id=ti.dag_id, run_id=ti.run_id)
         session.commit()
         for table in tables:
-            assert session.query(table).count() == 1
+            assert session.scalar(select(func.count()).select_from(table)) == 1
 
-        ti_note = session.query(TaskInstanceNote).filter_by(ti_id=ti.id).one()
+        ti_note = session.scalar(select(TaskInstanceNote).where(TaskInstanceNote.ti_id == ti.id))
         assert ti_note.content == "sample note"
 
         ti.clear_db_references(session)
         for table in tables:
-            assert session.query(table).count() == 0
+            assert session.scalar(select(func.count()).select_from(table)) == 0
 
-        assert session.query(TaskInstanceNote).filter_by(ti_id=ti.id).one_or_none() is None
+        assert session.scalar(select(TaskInstanceNote).where(TaskInstanceNote.ti_id == ti.id)) is None
 
     def test_skipped_task_call_on_skipped_callback(self, dag_maker):
         def raise_skip_exception():
@@ -2755,12 +2755,12 @@ class TestTaskInstance:
         try_id = ti.id
         with pytest.raises(AirflowException):
             ti.run()
-        ti = session.query(TaskInstance).one()
+        ti = session.scalar(select(TaskInstance))
         # the ti.id should be different from the previous one
         assert ti.id != try_id
         assert ti.state == State.UP_FOR_RETRY
-        assert session.query(TaskInstance).count() == 1
-        tih = session.query(TaskInstanceHistory).all()
+        assert session.scalar(select(func.count()).select_from(TaskInstance)) == 1
+        tih = session.scalars(select(TaskInstanceHistory)).all()
         assert len(tih) == 1
         # the new try_id should be different from what's recorded in tih
         assert str(tih[0].task_instance_id) == try_id
@@ -2786,16 +2786,16 @@ class TestTaskInstance:
         try_id = ti.id
         with pytest.raises(TypeError):
             ti.run()
-        ti = session.query(TaskInstance).one()
+        ti = session.scalar(select(TaskInstance))
         # the ti.id should be different from the previous one
         assert ti.id != try_id
         assert ti.state == State.UP_FOR_RETRY
-        assert session.query(TaskInstance).count() == 1
-        tih = session.query(TaskInstanceHistory).all()
+        assert session.scalar(select(func.count()).select_from(TaskInstance)) == 1
+        tih = session.scalars(select(TaskInstanceHistory)).all()
         assert len(tih) == 1
         # the new try_id should be different from what's recorded in tih
         assert str(tih[0].task_instance_id) == try_id
-        hitl_histories = session.query(HITLDetailHistory).all()
+        hitl_histories = session.scalars(select(HITLDetailHistory)).all()
         assert len(hitl_histories) == 1
         assert str(hitl_histories[0].task_instance.id) == try_id
 
@@ -2852,7 +2852,7 @@ class TestTaskInstanceRecordTaskMapXComPush:
     def setup_class(self):
         """Ensure we start fresh."""
         with create_session() as session:
-            session.query(TaskMap).delete()
+            session.execute(delete(TaskMap))
 
     @pytest.mark.parametrize("xcom_value", [[1, 2, 3], {"a": 1, "b": 2}, "abc"])
     def test_not_recorded_if_leaf(self, dag_maker, xcom_value):
@@ -2868,7 +2868,7 @@ class TestTaskInstanceRecordTaskMapXComPush:
         ti = next(ti for ti in dag_maker.create_dagrun().task_instances if ti.task_id == "push_something")
         ti.run()
 
-        assert dag_maker.session.query(TaskMap).count() == 0
+        assert dag_maker.session.scalar(select(func.count()).select_from(TaskMap)) == 0
 
     @pytest.mark.parametrize("xcom_value", [[1, 2, 3], {"a": 1, "b": 2}, "abc"])
     def test_not_recorded_if_not_used(self, dag_maker, xcom_value):
@@ -2888,7 +2888,7 @@ class TestTaskInstanceRecordTaskMapXComPush:
         ti = next(ti for ti in dag_maker.create_dagrun().task_instances if ti.task_id == "push_something")
         ti.run()
 
-        assert dag_maker.session.query(TaskMap).count() == 0
+        assert dag_maker.session.scalar(select(func.count()).select_from(TaskMap)) == 0
 
     @pytest.mark.parametrize("xcom_1", [[1, 2, 3], {"a": 1, "b": 2}, "abc"])
     @pytest.mark.parametrize("xcom_4", [[1, 2, 3], {"a": 1, "b": 2}])
@@ -2927,16 +2927,16 @@ class TestTaskInstanceRecordTaskMapXComPush:
         tis = {ti.task_id: ti for ti in dag_maker.create_dagrun().task_instances}
 
         tis["push_1"].run()
-        assert dag_maker.session.query(TaskMap).count() == 0
+        assert dag_maker.session.scalar(select(func.count()).select_from(TaskMap)) == 0
 
         tis["push_2"].run()
-        assert dag_maker.session.query(TaskMap).count() == 1
+        assert dag_maker.session.scalar(select(func.count()).select_from(TaskMap)) == 1
 
         tis["push_3"].run()
-        assert dag_maker.session.query(TaskMap).count() == 1
+        assert dag_maker.session.scalar(select(func.count()).select_from(TaskMap)) == 1
 
         tis["push_4"].run()
-        assert dag_maker.session.query(TaskMap).count() == 2
+        assert dag_maker.session.scalar(select(func.count()).select_from(TaskMap)) == 2
 
 
 class TestMappedTaskInstanceReceiveValue:
@@ -2959,12 +2959,11 @@ class TestMappedTaskInstanceReceiveValue:
             show_task = show.expand(value=literal).operator
 
         dag_run = dag_maker.create_dagrun()
-        mapped_tis = (
-            session.query(TI)
-            .filter_by(task_id="show", dag_id=dag_run.dag_id, run_id=dag_run.run_id)
+        mapped_tis = session.scalars(
+            select(TI)
+            .where(TI.task_id == "show", TI.dag_id == dag_run.dag_id, TI.run_id == dag_run.run_id)
             .order_by(TI.map_index)
-            .all()
-        )
+        ).all()
         assert len(mapped_tis) == len(literal)
 
         for ti in sorted(mapped_tis, key=operator.attrgetter("map_index")):
@@ -3030,16 +3029,15 @@ class TestMappedTaskInstanceReceiveValue:
         assert len(mapped_tis) == 0  # Expanded at parse!
         assert max_map_index == 5
 
-        tis = (
-            session.query(TaskInstance)
-            .filter(
+        tis = session.scalars(
+            select(TaskInstance)
+            .where(
                 TaskInstance.dag_id == dag.dag_id,
                 TaskInstance.task_id == "show",
                 TaskInstance.run_id == dag_run.run_id,
             )
             .order_by(TaskInstance.map_index)
-            .all()
-        )
+        ).all()
         for ti in tis:
             ti.refresh_from_task(show_task)
             dag_maker.run_ti(ti.task_id, map_index=ti.map_index, dag_run=dag_run, session=session)
@@ -3140,14 +3138,16 @@ def test_taskinstance_with_note(create_task_instance, session):
     session.add(ti)
     session.commit()
 
-    ti_note: TaskInstanceNote = session.query(TaskInstanceNote).filter_by(ti_id=ti.id).one()
+    ti_note: TaskInstanceNote = session.scalar(
+        select(TaskInstanceNote).where(TaskInstanceNote.ti_id == ti.id)
+    )
     assert ti_note.content == "ti with note"
 
     session.delete(ti)
     session.commit()
 
-    assert session.query(TaskInstance).filter_by(id=ti.id).one_or_none() is None
-    assert session.query(TaskInstanceNote).filter_by(ti_id=ti.id).one_or_none() is None
+    assert session.scalar(select(TaskInstance).where(TaskInstance.id == ti.id)) is None
+    assert session.scalar(select(TaskInstanceNote).where(TaskInstanceNote.ti_id == ti.id)) is None
 
 
 def test__refresh_from_db_should_not_increment_try_number(dag_maker, session):


### PR DESCRIPTION
related: #59402

Migrate deprecated SQLAlchemy Query object usage to SQLAlchemy 2.0 style in the following test files:
- `airflow-core/tests/unit/models/test_dag.py`
- `airflow-core/tests/unit/models/test_dagcode.py`
- `airflow-core/tests/unit/models/test_mappedoperator.py`
- `airflow-core/tests/unit/models/test_taskinstance.py`
- `airflow-core/tests/unit/models/test_variable.py`

---
^ Add meaningful description above
Read the Pull Request Guidelines for more information.
In case of fundamental code changes, an Airflow Improvement Proposal (AIP) is needed.
In case of a new dependency, check compliance with the ASF 3rd Party License Policy.
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in airflow-core/newsfragments.