### PR TITLE
Suppress Warning in Executor for Supervisor on os.fork()

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -29,6 +29,7 @@ import signal
 import sys
 import threading
 import time
+import warnings
 import weakref
 from collections import deque
 from collections.abc import Callable, Generator
@@ -477,6 +478,13 @@ class WatchedSubprocess:
         # Open the socketpair before forking off the child, so that it is open when we fork.
         child_logs, read_logs = socketpair()
 
+        # Prevent on console:
+        # DeprecationWarning: This process (pid=NNN) is multi-threaded, use of fork() may lead to deadlocks in the child.
+        warnings.filterwarnings(
+            "ignore",
+            module="airflow.sdk.execution_time.supervisor",
+            message=".*use of fork() may lead to deadlocks in the child.",
+        )
         pid = os.fork()
         if pid == 0:
             # Close and delete of the parent end of the sockets.


### PR DESCRIPTION
While I was fixing Edge Worker bugs I noticed that launched processes in the executor/worker always emit warnings in style:
```
DeprecationWarning: This process (pid=NNN) is multi-threaded, use of fork() may lead to deadlocks in the child.
```
I assume we are aware in Airflow that this is not a deprecation and the way we fork processes is not in danger of deadlock. Therefore I propose to suppress the warning. Assuming it is not planned to fix this.

Note proposing to fix it as it also appears in all other executors in console, seen in LocalExecutor as well.