### PR TITLE
Add DAG importer abstraction layer

### DIFF
--- a/airflow-core/.pre-commit-config.yaml
+++ b/airflow-core/.pre-commit-config.yaml
@@ -340,9 +340,10 @@ repos:
           ^src/airflow/cli/commands/triggerer_command.py$|
           ^src/airflow/configuration\.py$|
           ^src/airflow/dag_processing/collection\.py$|
+          ^src/airflow/dag_processing/dagbag\.py$|
+          ^src/airflow/dag_processing/importers/.*\.py$|
           ^src/airflow/dag_processing/manager\.py$|
           ^src/airflow/dag_processing/processor\.py$|
-          ^src/airflow/dag_processing/dagbag\.py$|
           ^src/airflow/datasets/metadata\.py$|
           ^src/airflow/exceptions\.py$|
           ^src/airflow/executors/local_executor\.py$|

--- a/airflow-core/src/airflow/dag_processing/dagbag.py
+++ b/airflow-core/src/airflow/dag_processing/dagbag.py
@@ -18,16 +18,11 @@
 from __future__ import annotations
 
 import contextlib
-import importlib
-import importlib.machinery
-import importlib.util
 import os
-import signal
-import sys
 import textwrap
-import traceback
 import warnings
 import zipfile
+from collections.abc import Generator
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple
@@ -37,6 +32,7 @@ from tabulate import tabulate
 from airflow import settings
 from airflow._shared.timezones import timezone
 from airflow.configuration import conf
