### PR TITLE
Fix/optimize hitl polling

### DIFF
--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -167,8 +167,24 @@ ARG_BUNDLE_NAME = Arg(
     default=None,
     action="append",
 )
-ARG_START_DATE = Arg(("-s", "--start-date"), help="Override start_date YYYY-MM-DD", type=parsedate)
-ARG_END_DATE = Arg(("-e", "--end-date"), help="Override end_date YYYY-MM-DD", type=parsedate)
+ARG_START_DATE = Arg(
+    ("-s", "--start-date"),
+    help=(
+        "Override start_date. Accepts multiple datetime formats including: "
+        "YYYY-MM-DD, YYYY-MM-DDTHH:MM:SS, YYYY-MM-DDTHH:MM:SS±HH:MM (ISO 8601), "
+        "and other formats supported by pendulum.parse()"
+    ),
+    type=parsedate,
+)
+ARG_END_DATE = Arg(
+    ("-e", "--end-date"),
+    help=(
+        "Override end_date. Accepts multiple datetime formats including: "
+        "YYYY-MM-DD, YYYY-MM-DDTHH:MM:SS, YYYY-MM-DDTHH:MM:SS±HH:MM (ISO 8601), "
+        "and other formats supported by pendulum.parse()"
+    ),
+    type=parsedate,
+)
 ARG_OUTPUT_PATH = Arg(
     (
         "-o",

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -167,24 +167,8 @@ ARG_BUNDLE_NAME = Arg(
     default=None,
     action="append",
 )
-ARG_START_DATE = Arg(
-    ("-s", "--start-date"),
-    help=(
-        "Override start_date. Accepts multiple datetime formats including: "
-        "YYYY-MM-DD, YYYY-MM-DDTHH:MM:SS, YYYY-MM-DDTHH:MM:SS±HH:MM (ISO 8601), "
-        "and other formats supported by pendulum.parse()"
-    ),
-    type=parsedate,
-)
-ARG_END_DATE = Arg(
-    ("-e", "--end-date"),
-    help=(
-        "Override end_date. Accepts multiple datetime formats including: "
-        "YYYY-MM-DD, YYYY-MM-DDTHH:MM:SS, YYYY-MM-DDTHH:MM:SS±HH:MM (ISO 8601), "
-        "and other formats supported by pendulum.parse()"
-    ),
-    type=parsedate,
-)
+ARG_START_DATE = Arg(("-s", "--start-date"), help="Override start_date YYYY-MM-DD", type=parsedate)
+ARG_END_DATE = Arg(("-e", "--end-date"), help="Override end_date YYYY-MM-DD", type=parsedate)
 ARG_OUTPUT_PATH = Arg(
     (
         "-o",

--- a/airflow-core/src/airflow/migrations/versions/0094_3_2_0_increase_external_executor_id_length.py
+++ b/airflow-core/src/airflow/migrations/versions/0094_3_2_0_increase_external_executor_id_length.py
@@ -1,0 +1,73 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Increase external_executor_id length to 1000.
+
+Revision ID: f1a2b3c4d5e6
+Revises: 665854ef0536
+Create Date: 2025-12-26 00:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+from airflow.migrations.db_types import StringID
+
+# revision identifiers, used by Alembic.
+revision = "f1a2b3c4d5e6"
+down_revision = "665854ef0536"
+branch_labels = None
+depends_on = None
+airflow_version = "3.2.0"
+
+
+def upgrade():
+    """Increase external_executor_id column length from 250 to 1000 chars."""
+    with op.batch_alter_table("task_instance") as batch_op:
+        batch_op.alter_column(
+            "external_executor_id",
+            type_=StringID(length=1000),
+            existing_nullable=True,
+        )
+
+    with op.batch_alter_table("task_instance_history") as batch_op:
+        batch_op.alter_column(
+            "external_executor_id",
+            type_=StringID(length=1000),
+            existing_nullable=True,
+        )
+
+
+def downgrade():
+    """Revert external_executor_id column length from 1000 to 250 chars."""
+    with op.batch_alter_table("task_instance") as batch_op:
+        batch_op.alter_column(
+            "external_executor_id",
+            type_=StringID(length=250),
+            existing_nullable=True,
+        )
+
+    with op.batch_alter_table("task_instance_history") as batch_op:
+        batch_op.alter_column(
+            "external_executor_id",
+            type_=StringID(length=250),
+            existing_nullable=True,
+        )

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -427,7 +427,7 @@ class TaskInstance(Base, LoggingMixin):
         String(250), server_default=SpanStatus.NOT_STARTED, nullable=False
     )
 
-    external_executor_id: Mapped[str | None] = mapped_column(StringID(), nullable=True)
+    external_executor_id: Mapped[str | None] = mapped_column(StringID(length=1000), nullable=True)
 
     # The trigger to resume on if we are in state DEFERRED
     trigger_id: Mapped[int | None] = mapped_column(Integer, nullable=True)

--- a/airflow-core/src/airflow/models/taskinstancehistory.py
+++ b/airflow-core/src/airflow/models/taskinstancehistory.py
@@ -105,7 +105,7 @@ class TaskInstanceHistory(Base):
         String(250), server_default=SpanStatus.NOT_STARTED, nullable=False
     )
 
-    external_executor_id: Mapped[str | None] = mapped_column(StringID(), nullable=True)
+    external_executor_id: Mapped[str | None] = mapped_column(StringID(length=1000), nullable=True)
     trigger_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
     trigger_timeout: Mapped[DateTime | None] = mapped_column(DateTime, nullable=True)
     next_method: Mapped[str | None] = mapped_column(String(1000), nullable=True)

--- a/airflow-core/src/airflow/ui/src/queries/useRefreshOnNewDagRuns.test.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useRefreshOnNewDagRuns.test.ts
@@ -1,0 +1,231 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+import { useRefreshOnNewDagRuns } from "./useRefreshOnNewDagRuns";
+import * as openApiQueries from "../openapi/queries";
+import * as useConfigModule from "./useConfig";
+
+// Mock the dependencies
+vi.mock("../openapi/queries", () => ({
+  useDagServiceGetDagDetailsKey: "dag-details-key",
+  UseDagRunServiceGetDagRunsKeyFn: vi.fn(() => ["dag-runs-key"]),
+  UseDagServiceGetDagDetailsKeyFn: vi.fn(() => ["dag-details-fn-key"]),
+  useDagServiceGetDagsUi: "dags-ui-key",
+  UseTaskInstanceServiceGetTaskInstancesKeyFn: vi.fn(() => ["task-instances-key"]),
+  UseGridServiceGetDagStructureKeyFn: vi.fn(() => ["grid-structure-key"]),
+  UseGridServiceGetGridRunsKeyFn: vi.fn(() => ["grid-runs-key"]),
+  useDagServiceGetLatestRunInfo: vi.fn(),
+}));
+
+vi.mock("./useConfig", () => ({
+  useConfig: vi.fn(),
+}));
+
+describe("useRefreshOnNewDagRuns", () => {
+  let queryClient: QueryClient;
+  let wrapper: ({ children }: { children: ReactNode }) => JSX.Element;
+
+  beforeEach(() => {
+    // Create a new QueryClient for each test
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+
+    // Create wrapper with QueryClientProvider
+    wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    // Mock useConfig to return auto refresh interval
+    vi.mocked(useConfigModule.useConfig).mockReturnValue(5);
+
+    // Reset all mocks
+    vi.clearAllMocks();
+  });
+
+  it("should not invalidate queries on initial load when latestDagRunId is undefined", () => {
+    const dagId = "test_dag";
+    const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    // Mock useDagServiceGetLatestRunInfo to return undefined initially
+    vi.mocked(openApiQueries.useDagServiceGetLatestRunInfo).mockReturnValue({
+      data: undefined,
+    } as ReturnType<typeof openApiQueries.useDagServiceGetLatestRunInfo>);
+
+    renderHook(() => useRefreshOnNewDagRuns(dagId, false), { wrapper });
+
+    // Should not invalidate queries when data is undefined on initial load
+    expect(invalidateQueriesSpy).not.toHaveBeenCalled();
+  });
+
+  it("should not invalidate queries on initial load when latestDagRunId is first fetched", () => {
+    const dagId = "test_dag";
+    const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    // Mock useDagServiceGetLatestRunInfo to return a run_id on first render
+    vi.mocked(openApiQueries.useDagServiceGetLatestRunInfo).mockReturnValue({
+      data: { run_id: "run_123" },
+    } as ReturnType<typeof openApiQueries.useDagServiceGetLatestRunInfo>);
+
+    renderHook(() => useRefreshOnNewDagRuns(dagId, false), { wrapper });
+
+    // Should not invalidate queries on initial load even when latestDagRunId is present
+    expect(invalidateQueriesSpy).not.toHaveBeenCalled();
+  });
+
+  it("should invalidate queries when a new DAG run appears", async () => {
+    const dagId = "test_dag";
+    const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    // Start with initial run_id
+    vi.mocked(openApiQueries.useDagServiceGetLatestRunInfo).mockReturnValue({
+      data: { run_id: "run_123" },
+    } as ReturnType<typeof openApiQueries.useDagServiceGetLatestRunInfo>);
+
+    const { rerender } = renderHook(() => useRefreshOnNewDagRuns(dagId, false), { wrapper });
+
+    // Initial render should not invalidate
+    expect(invalidateQueriesSpy).not.toHaveBeenCalled();
+
+    // Update to a new run_id
+    vi.mocked(openApiQueries.useDagServiceGetLatestRunInfo).mockReturnValue({
+      data: { run_id: "run_456" },
+    } as ReturnType<typeof openApiQueries.useDagServiceGetLatestRunInfo>);
+
+    rerender();
+
+    // Should now invalidate queries because run_id changed
+    await waitFor(() => {
+      expect(invalidateQueriesSpy).toHaveBeenCalled();
+    });
+
+    // Verify all the expected query keys were invalidated
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ["dags-ui-key"] });
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ["dag-details-key"] });
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ["dag-details-fn-key"] });
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ["dag-runs-key"] });
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ["task-instances-key"] });
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ["grid-structure-key"] });
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: ["grid-runs-key"] });
+  });
+
+  it("should not invalidate queries when latestDagRunId remains the same", () => {
+    const dagId = "test_dag";
+    const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    // Mock with same run_id
+    vi.mocked(openApiQueries.useDagServiceGetLatestRunInfo).mockReturnValue({
+      data: { run_id: "run_123" },
+    } as ReturnType<typeof openApiQueries.useDagServiceGetLatestRunInfo>);
+
+    const { rerender } = renderHook(() => useRefreshOnNewDagRuns(dagId, false), { wrapper });
+
+    // Initial render - no invalidation
+    expect(invalidateQueriesSpy).not.toHaveBeenCalled();
+
+    // Rerender with same run_id
+    rerender();
+
+    // Should still not invalidate because run_id hasn't changed
+    expect(invalidateQueriesSpy).not.toHaveBeenCalled();
+  });
+
+  it("should handle transition from undefined to defined run_id without invalidation on first occurrence", async () => {
+    const dagId = "test_dag";
+    const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    // Start with undefined
+    vi.mocked(openApiQueries.useDagServiceGetLatestRunInfo).mockReturnValue({
+      data: undefined,
+    } as ReturnType<typeof openApiQueries.useDagServiceGetLatestRunInfo>);
+
+    const { rerender } = renderHook(() => useRefreshOnNewDagRuns(dagId, false), { wrapper });
+
+    // No invalidation on initial undefined
+    expect(invalidateQueriesSpy).not.toHaveBeenCalled();
+
+    // Update to have a run_id (simulating data being fetched)
+    vi.mocked(openApiQueries.useDagServiceGetLatestRunInfo).mockReturnValue({
+      data: { run_id: "run_123" },
+    } as ReturnType<typeof openApiQueries.useDagServiceGetLatestRunInfo>);
+
+    rerender();
+
+    // Should not invalidate on first transition from undefined to defined
+    expect(invalidateQueriesSpy).not.toHaveBeenCalled();
+  });
+
+  it("should not fetch latest run info when hasPendingRuns is true", () => {
+    const dagId = "test_dag";
+
+    renderHook(() => useRefreshOnNewDagRuns(dagId, true), { wrapper });
+
+    // Verify useDagServiceGetLatestRunInfo was called with enabled: false
+    expect(openApiQueries.useDagServiceGetLatestRunInfo).toHaveBeenCalledWith(
+      { dagId },
+      undefined,
+      expect.objectContaining({
+        enabled: false,
+      }),
+    );
+  });
+
+  it("should use custom auto refresh interval from config", () => {
+    const dagId = "test_dag";
+    const customInterval = 10;
+
+    vi.mocked(useConfigModule.useConfig).mockReturnValue(customInterval);
+
+    renderHook(() => useRefreshOnNewDagRuns(dagId, false), { wrapper });
+
+    // Verify useDagServiceGetLatestRunInfo was called with custom interval
+    expect(openApiQueries.useDagServiceGetLatestRunInfo).toHaveBeenCalledWith(
+      { dagId },
+      undefined,
+      expect.objectContaining({
+        refetchInterval: customInterval * 1000, // Should be in milliseconds
+      }),
+    );
+  });
+
+  it("should use default 5 second interval when auto_refresh_interval is not set", () => {
+    const dagId = "test_dag";
+
+    vi.mocked(useConfigModule.useConfig).mockReturnValue(0);
+
+    renderHook(() => useRefreshOnNewDagRuns(dagId, false), { wrapper });
+
+    // Verify useDagServiceGetLatestRunInfo was called with default 5000ms
+    expect(openApiQueries.useDagServiceGetLatestRunInfo).toHaveBeenCalledWith(
+      { dagId },
+      undefined,
+      expect.objectContaining({
+        refetchInterval: 5000,
+      }),
+    );
+  });
+});

