### PR TITLE
Exclude Dockerfile.pmc from RAT checks

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -49,6 +49,7 @@ generated/*
 .gitmodules
 prod_image_installed_providers.txt
 airflow_pre_installed_providers.txt
+Dockerfile.pmc
 
 # Generated doc files
 .*html


### PR DESCRIPTION
During providers release checks I noticed that RAT complained about the `Dockerfile.pmc` sitting around which is produced during providers checks - but it is in `.gitignore` so no harm if we also ignore from RAT checks.

Alternative we need to change instructions to `rm Dockerfile.pmc` before RAT checks.