### PR TITLE
KubernetesPodOperator check xcom sidecar running before trying to read xcom

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -76,6 +76,10 @@ Sentinel for no xcom result.
 """
 
 
+class XComRetrievalError(AirflowException):
+    """When not possible to get xcom."""
+
+
 class PodPhase:
     """
     Possible pod phases.
@@ -843,6 +847,12 @@ class PodManager(LoggingMixin):
 
     def extract_xcom(self, pod: V1Pod) -> str:
         """Retrieve XCom value and kill xcom sidecar container."""
+        # make sure that xcom sidecar container is still running
+        if not self.container_is_running(pod, PodDefaults.SIDECAR_CONTAINER_NAME):
+            raise XComRetrievalError(
+                f"{PodDefaults.SIDECAR_CONTAINER_NAME} container is not running! Not possible to read xcom from pod: {pod.metadata.name}"
+            )
+
         try:
             result = self.extract_xcom_json(pod)
             return result
@@ -887,7 +897,7 @@ class PodManager(LoggingMixin):
                 json.loads(result)
 
         if result is None:
-            raise AirflowException(f"Failed to extract xcom from pod: {pod.metadata.name}")
+            raise XComRetrievalError(f"Failed to extract xcom from pod: {pod.metadata.name}")
         return result
 
     @generic_api_retry

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_pod_manager.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_pod_manager.py
@@ -35,6 +35,7 @@ from airflow.providers.cncf.kubernetes.utils.pod_manager import (
     PodLogsConsumer,
     PodManager,
     PodPhase,
+    XComRetrievalError,
     log_pod_event,
     parse_log_line,
 )
@@ -842,7 +843,13 @@ class TestPodManager:
 
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.kubernetes_stream")
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.extract_xcom_kill")
-    def test_extract_xcom_success(self, mock_exec_xcom_kill, mock_kubernetes_stream):
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.container_is_running",
+        return_value=True,
+    )
+    def test_extract_xcom_success(
+        self, mock_container_is_running, mock_exec_xcom_kill, mock_kubernetes_stream
+    ):
         """test when valid json is retrieved from xcom sidecar container."""
         xcom_json = """{"a": "true"}"""
         mock_pod = MagicMock()
@@ -856,7 +863,13 @@ class TestPodManager:
 
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.kubernetes_stream")
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.extract_xcom_kill")
-    def test_extract_xcom_failure(self, mock_exec_xcom_kill, mock_kubernetes_stream):
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.container_is_running",
+        return_value=True,
+    )
+    def test_extract_xcom_failure(
+        self, mock_container_is_running, mock_exec_xcom_kill, mock_kubernetes_stream
+    ):
         """test when invalid json is retrieved from xcom sidecar container."""
         xcom_json = """{"a": "tru"""  # codespell:ignore tru
         mock_pod = MagicMock()
@@ -870,7 +883,11 @@ class TestPodManager:
 
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.kubernetes_stream")
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.extract_xcom_kill")
-    def test_extract_xcom_empty(self, mock_exec_xcom_kill, mock_kubernetes_stream):
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.container_is_running",
+        return_value=True,
+    )
+    def test_extract_xcom_empty(self, mock_container_is_running, mock_exec_xcom_kill, mock_kubernetes_stream):
         """test when __airflow_xcom_result_empty__ is retrieved from xcom sidecar container."""
         mock_pod = MagicMock()
         xcom_result = "__airflow_xcom_result_empty__"
@@ -884,16 +901,33 @@ class TestPodManager:
 
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.kubernetes_stream")
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.extract_xcom_kill")
-    def test_extract_xcom_none(self, mock_exec_xcom_kill, mock_kubernetes_stream):
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.container_is_running",
+        return_value=True,
+    )
+    def test_extract_xcom_none(self, mock_container_is_running, mock_exec_xcom_kill, mock_kubernetes_stream):
         """test when None is retrieved from xcom sidecar container."""
         mock_pod = MagicMock()
         mock_client = MagicMock()
         mock_client.peek_stderr.return_value = ""
         mock_client.read_all.return_value = None
         mock_kubernetes_stream.return_value = mock_client
-        with pytest.raises(AirflowException):
+        with pytest.raises(XComRetrievalError, match=r"Failed to extract xcom from pod:"):
             self.pod_manager.extract_xcom(pod=mock_pod)
         assert mock_exec_xcom_kill.call_count == 1
+
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.container_is_running",
+        return_value=False,
+    )
+    def test_extract_xcom_where_sidecar_terminated(self, mock_container_is_running):
+        """test when None is retrieved from xcom sidecar container."""
+        mock_pod = MagicMock()
+        with pytest.raises(
+            XComRetrievalError,
+            match=r"container is not running! Not possible to read xcom from pod:",
+        ):
+            self.pod_manager.extract_xcom(pod=mock_pod)
 
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.container_is_terminated")
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.container_is_running")

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_pod_manager.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_pod_manager.py
@@ -920,7 +920,7 @@ class TestPodManager:
         "airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.container_is_running",
         return_value=False,
     )
-    def test_extract_xcom_where_sidecar_terminated(self, mock_container_is_running):
+    def test_extract_xcom_sidecar_terminated(self, mock_container_is_running):
         """test when None is retrieved from xcom sidecar container."""
         mock_pod = MagicMock()
         with pytest.raises(


### PR DESCRIPTION
# Overview

We observed Kubernetes API errors in KubernetesPodOperator when a pod is evicted. In this state the xcom sidecar container has already terminated, so exec/read attempts fail. The previous exception did not clearly indicate that the sidecar was no longer running, making it hard to understand why no XCom output could be read. The new exception message explicitly states that the sidecar is not running, clarifying why XCom retrieval failed.


# Change Summary

* KubernetesPodOperator now checks that the xcom sidecar container is running before attempting to read the XCom output.
