### PR TITLE
UI: add task instance summary to DAG cards

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/ui/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/ui/dags.py
@@ -34,7 +34,7 @@ class DAGWithLatestDagRunsResponse(DAGResponse):
 
     asset_expression: dict | None
     latest_dag_runs: list[DAGRunLightResponse]
-    latest_run_stats: LatestRunStats | None = None
+    latest_run_stats: dict[TaskInstanceState, int] | None = None
     pending_actions: list[HITLDetail]
     is_favorite: bool
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/ui/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/ui/dags.py
@@ -28,6 +28,7 @@ class DAGWithLatestDagRunsResponse(DAGResponse):
 
     asset_expression: dict | None
     latest_dag_runs: list[DAGRunLightResponse]
+    task_instance_summary: dict[str, int] | None = None
     pending_actions: list[HITLDetail]
     is_favorite: bool
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/ui/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/ui/dags.py
@@ -23,12 +23,18 @@ from airflow.api_fastapi.core_api.datamodels.hitl import HITLDetail
 from airflow.api_fastapi.core_api.datamodels.ui.dag_runs import DAGRunLightResponse
 
 
+class LatestRunStats(BaseModel):
+    """Stats for the latest DAG run."""
+
+    task_instance_counts: dict[str, int]
+
+
 class DAGWithLatestDagRunsResponse(DAGResponse):
     """DAG with latest dag runs response serializer."""
 
     asset_expression: dict | None
     latest_dag_runs: list[DAGRunLightResponse]
-    task_instance_summary: dict[str, int] | None = None
+    latest_run_stats: LatestRunStats | None = None
     pending_actions: list[HITLDetail]
     is_favorite: bool
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -1707,6 +1707,13 @@ components:
             $ref: '#/components/schemas/DAGRunLightResponse'
           type: array
           title: Latest Dag Runs
+        task_instance_summary:
+          anyOf:
+          - additionalProperties:
+              type: integer
+            type: object
+          - type: 'null'
+          title: Task Instance Summary
         pending_actions:
           items:
             $ref: '#/components/schemas/HITLDetail'

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -1707,13 +1707,10 @@ components:
             $ref: '#/components/schemas/DAGRunLightResponse'
           type: array
           title: Latest Dag Runs
-        task_instance_summary:
+        latest_run_stats:
           anyOf:
-          - additionalProperties:
-              type: integer
-            type: object
+          - $ref: '#/components/schemas/LatestRunStats'
           - type: 'null'
-          title: Task Instance Summary
         pending_actions:
           items:
             $ref: '#/components/schemas/HITLDetail'
@@ -2220,6 +2217,18 @@ components:
       - unixname
       title: JobResponse
       description: Job serializer for responses.
+    LatestRunStats:
+      properties:
+        task_instance_counts:
+          additionalProperties:
+            type: integer
+          type: object
+          title: Task Instance Counts
+      type: object
+      required:
+      - task_instance_counts
+      title: LatestRunStats
+      description: Stats for the latest DAG run.
     LightGridTaskInstanceSummary:
       properties:
         task_id:

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -7654,19 +7654,15 @@ export const $DAGWithLatestDagRunsResponse = {
             type: 'array',
             title: 'Latest Dag Runs'
         },
