### PR TITLE
[API] /connections/test: Use stored password for saved connections and fix DBT hook URL

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/connections.py
@@ -249,7 +249,8 @@ def test_connection(
         test_status, test_message = conn.test_connection()
         return ConnectionTestResponse.model_validate({"status": test_status, "message": test_message})
     finally:
-        os.environ.pop(conn_env_var, None)
+        if conn_env_var:
+            os.environ.pop(conn_env_var, None)
 
 
 @connections_router.post(

--- a/providers/dbt/cloud/src/airflow/providers/dbt/cloud/hooks/dbt.py
+++ b/providers/dbt/cloud/src/airflow/providers/dbt/cloud/hooks/dbt.py
@@ -926,10 +926,11 @@ class DbtCloudHook(HttpHook):
         """
         return self._run_and_get_response(method="POST", endpoint=f"{account_id}/jobs/{job_id}/rerun/")
 
-    def test_connection(self) -> tuple[bool, str]:
+    @fallback_to_default_account
+    def test_connection(self, account_id: int | None = None) -> tuple[bool, str]:
         """Test dbt Cloud connection."""
         try:
-            self._run_and_get_response()
+            self._run_and_get_response(endpoint=f"{account_id}/")
             return True, "Successfully connected to dbt Cloud."
         except Exception as e:
             return False, str(e)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
This PR fixes the /connections/test route in Airflow v3 to handle masked passwords correctly and ensures DBT hooks test connections without errors.

**What/Why**

- Use stored password for saved connections instead of the masked "***".
- If the connection is not saved, create a transient in-memory connection from the request body.
- Fix DBT hook to use the correct connection URL during testing and avoid 400 errors.

**How**

- Fetch the connection from the DB if connection_id is provided; otherwise, create a transient connection.
- Added unit tests to cover saved and transient connections.
- Updated dbt hook to use correct url

**Impact**

- Fixes saved and transient connection testing failures and resolves DBT hook 400 errors.
- Earlier versions are also affected and will require separate backports or PRs. The issue is specifically reported in 2.x version

closes: #58941
related: #58941

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
