### PR TITLE
Limit deltalake to not include 1.3.0 version

### DIFF
--- a/providers/databricks/pyproject.toml
+++ b/providers/databricks/pyproject.toml
@@ -101,7 +101,8 @@ dev = [
     "apache-airflow-providers-common-sql",
     "apache-airflow-providers-openlineage",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
-    "deltalake>=1.1.3",
+    # deltalake 1.3.0 does not have Linux ARM64 wheels https://pypi.org/project/deltalake/1.3.0/#files
+    "deltalake>=1.1.3, !=1.3.0",
     "apache-airflow-providers-fab>=2.2.0; python_version < '3.13'",
     "apache-airflow-providers-microsoft-azure",
     "apache-airflow-providers-common-sql[pandas,polars]",


### PR DESCRIPTION
Deltalake 1.3.0 doesn't have Linux ARM64 wheels, breaking CI [builds](https://github.com/apache/airflow/actions/runs/20622090399/job/59226794981) on linux/arm64.

**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
