### PR TITLE
Ensure graceful shutdown for Edge Tasks in Airflow 3

### DIFF
--- a/providers/edge3/src/airflow/providers/edge3/cli/worker.py
+++ b/providers/edge3/src/airflow/providers/edge3/cli/worker.py
@@ -145,7 +145,8 @@ class EdgeWorker:
     def shutdown_handler(self, sig, frame):
         logger.info("SIGTERM received. Terminating all jobs and quit")
         for job in EdgeWorker.jobs:
-            os.killpg(job.process.pid, signal.SIGTERM)
+            if job.process.pid:
+                os.kill(job.process.pid, signal.SIGTERM)
         EdgeWorker.drain = True
 
     def _get_sysinfo(self) -> dict:
@@ -193,7 +194,7 @@ class EdgeWorker:
         from airflow.sdk.execution_time.supervisor import supervise
 
         # Ignore ctrl-c in this process -- we don't want to kill _this_ one. we let tasks run to completion
-        signal.signal(signal.SIGINT, signal.SIG_IGN)
+        os.setpgrp()
 
         logger.info("Worker starting up pid=%d", os.getpid())
         setproctitle(f"airflow edge worker: {workload.ti.key}")


### PR DESCRIPTION
While we had a patch in Edge for Airflow 2 by @majorosdonat in PR https://github.com/apache/airflow/pull/43927 I noticed while attempting to implement a better event loop in Edge that the CTRL-C handling was not proper in Airflow 3.

In order not to delay a fix, this PR changes accordingly like the previous PR the same behavior in Airflow 3:
If in the console via CTRL-C or via `kill $EDGE_WORKER_PID` an interrupt is send to the worker, the signal is not sent to child processes (which kills the task execution) but gracefully shuts down the worker - waiting to complete pending jobs w/o picking new ones.
This is preventing the (currnent) effect that tasks are just killed leaving them in failed state as well as also allows a graceful shutdown in case of a rolling release.

I am not sure why the same method that was applied in Airflow 2 is not working in Airflow 3 (probably because of supervisor handling...) but via `os.setpgrp()`is is working.

Also fixed the way hiw the killing via SIGTERM is handled, it was formerly sending the SIGTERM to the process group (not the process) and using the PID and not the needed PGID... but this would have an endless loop of signalling to the worker itself. So fixing this as well.