### PR TITLE
Refactor DAG file queuing and fix redundant processing

### DIFF
--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -342,7 +342,7 @@ class TestDagFileProcessorManager:
         manager.prepare_file_queue(
             known_files={"any": set((*dag_files, *_get_file_infos(["file_4-ss=1.0.py"])))}
         )
-        # manager.add_files_to_queue()
+        # manager._add_new_files_to_queue()
         ordered_files = _get_file_infos(
             [
                 "file_3-ss=4.0.py",
@@ -352,6 +352,41 @@ class TestDagFileProcessorManager:
             ]
         )
         assert manager._file_queue == deque(ordered_files)
+
+    def test_add_new_files_to_queue_behavior(self):
+        """
+        Check that _add_new_files_to_queue:
+        1. Adds new files to the front of the queue.
+        2. Skips files that are currently being processed.
+        3. Skips files that have already been processed (in _file_stats).
+        4. Does not re-add files already in the queue.
+        """
+        manager = DagFileProcessorManager(max_runs=1)
+        file_1 = DagFileInfo(bundle_name="testing", rel_path=Path("file_1.py"), bundle_path=TEST_DAGS_FOLDER)
+        file_2 = DagFileInfo(bundle_name="testing", rel_path=Path("file_2.py"), bundle_path=TEST_DAGS_FOLDER)
+        file_3 = DagFileInfo(bundle_name="testing", rel_path=Path("file_3.py"), bundle_path=TEST_DAGS_FOLDER)
+        file_4 = DagFileInfo(bundle_name="testing", rel_path=Path("file_4.py"), bundle_path=TEST_DAGS_FOLDER)
+
+        # Setup:
+        # file_1 is already in the queue
+        manager._file_queue = deque([file_1])
+
+        # file_3 is currently being processed
+        manager._processors[file_3] = MagicMock()
+
+        # file_4 has already been processed
+        manager._file_stats[file_4] = DagFileStat(num_dags=1)
+
+        # known_files contains all four
+        known_files = {"testing": {file_1, file_2, file_3, file_4}}
+
+        manager._add_new_files_to_queue(known_files)
+
+        # file_4 should be ignored (in file_stats)
+        # file_3 should be ignored (processing)
+        # file_2 should be at the front (new)
+        # file_1 should remain (already in queue)
+        assert list(manager._file_queue) == [file_2, file_1]
 
     @conf_vars({("dag_processor", "file_parsing_sort_mode"): "modified_time"})
     @mock.patch("airflow.utils.file.os.path.getmtime", new=mock_get_mtime)


### PR DESCRIPTION
Renamed `add_files_to_queue` to `_add_new_files_to_queue` in `DagFileProcessorManager` to reduce confusion with `_add_files_to_queue` and better reflect its internal usage for newly discovered files.

We also call the method only after a bundle has refreshed - we can't find new files without that, so doing it in every loop is wasteful.

The method now checks `_processors` in addition to `_file_stats` before adding files. This prevents a race condition where files currently being processed (which don't yet have stats) were erroneously re-added to the parsing queue.

The method also now results in the `dag_processing.file_path_queue_size` gauge being emitted after adding new files to the queue, and reduces log noise by having a single log line vs one per file.