### PR TITLE
revert: remove k8s namespace and worker image deprecations

### DIFF
--- a/providers/cncf/kubernetes/provider.yaml
+++ b/providers/cncf/kubernetes/provider.yaml
@@ -214,9 +214,6 @@ config:
         type: string
         example: ~
         default: ""
-        deprecated: true
-        deprecation_reason: |
-          This configuration is deprecated. Use `pod_template_file` to specify container image instead.
       worker_container_tag:
         description: |
           The tag of the Kubernetes Image for the Worker to Run
@@ -224,9 +221,6 @@ config:
         type: string
         example: ~
         default: ""
-        deprecated: true
-        deprecation_reason: |
-          This configuration is deprecated. Use `pod_template_file` to specify the image tag instead.
       namespace:
         description: |
           The Kubernetes namespace where airflow workers should be created. Defaults to ``default``
@@ -234,9 +228,6 @@ config:
         type: string
         example: ~
         default: "default"
-        deprecated: true
-        deprecation_reason: |
-          This configuration is deprecated. Use `pod_template_file` to specify namespace instead.
       delete_worker_pods:
         description: |
           If True, all worker pods will be deleted upon termination

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/get_provider_info.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/get_provider_info.py
@@ -135,8 +135,6 @@ def get_provider_info():
                         "type": "string",
                         "example": None,
                         "default": "",
-                        "deprecated": True,
-                        "deprecation_reason": "This configuration is deprecated. Use `pod_template_file` to specify container image instead.\n",
                     },
                     "worker_container_tag": {
                         "description": "The tag of the Kubernetes Image for the Worker to Run\n",
@@ -144,8 +142,6 @@ def get_provider_info():
                         "type": "string",
                         "example": None,
                         "default": "",
-                        "deprecated": True,
-                        "deprecation_reason": "This configuration is deprecated. Use `pod_template_file` to specify the image tag instead.\n",
                     },
                     "namespace": {
                         "description": "The Kubernetes namespace where airflow workers should be created. Defaults to ``default``\n",
@@ -153,8 +149,6 @@ def get_provider_info():
                         "type": "string",
                         "example": None,
                         "default": "default",
-                        "deprecated": True,
-                        "deprecation_reason": "This configuration is deprecated. Use `pod_template_file` to specify namespace instead.\n",
                     },
                     "delete_worker_pods": {
                         "description": "If True, all worker pods will be deleted upon termination\n",

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/kube_config.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/kube_config.py
@@ -16,10 +16,8 @@
 # under the License.
 from __future__ import annotations
 
-import warnings
-
 from airflow.configuration import conf
-from airflow.exceptions import AirflowConfigException, AirflowProviderDeprecationWarning
+from airflow.exceptions import AirflowConfigException
 from airflow.settings import AIRFLOW_HOME
 
 
@@ -55,21 +53,8 @@ class KubeConfig:
             self.kubernetes_section, "worker_pods_creation_batch_size"
         )
         self.worker_container_repository = conf.get(self.kubernetes_section, "worker_container_repository")
-        if self.worker_container_repository:
-            warnings.warn(
-                "Configuration 'worker_container_repository' is deprecated. "
-                "Use 'pod_template_file' to specify the container image repository instead.",
-                AirflowProviderDeprecationWarning,
-                stacklevel=2,
-            )
         self.worker_container_tag = conf.get(self.kubernetes_section, "worker_container_tag")
-        if self.worker_container_tag:
-            warnings.warn(
-                "Configuration 'worker_container_tag' is deprecated. "
-                "Use 'pod_template_file' to specify the container image tag instead.",
-                AirflowProviderDeprecationWarning,
-                stacklevel=2,
-            )
+
         if self.worker_container_repository and self.worker_container_tag:
             self.kube_image = f"{self.worker_container_repository}:{self.worker_container_tag}"
         else:
@@ -80,13 +65,6 @@ class KubeConfig:
         # cluster has RBAC enabled, your scheduler may need service account permissions to
         # create, watch, get, and delete pods in this namespace.
         self.kube_namespace = conf.get(self.kubernetes_section, "namespace")
-        if self.kube_namespace and self.kube_namespace != "default":
-            warnings.warn(
-                "Configuration 'namespace' is deprecated. "
-                "Use 'pod_template_file' to specify the namespace instead.",
-                AirflowProviderDeprecationWarning,
-                stacklevel=2,
-            )
         self.multi_namespace_mode = conf.getboolean(self.kubernetes_section, "multi_namespace_mode")
         if self.multi_namespace_mode and conf.get(
             self.kubernetes_section, "multi_namespace_mode_namespace_list"


### PR DESCRIPTION
### Summary
Reverts the deprecation of `namespace`, `worker_container_repository`, and `worker_container_tag` in the CNCF Kubernetes provider. As discussed in #59563, these parameters are still required for the `KubernetesExecutor` to function correctly and were emitting unavoidable warning logs for users.

closes: #59563