### PR TITLE
Fix user creation in FAB fails when no role specified

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/views/user.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/views/user.py
@@ -26,6 +26,7 @@ from flask_appbuilder.security.views import (
     UserOAuthModelView,
     UserRemoteUserModelView,
 )
+from wtforms.validators import DataRequired
 
 from airflow.providers.fab.www.security import permissions
 
@@ -185,6 +186,8 @@ class CustomUserDBModelView(MultiResourceUserMixin, UserDBModelView):
         "password",
         "conf_password",
     ]
+
+    validators_columns = {"roles": [DataRequired()]}
 
     base_permissions = [
         permissions.ACTION_CAN_CREATE,


### PR DESCRIPTION
Fixes #59963

## Problem
When creating a user in FAB without selecting a role, the system was throwing HTTP 500 error due to `KeyError: 'groups'`.

## Solution
This fix adds `DataRequired` validator to the roles field in `CustomUserDBModelView` to show a proper validation error instead.

## Testing
- Added unit test `test_user_creation_without_role_shows_validation_error` to verify the fix

https://github.com/user-attachments/assets/e4d31f19-1baf-4346-921f-20c64001d1ff



## Changes
- `providers/fab/src/airflow/providers/fab/auth_manager/views/user.py`: Added `validators_columns` with `DataRequired` for roles field
- `providers/fab/tests/unit/fab/www/views/test_views_custom_user_views.py`: Added regression test

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
