### PR TITLE
Remove config sensitive data from airflowctl #59843

### DIFF
--- a/airflow-ctl/src/airflowctl/api/operations.py
+++ b/airflow-ctl/src/airflowctl/api/operations.py
@@ -72,6 +72,7 @@ from airflowctl.api.datamodels.generated import (
     VersionInfo,
 )
 from airflowctl.exceptions import AirflowCtlConnectionException
+from airflowctl.utils.config_masking import mask_config
 
 if TYPE_CHECKING:
     from airflowctl.api.client import Client
@@ -360,7 +361,8 @@ class ConfigOperations(BaseOperations):
         """Get a config from the API server."""
         try:
             self.response = self.client.get(f"/config/section/{section}/option/{option}")
-            return Config.model_validate_json(self.response.content)
+            config_response = Config.model_validate_json(self.response.content)
+            return Config.model_validate(mask_config(config_response))
         except ServerResponseError as e:
             raise e
 
@@ -368,7 +370,9 @@ class ConfigOperations(BaseOperations):
         """List all configs from the API server."""
         try:
             self.response = self.client.get("/config")
-            return Config.model_validate_json(self.response.content)
+            config_response = Config.model_validate_json(self.response.content)
+            return Config.model_validate(mask_config(config_response))
+
         except ServerResponseError as e:
             raise e
 

--- a/airflow-ctl/src/airflowctl/ctl/commands/config_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/config_command.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 import rich
 
 from airflowctl.api.client import NEW_API_CLIENT, ClientKind, provide_api_client
+from airflowctl.utils.config_masking import mask_config, is_sensitive_config_key
 
 if TYPE_CHECKING:
     from airflowctl.api.datamodels.generated import Config
@@ -774,7 +775,7 @@ def lint(args, api_client=NEW_API_CLIENT) -> None:
     ignore_options = args.ignore_option or []
 
     try:
