### PR TITLE
Remove dags update testing

### DIFF
--- a/airflow-ctl-tests/tests/airflowctl_tests/test_airflowctl_commands.py
+++ b/airflow-ctl-tests/tests/airflowctl_tests/test_airflowctl_commands.py
@@ -90,8 +90,6 @@ TEST_COMMANDS = [
     "dags unpause example_bash_operator",
     # DAG Run commands
     f'dagrun get --dag-id=example_bash_operator --dag-run-id="manual__{ONE_DATE_PARAM}"',
-    "dags update --dag-id=example_bash_operator --no-is-paused",
-    # DAG Run commands
     "dagrun list --dag-id example_bash_operator --state success --limit=1",
     # Jobs commands
     "jobs list",


### PR DESCRIPTION
## Why:
* When I fixed CI of [59873](https://github.com/apache/airflow/pull/59873), I saw an error 
* <img width="938" height="47" alt="image" src="https://github.com/user-attachments/assets/1e8008cf-12bf-4a39-9aa9-d79b937c4284" />
* Then I checked [cli-and-env-variables-ref.html#dags](https://airflow.apache.org/docs/apache-airflow/stable/cli-and-env-variables-ref.html#dags) and airflow-core/src/airflow/cli/commands/dag_command.py, I did not see `dags update` command

## How
* Remove `dags update` test


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
