### PR TITLE
Fix flaky tests related to github api rate limits

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -1409,7 +1409,11 @@ class SelectiveChecks:
 
         response = requests.get(url, headers=headers, params=payload)
         if response.status_code != 200:
-            get_console().print(f"[red]Error while listing workflow runs error: {response.json()}.\n")
+            try:
+                error_msg = response.json()
+            except ValueError:
+                error_msg = response.text[:200]  # Truncate long HTML responses
+            get_console().print(f"[red]Error while listing workflow runs error: {error_msg}.\n")
             return None
         runs = response.json().get("workflow_runs", [])
         if not runs:
@@ -1419,6 +1423,13 @@ class SelectiveChecks:
             return None
         jobs_url = runs[0].get("jobs_url")
         jobs_response = requests.get(jobs_url, headers=headers)
+        if jobs_response.status_code != 200:
+            try:
+                error_msg = jobs_response.json()
+            except ValueError:
+                error_msg = jobs_response.text[:200]
+            get_console().print(f"[red]Error while listing jobs error: {error_msg}.\n")
+            return None
         jobs = jobs_response.json().get("jobs", [])
         if not jobs:
             get_console().print("[yellow]No jobs information found for jobs %s.\n", jobs_url)

--- a/dev/breeze/tests/conftest.py
+++ b/dev/breeze/tests/conftest.py
@@ -36,3 +36,11 @@ def pytest_unconfigure(config):
 @pytest.fixture(autouse=True)
 def clear_clearable_cache():
     clear_all_cached_functions()
+
+
+@pytest.fixture
+def json_decode_error():
+    """Provide a requests.exceptions.JSONDecodeError for mocking API failures."""
+    import requests
+
+    return requests.exceptions.JSONDecodeError("", "", 0)

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -1809,12 +1809,26 @@ def test_expected_output_pull_request_v2_7(
         ),
     ],
 )
+@patch.dict("os.environ", {"GITHUB_TOKEN": "test_token"})
+@patch("requests.get")
 def test_expected_output_push(
+    mock_get,
     files: tuple[str, ...],
     pr_labels: tuple[str, ...],
     default_branch: str,
     expected_outputs: dict[str, str],
 ):
+    # Mock GitHub API calls for runner_type property (used in PUSH events)
+    workflow_response = Mock()
+    workflow_response.status_code = 200
+    workflow_response.json.return_value = {"workflow_runs": [{"jobs_url": "https://api.github.com/jobs/123"}]}
+    jobs_response = Mock()
+    jobs_response.status_code = 200
+    jobs_response.json.return_value = {
+        "jobs": [{"name": "Basic tests (ubuntu-22.04)", "labels": ["ubuntu-22.04"]}]
+    }
+    mock_get.side_effect = [workflow_response, jobs_response]
+
     stderr = SelectiveChecks(
         files=files,
         commit_ref=NEUTRAL_COMMIT,
@@ -2027,7 +2041,20 @@ def test_expected_output_pull_request_target(
         GithubEvents.SCHEDULE,
     ],
 )
-def test_no_commit_provided_trigger_full_build_for_any_event_type(github_event):
+@patch.dict("os.environ", {"GITHUB_TOKEN": "test_token"})
+@patch("requests.get")
+def test_no_commit_provided_trigger_full_build_for_any_event_type(mock_get, github_event):
+    # Mock GitHub API calls for runner_type property (used in PUSH/SCHEDULE events)
+    workflow_response = Mock()
+    workflow_response.status_code = 200
+    workflow_response.json.return_value = {"workflow_runs": [{"jobs_url": "https://api.github.com/jobs/123"}]}
+    jobs_response = Mock()
+    jobs_response.status_code = 200
+    jobs_response.json.return_value = {
+        "jobs": [{"name": "Basic tests (ubuntu-22.04)", "labels": ["ubuntu-22.04"]}]
+    }
+    mock_get.side_effect = [workflow_response, jobs_response]
+
     stderr = SelectiveChecks(
         files=(),
         commit_ref="",
@@ -2063,7 +2090,20 @@ def test_no_commit_provided_trigger_full_build_for_any_event_type(github_event):
         GithubEvents.SCHEDULE,
     ],
 )
