### PR TITLE
Hide sensitive values from airflow connections list

### DIFF
--- a/airflow-core/newsfragments/59844.improvement.rst
+++ b/airflow-core/newsfragments/59844.improvement.rst
@@ -1,0 +1,1 @@
+Prevent airflow connections list from exposing sensitive connection values by default.

--- a/airflow-core/src/airflow/cli/commands/connection_command.py
+++ b/airflow-core/src/airflow/cli/commands/connection_command.py
@@ -78,6 +78,18 @@ def connections_get(args):
     )
 
 
+def _connection_list_mapper(conn: Connection) -> dict[str, Any]:
+    return {
+        "id": conn.id,
+        "conn_id": conn.conn_id,
+        "conn_type": conn.conn_type,
+        "description": conn.description,
+        "host": conn.host,
+        "schema": conn.schema,
+        "port": conn.port,
+    }
+
+
 @suppress_logs_and_warning
 @providers_configuration_loaded
 def connections_list(args):
@@ -89,7 +101,7 @@ def connections_list(args):
         AirflowConsole().print_as(
             data=conns,
             output=args.output,
-            mapper=_connection_mapper,
+            mapper=_connection_list_mapper,
         )
 
 


### PR DESCRIPTION

This PR updates `airflow connections list` to no longer display sensitive
connection values (such as login, password, or credential-containing URIs)
by default.

The change only affects the list command. The `airflow connections get`
command remains unchanged, as it is explicitly intended for retrieving full
connection details.

A unit test is added to prevent regressions, and a newsfragment documents
the user-facing behavior change.

Fixes #59844