-        all_configs = api_client.configs.list()
+        all_configs = mask_config(api_client.configs.list())
         for configuration in CONFIGS_CHANGES:
             if (
                 section_to_check_if_provided

--- a/airflow-ctl/src/airflowctl/utils/config_masking.py
+++ b/airflow-ctl/src/airflowctl/utils/config_masking.py
@@ -1,0 +1,118 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Mask Sensitive information in Config."""
+from __future__ import annotations
+
+from typing import Any
+
+SENSITIVE_CONFIG_OPTIONS = frozenset({
+    # Database credentials
+    "sql_alchemy_conn",
+    "sql_alchemy_connect_args",
+
+    # API credentials
+    "api_key",
+    "api_secret",
+    "fernet_key",
+
+    # Email credentials
+    "smtp_password",
+
+    # Secret keys
+    "secret_key",
+    "jwt_secret_key",
+
+    # External service credentials
+    "access_key",
+    "access_key_id",
+    "access_key_secret",
+    "secret_access_key",
+
+    # Generic sensitive patterns (suffixes)
+    "_password",
+    "_secret",
+    "_key",
+    "_token",
+    "_credential",
+})
+
+replacement_value = "***"
+
+
+def is_sensitive_config_key(key: str) -> bool:
+    """
+    Determine if a configuration key should be treated as sensitive.
+
+    Return True if sensitive, else False
+    """
+    if not key:
+        return False
+    key_lower = key.strip().lower()
+
+    if key_lower in SENSITIVE_CONFIG_OPTIONS:
+        return True
+    for suffix in ["_password", "_secret", "_key", "_token", "_credential"]:
+        if key_lower.endswith(suffix):
+            return True
+    return False
+
+
+def mask_config_value(key: str, value: Any) -> str:
+    """Mask a configuration if the key is sensitive."""
+    if not is_sensitive_config_key(key):
+        return replacement_value
+
+    # Handle Dictionary Values
+    if isinstance(value, dict):
+        return {k: mask_config_value(k, v) for k, v in value.items()}
+
+    # List Values
+    if isinstance(value, list):
+        return [str(mask_config_value(str(i), i)) for i in value]
+
+    return str(value) if value is not None else ""
+
+
+def mask_config_section(section_name: str, options: list[dict]) -> list[dict]:
+    """Mask all sensitive sections in configuration section."""
+    return [
+        {
+            "key": opt["key"],
+            "value": mask_config_value(opt["key"], opt.get("value"))
+        }
+        for opt in options
+    ]
+
+
+def mask_config(config: Any) -> Any:
+    """Recursively Mask configuration values."""
+    if isinstance(config, dict):
+        return {k: mask_config_value(k, v) for k, v in config.items()}
+
+    if hasattr(config, "sections"):
+        masked_sections = []
+        for section in config.sections:
+            masked_options = [
+                {"key": opt.key, "value": mask_config_value(opt.key, opt.value)}
+                for opt in section.options
+            ]
+        masked_sections.append({
+            "name": section.name,
+            "options": masked_options
+        })
+        return {"sections": masked_sections}
+    return config

--- a/airflow-ctl/tests/airflow_ctl/utils/test_config_masking.py
+++ b/airflow-ctl/tests/airflow_ctl/utils/test_config_masking.py
@@ -1,0 +1,79 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+import pytest
+from airflowctl.api.datamodels.generated import Config, ConfigSection, ConfigOption
+from airflowctl.utils.config_masking import (
+    is_sensitive_config_key,
+    mask_config_value,
+    mask_config,
+)
+
+
+class TestIsSensitiveConfigKey:
+    """Test sensitivity detection for config keys."""
+
+    def test_detects_sensitive_keys(self):
+        assert is_sensitive_config_key("smtp_password")
+        assert is_sensitive_config_key("sql_alchemy_conn")
+        assert is_sensitive_config_key("fernet_key")
+
+    def test_ignores_non_sensitive_keys(self):
+        assert not is_sensitive_config_key("parallelism")
+        assert not is_sensitive_config_key("dagbag_import_timeout")
+
+
+class TestMaskConfigValue:
+    """Test value masking."""
+
+    def test_masks_sensitive_values(self):
+        assert mask_config_value("smtp_password", "secret123") == "***"
+        assert mask_config_value("fernet_key", "my_secret_key") == "***"
+
+    def test_preserves_non_sensitive_values(self):
+        assert mask_config_value("parallelism", "32") == "32"
+        assert mask_config_value("dagbag_import_timeout", "30") == "30"
+
+
+class TestMaskConfig:
+    """Test config object masking (entry point for API operations)."""
+
+    def test_masks_pydantic_config_object(self):
+        """Pydantic Config objects should be masked."""
+        config = Config(
+            sections=[
+                ConfigSection(
+                    name="core",
+                    options=[
+                        ConfigOption(key="parallelism", value="32"),
+                        ConfigOption(key="sql_alchemy_conn", value="postgresql://user:pass@db"),
+                    ]
+                )
+            ]
+        )
+        result = mask_config(config)
+
+        assert isinstance(result, Config)
+        assert hasattr(result, "sections")
+
+        core_section = result.sections[0]
+        opts = {opt.key: opt.value for opt in core_section.options}
+
+        assert opts["parallelism"] == "32"
+        assert opts["sql_alchemy_conn"] == "***"
+


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes #59843

Changes:
1. Created a new file `airflow-ctl/src/airflowctl/utils/config_masking.py` for identifying and masking sensitive config data.  
2. Modified `airflow-ctl/src/airflowctl/api/operations.py` to ensure that all config data returned from API is masked before being used.
3. Modified `airflow-ctl/src/airflowctl/ctl/commands/config_command.py` to ensure all config displayed in CLI is already masked.
4. Created `airflow-ctl/tests/airflow_ctl/utils/test_config_masking.py` to test if the masking utility function works correctly.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
