### PR TITLE
Fix asset scheduling for stale DAGs (#59337)

### DIFF
--- a/airflow-core/src/airflow/assets/manager.py
+++ b/airflow-core/src/airflow/assets/manager.py
@@ -230,9 +230,7 @@ class AssetManager(LoggingMixin):
         session.add(asset_event)
         session.flush()  # Ensure the event is written earlier than ADRQ entries below.
 
-        dags_to_queue_from_asset = {
-            ref.dag for ref in asset_model.scheduled_dags if not ref.dag.is_stale and not ref.dag.is_paused
-        }
+        dags_to_queue_from_asset = {ref.dag for ref in asset_model.scheduled_dags if not ref.dag.is_paused}
 
         dags_to_queue_from_asset_alias = set()
         if source_alias_names:
@@ -251,7 +249,7 @@ class AssetManager(LoggingMixin):
                 dags_to_queue_from_asset_alias |= {
                     alias_ref.dag
                     for alias_ref in asset_alias_model.scheduled_dags
-                    if not alias_ref.dag.is_stale and not alias_ref.dag.is_paused
+                    if not alias_ref.dag.is_paused
                 }
 
         dags_to_queue_from_asset_ref = set(
@@ -263,7 +261,8 @@ class AssetManager(LoggingMixin):
                     or_(
                         DagScheduleAssetNameReference.name == asset.name,
                         DagScheduleAssetUriReference.uri == asset.uri,
-                    )
+                    ),
+                    DagModel.is_paused.is_(False),
                 )
             )
         )

--- a/airflow-core/tests/unit/assets/test_manager.py
+++ b/airflow-core/tests/unit/assets/test_manager.py
@@ -260,7 +260,7 @@ class TestAssetManager:
         assert len(set(ids)) == 1
         assert session.scalar(select(func.count()).select_from(AssetPartitionDagRun)) == 1
 
-    @pytest.mark.usefixtures("dag_maker", "testing_dag_bundle")
+    @pytest.mark.usefixtures("testing_dag_bundle")
     def test_register_asset_change_queues_stale_dag(self, session, mock_task_instance):
         asset_manager = AssetManager()
         bundle_name = "testing"
@@ -273,12 +273,12 @@ class TestAssetManager:
         asm = AssetModel(uri=asset_uri, name=asset_name, group="asset")
         session.add(asm)
 
-        # Setup a DAG that is STALE but NOT PAUSED
-        # We want stale DAGs to still receive asset updates
+        # Setup a Dag that is STALE but NOT PAUSED
+        # We want stale Dags to still receive asset updates
         stale_dag = DagModel(dag_id="stale_dag", is_stale=True, is_paused=False, bundle_name=bundle_name)
         session.add(stale_dag)
 
-        # Link the Stale DAG to the Asset
+        # Link the Stale Dag to the Asset
         asm.scheduled_dags = [DagScheduleAssetReference(dag_id=stale_dag.dag_id)]
 
         session.execute(delete(AssetDagRunQueue))
@@ -290,7 +290,7 @@ class TestAssetManager:
         )
         session.flush()
 
-        # Verify the stale DAG was NOT ignored
+        # Verify the stale Dag was NOT ignored
         assert session.scalar(select(func.count()).select_from(AssetDagRunQueue)) == 1
 
         queued_id = session.scalar(select(AssetDagRunQueue.target_dag_id))

--- a/airflow-core/tests/unit/assets/test_manager.py
+++ b/airflow-core/tests/unit/assets/test_manager.py
@@ -259,3 +259,39 @@ class TestAssetManager:
 
         assert len(set(ids)) == 1
         assert session.scalar(select(func.count()).select_from(AssetPartitionDagRun)) == 1
+
+    @pytest.mark.usefixtures("dag_maker", "testing_dag_bundle")
+    def test_register_asset_change_queues_stale_dag(self, session, mock_task_instance):
+        asset_manager = AssetManager()
+        bundle_name = "testing"
+
+        # Setup an Asset
+        asset_uri = "test://stale_asset/"
+        asset_name = "test_stale_asset"
+        asset_definition = Asset(uri=asset_uri, name=asset_name)
+
+        asm = AssetModel(uri=asset_uri, name=asset_name, group="asset")
+        session.add(asm)
+
+        # Setup a DAG that is STALE but NOT PAUSED
+        # We want stale DAGs to still receive asset updates
+        stale_dag = DagModel(dag_id="stale_dag", is_stale=True, is_paused=False, bundle_name=bundle_name)
+        session.add(stale_dag)
+
+        # Link the Stale DAG to the Asset
+        asm.scheduled_dags = [DagScheduleAssetReference(dag_id=stale_dag.dag_id)]
+
+        session.execute(delete(AssetDagRunQueue))
+        session.flush()
+
+        # Register the asset change
+        asset_manager.register_asset_change(
+            task_instance=mock_task_instance, asset=asset_definition, session=session
+        )
+        session.flush()
+
+        # Verify the stale DAG was NOT ignored
+        assert session.scalar(select(func.count()).select_from(AssetDagRunQueue)) == 1
+
+        queued_id = session.scalar(select(AssetDagRunQueue.target_dag_id))
+        assert queued_id == "stale_dag"

--- a/airflow-core/tests/unit/listeners/test_asset_listener.py
+++ b/airflow-core/tests/unit/listeners/test_asset_listener.py
@@ -57,7 +57,7 @@ def test_asset_listener_on_asset_changed_gets_calls(
     )
     ti.run()
 
-    assert len(asset_listener.changed) == 1
-    assert asset_listener.changed[0].uri == asset_uri
-    assert asset_listener.changed[0].name == asset_name
-    assert asset_listener.changed[0].group == asset_group
+    assert len(asset_listener.changed) == 2
+    assert asset_listener.changed[-1].uri == asset_uri
+    assert asset_listener.changed[-1].name == asset_name
+    assert asset_listener.changed[-1].group == asset_group

--- a/airflow-core/tests/unit/listeners/test_asset_listener.py
+++ b/airflow-core/tests/unit/listeners/test_asset_listener.py
@@ -57,7 +57,7 @@ def test_asset_listener_on_asset_changed_gets_calls(
     )
     ti.run()
 
-    assert len(asset_listener.changed) == 2
-    assert asset_listener.changed[-1].uri == asset_uri
-    assert asset_listener.changed[-1].name == asset_name
-    assert asset_listener.changed[-1].group == asset_group
+    assert len(asset_listener.changed) == 1
+    assert asset_listener.changed[0].uri == asset_uri
+    assert asset_listener.changed[0].name == asset_name
+    assert asset_listener.changed[0].group == asset_group


### PR DESCRIPTION
### **fix(assets): queue asset updates for stale DAGs**

**closes:** #59337

#### **Summary**
This PR ensures that asset updates are recorded in the `AssetDagRunQueue` even if a DAG is currently in a "stale" state. By allowing these updates to be queued, DAGs will automatically trigger their missed runs once they are successfully parsed and become healthy again, rather than remaining idle.

#### **Changes**
* **Backend:** Modified `AssetManager.register_asset_change` in `manager.py` to remove `is_stale` filtering while maintaining `is_paused` checks across direct, alias, and name/URI asset references.
* **Database:** Refined the SQLAlchemy query for asset name/URI references to explicitly exclude paused DAGs for logic consistency.
* **Tests:** Added a regression test in `test_manager.py` that mocks a stale DAG state and verifies it is correctly added to the `AssetDagRunQueue` upon an asset event.