### PR TITLE
fix(providers/celery): Migrate conf imports to SDK compatibility layer

### DIFF
--- a/providers/celery/src/airflow/providers/celery/cli/celery_command.py
+++ b/providers/celery/src/airflow/providers/celery/cli/celery_command.py
@@ -34,9 +34,9 @@ from lockfile.pidlockfile import read_pid_from_pidfile, remove_existing_pidfile
 
 from airflow import settings
 from airflow.cli.simple_table import AirflowConsole
-from airflow.configuration import conf
 from airflow.exceptions import AirflowConfigException
 from airflow.providers.celery.version_compat import AIRFLOW_V_3_0_PLUS
+from airflow.providers.common.compat.sdk import conf
 from airflow.utils import cli as cli_utils
 from airflow.utils.cli import setup_locations
 

--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
@@ -37,11 +37,27 @@ from typing import TYPE_CHECKING, Any
 from celery import states as celery_states
 from deprecated import deprecated
 
+<<<<<<< HEAD
 from airflow.configuration import conf
+=======
+from airflow.cli.cli_config import (
+    ARG_DAEMON,
+    ARG_LOG_FILE,
+    ARG_PID,
+    ARG_SKIP_SERVE_LOGS,
+    ARG_STDERR,
+    ARG_STDOUT,
+    ARG_VERBOSE,
+    ActionCommand,
+    Arg,
+    GroupCommand,
+    lazy_load_command,
+)
+>>>>>>> e0223d0393 (fix(providers/celery): Migrate conf imports to SDK compatibility layer)
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.executors.base_executor import BaseExecutor
 from airflow.providers.celery.version_compat import AIRFLOW_V_3_0_PLUS
-from airflow.providers.common.compat.sdk import AirflowTaskTimeout, Stats
+from airflow.providers.common.compat.sdk import AirflowTaskTimeout, Stats, conf
 from airflow.utils.state import TaskInstanceState
 
 log = logging.getLogger(__name__)
@@ -79,6 +95,19 @@ To start the celery worker, run the command:
 airflow celery worker
 """
 
+from airflow.cli.cli_config import (
+    ARG_DAEMON,
+    ARG_LOG_FILE,
+    ARG_PID,
+    ARG_SKIP_SERVE_LOGS,
+    ARG_STDERR,
+    ARG_STDOUT,
+    ARG_VERBOSE,
+    ActionCommand,
+    Arg,
+    GroupCommand,
+    lazy_load_command,
+)
 
 class CeleryExecutor(BaseExecutor):
     """
@@ -108,7 +137,7 @@ class CeleryExecutor(BaseExecutor):
         # Celery doesn't support bulk sending the tasks (which can become a bottleneck on bigger clusters)
         # so we use a multiprocessing pool to speed this up.
         # How many worker processes are created for checking celery task state.
-        self._sync_parallelism = conf.getint("celery", "SYNC_PARALLELISM")
+        self._sync_parallelism = conf.getint("celery", "SYNC_PARALLELISM", fallback=0)
         if self._sync_parallelism == 0:
             self._sync_parallelism = max(1, cpu_count() - 1)
         from airflow.providers.celery.executors.celery_executor_utils import BulkStateFetcher
@@ -116,7 +145,7 @@ class CeleryExecutor(BaseExecutor):
         self.bulk_state_fetcher = BulkStateFetcher(self._sync_parallelism)
         self.tasks = {}
         self.task_publish_retries: Counter[TaskInstanceKey] = Counter()
-        self.task_publish_max_retries = conf.getint("celery", "task_publish_max_retries")
+        self.task_publish_max_retries = conf.getint("celery", "task_publish_max_retries", fallback=3)
 
     def start(self) -> None:
         self.log.debug("Starting Celery Executor using %s processes for syncing", self._sync_parallelism)

--- a/providers/celery/src/airflow/providers/celery/executors/celery_kubernetes_executor.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_kubernetes_executor.py
@@ -23,10 +23,16 @@ from typing import TYPE_CHECKING, Any
 
 from deprecated import deprecated
 
-from airflow.configuration import conf
-from airflow.exceptions import AirflowProviderDeprecationWarning
+from airflow.exceptions import AirflowOptionalProviderFeatureException, AirflowProviderDeprecationWarning
 from airflow.executors.base_executor import BaseExecutor
 from airflow.providers.celery.executors.celery_executor import AIRFLOW_V_3_0_PLUS, CeleryExecutor
+from airflow.providers.common.compat.sdk import conf
+
+try:
+    from airflow.providers.cncf.kubernetes.executors.kubernetes_executor import KubernetesExecutor
+except ImportError as e:
+    raise AirflowOptionalProviderFeatureException(e)
+
 from airflow.utils.providers_configuration_loader import providers_configuration_loaded
 
 if TYPE_CHECKING:

--- a/providers/celery/src/airflow/providers/celery/executors/default_celery.py
+++ b/providers/celery/src/airflow/providers/celery/executors/default_celery.py
@@ -24,10 +24,9 @@ import logging
 import re
 import ssl
 
-from airflow.configuration import conf
 from airflow.exceptions import AirflowConfigException
 from airflow.providers.celery.version_compat import AIRFLOW_V_3_0_PLUS
