### PR TITLE
fix(providers/winrm): Add missing hook class attributes

### DIFF
--- a/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/hooks/winrm.py
+++ b/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/hooks/winrm.py
@@ -72,6 +72,11 @@ class WinRMHook(BaseHook):
     :param send_cbt: Will send the channel bindings over a HTTPS channel (Default: True)
     """
 
+    conn_name_attr = "ssh_conn_id"
+    default_conn_name = "winrm_default"
+    conn_type = "winrm"
+    hook_name = "WinRM"
+
     def __init__(
         self,
         ssh_conn_id: str | None = None,


### PR DESCRIPTION
## Summary

Adds missing connection type attributes (`conn_type`, `conn_name_attr`, 
`default_conn_name`, `hook_name`) to `WinRMHook` to enable proper 
connection type registration in the Airflow UI.

## Related Issue

Fixes part of #28790

## Testing

- [x] Unit tests pass (7/7)
- [x] Verified attributes load correctly via Python import