### PR TITLE
Guide users away from deprecated datetime macros

### DIFF
--- a/airflow-core/docs/templates-ref.rst
+++ b/airflow-core/docs/templates-ref.rst
@@ -175,16 +175,17 @@ Macros are a way to expose objects to your templates and live under the
 
 A few commonly used libraries and methods are made available.
 
-=================================   ==============================================
+=================================   ========================================================================================================================================================================
 Variable                            Description
-=================================   ==============================================
-``macros.datetime``                 The standard lib's :class:`datetime.datetime`
+=================================   ========================================================================================================================================================================
+``macros.datetime``                 The standard lib's :class:`datetime.datetime`.
+                                    Note: ``utcnow()`` is deprecated in Python 3.12+; use ``now(macros.dateutil.tz.UTC)`` instead.
 ``macros.timedelta``                The standard lib's :class:`datetime.timedelta`
 ``macros.dateutil``                 A reference to the ``dateutil`` package
 ``macros.time``                     The standard lib's :mod:`time`
 ``macros.uuid``                     The standard lib's :mod:`uuid`
 ``macros.random``                   The standard lib's :class:`random.random`
-=================================   ==============================================
+=================================   ========================================================================================================================================================================
 
 Some Airflow specific macros are also defined:
 


### PR DESCRIPTION

### Related Issues
Closes: #41772

### Description
This PR updates the documentation for Airflow macros to guide users away from the deprecated `datetime.utcnow()` and `datetime.utcfromtimestamp()` methods, as per Issue #41772. 

It recommends using `macros.datetime.now(macros.dateutil.tz.UTC)` which is the modern non-deprecated way to handle UTC in Python 3.12+.
