### PR TITLE
Strip off shared secrets masker's dependency from conf

### DIFF
--- a/airflow-core/src/airflow/settings.py
+++ b/airflow-core/src/airflow/settings.py
@@ -612,10 +612,13 @@ def _configure_secrets_masker():
     if sensitive_variable_fields:
         sensitive_fields |= frozenset({field.strip() for field in sensitive_variable_fields.split(",")})
 
+    hide_sensitive_var_conn_fields = conf.getboolean("core", "hide_sensitive_var_conn_fields")
+
     core_masker = secrets_masker_core()
     core_masker.min_length_to_mask = min_length_to_mask
     core_masker.sensitive_variables_fields = list(sensitive_fields)
     core_masker.secret_mask_adapter = secret_mask_adapter
+    core_masker.hide_sensitive_var_conn_fields = hide_sensitive_var_conn_fields
 
     from airflow.sdk._shared.secrets_masker import _secrets_masker as sdk_secrets_masker
 
@@ -623,6 +626,7 @@ def _configure_secrets_masker():
     sdk_masker.min_length_to_mask = min_length_to_mask
     sdk_masker.sensitive_variables_fields = list(sensitive_fields)
     sdk_masker.secret_mask_adapter = secret_mask_adapter
+    sdk_masker.hide_sensitive_var_conn_fields = hide_sensitive_var_conn_fields
 
 
 def configure_action_logging() -> None:

--- a/shared/secrets_masker/src/airflow_shared/secrets_masker/secrets_masker.py
+++ b/shared/secrets_masker/src/airflow_shared/secrets_masker/secrets_masker.py
@@ -196,6 +196,7 @@ class SecretsMasker(logging.Filter):
         super().__init__()
         self.patterns = set()
         self.sensitive_variables_fields = []
+        self.hide_sensitive_var_conn_fields = True
 
     @classmethod
     def __init_subclass__(cls, **kwargs):
@@ -527,9 +528,7 @@ class SecretsMasker(logging.Filter):
 
         Name might be a Variable name, or key in conn.extra_dejson, for example.
         """
-        from airflow.configuration import conf
-
-        if isinstance(name, str) and conf.getboolean("core", "hide_sensitive_var_conn_fields"):
+        if isinstance(name, str) and self.hide_sensitive_var_conn_fields:
             name = name.strip().lower()
             return any(s in name for s in self.sensitive_variables_fields)
         return False

--- a/shared/secrets_masker/tests/secrets_masker/test_secrets_masker.py
+++ b/shared/secrets_masker/tests/secrets_masker/test_secrets_masker.py
@@ -474,6 +474,16 @@ class TestShouldHideValueForKey:
             configure_secrets_masker_for_test(masker, sensitive_fields=sensitive_fields)
             assert expected_result == masker.should_hide_value_for_key(key)
 
+    @pytest.mark.parametrize("hide_sensitive_var_conn_fields", [True, False])
+    def test_hiding_disabled(self, hide_sensitive_var_conn_fields):
+        """Test that hiding can be disabled via hide_sensitive_var_conn_fields."""
+        masker = SecretsMasker()
+        configure_secrets_masker_for_test(masker)
+
+        masker.hide_sensitive_var_conn_fields = hide_sensitive_var_conn_fields
+        assert masker.should_hide_value_for_key("password") is hide_sensitive_var_conn_fields
+        assert masker.should_hide_value_for_key("GOOGLE_API_KEY") is hide_sensitive_var_conn_fields
+
 
 class ShortExcFormatter(logging.Formatter):
     """Don't include full path in exc_info messages"""


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Realised in this run: https://github.com/apache/airflow/actions/runs/20651537490/job/59297235389?pr=59971 that the secrets masker uses `airflow.configuration` which was done as part of an effort to remove globals: #59875

I am following same pattern as #55259 and achieving this through an injection / initialisation pattern.

Also realised that this functionality didn't have a test case, so added that as well.

I will be pushing a follow up to have some checks in prek hook to ensure no such imports slip in.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
