### PR TITLE
Fix compatibility with FastAPI>=0.128.0

### DIFF
--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -77,7 +77,7 @@ dependencies = [
     "argcomplete>=1.10",
     "asgiref>=2.3.0",
     "attrs>=22.1.0, !=25.2.0",
-    "cadwyn>=5.6.2",
+    "cadwyn>=6.0.0",
     "colorlog>=6.8.2",
     "cron-descriptor>=1.2.24",
     "croniter>=2.0.2",
@@ -85,12 +85,7 @@ dependencies = [
     "cryptography>=41.0.0,<46.0.0",
     "deprecated>=1.2.13",
     "dill>=0.2.2",
-    # Cadwyn is not compatible with FastAPI 0.128.0 due to dropping of Pydantic v1 and Cadwyn using some
-    # internal methods dropped in FastAPI 0.128.0. Tracked in https://github.com/zmievsa/cadwyn/issues/316
-    # We will also have to fix `task-sdk/dev/generate_task_sdk_models.py` script as we are mocking removed
-    # _get_long_model_name method there once Cadwyn releases a new version - we should find a better way
-    # to override long model name (if it is still needed) without relying on private methods.
-    "fastapi[standard-no-fastapi-cloud-cli]>=0.127.0,<0.128.0",
+    "fastapi[standard-no-fastapi-cloud-cli]>=0.128.0",
     "uvicorn>=0.37.0",
     "starlette>=0.45.0",
     "httpx>=0.25.0",

--- a/task-sdk/dev/generate_task_sdk_models.py
+++ b/task-sdk/dev/generate_task_sdk_models.py
@@ -20,7 +20,6 @@ import json
 import os
 import sys
 from pathlib import Path
-from unittest import mock
 
 import httpx
 from datamodel_code_generator import (
@@ -76,7 +75,6 @@ def load_config():
     return cfg
 
 
-@mock.patch("fastapi._compat.v2.get_long_model_name", lambda model: model.__name__)
 def generate_file():
     from airflow.api_fastapi.execution_api.app import InProcessExecutionAPI
 


### PR DESCRIPTION
Ad Cadwyn 6.0.0rc1 is released with compatibility with FastAPI 0.128.0+, we can now attempt to run the tests with it and see what else needs to be fixed.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
