### PR TITLE
Run goimports CI hook serially to avoid race conditions

### DIFF
--- a/go-sdk/.pre-commit-config.yaml
+++ b/go-sdk/.pre-commit-config.yaml
@@ -60,6 +60,7 @@ repos:
         additional_dependencies: [github.com/incu6us/goimports-reviser/v3@v3.10.0]
         types: [go]
         language: golang
+        require_serial: true
       - id: gofmt
         name: Format go code
         entry: golines --base-formatter=gofumpt --write-output --max-len=100 --chain-split-dots


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This is an attempt to fix intermittent goimports CI failures like this one:

Log:
```go
  2026/01/02 19:52:19 Paths: [sdk/connection_test.go sdk/sdk.go internal/protov1/plugin.pb.go bundle/bundlev1/bundlev1server/doc.go pkg/api/mocks/AssetEventsClient.go pkg/logging/level.go pkg/logging/stdbridge.go pkg/worker/init.go pkg/logging/server/server.go edge/worker.go pkg/api/mocks/VariablesClient.go bundle/bundlev1/bundlev1client/doc.go pkg/logging/shclog/shclog.go pkg/api/mocks/XcomsClient.go]
  2026/01/02 19:52:19 Processing sdk/connection_test.go
  2026/01/02 19:52:20 Processing sdk/sdk.go
  2026/01/02 19:52:20 Processing internal/protov1/plugin.pb.go
  2026/01/02 19:52:20 Processing bundle/bundlev1/bundlev1server/doc.go
  2026/01/02 19:52:20 Processing pkg/api/mocks/AssetEventsClient.go
  2026/01/02 19:52:21 Processing pkg/logging/level.go
  2026/01/02 19:52:21 Processing pkg/logging/stdbridge.go
  2026/01/02 19:52:21 Processing pkg/worker/init.go
  2026/01/02 19:52:21 Processing pkg/logging/server/server.go
  2026/01/02 19:52:21 Processing edge/worker.go
  2026/01/02 19:52:21 Processing pkg/api/mocks/VariablesClient.go
  2026/01/02 19:52:21 Processing bundle/bundlev1/bundlev1client/doc.go
  2026/01/02 19:52:22 Processing pkg/logging/shclog/shclog.go
  2026/01/02 19:52:22 Processing pkg/api/mocks/XcomsClient.go
  2026/01/02 19:52:19 Paths: [sdk/client.go pkg/api/client.go pkg/api/client.gen.go example/bundle/main_test.go pkg/logging/server/server_test.go pkg/edgeapi/client.gen.go example/bundle/main.go pkg/edgeapi/client.go edge/commands/root.go pkg/api/init.go pkg/logging/tee.go bundle/bundlev1/task_test.go cmd/airflow-go-edge-worker/main.go pkg/api/mocks/ClientInterface.go]
  2026/01/02 19:52:19 Processing sdk/client.go
  2026/01/02 19:52:20 Processing pkg/api/client.go
  2026/01/02 19:52:20 Processing pkg/api/client.gen.go
  2026/01/02 19:52:20 Processing example/bundle/main_test.go
  2026/01/02 19:52:21 Processing pkg/logging/server/server_test.go
  2026/01/02 19:52:21 Processing pkg/edgeapi/client.gen.go
  2026/01/02 19:52:21 Processing example/bundle/main.go
  2026/01/02 19:52:21 Processing pkg/edgeapi/client.go
  2026/01/02 19:52:21 Processing edge/commands/root.go
  2026/01/02 19:52:22 Processing pkg/api/init.go
  2026/01/02 19:52:22 Processing pkg/logging/tee.go
  2026/01/02 19:52:22 Processing bundle/bundlev1/task_test.go
  2026/01/02 19:52:22 Processing cmd/airflow-go-edge-worker/main.go
  2026/01/02 19:52:22 Processing pkg/api/mocks/ClientInterface.go
  2026/01/02 19:52:19 Paths: [bundle/bundlev1/doc.go pkg/api/mocks/AssetsClient.go edge/commands/run.go pkg/bundles/shared/handshake.go sdk/connection.go internal/protov1/plugin_grpc.pb.go pkg/worker/runner_test.go sdk/errors.go sdk/doc.go bundle/bundlev1/bundlev1client/grpc.go pkg/config/config.go pkg/api/mocks/TaskReschedulesClient.go pkg/api/mocks/ConnectionsClient.go bundle/bundlev1/registry_test.go]
  2026/01/02 19:52:19 Processing bundle/bundlev1/doc.go
  2026/01/02 19:52:20 Processing pkg/api/mocks/AssetsClient.go
  2026/01/02 19:52:20 Processing edge/commands/run.go
  2026/01/02 19:52:21 Processing pkg/bundles/shared/handshake.go
  2026/01/02 19:52:21 Processing sdk/connection.go
  2026/01/02 19:52:21 Processing internal/protov1/plugin_grpc.pb.go
  2026/01/02 19:52:21 Processing pkg/worker/runner_test.go
  2026/01/02 19:52:21 Processing sdk/errors.go
  client_test.go:1:1: expected 'package', found 'EOF'
  2026/01/02 19:52:22 Failed to fix file: package has an errors
  2026/01/02 19:52:19 Paths: [bundle/bundlev1/registry.go pkg/api/mocks/DagRunsClient.go pkg/worker/runner.go bundle/bundlev1/bundlev1server/impl/plugin.go pkg/sdkcontext/keys.go pkg/api/models.go pkg/api/mocks/TaskInstancesClient.go bundle/bundlev1/schemas.go bundle/bundlev1/task.go pkg/logging/attrs.go sdk/client_test.go bundle/bundlev1/bundlev1server/server.go pkg/bundles/shared/discovery.go]
  2026/01/02 19:52:19 Processing bundle/bundlev1/registry.go
  2026/01/02 19:52:20 Processing pkg/api/mocks/DagRunsClient.go
  2026/01/02 19:52:20 Processing pkg/worker/runner.go
  2026/01/02 19:52:20 Processing bundle/bundlev1/bundlev1server/impl/plugin.go
  2026/01/02 19:52:21 Processing pkg/sdkcontext/keys.go
  2026/01/02 19:52:21 Processing pkg/api/models.go
  2026/01/02 19:52:21 Processing pkg/api/mocks/TaskInstancesClient.go
  2026/01/02 19:52:21 Processing bundle/bundlev1/schemas.go
  2026/01/02 19:52:21 Processing bundle/bundlev1/task.go
  2026/01/02 19:52:21 Processing pkg/logging/attrs.go
  2026/01/02 19:52:21 Processing sdk/client_test.go
  2026/01/02 19:52:22 Processing bundle/bundlev1/bundlev1server/server.go
  2026/01/02 19:52:22 Processing pkg/bundles/shared/discovery.go
```

You can observe that the paths being processed:
```go
2026/01/02 19:52:19 Paths: [sdk/connection_test.go sdk/sdk.go ...]
2026/01/02 19:52:19 Paths: [sdk/client.go pkg/api/client.go ...]  
2026/01/02 19:52:19 Paths: [bundle/bundlev1/doc.go pkg/api/mocks/AssetsClient.go ...]
2026/01/02 19:52:19 Paths: [bundle/bundlev1/registry.go pkg/api/mocks/DagRunsClient.go ...]
```

as batch runs all start at the exact same timestamp (19:52:19), running concurrrently.

This essentially means that the goimports-revister picks a file, modifies import order and writes it back. When multiple workers run here, its likely that:
- One worker reads a file while another is in the middle of writing it

Attempting to fix this by adding serial running ability, to enforce sequential runs.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
