### PR TITLE
Move find_path_from_directory to shared module_loading library

### DIFF
--- a/airflow-core/src/airflow/plugins_manager.py
+++ b/airflow-core/src/airflow/plugins_manager.py
@@ -32,13 +32,17 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from airflow import settings
-from airflow._shared.module_loading import entry_points_with_dist, import_string, qualname
+from airflow._shared.module_loading import (
+    entry_points_with_dist,
+    find_path_from_directory,
+    import_string,
+    qualname,
+)
 from airflow.configuration import conf
 from airflow.task.priority_strategy import (
     PriorityWeightStrategy,
     airflow_priority_weight_strategies,
 )
-from airflow.utils.file import find_path_from_directory
 
 if TYPE_CHECKING:
     from airflow.lineage.hook import HookLineageReader
@@ -205,7 +209,8 @@ def _load_plugins_from_plugin_directory() -> tuple[list[AirflowPlugin], dict[str
     if settings.PLUGINS_FOLDER is None:
         raise ValueError("Plugins folder is not set")
     log.debug("Loading plugins from directory: %s", settings.PLUGINS_FOLDER)
-    files = find_path_from_directory(settings.PLUGINS_FOLDER, ".airflowignore")
+    ignore_file_syntax = conf.get_mandatory_value("core", "DAG_IGNORE_FILE_SYNTAX", fallback="glob")
+    files = find_path_from_directory(settings.PLUGINS_FOLDER, ".airflowignore", ignore_file_syntax)
     plugin_search_locations: list[tuple[str, Generator[str, None, None]]] = [("", files)]
 
     if conf.getboolean("core", "LOAD_EXAMPLES"):
@@ -213,7 +218,7 @@ def _load_plugins_from_plugin_directory() -> tuple[list[AirflowPlugin], dict[str
         from airflow.example_dags import plugins as example_plugins
 
         example_plugins_folder = next(iter(example_plugins.__path__))
-        example_files = find_path_from_directory(example_plugins_folder, ".airflowignore")
+        example_files = find_path_from_directory(example_plugins_folder, ".airflowignore", ignore_file_syntax)
         plugin_search_locations.append((example_plugins.__name__, example_files))
 
     plugins: list[AirflowPlugin] = []

--- a/airflow-core/src/airflow/utils/file.py
+++ b/airflow-core/src/airflow/utils/file.py
@@ -26,103 +26,14 @@ import zipfile
 from collections.abc import Generator
 from io import TextIOWrapper
 from pathlib import Path
-from re import Pattern
-from typing import NamedTuple, Protocol, overload
+from typing import overload
 
-from pathspec.patterns import GitWildMatchPattern
-
+from airflow._shared.module_loading import find_path_from_directory
 from airflow.configuration import conf
 
 log = logging.getLogger(__name__)
 
 MODIFIED_DAG_MODULE_NAME = "unusual_prefix_{path_hash}_{module_name}"
-
-
-class _IgnoreRule(Protocol):
-    """Interface for ignore rules for structural subtyping."""
-
-    @staticmethod
-    def compile(pattern: str, base_dir: Path, definition_file: Path) -> _IgnoreRule | None:
-        """
-        Build an ignore rule from the supplied pattern.
-
-        ``base_dir`` and ``definition_file`` should be absolute paths.
-        """
-
-    @staticmethod
-    def match(path: Path, rules: list[_IgnoreRule]) -> bool:
-        """Match a candidate absolute path against a list of rules."""
-
-
-class _RegexpIgnoreRule(NamedTuple):
-    """Typed namedtuple with utility functions for regexp ignore rules."""
-
-    pattern: Pattern
-    base_dir: Path
-
-    @staticmethod
-    def compile(pattern: str, base_dir: Path, definition_file: Path) -> _IgnoreRule | None:
-        """Build an ignore rule from the supplied regexp pattern and log a useful warning if it is invalid."""
-        try:
-            return _RegexpIgnoreRule(re.compile(pattern), base_dir)
-        except re.error as e:
-            log.warning("Ignoring invalid regex '%s' from %s: %s", pattern, definition_file, e)
-            return None
-
-    @staticmethod
-    def match(path: Path, rules: list[_IgnoreRule]) -> bool:
-        """Match a list of ignore rules against the supplied path."""
-        for rule in rules:
-            if not isinstance(rule, _RegexpIgnoreRule):
-                raise ValueError(f"_RegexpIgnoreRule cannot match rules of type: {type(rule)}")
-            if rule.pattern.search(str(path.relative_to(rule.base_dir))) is not None:
-                return True
-        return False
-
-
-class _GlobIgnoreRule(NamedTuple):
-    """Typed namedtuple with utility functions for glob ignore rules."""
-
-    wild_match_pattern: GitWildMatchPattern
-    relative_to: Path | None = None
-
-    @staticmethod
-    def compile(pattern: str, base_dir: Path, definition_file: Path) -> _IgnoreRule | None:
-        """Build an ignore rule from the supplied glob pattern and log a useful warning if it is invalid."""
-        relative_to: Path | None = None
-        if pattern.strip() == "/":
-            # "/" doesn't match anything in gitignore
-            log.warning("Ignoring no-op glob pattern '/' from %s", definition_file)
-            return None
-        if pattern.startswith("/") or "/" in pattern.rstrip("/"):
-            # See https://git-scm.com/docs/gitignore
-            # > If there is a separator at the beginning or middle (or both) of the pattern, then the
-            # > pattern is relative to the directory level of the particular .gitignore file itself.
-            # > Otherwise the pattern may also match at any level below the .gitignore level.
-            relative_to = definition_file.parent
-
-        ignore_pattern = GitWildMatchPattern(pattern)
-        return _GlobIgnoreRule(wild_match_pattern=ignore_pattern, relative_to=relative_to)
-
-    @staticmethod
-    def match(path: Path, rules: list[_IgnoreRule]) -> bool:
-        """Match a list of ignore rules against the supplied path, accounting for exclusion rules and ordering."""
-        matched = False
-        for rule in rules:
-            if not isinstance(rule, _GlobIgnoreRule):
-                raise ValueError(f"_GlobIgnoreRule cannot match rules of type: {type(rule)}")
-            rel_obj = path.relative_to(rule.relative_to) if rule.relative_to else Path(path.name)
-            if path.is_dir():
-                rel_path = f"{rel_obj.as_posix()}/"
-            else:
-                rel_path = rel_obj.as_posix()
-            if (
-                rule.wild_match_pattern.include is not None
-                and rule.wild_match_pattern.match_file(rel_path) is not None
-            ):
-                matched = rule.wild_match_pattern.include
-
-        return matched
 
 
 ZIP_REGEX = re.compile(rf"((.*\.zip){re.escape(os.sep)})?(.*)")
@@ -164,84 +75,6 @@ def open_maybe_zipped(fileloc, mode="r"):
     return open(fileloc, mode=mode)
 
 
-def _find_path_from_directory(
-    base_dir_path: str | os.PathLike[str],
-    ignore_file_name: str,
-    ignore_rule_type: type[_IgnoreRule],
-) -> Generator[str, None, None]:
-    """
-    Recursively search the base path and return the list of file paths that should not be ignored.
-
-    :param base_dir_path: the base path to be searched
-    :param ignore_file_name: the file name containing regular expressions for files that should be ignored.
-    :param ignore_rule_type: the concrete class for ignore rules, which implements the _IgnoreRule interface.
-
-    :return: a generator of file paths which should not be ignored.
-    """
-    # A Dict of patterns, keyed using resolved, absolute paths
-    patterns_by_dir: dict[Path, list[_IgnoreRule]] = {}
-
-    for root, dirs, files in os.walk(base_dir_path, followlinks=True):
-        patterns: list[_IgnoreRule] = patterns_by_dir.get(Path(root).resolve(), [])
-
-        ignore_file_path = Path(root) / ignore_file_name
-        if ignore_file_path.is_file():
-            with open(ignore_file_path) as ifile:
-                patterns_to_match_excluding_comments = [
-                    re.sub(r"\s*#.*", "", line) for line in ifile.read().split("\n")
-                ]
-                # append new patterns and filter out "None" objects, which are invalid patterns
-                patterns += [
-                    p
-                    for p in [
-                        ignore_rule_type.compile(pattern, Path(base_dir_path), ignore_file_path)
-                        for pattern in patterns_to_match_excluding_comments
-                        if pattern
-                    ]
-                    if p is not None
-                ]
-                # evaluation order of patterns is important with negation
-                # so that later patterns can override earlier patterns
-
-        dirs[:] = [subdir for subdir in dirs if not ignore_rule_type.match(Path(root) / subdir, patterns)]
-        # explicit loop for infinite recursion detection since we are following symlinks in this walk
-        for sd in dirs:
-            dirpath = (Path(root) / sd).resolve()
-            if dirpath in patterns_by_dir:
-                raise RuntimeError(
-                    "Detected recursive loop when walking DAG directory "
-                    f"{base_dir_path}: {dirpath} has appeared more than once."
-                )
-            patterns_by_dir.update({dirpath: patterns.copy()})
-
-        for file in files:
-            if file != ignore_file_name:
-                abs_file_path = Path(root) / file
-                if not ignore_rule_type.match(abs_file_path, patterns):
-                    yield str(abs_file_path)
-
-
-def find_path_from_directory(
-    base_dir_path: str | os.PathLike[str],
-    ignore_file_name: str,
-    ignore_file_syntax: str = conf.get_mandatory_value("core", "DAG_IGNORE_FILE_SYNTAX", fallback="glob"),
-) -> Generator[str, None, None]:
-    """
-    Recursively search the base path for a list of file paths that should not be ignored.
-
-    :param base_dir_path: the base path to be searched
-    :param ignore_file_name: the file name in which specifies the patterns of files/dirs to be ignored
-    :param ignore_file_syntax: the syntax of patterns in the ignore file: regexp or glob
-
-    :return: a generator of file paths.
-    """
-    if ignore_file_syntax == "glob" or not ignore_file_syntax:
-        return _find_path_from_directory(base_dir_path, ignore_file_name, _GlobIgnoreRule)
-    if ignore_file_syntax == "regexp":
-        return _find_path_from_directory(base_dir_path, ignore_file_name, _RegexpIgnoreRule)
-    raise ValueError(f"Unsupported ignore_file_syntax: {ignore_file_syntax}")
-
-
 def list_py_file_paths(
     directory: str | os.PathLike[str] | None,
     safe_mode: bool = conf.getboolean("core", "DAG_DISCOVERY_SAFE_MODE", fallback=True),
@@ -269,8 +102,9 @@ def list_py_file_paths(
 def find_dag_file_paths(directory: str | os.PathLike[str], safe_mode: bool) -> list[str]:
     """Find file paths of all DAG files."""
     file_paths = []
+    ignore_file_syntax = conf.get_mandatory_value("core", "DAG_IGNORE_FILE_SYNTAX", fallback="glob")
 
-    for file_path in find_path_from_directory(directory, ".airflowignore"):
+    for file_path in find_path_from_directory(directory, ".airflowignore", ignore_file_syntax):
         path = Path(file_path)
         try:
             if path.is_file() and (path.suffix == ".py" or zipfile.is_zipfile(path)):

--- a/airflow-core/tests/unit/plugins/test_plugin_ignore.py
+++ b/airflow-core/tests/unit/plugins/test_plugin_ignore.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from airflow import settings
-from airflow.utils.file import find_path_from_directory
+from airflow._shared.module_loading import find_path_from_directory
 
 
 def populate_dir(root_path):

--- a/airflow-core/tests/unit/utils/test_file.py
+++ b/airflow-core/tests/unit/utils/test_file.py
@@ -19,16 +19,15 @@ from __future__ import annotations
 
 import os
 import zipfile
-from pathlib import Path
 from pprint import pformat
 from unittest import mock
 
 import pytest
 
+from airflow._shared.module_loading import find_path_from_directory
 from airflow.utils import file as file_utils
 from airflow.utils.file import (
     correct_maybe_zipped,
-    find_path_from_directory,
     list_py_file_paths,
     open_maybe_zipped,
 )
@@ -97,23 +96,6 @@ class TestOpenMaybeZipped:
 
 
 class TestListPyFilesPath:
-    @pytest.fixture
-    def test_dir(self, tmp_path):
-        # create test tree with symlinks
-        source = os.path.join(tmp_path, "folder")
-        target = os.path.join(tmp_path, "symlink")
-        py_file = os.path.join(source, "hello_world.py")
-        ignore_file = os.path.join(tmp_path, ".airflowignore")
-        os.mkdir(source)
-        os.symlink(source, target)
-        # write ignore files
-        with open(ignore_file, "w") as f:
-            f.write("folder")
-        # write sample pyfile
-        with open(py_file, "w") as f:
-            f.write("print('hello world')")
-        return tmp_path
-
     def test_find_path_from_directory_regex_ignore(self):
         should_ignore = [
             "test_invalid_cron.py",
@@ -154,105 +136,10 @@ class TestListPyFilesPath:
             f"actual_included_filenames: {pformat(actual_included_filenames)}\nexpected_included_filenames: {pformat(should_not_ignore)}"
         )
 
-    def test_find_path_from_directory_respects_symlinks_regexp_ignore(self, test_dir):
-        ignore_list_file = ".airflowignore"
-        found = list(find_path_from_directory(test_dir, ignore_list_file))
-
-        assert os.path.join(test_dir, "symlink", "hello_world.py") in found
-        assert os.path.join(test_dir, "folder", "hello_world.py") not in found
-
-    def test_find_path_from_directory_respects_symlinks_glob_ignore(self, test_dir):
-        ignore_list_file = ".airflowignore"
-        found = list(find_path_from_directory(test_dir, ignore_list_file, ignore_file_syntax="glob"))
-
-        assert os.path.join(test_dir, "symlink", "hello_world.py") in found
-        assert os.path.join(test_dir, "folder", "hello_world.py") not in found
-
-    def test_find_path_from_directory_fails_on_recursive_link(self, test_dir):
-        # add a recursive link
-        recursing_src = os.path.join(test_dir, "folder2", "recursor")
-        recursing_tgt = os.path.join(test_dir, "folder2")
-        os.mkdir(recursing_tgt)
-        os.symlink(recursing_tgt, recursing_src)
-
-        ignore_list_file = ".airflowignore"
-
-        error_message = (
-            f"Detected recursive loop when walking DAG directory {test_dir}: "
-            f"{Path(recursing_tgt).resolve()} has appeared more than once."
-        )
-        with pytest.raises(RuntimeError, match=error_message):
-            list(find_path_from_directory(test_dir, ignore_list_file, ignore_file_syntax="glob"))
-
     def test_might_contain_dag_with_default_callable(self):
         file_path_with_dag = os.path.join(TEST_DAGS_FOLDER, "test_scheduler_dags.py")
 
         assert file_utils.might_contain_dag(file_path=file_path_with_dag, safe_mode=True)
-
-    def test_airflowignore_negation_unignore_subfolder_file_glob(self, tmp_path):
-        """Ensure negation rules can unignore a subfolder and a file inside it when using glob syntax.
-
-        Patterns:
-          *                     -> ignore everything
-          !subfolder/           -> unignore the subfolder (must match directory rule)
-          !subfolder/keep.py    -> unignore a specific file inside the subfolder
-        """
-        dags_root = tmp_path / "dags"
-        (dags_root / "subfolder").mkdir(parents=True)
-        # files
-        (dags_root / "drop.py").write_text("raise Exception('ignored')\n")
-        (dags_root / "subfolder" / "keep.py").write_text("# should be discovered\n")
-        (dags_root / "subfolder" / "drop.py").write_text("raise Exception('ignored')\n")
-
-        (dags_root / ".airflowignore").write_text(
-            "\n".join(
-                [
-                    "*",
-                    "!subfolder/",
-                    "!subfolder/keep.py",
-                ]
-            )
-        )
-
-        detected = set()
-        for raw in find_path_from_directory(dags_root, ".airflowignore", "glob"):
-            p = Path(raw)
-            if p.is_file() and p.suffix == ".py":
-                detected.add(p.relative_to(dags_root).as_posix())
-
-        assert detected == {"subfolder/keep.py"}
-
-    def test_airflowignore_negation_nested_with_globstar(self, tmp_path):
-        """Negation with ** should work for nested subfolders."""
-        dags_root = tmp_path / "dags"
-        nested = dags_root / "a" / "b" / "subfolder"
-        nested.mkdir(parents=True)
-
-        # files
-        (dags_root / "ignore_top.py").write_text("raise Exception('ignored')\n")
-        (nested / "keep.py").write_text("# should be discovered\n")
-        (nested / "drop.py").write_text("raise Exception('ignored')\n")
-
-        (dags_root / ".airflowignore").write_text(
-            "\n".join(
-                [
-                    "*",
-                    "!a/",
-                    "!a/b/",
-                    "!**/subfolder/",
-                    "!**/subfolder/keep.py",
-                    "drop.py",
-                ]
-            )
-        )
-
-        detected = set()
-        for raw in find_path_from_directory(dags_root, ".airflowignore", "glob"):
-            p = Path(raw)
-            if p.is_file() and p.suffix == ".py":
-                detected.add(p.relative_to(dags_root).as_posix())
-
-        assert detected == {"a/b/subfolder/keep.py"}
 
     @conf_vars({("core", "might_contain_dag_callable"): "unit.utils.test_file.might_contain_dag"})
     def test_might_contain_dag(self):

--- a/shared/module_loading/pyproject.toml
+++ b/shared/module_loading/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 
 dependencies = [
     'importlib_metadata>=6.5;python_version<"3.12"',
+    "pathspec>=0.9.0",
 ]
 
 [dependency-groups]

--- a/shared/module_loading/src/airflow_shared/module_loading/__init__.py
+++ b/shared/module_loading/src/airflow_shared/module_loading/__init__.py
@@ -26,7 +26,7 @@ from collections.abc import Callable, Iterator
 from importlib import import_module
 from typing import TYPE_CHECKING
 
-from airflow_shared.module_loading.file_discovery import (
+from .file_discovery import (
     find_path_from_directory as find_path_from_directory,
 )
 

--- a/shared/module_loading/src/airflow_shared/module_loading/__init__.py
+++ b/shared/module_loading/src/airflow_shared/module_loading/__init__.py
@@ -26,6 +26,10 @@ from collections.abc import Callable, Iterator
 from importlib import import_module
 from typing import TYPE_CHECKING
 
+from airflow_shared.module_loading.file_discovery import (
+    find_path_from_directory as find_path_from_directory,
+)
+
 if sys.version_info >= (3, 12):
     from importlib import metadata
 else:

--- a/shared/module_loading/src/airflow_shared/module_loading/file_discovery.py
+++ b/shared/module_loading/src/airflow_shared/module_loading/file_discovery.py
@@ -1,0 +1,197 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""File discovery utilities for finding files while respecting ignore patterns."""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from collections.abc import Generator
+from pathlib import Path
+from re import Pattern
+from typing import NamedTuple, Protocol
+
+from pathspec.patterns import GitWildMatchPattern
+
+log = logging.getLogger(__name__)
+
+
+class _IgnoreRule(Protocol):
+    """Interface for ignore rules for structural subtyping."""
+
+    @staticmethod
+    def compile(pattern: str, base_dir: Path, definition_file: Path) -> _IgnoreRule | None:
+        """
+        Build an ignore rule from the supplied pattern.
+
+        ``base_dir`` and ``definition_file`` should be absolute paths.
+        """
+
+    @staticmethod
+    def match(path: Path, rules: list[_IgnoreRule]) -> bool:
+        """Match a candidate absolute path against a list of rules."""
+
+
+class _RegexpIgnoreRule(NamedTuple):
+    """Typed namedtuple with utility functions for regexp ignore rules."""
+
+    pattern: Pattern
+    base_dir: Path
+
+    @staticmethod
+    def compile(pattern: str, base_dir: Path, definition_file: Path) -> _IgnoreRule | None:
+        """Build an ignore rule from the supplied regexp pattern and log a useful warning if it is invalid."""
+        try:
+            return _RegexpIgnoreRule(re.compile(pattern), base_dir)
+        except re.error as e:
+            log.warning("Ignoring invalid regex '%s' from %s: %s", pattern, definition_file, e)
+            return None
+
+    @staticmethod
+    def match(path: Path, rules: list[_IgnoreRule]) -> bool:
+        """Match a list of ignore rules against the supplied path."""
+        for rule in rules:
+            if not isinstance(rule, _RegexpIgnoreRule):
+                raise ValueError(f"_RegexpIgnoreRule cannot match rules of type: {type(rule)}")
+            if rule.pattern.search(str(path.relative_to(rule.base_dir))) is not None:
+                return True
+        return False
+
+
+class _GlobIgnoreRule(NamedTuple):
+    """Typed namedtuple with utility functions for glob ignore rules."""
+
+    wild_match_pattern: GitWildMatchPattern
+    relative_to: Path | None = None
+
+    @staticmethod
+    def compile(pattern: str, base_dir: Path, definition_file: Path) -> _IgnoreRule | None:
+        """Build an ignore rule from the supplied glob pattern and log a useful warning if it is invalid."""
+        relative_to: Path | None = None
+        if pattern.strip() == "/":
+            # "/" doesn't match anything in gitignore
+            log.warning("Ignoring no-op glob pattern '/' from %s", definition_file)
+            return None
+        if pattern.startswith("/") or "/" in pattern.rstrip("/"):
+            # See https://git-scm.com/docs/gitignore
+            # > If there is a separator at the beginning or middle (or both) of the pattern, then the
+            # > pattern is relative to the directory level of the particular .gitignore file itself.
+            # > Otherwise the pattern may also match at any level below the .gitignore level.
+            relative_to = definition_file.parent
+
+        ignore_pattern = GitWildMatchPattern(pattern)
+        return _GlobIgnoreRule(wild_match_pattern=ignore_pattern, relative_to=relative_to)
+
+    @staticmethod
+    def match(path: Path, rules: list[_IgnoreRule]) -> bool:
+        """Match a list of ignore rules against the supplied path, accounting for exclusion rules and ordering."""
+        matched = False
+        for rule in rules:
+            if not isinstance(rule, _GlobIgnoreRule):
+                raise ValueError(f"_GlobIgnoreRule cannot match rules of type: {type(rule)}")
+            rel_obj = path.relative_to(rule.relative_to) if rule.relative_to else Path(path.name)
+            if path.is_dir():
+                rel_path = f"{rel_obj.as_posix()}/"
+            else:
+                rel_path = rel_obj.as_posix()
+            if (
+                rule.wild_match_pattern.include is not None
+                and rule.wild_match_pattern.match_file(rel_path) is not None
+            ):
+                matched = rule.wild_match_pattern.include
+
+        return matched
+
+
+def _find_path_from_directory(
+    base_dir_path: str | os.PathLike[str],
+    ignore_file_name: str,
+    ignore_rule_type: type[_IgnoreRule],
+) -> Generator[str, None, None]:
+    """
+    Recursively search the base path and return the list of file paths that should not be ignored.
+
+    :param base_dir_path: the base path to be searched
+    :param ignore_file_name: the file name containing regular expressions for files that should be ignored.
+    :param ignore_rule_type: the concrete class for ignore rules, which implements the _IgnoreRule interface.
+
+    :return: a generator of file paths which should not be ignored.
+    """
+    # A Dict of patterns, keyed using resolved, absolute paths
+    patterns_by_dir: dict[Path, list[_IgnoreRule]] = {}
+
+    for root, dirs, files in os.walk(base_dir_path, followlinks=True):
+        patterns: list[_IgnoreRule] = patterns_by_dir.get(Path(root).resolve(), [])
+
+        ignore_file_path = Path(root) / ignore_file_name
+        if ignore_file_path.is_file():
+            with open(ignore_file_path) as ifile:
+                patterns_to_match_excluding_comments = [
+                    re.sub(r"\s*#.*", "", line) for line in ifile.read().split("\n")
+                ]
+                # append new patterns and filter out "None" objects, which are invalid patterns
+                patterns += [
+                    p
+                    for p in [
+                        ignore_rule_type.compile(pattern, Path(base_dir_path), ignore_file_path)
+                        for pattern in patterns_to_match_excluding_comments
+                        if pattern
+                    ]
+                    if p is not None
+                ]
+                # evaluation order of patterns is important with negation
+                # so that later patterns can override earlier patterns
+
+        dirs[:] = [subdir for subdir in dirs if not ignore_rule_type.match(Path(root) / subdir, patterns)]
+        # explicit loop for infinite recursion detection since we are following symlinks in this walk
+        for sd in dirs:
+            dirpath = (Path(root) / sd).resolve()
+            if dirpath in patterns_by_dir:
+                raise RuntimeError(
+                    "Detected recursive loop when walking DAG directory "
+                    f"{base_dir_path}: {dirpath} has appeared more than once."
+                )
+            patterns_by_dir.update({dirpath: patterns.copy()})
+
+        for file in files:
+            if file != ignore_file_name:
+                abs_file_path = Path(root) / file
+                if not ignore_rule_type.match(abs_file_path, patterns):
+                    yield str(abs_file_path)
+
+
+def find_path_from_directory(
+    base_dir_path: str | os.PathLike[str],
+    ignore_file_name: str,
+    ignore_file_syntax: str = "glob",
+) -> Generator[str, None, None]:
+    """
+    Recursively search the base path for a list of file paths that should not be ignored.
+
+    :param base_dir_path: the base path to be searched
+    :param ignore_file_name: the file name in which specifies the patterns of files/dirs to be ignored
+    :param ignore_file_syntax: the syntax of patterns in the ignore file: regexp or glob (default: glob)
+
+    :return: a generator of file paths.
+    """
+    if ignore_file_syntax == "glob" or not ignore_file_syntax:
+        return _find_path_from_directory(base_dir_path, ignore_file_name, _GlobIgnoreRule)
+    if ignore_file_syntax == "regexp":
+        return _find_path_from_directory(base_dir_path, ignore_file_name, _RegexpIgnoreRule)
+    raise ValueError(f"Unsupported ignore_file_syntax: {ignore_file_syntax}")

--- a/shared/module_loading/tests/module_loading/test_file_discovery.py
+++ b/shared/module_loading/tests/module_loading/test_file_discovery.py
@@ -1,0 +1,139 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from airflow_shared.module_loading import find_path_from_directory
+
+
+class TestFindPathFromDirectory:
+    @pytest.fixture
+    def test_dir(self, tmp_path):
+        # create test tree with symlinks
+        source = os.path.join(tmp_path, "folder")
+        target = os.path.join(tmp_path, "symlink")
+        py_file = os.path.join(source, "hello_world.py")
+        ignore_file = os.path.join(tmp_path, ".airflowignore")
+        os.mkdir(source)
+        os.symlink(source, target)
+        # write ignore files
+        with open(ignore_file, "w") as f:
+            f.write("folder")
+        # write sample pyfile
+        with open(py_file, "w") as f:
+            f.write("print('hello world')")
+        return tmp_path
+
+    def test_find_path_from_directory_respects_symlinks_regexp_ignore(self, test_dir):
+        ignore_list_file = ".airflowignore"
+        found = list(find_path_from_directory(test_dir, ignore_list_file, "regexp"))
+
+        assert os.path.join(test_dir, "symlink", "hello_world.py") in found
+        assert os.path.join(test_dir, "folder", "hello_world.py") not in found
+
+    def test_find_path_from_directory_respects_symlinks_glob_ignore(self, test_dir):
+        ignore_list_file = ".airflowignore"
+        found = list(find_path_from_directory(test_dir, ignore_list_file, ignore_file_syntax="glob"))
+
+        assert os.path.join(test_dir, "symlink", "hello_world.py") in found
+        assert os.path.join(test_dir, "folder", "hello_world.py") not in found
+
+    def test_find_path_from_directory_fails_on_recursive_link(self, test_dir):
+        # add a recursive link
+        recursing_src = os.path.join(test_dir, "folder2", "recursor")
+        recursing_tgt = os.path.join(test_dir, "folder2")
+        os.mkdir(recursing_tgt)
+        os.symlink(recursing_tgt, recursing_src)
+
+        ignore_list_file = ".airflowignore"
+
+        error_message = (
+            f"Detected recursive loop when walking DAG directory {test_dir}: "
+            f"{Path(recursing_tgt).resolve()} has appeared more than once."
+        )
+        with pytest.raises(RuntimeError, match=error_message):
+            list(find_path_from_directory(test_dir, ignore_list_file, ignore_file_syntax="glob"))
+
+    def test_airflowignore_negation_unignore_subfolder_file_glob(self, tmp_path):
+        """Ensure negation rules can unignore a subfolder and a file inside it when using glob syntax.
+
+        Patterns:
+          *                     -> ignore everything
+          !subfolder/           -> unignore the subfolder (must match directory rule)
+          !subfolder/keep.py    -> unignore a specific file inside the subfolder
+        """
+        dags_root = tmp_path / "dags"
+        (dags_root / "subfolder").mkdir(parents=True)
+        # files
+        (dags_root / "drop.py").write_text("raise Exception('ignored')\n")
+        (dags_root / "subfolder" / "keep.py").write_text("# should be discovered\n")
+        (dags_root / "subfolder" / "drop.py").write_text("raise Exception('ignored')\n")
+
+        (dags_root / ".airflowignore").write_text(
+            "\n".join(
+                [
+                    "*",
+                    "!subfolder/",
+                    "!subfolder/keep.py",
+                ]
+            )
+        )
+
+        detected = set()
+        for raw in find_path_from_directory(dags_root, ".airflowignore", "glob"):
+            p = Path(raw)
+            if p.is_file() and p.suffix == ".py":
+                detected.add(p.relative_to(dags_root).as_posix())
+
+        assert detected == {"subfolder/keep.py"}
+
+    def test_airflowignore_negation_nested_with_globstar(self, tmp_path):
+        """Negation with ** should work for nested subfolders."""
+        dags_root = tmp_path / "dags"
+        nested = dags_root / "a" / "b" / "subfolder"
+        nested.mkdir(parents=True)
+
+        # files
+        (dags_root / "ignore_top.py").write_text("raise Exception('ignored')\n")
+        (nested / "keep.py").write_text("# should be discovered\n")
+        (nested / "drop.py").write_text("raise Exception('ignored')\n")
+
+        (dags_root / ".airflowignore").write_text(
+            "\n".join(
+                [
+                    "*",
+                    "!a/",
+                    "!a/b/",
+                    "!**/subfolder/",
+                    "!**/subfolder/keep.py",
+                    "drop.py",
+                ]
+            )
+        )
+
+        detected = set()
+        for raw in find_path_from_directory(dags_root, ".airflowignore", "glob"):
+            p = Path(raw)
+            if p.is_file() and p.suffix == ".py":
+                detected.add(p.relative_to(dags_root).as_posix())
+
+        assert detected == {"a/b/subfolder/keep.py"}

--- a/task-sdk/pyproject.toml
+++ b/task-sdk/pyproject.toml
@@ -79,6 +79,7 @@ dependencies = [
     # End of shared configuration dependencies
     # Start of shared module-loading dependencies
     'importlib_metadata>=6.5;python_version<"3.12"',
+    "pathspec>=0.9.0",
     # End of shared module-loading dependencies
 ]
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This is a precursor to: https://github.com/apache/airflow/pull/59956 to remove usages of `airflow` references in shared libraries.

There are some utilities like this one: `find_path_from_directory` which is needed in dag path discovery as well in plugins manager. Right now its present in `utils.file`. 

Since it is a module_loading related utility, moving it to module_loading shared library made the most sense. This allows shared libraries like plugins_manager to use the
function without importing from `airflow.*`

Changes of note:
- New file `shared/module_loading/file_discovery.py`
- Update `airflow.utils.file` to import from shared and inline config
- Update `plugins_manager` to import from shared library

The method in shared library defaults to "glob" syntax. Any callers that needed a change have been updated to instead inject the dependency config after reading it from `conf`

Deprecation works:
```python
from airflow.utils.file import find_path_from_directory
<ipython-input-2-a3047d0a2d8f>:1 DeprecatedImportWarning: Importing find_path_from_directory from airflow.utils.file is deprecated and will be removed in a future version. Use airflow._shared.module_loading.find_path_from_directory instead.

```

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
