### PR TITLE
Allow custom volumeClaimTemplates when logs.persistence.enabled is true

### DIFF
--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -461,8 +461,10 @@ spec:
   {{- else if not $persistence }}
         - name: logs
           emptyDir: {{- toYaml (default (dict) .Values.logs.emptyDirConfig) | nindent 12 }}
-  {{- else }}
+  {{- end }}
+  {{- if and $persistence (or (not .Values.logs.persistence.enabled) .Values.workers.volumeClaimTemplates) }}
   volumeClaimTemplates:
+    {{- if not .Values.logs.persistence.enabled }}
     - apiVersion: v1
       kind: PersistentVolumeClaim
       metadata:
@@ -478,6 +480,7 @@ spec:
         resources:
           requests:
             storage: {{ .Values.workers.persistence.size }}
+    {{- end }}
     {{- with .Values.workers.volumeClaimTemplates }}
       {{- toYaml . | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
## Fixes : #59571
## Problem
Custom volumeClaimTemplates for workers were ignored when workers.persistence.enabled: true and logs.persistence.enabled: true. The volumeClaimTemplates section was only rendered in the {{- else }} branch, which only runs when logs.persistence.enabled: false. As a result, custom templates were never created, causing pods to fail with volume mount errors.
## Root Cause:
The template logic in worker-deployment.yaml had the volumeClaimTemplates section nested inside an {{- else }} block that only executed when logs.persistence.enabled: false. When logs.persistence.enabled: true, the code took the first branch (creating logs as a regular PVC) and skipped the {{- else }} block entirely, preventing custom volumeClaimTemplates from being rendered.
## Solution
Separated the volumeClaimTemplates logic from the logs volume handling. The volumeClaimTemplates section is now created independently when:
workers.persistence.enabled: true (StatefulSet is used), AND
Either logs.persistence.enabled: false (logs needs to be a template) OR custom volumeClaimTemplates are provided
This ensures custom volumeClaimTemplates are always rendered when provided, regardless of the logs persistence setting.