### PR TITLE
PartitionMapper, IdentityMapper, PartitionedAssetTimetable - core / task-sdk separation

### DIFF
--- a/airflow-core/src/airflow/partition_mapper/__init__.py
+++ b/airflow-core/src/airflow/partition_mapper/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow-core/src/airflow/partition_mapper/base.py
+++ b/airflow-core/src/airflow/partition_mapper/base.py
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+class PartitionMapper(ABC):
+    """
+    Base partition mapper class.
+
+    Maps keys from asset events to target dag run partitions.
+    """
+
+    @abstractmethod
+    def to_downstream(self, key: str) -> str:
+        """Return the target key that the given source partition key maps to."""
+
+    @abstractmethod
+    def to_upstream(self, key: str) -> Iterable[str]:
+        """Yield the source keys that map to the given target partition key."""
+
+    def serialize(self) -> dict[str, Any]:
+        return {}
+
+    @classmethod
+    def deserialize(cls, data: dict[str, Any]) -> PartitionMapper:
+        return cls()

--- a/airflow-core/src/airflow/partition_mapper/identity.py
+++ b/airflow-core/src/airflow/partition_mapper/identity.py
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from airflow.partition_mapper.base import PartitionMapper
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+class IdentityMapper(PartitionMapper):
+    """Partition mapper that does not change the key."""
+
+    def to_downstream(self, key: str) -> str:
+        return key
+
+    def to_upstream(self, key: str) -> Iterable[str]:
+        yield key

--- a/airflow-core/src/airflow/serialization/decoders.py
+++ b/airflow-core/src/airflow/serialization/decoders.py
@@ -35,10 +35,16 @@ from airflow.serialization.definitions.assets import (
     SerializedAssetWatcher,
 )
 from airflow.serialization.enums import DagAttributeTypes as DAT, Encoding
-from airflow.serialization.helpers import find_registered_custom_timetable, is_core_timetable_import_path
+from airflow.serialization.helpers import (
+    PartitionMapperNotFound,
+    find_registered_custom_timetable,
+    is_core_timetable_import_path,
+    load_partition_mapper,
+)
 
 if TYPE_CHECKING:
     from airflow.timetables.base import Timetable as CoreTimetable
+    from airflow.timetables.simple import PartitionMapper
 
 R = TypeVar("R")
 
@@ -139,3 +145,18 @@ def decode_timetable(var: dict[str, Any]) -> CoreTimetable:
     else:
         timetable_type = find_registered_custom_timetable(importable_string)
     return timetable_type.deserialize(var[Encoding.VAR])
+
+
+def decode_partition_mapper(var: dict[str, Any]) -> PartitionMapper:
+    """
+    Decode a previously serialized PartitionMapper.
+
+    Most of the deserialization logic is delegated to the actual type, which
+    we import from string.
+
+    :meta private:
+    """
+    importable_string = var[Encoding.TYPE]
+    if (partition_mapper_class := load_partition_mapper(importable_string)) is not None:
+        return partition_mapper_class.deserialize(var[Encoding.VAR])
+    raise PartitionMapperNotFound(importable_string)

--- a/airflow-core/src/airflow/serialization/decoders.py
+++ b/airflow-core/src/airflow/serialization/decoders.py
@@ -43,8 +43,8 @@ from airflow.serialization.helpers import (
 )
 
 if TYPE_CHECKING:
+    from airflow.partition_mapper.base import PartitionMapper
     from airflow.timetables.base import Timetable as CoreTimetable
-    from airflow.timetables.simple import PartitionMapper
 
 R = TypeVar("R")
 

--- a/airflow-core/src/airflow/serialization/encoders.py
+++ b/airflow-core/src/airflow/serialization/encoders.py
@@ -197,16 +197,16 @@ def encode_timetable(var: BaseTimetable | CoreTimetable) -> dict[str, Any]:
     """
     Encode a timetable instance.
 
-    See ``_TimetableSerializer.serialize()`` for more implementation detail.
+    See ``_Serializer.serialize()`` for more implementation detail.
 
     :meta private:
     """
     importable_string = _get_serialized_timetable_import_path(var)