-        task_instance_summary: {
+        latest_run_stats: {
             anyOf: [
                 {
-                    additionalProperties: {
-                        type: 'integer'
-                    },
-                    type: 'object'
+                    '$ref': '#/components/schemas/LatestRunStats'
                 },
                 {
                     type: 'null'
                 }
-            ],
-            title: 'Task Instance Summary'
+            ]
         },
         pending_actions: {
             items: {
@@ -7953,6 +7949,22 @@ export const $HistoricalMetricDataResponse = {
     required: ['dag_run_types', 'dag_run_states', 'task_instance_states'],
     title: 'HistoricalMetricDataResponse',
     description: 'Historical Metric Data serializer for responses.'
+} as const;
+
+export const $LatestRunStats = {
+    properties: {
+        task_instance_counts: {
+            additionalProperties: {
+                type: 'integer'
+            },
+            type: 'object',
+            title: 'Task Instance Counts'
+        }
+    },
+    type: 'object',
+    required: ['task_instance_counts'],
+    title: 'LatestRunStats',
+    description: 'Stats for the latest DAG run.'
 } as const;
 
 export const $LightGridTaskInstanceSummary = {

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -7654,6 +7654,20 @@ export const $DAGWithLatestDagRunsResponse = {
             type: 'array',
             title: 'Latest Dag Runs'
         },
+        task_instance_summary: {
+            anyOf: [
+                {
+                    additionalProperties: {
+                        type: 'integer'
+                    },
+                    type: 'object'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Task Instance Summary'
+        },
         pending_actions: {
             items: {
                 '$ref': '#/components/schemas/HITLDetail'

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -1887,9 +1887,7 @@ export type DAGWithLatestDagRunsResponse = {
     [key: string]: unknown;
 } | null;
     latest_dag_runs: Array<DAGRunLightResponse>;
-    task_instance_summary?: {
-    [key: string]: (number);
-} | null;
+    latest_run_stats?: LatestRunStats | null;
     pending_actions: Array<HITLDetail>;
     is_favorite: boolean;
     /**
@@ -1966,6 +1964,15 @@ export type HistoricalMetricDataResponse = {
     dag_run_types: DAGRunTypes;
     dag_run_states: DAGRunStates;
     task_instance_states: TaskInstanceStateCount;
+};
+
+/**
+ * Stats for the latest DAG run.
+ */
+export type LatestRunStats = {
+    task_instance_counts: {
+    [key: string]: (number);
+};
 };
 
 /**

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -1887,6 +1887,9 @@ export type DAGWithLatestDagRunsResponse = {
     [key: string]: unknown;
 } | null;
     latest_dag_runs: Array<DAGRunLightResponse>;
+    task_instance_summary?: {
+    [key: string]: (number);
+} | null;
     pending_actions: Array<HITLDetail>;
     is_favorite: boolean;
     /**

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
@@ -263,6 +263,7 @@
   },
   "taskInstance_one": "Task Instance",
   "taskInstance_other": "Task Instances",
+  "taskInstanceSummary": "Task Instance Summary",
   "timeRange": {
     "last12Hours": "Last 12 Hours",
     "last24Hours": "Last 24 Hours",

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.test.tsx
@@ -54,11 +54,7 @@ vi.mock("openapi/queries", async () => {
     ...actual,
     useTaskInstanceServiceGetTaskInstances: () => ({
       data: {
-        task_instances: [
-          { state: "success" },
-          { state: "success" },
-          { state: "failed" },
-        ],
+        task_instances: [{ state: "success" }, { state: "success" }, { state: "failed" }],
       },
       isLoading: false,
     }),

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.test.tsx
@@ -107,7 +107,7 @@ const mockDag = {
   pending_actions: [],
   relative_fileloc: "nested_task_groups.py",
   tags: [],
-  task_instance_summary: { success: 2, failed: 1 },
+  latest_run_stats: { task_instance_counts: { success: 2, failed: 1 } },
   timetable_description: "Every minute",
   timetable_summary: "* * * * *",
 } satisfies DAGWithLatestDagRunsResponse;
@@ -235,17 +235,17 @@ describe("DagCard", () => {
     expect(stateBadges[0]).toHaveAttribute("aria-label", "failed");
   });
 
-  it("DagCard should render TaskInstanceSummary when DAG has task_instance_summary", () => {
+  it("DagCard should render TaskInstanceSummary when DAG has latest_run_stats", () => {
     render(<DagCard dag={mockDag} />, { wrapper: GMTWrapper });
     const taskInstanceSummary = screen.getByTestId("task-instance-summary");
 
     expect(taskInstanceSummary).toBeInTheDocument();
   });
 
-  it("DagCard should not render TaskInstanceSummary when DAG has no task_instance_summary", () => {
+  it("DagCard should not render TaskInstanceSummary when DAG has no latest_run_stats", () => {
     const mockDagWithNoSummary = {
       ...mockDag,
-      task_instance_summary: null,
+      latest_run_stats: null,
     } satisfies DAGWithLatestDagRunsResponse;
 
     render(<DagCard dag={mockDagWithNoSummary} />, { wrapper: GMTWrapper });

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.test.tsx
@@ -46,21 +46,6 @@ vi.mock("src/context/timezone", async () => {
   };
 });
 
-// Mock the task instances API to return sample data
-vi.mock("openapi/queries", async () => {
-  const actual = await vi.importActual("openapi/queries");
-
-  return {
-    ...actual,
-    useTaskInstanceServiceGetTaskInstances: () => ({
-      data: {
-        task_instances: [{ state: "success" }, { state: "success" }, { state: "failed" }],
-      },
-      isLoading: false,
-    }),
-  };
-});
-
 // Custom wrapper that uses GMT timezone
 const GMTWrapper = ({ children }: PropsWithChildren) => (
   <BaseWrapper>
@@ -122,6 +107,7 @@ const mockDag = {
   pending_actions: [],
   relative_fileloc: "nested_task_groups.py",
   tags: [],
+  task_instance_summary: { success: 2, failed: 1 },
   timetable_description: "Every minute",
   timetable_summary: "* * * * *",
 } satisfies DAGWithLatestDagRunsResponse;
@@ -249,20 +235,20 @@ describe("DagCard", () => {
     expect(stateBadges[0]).toHaveAttribute("aria-label", "failed");
   });
 
-  it("DagCard should render TaskInstanceSummary when DAG has a latest run", () => {
+  it("DagCard should render TaskInstanceSummary when DAG has task_instance_summary", () => {
     render(<DagCard dag={mockDag} />, { wrapper: GMTWrapper });
     const taskInstanceSummary = screen.getByTestId("task-instance-summary");
 
     expect(taskInstanceSummary).toBeInTheDocument();
   });
 
-  it("DagCard should not render TaskInstanceSummary when DAG has no latest run", () => {
-    const mockDagWithNoRuns = {
+  it("DagCard should not render TaskInstanceSummary when DAG has no task_instance_summary", () => {
+    const mockDagWithNoSummary = {
       ...mockDag,
-      latest_dag_runs: [],
+      task_instance_summary: null,
     } satisfies DAGWithLatestDagRunsResponse;
 
-    render(<DagCard dag={mockDagWithNoRuns} />, { wrapper: GMTWrapper });
+    render(<DagCard dag={mockDagWithNoSummary} />, { wrapper: GMTWrapper });
     const taskInstanceSummary = screen.queryByTestId("task-instance-summary");
 
     expect(taskInstanceSummary).toBeNull();

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -90,6 +90,15 @@ export const DagCard = ({ dag }: Props) => {
           />
         </Stat>
 
+        <Stat data-testid="next-run" label={translate("dagDetails.nextRun")}>
+          {Boolean(dag.next_dagrun_run_after) ? (
+            <DagRunInfo
+              logicalDate={dag.next_dagrun_logical_date}
+              runAfter={dag.next_dagrun_run_after as string}
+            />
+          ) : undefined}
+        </Stat>
+
         <Stat data-testid="latest-run" label={translate("dagDetails.latestRun")}>
           {latestRun ? (
             <Link asChild color="fg.info">

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -111,9 +111,7 @@ export const DagCard = ({ dag }: Props) => {
 
         {latestRun ? (
           <TaskInstanceSummary dagId={dag.dag_id} runId={latestRun.run_id} />
-        ) : (
-          <Stat label={translate("taskInstanceSummary")}>—</Stat>
-        )}
+        ) : undefined}
 
         <RecentRuns latestRuns={dag.latest_dag_runs} />
       </SimpleGrid>

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -17,17 +17,7 @@
  * under the License.
  */
 
-import {
-  Box,
-  Flex,
-  HStack,
-  SimpleGrid,
-  Link,
-  Spinner,
-  Badge,
-  Wrap,
-  WrapItem,
-} from "@chakra-ui/react";
+import { Box, Flex, HStack, SimpleGrid, Link, Spinner } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 import { Link as RouterLink } from "react-router-dom";
 
@@ -41,75 +31,16 @@ import { TogglePause } from "src/components/TogglePause";
 import TriggerDAGButton from "src/components/TriggerDag/TriggerDAGButton";
 import { Tooltip } from "src/components/ui";
 import { isStatePending, useAutoRefresh } from "src/utils";
-import { useTaskInstances } from "src/queries/useTaskInstances";
 
 import { DagTags } from "./DagTags";
 import { RecentRuns } from "./RecentRuns";
 import { Schedule } from "./Schedule";
+import { TaskInstanceSummary } from "./TaskInstanceSummary";
 
 type Props = {
   readonly dag: DAGWithLatestDagRunsResponse;
 };
 
-/* -------------------------------
- * Task Instance Summary Component
- * ------------------------------- */
-type TaskSummaryProps = {
-  dagId: string;
-  runId: string;
-};
-
-const TaskInstanceSummary = ({ dagId, runId }: TaskSummaryProps) => {
-  const { data, isLoading } = useTaskInstances({
-    dagId,
-    dagRunId: runId,
-    limit: 0,
-  });
-
-  if (isLoading) {
-    return <Spinner size="sm" />;
-  }
-
-  if (!data?.task_instances?.length) {
-    return null;
-  }
-
-  const counts = data.task_instances.reduce<Record<string, number>>((acc, ti) => {
-    if (ti.state) {
-      acc[ti.state] = (acc[ti.state] ?? 0) + 1;
-    }
-    return acc;
-  }, {});
-
-  const STATE_COLORS: Record<string, string> = {
-    success: "green",
-    failed: "red",
-    running: "yellow",
-    skipped: "gray",
-    upstream_failed: "red",
-  };
-
-  return (
-    <Wrap>
-      {Object.entries(counts).map(([state, count]) => (
-        <WrapItem key={state}>
-          <Link
-            as={RouterLink}
-            to={`/dags/${dagId}/runs/${runId}/tasks?state=${state}`}
-          >
-            <Badge colorScheme={STATE_COLORS[state] ?? "gray"}>
-              {state}: {count}
-            </Badge>
-          </Link>
-        </WrapItem>
-      ))}
-    </Wrap>
-  );
-};
-
-/* -------------------------------
- * DAG Card
- * ------------------------------- */
 export const DagCard = ({ dag }: Props) => {
   const { t: translate } = useTranslation(["common", "dag"]);
   const [latestRun] = dag.latest_dag_runs;
@@ -178,12 +109,11 @@ export const DagCard = ({ dag }: Props) => {
           ) : undefined}
         </Stat>
 
-        {/* 🔽 NEW: Task Instance Summary */}
-        <Stat label={translate("dagDetails.taskSummary")}>
-          {latestRun ? (
-            <TaskInstanceSummary dagId={dag.dag_id} runId={latestRun.run_id} />
-          ) : undefined}
-        </Stat>
+        {latestRun ? (
+          <TaskInstanceSummary dagId={dag.dag_id} runId={latestRun.run_id} />
+        ) : (
+          <Stat label={translate("taskInstanceSummary")}>—</Stat>
+        )}
 
         <RecentRuns latestRuns={dag.latest_dag_runs} />
       </SimpleGrid>

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -117,7 +117,7 @@ export const DagCard = ({ dag }: Props) => {
           ) : undefined}
         </Stat>
 
-        <TaskInstanceSummary taskInstanceSummary={dag.task_instance_summary} />
+        <TaskInstanceSummary latestRunStats={dag.latest_run_stats} />
 
         <RecentRuns latestRuns={dag.latest_dag_runs} />
       </SimpleGrid>

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -117,7 +117,7 @@ export const DagCard = ({ dag }: Props) => {
           ) : undefined}
         </Stat>
 
-        {latestRun ? <TaskInstanceSummary dagId={dag.dag_id} runId={latestRun.run_id} /> : undefined}
+        <TaskInstanceSummary taskInstanceSummary={dag.task_instance_summary} />
 
         <RecentRuns latestRuns={dag.latest_dag_runs} />
       </SimpleGrid>

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 import { Box, Flex, HStack, SimpleGrid, Link, Spinner } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 import { Link as RouterLink } from "react-router-dom";
@@ -118,9 +117,7 @@ export const DagCard = ({ dag }: Props) => {
           ) : undefined}
         </Stat>
 
-        {latestRun ? (
-          <TaskInstanceSummary dagId={dag.dag_id} runId={latestRun.run_id} />
-        ) : undefined}
+        {latestRun ? <TaskInstanceSummary dagId={dag.dag_id} runId={latestRun.run_id} /> : undefined}
 
         <RecentRuns latestRuns={dag.latest_dag_runs} />
       </SimpleGrid>

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/TaskInstanceSummary.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/TaskInstanceSummary.tsx
@@ -1,0 +1,82 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { HStack, Spinner, Text } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
+
+import { useTaskInstanceServiceGetTaskInstances } from "openapi/queries";
+import type { TaskInstanceState } from "openapi/requests/types.gen";
+import { StateBadge } from "src/components/StateBadge";
+import { Stat } from "src/components/Stat";
+
+type Props = {
+  readonly dagId: string;
+  readonly runId: string;
+};
+
+export const TaskInstanceSummary = ({ dagId, runId }: Props) => {
+  const { t: translate } = useTranslation("common");
+
+  const { data, isLoading } = useTaskInstanceServiceGetTaskInstances({
+    dagId,
+    dagRunId: runId,
+    limit: 1000,
+  });
+
+  if (isLoading) {
+    return (
+      <Stat label={translate("taskInstanceSummary")}>
+        <Spinner size="sm" />
+      </Stat>
+    );
+  }
+
+  // Count task instances by state
+  const stateCounts: Record<string, number> = {};
+
+  data?.task_instances?.forEach((ti) => {
+    const state = ti.state ?? "no_status";
+
+    stateCounts[state] = (stateCounts[state] ?? 0) + 1;
+  });
+
+  const stateEntries = Object.entries(stateCounts);
+
+  if (stateEntries.length === 0) {
+    return (
+      <Stat label={translate("taskInstanceSummary")}>
+        <Text color="fg.muted" fontSize="sm">
+          —
+        </Text>
+      </Stat>
+    );
+  }
+
+  return (
+    <Stat data-testid="task-instance-summary" label={translate("taskInstanceSummary")}>
+      <HStack flexWrap="wrap" gap={1}>
+        {stateEntries.map(([state, count]) => (
+          <StateBadge key={state} state={state as TaskInstanceState}>
+            {count}
+          </StateBadge>
+        ))}
+      </HStack>
+    </Stat>
+  );
+};

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/TaskInstanceSummary.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/TaskInstanceSummary.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { HStack, Spinner, Text } from "@chakra-ui/react";
+import { HStack, Spinner } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 
 import { useTaskInstanceServiceGetTaskInstances } from "openapi/queries";
@@ -59,13 +59,7 @@ export const TaskInstanceSummary = ({ dagId, runId }: Props) => {
   const stateEntries = Object.entries(stateCounts);
 
   if (stateEntries.length === 0) {
-    return (
-      <Stat label={translate("taskInstanceSummary")}>
-        <Text color="fg.muted" fontSize="sm">
-          —
-        </Text>
-      </Stat>
-    );
+    return null;
   }
 
   return (

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/TaskInstanceSummary.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/TaskInstanceSummary.tsx
@@ -19,22 +19,22 @@
 import { HStack } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 
-import type { TaskInstanceState } from "openapi/requests/types.gen";
+import type { LatestRunStats, TaskInstanceState } from "openapi/requests/types.gen";
 import { Stat } from "src/components/Stat";
 import { StateBadge } from "src/components/StateBadge";
 
 type Props = {
-  readonly taskInstanceSummary: Record<string, number> | null | undefined;
+  readonly latestRunStats: LatestRunStats | null | undefined;
 };
 
-export const TaskInstanceSummary = ({ taskInstanceSummary }: Props) => {
+export const TaskInstanceSummary = ({ latestRunStats }: Props) => {
   const { t: translate } = useTranslation("common");
 
-  if (!taskInstanceSummary) {
+  if (!latestRunStats) {
     return null;
   }
 
-  const stateEntries = Object.entries(taskInstanceSummary);
+  const stateEntries = Object.entries(latestRunStats.task_instance_counts);
 
   if (stateEntries.length === 0) {
     return null;

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/TaskInstanceSummary.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/TaskInstanceSummary.tsx
@@ -16,14 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 import { HStack, Spinner } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 
 import { useTaskInstanceServiceGetTaskInstances } from "openapi/queries";
 import type { TaskInstanceState } from "openapi/requests/types.gen";
-import { StateBadge } from "src/components/StateBadge";
 import { Stat } from "src/components/Stat";
+import { StateBadge } from "src/components/StateBadge";
 
 type Props = {
   readonly dagId: string;
@@ -56,6 +55,7 @@ export const TaskInstanceSummary = ({ dagId, runId }: Props) => {
 
   data.task_instances.forEach((ti) => {
     const state = ti.state ?? "no_status";
+
     stateCounts[state] = (stateCounts[state] ?? 0) + 1;
   });
 

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/TaskInstanceSummary.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/TaskInstanceSummary.tsx
@@ -47,12 +47,15 @@ export const TaskInstanceSummary = ({ dagId, runId }: Props) => {
     );
   }
 
+  if (!data) {
+    return null;
+  }
+
   // Count task instances by state
   const stateCounts: Record<string, number> = {};
 
-  data?.task_instances?.forEach((ti) => {
+  data.task_instances.forEach((ti) => {
     const state = ti.state ?? "no_status";
-
     stateCounts[state] = (stateCounts[state] ?? 0) + 1;
   });
 

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/TaskInstanceSummary.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/TaskInstanceSummary.tsx
@@ -16,50 +16,25 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { HStack, Spinner } from "@chakra-ui/react";
+import { HStack } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 
-import { useTaskInstanceServiceGetTaskInstances } from "openapi/queries";
 import type { TaskInstanceState } from "openapi/requests/types.gen";
 import { Stat } from "src/components/Stat";
 import { StateBadge } from "src/components/StateBadge";
 
 type Props = {
-  readonly dagId: string;
-  readonly runId: string;
+  readonly taskInstanceSummary: Record<string, number> | null | undefined;
 };
 
-export const TaskInstanceSummary = ({ dagId, runId }: Props) => {
+export const TaskInstanceSummary = ({ taskInstanceSummary }: Props) => {
   const { t: translate } = useTranslation("common");
 
-  const { data, isLoading } = useTaskInstanceServiceGetTaskInstances({
-    dagId,
-    dagRunId: runId,
-    limit: 1000,
-  });
-
-  if (isLoading) {
-    return (
-      <Stat label={translate("taskInstanceSummary")}>
-        <Spinner size="sm" />
-      </Stat>
-    );
-  }
-
-  if (!data) {
+  if (!taskInstanceSummary) {
     return null;
   }
 
-  // Count task instances by state
-  const stateCounts: Record<string, number> = {};
-
-  data.task_instances.forEach((ti) => {
-    const state = ti.state ?? "no_status";
-
-    stateCounts[state] = (stateCounts[state] ?? 0) + 1;
-  });
-
-  const stateEntries = Object.entries(stateCounts);
+  const stateEntries = Object.entries(taskInstanceSummary);
 
   if (stateEntries.length === 0) {
     return null;

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_dags.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_dags.py
@@ -21,6 +21,7 @@ from unittest import mock
 import pendulum
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy import insert
 from sqlalchemy.orm import Session
 
 from airflow.models import DagRun
@@ -32,8 +33,6 @@ from airflow.sdk.timezone import utcnow
 from airflow.utils.session import provide_session
 from airflow.utils.state import DagRunState, TaskInstanceState
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
-
-from sqlalchemy import insert
 
 from tests_common.test_utils.asserts import count_queries
 from unit.api_fastapi.core_api.routes.public.test_dags import (
@@ -129,7 +128,7 @@ class TestGetDagRuns(TestPublicDagEndpoint):
                 previous_run_after = dag_run["run_after"]
 
     @pytest.fixture
-    def setup_hitl_data(self, create_task_instance: TaskInstance, session: Session):
+    def setup_hitl_data(self, create_task_instance: TI, session: Session):
         """Setup HITL test data for parametrized tests."""
         # 3 Dags (test_dag0 created here and test_dag1, test_dag2 created in setup_dag_runs)
         # 5 task instances in test_dag0

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_dags.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_dags.py
@@ -384,10 +384,10 @@ class TestGetDagRuns(TestPublicDagEndpoint):
         dag1_data = next(dag for dag in body["dags"] if dag["dag_id"] == DAG1_ID)
         assert dag1_data["is_favorite"] is False
 
-    def test_task_instance_summary_returns_aggregated_counts(
+    def test_latest_run_stats_returns_aggregated_counts(
         self, test_client, session
     ):
-        """Test that task_instance_summary returns aggregated task instance counts by state."""
+        """Test that latest_run_stats returns aggregated task instance counts by state."""
         dag_id = "test_dag_ti_summary"
 
         # Create a DAG
@@ -443,20 +443,20 @@ class TestGetDagRuns(TestPublicDagEndpoint):
         assert response.status_code == 200
         body = response.json()
 
-        # Verify task_instance_summary is present and correct
+        # Verify latest_run_stats is present and correct
         assert body["total_entries"] == 1
         dag_data = body["dags"][0]
-        assert "task_instance_summary" in dag_data
+        assert "latest_run_stats" in dag_data
 
-        summary = dag_data["task_instance_summary"]
+        summary = dag_data["latest_run_stats"]["task_instance_counts"]
         assert summary.get("success") == 3
         assert summary.get("failed") == 2
         assert summary.get("running") == 1
 
-    def test_task_instance_summary_only_includes_latest_run(
+    def test_latest_run_stats_only_includes_latest_run(
         self, test_client, session
     ):
-        """Test that task_instance_summary only includes task instances from the latest DAG run."""
+        """Test that latest_run_stats only includes task instances from the latest DAG run."""
         dag_id = "test_dag_ti_summary_latest"
 
         # Create a DAG
@@ -532,17 +532,17 @@ class TestGetDagRuns(TestPublicDagEndpoint):
         assert response.status_code == 200
         body = response.json()
 
-        # Verify task_instance_summary only reflects the latest run
+        # Verify latest_run_stats only reflects the latest run
         dag_data = body["dags"][0]
-        summary = dag_data["task_instance_summary"]
+        summary = dag_data["latest_run_stats"]["task_instance_counts"]
 
         # Should only have success states from the newer run
         assert summary.get("success") == 2
         # Should NOT include failed states from older run
         assert summary.get("failed") is None
 
-    def test_task_instance_summary_empty_when_no_task_instances(self, test_client, session):
-        """Test that task_instance_summary is empty when DAG has no task instances."""
+    def test_latest_run_stats_empty_when_no_task_instances(self, test_client, session):
+        """Test that latest_run_stats is empty when DAG has no task instances."""
         dag_id = "test_dag_no_ti"
 
         # Create a DAG without any task instances
@@ -560,7 +560,7 @@ class TestGetDagRuns(TestPublicDagEndpoint):
         assert response.status_code == 200
         body = response.json()
 
-        # Verify task_instance_summary is empty
+        # Verify latest_run_stats has empty task_instance_counts
         dag_data = body["dags"][0]
-        assert dag_data["task_instance_summary"] == {}
+        assert dag_data["latest_run_stats"]["task_instance_counts"] == {}
 


### PR DESCRIPTION
### What does this PR do?

Adds a compact Task Instance summary to DAG cards on the DAG list page,
showing task state counts for the most recent DagRun.

This helps operators quickly identify DAGs that need attention and restores
at-a-glance operational visibility similar to what existed in Airflow 2.

### How was this implemented?

- UI-only change
- Uses existing Task Instance query hooks
- Displays task state counts for the most recent DagRun
- Clickable state badges link to the filtered task list

### Testing

This is a UI-only change. I was not able to fully run the Airflow UI locally,
but the implementation follows existing DagCard patterns and relies on
existing APIs. CI should validate the build and types.

### Related issue

Fixes #50624
