### PR TITLE
Add testing details in db migration contrib docs

### DIFF
--- a/contributing-docs/14_metadata_database_updates.rst
+++ b/contributing-docs/14_metadata_database_updates.rst
@@ -49,6 +49,13 @@ After your new migration file is run through prek hook it will look like this:
 
 This represents that your migration is the 1234th migration and expected for release in Airflow version A.B.C.
 
+.. warning::
+
+   In rare cases, you may need to manually modify the migration logic of your auto-generated migration script.
+   If you must make manual changes to your migration script, **you must ensure you're not referencing any ORM classes
+   within your migration script**. Directly referring to an ORM class definition within a migration script can lead to
+   unexpected and / or broken downgrade pathways in the future, `as described here <https://github.com/apache/airflow/issues/59871>`_.
+
 How to Resolve Conflicts When Rebasing
 --------------------------------------
 
@@ -75,6 +82,16 @@ To resolve these conflicts:
 
 3. Add the updated files to the staging area and continue with the rebase.
 
+Running migration CI tests locally
+----------------------------------
+
+The various CI migration tests are defined in ``.github/actions/migration_tests/action.yml``. These tests ensure the
+database upgrades and downgrades are still functional from the lowest supported source migration version, to the latest version,
+and back down to the former. To run any of those CI tests on your machine, you can:
+
+1. Copy the relevant command (specified by the ``run`` key for the relevant CI job), and replace the environment variable references with their literal values defined in the sibling ``env`` section.
+2. Run the command you created from step 1, troubleshooting errors as needed.
+
 How to hook your application into Airflow's migration process
 -------------------------------------------------------------
 
@@ -83,12 +100,12 @@ This feature is useful if you have a custom database schema that you want to mig
 This guide will show you how to hook your application into Airflow's migration process.
 
 Subclass the BaseDBManager
-==========================
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 To hook your application into Airflow's migration process, you need to subclass the ``BaseDBManager`` class from the
 ``airflow.utils.db_manager`` module. This class provides methods for running Alembic migrations.
 
-Create Alembic migration scripts
-================================
+Create Alembic migration scripts for your application
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 At the root of your application, run "alembic init migrations" to create a new migrations directory. Set the
 ``version_table`` variable in the ``env.py`` file to the name of the table that stores the migration history. Specify this
 version_table in the ``version_table`` argument of the alembic's ``context.configure`` method of the ``run_migration_online``


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
Related to: https://github.com/apache/airflow/issues/59871

## What?
* Adds section on reproducing CI migration tests in a development environment.
* Adds a warning about ORM references in migration scripts.
* Cleans up section / sub-section formatting for clearer topic segmentation.

## Why?
* There are a number of recent threads in the Airflow Slack (including several I started) with questions on reproducing migration test failures in CI.
* As detailed more thoroughly in the related issue (linked above) ORM references in alembic migration scripts can cause problems for future migrations and downgrade-ability. Even after we have a pre-commit check to prevent this, we should still explain why that practice is discouraged.