### PR TITLE
Source odbc provider to use airflow.sdk.configuration.conf

### DIFF
--- a/providers/odbc/docs/index.rst
+++ b/providers/odbc/docs/index.rst
@@ -97,14 +97,15 @@ Requirements
 
 The minimum Apache Airflow version supported by this provider distribution is ``2.11.0``.
 
-=======================================  =====================================
-PIP package                              Version required
-=======================================  =====================================
-``apache-airflow``                       ``>=2.11.0``
-``apache-airflow-providers-common-sql``  ``>=1.20.0``
-``pyodbc``                               ``>=5.0.0; python_version < "3.13"``
-``pyodbc``                               ``>=5.2.0; python_version >= "3.13"``
-=======================================  =====================================
+==========================================  =====================================
+PIP package                                 Version required
+==========================================  =====================================
+``apache-airflow``                          ``>=2.11.0``
+``apache-airflow-providers-common-compat``  ``>=1.10.1``
+``apache-airflow-providers-common-sql``     ``>=1.20.0``
+``pyodbc``                                  ``>=5.0.0; python_version < "3.13"``
+``pyodbc``                                  ``>=5.2.0; python_version >= "3.13"``
+==========================================  =====================================
 
 Cross provider package dependencies
 -----------------------------------

--- a/providers/odbc/docs/index.rst
+++ b/providers/odbc/docs/index.rst
@@ -116,14 +116,15 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-odbc[common.sql]
+    pip install apache-airflow-providers-odbc[common.compat]
 
 
-============================================================================================================  ==============
-Dependent package                                                                                             Extra
-============================================================================================================  ==============
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_  ``common.sql``
-============================================================================================================  ==============
+==================================================================================================================  =================
+Dependent package                                                                                                   Extra
+==================================================================================================================  =================
+`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
+`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
+==================================================================================================================  =================
 
 Downloading official packages
 -----------------------------

--- a/providers/odbc/pyproject.toml
+++ b/providers/odbc/pyproject.toml
@@ -64,11 +64,19 @@ dependencies = [
     "pyodbc>=5.2.0; python_version >= '3.13'",
 ]
 
+# The optional dependencies should be modified in place in the generated file
+# Any change in the dependencies is preserved when the file is regenerated
+[project.optional-dependencies]
+"common.compat" = [
+    "apache-airflow-providers-common-compat"
+]
+
 [dependency-groups]
 dev = [
     "apache-airflow",
     "apache-airflow-task-sdk",
     "apache-airflow-devel-common",
+    "apache-airflow-providers-common-compat",
     "apache-airflow-providers-common-sql",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
 ]

--- a/providers/odbc/pyproject.toml
+++ b/providers/odbc/pyproject.toml
@@ -59,16 +59,10 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.11.0",
+    "apache-airflow-providers-common-compat>=1.10.1", # use next version
     "apache-airflow-providers-common-sql>=1.20.0",
     "pyodbc>=5.0.0; python_version < '3.13'",
     "pyodbc>=5.2.0; python_version >= '3.13'",
-]
-
-# The optional dependencies should be modified in place in the generated file
-# Any change in the dependencies is preserved when the file is regenerated
-[project.optional-dependencies]
-"common.compat" = [
-    "apache-airflow-providers-common-compat"
 ]
 
 [dependency-groups]

--- a/providers/odbc/src/airflow/providers/odbc/hooks/odbc.py
+++ b/providers/odbc/src/airflow/providers/odbc/hooks/odbc.py
@@ -97,7 +97,7 @@ class OdbcHook(DbApiHook):
     def driver(self) -> str | None:
         """Driver from init param if given; else try to find one in connection extra."""
         extra_driver = self.connection_extra_lower.get("driver")
-        from airflow.configuration import conf
+        from airflow.providers.common.compat.sdk import conf
 
         if extra_driver and conf.getboolean("providers.odbc", "allow_driver_in_extra", fallback=False):
             self._driver = extra_driver


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
This is PR migrates the odbc provider to use airflow.sdk.configuration.conf instead of airflow.configuration.conf. This change maintains backward compatibility through the common compat module.

related: [#60000](https://github.com/apache/airflow/issues/60000)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
