### PR TITLE
Exclude FastAPI 0.128.0

### DIFF
--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -85,7 +85,7 @@ dependencies = [
     "cryptography>=41.0.0,<46.0.0",
     "deprecated>=1.2.13",
     "dill>=0.2.2",
-    "fastapi[standard-no-fastapi-cloud-cli]>=0.127.0",
+    "fastapi[standard-no-fastapi-cloud-cli]>=0.127.0,!=0.128.0",
     "uvicorn>=0.37.0",
     "starlette>=0.45.0",
     "httpx>=0.25.0",


### PR DESCRIPTION
Short term / interim fix as it seems FastAPI 0.128.0 broke Cadwyn again as well as our TaskSDK model generation, see https://github.com/apache/airflow/actions/runs/20540936521