### PR TITLE
fix(providers/winrm): Add connection-types to provider configuration

### DIFF
--- a/providers/microsoft/winrm/provider.yaml
+++ b/providers/microsoft/winrm/provider.yaml
@@ -81,3 +81,7 @@ hooks:
   - integration-name: Windows Remote Management (WinRM)
     python-modules:
       - airflow.providers.microsoft.winrm.hooks.winrm
+
+connection-types:
+  - hook-class-name: airflow.providers.microsoft.winrm.hooks.winrm.WinRMHook
+    connection-type: winrm

--- a/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/get_provider_info.py
+++ b/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/get_provider_info.py
@@ -47,4 +47,10 @@ def get_provider_info():
                 "python-modules": ["airflow.providers.microsoft.winrm.hooks.winrm"],
             }
         ],
+        "connection-types": [
+            {
+                "hook-class-name": "airflow.providers.microsoft.winrm.hooks.winrm.WinRMHook",
+                "connection-type": "winrm",
+            }
+        ],
     }


### PR DESCRIPTION
Adds `connection-types` section to WinRM provider configuration to enable 
WinRM connection type visibility in the Airflow UI connection dropdown.


This is a follow-up to PR #60009 which added `conn_type` class attributes to [WinRMHook](cci:2://file:///Users/ftakelait/Documents/open-source-contribution-airflow/airflow/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/hooks/winrm.py:33:0-302:32).

## Changes

- Added `connection-types` to [provider.yaml](https://github.com/apache/airflow/blob/84110f44b73ac9ee8383d9066001e0ee17c9b5e8/providers/microsoft/winrm/provider.yaml)
- Updated [get_provider_info.py](https://github.com/apache/airflow/blob/84110f44b73ac9ee8383d9066001e0ee17c9b5e8/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/get_provider_info.py) (auto-generated file)

## Related Issue

Fixes part of #28790

## Testing

- [x] Pre-commit checks pass
- [x] Unit tests pass (7/7)
- [x] Verified `connection-types` returned by [get_provider_info()](https://github.com/apache/airflow/blob/84110f44b73ac9ee8383d9066001e0ee17c9b5e8/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/get_provider_info.py#L24) 
`connection-types: [{'hook-class-name': 'airflow.providers.microsoft.winrm.hooks.winrm.WinRMHook', 'connection-type': 'winrm'}]`
- [x] Verified WinRM appears in UI connection type dropdown