### PR TITLE
Add configs to set bundle file & folder permissions

### DIFF
--- a/airflow-core/docs/administration-and-deployment/dag-bundles.rst
+++ b/airflow-core/docs/administration-and-deployment/dag-bundles.rst
@@ -122,6 +122,32 @@ Starting Airflow 3.0.2 git is pre installed in the base image. However, if you a
   ENV GIT_PYTHON_REFRESH=quiet
 
 
+Using DAG Bundles with User Impersonation
+-----------------------------------------
+
+When using ``run_as_user`` (user impersonation) with DAG bundles, ensure proper file permissions
+are configured so that impersonated users can access bundle files created by the main Airflow process.
+
+1. All impersonated users and the Airflow user should be in the same group
+2. Configure appropriate umask settings (e.g., ``umask 0002``)
+3. Set :ref:`config:dag_processor__dag_bundle_new_folder_permissions` to ``0o775`` (default)
+4. Set :ref:`config:dag_processor__dag_bundle_new_file_permissions` to ``0o664`` (default)
+
+Example configuration:
+
+.. code-block:: ini
+
+    [dag_processor]
+    dag_bundle_new_folder_permissions = 0o775
+    dag_bundle_new_file_permissions = 0o664
+
+.. note::
+
+    This permission-based approach is a temporary solution. Future versions of Airflow
+    will handle multi-user access through supervisor-based bundle operations, eliminating
+    the need for shared group permissions.
+
+
 Writing custom Dag bundles
 --------------------------
 

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -2465,6 +2465,36 @@ dag_processor:
       example: "/tmp/some-place"
       default: ~
 
+    dag_bundle_new_folder_permissions:
+      description: |
+        Permissions to set on new DAG bundle directories. When using user impersonation
+        (``run_as_user``), these should be group-writable (e.g., ``0o775``) so that
+        impersonated users can access the bundle files.
+
+        The value should be an octal string (e.g., ``0o775``). The default allows
+        owner read/write/execute and group read/write/execute.
+
+        This is similar to ``[logging] file_task_handler_new_folder_permissions``.
+      version_added: 3.2.0
+      type: string
+      example: "0o775"
+      default: "0o775"
+
+    dag_bundle_new_file_permissions:
+      description: |
+        Permissions to set on new DAG bundle files (lock files, tracking files, etc.).
+        When using user impersonation (``run_as_user``), these should be group-writable
+        (e.g., ``0o664``) so that impersonated users can access the files.
+
+        The value should be an octal string (e.g., ``0o664``). The default allows
+        owner read/write and group read/write.
+
+        This is similar to ``[logging] file_task_handler_new_file_permissions``.
+      version_added: 3.2.0
+      type: string
+      example: "0o664"
+      default: "0o664"
+
     dag_bundle_config_list:
       description: |
         List of backend configs.  Must supply name, classpath, and kwargs for each backend.


### PR DESCRIPTION
```diff
- This PR was created with the help of AI
```

### Context
When using DAG bundles (particularly Git bundles) with user impersonation (`run_as_user`), tasks can fail due to permission conflicts. The root cause is that bundles are initialized by the main airflow user BEFORE impersonation happens, but the impersonated user later needs access to bundle resources like lock files and tracking directories.

#### Specific issues encountered:

1. Lock files created with restrictive permissions block impersonated users
1. Tracking directories inaccessible to impersonated users
1. Git's "dubious ownership" error when different users access the same repository

### Changes
This PR provides the foundation for fixing impersonation + bundle permission issues:

1. Configuration options allow users to customize permissions based on their environment
1. Default group-writable permissions (775/664) work out-of-the-box for environments where the airflow user and impersonated users share a common group
1. Lock and tracking files are now created with appropriate permissions, eliminating the most common permission errors
1. Mirrors existing patterns - similar to `[logging] file_task_handler_new_file_permissions` which solves the same problem for log files

#### Related Changes (follow-up PRs)
This is part 1 of 3 PRs to fully address the impersonation + bundles issue:

1. PR 1 (this one): airflow-core
1. PR 2: providers/git - https://github.com/apache/airflow/pull/60280
1. PR 3: task-sdk -  https://github.com/apache/airflow/pull/60278

## Architecture Note

This PR implements a permission-based solution where the bundle repository
is made group-writable so that multiple users (Airflow user + impersonated
users) can all perform git operations. 

**Long-term improvement:** As discussed in comments, a better solution would
be to add bundle fetching to the Execution API, so only the supervisor needs
write access. This PR provides a working solution in the meantime.  See: 
https://github.com/apache/airflow/pull/60270#issuecomment-3729119122
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