-    return {Encoding.TYPE: importable_string, Encoding.VAR: _serializer.serialize(var)}
+    return {Encoding.TYPE: importable_string, Encoding.VAR: _serializer.serialize_timetable(var)}
 
 
-class _TimetableSerializer:
-    """Timetable serialization logic."""
+class _Serializer:
+    """Serialization logic."""
 
     BUILTIN_TIMETABLES: dict[type, str] = {
         AssetOrTimeSchedule: "airflow.timetables.assets.AssetOrTimeSchedule",
@@ -224,7 +224,7 @@ class _TimetableSerializer:
     }
 
     @functools.singledispatchmethod
-    def serialize(self, timetable: BaseTimetable | CoreTimetable) -> dict[str, Any]:
+    def serialize_timetable(self, timetable: BaseTimetable | CoreTimetable) -> dict[str, Any]:
         """
         Serialize a timetable into a JSON-compatible dict for storage.
 
@@ -242,17 +242,17 @@ class _TimetableSerializer:
             raise NotImplementedError(f"can not serialize timetable {type(timetable).__name__}")
         return timetable.serialize()
 
-    @serialize.register(ContinuousTimetable)
-    @serialize.register(NullTimetable)
-    @serialize.register(OnceTimetable)
+    @serialize_timetable.register(ContinuousTimetable)
+    @serialize_timetable.register(NullTimetable)
+    @serialize_timetable.register(OnceTimetable)
     def _(self, timetable: ContinuousTimetable | NullTimetable | OnceTimetable) -> dict[str, Any]:
         return {}
 
-    @serialize.register
+    @serialize_timetable.register
     def _(self, timetable: AssetTriggeredTimetable) -> dict[str, Any]:
         return {"asset_condition": encode_asset_like(timetable.asset_condition)}
 
-    @serialize.register
+    @serialize_timetable.register
     def _(self, timetable: EventsTimetable) -> dict[str, Any]:
         return {
             "event_dates": [x.isoformat(sep="T") for x in timetable.event_dates],
@@ -260,15 +260,15 @@ class _TimetableSerializer:
             "description": timetable.description,
         }
 
-    @serialize.register
+    @serialize_timetable.register
     def _(self, timetable: CronDataIntervalTimetable) -> dict[str, Any]:
         return {"expression": timetable.expression, "timezone": encode_timezone(timetable.timezone)}
 
-    @serialize.register
+    @serialize_timetable.register
     def _(self, timetable: DeltaDataIntervalTimetable) -> dict[str, Any]:
         return {"delta": encode_interval(timetable.delta)}
 
-    @serialize.register
+    @serialize_timetable.register
     def _(self, timetable: CronTriggerTimetable) -> dict[str, Any]:
         return {
             "expression": timetable.expression,
@@ -277,14 +277,14 @@ class _TimetableSerializer:
             "run_immediately": encode_run_immediately(timetable.run_immediately),
         }
 
-    @serialize.register
+    @serialize_timetable.register
     def _(self, timetable: DeltaTriggerTimetable) -> dict[str, Any]:
         return {
             "delta": encode_interval(timetable.delta),
             "interval": encode_interval(timetable.interval),
         }
 
-    @serialize.register
+    @serialize_timetable.register
     def _(self, timetable: MultipleCronTriggerTimetable) -> dict[str, Any]:
         # All timetables share the same timezone, interval, and run_immediately
         # values, so we can just use the first to represent them.
@@ -296,26 +296,38 @@ class _TimetableSerializer:
             "run_immediately": encode_run_immediately(representitive.run_immediately),
         }
 
-    @serialize.register
+    @serialize_timetable.register
     def _(self, timetable: AssetOrTimeSchedule) -> dict[str, Any]:
         return {
             "asset_condition": encode_asset_like(timetable.asset_condition),
             "timetable": encode_timetable(timetable.timetable),
         }
 
-    @serialize.register
+    @serialize_timetable.register
     def _(self, timetable: CoreTimetable) -> dict[str, Any]:
         return timetable.serialize()
 
-    @serialize.register
+    @serialize_timetable.register
     def _(self, timetable: PartitionedAssetTimetable) -> dict[str, Any]:
         return {
             "asset_condition": encode_asset_like(timetable.asset_condition),
             "partition_mapper": encode_partition_mapper(timetable.partition_mapper),
         }
 
+    BUILTIN_PARTITION_MAPPERS: dict[type, str] = {
+        IdentityMapper: "airflow.timetables.simple.IdentityMapper",
+    }
 
-_serializer = _TimetableSerializer()
+    @functools.singledispatchmethod
+    def serialize_partition_mapper(self, partition_mapper: PartitionMapper) -> dict[str, Any]:
+        raise NotImplementedError
+
+    @serialize_partition_mapper.register
+    def _(self, partition_mapper: IdentityMapper) -> dict[str, Any]:
+        return {}
+
+
+_serializer = _Serializer()
 
 
 @overload
@@ -366,23 +378,6 @@ def ensure_serialized_asset(obj: BaseAsset | SerializedAssetBase) -> SerializedA
     return decode_asset_like(encode_asset_like(obj))
 
 
-class _PartitionMapperSerializer:
-    BUILTIN_PARTITION_MAPPERS: dict[type, str] = {
-        IdentityMapper: "airflow.timetables.simple.IdentityMapper",
-    }
-
-    @functools.singledispatchmethod
-    def serialize(self, partition_mapper: PartitionMapper) -> dict[str, Any]:
-        raise NotImplementedError
-
-    @serialize.register
-    def _(self, partition_mapper: IdentityMapper) -> dict[str, Any]:
-        return {}
-
-
-_partition_mapper_serializer = _PartitionMapperSerializer()
-
-
 def encode_partition_mapper(var: PartitionMapper) -> dict[str, Any]:
     """
     Encode a PartitionMapper instance.
