### PR TITLE
Fix Triggerer crashing if Trigger uses builtin print function

### DIFF
--- a/shared/logging/src/airflow_shared/logging/percent_formatter.py
+++ b/shared/logging/src/airflow_shared/logging/percent_formatter.py
@@ -53,17 +53,16 @@ class _LazyLogRecordDict(collections.abc.Mapping):
         # If there is no callsite info (often for stdout/stderr), show the same sort of thing that stdlib
         # logging would
         # https://github.com/python/cpython/blob/d3c888b4ec15dbd7d6b6ef4f15b558af77c228af/Lib/logging/__init__.py#L1652C34-L1652C48
-        if key == "lineno":
-            return self.event.get("lineno", 0)
+        if key in {"lineno", "process", "thread"}:
+            return self.event.get(key, 0)
         if key == "filename":
             return self.event.get("filename", "(unknown file)")
         if key == "funcName":
             return self.event.get("funcName", "(unknown function)")
-
         if key in PercentFormatRender.callsite_parameters:
-            return self.event.get(PercentFormatRender.callsite_parameters[key].value)
+            return self.event.get(PercentFormatRender.callsite_parameters[key].value, "(unknown)")
         if key == "name":
-            return self.event.get("logger") or self.event.get("logger_name")
+            return self.event.get("logger") or self.event.get("logger_name", "(unknown)")
         if key == "levelname":
             return self.event.get("level", self.method_name).upper()
         if key == "asctime" or key == "created":
@@ -85,7 +84,7 @@ class _LazyLogRecordDict(collections.abc.Mapping):
                 return ""
             return self.level_styles.get(self.event.get("level", self.method_name), "")
 
-        return self.event[key]
+        return self.event.get(key)
 
     def __iter__(self):
         return self.event.__iter__()

--- a/shared/logging/src/airflow_shared/logging/percent_formatter.py
+++ b/shared/logging/src/airflow_shared/logging/percent_formatter.py
@@ -53,8 +53,8 @@ class _LazyLogRecordDict(collections.abc.Mapping):
         # If there is no callsite info (often for stdout/stderr), show the same sort of thing that stdlib
         # logging would
         # https://github.com/python/cpython/blob/d3c888b4ec15dbd7d6b6ef4f15b558af77c228af/Lib/logging/__init__.py#L1652C34-L1652C48
-        if key in {"lineno", "process", "thread"}:
-            return self.event.get(key, 0)
+        if key == "lineno":
+            return self.event.get("lineno") or 0
         if key == "filename":
             return self.event.get("filename", "(unknown file)")
         if key == "funcName":

--- a/shared/logging/tests/logging/test_percent_formatter.py
+++ b/shared/logging/tests/logging/test_percent_formatter.py
@@ -29,3 +29,14 @@ class TestPercentFormatRender:
         formatted = fmter(mock.Mock(name="Logger"), "info", {"event": "our msg"})
 
         assert formatted == "(unknown file):0 our msg"
+
+    def test_lineno_is_none(self):
+        fmter = PercentFormatRender("%(filename)s:%(lineno)d %(message)s")
+
+        formatted = fmter(
+            mock.Mock(name="Logger"),
+            "info",
+            {"event": "our msg", "filename": "test.py", "lineno": None},
+        )
+
+        assert formatted == "test.py:0 our msg"


### PR DESCRIPTION
closes: #59117

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
