### PR TITLE
Update french translation for 3.1.6

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/admin.json
@@ -52,6 +52,12 @@
     "searchPlaceholder": "Rechercher les connexions",
     "test": "Tester la connexion",
     "testDisabled": "Le test de connexion est désactivé. Veuillez contacter un administrateur pour l'activer.",
+    "testError": {
+      "title": "Échec du test de connexion"
+    },
+    "testSuccess": {
+      "title": "Test de connexion réussi"
+    },
     "typeMeta": {
       "error": "Échec de la récupération des métadonnées du type de connexion",
       "standardFields": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/assets.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/assets.json
@@ -1,5 +1,6 @@
 {
   "consumingDags": "Dags consomatteurs",
+  "consumingTasks": "Tâches consommatrices",
   "createEvent": {
     "button": "Créer un événement",
     "manual": {
@@ -21,6 +22,7 @@
     },
     "title": "Créer un événement d'Asset pour {{name}}"
   },
+  "extra": "Extra",
   "group": "Group",
   "lastAssetEvent": "Dernier événement d'Asset",
   "name": "Nom",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/common.json
@@ -85,12 +85,18 @@
     "githubRepo": "Repo GitHub",
     "restApiReference": "Référence API REST"
   },
+  "download": {
+    "download": "Télécharger",
+    "hotkey": "d",
+    "tooltip": "Appuyez sur {{hotkey}} pour télécharger les journaux"
+  },
   "duration": "Durée",
   "endDate": "Date de fin",
   "error": {
     "back": "Retour",
     "defaultMessage": "Une erreur inattendue est survenue",
     "home": "Accueil",
+    "invalidUrl": "Page introuvable. Veuillez vérifier l'URL et réessayer.",
     "notFound": "Page introuvable",
     "title": "Erreur"
   },

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/dags.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/dags.json
@@ -20,7 +20,8 @@
       "all": "Tous",
       "paused": "En pause"
     },
-    "runIdPatternFilter": "Rechercher des exécutions de Dag"
+    "runIdPatternFilter": "Rechercher des exécutions de Dag",
+    "triggeringUserNameFilter": "Rechercher par utilisateur déclencheur"
   },
   "ownerLink": "Lien du propriétaire pour {{owner}}",
   "runAndTaskActions": {


### PR DESCRIPTION
This improves a little bit on main (90.4% to 91.5%), but most importantly when this will be backported to 3.x test branch:
<img width="1445" height="785" alt="Screenshot 2026-01-06 at 10 56 27" src="https://github.com/user-attachments/assets/702f9ca0-ccc2-4c68-9080-6693ff58470d" />