@@ -394,11 +389,11 @@ def encode_partition_mapper(var: PartitionMapper) -> dict[str, Any]:
     """
     var_type = qualname(type(var))
     if not is_core_partition_mapper_import_path(var_type):
-        var_type = _partition_mapper_serializer.BUILTIN_PARTITION_MAPPERS[type(var)]
+        var_type = _serializer.BUILTIN_PARTITION_MAPPERS[type(var)]
 
     # TODO: (AIP-76) handle airflow plugins cases (not part of 3.2)
 
     return {
         Encoding.TYPE: var_type,
-        Encoding.VAR: _partition_mapper_serializer.serialize(var),
+        Encoding.VAR: _serializer.serialize_partition_mapper(var),
     }

--- a/airflow-core/src/airflow/serialization/encoders.py
+++ b/airflow-core/src/airflow/serialization/encoders.py
@@ -39,6 +39,7 @@ from airflow.sdk import (
     EventsTimetable,
     IdentityMapper,
     MultipleCronTriggerTimetable,
+    PartitionMapper,
 )
 from airflow.sdk.bases.timetable import BaseTimetable
 from airflow.sdk.definitions.asset import AssetRef

--- a/airflow-core/src/airflow/serialization/encoders.py
+++ b/airflow-core/src/airflow/serialization/encoders.py
@@ -315,7 +315,7 @@ class _Serializer:
         }
 
     BUILTIN_PARTITION_MAPPERS: dict[type, str] = {
-        IdentityMapper: "airflow.timetables.simple.IdentityMapper",
+        IdentityMapper: "airflow.partition_mapper.identity.IdentityMapper",
     }
 
     @functools.singledispatchmethod

--- a/airflow-core/src/airflow/serialization/helpers.py
+++ b/airflow-core/src/airflow/serialization/helpers.py
@@ -27,8 +27,8 @@ from airflow.configuration import conf
 from airflow.settings import json
 
 if TYPE_CHECKING:
+    from airflow.partition_mapper.base import PartitionMapper
     from airflow.timetables.base import Timetable as CoreTimetable
-    from airflow.timetables.simple import PartitionMapper
 
 
 def serialize_template_field(template_field: Any, name: str) -> str | dict | list | int | float:
@@ -152,7 +152,7 @@ class PartitionMapperNotFound(ValueError):
 
 def is_core_partition_mapper_import_path(importable_string: str) -> bool:
     """Whether an importable string points to a core partition mapper class."""
-    return importable_string.startswith("airflow.timetables.")
+    return importable_string.startswith("airflow.partition_mapper.")
 
 
 def load_partition_mapper(importable_string: str) -> PartitionMapper | None:

--- a/airflow-core/src/airflow/serialization/helpers.py
+++ b/airflow-core/src/airflow/serialization/helpers.py
@@ -14,20 +14,21 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Serialized DAG and BaseOperator."""
+"""Serialized Dag and BaseOperator."""
 
 from __future__ import annotations
 
 import contextlib
 from typing import TYPE_CHECKING, Any
 
