### PR TITLE
Using unified BaseModel for rest api

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/log.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/log.py
@@ -19,7 +19,9 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Annotated
 
-from pydantic import BaseModel, ConfigDict, WithJsonSchema
+from pydantic import ConfigDict, WithJsonSchema
+
+from airflow.api_fastapi.core_api.base import BaseModel
 
 
 class StructuredLogMessage(BaseModel):
@@ -33,7 +35,7 @@ class StructuredLogMessage(BaseModel):
     ] = None
     event: str
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="allow", from_attributes=True)
 
 
 class TaskInstancesLogResponse(BaseModel):

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/ui/calendar.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/ui/calendar.py
@@ -19,8 +19,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel
-
+from airflow.api_fastapi.core_api.base import BaseModel
 from airflow.utils.state import DagRunState
 
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/ui/config.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/ui/config.py
@@ -16,9 +16,8 @@
 # under the License.
 from __future__ import annotations
 
-from pydantic import BaseModel
-
 from airflow.api_fastapi.common.types import Theme, UIAlert
+from airflow.api_fastapi.core_api.base import BaseModel
 
 
 class ConfigResponse(BaseModel):

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/ui/grid.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/ui/grid.py
@@ -19,8 +19,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel
-
+from airflow.api_fastapi.core_api.base import BaseModel
 from airflow.utils.state import TaskInstanceState
 
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/exceptions.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/exceptions.py
@@ -17,7 +17,7 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from airflow.api_fastapi.core_api.base import BaseModel
 
 
 class HTTPExceptionResponse(BaseModel):

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
@@ -21,11 +21,12 @@ import logging
 from typing import Annotated
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, Request, Response, status
-from pydantic import BaseModel, JsonValue
+from pydantic import JsonValue
 from sqlalchemy import delete
 from sqlalchemy.sql.selectable import Select
 
 from airflow.api_fastapi.common.db.common import SessionDep
+from airflow.api_fastapi.core_api.base import BaseModel
 from airflow.api_fastapi.execution_api.datamodels.xcom import (
     XComResponse,
     XComSequenceIndexResponse,


### PR DESCRIPTION
## Why:
* [44267](https://github.com/apache/airflow/pull/44267) created BaseModel for rest api. I thought that we could refactor BaseModel of pydantic to BaseModel in airflow-core/src/airflow/api_fastapi/core_api/base.py.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
