### PR TITLE
Breeze: keep OpenAPI Generator version in sync during CI upgrades

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -301,21 +301,16 @@ jobs:
           --hook-stage manual upgrade-important-versions || true
         if: always()
         env:
-          UPGRADE_UV: "true"
           UPGRADE_PIP: "false"
           UPGRADE_PYTHON: "false"
           UPGRADE_GOLANG: "false"
-          UPGRADE_PREK: "true"
           UPGRADE_NODE_LTS: "false"
           UPGRADE_HATCH: "false"
           UPGRADE_PYYAML: "false"
           UPGRADE_GITPYTHON: "false"
           UPGRADE_RICH: "false"
           UPGRADE_RUFF: "false"
-          UPGRADE_MPROCS: "true"
           UPGRADE_MYPY: "false"
-          UPGRADE_PROTOC: "false"
-          UPGRADE_OPENAPI_GENERATOR: "false"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "Run automated upgrade for important versions minus uv (failing if needed)"
         run: |
@@ -329,17 +324,7 @@ jobs:
         if: always()
         env:
           UPGRADE_UV: "false"
-          UPGRADE_PIP: "true"
-          UPGRADE_PYTHON: "true"
-          UPGRADE_GOLANG: "true"
           UPGRADE_PREK: "false"
-          UPGRADE_NODE_LTS: "true"
-          UPGRADE_HATCH: "true"
-          UPGRADE_PYYAML: "true"
-          UPGRADE_GITPYTHON: "true"
-          UPGRADE_RICH: "true"
-          UPGRADE_RUFF: "true"
-          UPGRADE_MYPY: "true"
           UPGRADE_MPROCS: "false"
           UPGRADE_PROTOC: "false"
           UPGRADE_OPENAPI_GENERATOR: "false"

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -315,6 +315,7 @@ jobs:
           UPGRADE_MPROCS: "true"
           UPGRADE_MYPY: "false"
           UPGRADE_PROTOC: "false"
+          UPGRADE_OPENAPI_GENERATOR: "false"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "Run automated upgrade for important versions minus uv (failing if needed)"
         run: |
@@ -341,6 +342,7 @@ jobs:
           UPGRADE_MYPY: "true"
           UPGRADE_MPROCS: "false"
           UPGRADE_PROTOC: "false"
+          UPGRADE_OPENAPI_GENERATOR: "false"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test-airflow-release-commands:

--- a/dev/breeze/src/airflow_breeze/commands/ci_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_commands.py
@@ -39,6 +39,7 @@ from airflow_breeze.commands.common_options import (
     option_github_repository,
     option_verbose,
 )
