### PR TITLE
fix: handle small max_templated_field_length safely

### DIFF
--- a/airflow-core/src/airflow/serialization/helpers.py
+++ b/airflow-core/src/airflow/serialization/helpers.py
@@ -36,14 +36,15 @@ def _truncate_rendered_value(rendered: str, max_length: int) -> str:
     prefix = "Truncated. You can change this behaviour in [core]max_templated_field_length. "
     suffix = "..."
 
-    if max_length <= len(prefix):
-        return rendered[:max_length]
+    if max_length <= len(suffix):
+        return suffix[:max_length]
+
+    if max_length <= len(prefix) + len(suffix):
+        return (prefix + suffix)[:max_length]
 
     available = max_length - len(prefix) - len(suffix)
-    if available <= 0:
-        return rendered[:max_length]
+    return f"{prefix}{rendered[:available]}{suffix}"
 
-    return f"{prefix}{rendered[:available]!r}{suffix}"
 
 
 def _safe_truncate_rendered_value(rendered: Any, max_length: int) -> str:

--- a/airflow-core/src/airflow/serialization/helpers.py
+++ b/airflow-core/src/airflow/serialization/helpers.py
@@ -28,6 +28,7 @@ from airflow.settings import json
 if TYPE_CHECKING:
     from airflow.timetables.base import Timetable as CoreTimetable
 
+
 def _truncate_rendered_value(rendered: str, max_length: int) -> str:
     if max_length <= 0:
         return ""
@@ -44,6 +45,9 @@ def _truncate_rendered_value(rendered: str, max_length: int) -> str:
 
     return f"{prefix}{rendered[:available]!r}{suffix}"
 
+
+def _safe_truncate_rendered_value(rendered: Any, max_length: int) -> str:
+    return _truncate_rendered_value(str(rendered), max_length)
 
 
 def serialize_template_field(template_field: Any, name: str) -> str | dict | list | int | float:
@@ -91,7 +95,7 @@ def serialize_template_field(template_field: Any, name: str) -> str | dict | lis
             serialized = str(template_field)
         if len(serialized) > max_length:
             rendered = redact(serialized, name)
-            return _truncate_rendered_value(rendered, max_length)
+            return _safe_truncate_rendered_value(rendered, max_length)
         return serialized
     if not template_field and not isinstance(template_field, tuple):
         # Avoid unnecessary serialization steps for empty fields unless they are tuples
@@ -105,7 +109,7 @@ def serialize_template_field(template_field: Any, name: str) -> str | dict | lis
     serialized = str(template_field)
     if len(serialized) > max_length:
         rendered = redact(serialized, name)
-        return _truncate_rendered_value(rendered, max_length)
+        return _safe_truncate_rendered_value(rendered, max_length)
     return template_field
 
 

--- a/airflow-core/src/airflow/serialization/helpers.py
+++ b/airflow-core/src/airflow/serialization/helpers.py
@@ -33,17 +33,25 @@ def _truncate_rendered_value(rendered: str, max_length: int) -> str:
     if max_length <= 0:
         return ""
 
-    prefix = "Truncated. You can change this behaviour in [core]max_templated_field_length. "
+    prefix = (
+        "Truncated. You can change this behaviour in "
+        "[core]max_templated_field_length. "
+    )
     suffix = "..."
+    value = str(rendered)
 
-    if max_length <= len(suffix):
-        return suffix[:max_length]
+    trunc_only = f"{prefix}{suffix}"
 
-    if max_length <= len(prefix) + len(suffix):
-        return (prefix + suffix)[:max_length]
+    if max_length < len(trunc_only):
+        return trunc_only
 
-    available = max_length - len(prefix) - len(suffix)
-    return f"{prefix}{rendered[:available]}{suffix}"
+    overhead = len(prefix) + 2 + len(suffix)
+    available = max_length - overhead
+
+    if available <= 0:
+        return trunc_only
+
+    return f"{prefix}'{value[:available]}'{suffix}"
 
 
 

--- a/airflow-core/tests/unit/serialization/test_helpers.py
+++ b/airflow-core/tests/unit/serialization/test_helpers.py
@@ -1,0 +1,9 @@
+def test_serialize_template_field_with_very_small_max_length(monkeypatch):
+    monkeypatch.setenv("AIRFLOW__CORE__MAX_TEMPLATED_FIELD_LENGTH", "1")
+
+    from airflow.serialization.helpers import serialize_template_field
+
+    result = serialize_template_field("This is a long string", "test")
+
+    assert result
+    assert len(result) <= 1

--- a/airflow-core/tests/unit/serialization/test_helpers.py
+++ b/airflow-core/tests/unit/serialization/test_helpers.py
@@ -1,3 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+
 def test_serialize_template_field_with_very_small_max_length(monkeypatch):
     monkeypatch.setenv("AIRFLOW__CORE__MAX_TEMPLATED_FIELD_LENGTH", "1")
 

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -830,18 +830,25 @@ def _truncate_rendered_value(rendered: str, max_length: int) -> str:
     if max_length <= 0:
         return ""
 
-    prefix = "Truncated. You can change this behaviour in [core]max_templated_field_length. "
+    prefix = (
+        "Truncated. You can change this behaviour in "
+        "[core]max_templated_field_length. "
+    )
     suffix = "..."
+    value = str(rendered)
 
-    if max_length <= len(suffix):
-        return suffix[:max_length]
+    trunc_only = f"{prefix}{suffix}"
 
-    if max_length <= len(prefix) + len(suffix):
-        return (prefix + suffix)[:max_length]
+    if max_length < len(trunc_only):
+        return trunc_only
 
-    available = max_length - len(prefix) - len(suffix)
-    return f"{prefix}{rendered[:available]}{suffix}"
+    overhead = len(prefix) + 2 + len(suffix)
+    available = max_length - overhead
 
+    if available <= 0:
+        return trunc_only
+
+    return f"{prefix}'{value[:available]}'{suffix}"
 def _safe_truncate_rendered_value(rendered: Any, max_length: int) -> str:
     return _truncate_rendered_value(str(rendered), max_length)
 


### PR DESCRIPTION
Fixes incorrect truncation when [core] max_templated_field_length is set to very small values.

Previously, negative slicing could result in empty or malformed output.
This change ensures truncation always respects the configured maximum length.

Related: #59877