--- a/airflow-core/src/airflow/ui/src/queries/useRefreshOnNewDagRuns.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useRefreshOnNewDagRuns.ts
@@ -45,6 +45,13 @@ export const useRefreshOnNewDagRuns = (dagId: string, hasPendingRuns: boolean | 
   useEffect(() => {
     const latestDagRunId = latestDagRun?.run_id;
 
+    // On initial load, just set the ref without invalidating cache
+    if (previousDagRunIdRef.current === undefined) {
+      previousDagRunIdRef.current = latestDagRunId;
+      return;
+    }
+
+    // Only invalidate cache when there's a new DAG run (not on initial load)
     if ((latestDagRunId ?? "") && previousDagRunIdRef.current !== latestDagRunId) {
       previousDagRunIdRef.current = latestDagRunId;
 


### PR DESCRIPTION
Description:

The NeedsReviewButton component was continuously polling the /api/v2/dags/{dag_id}/dagRuns/{dag_run_id}/hitlDetails endpoint even when there were no pending or deferred task instances, causing unnecessary server load.

Changes:

Added preliminary check for deferred task instances using the lightweight getTaskInstances endpoint
Only call hitlDetails API when deferred tasks actually exist
Used React Query's [enabled](vscode-file://vscode-app/c:/Users/aruno/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) option to conditionally enable the query
Impact:

Reduces unnecessary API calls when no pending runs exist
Improves server performance and reduces load
Maintains same functionality when pending actions are present
How to verify:

Load a DAG with completed runs and no pending tasks (e.g., example_bash_operator)
Check network tab - hitlDetails endpoint should NOT be called
Create a DAG with deferred task instances - endpoint should now be called.

Closes Issue no. 59760