-from airflow._shared.module_loading import qualname
+from airflow._shared.module_loading import import_string, qualname
 from airflow._shared.secrets_masker import redact
 from airflow.configuration import conf
 from airflow.settings import json
 
 if TYPE_CHECKING:
     from airflow.timetables.base import Timetable as CoreTimetable
+    from airflow.timetables.simple import PartitionMapper
 
 
 def serialize_template_field(template_field: Any, name: str) -> str | dict | list | int | float:
@@ -133,3 +134,29 @@ def find_registered_custom_timetable(importable_string: str) -> type[CoreTimetab
 def is_core_timetable_import_path(importable_string: str) -> bool:
     """Whether an importable string points to a core timetable class."""
     return importable_string.startswith("airflow.timetables.")
+
+
+class PartitionMapperNotFound(ValueError):
+    """Raise when a PartitionMapper cannot be found."""
+
+    def __init__(self, type_string: str) -> None:
+        self.type_string = type_string
+
+    def __str__(self) -> str:
+        return (
+            f"PartitionMapper class {self.type_string!r} could not be imported or "
+            "you have a top level database access that disrupted the session. "
+            "Please check the airflow best practices documentation."
+        )
+
+
+def is_core_partition_mapper_import_path(importable_string: str) -> bool:
+    """Whether an importable string points to a core partition mapper class."""
+    return importable_string.startswith("airflow.timetables.")
+
+
+def load_partition_mapper(importable_string: str) -> PartitionMapper | None:
+    if is_core_partition_mapper_import_path(importable_string):
+        return import_string(importable_string)
+    # TODO: (AIP-76) handle airflow plugins cases (3.3+)
+    return None

--- a/airflow-core/src/airflow/timetables/simple.py
+++ b/airflow-core/src/airflow/timetables/simple.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, TypeAlias
 
 from airflow._shared.timezones import timezone
@@ -34,10 +33,11 @@ except ModuleNotFoundError:
 
 
 if TYPE_CHECKING:
-    from collections.abc import Collection, Iterable, Sequence
+    from collections.abc import Collection, Sequence
 
     from pendulum import DateTime
 
+    from airflow.partition_mapper.base import PartitionMapper
     from airflow.timetables.base import TimeRestriction
     from airflow.utils.types import DagRunType
 
@@ -263,36 +263,3 @@ class PartitionedAssetTimetable(AssetTriggeredTimetable):
             assets=decode_asset_like(data["asset_condition"]),
             partition_mapper=decode_partition_mapper(data["partition_mapper"]),
         )
-
-
-class PartitionMapper(ABC):
-    """
-    Base partition mapper class.
-
-    Maps keys from asset events to target dag run partitions.
-    """
-
-    @abstractmethod
-    def to_downstream(self, key: str) -> str:
-        """Return the target key that the given source partition key maps to."""
-
-    @abstractmethod
-    def to_upstream(self, key: str) -> Iterable[str]:
-        """Yield the source keys that map to the given target partition key."""
-
-    def serialize(self) -> dict[str, Any]:
-        return {}
-
-    @classmethod
-    def deserialize(cls, data: dict[str, Any]) -> PartitionMapper:
-        return cls()
-
-
-class IdentityMapper(PartitionMapper):
-    """Partition mapper that does not change the key."""
-
-    def to_downstream(self, key: str) -> str:
-        return key
-
-    def to_upstream(self, key: str) -> Iterable[str]:
-        yield key

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -82,10 +82,10 @@ from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.standard.triggers.file import FileDeleteTrigger
 from airflow.sdk import DAG, Asset, AssetAlias, AssetWatcher, task
 from airflow.sdk.definitions.callback import AsyncCallback, SyncCallback
+from airflow.sdk.definitions.timetables.assets import IdentityMapper, PartitionedAssetTimetable
 from airflow.serialization.definitions.dag import SerializedDAG
 from airflow.serialization.serialized_objects import LazyDeserializedDAG
 from airflow.timetables.base import DataInterval
-from airflow.timetables.simple import IdentityMapper, PartitionedAssetTimetable
 from airflow.utils.session import create_session, provide_session
 from airflow.utils.span_status import SpanStatus
 from airflow.utils.state import DagRunState, State, TaskInstanceState

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -82,7 +82,8 @@ from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.standard.triggers.file import FileDeleteTrigger
 from airflow.sdk import DAG, Asset, AssetAlias, AssetWatcher, task
 from airflow.sdk.definitions.callback import AsyncCallback, SyncCallback
