### PR TITLE
add redis statefulset persistentVolumeClaimRetentionPolicy support

### DIFF
--- a/chart/templates/redis/redis-statefulset.yaml
+++ b/chart/templates/redis/redis-statefulset.yaml
@@ -28,6 +28,7 @@
 {{- $securityContext := include "localPodSecurityContext" .Values.redis }}
 {{- $containerSecurityContext := include "externalContainerSecurityContext" .Values.redis }}
 {{- $containerLifecycleHooks := .Values.redis.containerLifecycleHooks }}
+{{- $persistence := .Values.redis.persistence.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -46,6 +47,9 @@ metadata:
   {{- end }}
 spec:
   serviceName: {{ include "airflow.fullname" . }}-redis
+  {{- if and $persistence .Values.redis.persistence.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.redis.persistence.persistentVolumeClaimRetentionPolicy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       tier: airflow
@@ -109,7 +113,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "redis_password_secret" . }}
                   key: password
-  {{- if not .Values.redis.persistence.enabled }}
+  {{- if not $persistence }}
       volumes:
         - name: redis-db
           emptyDir: {{- toYaml (default (dict) .Values.redis.emptyDirConfig) | nindent 12 }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -8252,6 +8252,10 @@
                                 "null"
                             ],
                             "default": null
+                        },
+                        "persistentVolumeClaimRetentionPolicy": {
+                            "$ref": "#/definitions/persistentVolumeClaimRetentionPolicy",
+                            "description": "PersistentVolumeClaim retention policy to be used in the lifecycle of a StatefulSet."
                         }
                     }
                 },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2743,6 +2743,11 @@ redis:
     # the name of an existing PVC to use
     existingClaim:
 
+    persistentVolumeClaimRetentionPolicy: ~
+    # persistentVolumeClaimRetentionPolicy:
+    #   whenDeleted: Delete
+    #   whenScaled: Delete
+
   # Configuration for empty dir volume (if redis.persistence.enabled == false)
   # emptyDirConfig:
   #   sizeLimit: 1Gi


### PR DESCRIPTION
**Issue Description**

Currently when a user provisions an airflow deployment using helm with celery executor on kubernetes, redis statefulset is spinned up provisioned with a storage sized to 1gb by default. when a user tries to switch the executor type to kubernetes and triggers a upgrade through helm components matching the executor type will either gets removed or updated.

The core problem here redis pvc is still present in the same namespace due to the default behaviour of how the persistentVolumeClaimRetentionPolicy is set to retain by default.


**What this PR does** 

This PR adds configurable persistentVolumeClaimRetentionPolicy into redis statefulset allows the user to decide either to delete the pvc provisioned by the redis statefulset or to retain them upon deletion
