### PR TITLE
Bugfix/fix fernet after removal global in configuration

### DIFF
--- a/airflow-core/src/airflow/configuration.py
+++ b/airflow-core/src/airflow/configuration.py
@@ -74,8 +74,8 @@ ENV_VAR_PREFIX = "AIRFLOW__"
 class _SecretKeys:
     """Holds the secret keys used in Airflow during runtime."""
 
-    fernet_key: str | None = None
-    jwt_secret_key: str | None = None
+    fernet_key: str = ""  # Set only if needed when generating a new file
+    jwt_secret_key: str = ""
 
 
 class ConfigModifications:
@@ -743,7 +743,7 @@ def write_default_airflow_configuration_if_needed() -> AirflowConfigParser:
                 raise FileNotFoundError(msg) from None
             log.debug("Create directory %r for Airflow config", config_directory.__fspath__())
             config_directory.mkdir(parents=True, exist_ok=True)
-        if conf.get("core", "fernet_key", fallback=None) in (None, ""):
+        if not conf.get("core", "fernet_key"):
             # We know that fernet_key is not set, so we can generate it, set as global key
             # and also write it to the config file so that same key will be used next time
             _SecretKeys.fernet_key = _generate_fernet_key()

--- a/airflow-core/tests/unit/core/test_configuration.py
+++ b/airflow-core/tests/unit/core/test_configuration.py
@@ -1974,3 +1974,16 @@ def test_write_default_config_contains_generated_secrets(tmp_path, monkeypatch):
 
     assert fernet_line == f"fernet_key = {airflow.configuration._SecretKeys.fernet_key}"
     assert jwt_secret_line == f"jwt_secret = {airflow.configuration._SecretKeys.jwt_secret_key}"
+
+
+@conf_vars({("core", "fernet_key"): ""})
+def test_ensure_fernet_is_generated(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    import airflow.configuration
+
+    cfgpath = tmp_path / "airflow-not-existing.cfg"
+    monkeypatch.setattr(airflow.configuration, "AIRFLOW_CONFIG", str(cfgpath))
+
+    airflow.configuration.write_default_airflow_configuration_if_needed()
+
+    assert airflow.configuration._SecretKeys.fernet_key
+    assert airflow.configuration._SecretKeys.fernet_key != "None"


### PR DESCRIPTION
Had a longer research in iterations in our codebase why PR https://github.com/apache/airflow/pull/59819/ created a regression in retrieving variables as discussed in Slack (https://apache-airflow.slack.com/archives/C06K9Q5G2UA/p1767101218465539)

Root cause was due to refactoring I changed the default initialization of the fernet_key to be `None` instead of an empty string. This casued the config getter when checking to fallback where `None` was actually passed as fallback but the config value defaults existed and while preparing the default it was attempted to expand variables in the defaults which had in this case not been iniitalized and the string formatter made `"None"` into the defaults which then prevented triggering a regeneration of a new fernet. Which then as using `"None"` (String) as Fernet caused variables to fail encoding in DB.

Fix is to use empty string for fernet (as well to be consistent with JWT) as before PR #59819 - to be on the safe side removing the fallback and bad check for missing fernet being passed in config.

This PR fixes the regression and adds a test hoping that this does not happen again.