### PR TITLE
Make SQLAlchemy optional for Postgres provider

### DIFF
--- a/providers/postgres/pyproject.toml
+++ b/providers/postgres/pyproject.toml
@@ -69,6 +69,11 @@ dependencies = [
 # The optional dependencies should be modified in place in the generated file
 # Any change in the dependencies is preserved when the file is regenerated
 [project.optional-dependencies]
+sqlalchemy = [
+    "sqlalchemy>=1.4.49"git status
+git status
+
+]
 "amazon" = [
     "apache-airflow-providers-amazon>=2.6.0",
 ]

--- a/providers/postgres/pyproject.toml
+++ b/providers/postgres/pyproject.toml
@@ -70,9 +70,7 @@ dependencies = [
 # Any change in the dependencies is preserved when the file is regenerated
 [project.optional-dependencies]
 sqlalchemy = [
-    "sqlalchemy>=1.4.49"git status
-git status
-
+    "sqlalchemy>=1.4.49"
 ]
 "amazon" = [
     "apache-airflow-providers-amazon>=2.6.0",

--- a/providers/postgres/src/airflow/providers/postgres/hooks/postgres.py
+++ b/providers/postgres/src/airflow/providers/postgres/hooks/postgres.py
@@ -27,7 +27,6 @@ import psycopg2
 import psycopg2.extras
 from more_itertools import chunked
 from psycopg2.extras import DictCursor, NamedTupleCursor, RealDictCursor, execute_batch
-from sqlalchemy.engine import URL
 
 from airflow.exceptions import AirflowOptionalProviderFeatureException
 from airflow.providers.common.compat.sdk import AirflowException, Connection, conf
@@ -166,7 +165,14 @@ class PostgresHook(DbApiHook):
         return dst_type(value) if value is not None else None
 
     @property
-    def sqlalchemy_url(self) -> URL:
+    def sqlalchemy_url(self):
+        try:
+            from sqlalchemy.engine import URL
+        except (ImportError, ModuleNotFoundError) as err:
+            raise AirflowOptionalProviderFeatureException(
+                "SQLAlchemy is not installed. Please install it with "
+                "`pip install apache-airflow-providers-postgres[sqlalchemy]`."
+            ) from err
         conn = self.connection
         query = conn.extra_dejson.get("sqlalchemy_query", {})
         if not isinstance(query, dict):

--- a/providers/postgres/src/airflow/providers/postgres/hooks/postgres.py
+++ b/providers/postgres/src/airflow/providers/postgres/hooks/postgres.py
@@ -56,6 +56,8 @@ if TYPE_CHECKING:
 
     from airflow.providers.common.sql.dialects.dialect import Dialect
     from airflow.providers.openlineage.sqlparser import DatabaseInfo
+    from sqlalchemy.engine import URL
+
 
     if USE_PSYCOPG3:
         from psycopg.errors import Diagnostic
@@ -165,7 +167,7 @@ class PostgresHook(DbApiHook):
         return dst_type(value) if value is not None else None
 
     @property
-    def sqlalchemy_url(self):
+    def sqlalchemy_url(self) -> URL:
         try:
             from sqlalchemy.engine import URL
         except (ImportError, ModuleNotFoundError) as err:


### PR DESCRIPTION
This PR makes SQLAlchemy an optional dependency for the Postgres provider, following the same pattern already applied to other providers (for example Presto and Exasol).

### Summary of changes
- Removed hard SQLAlchemy imports from module level
- Imported SQLAlchemy lazily inside methods that require it
- Raised `AirflowOptionalProviderFeatureException` when SQLAlchemy-dependent functionality is used without SQLAlchemy installed
- Kept SQLAlchemy as an optional extra dependency

This aligns the Postgres provider with the guidance described in the parent issue.

### Note
Apologies for any confusion earlier — I had to delete the previous PR due to some local issues and have opened this new PR with the corrected and final changes.

### References
- Related to: #59905
- Parent issue: #59895
