### PR TITLE
docs(sftp): Document python_callable, op_args, and op_kwargs in SFTPSensor

### DIFF
--- a/providers/sftp/docs/sensors/sftp_sensor.rst
+++ b/providers/sftp/docs/sensors/sftp_sensor.rst
@@ -30,14 +30,26 @@ To get more information about this sensor visit :class:`~airflow.providers.sftp.
 
 We can also use TaskFlow API. It takes the same arguments as the :class:`~airflow.providers.sftp.sensors.sftp.SFTPSensor` along with -
 
-op_args (optional)
-    A list of positional arguments that will get unpacked when
-    calling your callable (templated)
-op_kwargs (optional)
-    A dictionary of keyword arguments that will get unpacked
-    in your function (templated)
+python_callable (optional)
+    A callable that will be executed after files matching the sensor criteria are found.
+    This allows you to process the found files with custom logic. The callable receives:
 
-Whatever returned by the python callable is put into XCom.
+    - Positional arguments from ``op_args``
+    - Keyword arguments from ``op_kwargs``, with ``files_found`` automatically added
+      (if ``op_kwargs`` is provided and not empty) containing the list of files that matched
+      the sensor criteria
+
+    The return value of the callable is stored in XCom along with the ``files_found`` list,
+    accessible via ``{"files_found": [...], "decorator_return_value": <callable_return_value>}``.
+
+op_args (optional)
+    A list of positional arguments that will get unpacked when calling your callable (templated).
+    Only used when ``python_callable`` is provided.
+
+op_kwargs (optional)
+    A dictionary of keyword arguments that will get unpacked in your function (templated).
+    If provided and not empty, the ``files_found`` list is automatically added to this dictionary
+    when the callable is invoked. Only used when ``python_callable`` is provided.
 
 .. exampleinclude:: /../../sftp/tests/system/sftp/example_sftp_sensor.py
     :language: python

--- a/providers/sftp/src/airflow/providers/sftp/sensors/sftp.py
+++ b/providers/sftp/src/airflow/providers/sftp/sensors/sftp.py
@@ -43,6 +43,15 @@ class SFTPSensor(BaseSensorOperator):
     :param file_pattern: The pattern that will be used to match the file (fnmatch format)
     :param sftp_conn_id: The connection to run the sensor against
     :param newer_than: DateTime for which the file or file path should be newer than, comparison is inclusive
+    :param python_callable: Optional callable that will be called after files are found. The callable
+        will receive the found files list in ``op_kwargs['files_found']`` if ``op_kwargs`` is provided
+        and not empty. The return value of the callable will be stored in XCom along with the
+        files_found list.
+    :param op_args: A list of positional arguments that will get unpacked when calling your callable
+        (templated). Only used when ``python_callable`` is provided.
+    :param op_kwargs: A dictionary of keyword arguments that will get unpacked in your callable
+        (templated). If provided and not empty, the ``files_found`` list will be automatically added
+        to this dictionary. Only used when ``python_callable`` is provided.
     :param deferrable: If waiting for completion, whether to defer the task until done, default is ``False``.
     """
 


### PR DESCRIPTION
Added missing documentation for `python_callable`, `op_args`, and `op_kwargs` parameters in `SFTPSensor`.

**Changes:**
- Added parameter documentation to class docstring
- Improved usage documentation to explain when and how these parameters are used
- Clarified that `files_found` is added to `op_kwargs` only when `op_kwargs` is provided and not empty

Fixes documentation gaps where these parameters existed in the implementation but were not properly documented.

## Solves #60184