+from airflow.dag_processing.importers import get_importer_registry
 from airflow.exceptions import (
     AirflowClusterPolicyError,
     AirflowClusterPolicySkipDag,
@@ -49,19 +45,11 @@ from airflow.executors.executor_loader import ExecutorLoader
 from airflow.listeners.listener import get_listener_manager
 from airflow.serialization.definitions.notset import NOTSET, ArgNotSet, is_arg_set
 from airflow.serialization.serialized_objects import LazyDeserializedDAG
-from airflow.utils.docs import get_docs_url
-from airflow.utils.file import (
-    correct_maybe_zipped,
-    get_unique_dag_module_name,
-    list_py_file_paths,
-    might_contain_dag,
-)
+from airflow.utils.file import correct_maybe_zipped
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import NEW_SESSION, provide_session
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
-
     from sqlalchemy.orm import Session
 
     from airflow import DAG
@@ -109,32 +97,6 @@ class FileLoadStat(NamedTuple):
     warning_num: int
     bundle_path: Path | None
     bundle_name: str | None
-
-
-@contextlib.contextmanager
-def timeout(seconds=1, error_message="Timeout"):
-    import logging
-
-    log = logging.getLogger(__name__)
-    error_message = error_message + ", PID: " + str(os.getpid())
-
-    def handle_timeout(signum, frame):
-        """Log information and raises AirflowTaskTimeout."""
-        log.error("Process timed out, PID: %s", str(os.getpid()))
-        from airflow.sdk.exceptions import AirflowTaskTimeout
-
-        raise AirflowTaskTimeout(error_message)
-
-    try:
-        try:
-            signal.signal(signal.SIGALRM, handle_timeout)
-            signal.setitimer(signal.ITIMER_REAL, seconds)
-        except ValueError:
-            log.warning("timeout can't be used in the current context", exc_info=True)
-        yield
-    finally:
-        with contextlib.suppress(ValueError):
-            signal.setitimer(signal.ITIMER_REAL, 0)
 
 
 def _executor_exists(executor_name: str, team_name: str | None) -> bool:
@@ -315,19 +277,11 @@ class DagBag(LoggingMixin):
         return self.dags.get(dag_id)
 
     def process_file(self, filepath, only_if_updated=True, safe_mode=True):
-        """Given a path to a python module or zip file, import the module and look for dag objects within."""
-        from airflow.sdk.definitions._internal.contextmanager import DagContext
-
-        # if the source file no longer exists in the DB or in the filesystem,
-        # return an empty list
-        # todo: raise exception?
-
+        """Process a DAG file and return found DAGs."""
         if filepath is None or not os.path.isfile(filepath):
             return []
 
         try:
-            # This failed before in what may have been a git sync
-            # race condition
             file_last_changed_on_disk = datetime.fromtimestamp(os.path.getmtime(filepath))
             if (
                 only_if_updated
@@ -339,29 +293,72 @@ class DagBag(LoggingMixin):
             self.log.exception(e)
             return []
 
-        # Ensure we don't pick up anything else we didn't mean to
-        DagContext.autoregistered_dags.clear()
-
         self.captured_warnings.pop(filepath, None)
-        with _capture_with_reraise() as captured_warnings:
-            if filepath.endswith(".py") or not zipfile.is_zipfile(filepath):
-                mods = self._load_modules_from_file(filepath, safe_mode)
-            else:
-                mods = self._load_modules_from_zip(filepath, safe_mode)
 
-        if captured_warnings:
-            formatted_warnings = []
-            for msg in captured_warnings:
-                category = msg.category.__name__
-                if (module := msg.category.__module__) != "builtins":
-                    category = f"{module}.{category}"
-                formatted_warnings.append(f"{msg.filename}:{msg.lineno}: {category}: {msg.message}")
+        registry = get_importer_registry()
+        importer = registry.get_importer(filepath)
+
+        if importer is None:
+            self.log.debug("No importer found for file: %s", filepath)
+            return []
+
+        result = importer.import_file(
+            file_path=filepath,
+            bundle_path=self.bundle_path,
+            bundle_name=self.bundle_name,
+            safe_mode=safe_mode,
+        )
+
+        if result.skipped_files:
+            for skipped in result.skipped_files:
+                if not self.has_logged:
+                    self.has_logged = True
+                    self.log.info("File %s assumed to contain no DAGs. Skipping.", skipped)
+
+        if result.errors:
+            for error in result.errors:
+                # Use the file path from error for ZIP files (contains zip/file.py format)
+                # For regular files, use the original filepath
+                if zipfile.is_zipfile(filepath):
+                    error_path = error.file_path if error.file_path else filepath
+                else:
+                    error_path = filepath
+                error_msg = error.stacktrace if error.stacktrace else error.message
+                self.import_errors[error_path] = error_msg
+                self.log.error("Error loading DAG from %s: %s", error_path, error.message)
+
+        if result.warnings:
+            formatted_warnings = [
+                f"{w.file_path}:{w.line_number}: {w.warning_type}: {w.message}" for w in result.warnings
+            ]
             self.captured_warnings[filepath] = tuple(formatted_warnings)
+            # Re-emit warnings so they can be handled by Python's warning system
+            for w in result.warnings:
+                warnings.warn_explicit(
+                    message=w.message,
+                    category=UserWarning,
+                    filename=w.file_path,
+                    lineno=w.line_number or 0,
+                )
 
-        found_dags = self._process_modules(filepath, mods, file_last_changed_on_disk)
+        bagged_dags = []
+        for dag in result.dags:
+            try:
+                if dag.fileloc is None:
+                    dag.fileloc = filepath
+                # Validate before adding to bag (matches original _process_modules behavior)
+                dag.validate()
+                _validate_executor_fields(dag, self.bundle_name)
+                self.bag_dag(dag=dag)
+                bagged_dags.append(dag)
+            except AirflowClusterPolicySkipDag:
+                self.log.debug("DAG %s skipped by cluster policy", dag.dag_id)
+            except Exception as e:
+                self.log.exception("Error bagging DAG from %s", filepath)
+                self.import_errors[filepath] = f"{type(e).__name__}: {e}"
 
         self.file_last_changed[filepath] = file_last_changed_on_disk
-        return found_dags
+        return bagged_dags
 
     @property
     def dag_warnings(self) -> set[DagWarning]:
@@ -403,162 +400,6 @@ class DagBag(LoggingMixin):
             return str(Path(filepath).relative_to(self.bundle_path))
         return filepath
 
-    def _load_modules_from_file(self, filepath, safe_mode):
-        from airflow.sdk.definitions._internal.contextmanager import DagContext
-
-        def handler(signum, frame):
-            """Handle SIGSEGV signal and let the user know that the import failed."""
-            msg = f"Received SIGSEGV signal while processing {filepath}."
-            self.log.error(msg)
-            relative_filepath = self._get_relative_fileloc(filepath)
-            self.import_errors[relative_filepath] = msg
-
-        try:
-            signal.signal(signal.SIGSEGV, handler)
-        except ValueError:
-            self.log.warning("SIGSEGV signal handler registration failed. Not in the main thread")
-
-        if not might_contain_dag(filepath, safe_mode):
-            # Don't want to spam user with skip messages
-            if not self.has_logged:
-                self.has_logged = True
-                self.log.info("File %s assumed to contain no DAGs. Skipping.", filepath)
-            return []
-
-        self.log.debug("Importing %s", filepath)
-        mod_name = get_unique_dag_module_name(filepath)
-
-        if mod_name in sys.modules:
-            del sys.modules[mod_name]
-
-        DagContext.current_autoregister_module_name = mod_name
-
-        def parse(mod_name, filepath):
-            try:
-                loader = importlib.machinery.SourceFileLoader(mod_name, filepath)
-                spec = importlib.util.spec_from_loader(mod_name, loader)
-                new_module = importlib.util.module_from_spec(spec)
-                sys.modules[spec.name] = new_module
-                loader.exec_module(new_module)
-                return [new_module]
-            except KeyboardInterrupt:
-                # re-raise ctrl-c
-                raise
-            except BaseException as e:
-                # Normally you shouldn't catch BaseException, but in this case we want to, as, pytest.skip
-                # raises an exception which does not inherit from Exception, and we want to catch that here.
-                # This would also catch `exit()` in a dag file
-                DagContext.autoregistered_dags.clear()
-                self.log.exception("Failed to import: %s", filepath)
-                relative_filepath = self._get_relative_fileloc(filepath)
-                if self.dagbag_import_error_tracebacks:
-                    self.import_errors[relative_filepath] = traceback.format_exc(
-                        limit=-self.dagbag_import_error_traceback_depth
-                    )
-                else:
-                    self.import_errors[relative_filepath] = str(e)
-                return []
-
-        dagbag_import_timeout = settings.get_dagbag_import_timeout(filepath)
-
-        if not isinstance(dagbag_import_timeout, (int, float)):
-            raise TypeError(
-                f"Value ({dagbag_import_timeout}) from get_dagbag_import_timeout must be int or float"
-            )
-
-        if dagbag_import_timeout <= 0:  # no parsing timeout
-            return parse(mod_name, filepath)
-
-        timeout_msg = (
-            f"DagBag import timeout for {filepath} after {dagbag_import_timeout}s.\n"
-            "Please take a look at these docs to improve your DAG import time:\n"
-            f"* {get_docs_url('best-practices.html#top-level-python-code')}\n"
-            f"* {get_docs_url('best-practices.html#reducing-dag-complexity')}"
-        )
-        with timeout(dagbag_import_timeout, error_message=timeout_msg):
-            return parse(mod_name, filepath)
-
-    def _load_modules_from_zip(self, filepath, safe_mode):
-        from airflow.sdk.definitions._internal.contextmanager import DagContext
-
-        mods = []
-        with zipfile.ZipFile(filepath) as current_zip_file:
-            for zip_info in current_zip_file.infolist():
-                zip_path = Path(zip_info.filename)
-                if zip_path.suffix not in [".py", ".pyc"] or len(zip_path.parts) > 1:
-                    continue
-
-                if zip_path.stem == "__init__":
-                    self.log.warning("Found %s at root of %s", zip_path.name, filepath)
-
-                self.log.debug("Reading %s from %s", zip_info.filename, filepath)
-
-                if not might_contain_dag(zip_info.filename, safe_mode, current_zip_file):
-                    # todo: create ignore list
-                    # Don't want to spam user with skip messages
-                    if not self.has_logged:
-                        self.has_logged = True
-                        self.log.info(
-                            "File %s:%s assumed to contain no DAGs. Skipping.", filepath, zip_info.filename
-                        )
-                    continue
-
-                mod_name = zip_path.stem
-                if mod_name in sys.modules:
-                    del sys.modules[mod_name]
-
-                DagContext.current_autoregister_module_name = mod_name
-                try:
-                    sys.path.insert(0, filepath)
-                    current_module = importlib.import_module(mod_name)
-                    mods.append(current_module)
-                except Exception as e:
-                    DagContext.autoregistered_dags.clear()
-                    fileloc = os.path.join(filepath, zip_info.filename)
-                    self.log.exception("Failed to import: %s", fileloc)
-                    relative_fileloc = self._get_relative_fileloc(fileloc)
-                    if self.dagbag_import_error_tracebacks:
-                        self.import_errors[relative_fileloc] = traceback.format_exc(
-                            limit=-self.dagbag_import_error_traceback_depth
-                        )
-                    else:
-                        self.import_errors[relative_fileloc] = str(e)
-                finally:
-                    if sys.path[0] == filepath:
-                        del sys.path[0]
-        return mods
-
-    def _process_modules(self, filepath, mods, file_last_changed_on_disk):
-        from airflow.sdk import DAG
-        from airflow.sdk.definitions._internal.contextmanager import DagContext
-
-        top_level_dags = {(o, m) for m in mods for o in m.__dict__.values() if isinstance(o, DAG)}
-
-        top_level_dags.update(DagContext.autoregistered_dags)
-
-        DagContext.current_autoregister_module_name = None
-        DagContext.autoregistered_dags.clear()
-
-        found_dags = []
-
-        for dag, mod in top_level_dags:
-            dag.fileloc = mod.__file__
-            relative_fileloc = self._get_relative_fileloc(dag.fileloc)
-            dag.relative_fileloc = relative_fileloc
-            try:
-                dag.validate()
-                _validate_executor_fields(dag, self.bundle_name)
-                self.bag_dag(dag=dag)
-            except AirflowClusterPolicySkipDag:
-                pass
-            except Exception as e:
-                self.log.exception("Failed to bag_dag: %s", dag.fileloc)
-                self.import_errors[relative_fileloc] = f"{type(e).__name__}: {e}"
-                self.file_last_changed[dag.fileloc] = file_last_changed_on_disk
-            else:
-                found_dags.append(dag)
-        return found_dags
-
     def bag_dag(self, dag: DAG):
         """
         Add the DAG into the bag.
@@ -566,17 +407,14 @@ class DagBag(LoggingMixin):
         :raises: AirflowDagCycleException if a cycle is detected.
         :raises: AirflowDagDuplicatedIdException if this dag already exists in the bag.
         """
-        dag.check_cycle()  # throws exception if a task cycle is found
-
+        dag.check_cycle()
         dag.resolve_template_files()
         dag.last_loaded = timezone.utcnow()
 
         try:
-            # Check policies
             settings.dag_policy(dag)
 
             for task in dag.tasks:
-                # The listeners are not supported when ending a task via a trigger on asynchronous operators.
                 if getattr(task, "end_from_trigger", False) and get_listener_manager().has_listeners:
                     raise AirflowException(
                         "Listeners are not supported with end_from_trigger=True for deferrable operators. "
@@ -636,14 +474,15 @@ class DagBag(LoggingMixin):
         # Ensure dag_folder is a str -- it may have been a pathlib.Path
         dag_folder = correct_maybe_zipped(str(dag_folder))
 
-        files_to_parse = list_py_file_paths(dag_folder, safe_mode=safe_mode)
+        registry = get_importer_registry()
+        files_to_parse = registry.list_dag_files(dag_folder, safe_mode=safe_mode)
 
         if include_examples:
             from airflow import example_dags
 
             example_dag_folder = next(iter(example_dags.__path__))
 
-            files_to_parse.extend(list_py_file_paths(example_dag_folder, safe_mode=safe_mode))
+            files_to_parse.extend(registry.list_dag_files(example_dag_folder, safe_mode=safe_mode))
 
         for filepath in files_to_parse:
             try:

--- a/airflow-core/src/airflow/dag_processing/dagbag.py
+++ b/airflow-core/src/airflow/dag_processing/dagbag.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import sys
 import textwrap
 import warnings
 import zipfile

--- a/airflow-core/src/airflow/dag_processing/importers/__init__.py
+++ b/airflow-core/src/airflow/dag_processing/importers/__init__.py
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""DAG Importers - pluggable mechanism for importing DAGs from different file formats."""
+
+from __future__ import annotations
+
+from airflow.dag_processing.importers.base import (
+    AbstractDagImporter,
+    DagImporterRegistry,
+    DagImportError,
+    DagImportResult,
+    DagImportWarning,
+    get_importer_registry,
+)
+from airflow.dag_processing.importers.python_importer import PythonDagImporter
+
+__all__ = [
+    "AbstractDagImporter",
+    "DagImportError",
+    "DagImporterRegistry",
+    "DagImportResult",
+    "DagImportWarning",
+    "PythonDagImporter",
+    "get_importer_registry",
+]

--- a/airflow-core/src/airflow/dag_processing/importers/base.py
+++ b/airflow-core/src/airflow/dag_processing/importers/base.py
@@ -1,0 +1,266 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Abstract base class for DAG importers."""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from abc import ABC, abstractmethod
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from airflow._shared.module_loading.file_discovery import find_path_from_directory
+from airflow.configuration import conf
+from airflow.utils.file import might_contain_dag
+
+if TYPE_CHECKING:
+    from airflow.sdk import DAG
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class DagImportError:
+    """Structured error information for DAG import failures."""
+
+    file_path: str
+    message: str
+    error_type: str = "import"
+    line_number: int | None = None
+    column_number: int | None = None
+    context: str | None = None
+    suggestion: str | None = None
+    stacktrace: str | None = None
+
+    def format_message(self) -> str:
+        """Format the error as a human-readable string."""
+        parts = [f"Error in {self.file_path}"]
+        if self.line_number is not None:
+            loc = f"line {self.line_number}"
+            if self.column_number is not None:
+                loc += f", column {self.column_number}"
+            parts.append(f"Location: {loc}")
+        parts.append(f"Error ({self.error_type}): {self.message}")
+        if self.context:
+            parts.append(f"Context:\n{self.context}")
+        if self.suggestion:
+            parts.append(f"Suggestion: {self.suggestion}")
+        return "\n".join(parts)
+
+
+@dataclass
+class DagImportWarning:
+    """Warning information for non-fatal issues during DAG import."""
+
+    file_path: str
+    message: str
+    warning_type: str = "general"
+    line_number: int | None = None
+
+
+@dataclass
+class DagImportResult:
+    """Result of importing DAGs from a file."""
+
+    file_path: str
+    dags: list[DAG] = field(default_factory=list)
+    errors: list[DagImportError] = field(default_factory=list)
+    skipped_files: list[str] = field(default_factory=list)
+    warnings: list[DagImportWarning] = field(default_factory=list)
+
+    @property
+    def success(self) -> bool:
+        """Return True if no fatal errors occurred."""
+        return len(self.errors) == 0
+
+
+class AbstractDagImporter(ABC):
+    """Abstract base class for DAG importers."""
+
+    @classmethod
+    @abstractmethod
+    def supported_extensions(cls) -> list[str]:
+        """Return file extensions this importer handles (e.g., ['.py', '.zip'])."""
+
+    @abstractmethod
+    def import_file(
+        self,
+        file_path: str | Path,
+        *,
+        bundle_path: Path | None = None,
+        bundle_name: str | None = None,
+        safe_mode: bool = True,
+    ) -> DagImportResult:
+        """Import DAGs from a file."""
+
+    def can_handle(self, file_path: str | Path) -> bool:
+        """Check if this importer can handle the given file."""
+        path = Path(file_path) if isinstance(file_path, str) else file_path
+        return path.suffix.lower() in self.supported_extensions()
+
+    def get_relative_path(self, file_path: str | Path, bundle_path: Path | None) -> str:
+        """Get the relative file path from the bundle root."""
+        if bundle_path is None:
+            return str(file_path)
+        try:
+            return str(Path(file_path).relative_to(bundle_path))
+        except ValueError:
+            return str(file_path)
+
+    def list_dag_files(
+        self,
+        directory: str | os.PathLike[str],
+        safe_mode: bool = True,
+    ) -> Iterator[str]:
+        """
+        List DAG files in a directory that this importer can handle.
+
+        Override this method to customize file discovery for your importer.
+        The default implementation finds files matching supported_extensions()
+        and respects .airflowignore files.
+
+        :param directory: Directory to search for DAG files
+        :param safe_mode: Whether to use heuristics to filter non-DAG files
+        :return: Iterator of file paths
+        """
+        ignore_file_syntax = conf.get_mandatory_value("core", "DAG_IGNORE_FILE_SYNTAX", fallback="glob")
+        supported_exts = [ext.lower() for ext in self.supported_extensions()]
+
+        for file_path in find_path_from_directory(directory, ".airflowignore", ignore_file_syntax):
+            path = Path(file_path)
+
+            if not path.is_file():
+                continue
+
+            # Check if this importer handles this file extension
+            if path.suffix.lower() not in supported_exts:
+                continue
+
+            # Apply safe_mode heuristic if enabled
+            if safe_mode and not might_contain_dag(file_path, safe_mode):
+                continue
+
+            yield file_path
+
+
+class DagImporterRegistry:
+    """
+    Registry for DAG importers. Singleton that manages importers by file extension.
+
+    Each file extension can only be handled by one importer at a time. If multiple
+    importers claim the same extension, the last registered one wins and a warning
+    is logged. The built-in PythonDagImporter handles .py and .zip extensions.
+    """
+
+    _instance: DagImporterRegistry | None = None
+    _importers: dict[str, AbstractDagImporter]
+    _lock = threading.Lock()
+
+    def __new__(cls) -> DagImporterRegistry:
+        with cls._lock:
+            if cls._instance is None:
+                cls._instance = super().__new__(cls)
+                cls._instance._importers = {}
+                cls._instance._register_default_importers()
+        return cls._instance
+
+    def _register_default_importers(self) -> None:
+        from airflow.dag_processing.importers.python_importer import PythonDagImporter
+
+        self.register(PythonDagImporter())
+
+    def register(self, importer: AbstractDagImporter) -> None:
+        """
+        Register an importer for its supported extensions.
+
+        Each extension can only have one importer. If an extension is already registered,
+        the new importer will override it and a warning will be logged.
+        """
+        for ext in importer.supported_extensions():
+            ext_lower = ext.lower()
+            if ext_lower in self._importers:
+                existing = self._importers[ext_lower]
+                log.warning(
+                    "Extension '%s' already registered by %s, overriding with %s",
+                    ext,
+                    type(existing).__name__,
+                    type(importer).__name__,
+                )
+            self._importers[ext_lower] = importer
+
+    def get_importer(self, file_path: str | Path) -> AbstractDagImporter | None:
+        """Get the appropriate importer for a file, or None if unsupported."""
+        path = Path(file_path) if isinstance(file_path, str) else file_path
+        return self._importers.get(path.suffix.lower())
+
+    def can_handle(self, file_path: str | Path) -> bool:
+        """Check if any registered importer can handle this file."""
+        return self.get_importer(file_path) is not None
+
+    def supported_extensions(self) -> list[str]:
+        """Return all registered file extensions."""
+        return list(self._importers.keys())
+
+    def list_dag_files(
+        self,
+        directory: str | os.PathLike[str],
+        safe_mode: bool = True,
+    ) -> list[str]:
+        """
+        List all DAG files in a directory using all registered importers.
+
+        If directory is actually a file, returns that file if any importer can handle it.
+
+        :param directory: Directory (or file) to search for DAG files
+        :param safe_mode: Whether to use heuristics to filter non-DAG files
+        :return: List of file paths (deduplicated)
+        """
+        path = Path(directory)
+
+        # If it's a file, just return it if we can handle it
+        if path.is_file():
+            if self.can_handle(path):
+                return [str(path)]
+            return []
+
+        if not path.is_dir():
+            return []
+
+        seen_files: set[str] = set()
+        file_paths: list[str] = []
+
+        for importer in set(self._importers.values()):
+            for file_path in importer.list_dag_files(directory, safe_mode):
+                if file_path not in seen_files:
+                    seen_files.add(file_path)
+                    file_paths.append(file_path)
+
+        return file_paths
+
+    @classmethod
+    def reset(cls) -> None:
+        """Reset the singleton (for testing)."""
+        cls._instance = None
+
+
+def get_importer_registry() -> DagImporterRegistry:
+    """Get the global importer registry instance."""
+    return DagImporterRegistry()

--- a/airflow-core/src/airflow/dag_processing/importers/python_importer.py
+++ b/airflow-core/src/airflow/dag_processing/importers/python_importer.py
@@ -1,0 +1,360 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Python DAG importer - imports DAGs from Python files."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib
+import importlib.machinery
+import importlib.util
+import logging
+import os
+import signal
+import sys
+import traceback
+import warnings
+import zipfile
+from collections.abc import Iterator
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from airflow import settings
+from airflow._shared.module_loading.file_discovery import find_path_from_directory
+from airflow.configuration import conf
+from airflow.dag_processing.importers.base import (
+    AbstractDagImporter,
+    DagImportError,
+    DagImportResult,
+    DagImportWarning,
+)
+from airflow.utils.docs import get_docs_url
+from airflow.utils.file import get_unique_dag_module_name, might_contain_dag
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+    from airflow.sdk import DAG
+
+log = logging.getLogger(__name__)
+
+
+@contextlib.contextmanager
+def _timeout(seconds: float = 1, error_message: str = "Timeout"):
+    """Context manager for timing out operations."""
+    error_message = error_message + ", PID: " + str(os.getpid())
+
+    def handle_timeout(signum, frame):
+        log.error("Process timed out, PID: %s", str(os.getpid()))
+        from airflow.sdk.exceptions import AirflowTaskTimeout
+
+        raise AirflowTaskTimeout(error_message)
+
+    try:
+        try:
+            signal.signal(signal.SIGALRM, handle_timeout)
+            signal.setitimer(signal.ITIMER_REAL, seconds)
+        except ValueError:
+            log.warning("timeout can't be used in the current context", exc_info=True)
+        yield
+    finally:
+        with contextlib.suppress(ValueError):
+            signal.setitimer(signal.ITIMER_REAL, 0)
+
+
+class PythonDagImporter(AbstractDagImporter):
+    """
+    Importer for Python DAG files and zip archives containing Python DAGs.
+
+    This is the default importer registered with the DagImporterRegistry. It handles:
+    - .py files: Standard Python DAG files
+    - .zip files: ZIP archives containing Python DAG files
+
+    Note: The .zip extension is exclusively owned by this importer. If you need to
+    support other file formats inside ZIP archives (e.g., YAML), you would need to
+    either extend this importer or create a composite importer that delegates based
+    on the contents of the archive.
+    """
+
+    @classmethod
+    def supported_extensions(cls) -> list[str]:
+        """Return file extensions handled by this importer (.py and .zip)."""
+        return [".py", ".zip"]
+
+    def list_dag_files(
+        self,
+        directory: str | os.PathLike[str],
+        safe_mode: bool = True,
+    ) -> Iterator[str]:
+        """
+        List Python DAG files in a directory.
+
+        Handles both .py files and .zip archives containing Python DAGs.
+        Respects .airflowignore files in the directory tree.
+        """
+        ignore_file_syntax = conf.get_mandatory_value("core", "DAG_IGNORE_FILE_SYNTAX", fallback="glob")
+
+        for file_path in find_path_from_directory(directory, ".airflowignore", ignore_file_syntax):
+            path = Path(file_path)
+            try:
+                if path.is_file() and (path.suffix.lower() == ".py" or zipfile.is_zipfile(path)):
+                    if might_contain_dag(file_path, safe_mode):
+                        yield file_path
+            except Exception:
+                log.exception("Error while examining %s", file_path)
+
+    def import_file(
+        self,
+        file_path: str | Path,
+        *,
+        bundle_path: Path | None = None,
+        bundle_name: str | None = None,
+        safe_mode: bool = True,
+    ) -> DagImportResult:
+        """
+        Import DAGs from a Python file or zip archive.
+
+        :param file_path: Path to the Python file to import.
+        :param bundle_path: Path to the bundle root.
+        :param bundle_name: Name of the bundle.
+        :param safe_mode: If True, skip files that don't appear to contain DAGs.
+        :return: DagImportResult with imported DAGs and any errors.
+        """
+        from airflow.sdk.definitions._internal.contextmanager import DagContext
+
+        filepath = str(file_path)
+        relative_path = self.get_relative_path(filepath, bundle_path)
+        result = DagImportResult(file_path=relative_path)
+
+        if not os.path.isfile(filepath):
+            result.errors.append(
+                DagImportError(
+                    file_path=relative_path,
+                    message=f"File not found: {filepath}",
+                    error_type="file_not_found",
+                )
+            )
+            return result
+
+        # Clear any autoregistered dags from previous imports
+        DagContext.autoregistered_dags.clear()
+
+        # Capture warnings during import
+        captured_warnings: list[warnings.WarningMessage] = []
+
+        try:
+            with warnings.catch_warnings(record=True) as captured_warnings:
+                if filepath.endswith(".py") or not zipfile.is_zipfile(filepath):
+                    modules = self._load_modules_from_file(filepath, safe_mode, result)
+                else:
+                    modules = self._load_modules_from_zip(filepath, safe_mode, result)
+        except TypeError:
+            # Configuration errors (e.g., invalid timeout type) should propagate
+            raise
+        except Exception as e:
+            result.errors.append(
+                DagImportError(
+                    file_path=relative_path,
+                    message=str(e),
+                    error_type="import",
+                    stacktrace=traceback.format_exc(),
+                )
+            )
+            return result
+
+        # Convert captured warnings to DagImportWarning
+        for warn_msg in captured_warnings:
+            category = warn_msg.category.__name__
+            if (module := warn_msg.category.__module__) != "builtins":
+                category = f"{module}.{category}"
+            result.warnings.append(
+                DagImportWarning(
+                    file_path=warn_msg.filename,
+                    message=str(warn_msg.message),
+                    warning_type=category,
+                    line_number=warn_msg.lineno,
+                )
+            )
+
+        # Process imported modules to extract DAGs
+        self._process_modules(filepath, modules, bundle_name, bundle_path, result)
+
+        return result
+
+    def _load_modules_from_file(
+        self, filepath: str, safe_mode: bool, result: DagImportResult
+    ) -> list[ModuleType]:
+        from airflow.sdk.definitions._internal.contextmanager import DagContext
+
+        def sigsegv_handler(signum, frame):
+            msg = f"Received SIGSEGV signal while processing {filepath}."
+            log.error(msg)
+            result.errors.append(
+                DagImportError(
+                    file_path=result.file_path,
+                    message=msg,
+                    error_type="segfault",
+                )
+            )
+
+        try:
+            signal.signal(signal.SIGSEGV, sigsegv_handler)
+        except ValueError:
+            log.warning("SIGSEGV signal handler registration failed. Not in the main thread")
+
+        if not might_contain_dag(filepath, safe_mode):
+            log.debug("File %s assumed to contain no DAGs. Skipping.", filepath)
+            result.skipped_files.append(filepath)
+            return []
+
+        log.debug("Importing %s", filepath)
+        mod_name = get_unique_dag_module_name(filepath)
+
+        if mod_name in sys.modules:
+            del sys.modules[mod_name]
+
+        DagContext.current_autoregister_module_name = mod_name
+
+        def parse(mod_name: str, filepath: str) -> list[ModuleType]:
+            try:
+                loader = importlib.machinery.SourceFileLoader(mod_name, filepath)
+                spec = importlib.util.spec_from_loader(mod_name, loader)
+                new_module = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+                sys.modules[spec.name] = new_module  # type: ignore[union-attr]
+                loader.exec_module(new_module)
+                return [new_module]
+            except KeyboardInterrupt:
+                raise
+            except BaseException as e:
+                DagContext.autoregistered_dags.clear()
+                log.exception("Failed to import: %s", filepath)
+                if conf.getboolean("core", "dagbag_import_error_tracebacks"):
+                    stacktrace = traceback.format_exc(
+                        limit=-conf.getint("core", "dagbag_import_error_traceback_depth")
+                    )
+                else:
+                    stacktrace = None
+                result.errors.append(
+                    DagImportError(
+                        file_path=result.file_path,
+                        message=str(e),
+                        error_type="import",
+                        stacktrace=stacktrace,
+                    )
+                )
+                return []
+
+        dagbag_import_timeout = settings.get_dagbag_import_timeout(filepath)
+
+        if not isinstance(dagbag_import_timeout, (int, float)):
+            raise TypeError(
+                f"Value ({dagbag_import_timeout}) from get_dagbag_import_timeout must be int or float"
+            )
+
+        if dagbag_import_timeout <= 0:
+            return parse(mod_name, filepath)
+
+        timeout_msg = (
+            f"DagBag import timeout for {filepath} after {dagbag_import_timeout}s.\n"
+            "Please take a look at these docs to improve your DAG import time:\n"
+            f"* {get_docs_url('best-practices.html#top-level-python-code')}\n"
+            f"* {get_docs_url('best-practices.html#reducing-dag-complexity')}"
+        )
+        with _timeout(dagbag_import_timeout, error_message=timeout_msg):
+            return parse(mod_name, filepath)
+
+    def _load_modules_from_zip(
+        self, filepath: str, safe_mode: bool, result: DagImportResult
+    ) -> list[ModuleType]:
+        """Load Python modules from a zip archive."""
+        from airflow.sdk.definitions._internal.contextmanager import DagContext
+
+        mods: list[ModuleType] = []
+        with zipfile.ZipFile(filepath) as current_zip_file:
+            for zip_info in current_zip_file.infolist():
+                zip_path = Path(zip_info.filename)
+                if zip_path.suffix not in [".py", ".pyc"] or len(zip_path.parts) > 1:
+                    continue
+
+                if zip_path.stem == "__init__":
+                    log.warning("Found %s at root of %s", zip_path.name, filepath)
+
+                log.debug("Reading %s from %s", zip_info.filename, filepath)
+
+                if not might_contain_dag(zip_info.filename, safe_mode, current_zip_file):
+                    result.skipped_files.append(f"{filepath}:{zip_info.filename}")
+                    continue
+
+                mod_name = zip_path.stem
+                if mod_name in sys.modules:
+                    del sys.modules[mod_name]
+
+                DagContext.current_autoregister_module_name = mod_name
+                try:
+                    sys.path.insert(0, filepath)
+                    current_module = importlib.import_module(mod_name)
+                    mods.append(current_module)
+                except Exception as e:
+                    DagContext.autoregistered_dags.clear()
+                    fileloc = os.path.join(filepath, zip_info.filename)
+                    log.exception("Failed to import: %s", fileloc)
+                    if conf.getboolean("core", "dagbag_import_error_tracebacks"):
+                        stacktrace = traceback.format_exc(
+                            limit=-conf.getint("core", "dagbag_import_error_traceback_depth")
+                        )
+                    else:
+                        stacktrace = None
+                    result.errors.append(
+                        DagImportError(
+                            file_path=fileloc,  # Use the file path inside the ZIP
+                            message=str(e),
+                            error_type="import",
+                            stacktrace=stacktrace,
+                        )
+                    )
+                finally:
+                    if sys.path[0] == filepath:
+                        del sys.path[0]
+        return mods
+
+    def _process_modules(
+        self,
+        filepath: str,
+        mods: list[Any],
+        bundle_name: str | None,
+        bundle_path: Path | None,
+        result: DagImportResult,
+    ) -> None:
+        """Extract DAG objects from modules. Validation happens in bag_dag()."""
+        from airflow.sdk import DAG
+        from airflow.sdk.definitions._internal.contextmanager import DagContext
+
+        top_level_dags: set[tuple[DAG, Any]] = {
+            (o, m) for m in mods for o in m.__dict__.values() if isinstance(o, DAG)
+        }
+        top_level_dags.update(DagContext.autoregistered_dags)
+
+        DagContext.current_autoregister_module_name = None
+        DagContext.autoregistered_dags.clear()
+
+        for dag, mod in top_level_dags:
+            dag.fileloc = mod.__file__
+            relative_fileloc = self.get_relative_path(dag.fileloc, bundle_path)
+            dag.relative_fileloc = relative_fileloc
+
+            result.dags.append(dag)
+            log.debug("Found DAG %s", dag.dag_id)

--- a/airflow-core/tests/unit/dag_processing/importers/__init__.py
+++ b/airflow-core/tests/unit/dag_processing/importers/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow-core/tests/unit/dag_processing/importers/test_registry.py
+++ b/airflow-core/tests/unit/dag_processing/importers/test_registry.py
@@ -1,0 +1,99 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for the DagImporterRegistry."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from airflow.dag_processing.importers import (
+    DagImporterRegistry,
+    PythonDagImporter,
+    get_importer_registry,
+)
+
+
+class TestDagImporterRegistry:
+    """Test the DagImporterRegistry singleton."""
+
+    def setup_method(self):
+        """Reset the registry before each test."""
+        DagImporterRegistry.reset()
+
+    def teardown_method(self):
+        """Reset the registry after each test."""
+        DagImporterRegistry.reset()
+
+    def test_singleton_pattern(self):
+        """Registry should return the same instance."""
+        registry1 = get_importer_registry()
+        registry2 = get_importer_registry()
+        assert registry1 is registry2
+
+    def test_default_importers_registered(self):
+        """Registry should have Python importer by default."""
+        registry = get_importer_registry()
+        extensions = registry.supported_extensions()
+
+        assert ".py" in extensions
+
+    def test_get_importer_for_python(self):
+        """Should return PythonDagImporter for .py files."""
+        registry = get_importer_registry()
+        importer = registry.get_importer("test.py")
+
+        assert importer is not None
+        assert isinstance(importer, PythonDagImporter)
+
+    def test_get_importer_for_unknown(self):
+        """Should return None for unknown file types."""
+        registry = get_importer_registry()
+        importer = registry.get_importer("test.txt")
+
+        assert importer is None
+
+    def test_can_handle_supported_files(self):
+        """can_handle should return True for supported file types."""
+        registry = get_importer_registry()
+
+        assert registry.can_handle("dag.py")
+        assert registry.can_handle(Path("subdir/dag.py"))
+
+    def test_can_handle_unsupported_files(self):
+        """can_handle should return False for unsupported file types."""
+        registry = get_importer_registry()
+
+        assert not registry.can_handle("readme.txt")
+        assert not registry.can_handle("config.json")
+        assert not registry.can_handle("script.sh")
+
+    def test_case_insensitive_extension_matching(self):
+        """Extension matching should be case-insensitive."""
+        registry = get_importer_registry()
+
+        # All these should be handled
+        assert registry.can_handle("dag.PY")
+        assert registry.can_handle("dag.Py")
+
+    def test_reset_clears_singleton(self):
+        """reset() should clear the singleton instance."""
+        registry1 = get_importer_registry()
+        DagImporterRegistry.reset()
+        registry2 = get_importer_registry()
+
+        # Should be different instances after reset
+        assert registry1 is not registry2


### PR DESCRIPTION
Introduces a pluggable importer architecture for DAG files. This enables future support for non-Python DAG formats (YAML, etc.) while maintaining full backwards compatibility with existing behavior.

This _should_ make it easier for [AIP-85 Extendable DAG parsing controls](https://cwiki.apache.org/confluence/x/_Q7OEg). So not documenting it purposely until then.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
