### PR TITLE
 Add PodDisruptionBudget support for DAG Processor

### DIFF
--- a/chart/newsfragments/60242.improvement.rst
+++ b/chart/newsfragments/60242.improvement.rst
@@ -1,0 +1,1 @@
+Expose ``dagProcessor.podDisruptionBudget`` settings so the DAG Processor can be protected with a configurable PodDisruptionBudget, matching the other components.

--- a/chart/templates/dag-processor/dag-processor-poddisruptionbudget.yaml
+++ b/chart/templates/dag-processor/dag-processor-poddisruptionbudget.yaml
@@ -1,0 +1,50 @@
+{{/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/}}
+
+################################
+## Airflow Dag Processor PodDisruptionBudget
+#################################
+{{- if semverCompare ">=2.3.0" .Values.airflowVersion }}
+{{- $enabled := .Values.dagProcessor.enabled }}
+{{- if eq $enabled nil}}
+  {{ $enabled = ternary true false (semverCompare ">=3.0.0" .Values.airflowVersion) }}
+{{- end }}
+{{- if and $enabled .Values.dagProcessor.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "airflow.fullname" . }}-dag-processor-pdb
+  labels:
+    tier: airflow
+    component: dag-processor
+    release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+    {{- if or (.Values.labels) (.Values.dagProcessor.labels) }}
+      {{- mustMerge .Values.dagProcessor.labels .Values.labels | toYaml | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      tier: airflow
+      component: dag-processor
+      release: {{ .Release.Name }}
+  {{- toYaml .Values.dagProcessor.podDisruptionBudget.config | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -4189,6 +4189,41 @@
                         }
                     }
                 },
+                "podDisruptionBudget": {
+                    "description": "Dag processor pod disruption budget.",
+                    "type": "object",
+                    "additionalProperties": true,
+                    "properties": {
+                        "enabled": {
+                            "description": "Enable pod disruption budget.",
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "config": {
+                            "description": "Disruption budget configuration.",
+                            "type": "object",
+                            "additionalProperties": true,
+                            "properties": {
+                                "maxUnavailable": {
+                                    "description": "Max unavailable pods for dag processor.",
+                                    "type": [
+                                        "integer",
+                                        "string"
+                                    ],
+                                    "default": 1
+                                },
+                                "minAvailable": {
+                                    "description": "Min available pods for dag processor.",
+                                    "type": [
+                                        "integer",
+                                        "string"
+                                    ],
+                                    "default": 1
+                                }
+                            }
+                        }
+                    }
+                },
                 "resources": {
                     "description": "Resources for dag processor pods.",
                     "type": "object",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2216,6 +2216,16 @@ dagProcessor:
     # Annotations to add to dag processor kubernetes service account.
     annotations: {}
 
+  # Dag processor pod disruption budget
+  podDisruptionBudget:
+    enabled: false
+
+    # PDB configuration
+    config:
+      # minAvailable and maxUnavailable are mutually exclusive
+      maxUnavailable: 1
+      # minAvailable: 1
+
   # When not set, the values defined in the global securityContext will be used
   securityContext: {}
   #  runAsUser: 50000


### PR DESCRIPTION
This PR adds PodDisruptionBudget configuration support for the DAG Processor component in the Airflow Helm chart, bringing it to feature parity with other components (scheduler, webserver, API server, workers, etc.).

Previously, the DAG Processor was the only major component lacking PodDisruptionBudget configuration, making it impossible to protect DAG Processor pods from voluntary disruptions during cluster operations like node drains or upgrades.

# Testing Performed

All validation was performed locally on Windows with manual checks due to some pre-commit hooks having Windows compatibility issues:

# 1. JSON Schema Validation
`powershell
python -m json.tool chart/values.schema.json
# Result: Valid JSON, no syntax errors
`

# 2. Helm Lint
powershell
helm lint chart
# Result: 1 chart(s) linted, 0 chart(s) failed

# 3. Helm Template Rendering
`powershell
helm template test chart --set dagProcessor.enabled=true --set dagProcessor.podDisruptionBudget.enabled=true
`
Closes #60242