-from airflow.sdk.definitions.timetables.assets import IdentityMapper, PartitionedAssetTimetable
+from airflow.sdk.definitions.partition_mapper.identity import IdentityMapper
+from airflow.sdk.definitions.timetables.assets import PartitionedAssetTimetable
 from airflow.serialization.definitions.dag import SerializedDAG
 from airflow.serialization.serialized_objects import LazyDeserializedDAG
 from airflow.timetables.base import DataInterval

--- a/airflow-core/tests/unit/models/test_taskinstance.py
+++ b/airflow-core/tests/unit/models/test_taskinstance.py
@@ -67,7 +67,18 @@ from airflow.providers.standard.operators.bash import BashOperator
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.standard.operators.python import PythonOperator
 from airflow.providers.standard.sensors.python import PythonSensor
-from airflow.sdk import DAG, Asset, AssetAlias, BaseOperator, BaseSensorOperator, Metadata, task, task_group
+from airflow.sdk import (
+    DAG,
+    Asset,
+    AssetAlias,
+    BaseOperator,
+    BaseSensorOperator,
+    IdentityMapper,
+    Metadata,
+    PartitionedAssetTimetable,
+    task,
+    task_group,
+)
 from airflow.sdk.api.datamodels._generated import AssetEventResponse, AssetResponse
 from airflow.sdk.definitions.param import process_params
 from airflow.sdk.definitions.taskgroup import TaskGroup
@@ -83,7 +94,6 @@ from airflow.ti_deps.dependencies_states import RUNNABLE_STATES
 from airflow.ti_deps.deps.base_ti_dep import TIDepStatus
 from airflow.ti_deps.deps.ready_to_reschedule import ReadyToRescheduleDep
 from airflow.ti_deps.deps.trigger_rule_dep import TriggerRuleDep, _UpstreamTIStates
-from airflow.timetables.simple import IdentityMapper, PartitionedAssetTimetable
 from airflow.utils.session import create_session, provide_session
 from airflow.utils.span_status import SpanStatus
 from airflow.utils.state import DagRunState, State, TaskInstanceState

