### PR TITLE
Automatically add pydantic extra when installing airflow 2 in breeze

### DIFF
--- a/scripts/in_container/install_airflow_and_providers.py
+++ b/scripts/in_container/install_airflow_and_providers.py
@@ -401,6 +401,11 @@ def find_installation_spec(
                     github_repository=github_repository,
                     python_version=python_version,
                 )
+            if airflow_version.startswith("2."):
+                # We need to make sure that pydantic is added as extra for Airflow 2.x
+                # because it's not in extras by default, and pydantic incompatible version is
+                # installed by default in the container and breaks serialization import
+                airflow_extras = _add_pydantic_to_extras(airflow_extras)
             if airflow_extras:
                 airflow_distribution_spec += airflow_extras
         # We always install latest task-sdk - it's independent from Airflow
@@ -499,6 +504,8 @@ def find_installation_spec(
         sys.exit(1)
     else:
         compile_ui_assets = False
+        if use_airflow_version.startswith("2"):
+            airflow_extras = _add_pydantic_to_extras(airflow_extras)
         console.print(f"\nInstalling airflow via apache-airflow=={use_airflow_version}")
         airflow_distribution_spec = f"apache-airflow{airflow_extras}=={use_airflow_version}"
         airflow_core_distribution_spec = (
@@ -567,6 +574,16 @@ def find_installation_spec(
     )
     console.print("[bright_blue]Installation specification:[/]", installation_spec)
     return installation_spec
+
+
+def _add_pydantic_to_extras(airflow_extras: str) -> str:
+    console.print("[yellow]Adding pydantic to airflow extras for Airflow 2.x")
+    if airflow_extras:
+        airflow_extras = "[" + airflow_extras.strip("[]") + ",pydantic]"
+    else:
+        airflow_extras = "[pydantic]"
+    console.print(f"[yellow]New extras: {airflow_extras.strip('[]')}")
+    return airflow_extras
 
 
 def download_airflow_source_tarball(installation_spec: InstallationSpec):


### PR DESCRIPTION
When installing Airflow 2 in Breeze, we need to add pydantic as extra, because pydantic in Airflow 2 was not a required dependency and installation of airflow even with constraints willl not downgrade pydantic to the version that was supported in Airflow 2.

When we detect that airflow 2 is installed (either by specified version number or by retrieving the version from the dist package) we simply extend the extras with pydantic and that causes airflow installation to downgrade pydantic to the version that is specified in constraints of selected airflow version.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
