### PR TITLE
Improve processes of re-publishing docs

### DIFF
--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -60,6 +60,8 @@
   - [Update default Airflow version in the helm chart](#update-default-airflow-version-in-the-helm-chart)
   - [Update airflow/config_templates/config.yml file](#update-airflowconfig_templatesconfigyml-file)
   - [API clients](#api-clients)
+- [Additional processes](#additional-processes)
+  - [Fixing released documentation](#fixing-released-documentation)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -1458,3 +1460,35 @@ According to the policy above, if we have to release clients:
 
     - [Python client](https://github.com/apache/airflow/blob/main/dev/README_RELEASE_PYTHON_CLIENT.md)
     - [Go client](https://github.com/apache/airflow-client-go/blob/main/dev/README_RELEASE_CLIENT.md)
+
+# Additional processes
+
+Those processes are related to the release of Airflow but should be run in exceptional situations.
+
+## Fixing released documentation
+
+Sometimes we want to rebuild the documentation with some fixes that were merged in main or `v3-X-stable`
+branch, for example when there are html layout changes or typo fixes, or formatting issue fixes.
+
+In this case the process is as follows:
+
+* When you want to re-publish `3.X.Y` docs, create (or pull if already created) `3.X.Y-docs` branch
+* Cherry-pick changes you want to add and push to the main `apache/airflow` repo
+* Run the publishing workflow.
+
+In case you are releasing latest released version of Airflow (which should be most of the cases), run this:
+
+```bash
+breeze workflow-run publish-docs --site-env live --ref 3.X.Y-docs \
+   --skip-tag-validation --airflow-version 3.X.Y \
+   apache-airflow
+```
+
+In case you are releasing an older version of Airflow, you should skip writing to the stable folder
+
+```bash
+breeze workflow-run publish-docs --site-env live --ref 3.X.Y-docs \
+   --skip-tag-validation --airflow-version 3.X.Y \
+   --skip-write-to-stable-folder \
+   apache-airflow
+```

--- a/dev/README_RELEASE_AIRFLOWCTL.md
+++ b/dev/README_RELEASE_AIRFLOWCTL.md
@@ -51,6 +51,8 @@
   - [Add Blog post about the release](#add-blog-post-about-the-release)
   - [Add release data to Apache Committee Report Helper](#add-release-data-to-apache-committee-report-helper)
   - [Close the testing status issue](#close-the-testing-status-issue)
+- [Additional processes](#additional-processes)
+  - [Fixing released documentation](#fixing-released-documentation)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -1013,4 +1015,35 @@ Don't forget to thank the folks who tested and close the issue tracking the test
 
 ```
 Thank you everyone. Airflow-ctl is released.
+```
+
+# Additional processes
+
+## Fixing released documentation
+
+Sometimes we want to rebuild the documentation with some fixes that were merged in main
+branch, for example when there are html layout changes or typo fixes, or formatting issue fixes.
+
+In this case the process is as follows:
+
+* When you want to re-publish `airflow-ctl/X.Y.Z` docs, create (or pull if already created)
+  `airflow-ctl/X.Y.Z-docs` branch
+* Cherry-pick changes you want to add and push to the main `apache/airflow` repo
+* Run the publishing workflow.
+
+In case you are releasing latest released version of airflow-ctl (which should be most of the cases), run this:
+
+```bash
+breeze workflow-run publish-docs --site-env live --ref airflow-ctl/X.Y.Z-docs \
+   --skip-tag-validation \
+   apache-airflow-ctl
+```
+
+In case you are releasing an older version of airflow-ctl, you should skip writing to the stable folder
+
+```bash
+breeze workflow-run publish-docs --site-env live --ref airflow-ctl/X.Y.Z-docs \
+   --skip-tag-validation \
+   --skip-write-to-stable-folder \
+   apache-airflow-ctl
 ```


### PR DESCRIPTION
We have been using rather brittle approach to re-publish docs when we had to apply some changes to the released documentation (such as formatting changes or typo fixes). We had to remember about those cherry-picks to apply them again in case of re-re-publish and of course - we forgot.

This PR adds a better process for that that can be followed by the release manager easily - and such re-publishing of the docs will be tracked in a new `TAG-docs` branch that we should create and release the documentation from - those branches will track any changes already applied and any re-re-re*-publishing will be based on the previous re-re*publishing.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
