### PR TITLE
Hardened Docker base images fail due to usrmerge incompatibility on Debian 12

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -30,7 +30,7 @@
 #
 # Related: https://github.com/apache/airflow/issues/58337
 ARG PYTHON_LTO="true"
-ARG BASE_IMAGE="debian:bookworm-slim"
+ARG BASE_IMAGE="dhi.io/python:3.12-debian12-dev"
 
 ##############################################################################################
 # This is the script image where we keep all inlined bash scripts needed in other segments


### PR DESCRIPTION
While experimenting with switching Airflow CI images to Docker Hardened Images (dhi.io/python:*), CI builds consistently fail during OS dependency installation on Debian 12.
The failure is caused by` usrmerge` being implicitly installed as a dependency (via lsb-release) and breaking during its post-installation step due to filesystem restrictions in hardened images.
This issue is deterministic and cannot be resolved through script-level workarounds.

**Environment**

- Base image: dhi.io/python:3.12-debian12-dev
- OS: Debian 12 (bookworm)
- Context: Airflow CI Docker build
- Affected script: install_os_dependencies.sh

**Observed Failure**
During apt-get install, `usrmerge` is pulled in automatically:
```
Unpacking usrmerge (37~deb12u1) ...
Setting up usrmerge (37~deb12u1) ...
removed '/lib64'
/var/lib/dpkg/info/usrmerge.postinst: line 70: /usr/bin/rmdir: cannot execute: required file not found
dpkg: error processing package usrmerge (--configure)

```
This leaves dpkg in a half-configured state and causes the Docker build to fail permanently.

**Root Cause Analysis**

- `usrmerge `is installed indirectly, primarily via lsb-release
- Debian executes `usrmerge.postinst` immediately during unpack
- Hardened Docker images intentionally restrict filesystem operations
- `usrmerge `attempts to:
- remove /lib64
- execute /usr/bin/rmdir
- These operations are blocked by the hardened image

Once `usrmerge `reaches the unpack phase, no cleanup, purge, or hold can recover the build.

**What Was Tried (and Why It Does Not Work)**

The following approaches were tested and confirmed ineffective:

- apt-mark hold usrmerge
- apt-get purge usrmerge
- Post-install cleanup or symlink fixes
- Conditional logic inside install_os_dependencies.sh
- Reordering or splitting apt installs
All of these fail because `usrmerge `executes its post-install script before any script-level logic can intervene.

**Validation**

Switching back to a non-hardened base image confirms the diagnosis:

`FROM python:3.12-slim-bookworm`
- CI build completes successfully
- No `usrmerge `installation
- No `dpkg `corruption
This proves the failure is caused by base-image incompatibility, not Airflow scripts.

**Conclusion**

This is not a bug in Airflow’s Docker scripts.

It is an incompatibility between:
Debian 12’s `usrmerge `lifecycle
and Docker Hardened Images’ filesystem restrictions

As long as `usrmerge `is allowed to unpack, CI builds on hardened images will fail.