### PR TITLE
Investigate disk space and layout of runner

### DIFF
--- a/scripts/ci/make_mnt_writeable.sh
+++ b/scripts/ci/make_mnt_writeable.sh
@@ -21,7 +21,10 @@ function make_mnt_writeable {
     lsblk
     sudo blkid
     echo "Check that we have expected /mnt to be a separate mount"
-    lsblk | grep -q /mnt
+    if ! lsblk | grep -q /mnt; then
+        echo "/mnt is missing as a separate mount, runner misconfigured!"
+        exit 42
+    fi
     echo "Checking free space!"
     df -H
     echo "Cleaning /mnt just in case it is not empty"

--- a/scripts/ci/make_mnt_writeable.sh
+++ b/scripts/ci/make_mnt_writeable.sh
@@ -17,6 +17,9 @@
 # under the License.
 function make_mnt_writeable {
     set -x
+    echo "Investigating node disks"
+    lsblk
+    blkid
     echo "Checking free space!"
     df -H
     echo "Cleaning /mnt just in case it is not empty"

--- a/scripts/ci/make_mnt_writeable.sh
+++ b/scripts/ci/make_mnt_writeable.sh
@@ -21,7 +21,7 @@ function make_mnt_writeable {
     lsblk
     sudo blkid
     echo "Check that we have expected /mnt to be a separate mount"
-    if ! lsblk | grep -q /NegativeTest; then
+    if ! lsblk | grep -q /mnt; then
         echo "/mnt is missing as a separate mount, runner misconfigured!"
         exit 42
     fi

--- a/scripts/ci/make_mnt_writeable.sh
+++ b/scripts/ci/make_mnt_writeable.sh
@@ -21,7 +21,7 @@ function make_mnt_writeable {
     lsblk
     sudo blkid
     echo "Check that we have expected /mnt to be a separate mount"
-    if ! lsblk | grep -q /mnt; then
+    if ! lsblk | grep -q /NegativeTest; then
         echo "/mnt is missing as a separate mount, runner misconfigured!"
         exit 42
     fi

--- a/scripts/ci/make_mnt_writeable.sh
+++ b/scripts/ci/make_mnt_writeable.sh
@@ -19,7 +19,9 @@ function make_mnt_writeable {
     set -x
     echo "Investigating node disks"
     lsblk
-    blkid
+    sudo blkid
+    echo "Check that we have expected /mnt to be a separate mount"
+    lsblk | grep -q /mnt
     echo "Checking free space!"
     df -H
     echo "Cleaning /mnt just in case it is not empty"


### PR DESCRIPTION
It seems some runners are lagging the /mnt (dev/sda1) mount which leads to follow-up problems in insufficient disk space.

Examples:
- https://github.com/apache/airflow/actions/runs/20636344059/job/59262494909

Add a validation to the entry of the CI building to fail fast with appropriate message.