### PR TITLE
Replace deprecated import for utcnow() to the new one

### DIFF
--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_pod_manager.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_pod_manager.py
@@ -38,8 +38,7 @@ from airflow.providers.cncf.kubernetes.utils.pod_manager import (
     log_pod_event,
     parse_log_line,
 )
-from airflow.providers.common.compat.sdk import AirflowException
-from airflow.utils.timezone import utc
+from airflow.providers.common.compat.sdk import AirflowException, timezone
 
 from unit.cncf.kubernetes.test_callbacks import MockKubernetesPodOperatorCallback, MockWrapper
 
@@ -1422,43 +1421,43 @@ class TestPodLogsConsumer:
         [
             (
                 False,
-                datetime(2022, 1, 1, 0, 0, 0, 0, tzinfo=utc),
-                datetime(2022, 1, 1, 0, 1, 0, 0, tzinfo=utc),
+                datetime(2022, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc),
+                datetime(2022, 1, 1, 0, 1, 0, 0, tzinfo=timezone.utc),
                 120,
                 True,
             ),
             (
                 False,
-                datetime(2022, 1, 1, 0, 0, 0, 0, tzinfo=utc),
-                datetime(2022, 1, 1, 0, 2, 0, 0, tzinfo=utc),
+                datetime(2022, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc),
+                datetime(2022, 1, 1, 0, 2, 0, 0, tzinfo=timezone.utc),
                 120,
                 False,
             ),
             (
                 False,
-                datetime(2022, 1, 1, 0, 0, 0, 0, tzinfo=utc),
-                datetime(2022, 1, 1, 0, 5, 0, 0, tzinfo=utc),
+                datetime(2022, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc),
+                datetime(2022, 1, 1, 0, 5, 0, 0, tzinfo=timezone.utc),
                 120,
                 False,
             ),
             (
                 True,
-                datetime(2022, 1, 1, 0, 0, 0, 0, tzinfo=utc),
-                datetime(2022, 1, 1, 0, 1, 0, 0, tzinfo=utc),
+                datetime(2022, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc),
+                datetime(2022, 1, 1, 0, 1, 0, 0, tzinfo=timezone.utc),
                 120,
                 True,
             ),
             (
                 True,
-                datetime(2022, 1, 1, 0, 0, 0, 0, tzinfo=utc),
-                datetime(2022, 1, 1, 0, 2, 0, 0, tzinfo=utc),
+                datetime(2022, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc),
+                datetime(2022, 1, 1, 0, 2, 0, 0, tzinfo=timezone.utc),
                 120,
                 True,
             ),
             (
                 True,
-                datetime(2022, 1, 1, 0, 0, 0, 0, tzinfo=utc),
-                datetime(2022, 1, 1, 0, 5, 0, 0, tzinfo=utc),
+                datetime(2022, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc),
+                datetime(2022, 1, 1, 0, 5, 0, 0, tzinfo=timezone.utc),
                 120,
                 True,
             ),
@@ -1501,43 +1500,43 @@ class TestPodLogsConsumer:
         [
             (
                 120,
-                datetime(2023, 1, 1, 0, 0, 0, 0, tzinfo=utc),
-                datetime(2023, 1, 1, 0, 1, 0, 0, tzinfo=utc),
+                datetime(2023, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc),
+                datetime(2023, 1, 1, 0, 1, 0, 0, tzinfo=timezone.utc),
                 ["Read pod #0", "Read pod #1"],
                 ["Read pod #0", "Read pod #0"],
             ),
             (
                 120,
-                datetime(2023, 1, 1, 0, 0, 0, 0, tzinfo=utc),
-                datetime(2023, 1, 1, 0, 2, 0, 0, tzinfo=utc),
+                datetime(2023, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc),
+                datetime(2023, 1, 1, 0, 2, 0, 0, tzinfo=timezone.utc),
                 ["Read pod #0", "Read pod #1"],
                 ["Read pod #0", "Read pod #0"],
             ),
             (
                 120,
-                datetime(2023, 1, 1, 0, 0, 0, 0, tzinfo=utc),
-                datetime(2023, 1, 1, 0, 3, 0, 0, tzinfo=utc),
+                datetime(2023, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc),
+                datetime(2023, 1, 1, 0, 3, 0, 0, tzinfo=timezone.utc),
                 ["Read pod #0", "Read pod #1"],
                 ["Read pod #0", "Read pod #1"],
             ),
             (
                 2,
-                datetime(2023, 1, 1, 0, 0, 0, 0, tzinfo=utc),
-                datetime(2023, 1, 1, 0, 0, 1, 0, tzinfo=utc),
+                datetime(2023, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc),
+                datetime(2023, 1, 1, 0, 0, 1, 0, tzinfo=timezone.utc),
                 ["Read pod #0", "Read pod #1"],
                 ["Read pod #0", "Read pod #0"],
             ),
             (
                 2,
-                datetime(2023, 1, 1, 0, 0, 0, 0, tzinfo=utc),
-                datetime(2023, 1, 1, 0, 0, 2, 0, tzinfo=utc),
+                datetime(2023, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc),
+                datetime(2023, 1, 1, 0, 0, 2, 0, tzinfo=timezone.utc),
                 ["Read pod #0", "Read pod #1"],
                 ["Read pod #0", "Read pod #0"],
             ),
             (
                 2,
-                datetime(2023, 1, 1, 0, 0, 0, 0, tzinfo=utc),
-                datetime(2023, 1, 1, 0, 0, 3, 0, tzinfo=utc),
+                datetime(2023, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc),
+                datetime(2023, 1, 1, 0, 0, 3, 0, tzinfo=timezone.utc),
                 ["Read pod #0", "Read pod #1"],
                 ["Read pod #0", "Read pod #1"],
             ),

--- a/providers/google/src/airflow/providers/google/cloud/operators/kubernetes_engine.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/kubernetes_engine.py
@@ -40,7 +40,7 @@ from airflow.providers.cncf.kubernetes.operators.resource import (
     KubernetesDeleteResourceOperator,
 )
 from airflow.providers.cncf.kubernetes.utils.pod_manager import OnFinishAction
-from airflow.providers.common.compat.sdk import AirflowException, conf
+from airflow.providers.common.compat.sdk import AirflowException, conf, timezone
 from airflow.providers.google.cloud.hooks.kubernetes_engine import (
     GKEHook,
     GKEKubernetesHook,
@@ -59,7 +59,6 @@ from airflow.providers.google.cloud.triggers.kubernetes_engine import (
 )
 from airflow.providers.google.common.hooks.base_google import PROVIDE_PROJECT_ID
 from airflow.providers_manager import ProvidersManager
-from airflow.utils.timezone import utcnow
 
 try:
     from airflow.providers.cncf.kubernetes.operators.job import KubernetesDeleteJobOperator
@@ -663,7 +662,7 @@ class GKEStartPodOperator(GKEOperatorMixin, KubernetesPodOperator):
 
     def invoke_defer_method(self, last_log_time: DateTime | None = None):
         """Redefine triggers which are being used in child classes."""
-        trigger_start_time = utcnow()
+        trigger_start_time = timezone.utcnow()
         on_finish_action = self.on_finish_action
         if type(on_finish_action) is str and self.on_finish_action not in [i.value for i in OnFinishAction]:
             on_finish_action = self.on_finish_action.split(".")[-1].lower()  # type: ignore[assignment]

--- a/providers/google/tests/unit/google/cloud/operators/test_kubernetes_engine.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_kubernetes_engine.py
@@ -732,7 +732,7 @@ class TestGKEStartPodOperator:
     @mock.patch(GKE_OPERATORS_PATH.format("GKEClusterAuthDetails.fetch_cluster_info"))
     @mock.patch(GKE_OPERATORS_PATH.format("GKEHook"))
     @mock.patch(GKE_OPERATORS_PATH.format("GKEStartPodTrigger"))
-    @mock.patch(GKE_OPERATORS_PATH.format("utcnow"))
+    @mock.patch(GKE_OPERATORS_PATH.format("timezone.utcnow"))
     def test_invoke_defer_method(
         self, mock_utcnow, mock_trigger, mock_cluster_hook, mock_fetch_cluster_info, mock_defer
     ):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

In this PR I have replaced deprecated import for `timezone.utcnow()` to the `timezone` import from `common.compat.sdk` provider.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