-def test_files_provided_trigger_full_build_for_any_event_type(github_event):
+@patch.dict("os.environ", {"GITHUB_TOKEN": "test_token"})
+@patch("requests.get")
+def test_files_provided_trigger_full_build_for_any_event_type(mock_get, github_event):
+    # Mock GitHub API calls for runner_type property (used in PUSH/SCHEDULE events)
+    workflow_response = Mock()
+    workflow_response.status_code = 200
+    workflow_response.json.return_value = {"workflow_runs": [{"jobs_url": "https://api.github.com/jobs/123"}]}
+    jobs_response = Mock()
+    jobs_response.status_code = 200
+    jobs_response.json.return_value = {
+        "jobs": [{"name": "Basic tests (ubuntu-22.04)", "labels": ["ubuntu-22.04"]}]
+    }
+    mock_get.side_effect = [workflow_response, jobs_response]
+
     stderr = SelectiveChecks(
         files=(
             "airflow-core/src/airflow/ui/src/pages/Run/Details.tsx",
@@ -2526,6 +2566,7 @@ def test_get_job_label(mock_get):
     workflow_response.json.return_value = {"workflow_runs": [{"jobs_url": "https://api.github.com/jobs/123"}]}
 
     jobs_response = Mock()
+    jobs_response.status_code = 200
     jobs_response.json.return_value = {
         "jobs": [
             {"name": "Basic tests (ubuntu-22.04)", "labels": ["ubuntu-22.04"]},
@@ -2555,6 +2596,7 @@ def test_get_job_label_not_found(mock_get):
     workflow_response.json.return_value = {"workflow_runs": [{"jobs_url": "https://api.github.com/jobs/123"}]}
 
     jobs_response = Mock()
+    jobs_response.status_code = 200
     jobs_response.json.return_value = {
         "jobs": [
             {"name": "Basic tests (ubuntu-22.04)", "labels": []},
@@ -2567,6 +2609,57 @@ def test_get_job_label_not_found(mock_get):
     result = selective_checks.get_job_label("push", "main")
 
     assert result is None
+
+
+@pytest.mark.parametrize(
+    ("workflow_status", "jobs_status", "expected_result"),
+    [
+        pytest.param(504, 200, None, id="workflow_api_504_error"),
+        pytest.param(200, 503, None, id="jobs_api_503_error"),
+        pytest.param(200, 200, "ubuntu-22.04", id="both_apis_200_success"),
+    ],
+)
+@patch("requests.get")
+@patch.dict("os.environ", {"GITHUB_TOKEN": "test_token"})
+def test_get_job_label_api_status_codes(
+    mock_get, workflow_status, jobs_status, expected_result, json_decode_error
+):
+    """Test that get_job_label handles various HTTP status codes correctly."""
+    selective_checks = SelectiveChecks(
+        files=(),
+        github_event=GithubEvents.PULL_REQUEST,
+        github_repository="apache/airflow",
+        github_context_dict={},
+    )
+
+    workflow_response = Mock()
+    workflow_response.status_code = workflow_status
+    if workflow_status == 200:
+        workflow_response.json.return_value = {
+            "workflow_runs": [{"jobs_url": "https://api.github.com/jobs/123"}]
+        }
+    else:
+        workflow_response.json.side_effect = json_decode_error
+        workflow_response.text = "<html>Gateway Timeout</html>"
+
+    jobs_response = Mock()
+    jobs_response.status_code = jobs_status
+    if jobs_status == 200:
+        jobs_response.json.return_value = {
+            "jobs": [
+                {"name": "Basic tests (ubuntu-22.04)", "labels": ["ubuntu-22.04"]},
+                {"name": "Other job", "labels": ["ubuntu-22.04"]},
+            ]
+        }
+    else:
+        jobs_response.json.side_effect = json_decode_error
+        jobs_response.text = "<html>Service Unavailable</html>"
+
+    mock_get.side_effect = [workflow_response, jobs_response]
+
+    result = selective_checks.get_job_label("push", "main")
+
+    assert result == expected_result
 
 
 def test_runner_type_pr():
@@ -2592,6 +2685,7 @@ def test_runner_type_schedule(mock_get):
     workflow_response.json.return_value = {"workflow_runs": [{"jobs_url": "https://api.github.com/jobs/123"}]}
 
     jobs_response = Mock()
+    jobs_response.status_code = 200
     jobs_response.json.return_value = {
         "jobs": [
             {"name": "Basic tests / Test git clone on Windows", "labels": ["windows-2025"]},


### PR DESCRIPTION
### Context
https://github.com/apache/airflow/actions/runs/20565295970/job/59062570817#step:5:2745

```none
FAILED tests/test_selective_checks.py::test_expected_output_push[All tests run on push even if unimportant file changed] - requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
FAILED tests/test_selective_checks.py::test_expected_output_push[All tests except Providers and Helm run on push even if unimportant file changed in non-main branch] - requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
FAILED tests/test_selective_checks.py::test_expected_output_push[All tests run on push if core file changed] - requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
FAILED tests/test_selective_checks.py::test_no_commit_provided_trigger_full_build_for_any_event_type[GithubEvents.PUSH] - requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
FAILED tests/test_selective_checks.py::test_no_commit_provided_trigger_full_build_for_any_event_type[GithubEvents.SCHEDULE] - requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
FAILED tests/test_selective_checks.py::test_files_provided_trigger_full_build_for_any_event_type[GithubEvents.PUSH] - requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
FAILED tests/test_selective_checks.py::test_files_provided_trigger_full_build_for_any_event_type[GithubEvents.SCHEDULE] - requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

### Fix details
- Don't try to access the json of a non-200 response.
- Replace API calls with mocks.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
