### PR TITLE
Refactor devel-common/tests_common to use SQLA2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -472,7 +472,10 @@ repos:
             ^providers/edge3/.*\.py$|
             ^providers/mysql/.*\.py$|
             ^providers/openlineage/.*\.py$|
-            ^task_sdk.*\.py$
+            ^task_sdk.*\.py$|
+            ^devel-common/src/tests_common/pytest_plugin\.py$|
+            ^devel-common/src/tests_common/test_utils/.*\.py$
+
         pass_filenames: true
       - id: update-supported-versions
         name: Updates supported versions in documentation

--- a/devel-common/src/tests_common/pytest_plugin.py
+++ b/devel-common/src/tests_common/pytest_plugin.py
@@ -1252,10 +1252,16 @@ def dag_maker(request) -> Generator[DagMaker, None, None]:
             self.bundle_name = bundle_name or "dag_maker"
             self.bundle_version = bundle_version
             if AIRFLOW_V_3_0_PLUS:
+                from sqlalchemy import func, select
+
                 from airflow.models.dagbundle import DagBundleModel
 
                 if (
-                    self.session.query(DagBundleModel).filter(DagBundleModel.name == self.bundle_name).count()
+                    self.session.scalar(
+                        select(func.count())
+                        .select_from(DagBundleModel)
+                        .where(DagBundleModel.name == self.bundle_name)
+                    )
                     == 0
                 ):
                     self.session.add(DagBundleModel(name=self.bundle_name))
@@ -1285,39 +1291,25 @@ def dag_maker(request) -> Generator[DagMaker, None, None]:
                     self.session.rollback()
 
                     if AIRFLOW_V_3_0_PLUS:
+                        from sqlalchemy import delete
+
                         from airflow.models.dag_version import DagVersion
 
-                        self.session.query(DagRun).filter(DagRun.dag_id.in_(dag_ids)).delete(
-                            synchronize_session=False,
-                        )
-                        self.session.query(TaskInstance).filter(TaskInstance.dag_id.in_(dag_ids)).delete(
-                            synchronize_session=False,
-                        )
-                        self.session.query(DagVersion).filter(DagVersion.dag_id.in_(dag_ids)).delete(
-                            synchronize_session=False
-                        )
+                        self.session.execute(delete(DagRun).where(DagRun.dag_id.in_(dag_ids)))
+                        self.session.execute(delete(TaskInstance).where(TaskInstance.dag_id.in_(dag_ids)))
+                        self.session.execute(delete(DagVersion).where(DagVersion.dag_id.in_(dag_ids)))
                     else:
