### PR TITLE
Remove dry-run skip for SVN clone in release command

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -367,7 +367,7 @@ jobs:
           --task-sdk-version 1.0.0rc1 --sync-branch v3-1-test --answer yes --dry-run
       - name: "Check Airflow release process command"
         run: >
-          breeze release-management start-release --version 3.1.5
+          breeze release-management start-release --version 3.1.6
           --answer yes --dry-run
       - name: "Test providers metadata generation"
         run: |

--- a/dev/breeze/src/airflow_breeze/commands/release_command.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_command.py
@@ -29,7 +29,6 @@ from airflow_breeze.utils.confirm import confirm_action
 from airflow_breeze.utils.console import console_print
 from airflow_breeze.utils.path_utils import AIRFLOW_ROOT_PATH
 from airflow_breeze.utils.run_utils import run_command
-from airflow_breeze.utils.shared_options import get_dry_run
 
 # Pattern to match Airflow release versions (e.g., "3.0.5")
 RELEASE_PATTERN = re.compile(r"^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$")
@@ -426,34 +425,26 @@ def airflow_release(version, task_sdk_version):
     # Clone the asf repo
     os.chdir("..")
     working_dir = os.getcwd()
+    clone_asf_repo(working_dir)
     svn_dev_repo = f"{working_dir}/asf-dist/dev/airflow"
     svn_release_repo = f"{working_dir}/asf-dist/release/airflow"
+    console_print("SVN dev repo root:", svn_dev_repo)
+    console_print("SVN release repo root:", svn_release_repo)
 
-    if get_dry_run():
-        # Skip SVN clone in dry-run mode - use placeholder RCs for testing the workflow
-        console_print("[info]Skipping SVN operations in dry-run mode")
-        release_candidate = f"{version}rc1"
-        task_sdk_release_candidate = f"{task_sdk_version}rc1" if task_sdk_version else None
-    else:
-        clone_asf_repo(working_dir)
-        console_print("SVN dev repo root:", svn_dev_repo)
-        console_print("SVN release repo root:", svn_release_repo)
+    # Find the latest release candidate for the given version
+    console_print()
+    console_print("Finding latest release candidate from SVN dev directory...")
+    release_candidate = find_latest_release_candidate(version, svn_dev_repo, component="airflow")
+    if not release_candidate:
+        exit(f"No release candidate found for version {version} in SVN dev directory")
 
-        console_print()
-        console_print("Finding latest release candidate from SVN dev directory...")
-        release_candidate = find_latest_release_candidate(version, svn_dev_repo, component="airflow")
-        if not release_candidate:
-            exit(f"No release candidate found for version {version} in SVN dev directory")
-
-        task_sdk_release_candidate = None
-        if task_sdk_version:
-            task_sdk_release_candidate = find_latest_release_candidate(
-                task_sdk_version, svn_dev_repo, component="task-sdk"
-            )
-            if not task_sdk_release_candidate:
-                exit(
-                    f"No Task SDK release candidate found for version {task_sdk_version} in SVN dev directory"
-                )
+    task_sdk_release_candidate = None
+    if task_sdk_version:
+        task_sdk_release_candidate = find_latest_release_candidate(
+            task_sdk_version, svn_dev_repo, component="task-sdk"
+        )
+        if not task_sdk_release_candidate:
+            exit(f"No Task SDK release candidate found for version {task_sdk_version} in SVN dev directory")
 
     console_print()
     console_print("Airflow Release candidate:", release_candidate)


### PR DESCRIPTION
Start-release command was failing in dry-run mode because 
SVN clone was skipped in [PR](https://github.com/apache/airflow/pull/60284) but subsequent [operations](https://github.com/apache/airflow/blob/744440207aa19b08880552bebffbdbca5f850664/dev/breeze/src/airflow_breeze/commands/release_command.py#L471) (os.chdir) 
expected the directories to exist and started failing in [CI](https://github.com/apache/airflow/pull/60284). Initially I thought to skip those as well in dry mode, but in that case we will lose on test coverage
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
