### PR TITLE
Create /mnt/ folder in case it is missing in CI runners

### DIFF
--- a/scripts/ci/make_mnt_writeable.sh
+++ b/scripts/ci/make_mnt_writeable.sh
@@ -22,8 +22,9 @@ function make_mnt_writeable {
     sudo blkid
     echo "Check that we have expected /mnt to be a separate mount"
     if ! lsblk | grep -q /mnt; then
-        echo "/mnt is missing as a separate mount, runner misconfigured!"
-        exit 42
+        echo "!!!! /mnt is missing as a separate mount, runner misconfigured!"
+        echo "Creating /mnt drive hoping that it will be enough space to use in /"
+        sudo mkdir -p /mnt/
     fi
     echo "Checking free space!"
     df -H


### PR DESCRIPTION
Sometimes we get a worker that does not have /mnt filesystem mounted. In this case we will attempt to use the same approach as with other jobs - we will just create empty /mnt folder and hope the disk space will be enough to run the job we want to run

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
