### PR TITLE
docs: database support

### DIFF
--- a/airflow-core/docs/howto/set-up-database.rst
+++ b/airflow-core/docs/howto/set-up-database.rst
@@ -32,8 +32,8 @@ By default, Airflow uses **SQLite**, which is intended for development purposes 
 
 Airflow supports the following database engine versions, so make sure which version you have. Old versions may not support all SQL statements.
 
-* PostgreSQL: 12, 13, 14, 15, 16
-* MySQL: 8.0, `Innovation <https://dev.mysql.com/blog-archive/introducing-mysql-innovation-and-long-term-support-lts-versions>`_
+* PostgreSQL: 13, 14, 15, 16, 17
+* MySQL: 8.0, 8.4, `Innovation <https://dev.mysql.com/blog-archive/introducing-mysql-innovation-and-long-term-support-lts-versions>`_
 * SQLite: 3.15.0+
 
 If you plan on running more than one scheduler, you have to meet additional requirements.


### PR DESCRIPTION
[docs](https://airflow.apache.org/docs/apache-airflow/stable/howto/set-up-database.html#choosing-database-backend)

is not up to date 