### PR TITLE
`issue-60000-http`: Update conf imports for `http` provider

### DIFF
--- a/providers/http/pyproject.toml
+++ b/providers/http/pyproject.toml
@@ -59,7 +59,7 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.11.0",
-    "apache-airflow-providers-common-compat>=1.10.1",
+    "apache-airflow-providers-common-compat>=1.10.1",  # use next version
     # The 2.26.0 release of requests got rid of the chardet LGPL mandatory dependency, allowing us to
     # release it as a requirement for airflow
     "requests>=2.32.0,<3",

--- a/providers/http/src/airflow/providers/http/operators/http.py
+++ b/providers/http/src/airflow/providers/http/operators/http.py
@@ -25,8 +25,7 @@ from typing import TYPE_CHECKING, Any
 from aiohttp import BasicAuth
 from requests import Response
 
-from airflow.configuration import conf
-from airflow.providers.common.compat.sdk import AirflowException, BaseHook, BaseOperator
+from airflow.providers.common.compat.sdk import AirflowException, BaseHook, BaseOperator, conf
 from airflow.providers.http.triggers.http import HttpTrigger, serialize_auth_type
 from airflow.utils.helpers import merge_dicts
 

--- a/providers/http/src/airflow/providers/http/sensors/http.py
+++ b/providers/http/src/airflow/providers/http/sensors/http.py
@@ -21,8 +21,7 @@ from collections.abc import Callable, Sequence
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
-from airflow.configuration import conf
-from airflow.providers.common.compat.sdk import AirflowException, BaseSensorOperator
+from airflow.providers.common.compat.sdk import AirflowException, BaseSensorOperator, conf
 from airflow.providers.http.hooks.http import HttpHook
 from airflow.providers.http.triggers.http import HttpSensorTrigger
 


### PR DESCRIPTION
## Description

Per #60000, all instances of `from airflow.configuration import conf` are to be replaced with `from airflow.providers.common.compat.sdk import conf`. This PR implements these changes for the `http` provider.

## Testing

To test these changes, all unit tests for the `http` provider were executed. To reproduce this testing, the following command can be run:

```bash
breeze testing providers-tests --type-type "Providers[http]"
```

addresses: https://github.com/apache/airflow/issues/60000