### PR TITLE
Add workers.celery.args field

### DIFF
--- a/chart/newsfragments/60163.significant.rst
+++ b/chart/newsfragments/60163.significant.rst
@@ -1,0 +1,3 @@
+``workers.args`` command is now deprecated in favor of ``workers.celery.args``.
+
+Along the upgrade of Helm Chart version, change the configuration of ``workers.args`` to ``workers.celery.args`` or unset ``workers.celery.args`` to preserve previous behaviour of the Helm Chart.

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -204,6 +204,14 @@ DEPRECATION WARNING:
 
 {{- end }}
 
+{{- if ne (.Values.workers.args | toJson) (list "bash" "-c" "exec \\\nairflow {{ semverCompare \">=2.0.0\" .Values.airflowVersion | ternary \"celery worker\" \"worker\" }}" | toJson) }}
+
+ DEPRECATION WARNING:
+    `workers.args` has been renamed to `workers.celery.args`.
+    Please change your values as support for the old name will be dropped in a future release.
+
+{{- end }}
+
 {{ if (semverCompare ">=3.0.0" .Values.airflowVersion) }}
 #####################################################
 #  WARNING: You should set a static API secret key  #

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -252,8 +252,8 @@ spec:
           {{- if or .Values.workers.celery.command .Values.workers.command }}
           command: {{ tpl (toYaml (.Values.workers.celery.command | default .Values.workers.command)) . | nindent 12 }}
           {{- end }}
-          {{- if .Values.workers.args }}
-          args: {{ tpl (toYaml .Values.workers.args) . | nindent 12 }}
+          {{- if or .Values.workers.celery.args .Values.workers.args }}
+          args: {{ tpl (toYaml (.Values.workers.celery.args | default .Values.workers.args)) . | nindent 12 }}
           {{- end }}
           resources: {{- toYaml .Values.workers.resources | nindent 12 }}
           {{- if .Values.workers.livenessProbe.enabled }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1660,7 +1660,7 @@
                     "default": null
                 },
                 "args": {
-                    "description": "Args to use when running Airflow Celery workers (templated).",
+                    "description": "Args to use when running Airflow Celery workers (templated) (deprecated, use `workers.celery.args` instead).",
                     "type": [
                         "array",
                         "null"
@@ -2632,6 +2632,21 @@
                                 "type": "string"
                             },
                             "default": null
+                        },
+                        "args": {
+                            "description": "Args to use when running Airflow Celery workers (templated).",
+                            "type": [
+                                "array",
+                                "null"
+                            ],
+                            "items": {
+                                "type": "string"
+                            },
+                            "default": [
+                                "bash",
+                                "-c",
+                                "exec \\\nairflow {{ semverCompare \">=2.0.0\" .Values.airflowVersion | ternary \"celery worker\" \"worker\" }}"
+                            ]
                         },
                         "serviceAccount": {
                             "description": "Create ServiceAccount.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -650,6 +650,7 @@ workers:
   command: ~
 
   # Args to use when running Airflow Celery workers (templated)
+  # (deprecated, use `workers.celery.args` instead)
   args:
     - "bash"
     - "-c"
@@ -1023,6 +1024,14 @@ workers:
 
     # Command to use when running Airflow Celery workers (templated)
     command: ~
+
+    # Args to use when running Airflow Celery workers (templated)
+    args:
+      - "bash"
+      - "-c"
+      - |-
+        exec \
+        airflow {{ semverCompare ">=2.0.0" .Values.airflowVersion | ternary "celery worker" "worker" }}
 
     # Create ServiceAccount for Airflow Celery workers
     serviceAccount:

--- a/helm-tests/tests/helm_tests/airflow_core/test_worker.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_worker.py
@@ -817,10 +817,6 @@ class TestWorker:
             ({"celery": {"command": ["custom", "command"]}}, ["custom", "command"]),
             ({"celery": {"command": ["custom", "{{ .Release.Name }}"]}}, ["custom", "release-name"]),
             ({"command": ["test"], "celery": {"command": ["custom", "command"]}}, ["custom", "command"]),
-            (
-                {"command": ["test"], "celery": {"command": ["custom", "{{ .Release.Name }}"]}},
-                ["custom", "release-name"],
-            ),
         ],
     )
     def test_should_add_command(self, workers_values, expected):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

related: https://github.com/apache/airflow/issues/28880

This PR introduces a new `workers.celery.args` command and deprecates the old `workers.args` command (as it was only applicable to Celery workers).

I deleted one test case in `test_should_add_command` test in `test_workers.py` as it was a duplicate of one above.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
