### PR TITLE
Literal to str Enum for ResourceMethod & ExtendedResourceMethod

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/base_auth_manager.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/base_auth_manager.py
@@ -20,8 +20,9 @@ from __future__ import annotations
 import logging
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
+from enum import Enum
 from functools import cache
-from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from jwt import InvalidTokenError
 from sqlalchemy import select
@@ -72,10 +73,32 @@ if TYPE_CHECKING:
 
 # This cannot be in the TYPE_CHECKING block since some providers import it globally.
 # TODO: Move this inside once all providers drop Airflow 2.x support.
-# List of methods (or actions) a user can do against a resource
-ResourceMethod = Literal["GET", "POST", "PUT", "DELETE"]
-# Extends ``ResourceMethod`` to include "MENU". The method "MENU" is only supported with specific resources (menu items)
-ExtendedResourceMethod = Literal["GET", "POST", "PUT", "DELETE", "MENU"]
+
+
+class ResourceMethod(str, Enum):
+    """HTTP methods (actions) a user can perform against a resource."""
+
+    GET = "GET"
+    POST = "POST"
+    PUT = "PUT"
+    DELETE = "DELETE"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+class ExtendedResourceMethod(str, Enum):
+    """Extended HTTP methods including MENU for UI resource authorization. Extends ResourceMethod to include 'MENU'."""
+
+    GET = "GET"
+    POST = "POST"
+    PUT = "PUT"
+    DELETE = "DELETE"
+    MENU = "MENU"
+
+    def __str__(self) -> str:
+        return self.value
+
 
 log = logging.getLogger(__name__)
 T = TypeVar("T", bound=BaseUser)

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/base_auth_manager.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/base_auth_manager.py
@@ -488,7 +488,7 @@ class BaseAuthManager(Generic[T], LoggingMixin, metaclass=ABCMeta):
         self,
         *,
         user: T,
-        method: ResourceMethod = "GET",
+        method: ResourceMethod = ResourceMethod.GET,
         session: Session = NEW_SESSION,
     ) -> set[str]:
         """
@@ -519,7 +519,7 @@ class BaseAuthManager(Generic[T], LoggingMixin, metaclass=ABCMeta):
         *,
         conn_ids: set[str],
         user: T,
-        method: ResourceMethod = "GET",
+        method: ResourceMethod = ResourceMethod.GET,
         team_name: str | None = None,
     ) -> set[str]:
         """
@@ -548,7 +548,7 @@ class BaseAuthManager(Generic[T], LoggingMixin, metaclass=ABCMeta):
         self,
         *,
         user: T,
-        method: ResourceMethod = "GET",
+        method: ResourceMethod = ResourceMethod.GET,
         session: Session = NEW_SESSION,
     ) -> set[str]:
         """
@@ -587,7 +587,7 @@ class BaseAuthManager(Generic[T], LoggingMixin, metaclass=ABCMeta):
         *,
         dag_ids: set[str],
         user: T,
-        method: ResourceMethod = "GET",
+        method: ResourceMethod = ResourceMethod.GET,
         team_name: str | None = None,
     ) -> set[str]:
         """
@@ -616,7 +616,7 @@ class BaseAuthManager(Generic[T], LoggingMixin, metaclass=ABCMeta):
         self,
         *,
         user: T,
-        method: ResourceMethod = "GET",
+        method: ResourceMethod = ResourceMethod.GET,
         session: Session = NEW_SESSION,
     ) -> set[str]:
         """
@@ -647,7 +647,7 @@ class BaseAuthManager(Generic[T], LoggingMixin, metaclass=ABCMeta):
         *,
         pool_names: set[str],
         user: T,
-        method: ResourceMethod = "GET",
+        method: ResourceMethod = ResourceMethod.GET,
         team_name: str | None = None,
     ) -> set[str]:
         """
@@ -676,7 +676,7 @@ class BaseAuthManager(Generic[T], LoggingMixin, metaclass=ABCMeta):
         self,
         *,
         user: T,
