### PR TITLE
Fix breeze k8s dev doesn't include configure-cluster test resource

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
@@ -966,18 +966,24 @@ def _build_skaffold_config(
                         },
                         "setValues": set_values,
                     }
-                ]
-            }
+                ],
+            },
+            # include test sources (the `breeze k8s configure-cluster` command ) like nodeport for apiServer, volume for Dag, etc
+            # https://skaffold.dev/docs/references/yaml/?version=v4beta13#deploy-kubectl
+            "kubectl": {
+                "defaultNamespace": HELM_AIRFLOW_NAMESPACE,
+                "hooks": {
+                    "before": [
+                        {
+                            "host": {
+                                "command": ["kubectl", "apply", "-f", "nodeport.yaml,volumes.yaml"],
+                                "dir": (AIRFLOW_ROOT_PATH / "scripts" / "ci" / "kubernetes").as_posix(),
+                            }
+                        }
+                    ]
+                },
+            },
         },
-        "portForward": [
-            {
-                "resourceType": "deployment",
-                "resourceName": "airflow-api-server",
-                "namespace": HELM_AIRFLOW_NAMESPACE,
-                "port": 8080,
-                "localPort": api_server_port,
-            }
-        ],
     }
 
 

--- a/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
@@ -969,6 +969,15 @@ def _build_skaffold_config(
                 ]
             }
         },
+        "portForward": [
+            {
+                "resourceType": "deployment",
+                "resourceName": "airflow-api-server",
+                "namespace": HELM_AIRFLOW_NAMESPACE,
+                "port": 8080,
+                "localPort": api_server_port,
+            }
+        ],
     }
 
 

--- a/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
@@ -967,19 +967,36 @@ def _build_skaffold_config(
                         "setValues": set_values,
                     }
                 ],
-            },
-            # include test sources (the `breeze k8s configure-cluster` command ) like nodeport for apiServer, volume for Dag, etc
-            # https://skaffold.dev/docs/references/yaml/?version=v4beta13#deploy-kubectl
-            "kubectl": {
-                "defaultNamespace": HELM_AIRFLOW_NAMESPACE,
+                # include test sources (the `breeze k8s configure-cluster` command ) like nodeport for apiServer, volume for Dag, etc
+                # https://skaffold.dev/docs/references/yaml/?version=v4beta13#deploy-kubectl
                 "hooks": {
                     "before": [
                         {
                             "host": {
-                                "command": ["kubectl", "apply", "-f", "nodeport.yaml,volumes.yaml"],
+                                "command": [
+                                    "kubectl",
+                                    "apply",
+                                    "-f",
+                                    "volumes.yaml",
+                                    "--namespace",
+                                    HELM_DEFAULT_NAMESPACE,
+                                ],
                                 "dir": (AIRFLOW_ROOT_PATH / "scripts" / "ci" / "kubernetes").as_posix(),
                             }
-                        }
+                        },
+                        {
+                            "host": {
+                                "command": [
+                                    "kubectl",
+                                    "apply",
+                                    "-f",
+                                    "nodeport.yaml",
+                                    "--namespace",
+                                    HELM_AIRFLOW_NAMESPACE,
+                                ],
+                                "dir": (AIRFLOW_ROOT_PATH / "scripts" / "ci" / "kubernetes").as_posix(),
+                            }
+                        },
                     ]
                 },
             },


### PR DESCRIPTION
related: #59869 

## Why

In #59869, we add the hint that show `Alternatively, jump straight into development on Kubernetes with: breeze k8s dev --python {python} --kubernetes-version {kubernetes_version}` after running `breeze k8s create-cluster`

 https://github.com/apache/airflow/pull/59869/files#diff-ec0edb35ebfa2f51b6030b54f72eb90b0661eb310b0baea6e9c605f49c15123dR331-R335

However, when I run `breeze k8s dev` right after `breeze k8s create-cluster`. I'm not able to access API Server because the k8s test resources in `scripts/ci/kubernetes` are not deployed. Since we skip the `breeze k8s configure-cluster` command.

## What

We should also deploy the test resources in `scripts/ci/kubernetes` with skaffold in case the user didn't run `breeze k8s configure-cluster` before `breeze k8s dev`.


Technical detail: 
- I had tried the `deploy.kubectl` section multi deploy approach (https://github.com/GoogleContainerTools/skaffold/issues/528), but doesn't work as expected
- So I use lifecycle hooks instead
