### PR TITLE
Fix: Persist import errors from GitDagBundle to import_error table

### DIFF
--- a/airflow-core/src/airflow/dag_processing/processor.py
+++ b/airflow-core/src/airflow/dag_processing/processor.py
@@ -250,7 +250,9 @@ def _serialize_dags(
             dagbag_import_error_traceback_depth = conf.getint(
                 "core", "dagbag_import_error_traceback_depth", fallback=None
             )
-            serialization_import_errors[dag.fileloc] = traceback.format_exc(
+            # Use relative_fileloc to match the format of parse-time import errors
+            # This ensures consistency across bundle types (Git, Local, etc.)
+            serialization_import_errors[dag.relative_fileloc] = traceback.format_exc(
                 limit=-dagbag_import_error_traceback_depth
             )
     return serialized_dags, serialization_import_errors


### PR DESCRIPTION
Fixes #60059

The issue: Runtime errors during DAG parsing in GitDagBundle were being caught but not persisted to the import_error table, causing DAGs with errors to silently disappear from the UI instead of appearing under Import Errors. This was inconsistent with LocalDagBundle behavior.

Root cause: When DAG serialization failed in _serialize_dags(), the error was stored using dag.fileloc (absolute path) instead of dag.relative_fileloc (relative path). However, DagBag stores parse-time errors with relative paths, and the update_dag_parsing_results_in_db() function expects all import errors to be keyed by (bundle_name, relative_path) tuples.

This path inconsistency caused serialization errors to have absolute paths that couldn't be properly matched to their bundle context, resulting in failed DB inserts and silent failures.

Changes:
1. Updated _serialize_dags() to use dag.relative_fileloc instead of dag.fileloc when storing serialization errors, ensuring consistency with parse-time errors
2. Added test_serialization_errors_use_relative_paths() to verify serialization errors use relative paths across bundle types
3. Added test_import_errors_persisted_with_relative_paths() to validate end-to-end error persistence for bundle-backed DAGs

This fix ensures that all DAG errors (parse-time and serialization-time) are consistently tracked and displayed in the UI, regardless of bundle type (Git, Local, S3, GCS, etc.).

Closes #60059


