### PR TITLE
Sqlalchemy optional in presto provider

### DIFF
--- a/providers/presto/pyproject.toml
+++ b/providers/presto/pyproject.toml
@@ -74,6 +74,9 @@ dependencies = [
 "google" = [
     "apache-airflow-providers-google"
 ]
+"sqlalchemy" = [
+    "sqlalchemy>=1.4.49",
+]
 
 [dependency-groups]
 dev = [
@@ -85,6 +88,7 @@ dev = [
     "apache-airflow-providers-google",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
     "apache-airflow-providers-common-sql[pandas,polars]",
+    "apache-airflow-providers-presto[sqlalchemy]",
 ]
 
 # To build docs:

--- a/providers/presto/src/airflow/providers/presto/hooks/presto.py
+++ b/providers/presto/src/airflow/providers/presto/hooks/presto.py
@@ -25,7 +25,6 @@ import prestodb
 from deprecated import deprecated
 from prestodb.exceptions import DatabaseError
 from prestodb.transaction import IsolationLevel
-from sqlalchemy.engine import URL
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowOptionalProviderFeatureException, AirflowProviderDeprecationWarning
@@ -42,6 +41,8 @@ else:
     )
 
 if TYPE_CHECKING:
+    from sqlalchemy.engine import URL
+
     from airflow.models import Connection
 
 T = TypeVar("T")
@@ -150,6 +151,14 @@ class PrestoHook(DbApiHook):
     @property
     def sqlalchemy_url(self) -> URL:
         """Return a `sqlalchemy.engine.URL` object constructed from the connection."""
+        try:
+            from sqlalchemy.engine import URL
+        except (ImportError, ModuleNotFoundError) as err:
+            raise AirflowOptionalProviderFeatureException(
+                "SQLAlchemy is not installed. Please install it with "
+                "`pip install 'apache-airflow-providers-presto[sqlalchemy]'`."
+            ) from err
+
         conn = self.get_connection(self.get_conn_id())
         extra = conn.extra_dejson or {}
 


### PR DESCRIPTION
Make sqlalchemy optional dependency for presto provider

This change makes SQLAlchemy an optional dependency for the Presto provider. Runtime SQLAlchemy imports are now handled lazily and raise AirflowOptionalProviderFeatureException when the dependency is not installed.

## Related Issue:
https://github.com/apache/airflow/issues/59906