### PR TITLE
Change ubuntu img ver in k8s tests

### DIFF
--- a/kubernetes-tests/tests/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes-tests/tests/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -131,7 +131,7 @@ class TestKubernetesPodOperatorSystem:
                 "affinity": {},
                 "containers": [
                     {
-                        "image": "ubuntu:16.04",
+                        "image": "ubuntu",
                         "args": ["echo 10"],
                         "command": ["bash", "-cx"],
                         "env": [],
@@ -176,7 +176,7 @@ class TestKubernetesPodOperatorSystem:
         shutil.copy(kubeconfig_path, new_config_path)
         k = KubernetesPodOperator(
             namespace="default",
-            image="ubuntu:16.04",
+            image="ubuntu",
             cmds=["bash", "-cx"],
             arguments=["echo 10"],
             labels=self.labels,
@@ -193,7 +193,7 @@ class TestKubernetesPodOperatorSystem:
 
         k = KubernetesPodOperator(
             namespace="default",
-            image="ubuntu:16.04",
+            image="ubuntu",
             cmds=["bash", "-cx"],
             arguments=["echo 10"],
             labels=self.labels,
@@ -212,7 +212,7 @@ class TestKubernetesPodOperatorSystem:
     def test_working_pod(self):
         k = KubernetesPodOperator(
             namespace="default",
-            image="ubuntu:16.04",
+            image="ubuntu",
             cmds=["bash", "-cx"],
             arguments=["echo 10"],
             labels=self.labels,
@@ -229,7 +229,7 @@ class TestKubernetesPodOperatorSystem:
     def test_skip_cleanup(self):
         k = KubernetesPodOperator(
             namespace="unknown",
-            image="ubuntu:16.04",
+            image="ubuntu",
             cmds=["bash", "-cx"],
             arguments=["echo 10"],
             labels=self.labels,
@@ -244,7 +244,7 @@ class TestKubernetesPodOperatorSystem:
     def test_delete_operator_pod(self):
         k = KubernetesPodOperator(
             namespace="default",
-            image="ubuntu:16.04",
+            image="ubuntu",
             cmds=["bash", "-cx"],
             arguments=["echo 10"],
             labels=self.labels,
@@ -262,7 +262,7 @@ class TestKubernetesPodOperatorSystem:
     def test_skip_on_specified_exit_code(self):
         k = KubernetesPodOperator(
             namespace="default",
-            image="ubuntu:16.04",
+            image="ubuntu",
             cmds=["bash", "-cx"],
             arguments=["exit 42"],
             task_id=str(uuid4()),
@@ -282,7 +282,7 @@ class TestKubernetesPodOperatorSystem:
         """
         k = KubernetesPodOperator(
             namespace="default",
-            image="ubuntu:16.04",
+            image="ubuntu",
             cmds=["bash", "-cx"],
             arguments=["echo 10"],
             labels=self.labels,
@@ -304,7 +304,7 @@ class TestKubernetesPodOperatorSystem:
         """
         k = KubernetesPodOperator(
             namespace="default",
-            image="ubuntu:16.04",
+            image="ubuntu",
             cmds=["bash", "-cx"],
             arguments=["lalala"],
             labels=self.labels,
@@ -325,7 +325,7 @@ class TestKubernetesPodOperatorSystem:
     def test_pod_hostnetwork(self):
         k = KubernetesPodOperator(
             namespace="default",
-            image="ubuntu:16.04",
+            image="ubuntu",
             cmds=["bash", "-cx"],
             arguments=["echo 10"],
             labels=self.labels,
@@ -345,7 +345,7 @@ class TestKubernetesPodOperatorSystem:
         dns_policy = "ClusterFirstWithHostNet"
         k = KubernetesPodOperator(
             namespace="default",
-            image="ubuntu:16.04",
+            image="ubuntu",
             cmds=["bash", "-cx"],
             arguments=["echo 10"],
             labels=self.labels,
@@ -367,7 +367,7 @@ class TestKubernetesPodOperatorSystem:
         scheduler_name = "default-scheduler"
         k = KubernetesPodOperator(
             namespace="default",
-            image="ubuntu:16.04",
+            image="ubuntu",
             cmds=["bash", "-cx"],
             arguments=["echo 10"],
             labels=self.labels,
@@ -386,7 +386,7 @@ class TestKubernetesPodOperatorSystem:
         node_selector = {"beta.kubernetes.io/os": "linux"}
         k = KubernetesPodOperator(
             namespace="default",
-            image="ubuntu:16.04",
+            image="ubuntu",
             cmds=["bash", "-cx"],
             arguments=["echo 10"],
             labels=self.labels,
@@ -408,7 +408,7 @@ class TestKubernetesPodOperatorSystem:
         )
         k = KubernetesPodOperator(
             namespace="default",
-            image="ubuntu:16.04",
+            image="ubuntu",
             cmds=["bash", "-cx"],
             arguments=["echo 10"],
             labels=self.labels,
@@ -487,7 +487,7 @@ class TestKubernetesPodOperatorSystem:
         }
         k = KubernetesPodOperator(
             namespace="default",
-            image="ubuntu:16.04",
+            image="ubuntu",
             cmds=["bash", "-cx"],
             arguments=["echo 10"],
             labels=self.labels,
@@ -510,7 +510,7 @@ class TestKubernetesPodOperatorSystem:
 
         k = KubernetesPodOperator(
             namespace="default",
-            image="ubuntu:16.04",
+            image="ubuntu",
             cmds=["bash", "-cx"],
             arguments=["echo 10"],
             labels=self.labels,
@@ -541,7 +541,7 @@ class TestKubernetesPodOperatorSystem:
             ]
             k = KubernetesPodOperator(
                 namespace="default",
-                image="ubuntu:16.04",
+                image="ubuntu",
                 cmds=["bash", "-cx"],
                 arguments=args,
                 labels=self.labels,
@@ -571,7 +571,7 @@ class TestKubernetesPodOperatorSystem:
         name = str(uuid4())
         k = KubernetesPodOperator(
             namespace="default",
-            image="ubuntu:16.04",
+            image="ubuntu",
             cmds=["bash", "-cx"],
             arguments=["echo 10"],
             task_id=name,
@@ -596,7 +596,7 @@ class TestKubernetesPodOperatorSystem:
         name = str(uuid4())
         k = KubernetesPodOperator(
             namespace="default",
-            image="ubuntu:16.04",
+            image="ubuntu",
             cmds=["bash", "-cx"],
             arguments=["echo 10"],
             task_id=name,
@@ -620,7 +620,7 @@ class TestKubernetesPodOperatorSystem:
 
         k = KubernetesPodOperator(
             namespace="default",
-            image="ubuntu:16.04",
+            image="ubuntu",
             cmds=["bash", "-cx"],
             arguments=["echo 10"],
             labels=self.labels,
@@ -660,7 +660,7 @@ class TestKubernetesPodOperatorSystem:
     def test_faulty_service_account(self):
         k = KubernetesPodOperator(
             namespace="default",
-            image="ubuntu:16.04",
+            image="ubuntu",
             cmds=["bash", "-cx"],
             arguments=["echo 10"],
             labels=self.labels,
@@ -682,7 +682,7 @@ class TestKubernetesPodOperatorSystem:
         bad_internal_command = ["foobar 10 "]
         k = KubernetesPodOperator(
             namespace="default",
-            image="ubuntu:16.04",
+            image="ubuntu",
             cmds=["bash", "-cx"],
             arguments=bad_internal_command,
             labels=self.labels,
@@ -702,7 +702,7 @@ class TestKubernetesPodOperatorSystem:
         args = [f"echo '{json.dumps(expected)}' > /airflow/xcom/return.json"]
         k = KubernetesPodOperator(
             namespace="default",
-            image="ubuntu:16.04",
+            image="ubuntu",
             cmds=["bash", "-cx"],
             arguments=args,
             labels=self.labels,
@@ -726,7 +726,7 @@ class TestKubernetesPodOperatorSystem:
 
         k = KubernetesPodOperator(
             namespace="default",
-            image="ubuntu:16.04",
+            image="ubuntu",
             cmds=["bash", "-cx"],
             arguments=["echo 10"],
             env_vars=env_vars,
@@ -891,7 +891,7 @@ class TestKubernetesPodOperatorSystem:
 
         init_container = k8s.V1Container(
             name="init-container",
-            image="ubuntu:16.04",
+            image="ubuntu",
             env=init_environments,
             volume_mounts=volume_mounts,
             command=["bash", "-cx"],
@@ -904,7 +904,7 @@ class TestKubernetesPodOperatorSystem:
         )
         expected_init_container = {
             "name": "init-container",
-            "image": "ubuntu:16.04",
+            "image": "ubuntu",
             "command": ["bash", "-cx"],
             "args": ["echo 10"],
             "env": [{"name": "key1", "value": "value1"}, {"name": "key2", "value": "value2"}],
@@ -913,7 +913,7 @@ class TestKubernetesPodOperatorSystem:
 
         k = KubernetesPodOperator(
             namespace="default",
-            image="ubuntu:16.04",
+            image="ubuntu",
             cmds=["bash", "-cx"],
             arguments=["echo 10"],
             labels=self.labels,
@@ -1062,7 +1062,7 @@ class TestKubernetesPodOperatorSystem:
         priority_class_name = "medium-test"
         k = KubernetesPodOperator(
             namespace="default",
-            image="ubuntu:16.04",
+            image="ubuntu",
             cmds=["bash", "-cx"],
             arguments=["echo 10"],
             labels=self.labels,
@@ -1085,7 +1085,7 @@ class TestKubernetesPodOperatorSystem:
         pod_name_too_long = "a" * 221
         k = KubernetesPodOperator(
             namespace="default",
-            image="ubuntu:16.04",
+            image="ubuntu",
             cmds=["bash", "-cx"],
             arguments=["echo 10"],
             labels=self.labels,
@@ -1107,7 +1107,7 @@ class TestKubernetesPodOperatorSystem:
         namespace = "default"
         k = KubernetesPodOperator(
             namespace="default",
-            image="ubuntu:16.04",
+            image="ubuntu",
             cmds=["bash", "-cx"],
             arguments=["sleep 1000"],
             labels=self.labels,
@@ -1149,7 +1149,7 @@ class TestKubernetesPodOperatorSystem:
         def get_op():
             return KubernetesPodOperator(
                 namespace="default",
-                image="ubuntu:16.04",
+                image="ubuntu",
                 cmds=["bash", "-cx"],
                 arguments=["exit 1"],
                 labels=self.labels,
@@ -1210,7 +1210,7 @@ class TestKubernetesPodOperatorSystem:
     def test_changing_base_container_name_with_get_logs(self):
         k = KubernetesPodOperator(
             namespace="default",
-            image="ubuntu:16.04",
+            image="ubuntu",
             cmds=["bash", "-cx"],
             arguments=["echo 10"],
             labels=self.labels,
@@ -1240,7 +1240,7 @@ class TestKubernetesPodOperatorSystem:
         """
         k = KubernetesPodOperator(
             namespace="default",
-            image="ubuntu:16.04",
+            image="ubuntu",
             cmds=["bash", "-cx"],
             arguments=["echo 10"],
             labels=self.labels,
@@ -1270,7 +1270,7 @@ class TestKubernetesPodOperatorSystem:
         """
         k = KubernetesPodOperator(
             namespace="default",
-            image="ubuntu:16.04",
+            image="ubuntu",
             cmds=["bash", "-cx"],
             arguments=["sleep 3"],
             labels=self.labels,
@@ -1296,7 +1296,7 @@ class TestKubernetesPodOperatorSystem:
     def test_changing_base_container_name_failure(self):
         k = KubernetesPodOperator(
             namespace="default",
-            image="ubuntu:16.04",
+            image="ubuntu",
             cmds=["exit"],
             arguments=["1"],
             labels=self.labels,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
During checking the kubernetes_tests directory and its content, I noticed that:
1. We use a really old version of ubuntu image in some tests
2. In other tests, we user latest images of different images

This PR changed the Ubuntu image version to the latest.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
