### PR TITLE
Fix signal handling in triggerer job runner

### DIFF
--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -158,12 +158,13 @@ class TriggererJobRunner(BaseJobRunner, LoggingMixin):
             self.trigger_runner.stop = True
         else:
             self.log.warning("Forcing exit due to second exit signal %s", signum)
-
-            self.trigger_runner.kill(signal.SIGKILL)
+            if self.trigger_runner:
+                self.trigger_runner.kill(signal.SIGKILL)
             sys.exit(os.EX_SOFTWARE)
 
     def _execute(self) -> int | None:
         self.log.info("Starting the triggerer")
+        self.register_signals()
         try:
             # Kick off runner sub-process without DB access
             self.trigger_runner = TriggerRunnerSupervisor.start(
@@ -848,7 +849,6 @@ class TriggerRunner:
     failed_triggers: deque[tuple[int, BaseException | None]]
 
     # Should-we-stop flag
-    # TODO: set this in a sig-int handler
     stop: bool = False
 
     # TODO: connect this to the parent process
@@ -866,8 +866,14 @@ class TriggerRunner:
         self.failed_triggers = deque()
         self.job_id = None
 
+    def _handle_signal(self, signum, frame) -> None:
+        """Handle termination signals gracefully."""
+        self.stop = True
+
     def run(self):
-        """Sync entrypoint - just run a run in an async loop."""
+        """Sync entrypoint - just run arun in an async loop."""
+        signal.signal(signal.SIGINT, self._handle_signal)
+        signal.signal(signal.SIGTERM, self._handle_signal)
         asyncio.run(self.arun())
 
     async def arun(self):


### PR DESCRIPTION
We were not registering our signal handler in the triggerer job. This meant our logging, to improve visibility into the shutdown process, was missing.

Before:

```
2026-01-06T22:23:41.797530Z [info     ] Starting the triggerer         [airflow.jobs.triggerer_job_runner.TriggererJobRunner] loc=triggerer_job_runner.py:166
^C2026-01-06T22:23:42.811630Z [info     ] Waiting for triggers to clean up [airflow.jobs.triggerer_job_runner.TriggererJobRunner] loc=triggerer_job_runner.py:183
2026-01-06T22:23:42.817552Z [info     ] Process exited                 [supervisor] exit_code=-2 loc=supervisor.py:716 pid=5187 signal_sent=SIGINT
2026-01-06T22:23:42.818042Z [info     ] Exited trigger loop            [airflow.jobs.triggerer_job_runner.TriggererJobRunner] loc=triggerer_job_runner.py:188
```

After:

```
2026-01-06T22:24:12.663026Z [info     ] Starting the triggerer         [airflow.jobs.triggerer_job_runner.TriggererJobRunner] loc=triggerer_job_runner.py:166
^C2026-01-06T22:24:20.586689Z [info     ] Exiting gracefully upon receiving signal 2 [airflow.jobs.triggerer_job_runner.TriggererJobRunner] loc=triggerer_job_runner.py:157
2026-01-06T22:24:20.718223Z [info     ] Waiting for triggers to clean up [airflow.jobs.triggerer_job_runner.TriggererJobRunner] loc=triggerer_job_runner.py:184
2026-01-06T22:24:20.718660Z [info     ] Process exited                 [supervisor] exit_code=0 loc=supervisor.py:716 pid=6382 signal_sent=SIGINT
2026-01-06T22:24:20.718819Z [info     ] Exited trigger loop            [airflow.jobs.triggerer_job_runner.TriggererJobRunner] loc=triggerer_job_runner.py:189
```