### PR TITLE
Add warning when bundle path isn't accessible to impersonated user

### DIFF
--- a/airflow-core/docs/administration-and-deployment/dag-bundles.rst
+++ b/airflow-core/docs/administration-and-deployment/dag-bundles.rst
@@ -122,6 +122,23 @@ Starting Airflow 3.0.2 git is pre installed in the base image. However, if you a
   ENV GIT_PYTHON_REFRESH=quiet
 
 
+Using DAG Bundles with User Impersonation
+-----------------------------------------
+
+When using ``run_as_user`` (user impersonation) with DAG bundles, ensure proper file permissions
+are configured so that impersonated users can access bundle files created by the main Airflow process.
+
+1. All impersonated users and the Airflow user should be in the same group
+2. Configure appropriate umask settings (e.g., ``umask 0002``)
+
+
+.. note::
+
+    This permission-based approach is a temporary solution. Future versions of Airflow
+    will handle multi-user access through supervisor-based bundle operations, eliminating
+    the need for shared group permissions.
+
+
 Writing custom Dag bundles
 --------------------------
 


### PR DESCRIPTION
```diff
- This PR was created with the help of AI
```

Related: #60270, #60387

### Context
When using Git DAG bundles with user impersonation (`run_as_user`), tasks fail due to permission conflicts. The bundle is cloned by the main airflow user, but the impersonated user needs to access the repository files during task execution.

This PR provides **early warning** to help users diagnose these issues before they cause task failures.

### Changes
##### `_verify_bundle_access(bundle_instance, log)`
New helper function in `task_runner.py` that:
- Uses os.access() to verify actual read/execute permissions (works with Unix permissions, ACLs, SELinux, etc.)
- Raises AirflowException with a clear error message if the bundle is not accessible
- Includes a link to documentation for troubleshooting

The helper is called in `parse()` after `bundle_instance.initialize()`, which means it runs after impersonation occurs. This ensures the check reflects the impersonated user's actual access rights.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
