### PR TITLE
chore(breeze k8s): add dev hint after deploy-airflow

### DIFF
--- a/contributing-docs/testing/k8s_tests.rst
+++ b/contributing-docs/testing/k8s_tests.rst
@@ -503,7 +503,8 @@ Should show the status of current KinD cluster.
     Established connection to webserver at http://localhost:18150/health and it is healthy.
     Airflow Web server URL: http://localhost:18150 (admin/admin)
 
-    NEXT STEP: You might now run tests or interact with Airflow via shell (kubectl, pytest etc.) or k9s commands:
+    NEXT STEP: You might now run tests, interact with airflow via shell (kubectl, pytest etc.) or k9s commands,
+    or start the dev sync loop (dags/core hot-reload):
 
 
     breeze k8s tests
@@ -511,6 +512,8 @@ Should show the status of current KinD cluster.
     breeze k8s shell
 
     breeze k8s k9s
+
+    breeze k8s dev
 
 
 8. Run Kubernetes tests

--- a/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
@@ -1465,12 +1465,14 @@ def deploy_airflow(
         )
         if return_code == 0:
             get_console().print(
-                "\n[warning]NEXT STEP:[/][info] You might now run tests or interact "
-                "with airflow via shell (kubectl, pytest etc.) or k9s commands:\n"
+                "\n[warning]NEXT STEP:[/][info] You might now run tests, interact "
+                "with airflow via shell (kubectl, pytest etc.) or k9s commands, "
+                "or start the dev sync loop (dags/core hot-reload):\n"
             )
             get_console().print("\nbreeze k8s tests")
             get_console().print("\nbreeze k8s shell")
-            get_console().print("\nbreeze k8s k9s\n")
+            get_console().print("\nbreeze k8s k9s")
+            get_console().print("\nbreeze k8s dev\n")
         sys.exit(return_code)
 
 


### PR DESCRIPTION
Relate: #59747

Include a `breeze k8s dev` hint in the output of `breeze k8s deploy-airflow`.

### Before
<img width="877" height="208" alt="截圖 2025-12-30 下午3 36 07" src="https://github.com/user-attachments/assets/bf63e7a1-3575-4372-acaa-753de6e29d56" />

### After
<img width="1215" height="210" alt="截圖 2025-12-30 下午4 01 28" src="https://github.com/user-attachments/assets/aa7d62c6-3070-473c-b052-45b1a54f1ef2" />
