### PR TITLE
Make prek hook to check shared distributions resilient to empty dirs

### DIFF
--- a/scripts/ci/prek/check_shared_distributions_structure.py
+++ b/scripts/ci/prek/check_shared_distributions_structure.py
@@ -213,6 +213,12 @@ def main() -> None:
     all_ok = True
     for shared_project in SHARED_DIR.iterdir():
         if shared_project.is_dir():
+            # Not having a pyproject.toml means no distribution here, so using it as a marker to skip
+            if not (shared_project / "pyproject.toml").exists():
+                console.print(
+                    f"\n[yellow]Skipping empty directory:[/yellow] [magenta]{shared_project.name}[/magenta]"
+                )
+                continue
             ok = check_shared_distribution(shared_project)
             if not ok:
                 all_ok = False


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

While working on shared libraries, I often found myself changing git branches and due to which empty directory was left back by git when I moved branches.

When i try committing on the new branch which contains empty directory, the prek hook for checking shared distribution structure would start failing. Had to delete that empty dir to fix it, but the hook script could be more resilient.

Example:
```shell script
(apache-airflow) ➜  airflow git:(make-shared-prek-resilient) ✗ mkdir -p shared/abcd                                                           
(apache-airflow) ➜  airflow git:(make-shared-prek-resilient) ✗ prek run check-shared-distributions-structure --all-files

Check shared distributions structure.....................................Failed
- hook id: check-shared-distributions-structure
- exit code: 2

  Checking: configuration shared project
    pyproject.toml exists for configuration OK
    project name matches configuration and is 'apache-airflow-shared-configuration' OK
    src/airflow_shared/configuration exists for configuration OK
    src/airflow_shared/__init__.py does not exist for configuration OK
    tests/configuration exists for configuration OK
    'Private :: Do Not Upload' classifier is only classifier OK
    build-system is correct for configuration OK
    tool.hatch.build.targets.wheel is correct for configuration OK
    tool.ruff is correct for configuration OK
    tool.ruff.lint rules are correct for configuration OK
  Summary: configuration is OK

  Checking: timezones shared project
    pyproject.toml exists for timezones OK
    project name matches timezones and is 'apache-airflow-shared-timezones' OK
    src/airflow_shared/timezones exists for timezones OK
    src/airflow_shared/__init__.py does not exist for timezones OK
    tests/timezones exists for timezones OK
    'Private :: Do Not Upload' classifier is only classifier OK
    build-system is correct for timezones OK
    tool.hatch.build.targets.wheel is correct for timezones OK
    tool.ruff is correct for timezones OK
    tool.ruff.lint rules are correct for timezones OK
  Summary: timezones is OK

  Checking: dagnode shared project
    pyproject.toml exists for dagnode OK
    project name matches dagnode and is 'apache-airflow-shared-dagnode' OK
    src/airflow_shared/dagnode exists for dagnode OK
    src/airflow_shared/__init__.py does not exist for dagnode OK
    tests/dagnode exists for dagnode OK
    'Private :: Do Not Upload' classifier is only classifier OK
    build-system is correct for dagnode OK
    tool.hatch.build.targets.wheel is correct for dagnode OK
    tool.ruff is correct for dagnode OK
    tool.ruff.lint rules are correct for dagnode OK
  Summary: dagnode is OK

  Checking: observability shared project
    pyproject.toml exists for observability OK
    project name matches observability and is 'apache-airflow-shared-observability' OK
    src/airflow_shared/observability exists for observability OK
    src/airflow_shared/__init__.py does not exist for observability OK
    tests/observability exists for observability OK
    'Private :: Do Not Upload' classifier is only classifier OK
    build-system is correct for observability OK
    tool.hatch.build.targets.wheel is correct for observability OK
    tool.ruff is correct for observability OK
    tool.ruff.lint rules are correct for observability OK
  Summary: observability is OK

  Checking: secrets_backend shared project
    pyproject.toml exists for secrets_backend OK
    project name matches secrets_backend and is 'apache-airflow-shared-secrets-backend' OK
    src/airflow_shared/secrets_backend exists for secrets_backend OK
    src/airflow_shared/__init__.py does not exist for secrets_backend OK
    tests/secrets_backend exists for secrets_backend OK
    'Private :: Do Not Upload' classifier is only classifier OK
    build-system is correct for secrets_backend OK
    tool.hatch.build.targets.wheel is correct for secrets_backend OK
    tool.ruff is correct for secrets_backend OK
    tool.ruff.lint rules are correct for secrets_backend OK
  Summary: secrets_backend is OK

  Checking: abcd shared project
    pyproject.toml missing for for abcd

  Checking: secrets_masker shared project
    pyproject.toml exists for secrets_masker OK
    project name matches secrets_masker and is 'apache-airflow-shared-secrets-masker' OK
    src/airflow_shared/secrets_masker exists for secrets_masker OK
    src/airflow_shared/__init__.py does not exist for secrets_masker OK
    tests/secrets_masker exists for secrets_masker OK
    'Private :: Do Not Upload' classifier is only classifier OK
    build-system is correct for secrets_masker OK
    tool.hatch.build.targets.wheel is correct for secrets_masker OK
    tool.ruff is correct for secrets_masker OK
    tool.ruff.lint rules are correct for secrets_masker OK
  Summary: secrets_masker is OK

  Checking: logging shared project
    pyproject.toml exists for logging OK
    project name matches logging and is 'apache-airflow-shared-logging' OK
    src/airflow_shared/logging exists for logging OK
    src/airflow_shared/__init__.py does not exist for logging OK
    tests/logging exists for logging OK
    'Private :: Do Not Upload' classifier is only classifier OK
    build-system is correct for logging OK
    tool.hatch.build.targets.wheel is correct for logging OK
    tool.ruff is correct for logging OK
    tool.ruff.lint rules are correct for logging OK
  Summary: logging is OK

  Checking: module_loading shared project
    pyproject.toml exists for module_loading OK
    project name matches module_loading and is 'apache-airflow-shared-module-loading' OK
    src/airflow_shared/module_loading exists for module_loading OK
    src/airflow_shared/__init__.py does not exist for module_loading OK
    tests/module_loading exists for module_loading OK
    'Private :: Do Not Upload' classifier is only classifier OK
    build-system is correct for module_loading OK
    tool.hatch.build.targets.wheel is correct for module_loading OK
    tool.ruff is correct for module_loading OK
    tool.ruff.lint rules are correct for module_loading OK
  Summary: module_loading is OK
(apache-airflow) ➜  airflow git:(make-shared-prek-resilient) ✗ 
```