-        method: ResourceMethod = "GET",
+        method: ResourceMethod = ResourceMethod.GET,
         session: Session = NEW_SESSION,
     ) -> set[str]:
         """
@@ -694,7 +694,7 @@ class BaseAuthManager(Generic[T], LoggingMixin, metaclass=ABCMeta):
         *,
         teams_names: set[str],
         user: T,
-        method: ResourceMethod = "GET",
+        method: ResourceMethod = ResourceMethod.GET,
     ) -> set[str]:
         """
         Filter teams the user belongs to.
@@ -718,7 +718,7 @@ class BaseAuthManager(Generic[T], LoggingMixin, metaclass=ABCMeta):
         self,
         *,
         user: T,
-        method: ResourceMethod = "GET",
+        method: ResourceMethod = ResourceMethod.GET,
         session: Session = NEW_SESSION,
     ) -> set[str]:
         """
@@ -749,7 +749,7 @@ class BaseAuthManager(Generic[T], LoggingMixin, metaclass=ABCMeta):
         *,
         variable_keys: set[str],
         user: T,
-        method: ResourceMethod = "GET",
+        method: ResourceMethod = ResourceMethod.GET,
         team_name: str | None = None,
     ) -> set[str]:
         """

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
@@ -274,7 +274,7 @@ class SimpleAuthManager(BaseAuthManager[SimpleAuthManagerUser]):
         return self._is_authorized(method="GET", allow_role=SimpleAuthManagerRole.VIEWER, user=user)
 
     def is_authorized_custom_view(
-        self, *, method: ResourceMethod | str, resource_name: str, user: SimpleAuthManagerUser
+        self, *, method: ResourceMethod, resource_name: str, user: SimpleAuthManagerUser
     ):
         return self._is_authorized(method="GET", allow_role=SimpleAuthManagerRole.VIEWER, user=user)
 

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/cli/commands.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/cli/commands.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import get_args
 
 from keycloak import KeycloakAdmin, KeycloakError
 
@@ -119,7 +118,7 @@ def _get_client_uuid(args):
 
 def _get_scopes_to_create() -> list[dict]:
     """Get the list of scopes to be created."""
-    scopes = [{"name": method} for method in get_args(ResourceMethod)]
+    scopes = [{"name": method.value} for method in ResourceMethod]
     scopes.extend([{"name": "MENU"}, {"name": "LIST"}])
     return scopes
 
