### PR TITLE
Docs: fix typo in documentation publishing section

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -134,7 +134,7 @@ This workflow is used twice:
   bucket and the `live` website should be built and published.
 
 When the release manager publishes the documentation, they choose `auto` destination by default - depending on the
-tag they use - `staging` will be used to publish from pre-release tag and `live` will be used ot publish
+tag they use - `staging` will be used to publish from pre-release tag and `live` will be used to publish
 from the release tag.
 
 You can also specify whether `live` or `staging` documentation should be published manually - overriding


### PR DESCRIPTION
What does this PR do?
Fixes a small typo in the documentation publishing section.

Why is it needed?
Improves clarity and correctness of contributor documentation.

How was this tested?
Docs-only change.