After changes:
```
(apache-airflow) ➜  airflow git:(make-shared-prek-resilient) ✗ prek run check-shared-distributions-structure --all-files --verbose
Check shared distributions structure.....................................Passed
- hook id: check-shared-distributions-structure
- duration: 0.08s

  Checking: configuration shared project
    pyproject.toml exists for configuration OK
    project name matches configuration and is 'apache-airflow-shared-configuration' OK
    src/airflow_shared/configuration exists for configuration OK
    src/airflow_shared/__init__.py does not exist for configuration OK
    tests/configuration exists for configuration OK
    'Private :: Do Not Upload' classifier is only classifier OK
    build-system is correct for configuration OK
    tool.hatch.build.targets.wheel is correct for configuration OK
    tool.ruff is correct for configuration OK
    tool.ruff.lint rules are correct for configuration OK
  Summary: configuration is OK

  Checking: timezones shared project
    pyproject.toml exists for timezones OK
    project name matches timezones and is 'apache-airflow-shared-timezones' OK
    src/airflow_shared/timezones exists for timezones OK
    src/airflow_shared/__init__.py does not exist for timezones OK
    tests/timezones exists for timezones OK
    'Private :: Do Not Upload' classifier is only classifier OK
    build-system is correct for timezones OK
    tool.hatch.build.targets.wheel is correct for timezones OK
    tool.ruff is correct for timezones OK
    tool.ruff.lint rules are correct for timezones OK
  Summary: timezones is OK

  Checking: dagnode shared project
    pyproject.toml exists for dagnode OK
    project name matches dagnode and is 'apache-airflow-shared-dagnode' OK
    src/airflow_shared/dagnode exists for dagnode OK
    src/airflow_shared/__init__.py does not exist for dagnode OK
    tests/dagnode exists for dagnode OK
    'Private :: Do Not Upload' classifier is only classifier OK
    build-system is correct for dagnode OK
    tool.hatch.build.targets.wheel is correct for dagnode OK
    tool.ruff is correct for dagnode OK
    tool.ruff.lint rules are correct for dagnode OK
  Summary: dagnode is OK

  Checking: observability shared project
    pyproject.toml exists for observability OK
    project name matches observability and is 'apache-airflow-shared-observability' OK
    src/airflow_shared/observability exists for observability OK
    src/airflow_shared/__init__.py does not exist for observability OK
    tests/observability exists for observability OK
    'Private :: Do Not Upload' classifier is only classifier OK
    build-system is correct for observability OK
    tool.hatch.build.targets.wheel is correct for observability OK
    tool.ruff is correct for observability OK
    tool.ruff.lint rules are correct for observability OK
  Summary: observability is OK

  Checking: secrets_backend shared project
    pyproject.toml exists for secrets_backend OK
    project name matches secrets_backend and is 'apache-airflow-shared-secrets-backend' OK
    src/airflow_shared/secrets_backend exists for secrets_backend OK
    src/airflow_shared/__init__.py does not exist for secrets_backend OK
    tests/secrets_backend exists for secrets_backend OK
    'Private :: Do Not Upload' classifier is only classifier OK
    build-system is correct for secrets_backend OK
    tool.hatch.build.targets.wheel is correct for secrets_backend OK
    tool.ruff is correct for secrets_backend OK
    tool.ruff.lint rules are correct for secrets_backend OK
  Summary: secrets_backend is OK

  Skipping empty directory: abcd

  Checking: secrets_masker shared project
    pyproject.toml exists for secrets_masker OK
    project name matches secrets_masker and is 'apache-airflow-shared-secrets-masker' OK
    src/airflow_shared/secrets_masker exists for secrets_masker OK
    src/airflow_shared/__init__.py does not exist for secrets_masker OK
    tests/secrets_masker exists for secrets_masker OK
    'Private :: Do Not Upload' classifier is only classifier OK
    build-system is correct for secrets_masker OK
    tool.hatch.build.targets.wheel is correct for secrets_masker OK
    tool.ruff is correct for secrets_masker OK
    tool.ruff.lint rules are correct for secrets_masker OK
  Summary: secrets_masker is OK

  Checking: logging shared project
    pyproject.toml exists for logging OK
    project name matches logging and is 'apache-airflow-shared-logging' OK
    src/airflow_shared/logging exists for logging OK
    src/airflow_shared/__init__.py does not exist for logging OK
    tests/logging exists for logging OK
    'Private :: Do Not Upload' classifier is only classifier OK
    build-system is correct for logging OK
    tool.hatch.build.targets.wheel is correct for logging OK
    tool.ruff is correct for logging OK
    tool.ruff.lint rules are correct for logging OK
  Summary: logging is OK

  Checking: module_loading shared project
    pyproject.toml exists for module_loading OK
    project name matches module_loading and is 'apache-airflow-shared-module-loading' OK
    src/airflow_shared/module_loading exists for module_loading OK
    src/airflow_shared/__init__.py does not exist for module_loading OK
    tests/module_loading exists for module_loading OK
    'Private :: Do Not Upload' classifier is only classifier OK
    build-system is correct for module_loading OK
    tool.hatch.build.targets.wheel is correct for module_loading OK
    tool.ruff is correct for module_loading OK
    tool.ruff.lint rules are correct for module_loading OK
  Summary: module_loading is OK
```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