+from airflow_breeze.commands.release_management_commands import prepare_python_client
 from airflow_breeze.global_constants import (
     DEFAULT_PYTHON_MAJOR_MINOR_VERSION,
     PUBLIC_AMD_RUNNERS,
@@ -640,6 +641,9 @@ def upgrade(target_branch: str, create_pr: bool | None, switch_to_base: bool | N
     # Execute all upgrade commands with the environment containing GitHub token
     for command in upgrade_commands:
         run_command(command.split(), check=False, env=command_env)
+
+    get_console().print("[info]Regenerating OpenAPI Python client[/]")
+    prepare_python_client()
 
     res = run_command(["git", "diff", "--exit-code"], check=False)
     if res.returncode == 0:

--- a/dev/breeze/src/airflow_breeze/commands/ci_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_commands.py
@@ -39,7 +39,6 @@ from airflow_breeze.commands.common_options import (
     option_github_repository,
     option_verbose,
 )
-from airflow_breeze.commands.release_management_commands import prepare_python_client
 from airflow_breeze.global_constants import (
     DEFAULT_PYTHON_MAJOR_MINOR_VERSION,
     PUBLIC_AMD_RUNNERS,
@@ -641,9 +640,6 @@ def upgrade(target_branch: str, create_pr: bool | None, switch_to_base: bool | N
     # Execute all upgrade commands with the environment containing GitHub token
     for command in upgrade_commands:
         run_command(command.split(), check=False, env=command_env)
-
-    get_console().print("[info]Regenerating OpenAPI Python client[/]")
-    prepare_python_client()
 
     res = run_command(["git", "diff", "--exit-code"], check=False)
     if res.returncode == 0:

--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -3335,7 +3335,7 @@ SOURCE_API_YAML_PATH = (
     AIRFLOW_ROOT_PATH / "airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml"
 )
 TARGET_API_YAML_PATH = PYTHON_CLIENT_DIR_PATH / "v2.yaml"
-OPENAPI_GENERATOR_CLI_VER = "7.13.0"
+OPENAPI_GENERATOR_CLI_VER = "7.18.0"
 
 GENERATED_CLIENT_DIRECTORIES_TO_COPY: list[Path] = [
     Path("airflow_client") / "client",

--- a/scripts/ci/prek/upgrade_important_versions.py
+++ b/scripts/ci/prek/upgrade_important_versions.py
@@ -290,6 +290,19 @@ def get_latest_github_release_version(repo: str) -> str:
     return version
 
 
+def get_latest_openapi_generator_version() -> str:
+    if not UPGRADE_OPENAPI_GENERATOR:
+        return ""
+    if VERBOSE:
+        console.print("[bright_blue]Fetching latest OpenAPI generator version from GitHub")
+    url = "https://api.github.com/repos/OpenAPITools/openapi-generator/releases/latest"
+    headers = {"User-Agent": "Python requests"}
+    response = requests.get(url, headers=headers)
+    response.raise_for_status()
+    data = response.json()
+    return data["tag_name"].lstrip("v")
+
+
 class Quoting(Enum):
     UNQUOTED = 0
     SINGLE_QUOTED = 1
@@ -408,6 +421,7 @@ UPGRADE_RUFF: bool = get_env_bool("UPGRADE_RUFF")
 UPGRADE_UV: bool = get_env_bool("UPGRADE_UV")
 UPGRADE_MYPY: bool = get_env_bool("UPGRADE_MYPY")
 UPGRADE_PROTOC: bool = get_env_bool("UPGRADE_PROTOC")
+UPGRADE_OPENAPI_GENERATOR: bool = get_env_bool("UPGRADE_OPENAPI_GENERATOR")
 
 ALL_PYTHON_MAJOR_MINOR_VERSIONS = ["3.10", "3.11", "3.12", "3.13"]
 DEFAULT_PROD_IMAGE_PYTHON_VERSION = "3.12"
@@ -500,6 +514,9 @@ SIMPLE_VERSION_PATTERNS = {
     "mprocs": [
         (r"(ARG MPROCS_VERSION=)(\"[0-9.]+\")", 'ARG MPROCS_VERSION="{version}"'),
     ],
+    "openapi_generator": [
+        (r"(OPENAPI_GENERATOR_CLI_VER = )(\"[0-9.]+\")", 'OPENAPI_GENERATOR_CLI_VER = "{version}"'),
+    ],
 }
 
 
@@ -529,6 +546,7 @@ def fetch_all_package_versions() -> dict[str, str]:
         "node_lts": get_latest_lts_node_version() if UPGRADE_NODE_LTS else "",
         "protoc": get_latest_image_version("rvolosatovs/protoc") if UPGRADE_PROTOC else "",
         "mprocs": get_latest_github_release_version("pvolok/mprocs") if UPGRADE_MPROCS else "",
+        "openapi_generator": get_latest_openapi_generator_version() if UPGRADE_OPENAPI_GENERATOR else "",
     }
 
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #59229 
related:  #59229 


<!-- Please keep an empty line above the dashes. -->
---
Integrates OpenAPI Generator version updates into the existing Breeze CI upgrade flow, addressing the maintenance gap described in #59229. This ensures the pinned generator version is automatically kept in sync when running standard upgrade tooling, without changing generated clients or runtime behavior.

closes: #59229
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