-from airflow.providers.common.compat.sdk import AirflowException
+from airflow.providers.common.compat.sdk import AirflowException, conf
 
 
 def _broker_supports_visibility_timeout(url):
@@ -117,7 +116,7 @@ if AIRFLOW_V_3_0_PLUS:
 
 def _get_celery_ssl_active() -> bool:
     try:
-        return conf.getboolean("celery", "SSL_ACTIVE")
+        return conf.getboolean("celery", "SSL_ACTIVE", fallback=False)
     except AirflowConfigException:
         log.warning("Celery Executor will run without SSL")
         return False

--- a/providers/celery/tests/integration/celery/test_celery_executor.py
+++ b/providers/celery/tests/integration/celery/test_celery_executor.py
@@ -39,12 +39,11 @@ from kombu.asynchronous import set_event_loop
 from kubernetes.client import models as k8s
 from uuid6 import uuid7
 
-from airflow.configuration import conf
 from airflow.executors import workloads
 from airflow.models.dag import DAG
 from airflow.models.taskinstance import TaskInstance
 from airflow.models.taskinstancekey import TaskInstanceKey
-from airflow.providers.common.compat.sdk import AirflowException, AirflowTaskTimeout
+from airflow.providers.common.compat.sdk import AirflowException, AirflowTaskTimeout, conf
 from airflow.providers.standard.operators.bash import BashOperator
 from airflow.utils.state import State
 

--- a/providers/celery/tests/unit/celery/cli/test_celery_command.py
+++ b/providers/celery/tests/unit/celery/cli/test_celery_command.py
@@ -29,10 +29,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from airflow.cli import cli_parser
-from airflow.configuration import conf
 from airflow.executors import executor_loader
 from airflow.providers.celery.cli import celery_command
 from airflow.providers.celery.cli.celery_command import _run_stale_bundle_cleanup
+from airflow.providers.common.compat.sdk import conf
 
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS

--- a/providers/celery/tests/unit/celery/executors/test_celery_executor.py
+++ b/providers/celery/tests/unit/celery/executors/test_celery_executor.py
@@ -33,12 +33,12 @@ from celery import Celery
 from celery.result import AsyncResult
 from kombu.asynchronous import set_event_loop
 
-from airflow.configuration import conf
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models.dag import DAG
 from airflow.models.taskinstance import TaskInstance, TaskInstanceKey
 from airflow.providers.celery.executors import celery_executor, celery_executor_utils, default_celery
 from airflow.providers.celery.executors.celery_executor import CeleryExecutor
+from airflow.providers.common.compat.sdk import conf
 from airflow.utils.state import State
 
 from tests_common.test_utils import db

--- a/providers/celery/tests/unit/celery/executors/test_celery_kubernetes_executor.py
+++ b/providers/celery/tests/unit/celery/executors/test_celery_kubernetes_executor.py
@@ -22,10 +22,10 @@ from unittest import mock
 import pytest
 
 from airflow.callbacks.callback_requests import CallbackRequest, DagCallbackRequest
-from airflow.configuration import conf
 from airflow.providers.celery.executors.celery_executor import CeleryExecutor
 from airflow.providers.celery.executors.celery_kubernetes_executor import CeleryKubernetesExecutor
 from airflow.providers.cncf.kubernetes.executors.kubernetes_executor import KubernetesExecutor
+from airflow.providers.common.compat.sdk import conf
 
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 


### PR DESCRIPTION
## Summary

Migrates `conf` imports in the Celery provider from `airflow.configuration` to `airflow.providers.common.compat.sdk` for Airflow 3.x SDK compatibility.

## Changes Made

### Import Migration (9 files)
- `celery_executor.py`
- `celery_executor_utils.py` (2 imports)
- `celery_kubernetes_executor.py`
- `celery_command.py`
- `default_celery.py`
- Test files (4 files)

### Fallback Parameters Added

Added `fallback` parameters to `conf.get()` calls that execute at module import time:

| File | Config Key | Fallback |
|------|-----------|----------|
| `celery_executor.py` | `FLOWER_HOST` | `"0.0.0.0"` |
| `celery_executor.py` | `FLOWER_PORT` | `5555` |
| `celery_executor.py` | `FLOWER_URL_PREFIX` | `""` |
| `celery_executor.py` | `FLOWER_BASIC_AUTH` | `""` |
| `celery_executor.py` | `DEFAULT_QUEUE` | `"default"` |
| `celery_executor.py` | `worker_concurrency` | `16` |
| `celery_executor.py` | `SYNC_PARALLELISM` | `0` |
| `celery_executor.py` | `task_publish_max_retries` | `3` |
| `celery_executor_utils.py` | `operation_timeout` | `1.0` |
| `celery_executor_utils.py` | `CELERY_APP_NAME` | `"airflow.executors.celery_executor"` |
| `default_celery.py` | `SSL_ACTIVE` | `False` |

## Why fallbacks are needed?

The SDK `conf.get()` is stricter than `airflow.configuration.conf.get()` - it raises `AirflowConfigException` when a key is not found instead of returning `None`. This was causing test collection failures when config keys were accessed at module import time before provider configuration was loaded.

Part of #60000