### PR TITLE
Allow providers to consume AirflowConfigException from compat sdk

### DIFF
--- a/providers/common/compat/src/airflow/providers/common/compat/sdk.py
+++ b/providers/common/compat/src/airflow/providers/common/compat/sdk.py
@@ -81,6 +81,7 @@ if TYPE_CHECKING:
     from airflow.sdk.definitions.mappedoperator import MappedOperator as MappedOperator
     from airflow.sdk.definitions.template import literal as literal
     from airflow.sdk.exceptions import (
+        AirflowConfigException as AirflowConfigException,
         AirflowException as AirflowException,
         AirflowFailException as AirflowFailException,
         AirflowNotFoundException as AirflowNotFoundException,
@@ -254,6 +255,7 @@ _IMPORT_MAP: dict[str, str | tuple[str, ...]] = {
     # Configuration
     # ============================================================================
     "conf": ("airflow.sdk.configuration", "airflow.configuration"),
+    "AirflowConfigException": ("airflow.sdk.exceptions", "airflow.exceptions"),
 }
 
 # Airflow 3-only exceptions (not available in Airflow 2)

--- a/providers/openlineage/pyproject.toml
+++ b/providers/openlineage/pyproject.toml
@@ -60,7 +60,7 @@ requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-sql>=1.20.0",
-    "apache-airflow-providers-common-compat>=1.11.0",
+    "apache-airflow-providers-common-compat>=1.11.0",  # use next version
     "attrs>=22.2",
     "openlineage-integration-common>=1.41.0",
     "openlineage-python>=1.41.0",

--- a/providers/openlineage/tests/unit/openlineage/test_conf.py
+++ b/providers/openlineage/tests/unit/openlineage/test_conf.py
@@ -21,7 +21,7 @@ from unittest import mock
 
 import pytest
 
-from airflow.exceptions import AirflowConfigException
+from airflow.providers.common.compat.sdk import AirflowConfigException
 from airflow.providers.openlineage.conf import (
     _is_true,
     config_path,

--- a/task-sdk/src/airflow/sdk/exceptions.py
+++ b/task-sdk/src/airflow/sdk/exceptions.py
@@ -23,6 +23,9 @@ from typing import TYPE_CHECKING, Any
 
 from airflow.sdk import TriggerRule
 
+# Re exporting AirflowConfigException from shared configuration
+from airflow.sdk._shared.configuration.exceptions import AirflowConfigException as AirflowConfigException
+
 if TYPE_CHECKING:
     from collections.abc import Collection
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Tests on main are broken similar to: 
```python
________________________________________________________________ test_dag_state_change_process_pool_size_invalid_value_raise_error[false] ________________________________________________________________
task-sdk/src/airflow/sdk/_shared/configuration/parser.py:1050: in getint
    return int(val)
E   ValueError: invalid literal for int() with base 10: 'false'

During handling of the above exception, another exception occurred:
providers/openlineage/tests/unit/openlineage/test_conf.py:554: in test_dag_state_change_process_pool_size_invalid_value_raise_error
    dag_state_change_process_pool_size()
providers/openlineage/src/airflow/providers/openlineage/conf.py:155: in dag_state_change_process_pool_size
    return conf.getint(_CONFIG_SECTION, "dag_state_change_process_pool_size", fallback="1")
task-sdk/src/airflow/sdk/_shared/configuration/parser.py:1052: in getint
    raise AirflowConfigException(
E   airflow.sdk._shared.configuration.exceptions.AirflowConfigException: Failed to convert value to int. Please check "dag_state_change_process_pool_size" key in "openlineage" section. Current value: "false".
```

This is because of https://github.com/apache/airflow/pull/60026. This PR moved `conf` to compat sdk but not `AirflowConfigException`, so there was a mismatch in the exception raised and captured. Expected: `airflow.exceptions.AirflowConfigException`, caught: `airflow.sdk._shared.configuration.exceptions.AirflowConfigException`.

Hence, moving this exception into compat sdk as well. It would be beneficial in long run to do this.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
