### PR TITLE
[breaking] Make pyspark-client as default and  pyspark package optional

### DIFF
--- a/providers/apache/spark/README.rst
+++ b/providers/apache/spark/README.rst
@@ -55,7 +55,7 @@ PIP package                                 Version required
 ==========================================  ==================
 ``apache-airflow``                          ``>=2.11.0``
 ``apache-airflow-providers-common-compat``  ``>=1.12.0``
-``pyspark``                                 ``>=3.5.2``
+``pyspark-client``                          ``>=4.0.0``
 ``grpcio-status``                           ``>=1.59.0``
 ==========================================  ==================
 
@@ -87,6 +87,7 @@ Extra                Dependencies
 ===================  ===================================================
 ``cncf.kubernetes``  ``apache-airflow-providers-cncf-kubernetes>=7.4.0``
 ``openlineage``      ``apache-airflow-providers-openlineage``
+``pyspark``          ``pyspark>=4.0.0``
 ===================  ===================================================
 
 The changelog for the provider package can be found in the

--- a/providers/apache/spark/docs/changelog.rst
+++ b/providers/apache/spark/docs/changelog.rst
@@ -38,6 +38,8 @@ Breaking changes
 
     example: ``apache-airflow-providers-apache-spark[pyspark]==X.Y.Z``
 
+    Because the package ``pyspark`` is more than 400mb and is not necessary if only using spark-connect to trigger a job
+
   - The minimum pyspark and spark-connect version is now 4.0.0
 
 5.6.0

--- a/providers/apache/spark/docs/changelog.rst
+++ b/providers/apache/spark/docs/changelog.rst
@@ -28,6 +28,17 @@
 
 Changelog
 ---------
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+.. warning::
+  - The ``pyspark`` package is no longer included by default, so only the spark-connect connection will works by default.
+    If you want to keep using other spark connection types you must install the airflow spark provider
+    with the  ``pyspark`` extra
+
+    example: ``apache-airflow-providers-apache-spark[pyspark]==X.Y.Z``
+
+  - The minimum pyspark and spark-connect version is now 4.0.0
 
 5.6.0
 .....

--- a/providers/apache/spark/docs/index.rst
+++ b/providers/apache/spark/docs/index.rst
@@ -102,8 +102,8 @@ PIP package                                 Version required
 ==========================================  ==================
 ``apache-airflow``                          ``>=2.11.0``
 ``apache-airflow-providers-common-compat``  ``>=1.12.0``
-``pyspark``                                 ``>=3.5.2``
-``grpcio-status``                           ``>=1.59.0``
+``pyspark-client``                          ``>=4.0.0``
+``grpcio-status``                           ``>=1.67.0``
 ==========================================  ==================
 
 Cross provider package dependencies

--- a/providers/apache/spark/pyproject.toml
+++ b/providers/apache/spark/pyproject.toml
@@ -60,8 +60,8 @@ requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.12.0",
-    "pyspark>=3.5.2",
-    "grpcio-status>=1.59.0",
+    "pyspark-client>=4.0.0",
+    "grpcio-status>=1.67.0",
 ]
 
 # The optional dependencies should be modified in place in the generated file
@@ -73,6 +73,9 @@ dependencies = [
 "openlineage" = [
     "apache-airflow-providers-openlineage"
 ]
+"pyspark" = [
+    "pyspark>=4.0.0",
+]
 
 [dependency-groups]
 dev = [
@@ -83,6 +86,7 @@ dev = [
     "apache-airflow-providers-common-compat",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
     "apache-airflow-providers-openlineage",
+    "pyspark"
 ]
 
 # To build docs:

--- a/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_jdbc_script.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_jdbc_script.py
@@ -18,9 +18,15 @@
 from __future__ import annotations
 
 import argparse
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from pyspark.sql import SparkSession
+if TYPE_CHECKING:
+    from pyspark.sql import SparkSession
+
+try:
+    from pyspark.sql import SparkSession
+except ImportError:
+    pass
 
 SPARK_WRITE_TO_JDBC: str = "spark_to_jdbc"
 SPARK_READ_FROM_JDBC: str = "jdbc_to_spark"


### PR DESCRIPTION
current `apache.spark` provider need the package pyspark ( more than 400mb ) 

where I would like to only use the spark-client ( spark-connect ) to trigger a spark job ( that is 1.5mb )

```python
    @task.pyspark(conn_id="spark_connect")
    def my_job(spark,sc):
        df = spark.range(100).filter("id % 2 = 0")
        print(df.count())

# or 

    def my_pyspark_job(spark):
        df = spark.range(100).filter("id % 2 = 0")
        print(df.count())

    PySparkOperator(
        python_callable=my_pyspark_job, conn_id="spark_connect", task_id="spark_pyspark_job"
    )
        

```

this is a breaking change but it will make things lighter by default , wdyt ? thanks

( btw spark-client is only available since spark 4.0 and need  "grpcio >= 1.67.0" ( that conflict with apache-beam )  )