--- a/airflow-core/tests/unit/serialization/test_serialized_objects.py
+++ b/airflow-core/tests/unit/serialization/test_serialized_objects.py
@@ -79,6 +79,7 @@ from airflow.serialization.definitions.assets import (
 from airflow.serialization.definitions.deadline import DeadlineAlertFields
 from airflow.serialization.encoders import ensure_serialized_asset
 from airflow.serialization.enums import DagAttributeTypes as DAT, Encoding
+from airflow.serialization.helpers import PartitionMapperNotFound
 from airflow.serialization.serialized_objects import (
     BaseSerialization,
     DagSerialization,
@@ -712,6 +713,45 @@ def test_encode_timezone():
     assert encode_timezone(FixedTimezone(0)) == "UTC"
     with pytest.raises(ValueError, match="DAG timezone should be a pendulum.tz.Timezone"):
         encode_timezone(object())
+
+
+def test_encode_partition_mapper():
+    from airflow.sdk import IdentityMapper
+    from airflow.serialization.encoders import encode_partition_mapper
+
+    partition_mapper = IdentityMapper()
+    assert encode_partition_mapper(partition_mapper) == {
+        Encoding.TYPE: "airflow.timetables.simple.IdentityMapper",
+        Encoding.VAR: {},
+    }
+
+
+def test_decode_partition_mapper():
+    from airflow.sdk import IdentityMapper
+    from airflow.serialization.decoders import decode_partition_mapper
+    from airflow.serialization.encoders import encode_partition_mapper
+    from airflow.timetables.simple import IdentityMapper as CoreIdentityMapper
+
+    partition_mapper = IdentityMapper()
+    encoded_pm = encode_partition_mapper(partition_mapper)
+
+    core_pm = decode_partition_mapper(encoded_pm)
+
+    assert isinstance(core_pm, CoreIdentityMapper)
+
+
+def test_decode_partition_mapper_not_exists():
+    from airflow.serialization.decoders import decode_partition_mapper
+
+    with pytest.raises(
+        PartitionMapperNotFound,
+        match=(
+            "PartitionMapper class 'not_exists' could not be imported or "
+            "you have a top level database access that disrupted the session. "
+            "Please check the airflow best practices documentation."
+        ),
+    ):
+        decode_partition_mapper({Encoding.TYPE: "not_exists", Encoding.VAR: {}})
 
 
 class TestSerializedBaseOperator:

--- a/airflow-core/tests/unit/serialization/test_serialized_objects.py
+++ b/airflow-core/tests/unit/serialization/test_serialized_objects.py
@@ -721,16 +721,16 @@ def test_encode_partition_mapper():
 
     partition_mapper = IdentityMapper()
     assert encode_partition_mapper(partition_mapper) == {
-        Encoding.TYPE: "airflow.timetables.simple.IdentityMapper",
+        Encoding.TYPE: "airflow.partition_mapper.identity.IdentityMapper",
         Encoding.VAR: {},
     }
 
 
 def test_decode_partition_mapper():
+    from airflow.partition_mapper.identity import IdentityMapper as CoreIdentityMapper
     from airflow.sdk import IdentityMapper
     from airflow.serialization.decoders import decode_partition_mapper
     from airflow.serialization.encoders import encode_partition_mapper
-    from airflow.timetables.simple import IdentityMapper as CoreIdentityMapper
 
     partition_mapper = IdentityMapper()
     encoded_pm = encode_partition_mapper(partition_mapper)

--- a/airflow-core/tests/unit/timetables/test_assets_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_assets_timetable.py
@@ -142,7 +142,7 @@ def test_serialization(sdk_asset_timetable: SdkAssetOrTimeSchedule, monkeypatch:
     monkeypatch.setattr(
         "airflow.serialization.encoders.encode_timetable", lambda x: "mock_serialized_timetable"
     )
-    serialized = _serializer.serialize(sdk_asset_timetable)
+    serialized = _serializer.serialize_timetable(sdk_asset_timetable)
     assert serialized == {
         "timetable": "mock_serialized_timetable",
         "asset_condition": {

--- a/task-sdk/docs/api.rst
+++ b/task-sdk/docs/api.rst
@@ -171,6 +171,13 @@ Timetables
 
 .. autoapiclass:: airflow.sdk.MultipleCronTriggerTimetable
 
+.. autoapiclass:: airflow.sdk.PartitionMapper
+
+.. autoapiclass:: airflow.sdk.IdentityMapper
+
+.. autoapiclass:: airflow.sdk.PartitionedAssetTimetable
+
+
 I/O Helpers
 -----------
 .. autoapiclass:: airflow.sdk.ObjectStoragePath

--- a/task-sdk/src/airflow/sdk/__init__.py
+++ b/task-sdk/src/airflow/sdk/__init__.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from airflow.sdk.definitions.timetables.assets import IdentityMapper
+
 __all__ = [
     "__version__",
     "Asset",
@@ -42,12 +44,15 @@ __all__ = [
     "DeltaTriggerTimetable",
     "EdgeModifier",
     "EventsTimetable",
+    "IdentityMapper",
     "Label",
     "Metadata",
     "MultipleCronTriggerTimetable",
     "ObjectStoragePath",
     "Param",
     "ParamsDict",
+    "PartitionedAssetTimetable",
+    "PartitionMapper",
     "PokeReturnValue",
     "TaskGroup",
     "TaskInstanceState",
@@ -100,7 +105,12 @@ if TYPE_CHECKING:
     from airflow.sdk.definitions.param import Param, ParamsDict
     from airflow.sdk.definitions.taskgroup import TaskGroup
     from airflow.sdk.definitions.template import literal
-    from airflow.sdk.definitions.timetables.assets import AssetOrTimeSchedule
+    from airflow.sdk.definitions.timetables.assets import (
+        AssetOrTimeSchedule,
+        IdentityMapper,
+        PartitionedAssetTimetable,
+        PartitionMapper,
+    )
     from airflow.sdk.definitions.timetables.events import EventsTimetable
     from airflow.sdk.definitions.timetables.interval import (
         CronDataIntervalTimetable,
@@ -142,12 +152,15 @@ __lazy_imports: dict[str, str] = {
     "DeltaTriggerTimetable": ".definitions.timetables.trigger",
     "EdgeModifier": ".definitions.edges",
     "EventsTimetable": ".definitions.timetables.events",
+    "IdentityMapper": ".definitions.timetables.assets",
     "Label": ".definitions.edges",
     "Metadata": ".definitions.asset.metadata",
     "MultipleCronTriggerTimetable": ".definitions.timetables.trigger",
     "ObjectStoragePath": ".io.path",
     "Param": ".definitions.param",
     "ParamsDict": ".definitions.param",
+    "PartitionedAssetTimetable": ".definitions.timetables.assets",
+    "PartitionMapper": ".definitions.timetables.assets",
     "PokeReturnValue": ".bases.sensor",
     "SecretCache": ".execution_time.cache",
     "TaskGroup": ".definitions.taskgroup",

--- a/task-sdk/src/airflow/sdk/__init__.py
+++ b/task-sdk/src/airflow/sdk/__init__.py
@@ -18,8 +18,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from airflow.sdk.definitions.timetables.assets import IdentityMapper
-
 __all__ = [
     "__version__",
     "Asset",
@@ -103,13 +101,13 @@ if TYPE_CHECKING:
     from airflow.sdk.definitions.decorators.task_group import task_group
     from airflow.sdk.definitions.edges import EdgeModifier, Label
     from airflow.sdk.definitions.param import Param, ParamsDict
+    from airflow.sdk.definitions.partition_mapper.base import PartitionMapper
+    from airflow.sdk.definitions.partition_mapper.identity import IdentityMapper
     from airflow.sdk.definitions.taskgroup import TaskGroup
     from airflow.sdk.definitions.template import literal
     from airflow.sdk.definitions.timetables.assets import (
         AssetOrTimeSchedule,
-        IdentityMapper,
         PartitionedAssetTimetable,
-        PartitionMapper,
     )
     from airflow.sdk.definitions.timetables.events import EventsTimetable
     from airflow.sdk.definitions.timetables.interval import (
@@ -152,7 +150,7 @@ __lazy_imports: dict[str, str] = {
     "DeltaTriggerTimetable": ".definitions.timetables.trigger",
     "EdgeModifier": ".definitions.edges",
     "EventsTimetable": ".definitions.timetables.events",
-    "IdentityMapper": ".definitions.timetables.assets",
+    "IdentityMapper": ".definitions.partition_mapper.identity",
     "Label": ".definitions.edges",
     "Metadata": ".definitions.asset.metadata",
     "MultipleCronTriggerTimetable": ".definitions.timetables.trigger",
@@ -160,7 +158,7 @@ __lazy_imports: dict[str, str] = {
     "Param": ".definitions.param",
     "ParamsDict": ".definitions.param",
     "PartitionedAssetTimetable": ".definitions.timetables.assets",
-    "PartitionMapper": ".definitions.timetables.assets",
+    "PartitionMapper": ".definitions.partition_mapper.base",
     "PokeReturnValue": ".bases.sensor",
     "SecretCache": ".execution_time.cache",
     "TaskGroup": ".definitions.taskgroup",

--- a/task-sdk/src/airflow/sdk/__init__.pyi
+++ b/task-sdk/src/airflow/sdk/__init__.pyi
@@ -56,6 +56,8 @@ from airflow.sdk.definitions.decorators import setup as setup, task as task, tea
 from airflow.sdk.definitions.decorators.task_group import task_group as task_group
 from airflow.sdk.definitions.edges import EdgeModifier as EdgeModifier, Label as Label
 from airflow.sdk.definitions.param import Param as Param
+from airflow.sdk.definitions.partition_mapper.base import PartitionMapper
+from airflow.sdk.definitions.partition_mapper.identity import IdentityMapper
 from airflow.sdk.definitions.taskgroup import TaskGroup as TaskGroup
 from airflow.sdk.definitions.template import literal as literal
 from airflow.sdk.definitions.timetables.assets import (

--- a/task-sdk/src/airflow/sdk/__init__.pyi
+++ b/task-sdk/src/airflow/sdk/__init__.pyi
@@ -58,7 +58,10 @@ from airflow.sdk.definitions.edges import EdgeModifier as EdgeModifier, Label as
 from airflow.sdk.definitions.param import Param as Param
 from airflow.sdk.definitions.taskgroup import TaskGroup as TaskGroup
 from airflow.sdk.definitions.template import literal as literal
-from airflow.sdk.definitions.timetables.assets import AssetOrTimeSchedule
+from airflow.sdk.definitions.timetables.assets import (
+    AssetOrTimeSchedule,
+    PartitionedAssetTimetable,
+)
 from airflow.sdk.definitions.timetables.events import EventsTimetable
 from airflow.sdk.definitions.timetables.interval import (
     CronDataIntervalTimetable,
@@ -101,12 +104,15 @@ __all__ = [
     "DeltaTriggerTimetable",
     "EdgeModifier",
     "EventsTimetable",
+    "IdentityMapper",
     "Label",
     "Metadata",
     "MultipleCronTriggerTimetable",
     "ObjectStoragePath",
     "Param",
     "PokeReturnValue",
+    "PartitionedAssetTimetable",
+    "PartitionMapper",
     "SecretCache",
     "TaskGroup",
     "TaskInstanceState",

--- a/task-sdk/src/airflow/sdk/definitions/partition_mapper/__init__.py
+++ b/task-sdk/src/airflow/sdk/definitions/partition_mapper/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/task-sdk/src/airflow/sdk/definitions/partition_mapper/base.py
+++ b/task-sdk/src/airflow/sdk/definitions/partition_mapper/base.py
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+
+class PartitionMapper:
+    """
+    Base partition mapper class.
+
+    Maps keys from asset events to target dag run partitions.
+    """

--- a/task-sdk/src/airflow/sdk/definitions/partition_mapper/identity.py
+++ b/task-sdk/src/airflow/sdk/definitions/partition_mapper/identity.py
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from airflow.sdk.definitions.partition_mapper.base import PartitionMapper
+
+
+class IdentityMapper(PartitionMapper):
+    """Partition mapper that does not change the key."""

--- a/task-sdk/src/airflow/sdk/definitions/timetables/assets.py
+++ b/task-sdk/src/airflow/sdk/definitions/timetables/assets.py
@@ -17,14 +17,14 @@
 
 from __future__ import annotations
 
-import typing
+from typing import TYPE_CHECKING
 
 import attrs
 
 from airflow.sdk.bases.timetable import BaseTimetable
 from airflow.sdk.definitions.asset import AssetAll, BaseAsset
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     from collections.abc import Collection
 
     from airflow.sdk import Asset
@@ -41,6 +41,26 @@ class AssetTriggeredTimetable(BaseTimetable):
     """
 
     asset_condition: BaseAsset = attrs.field(alias="assets")
+
+
+class PartitionMapper:
+    """
+    Base partition mapper class.
+
+    Maps keys from asset events to target dag run partitions.
+    """
+
+
+class IdentityMapper(PartitionMapper):
+    """Partition mapper that does not change the key."""
+
+
+@attrs.define
+class PartitionedAssetTimetable(AssetTriggeredTimetable):
+    """Asset-driven timetable that listens for partitioned assets."""
+
+    asset_condition: BaseAsset = attrs.field(alias="assets")
+    partition_mapper: PartitionMapper
 
 
 def _coerce_assets(o: Collection[Asset] | BaseAsset) -> BaseAsset:

--- a/task-sdk/src/airflow/sdk/definitions/timetables/assets.py
+++ b/task-sdk/src/airflow/sdk/definitions/timetables/assets.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from collections.abc import Collection
 
     from airflow.sdk import Asset
+    from airflow.sdk.definitions.partition_mapper.base import PartitionMapper
 
 
 @attrs.define
@@ -41,18 +42,6 @@ class AssetTriggeredTimetable(BaseTimetable):
     """
 
     asset_condition: BaseAsset = attrs.field(alias="assets")
-
-
-class PartitionMapper:
-    """
-    Base partition mapper class.
-
-    Maps keys from asset events to target dag run partitions.
-    """
-
-
-class IdentityMapper(PartitionMapper):
-    """Partition mapper that does not change the key."""
 
 
 @attrs.define


### PR DESCRIPTION
## Why
core, task-sdk separation for PartitionMapper, IdentityMapper, and PartitionedAssetTimetable, 

closes: https://github.com/apache/airflow/issues/59318

## What
* Add PartitionMapper, IdentityMapper, and PartitionedAssetTimetable to `airflow.sdk`
* Serialize SDK ones and than deserialize them into the core counterpart for the server


<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
