### PR TITLE
Fix constraint mode when installing from dist or version airflow

### DIFF
--- a/scripts/in_container/install_airflow_and_providers.py
+++ b/scripts/in_container/install_airflow_and_providers.py
@@ -391,6 +391,8 @@ def find_installation_spec(
             airflow_version = get_airflow_version_from_package(airflow_distribution_spec)
             if airflow_version:
                 console.print(f"[bright_blue]Using airflow version retrieved from package: {airflow_version}")
+                console.print("[yellow]Constraints mode is forced to 'constraints': installation from dist")
+                airflow_constraints_mode = "constraints"
                 airflow_constraints_location = get_airflow_constraints_location(
                     install_airflow_with_constraints=install_airflow_with_constraints,
                     airflow_constraints_mode=airflow_constraints_mode,
@@ -503,6 +505,7 @@ def find_installation_spec(
         )
         sys.exit(1)
     else:
+        # Install specific airflow version
         compile_ui_assets = False
         if use_airflow_version.startswith("2"):
             airflow_extras = _add_pydantic_to_extras(airflow_extras)
@@ -511,6 +514,8 @@ def find_installation_spec(
         airflow_core_distribution_spec = (
             f"apache-airflow-core=={use_airflow_version}" if not use_airflow_version.startswith("2") else None
         )
+        console.print("[yellow]Constraints mode is forced to 'constraints': installation from PyPI")
+        airflow_constraints_mode = "constraints"
         airflow_constraints_location = get_airflow_constraints_location(
             install_airflow_with_constraints=install_airflow_with_constraints,
             airflow_constraints_mode=airflow_constraints_mode,


### PR DESCRIPTION
When Airflow is installed in breeze with `--use-airflow-version` and it's either wheel, dist or version number, we should use PyPI constraints, rather than source constraints, because in some edge cases, pre-installed providers might be installed using different version than the version specified in PyPI constraints.

This might happen if the dependency resolution run by uv will determine that another package is more important to be installed in higher version and that higher version conflicts with newer preinstalled provider version.

In this case Fab Provider is pinned with fab provider and the version of fab provider in v3-1-test sources was pretty old.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
