### PR TITLE
CLI: Mask sensitive values in connections and variables list by default

### DIFF
--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -198,6 +198,11 @@ ARG_PID = Arg(("--pid",), help="PID file location", nargs="?")
 ARG_DAEMON = Arg(
     ("-D", "--daemon"), help="Daemonize instead of running in the foreground", action="store_true"
 )
+ARG_SHOW_VALUES = Arg(
+    ("--show-values",),
+    help="Show sensitive values (e.g. connection passwords, variable values) instead of masking them",
+    action="store_true",
+)
 ARG_STDERR = Arg(("--stderr",), help="Redirect stderr to this file")
 ARG_STDOUT = Arg(("--stdout",), help="Redirect stdout to this file")
 ARG_LOG_FILE = Arg(("-l", "--log-file"), help="Location of the log file")
@@ -1543,7 +1548,7 @@ CONNECTIONS_COMMANDS = (
         name="list",
         help="List connections",
         func=lazy_load_command("airflow.cli.commands.connection_command.connections_list"),
-        args=(ARG_OUTPUT, ARG_VERBOSE, ARG_CONN_ID_FILTER),
+        args=(ARG_OUTPUT, ARG_VERBOSE, ARG_CONN_ID_FILTER, ARG_SHOW_VALUES),
     ),
     ActionCommand(
         name="add",

--- a/airflow-core/src/airflow/cli/commands/variable_command.py
+++ b/airflow-core/src/airflow/cli/commands/variable_command.py
@@ -45,7 +45,16 @@ def variables_list(args):
     """Display all the variables."""
     with create_session() as session:
         variables = session.scalars(select(Variable)).all()
-    AirflowConsole().print_as(data=variables, output=args.output, mapper=lambda x: {"key": x.key})
+
+    def variable_mapper(var):
+        return {
+            "key": var.key,
+            "val": var.val if args.show_values else "***",
+            "description": var.description,
+            "is_encrypted": var.is_encrypted,
+        }
+
+    AirflowConsole().print_as(data=variables, output=args.output, mapper=variable_mapper)
 
 
 @suppress_logs_and_warning


### PR DESCRIPTION
This PR introduces a --show-values flag to the 'connections list' and 'variables list' CLI commands to mask sensitive values (like passwords and variable values) by default. Closes: #59844