### PR TITLE
Airflowctl : Update dag_id to be a positional argument for dags pause/unpause command 

### DIFF
--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -252,9 +252,8 @@ ARG_AUTH_PASSWORD = Arg(
 
 # Dag Commands Args
 ARG_DAG_ID = Arg(
-    flags=("--dag-id",),
+    flags=("dag_id",),
     type=str,
-    dest="dag_id",
     help="The DAG ID of the DAG to pause or unpause",
 )
 

--- a/airflow-ctl/tests/airflow_ctl/ctl/commands/test_dag_command.py
+++ b/airflow-ctl/tests/airflow_ctl/ctl/commands/test_dag_command.py
@@ -93,7 +93,7 @@ class TestDagCommands:
         )
         assert self.dag_response_paused.is_paused is False
         dag_response_dict = dag_command.pause(
-            self.parser.parse_args(["dags", "pause", "--dag-id", self.dag_id]),
+            self.parser.parse_args(["dags", "pause", self.dag_id]),
             api_client=api_client,
         )
         assert dag_response_dict["is_paused"] is False
@@ -107,7 +107,7 @@ class TestDagCommands:
         )
         with pytest.raises(SystemExit):
             dag_command.pause(
-                self.parser.parse_args(["dags", "pause", "--dag-id", self.dag_id]),
+                self.parser.parse_args(["dags", "pause", self.dag_id]),
                 api_client=api_client,
             )
 
@@ -120,7 +120,7 @@ class TestDagCommands:
         )
         assert self.dag_response_unpaused.is_paused is True
         dag_response_dict = dag_command.unpause(
-            self.parser.parse_args(["dags", "unpause", "--dag-id", self.dag_id]),
+            self.parser.parse_args(["dags", "unpause", self.dag_id]),
             api_client=api_client,
         )
         assert dag_response_dict["is_paused"] is True
@@ -134,6 +134,6 @@ class TestDagCommands:
         )
         with pytest.raises(SystemExit):
             dag_command.unpause(
-                self.parser.parse_args(["dags", "unpause", "--dag-id", self.dag_id]),
+                self.parser.parse_args(["dags", "unpause", self.dag_id]),
                 api_client=api_client,
             )


### PR DESCRIPTION
Now dag_id works as  `airflowctl dags pause/unpase dag_id `
updated tests for the `airflowctl dags ` command 

closes : #57634

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
