### PR TITLE
Source yandex provider to use airflow.sdk.configuration.conf

### DIFF
--- a/providers/yandex/pyproject.toml
+++ b/providers/yandex/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
     "apache-airflow>=2.11.0",
     "yandexcloud>=0.308.0; python_version < '3.13'",
     "yandex-query-client>=0.1.4; python_version < '3.13'",
-    "apache-airflow-providers-common-compat>=1.8.0",
+    "apache-airflow-providers-common-compat>=1.8.0",  # use next version
 ]
 
 # The optional dependencies should be modified in place in the generated file

--- a/providers/yandex/src/airflow/providers/yandex/utils/user_agent.py
+++ b/providers/yandex/src/airflow/providers/yandex/utils/user_agent.py
@@ -24,7 +24,7 @@ from airflow.providers.yandex.utils.defaults import conn_type, hook_name
 def provider_user_agent() -> str | None:
     """Construct User-Agent from Airflow core & provider package versions."""
     from airflow import __version__ as airflow_version
-    from airflow.configuration import conf
+    from airflow.providers.common.compat.sdk import conf
     from airflow.providers_manager import ProvidersManager
 
     try:

--- a/providers/yandex/tests/unit/yandex/utils/test_user_agent.py
+++ b/providers/yandex/tests/unit/yandex/utils/test_user_agent.py
@@ -41,7 +41,7 @@ def test_provider_user_agent():
     user_agent_provider = f"{provider_name}/{provider.version}"
     assert user_agent_provider in user_agent
 
-    from airflow.configuration import conf
+    from airflow.providers.common.compat.sdk import conf
 
     user_agent_prefix = conf.get("yandex", "sdk_user_agent_prefix", fallback="")
     assert user_agent_prefix in user_agent


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
This is PR migrates the yandex provider to use airflow.sdk.configuration.conf instead of airflow.configuration.conf. This change maintains backward compatibility through the common compat module.

related: [#60000](https://github.com/apache/airflow/issues/60000)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
