### PR TITLE
UI - Fix table filters reseting when deleting a dag

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/DagActions/DeleteDagButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DagActions/DeleteDagButton.tsx
@@ -19,7 +19,7 @@
 import { Box, type ButtonProps, useDisclosure } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 import { FiTrash2 } from "react-icons/fi";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import DeleteDialog from "src/components/DeleteDialog";
 import ActionButton from "src/components/ui/ActionButton";
@@ -34,12 +34,18 @@ type DeleteDagButtonProps = {
 const DeleteDagButton = ({ dagDisplayName, dagId, width, withText = true }: DeleteDagButtonProps) => {
   const { onClose, onOpen, open } = useDisclosure();
   const navigate = useNavigate();
+  const location = useLocation();
   const { t: translate } = useTranslation("dags");
+
+  const isOnDagDetailPage = location.pathname.includes(`/dags/${dagId}`);
+
   const { isPending, mutate: deleteDag } = useDeleteDag({
     dagId,
     onSuccessConfirm: () => {
       onClose();
-      navigate("/dags");
+      if (isOnDagDetailPage) {
+        navigate("/dags");
+      }
     },
   });
 


### PR DESCRIPTION
Follow up of https://github.com/apache/airflow/pull/57265 that went stale.

This prevent the table filters from resetting when we delete a Dag. This is consistent with what we are doing for `DeleteRunButton`.