@@ -231,7 +230,7 @@ def _get_permissions_to_create(client: KeycloakAdmin, client_uuid: str) -> list[
         {
             "name": "Admin",
             "type": "scope-based",
-            "scope_names": list(get_args(ExtendedResourceMethod)) + ["LIST"],
+            "scope_names": [method.value for method in ExtendedResourceMethod] + ["LIST"],
         },
         {
             "name": "User",

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/cli/commands.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/cli/commands.py
@@ -18,15 +18,12 @@ from __future__ import annotations
 
 import json
 import logging
+from enum import Enum
+from typing import get_args
 
 from keycloak import KeycloakAdmin, KeycloakError
 
 from airflow.api_fastapi.auth.managers.base_auth_manager import ResourceMethod
-
-try:
-    from airflow.api_fastapi.auth.managers.base_auth_manager import ExtendedResourceMethod
-except ImportError:
-    from airflow.api_fastapi.auth.managers.base_auth_manager import ResourceMethod as ExtendedResourceMethod
 from airflow.api_fastapi.common.types import MenuItem
 from airflow.providers.common.compat.sdk import conf
 from airflow.providers.keycloak.auth_manager.cli.utils import dry_run_message_wrap, dry_run_preview
@@ -40,7 +37,39 @@ from airflow.providers.keycloak.auth_manager.resources import KeycloakResource
 from airflow.utils import cli as cli_utils
 from airflow.utils.providers_configuration_loader import providers_configuration_loaded
 
+try:
+    from airflow.api_fastapi.auth.managers.base_auth_manager import ExtendedResourceMethod
+except ImportError:
+    # Fallback for older Airflow versions where ExtendedResourceMethod doesn't exist
+    from airflow.api_fastapi.auth.managers.base_auth_manager import (
+        ResourceMethod as ExtendedResourceMethod,  # type: ignore[assignment]
+    )
+
 log = logging.getLogger(__name__)
+
+
+def _get_resource_methods() -> list[str]:
+    """
+    Get list of resource method values.
+
+    Provides backwards compatibility for Airflow <3.2 where ResourceMethod
+    was a Literal type, and Airflow >=3.2 where it's an Enum.
+    """
+    if isinstance(ResourceMethod, type) and issubclass(ResourceMethod, Enum):
+        return [method.value for method in ResourceMethod]
+    return list(get_args(ResourceMethod))
+
+
+def _get_extended_resource_methods() -> list[str]:
+    """
+    Get list of extended resource method values.
+
+    Provides backwards compatibility for Airflow <3.2 where ExtendedResourceMethod
+    was a Literal type, and Airflow >=3.2 where it's an Enum.
+    """
+    if isinstance(ExtendedResourceMethod, type) and issubclass(ExtendedResourceMethod, Enum):
+        return [method.value for method in ExtendedResourceMethod]
+    return list(get_args(ExtendedResourceMethod))
 
 
 @cli_utils.action_cli
@@ -118,7 +147,7 @@ def _get_client_uuid(args):
 
 def _get_scopes_to_create() -> list[dict]:
     """Get the list of scopes to be created."""
-    scopes = [{"name": method.value} for method in ResourceMethod]
+    scopes = [{"name": method} for method in _get_resource_methods()]
     scopes.extend([{"name": "MENU"}, {"name": "LIST"}])
     return scopes
 
@@ -230,7 +259,7 @@ def _get_permissions_to_create(client: KeycloakAdmin, client_uuid: str) -> list[
         {
             "name": "Admin",
             "type": "scope-based",
-            "scope_names": [method.value for method in ExtendedResourceMethod] + ["LIST"],
+            "scope_names": _get_extended_resource_methods() + ["LIST"],
         },
         {
             "name": "User",

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/cli/test_commands.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/cli/test_commands.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import importlib
-from typing import get_args
 from unittest.mock import Mock, call, patch
 
 import pytest
@@ -82,7 +81,7 @@ class TestCommands:
             create_scopes_command(self.arg_parser.parse_args(params))
 
         client.get_clients.assert_called_once_with()
-        scopes = [{"name": method} for method in get_args(ResourceMethod)]
+        scopes = [{"name": method.value} for method in ResourceMethod]
         calls = [call(client_id="test-id", payload=scope) for scope in scopes]
         client.create_client_authz_scopes.assert_has_calls(calls)
 

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/cli/test_commands.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/cli/test_commands.py
@@ -21,10 +21,10 @@ from unittest.mock import Mock, call, patch
 
 import pytest
 
-from airflow.api_fastapi.auth.managers.base_auth_manager import ResourceMethod
 from airflow.api_fastapi.common.types import MenuItem
 from airflow.cli import cli_parser
 from airflow.providers.keycloak.auth_manager.cli.commands import (
+    _get_resource_methods,
     create_all_command,
     create_permissions_command,
     create_resources_command,
@@ -81,7 +81,7 @@ class TestCommands:
             create_scopes_command(self.arg_parser.parse_args(params))
 
         client.get_clients.assert_called_once_with()
-        scopes = [{"name": method.value} for method in ResourceMethod]
+        scopes = [{"name": method} for method in _get_resource_methods()]
         calls = [call(client_id="test-id", payload=scope) for scope in scopes]
         client.create_client_authz_scopes.assert_has_calls(calls)
 


### PR DESCRIPTION
## Summary
  Convert `ResourceMethod` and `ExtendedResourceMethod` from `Literal` type aliases to proper `Enum` classes.

  This change:
  - Provides runtime validation for HTTP method values
  - Improves IDE autocomplete and discoverability
  - Maintains full backward compatibility (string comparisons still work)
  - Replaces `get_args()` pattern with cleaner enum iteration
