### PR TITLE
Docs: fix grammar and capitalization in Docker image docs

### DIFF
--- a/docker-stack-docs/README.md
+++ b/docker-stack-docs/README.md
@@ -41,7 +41,7 @@ You can find the following images there (Assuming Airflow version `3.2.0`):
 Those are "reference" regular images. They contain the most common set of extras, dependencies and providers that are
 often used by the users and they are good to "try-things-out" when you want to just take Airflow for a spin,
 
-You can also use "slim" images that contain only core airflow and are about half the size of the "regular" images
+You can also use "slim" images that contain only core Airflow and are about half the size of the "regular" images
 but you need to add all the [Reference for package extras](https://airflow.apache.org/docs/apache-airflow/stable/extra-packages-ref.html) and providers that you need separately
 via [Building the image](https://airflow.apache.org/docs/docker-stack/build.html#build-build-image).
 
@@ -61,7 +61,7 @@ default extras/providers installed are not used by everyone, sometimes others ex
 are needed, sometimes (very often actually) you need to add your own custom dependencies,
 packages or even custom providers. You can learn how to do it in [Building the image](https://airflow.apache.org/docs/docker-stack/build.html#build-build-image).
 
-The production images are build in DockerHub from released version and release candidates. There
+The production images are built in DockerHub from released version and release candidates. There
 are also images published from branches but they are used mainly for development and testing purpose.
 See [Airflow Git Branching](https://github.com/apache/airflow/blob/main/contributing-docs/10_working_with_git.rst#airflow-git-branches)
 for details.


### PR DESCRIPTION
What does this PR do?
Fixes minor grammar and capitalization issues in the Docker image documentation.

Why is it needed?
Improves clarity and consistency of the documentation.

How was this tested?
Docs-only change.