-                        self.session.query(SerializedDagModel).filter(
-                            SerializedDagModel.dag_id.in_(dag_ids)
-                        ).delete(synchronize_session=False)
-                        self.session.query(DagRun).filter(DagRun.dag_id.in_(dag_ids)).delete(
-                            synchronize_session=False,
+                        from sqlalchemy import delete
+
+                        self.session.execute(
+                            delete(SerializedDagModel).where(SerializedDagModel.dag_id.in_(dag_ids))
                         )
-                        self.session.query(TaskInstance).filter(TaskInstance.dag_id.in_(dag_ids)).delete(
-                            synchronize_session=False,
-                        )
-                    self.session.query(XCom).filter(XCom.dag_id.in_(dag_ids)).delete(
-                        synchronize_session=False,
-                    )
-                    self.session.query(DagModel).filter(DagModel.dag_id.in_(dag_ids)).delete(
-                        synchronize_session=False,
-                    )
-                    self.session.query(TaskMap).filter(TaskMap.dag_id.in_(dag_ids)).delete(
-                        synchronize_session=False,
-                    )
-                    self.session.query(AssetEvent).filter(AssetEvent.source_dag_id.in_(dag_ids)).delete(
-                        synchronize_session=False,
-                    )
+                        self.session.execute(delete(DagRun).where(DagRun.dag_id.in_(dag_ids)))
+                        self.session.execute(delete(TaskInstance).where(TaskInstance.dag_id.in_(dag_ids)))
+                    self.session.execute(delete(XCom).where(XCom.dag_id.in_(dag_ids)))
+                    self.session.execute(delete(DagModel).where(DagModel.dag_id.in_(dag_ids)))
+                    self.session.execute(delete(TaskMap).where(TaskMap.dag_id.in_(dag_ids)))
+                    self.session.execute(delete(AssetEvent).where(AssetEvent.source_dag_id.in_(dag_ids)))
                     self.session.commit()
                     if self._own_session:
                         self.session.expunge_all()
@@ -1714,10 +1706,12 @@ def create_log_template(request):
         session.commit()
 
         def _delete_log_template():
+            from sqlalchemy import delete
+
             from airflow.models import DagRun, TaskInstance
 
-            session.query(TaskInstance).delete()
-            session.query(DagRun).delete()
+            session.execute(delete(TaskInstance))
+            session.execute(delete(DagRun))
             session.delete(log_template)
             session.commit()
 
@@ -2753,11 +2747,18 @@ def testing_dag_bundle():
     from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
     if AIRFLOW_V_3_0_PLUS:
+        from sqlalchemy import func, select
+
         from airflow.models.dagbundle import DagBundleModel
         from airflow.utils.session import create_session
 
         with create_session() as session:
-            if session.query(DagBundleModel).filter(DagBundleModel.name == "testing").count() == 0:
+            if (
+                session.scalar(
+                    select(func.count()).select_from(DagBundleModel).where(DagBundleModel.name == "testing")
+                )
+                == 0
+            ):
                 testing = DagBundleModel(name="testing")
                 session.add(testing)
 
@@ -2767,11 +2768,13 @@ def testing_team():
     from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
     if AIRFLOW_V_3_0_PLUS:
+        from sqlalchemy import select
+
         from airflow.models.team import Team
         from airflow.utils.session import create_session
 
         with create_session() as session:
-            team = session.query(Team).filter_by(name="testing").one_or_none()
+            team = session.scalar(select(Team).where(Team.name == "testing"))
             if not team:
                 team = Team(name="testing")
                 session.add(team)

--- a/devel-common/src/tests_common/test_utils/api_client_helpers.py
+++ b/devel-common/src/tests_common/test_utils/api_client_helpers.py
@@ -114,14 +114,15 @@ def create_airflow_connection(connection_id: str, connection_conf: dict[str, Any
             print(f"Connection '{connection_id}' does not exist. A new one will be created")
         create_connection_request(connection_id=connection_id, connection=connection_conf)
     else:
+        from sqlalchemy import delete
+
         from airflow.models import Connection
         from airflow.settings import Session
 
         if Session is None:
             raise RuntimeError("Session not configured. Call configure_orm() first.")
         session = Session()
-        query = session.query(Connection).filter(Connection.conn_id == connection_id)
-        query.delete()
+        session.execute(delete(Connection).where(Connection.conn_id == connection_id))
         connection = Connection(conn_id=connection_id, **connection_conf)
         session.add(connection)
         session.commit()
@@ -135,12 +136,13 @@ def delete_airflow_connection(connection_id: str) -> None:
     if AIRFLOW_V_3_0_PLUS:
         delete_connection_request(connection_id=connection_id)
     else:
+        from sqlalchemy import delete
+
         from airflow.models import Connection
         from airflow.settings import Session
 
         if Session is None:
             raise RuntimeError("Session not configured. Call configure_orm() first.")
         session = Session()
-        query = session.query(Connection).filter(Connection.conn_id == connection_id)
-        query.delete()
+        session.execute(delete(Connection).where(Connection.conn_id == connection_id))
         session.commit()

--- a/devel-common/src/tests_common/test_utils/api_fastapi.py
+++ b/devel-common/src/tests_common/test_utils/api_fastapi.py
@@ -49,8 +49,10 @@ def _masked_value_check(data, sensitive_fields):
 
 
 def _check_last_log(session, dag_id, event, logical_date, expected_extra=None, check_masked=False):
-    logs = (
-        session.query(
+    from sqlalchemy import select
+
+    logs = session.execute(
+        select(
             Log.dag_id,
             Log.task_id,
             Log.event,
@@ -58,15 +60,14 @@ def _check_last_log(session, dag_id, event, logical_date, expected_extra=None, c
             Log.owner,
             Log.extra,
         )
-        .filter(
+        .where(
             Log.dag_id == dag_id,
             Log.event == event,
             Log.logical_date == logical_date,
         )
         .order_by(Log.dttm.desc())
         .limit(1)
-        .all()
-    )
+    ).all()
     assert len(logs) == 1
     assert logs[0].extra
     if expected_extra:
@@ -77,11 +78,10 @@ def _check_last_log(session, dag_id, event, logical_date, expected_extra=None, c
 
 
 def _check_dag_run_note(session, dr_id, note_data):
-    dr_note = (
-        session.query(DagRunNote)
-        .join(DagRun, DagRunNote.dag_run_id == DagRun.id)
-        .filter(DagRun.run_id == dr_id)
-        .one_or_none()
+    from sqlalchemy import select
+
+    dr_note = session.scalar(
+        select(DagRunNote).join(DagRun, DagRunNote.dag_run_id == DagRun.id).where(DagRun.run_id == dr_id)
     )
     if note_data is None:
         assert dr_note is None
@@ -91,7 +91,9 @@ def _check_dag_run_note(session, dr_id, note_data):
 
 
 def _check_task_instance_note(session, ti_id, note_data):
-    ti_note = session.query(TaskInstanceNote).filter_by(ti_id=ti_id).one_or_none()
+    from sqlalchemy import select
+
+    ti_note = session.scalar(select(TaskInstanceNote).where(TaskInstanceNote.ti_id == ti_id))
     if note_data is None:
         assert ti_note is None
     else:

--- a/devel-common/src/tests_common/test_utils/db.py
+++ b/devel-common/src/tests_common/test_utils/db.py
@@ -22,7 +22,7 @@ import os
 from tempfile import gettempdir
 from typing import TYPE_CHECKING
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 
 from airflow.configuration import conf
 from airflow.jobs.job import Job
@@ -200,14 +200,14 @@ def parse_and_sync_to_db(folder: Path | str, include_examples: bool = False):
 
 def clear_db_runs():
     with create_session() as session:
-        session.query(Job).delete()
-        session.query(Trigger).delete()
-        session.query(DagRun).delete()
-        session.query(TaskInstance).delete()
+        session.execute(delete(Job))
+        session.execute(delete(Trigger))
+        session.execute(delete(DagRun))
+        session.execute(delete(TaskInstance))
         try:
             from airflow.models import TaskInstanceHistory
 
-            session.query(TaskInstanceHistory).delete()
+            session.execute(delete(TaskInstanceHistory))
         except ImportError:
             pass
 
@@ -216,25 +216,25 @@ def clear_db_backfills():
     from airflow.models.backfill import Backfill, BackfillDagRun
 
     with create_session() as session:
-        session.query(BackfillDagRun).delete()
-        session.query(Backfill).delete()
+        session.execute(delete(BackfillDagRun))
+        session.execute(delete(Backfill))
 
 
 def clear_db_assets():
     with create_session() as session:
-        session.query(AssetEvent).delete()
-        session.query(AssetModel).delete()
-        session.query(AssetDagRunQueue).delete()
-        session.query(DagScheduleAssetReference).delete()
-        session.query(TaskOutletAssetReference).delete()
+        session.execute(delete(AssetEvent))
+        session.execute(delete(AssetModel))
+        session.execute(delete(AssetDagRunQueue))
+        session.execute(delete(DagScheduleAssetReference))
+        session.execute(delete(TaskOutletAssetReference))
         if AIRFLOW_V_3_1_PLUS:
             from airflow.models.asset import TaskInletAssetReference
 
-            session.query(TaskInletAssetReference).delete()
+            session.execute(delete(TaskInletAssetReference))
         from tests_common.test_utils.compat import AssetAliasModel, DagScheduleAssetAliasReference
 
-        session.query(AssetAliasModel).delete()
-        session.query(DagScheduleAssetAliasReference).delete()
+        session.execute(delete(AssetAliasModel))
+        session.execute(delete(DagScheduleAssetAliasReference))
         if AIRFLOW_V_3_0_PLUS:
             from airflow.models.asset import (
                 AssetActive,
@@ -242,13 +242,13 @@ def clear_db_assets():
                 DagScheduleAssetUriReference,
             )
 
-            session.query(AssetActive).delete()
-            session.query(DagScheduleAssetNameReference).delete()
-            session.query(DagScheduleAssetUriReference).delete()
+            session.execute(delete(AssetActive))
+            session.execute(delete(DagScheduleAssetNameReference))
+            session.execute(delete(DagScheduleAssetUriReference))
         if AIRFLOW_V_3_2_PLUS:
             from airflow.models.asset import AssetWatcherModel
 
-            session.query(AssetWatcherModel).delete()
+            session.execute(delete(AssetWatcherModel))
 
 
 def clear_db_triggers():
@@ -256,20 +256,20 @@ def clear_db_triggers():
         if AIRFLOW_V_3_2_PLUS:
             from airflow.models.asset import AssetWatcherModel
 
-            session.query(AssetWatcherModel).delete()
-        session.query(Trigger).delete()
+            session.execute(delete(AssetWatcherModel))
+        session.execute(delete(Trigger))
 
 
 def clear_db_dags():
     with create_session() as session:
         if AIRFLOW_V_3_1_PLUS:
-            session.query(DagFavorite).delete()
-        session.query(DagTag).delete()
-        session.query(DagOwnerAttributes).delete()
-        session.query(DagRun).delete(
-            synchronize_session=False
+            session.execute(delete(DagFavorite))
+        session.execute(delete(DagTag))
+        session.execute(delete(DagOwnerAttributes))
+        session.execute(
+            delete(DagRun)
         )  # todo: this should not be necessary because the fk to DagVersion should be ON DELETE SET NULL
-        session.query(DagModel).delete()
+        session.execute(delete(DagModel))
 
 
 def clear_db_deadline():
@@ -277,7 +277,7 @@ def clear_db_deadline():
         if AIRFLOW_V_3_0_PLUS:
             from airflow.models.deadline import Deadline
 
-            session.query(Deadline).delete()
+            session.execute(delete(Deadline))
 
 
 def drop_tables_with_prefix(prefix):
@@ -290,12 +290,12 @@ def drop_tables_with_prefix(prefix):
 
 def clear_db_serialized_dags():
     with create_session() as session:
-        session.query(SerializedDagModel).delete()
+        session.execute(delete(SerializedDagModel))
 
 
 def clear_db_pools():
     with create_session() as session:
-        session.query(Pool).delete()
+        session.execute(delete(Pool))
         add_default_pool_if_not_exists(session)
 
 
@@ -313,19 +313,19 @@ def clear_test_connections(add_default_connections_back=True):
 
 def clear_db_connections(add_default_connections_back=True):
     with create_session() as session:
-        session.query(Connection).delete()
+        session.execute(delete(Connection))
         if add_default_connections_back:
             create_default_connections(session)
 
 
 def clear_db_variables():
     with create_session() as session:
-        session.query(Variable).delete()
+        session.execute(delete(Variable))
 
 
 def clear_db_dag_code():
     with create_session() as session:
-        session.query(DagCode).delete()
+        session.execute(delete(DagCode))
 
 
 def clear_db_callbacks():
@@ -333,10 +333,10 @@ def clear_db_callbacks():
         if AIRFLOW_V_3_2_PLUS:
             from airflow.models.callback import Callback
 
-            session.query(Callback).delete()
+            session.execute(delete(Callback))
 
         else:
-            session.query(DbCallbackRequest).delete()
+            session.execute(delete(DbCallbackRequest))
 
 
 def set_default_pool_slots(slots):
@@ -347,22 +347,22 @@ def set_default_pool_slots(slots):
 
 def clear_rendered_ti_fields():
     with create_session() as session:
-        session.query(RenderedTaskInstanceFields).delete()
+        session.execute(delete(RenderedTaskInstanceFields))
 
 
 def clear_db_import_errors():
     with create_session() as session:
-        session.query(ParseImportError).delete()
+        session.execute(delete(ParseImportError))
 
 
 def clear_db_dag_warnings():
     with create_session() as session:
-        session.query(DagWarning).delete()
+        session.execute(delete(DagWarning))
 
 
 def clear_db_xcom():
     with create_session() as session:
-        session.query(XCom).delete()
+        session.execute(delete(XCom))
 
 
 def clear_db_pakl():
@@ -371,7 +371,7 @@ def clear_db_pakl():
     from airflow.models.asset import PartitionedAssetKeyLog
 
     with create_session() as session:
-        session.query(PartitionedAssetKeyLog).delete()
+        session.execute(delete(PartitionedAssetKeyLog))
 
 
 def clear_db_apdr():
@@ -380,43 +380,43 @@ def clear_db_apdr():
     from airflow.models.asset import AssetPartitionDagRun
 
     with create_session() as session:
-        session.query(AssetPartitionDagRun).delete()
+        session.execute(delete(AssetPartitionDagRun))
 
 
 def clear_db_logs():
     with create_session() as session:
-        session.query(Log).delete()
+        session.execute(delete(Log))
 
 
 def clear_db_jobs():
     with create_session() as session:
-        session.query(Job).delete()
+        session.execute(delete(Job))
 
 
 def clear_db_task_reschedule():
     with create_session() as session:
-        session.query(TaskReschedule).delete()
+        session.execute(delete(TaskReschedule))
 
 
 def clear_db_dag_parsing_requests():
     with create_session() as session:
         from airflow.models.dagbag import DagPriorityParsingRequest
 
-        session.query(DagPriorityParsingRequest).delete()
+        session.execute(delete(DagPriorityParsingRequest))
 
 
 def clear_db_dag_bundles():
     with create_session() as session:
         from airflow.models.dagbundle import DagBundleModel
 
-        session.query(DagBundleModel).delete()
+        session.execute(delete(DagBundleModel))
 
 
 def clear_db_teams():
     with create_session() as session:
         from airflow.models.team import Team
 
-        session.query(Team).delete()
+        session.execute(delete(Team))
 
 
 def clear_dag_specific_permissions():
@@ -442,19 +442,23 @@ def clear_dag_specific_permissions():
         else:
             raise
     with create_session() as session:
-        dag_resources = session.query(Resource).filter(Resource.name.like(f"{RESOURCE_DAG_PREFIX}%")).all()
+        dag_resources = session.scalars(
+            select(Resource).where(Resource.name.like(f"{RESOURCE_DAG_PREFIX}%"))
+        ).all()
         dag_resource_ids = [d.id for d in dag_resources]
 
-        dag_permissions = session.query(Permission).filter(Permission.resource_id.in_(dag_resource_ids)).all()
+        dag_permissions = session.scalars(
+            select(Permission).where(Permission.resource_id.in_(dag_resource_ids))
+        ).all()
         dag_permission_ids = [d.id for d in dag_permissions]
 
-        session.query(assoc_permission_role).filter(
-            assoc_permission_role.c.permission_view_id.in_(dag_permission_ids)
-        ).delete(synchronize_session=False)
-        session.query(Permission).filter(Permission.resource_id.in_(dag_resource_ids)).delete(
-            synchronize_session=False
+        session.execute(
+            delete(assoc_permission_role).where(
+                assoc_permission_role.c.permission_view_id.in_(dag_permission_ids)
+            )
         )
-        session.query(Resource).filter(Resource.id.in_(dag_resource_ids)).delete(synchronize_session=False)
+        session.execute(delete(Permission).where(Permission.resource_id.in_(dag_resource_ids)))
+        session.execute(delete(Resource).where(Resource.id.in_(dag_resource_ids)))
 
 
 def create_default_connections_for_tests():

--- a/devel-common/src/tests_common/test_utils/otel_utils.py
+++ b/devel-common/src/tests_common/test_utils/otel_utils.py
@@ -20,7 +20,7 @@ import json
 import logging
 import pprint
 
-from sqlalchemy import inspect
+from sqlalchemy import inspect, select
 
 from airflow.models import Base
 
@@ -40,8 +40,7 @@ def dump_airflow_metadata_db(session):
         log.debug("\nDumping table: %s", table_name)
         table = Base.metadata.tables.get(table_name)
         if table is not None:
-            query = session.query(table)
-            results = [dict(row) for row in query.all()]
+            results = [dict(row._mapping) for row in session.execute(select(table)).all()]
             db_dump[table_name] = results
             # Pretty-print the table contents
             if table_name == "connection":


### PR DESCRIPTION
related: #59402

Migrate deprecated SQLAlchemy Query object usage to SQLAlchemy 2.0 style in:
- `devel-common/src/tests_common/pytest_plugin.py`
- `devel-common/src/tests_common/test_utils/logs.py`
- `devel-common/src/tests_common/test_utils/api_client_helpers.py`
- `devel-common/src/tests_common/test_utils/otel_utils.py`
- `devel-common/src/tests_common/test_utils/api_fastapi.py`
- `devel-common/src/tests_common/test_utils/db.py`

---
^ Add meaningful description above
Read the Pull Request Guidelines for more information.
In case of fundamental code changes, an Airflow Improvement Proposal (AIP) is needed.
In case of a new dependency, check compliance with the ASF 3rd Party License Policy.
In case of backwards incompatible changes please leave a note in a newsfragment file, named {pr_number}.significant.rst or {issue_number}.significant.rst, in airflow-core/newsfragments.

