### PR TITLE
Concurrent backfills

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/backfills.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/backfills.py
@@ -46,7 +46,6 @@ from airflow.api_fastapi.logging.decorators import action_logging
 from airflow.exceptions import DagNotFound, DagRunTypeNotAllowed
 from airflow.models import DagRun
 from airflow.models.backfill import (
-    AlreadyRunningBackfill,
     Backfill,
     BackfillDagRun,
     DagNoScheduleException,
@@ -242,12 +241,6 @@ def create_backfill(
             run_on_latest_version=backfill_request.run_on_latest_version,
         )
         return BackfillResponse.model_validate(backfill_obj)
-
-    except AlreadyRunningBackfill:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=f"There is already a running backfill for dag {backfill_request.dag_id}",
-        )
 
     except DagNotFound:
         raise HTTPException(

--- a/airflow-core/src/airflow/models/backfill.py
+++ b/airflow-core/src/airflow/models/backfill.py
@@ -60,14 +60,6 @@ if TYPE_CHECKING:
 log = structlog.get_logger(__name__)
 
 
-class AlreadyRunningBackfill(AirflowException):
-    """
-    Raised when attempting to create backfill and one already active.
-
-    :meta private:
-    """
-
-
 class DagNoScheduleException(AirflowException):
     """
     Raised when attempting to create backfill for a Dag with no schedule.
@@ -573,20 +565,6 @@ def _create_backfill(
                 raise DagRunTypeNotAllowed(f"Dag with dag_id: '{dag_id}' does not allow backfill runs")
             if dag_model.timetable_summary == "None":
                 raise DagNoScheduleException(f"{dag_id} has no schedule")
-
-        num_active = session.scalar(
-            select(func.count()).where(
-                Backfill.dag_id == dag_id,
-                Backfill.completed_at.is_(None),
-            )
-        )
-        if num_active is None:
-            raise UnknownActiveBackfills(dag_id)
-        if num_active > 0:
-            raise AlreadyRunningBackfill(
-                f"Another backfill is running for Dag {dag_id}. "
-                f"There can be only one running backfill per Dag."
-            )
 
         dag = serdag.dag
         _validate_backfill_params(dag, reverse, from_date, to_date, reprocess_behavior)

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/components.json
@@ -33,7 +33,9 @@
     "backfillInProgress": "Backfill in progress",
     "cancel": "Cancel backfill",
     "pause": "Pause backfill",
-    "unpause": "Unpause backfill"
+    "unpause": "Unpause backfill",
+    "viewMore_one": "1 More Active Backfill",
+    "viewMore_other": "{{count}} More Active Backfills"
   },
   "clipboard": {
     "copy": "Copy"

--- a/airflow-core/src/airflow/ui/src/components/Banner/BackfillBanner.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Banner/BackfillBanner.tsx
@@ -16,11 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Button, HStack, Spacer, Text, type ButtonProps } from "@chakra-ui/react";
+import { Box, Button, HStack, Link, Spacer, Text, VStack, type ButtonProps } from "@chakra-ui/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { MdPause, MdPlayArrow, MdStop } from "react-icons/md";
 import { RiArrowGoBackFill } from "react-icons/ri";
+import { Link as RouterLink } from "react-router-dom";
 
 import {
   useBackfillServiceCancelBackfill,
@@ -65,7 +66,8 @@ const BackfillBanner = ({ dagId }: Props) => {
           : false,
     },
   );
-  const [backfill] = data?.backfills.filter((bf: BackfillResponse) => bf.completed_at === null) ?? [];
+  const [backfill] = data?.backfills ?? [];
+  const additionalBackfillsCount = (data?.backfills.length ?? 0) - 1;
 
   const queryClient = useQueryClient();
   const onSuccess = async () => {
@@ -105,35 +107,49 @@ const BackfillBanner = ({ dagId }: Props) => {
   return (
     <Box bg="info.solid" borderRadius="full" color="info.contrast" my="1" px="2" py="1">
       <HStack alignItems="center" ml={3}>
-        <RiArrowGoBackFill />
-        <Text key="backfill">{translate("banner.backfillInProgress")}:</Text>
-        <Text fontSize="sm">
-          {" "}
-          <Time datetime={backfill.from_date} /> - <Time datetime={backfill.to_date} />
-        </Text>
-
-        <Spacer flex="max-content" />
-        <ProgressBar size="xs" visibility="visible" />
-        <Button
-          aria-label={backfill.is_paused ? translate("banner.unpause") : translate("banner.pause")}
-          loading={isPausePending || isUnPausePending}
-          onClick={() => {
-            togglePause();
-          }}
-          {...buttonProps}
-        >
-          {backfill.is_paused ? <MdPlayArrow /> : <MdPause />}
-        </Button>
-        <Button
-          aria-label={translate("banner.cancel")}
-          loading={isStopPending}
-          onClick={() => {
-            cancel();
-          }}
-          {...buttonProps}
-        >
-          <MdStop />
-        </Button>
+        <VStack align="stretch" flex={1} gap={1}>
+          <HStack alignItems="center">
+            <RiArrowGoBackFill />
+            <Text key="backfill">{translate("banner.backfillInProgress")}:</Text>
+            <Text fontSize="sm">
+              {" "}
+              <Time datetime={backfill.from_date} /> - <Time datetime={backfill.to_date} />
+            </Text>
+            <Spacer flex="max-content" />
+            <ProgressBar size="xs" visibility="visible" />
+          </HStack>
+          {additionalBackfillsCount > 0 && (
+            <HStack mb={1}>
+              <Link asChild color="info.contrast" fontSize="sm" textDecoration="underline">
+                <RouterLink to={`/dags/${dagId}/backfills`}>
+                  {translate("banner.viewMore", { count: additionalBackfillsCount })}
+                </RouterLink>
+              </Link>
+            </HStack>
+          )}
+        </VStack>
+        <HStack>
+          <Button
+            aria-label={backfill.is_paused ? translate("banner.unpause") : translate("banner.pause")}
+            loading={isPausePending || isUnPausePending}
+            onClick={() => {
+              togglePause();
+            }}
+            {...buttonProps}
+          >
+            {backfill.is_paused ? <MdPlayArrow /> : <MdPause />}
+          </Button>
+          <Button
+            aria-label={translate("banner.cancel")}
+            loading={isStopPending}
+            onClick={() => {
+              cancel();
+            }}
+            {...buttonProps}
+          >
+            <MdStop />
+          </Button>
+        </HStack>
       </HStack>
     </Box>
   );

--- a/airflow-core/tests/unit/models/test_backfill.py
+++ b/airflow-core/tests/unit/models/test_backfill.py
@@ -28,7 +28,6 @@ from sqlalchemy import select
 from airflow._shared.timezones import timezone
 from airflow.models import DagModel, DagRun, TaskInstance
 from airflow.models.backfill import (
-    AlreadyRunningBackfill,
     Backfill,
     BackfillDagRun,
     BackfillDagRunExceptionReason,
@@ -411,10 +410,17 @@ def test_params_stored_correctly(dag_maker, session):
     )
 
 
-def test_active_dag_run(dag_maker, session):
+def test_overlapping_backfills_skip_overlapping_dates(dag_maker, session):
+    """
+    Verify that when creating a backfill that overlaps with an active one,
+    we create a BackfillDagRun for every requested date. Dates in the other
+    backfill's range are marked IN_FLIGHT (no DagRun created), others are created.
+    """
     with dag_maker(schedule="@daily") as dag:
         PythonOperator(task_id="hi", python_callable=print)
     session.commit()
+
+    # Create first backfill (2021-01-01 to 2021-01-05)
     b1 = _create_backfill(
         dag_id=dag.dag_id,
         from_date=pendulum.parse("2021-01-01"),
@@ -425,16 +431,103 @@ def test_active_dag_run(dag_maker, session):
         dag_run_conf={"this": "param"},
     )
     assert b1 is not None
-    with pytest.raises(AlreadyRunningBackfill, match="Another backfill is running for Dag"):
-        _create_backfill(
-            dag_id=dag.dag_id,
-            from_date=pendulum.parse("2021-02-01"),
-            to_date=pendulum.parse("2021-02-05"),
-            max_active_runs=10,
-            reverse=False,
-            triggering_user_name="pytest",
-            dag_run_conf={"this": "param"},
-        )
+
+    # Create overlapping backfill (2021-01-03 to 2021-01-07), should succeed
+    # All 5 dates get a BackfillDagRun. 01-03..01-05 are IN_FLIGHT, 01-06 and 01-07 get DagRuns
+    b2 = _create_backfill(
+        dag_id=dag.dag_id,
+        from_date=pendulum.parse("2021-01-03"),
+        to_date=pendulum.parse("2021-01-07"),
+        max_active_runs=10,
+        reverse=False,
+        triggering_user_name="pytest",
+        dag_run_conf={"this": "param"},
+    )
+    assert b2 is not None
+    assert b1.id != b2.id
+
+    b2_runs = list(
+        session.scalars(
+            select(BackfillDagRun)
+            .where(BackfillDagRun.backfill_id == b2.id)
+            .order_by(BackfillDagRun.logical_date)
+        ).all()
+    )
+    assert len(b2_runs) == 5
+
+    in_flight_dates = {
+        bdr.logical_date.date().isoformat()
+        for bdr in b2_runs
+        if bdr.exception_reason == BackfillDagRunExceptionReason.IN_FLIGHT
+    }
+    created_dates = {bdr.logical_date.date().isoformat() for bdr in b2_runs if bdr.dag_run_id is not None}
+
+    assert in_flight_dates == {"2021-01-03", "2021-01-04", "2021-01-05"}
+    assert created_dates == {"2021-01-06", "2021-01-07"}
+
+
+def test_non_overlapping_backfills_can_be_created(dag_maker, session):
+    """
+    Verify that two non-overlapping backfills can be created for the same Dag.
+    """
+    with dag_maker(schedule="@daily") as dag:
+        PythonOperator(task_id="hi", python_callable=print)
+    session.commit()
+
+    # Create first backfill
+    b1 = _create_backfill(
+        dag_id=dag.dag_id,
+        from_date=pendulum.parse("2021-01-01"),
+        to_date=pendulum.parse("2021-01-05"),
+        max_active_runs=10,
+        reverse=False,
+        triggering_user_name="pytest",
+        dag_run_conf={},
+    )
+    assert b1 is not None
+
+    # Create second non-overlapping backfill - should succeed
+    b2 = _create_backfill(
+        dag_id=dag.dag_id,
+        from_date=pendulum.parse("2021-01-10"),  # No overlap with first backfill
+        to_date=pendulum.parse("2021-01-15"),
+        max_active_runs=10,
+        reverse=False,
+        triggering_user_name="pytest",
+        dag_run_conf={},
+    )
+    assert b2 is not None
+    assert b1.id != b2.id
+
+    # Verify b1 has BackfillDagRun entries for all dates (2021-01-01 to 2021-01-05)
+    b1_runs = list(
+        session.scalars(
+            select(BackfillDagRun)
+            .where(BackfillDagRun.backfill_id == b1.id)
+            .order_by(BackfillDagRun.logical_date)
+        ).all()
+    )
+    assert len(b1_runs) == 5
+    b1_dates = {bdr.logical_date.date().isoformat() for bdr in b1_runs}
+    assert b1_dates == {"2021-01-01", "2021-01-02", "2021-01-03", "2021-01-04", "2021-01-05"}
+    # All should have dag_run_id set (no IN_FLIGHT)
+    assert all(bdr.dag_run_id is not None for bdr in b1_runs)
+    assert all(bdr.exception_reason is None for bdr in b1_runs)
+
+    # Verify b2 has BackfillDagRun entries for all dates (2021-01-10 to 2021-01-15)
+    b2_runs = list(
+        session.scalars(
+            select(BackfillDagRun)
+            .where(BackfillDagRun.backfill_id == b2.id)
+            .order_by(BackfillDagRun.logical_date)
+        ).all()
+    )
+    assert len(b2_runs) == 6
+    b2_dates = {bdr.logical_date.date().isoformat() for bdr in b2_runs}
+    assert b2_dates == {"2021-01-10", "2021-01-11", "2021-01-12", "2021-01-13", "2021-01-14", "2021-01-15"}
+    # All should have dag_run_id set (no IN_FLIGHT)
+    assert all(bdr.dag_run_id is not None for bdr in b2_runs)
+    assert all(bdr.exception_reason is None for bdr in b2_runs)
 
 
 def create_next_run(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
<!-- Please keep an empty line above the dashes. -->
This PR is to address the need to handle semi-frequent dataset revisions, I'm proposing that we allow multiple backfills to run for a single DAG as long as their date ranges do not overlap. This would let us trigger new backfills via the API to handle revisions without being blocked by an existing backfill “lock” on the DAG.

Screenshot:
<img width="1520" height="1046" alt="Screenshot_2026-01-07_17-35-27" src="https://github.com/user-attachments/assets/c7ca3ba0-15cb-47ce-898d-987fe5d71347" />
