### PR TITLE
Assorted SQLA2/Mypy fixes

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -3034,7 +3034,9 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 session=session,
             )
             active_non_backfill_runs = runs_dict.get(dag_model.dag_id, 0)
-        exceeds = active_non_backfill_runs >= dag_model.max_active_runs
+        exceeds = (
+            dag_model.max_active_runs is not None and active_non_backfill_runs >= dag_model.max_active_runs
+        )
         return exceeds, active_non_backfill_runs
 
 

--- a/airflow-core/src/airflow/models/trigger.py
+++ b/airflow-core/src/airflow/models/trigger.py
@@ -98,7 +98,7 @@ class Trigger(Base):
     encrypted_kwargs: Mapped[str] = mapped_column("kwargs", Text, nullable=False)
     created_date: Mapped[datetime.datetime] = mapped_column(UtcDateTime, nullable=False)
     triggerer_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
-    queue: Mapped[str] = mapped_column(String(256), nullable=True)
+    queue: Mapped[str | None] = mapped_column(String(256), nullable=True)
 
     triggerer_job = relationship(
         "Job",

--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/athena_sql.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/athena_sql.py
@@ -25,7 +25,7 @@ import pyathena
 try:
     from sqlalchemy.engine.url import URL
 except ImportError:
-    URL = None
+    URL = None  # type: ignore[assignment,misc]
 
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from airflow.providers.amazon.aws.utils.connection_wrapper import AwsConnectionWrapper

--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/redshift_sql.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/redshift_sql.py
@@ -27,7 +27,7 @@ try:
     from sqlalchemy import create_engine
     from sqlalchemy.engine.url import URL
 except ImportError:
-    URL = create_engine = None
+    URL = create_engine = None  # type: ignore[assignment,misc]
 
 from airflow.exceptions import AirflowOptionalProviderFeatureException
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook

--- a/providers/common/sql/src/airflow/providers/common/sql/hooks/sql.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/hooks/sql.py
@@ -35,11 +35,11 @@ try:
     from sqlalchemy.engine import make_url
     from sqlalchemy.exc import ArgumentError, NoSuchModuleError
 except ImportError:
-    create_engine = None
-    inspect = None
-    make_url = None
-    ArgumentError = Exception
-    NoSuchModuleError = Exception
+    create_engine = None  # type: ignore[assignment]
+    inspect = None  # type: ignore[assignment]
+    make_url = None  # type: ignore[assignment]
+    ArgumentError = Exception  # type: ignore[misc,assignment]
+    NoSuchModuleError = Exception  # type: ignore[misc,assignment]
 
 
 from airflow.exceptions import AirflowOptionalProviderFeatureException, AirflowProviderDeprecationWarning

--- a/providers/exasol/src/airflow/providers/exasol/hooks/exasol.py
+++ b/providers/exasol/src/airflow/providers/exasol/hooks/exasol.py
@@ -28,7 +28,7 @@ from pyexasol import ExaConnection, ExaStatement
 try:
     from sqlalchemy.engine import URL
 except ImportError:
-    URL = None
+    URL = None  # type: ignore[assignment,misc]
 
 from airflow.exceptions import AirflowOptionalProviderFeatureException, AirflowProviderDeprecationWarning
 from airflow.providers.common.sql.hooks.handlers import return_single_query_results

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
@@ -208,7 +208,7 @@ class TestOpenLineageListenerAirflow2:
             task_instance = create_task_instance(
                 t,
                 run_id=run_id,
-                dag_version_id=dagrun.created_dag_version_id,
+                dag_version_id=uuid.UUID(dagrun.created_dag_version_id),
             )
         else:
             task_instance = TaskInstance(t, run_id=run_id)  # type: ignore

--- a/providers/standard/tests/unit/standard/operators/test_hitl.py
+++ b/providers/standard/tests/unit/standard/operators/test_hitl.py
@@ -256,7 +256,7 @@ class TestHITLOperator:
 
         expected_params_in_trigger_kwargs: dict[str, dict[str, Any]]
         # trigger_kwargs are encoded via BaseSerialization in versions < 3.2
-        expected_ti_id = ti.id
+        expected_ti_id: str | UUID = ti.id
         if AIRFLOW_V_3_2_PLUS:
             expected_params_in_trigger_kwargs = expected_params
             # trigger_kwargs are encoded via serde from task sdk in versions >= 3.2

--- a/task-sdk/src/airflow/sdk/serde/__init__.py
+++ b/task-sdk/src/airflow/sdk/serde/__init__.py
@@ -25,7 +25,7 @@ import sys
 from fnmatch import fnmatch
 from importlib import import_module
 from re import Pattern
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast, overload
 
 import attr
 
@@ -83,6 +83,14 @@ def decode(d: dict[str, Any]) -> tuple[str, int, Any]:
     data = d.get(DATA)
 
     return classname, version, data
+
+
+@overload
+def serialize(o: dict, depth: int = 0) -> dict: ...
+@overload
+def serialize(o: None, depth: int = 0) -> None: ...
+@overload
+def serialize(o: object, depth: int = 0) -> U | None: ...
 
 
 def serialize(o: object, depth: int = 0) -> U | None:


### PR DESCRIPTION
### Context:
https://github.com/apache/airflow/actions/runs/20681629287/job/59376845610?pr=59218#step:7:1199
https://github.com/apache/airflow/actions/runs/20681629287/job/59376845598?pr=59218#step:7:4224

```none
airflow-core/src/airflow/models/trigger.py:130: error: Incompatible types in assignment (expression has type "str | None", variable has type "SQLCoreOperations[str] | str")  [assignment]
              self.queue = queue
                           ^~~~~

airflow-core/src/airflow/models/trigger.py:487: error: Incompatible types in assignment (expression has type "float | int | dict[Any, Any] | list[Any] | str | tuple[Any, ...] | set[Any] | None",
  variable has type "SQLCoreOperations[dict[Any, Any] | None] | dict[Any, Any] | None")  [assignment]
          task_instance.next_kwargs = serialize(next_kwargs)
                                      ^~~~~~~~~~~~~~~~~~~~~~

airflow-core/src/airflow/jobs/scheduler_job_runner.py:3037: error: Unsupported operand types for >= ("int" and "None")  [operator]
              exceeds = active_non_backfill_runs >= dag_model.max_active_runs
                        ^

airflow-core/src/airflow/jobs/scheduler_job_runner.py:3037: note: Right operand is of type "int | None"
  providers/common/sql/src/airflow/providers/common/sql/hooks/sql.py:38: error: Incompatible types in assignment (expression has type "None", variable has type overloaded function)  [assignment]
          create_engine = None
                          ^~~~

providers/common/sql/src/airflow/providers/common/sql/hooks/sql.py:39: error: Incompatible types in assignment (expression has type "None", variable has type overloaded function)  [assignment]
          inspect = None
                    ^~~~

providers/common/sql/src/airflow/providers/common/sql/hooks/sql.py:40: error: Incompatible types in assignment (expression has type "None", variable has type "Callable[[str | URL], URL]")  [assignment]
          make_url = None
                     ^~~~

providers/common/sql/src/airflow/providers/common/sql/hooks/sql.py:41: error: Cannot assign to a type  [misc]
          ArgumentError = Exception
          ^~~~~~~~~~~~~

providers/common/sql/src/airflow/providers/common/sql/hooks/sql.py:41: error: Incompatible types in assignment (expression has type "type[Exception]", variable has type "type[ArgumentError]") 
  [assignment]
          ArgumentError = Exception
                          ^~~~~~~~~

providers/common/sql/src/airflow/providers/common/sql/hooks/sql.py:42: error: Cannot assign to a type  [misc]
          NoSuchModuleError = Exception
          ^~~~~~~~~~~~~~~~~

providers/common/sql/src/airflow/providers/common/sql/hooks/sql.py:42: error: Incompatible types in assignment (expression has type "type[Exception]", variable has type "type[NoSuchModuleError]") 
  [assignment]
          NoSuchModuleError = Exception
                              ^~~~~~~~~

providers/exasol/src/airflow/providers/exasol/hooks/exasol.py:31: error: Cannot assign to a type  [misc]
          URL = None
          ^~~

providers/exasol/src/airflow/providers/exasol/hooks/exasol.py:31: error: Incompatible types in assignment (expression has type "None", variable has type "type[URL]")  [assignment]
          URL = None
                ^~~~

providers/standard/tests/unit/standard/operators/test_hitl.py:263: error: Incompatible types in assignment (expression has type "UUID", variable has type "str")  [assignment]
                  expected_ti_id = UUID(ti.id)
                                   ^~~~~~~~~~~

providers/openlineage/tests/unit/openlineage/plugins/test_listener.py:211: error: Argument "dag_version_id" to "create_task_instance" has incompatible type "str | None"; expected "UUID"  [arg-type]
                      dag_version_id=dagrun.created_dag_version_id,
                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~

providers/amazon/src/airflow/providers/amazon/aws/hooks/redshift_sql.py:30: error: Cannot assign to a type  [misc]
        URL = create_engine = None
        ^~~

providers/amazon/src/airflow/providers/amazon/aws/hooks/redshift_sql.py:30: error: Incompatible types in assignment (expression has
type "None", variable has type "type[URL]")  [assignment]
        URL = create_engine = None
        ^

providers/amazon/src/airflow/providers/amazon/aws/hooks/redshift_sql.py:30: error: Incompatible types in assignment (expression has
type "None", variable has type overloaded function)  [assignment]
        URL = create_engine = None
                              ^~~~

providers/amazon/src/airflow/providers/amazon/aws/hooks/athena_sql.py:28: error: Cannot assign to a type  [misc]
        URL = None
        ^~~

providers/amazon/src/airflow/providers/amazon/aws/hooks/athena_sql.py:28: error: Incompatible types in assignment (expression has type
"None", variable has type "type[URL]")  [assignment]
        URL = None
              ^~~~

```
Related: #59218, #59895

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
