### PR TITLE
Cache user object fetched per request in FAB auth manager for improved performance.

### DIFF
--- a/devel-common/pyproject.toml
+++ b/devel-common/pyproject.toml
@@ -127,6 +127,7 @@ dependencies = [
     "types-setuptools>=80.0.0.20250429",
     "types-tabulate>=0.9.0.20240106",
     "types-toml>=0.10.8.20240310",
+    "types-cachetools>=6.2.0.20251022",
 ]
 "pytest" = [
     # General pytest devel tools

--- a/providers/fab/docs/index.rst
+++ b/providers/fab/docs/index.rst
@@ -121,7 +121,7 @@ PIP package                                 Version required
 ``jmespath``                                ``>=0.7.0; python_version < "3.13"``
 ``werkzeug``                                ``>=2.2,<4; python_version < "3.13"``
 ``wtforms``                                 ``>=3.0,<4; python_version < "3.13"``
-``cachetools``                              ``>=5.0; python_version < "3.13"``
+``cachetools``                              ``>=6.0; python_version < "3.13"``
 ``flask_limiter``                           ``>3,!=3.13,<4``
 ==========================================  ==========================================
 

--- a/providers/fab/docs/index.rst
+++ b/providers/fab/docs/index.rst
@@ -121,6 +121,7 @@ PIP package                                 Version required
 ``jmespath``                                ``>=0.7.0; python_version < "3.13"``
 ``werkzeug``                                ``>=2.2,<4; python_version < "3.13"``
 ``wtforms``                                 ``>=3.0,<4; python_version < "3.13"``
+``cachetools``                              ``>=5.0; python_version < "3.13"``
 ``flask_limiter``                           ``>3,!=3.13,<4``
 ==========================================  ==========================================
 

--- a/providers/fab/provider.yaml
+++ b/providers/fab/provider.yaml
@@ -250,6 +250,14 @@ config:
         type: integer
         example: ~
         default: "1"
+      cache_ttl:
+        description: |
+          Number of seconds after which the user cache will expire to refetch updated user and
+          permissions.
+        version_added: 3.1.2
+        type: integer
+        example: ~
+        default: "30"
 
 auth-managers:
   - airflow.providers.fab.auth_manager.fab_auth_manager.FabAuthManager

--- a/providers/fab/provider.yaml
+++ b/providers/fab/provider.yaml
@@ -254,7 +254,7 @@ config:
         description: |
           Number of seconds after which the user cache will expire to refetch updated user and
           permissions.
-        version_added: 3.1.2
+        version_added: 3.2.0
         type: integer
         example: ~
         default: "30"

--- a/providers/fab/pyproject.toml
+++ b/providers/fab/pyproject.toml
@@ -81,7 +81,7 @@ dependencies = [
     "jmespath>=0.7.0; python_version < '3.13'",
     "werkzeug>=2.2,<4; python_version < '3.13'",
     "wtforms>=3.0,<4; python_version < '3.13'",
-    "cachetools>=5.0; python_version < '3.13'",
+    "cachetools>=6.0; python_version < '3.13'",
 
     # https://github.com/dpgaspar/Flask-AppBuilder/blob/release/4.6.3/setup.py#L54C8-L54C26
     # with an exclusion to account for https://github.com/alisaifee/flask-limiter/issues/479

--- a/providers/fab/pyproject.toml
+++ b/providers/fab/pyproject.toml
@@ -81,6 +81,7 @@ dependencies = [
     "jmespath>=0.7.0; python_version < '3.13'",
     "werkzeug>=2.2,<4; python_version < '3.13'",
     "wtforms>=3.0,<4; python_version < '3.13'",
+    "cachetools>=5.0; python_version < '3.13'",
 
     # https://github.com/dpgaspar/Flask-AppBuilder/blob/release/4.6.3/setup.py#L54C8-L54C26
     # with an exclusion to account for https://github.com/alisaifee/flask-limiter/issues/479

--- a/providers/fab/src/airflow/providers/fab/get_provider_info.py
+++ b/providers/fab/src/airflow/providers/fab/get_provider_info.py
@@ -177,6 +177,13 @@ def get_provider_info():
                         "example": None,
                         "default": "1",
                     },
+                    "cache_ttl": {
+                        "description": "Number of seconds after which the user cache will expire to refetch updated user and\npermissions.\n",
+                        "version_added": "3.1.2",
+                        "type": "integer",
+                        "example": None,
+                        "default": "30",
+                    },
                 },
             }
         },

--- a/providers/fab/src/airflow/providers/fab/get_provider_info.py
+++ b/providers/fab/src/airflow/providers/fab/get_provider_info.py
@@ -179,7 +179,7 @@ def get_provider_info():
                     },
                     "cache_ttl": {
                         "description": "Number of seconds after which the user cache will expire to refetch updated user and\npermissions.\n",
-                        "version_added": "3.1.2",
+                        "version_added": "3.2.0",
                         "type": "integer",
                         "example": None,
                         "default": "30",

--- a/providers/fab/tests/unit/fab/auth_manager/test_fab_auth_manager.py
+++ b/providers/fab/tests/unit/fab/auth_manager/test_fab_auth_manager.py
@@ -200,12 +200,10 @@ class TestFabAuthManager:
 
     def test_deserialize_user(self, flask_app, auth_manager_with_appbuilder):
         user = create_user(flask_app, "test")
-        assert not auth_manager_with_appbuilder.user_cache
         with assert_queries_count(2):
             result = auth_manager_with_appbuilder.deserialize_user({"sub": str(user.id)})
 
         assert user.get_id() == result.get_id()
-        assert auth_manager_with_appbuilder.user_cache[user.id] == user
 
         with assert_queries_count(0):
             result = auth_manager_with_appbuilder.deserialize_user({"sub": str(user.id)})


### PR DESCRIPTION
When a request is authenticated the user object is created from jwt token twice in the middleware layer and in the GetUserDep dependency resolution. Each token maps to a single user and hence cache the token's id to the user object so that it's reused.

`TTLCache` from cachetools is used to ensure the cached user objects expire to be fetched again. The TTL value is configurable through `fab.cache_ttl` configuration with a default of 30 seconds. Each worker and instance of auth manager has its own cache and they are not persisted to be reset as workers restart. In case this needs to be disabled then users can set the cache_ttl as 0. I have added test to ensure the cache is expired. In case of deployments with frequent roles and permission changes users can set this to lower value at the cost of frequent db queries. For deployments with lesser number of changes to roles and permissions this can be set to a higher value for better performance. This should mitigate the need to invalidate caches on roles and permission changes. If required this can be documented with more detail in changelog just to avoid confusion.

https://cachetools.readthedocs.io/en/latest/#cachetools.cachedmethod

closes #60265