### PR TITLE
Fix typos in documentation building guide

### DIFF
--- a/contributing-docs/11_documentation_building.rst
+++ b/contributing-docs/11_documentation_building.rst
@@ -36,12 +36,12 @@ Documentation in separate distributions:
 
 Documentation for general overview and summaries not connected with any specific distribution:
 
-* ``docker-stack-docs`` - documentation for Docker Stack'
+* ``docker-stack-docs`` - documentation for Docker Stack
 * ``providers-summary-docs`` - documentation for provider summary page
 
 Each of the distributions have a ``conf.py`` file in the root of the documentation and there
 are various configuration parameters for sphinx configured in the ``conf.py`` files. A number of common
-functions in those ``conf.py`` files are imported from ``deve-common`` distribution, from ``doc`` package,
+functions in those ``conf.py`` files are imported from ``devel-common`` distribution, from ``doc`` package,
 you can also find ``sphinx_ext`` folder there that keeps extensions used during our documentation build.
 
 Building documentation with uv in local venv


### PR DESCRIPTION
This PR fixes two minor typos in the documentation building guide:

1. Remove unnecessary trailing quote in line 39 (Docker Stack' -> Docker Stack)
2. Correct typo in line 44 (deve-common -> devel-common)

The `devel-common` directory actually exists in the repository, and this correction makes the documentation accurate.

This is a simple documentation fix that improves clarity and accuracy.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
