### PR TITLE
feat(helm): Add full probe configuration support for Scheduler (#60134)

### DIFF
--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -25,7 +25,7 @@
 {{- $local := contains "Local" .Values.executor }}
 # Is persistence enabled on the _workers_?
 # This is important because in $local mode, the scheduler assumes the role of the worker
-{{- $persistence := .Values.workers.persistence.enabled }}
+{{- $persistence := or .Values.workers.celery.persistence.enabled (and (not (has .Values.workers.celery.persistence.enabled (list true false))) .Values.workers.persistence.enabled) }}
 # If we're using a StatefulSet
 {{- $stateful := and $local $persistence }}
 # We can skip DAGs mounts on scheduler if dagProcessor is enabled, except with $local mode
@@ -75,8 +75,8 @@ spec:
   {{- if and $stateful .Values.scheduler.updateStrategy }}
   updateStrategy: {{- toYaml .Values.scheduler.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- if and $stateful .Values.workers.persistence.persistentVolumeClaimRetentionPolicy }}
-  persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.workers.persistence.persistentVolumeClaimRetentionPolicy  | nindent 4 }}
+  {{- if and $stateful (or .Values.workers.celery.persistence.persistentVolumeClaimRetentionPolicy .Values.workers.persistence.persistentVolumeClaimRetentionPolicy) }}
+  persistentVolumeClaimRetentionPolicy: {{- toYaml (.Values.workers.celery.persistence.persistentVolumeClaimRetentionPolicy | default .Values.workers.persistence.persistentVolumeClaimRetentionPolicy) | nindent 4 }}
   {{- end }}
   {{- if and (not $stateful) .Values.scheduler.strategy }}
   strategy: {{- toYaml .Values.scheduler.strategy | nindent 4 }}
@@ -206,11 +206,25 @@ spec:
             {{- include "custom_airflow_environment" . | indent 10 }}
             {{- include "standard_airflow_environment" . | indent 10 }}
             {{- include "container_extra_envs" (list . .Values.scheduler.env) | indent 10 }}
+          {{- if or (not (hasKey .Values.scheduler.livenessProbe "enabled")) .Values.scheduler.livenessProbe.enabled }}
           livenessProbe:
             initialDelaySeconds: {{ .Values.scheduler.livenessProbe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.scheduler.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.scheduler.livenessProbe.failureThreshold }}
             periodSeconds: {{ .Values.scheduler.livenessProbe.periodSeconds }}
+            {{- if .Values.scheduler.livenessProbe.successThreshold }}
+            successThreshold: {{ .Values.scheduler.livenessProbe.successThreshold }}
+            {{- end }}
+            {{- if .Values.scheduler.livenessProbe.terminationGracePeriodSeconds }}
+            terminationGracePeriodSeconds: {{ .Values.scheduler.livenessProbe.terminationGracePeriodSeconds }}
+            {{- end }}
+            {{- if .Values.scheduler.livenessProbe.httpGet }}
+            httpGet: {{- toYaml .Values.scheduler.livenessProbe.httpGet | nindent 14 }}
+            {{- else if .Values.scheduler.livenessProbe.tcpSocket }}
+            tcpSocket: {{- toYaml .Values.scheduler.livenessProbe.tcpSocket | nindent 14 }}
+            {{- else if .Values.scheduler.livenessProbe.grpc }}
+            grpc: {{- toYaml .Values.scheduler.livenessProbe.grpc | nindent 14 }}
+            {{- else }}
             exec:
               command:
                 {{- if .Values.scheduler.livenessProbe.command }}
@@ -218,11 +232,55 @@ spec:
                 {{- else }}
                   {{- include "scheduler_liveness_check_command" . | indent 14 }}
                 {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- if and (hasKey .Values.scheduler "readinessProbe") .Values.scheduler.readinessProbe.enabled }}
+          readinessProbe:
+            initialDelaySeconds: {{ .Values.scheduler.readinessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.scheduler.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.scheduler.readinessProbe.failureThreshold }}
+            periodSeconds: {{ .Values.scheduler.readinessProbe.periodSeconds }}
+            {{- if .Values.scheduler.readinessProbe.successThreshold }}
+            successThreshold: {{ .Values.scheduler.readinessProbe.successThreshold }}
+            {{- end }}
+            {{- if .Values.scheduler.readinessProbe.terminationGracePeriodSeconds }}
+            terminationGracePeriodSeconds: {{ .Values.scheduler.readinessProbe.terminationGracePeriodSeconds }}
+            {{- end }}
+            {{- if .Values.scheduler.readinessProbe.httpGet }}
+            httpGet: {{- toYaml .Values.scheduler.readinessProbe.httpGet | nindent 14 }}
+            {{- else if .Values.scheduler.readinessProbe.tcpSocket }}
+            tcpSocket: {{- toYaml .Values.scheduler.readinessProbe.tcpSocket | nindent 14 }}
+            {{- else if .Values.scheduler.readinessProbe.grpc }}
+            grpc: {{- toYaml .Values.scheduler.readinessProbe.grpc | nindent 14 }}
+            {{- else }}
+            exec:
+              command:
+                {{- if .Values.scheduler.readinessProbe.command }}
+                  {{- toYaml .Values.scheduler.readinessProbe.command  | nindent 16 }}
+                {{- else }}
+                  {{- include "scheduler_liveness_check_command" . | indent 14 }}
+                {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- if or (not (hasKey .Values.scheduler.startupProbe "enabled")) .Values.scheduler.startupProbe.enabled }}
           startupProbe:
             initialDelaySeconds: {{ .Values.scheduler.startupProbe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.scheduler.startupProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.scheduler.startupProbe.failureThreshold }}
             periodSeconds: {{ .Values.scheduler.startupProbe.periodSeconds }}
+            {{- if .Values.scheduler.startupProbe.successThreshold }}
+            successThreshold: {{ .Values.scheduler.startupProbe.successThreshold }}
+            {{- end }}
+            {{- if .Values.scheduler.startupProbe.terminationGracePeriodSeconds }}
+            terminationGracePeriodSeconds: {{ .Values.scheduler.startupProbe.terminationGracePeriodSeconds }}
+            {{- end }}
+            {{- if .Values.scheduler.startupProbe.httpGet }}
+            httpGet: {{- toYaml .Values.scheduler.startupProbe.httpGet | nindent 14 }}
+            {{- else if .Values.scheduler.startupProbe.tcpSocket }}
+            tcpSocket: {{- toYaml .Values.scheduler.startupProbe.tcpSocket | nindent 14 }}
+            {{- else if .Values.scheduler.startupProbe.grpc }}
+            grpc: {{- toYaml .Values.scheduler.startupProbe.grpc | nindent 14 }}
+            {{- else }}
             exec:
               command:
                 {{- if .Values.scheduler.startupProbe.command }}
@@ -230,6 +288,8 @@ spec:
                 {{- else }}
                   {{- include "scheduler_startup_check_command" . | indent 14 }}
                 {{- end }}
+            {{- end }}
+          {{- end }}
           {{- if and $local (not $remoteLogging) }}
           # Serve logs if we're in local mode and we have neither elasticsearch nor opensearch enabled.
           ports:
@@ -382,16 +442,16 @@ spec:
       kind: PersistentVolumeClaim
       metadata:
         name: logs
-        {{- if .Values.workers.persistence.annotations }}
-        annotations: {{- toYaml .Values.workers.persistence.annotations | nindent 10 }}
+        {{- if or .Values.workers.celery.persistence.annotations .Values.workers.persistence.annotations }}
+        annotations: {{- toYaml (.Values.workers.celery.persistence.annotations | default .Values.workers.persistence.annotations) | nindent 10 }}
         {{- end }}
       spec:
-      {{- if .Values.workers.persistence.storageClassName }}
-        storageClassName: {{ tpl .Values.workers.persistence.storageClassName . | quote }}
+      {{- if or .Values.workers.celery.persistence.storageClassName .Values.workers.persistence.storageClassName }}
+        storageClassName: {{ tpl (.Values.workers.celery.persistence.storageClassName | default .Values.workers.persistence.storageClassName) . | quote }}
       {{- end }}
         accessModes: ["ReadWriteOnce"]
         resources:
           requests:
-            storage: {{ .Values.workers.persistence.size }}
+            storage: {{ .Values.workers.celery.persistence.size | default .Values.workers.persistence.size }}
   {{- end }}
   {{- end }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1900,26 +1900,26 @@
                     }
                 },
                 "persistence": {
-                    "description": "Persistence configuration for Airflow Celery workers.",
+                    "description": "Persistence configuration for Airflow Celery workers (deprecated, use `workers.celery.persistence` instead).",
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
                         "enabled": {
-                            "description": "Enable persistent volumes.",
+                            "description": "Enable persistent volumes (deprecated, use `workers.celery.persistence.enabled` instead).",
                             "type": "boolean",
                             "default": true
                         },
                         "persistentVolumeClaimRetentionPolicy": {
                             "$ref": "#/definitions/persistentVolumeClaimRetentionPolicy",
-                            "description": "PersistentVolumeClaim retention policy to be used in the lifecycle of a StatefulSet."
+                            "description": "PersistentVolumeClaim retention policy to be used in the lifecycle of a StatefulSet (deprecated, use `workers.celery.persistence.persistentVolumeClaimRetentionPolicy` instead)."
                         },
                         "size": {
-                            "description": "Volume size for Airflow Celery worker StatefulSet.",
+                            "description": "Volume size for Airflow Celery worker StatefulSet (deprecated, use `workers.celery.persistence.size` instead).",
                             "type": "string",
                             "default": "100Gi"
                         },
                         "storageClassName": {
-                            "description": "If using a custom StorageClass, pass name ref to all StatefulSets here (templated).",
+                            "description": "If using a custom StorageClass, pass name ref to all StatefulSets here (templated) (deprecated, use `workers.celery.persistence.storageClassName` instead).",
                             "type": [
                                 "string",
                                 "null"
@@ -1927,12 +1927,12 @@
                             "default": null
                         },
                         "fixPermissions": {
-                            "description": "Execute init container to chown log directory. This is currently only needed in kind, due to usage of local-path provisioner.",
+                            "description": "Execute init container to chown log directory. This is currently only needed in kind, due to usage of local-path provisioner (deprecated, use `workers.celery.persistence.fixPermissions` instead).",
                             "type": "boolean",
                             "default": false
                         },
                         "annotations": {
-                            "description": "Annotations to add to Airflow Celery worker volumes.",
+                            "description": "Annotations to add to Airflow Celery worker volumes (deprecated, use `workers.celery.persistence.annotations` instead).",
                             "type": "object",
                             "default": {},
                             "additionalProperties": {
@@ -1940,7 +1940,7 @@
                             }
                         },
                         "securityContexts": {
-                            "description": "Security context definition for the persistence. If not set, the values from global `securityContexts` will be used.",
+                            "description": "Security context definition for the persistence. If not set, the values from global `securityContexts` will be used (deprecated, use `workers.celery.persistence.securityContexts` instead).",
                             "type": "object",
                             "x-docsSection": "Kubernetes",
                             "properties": {
@@ -2692,6 +2692,72 @@
                                     }
                                 }
                             }
+                        },
+                        "persistence": {
+                            "description": "Persistence configuration for Airflow Celery workers.",
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "enabled": {
+                                    "description": "Enable persistent volumes.",
+                                    "type": "boolean",
+                                    "default": true
+                                },
+                                "persistentVolumeClaimRetentionPolicy": {
+                                    "$ref": "#/definitions/persistentVolumeClaimRetentionPolicy",
+                                    "description": "PersistentVolumeClaim retention policy to be used in the lifecycle of a StatefulSet."
+                                },
+                                "size": {
+                                    "description": "Volume size for Airflow Celery worker StatefulSet.",
+                                    "type": "string",
+                                    "default": "100Gi"
+                                },
+                                "storageClassName": {
+                                    "description": "If using a custom StorageClass, pass name ref to all StatefulSets here (templated).",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "default": null
+                                },
+                                "fixPermissions": {
+                                    "description": "Execute init container to chown log directory. This is currently only needed in kind, due to usage of local-path provisioner.",
+                                    "type": "boolean",
+                                    "default": false
+                                },
+                                "annotations": {
+                                    "description": "Annotations to add to Airflow Celery worker volumes.",
+                                    "type": "object",
+                                    "default": {},
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    }
+                                },
+                                "securityContexts": {
+                                    "description": "Security context definition for the persistence. If not set, the values from global `securityContexts` will be used.",
+                                    "type": "object",
+                                    "x-docsSection": "Kubernetes",
+                                    "properties": {
+                                        "container": {
+                                            "description": "Container security context definition for the persistence.",
+                                            "type": "object",
+                                            "$ref": "#/definitions/io.k8s.api.core.v1.SecurityContext",
+                                            "default": {},
+                                            "x-docsSection": "Kubernetes",
+                                            "examples": [
+                                                {
+                                                    "allowPrivilegeEscalation": false,
+                                                    "capabilities": {
+                                                        "drop": [
+                                                            "ALL"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 },
@@ -2781,10 +2847,14 @@
                     ]
                 },
                 "livenessProbe": {
-                    "description": "Liveness probe configuration for scheduler container.",
+                    "description": "Liveness probe configuration for scheduler container. Supports full Kubernetes probe spec including exec, httpGet, tcpSocket, and grpc handlers.",
                     "type": "object",
-                    "additionalProperties": false,
                     "properties": {
+                        "enabled": {
+                            "description": "Enable the liveness probe.",
+                            "type": "boolean",
+                            "default": true
+                        },
                         "initialDelaySeconds": {
                             "description": "Number of seconds after the container has started before liveness probes are initiated.",
                             "type": "integer",
@@ -2805,8 +2875,16 @@
                             "type": "integer",
                             "default": 60
                         },
+                        "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Must be 1 for liveness. Minimum value is 1.",
+                            "type": "integer"
+                        },
+                        "terminationGracePeriodSeconds": {
+                            "description": "Duration in seconds the pod needs to terminate gracefully upon probe failure.",
+                            "type": "integer"
+                        },
                         "command": {
-                            "description": "Command for livenessProbe",
+                            "description": "Command for exec-based livenessProbe. Mutually exclusive with httpGet, tcpSocket, and grpc.",
                             "type": [
                                 "array",
                                 "null"
@@ -2817,14 +2895,94 @@
                                     "null"
                                 ]
                             }
+                        },
+                        "httpGet": {
+                            "description": "HTTPGet probe configuration. Mutually exclusive with exec, tcpSocket, and grpc.",
+                            "$ref": "#/definitions/io.k8s.api.core.v1.HTTPGetAction"
+                        },
+                        "tcpSocket": {
+                            "description": "TCPSocket probe configuration. Mutually exclusive with exec, httpGet, and grpc.",
+                            "$ref": "#/definitions/io.k8s.api.core.v1.TCPSocketAction"
+                        },
+                        "grpc": {
+                            "description": "GRPC probe configuration. Mutually exclusive with exec, httpGet, and tcpSocket.",
+                            "$ref": "#/definitions/io.k8s.api.core.v1.GRPCAction"
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "description": "Readiness probe configuration for scheduler container. Supports full Kubernetes probe spec including exec, httpGet, tcpSocket, and grpc handlers.",
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "description": "Enable the readiness probe.",
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before readiness probes are initiated.",
+                            "type": "integer",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out. Minimum value is 1 seconds.",
+                            "type": "integer",
+                            "default": 20
+                        },
+                        "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Minimum value is 1.",
+                            "type": "integer",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe. Minimum value is 1.",
+                            "type": "integer",
+                            "default": 60
+                        },
+                        "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Minimum value is 1.",
+                            "type": "integer"
+                        },
+                        "terminationGracePeriodSeconds": {
+                            "description": "Duration in seconds the pod needs to terminate gracefully upon probe failure.",
+                            "type": "integer"
+                        },
+                        "command": {
+                            "description": "Command for exec-based readinessProbe. Mutually exclusive with httpGet, tcpSocket, and grpc.",
+                            "type": [
+                                "array",
+                                "null"
+                            ],
+                            "items": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        },
+                        "httpGet": {
+                            "description": "HTTPGet probe configuration. Mutually exclusive with exec, tcpSocket, and grpc.",
+                            "$ref": "#/definitions/io.k8s.api.core.v1.HTTPGetAction"
+                        },
+                        "tcpSocket": {
+                            "description": "TCPSocket probe configuration. Mutually exclusive with exec, httpGet, and grpc.",
+                            "$ref": "#/definitions/io.k8s.api.core.v1.TCPSocketAction"
+                        },
+                        "grpc": {
+                            "description": "GRPC probe configuration. Mutually exclusive with exec, httpGet, and tcpSocket.",
+                            "$ref": "#/definitions/io.k8s.api.core.v1.GRPCAction"
                         }
                     }
                 },
                 "startupProbe": {
-                    "description": "Startup probe configuration for scheduler container.",
+                    "description": "Startup probe configuration for scheduler container. Supports full Kubernetes probe spec including exec, httpGet, tcpSocket, and grpc handlers.",
                     "type": "object",
-                    "additionalProperties": false,
                     "properties": {
+                        "enabled": {
+                            "description": "Enable the startup probe.",
+                            "type": "boolean",
+                            "default": true
+                        },
                         "initialDelaySeconds": {
                             "description": "Number of seconds after the container has started before startup probes are initiated.",
                             "type": "integer",
@@ -2845,8 +3003,16 @@
                             "type": "integer",
                             "default": 10
                         },
+                        "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Must be 1 for startup. Minimum value is 1.",
+                            "type": "integer"
+                        },
+                        "terminationGracePeriodSeconds": {
+                            "description": "Duration in seconds the pod needs to terminate gracefully upon probe failure.",
+                            "type": "integer"
+                        },
                         "command": {
-                            "description": "Command for livenessProbe",
+                            "description": "Command for exec-based startupProbe. Mutually exclusive with httpGet, tcpSocket, and grpc.",
                             "type": [
                                 "array",
                                 "null"
@@ -2857,6 +3023,18 @@
                                     "null"
                                 ]
                             }
+                        },
+                        "httpGet": {
+                            "description": "HTTPGet probe configuration. Mutually exclusive with exec, tcpSocket, and grpc.",
+                            "$ref": "#/definitions/io.k8s.api.core.v1.HTTPGetAction"
+                        },
+                        "tcpSocket": {
+                            "description": "TCPSocket probe configuration. Mutually exclusive with exec, httpGet, and grpc.",
+                            "$ref": "#/definitions/io.k8s.api.core.v1.TCPSocketAction"
+                        },
+                        "grpc": {
+                            "description": "GRPC probe configuration. Mutually exclusive with exec, httpGet, and tcpSocket.",
+                            "$ref": "#/definitions/io.k8s.api.core.v1.GRPCAction"
                         }
                     }
                 },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -797,32 +797,40 @@ workers:
     behavior: {}
 
   # Persistence volume configuration for Airflow Celery workers
+  # (deprecated, use `workers.celery.persistence` instead)
   persistence:
-    # Enable persistent volumes
+    # Enable persistent volumes (deprecated, use `workers.celery.persistence.enabled` instead)
     enabled: true
 
     # This policy determines whether PVCs should be deleted when StatefulSet is scaled down or removed
+    # (deprecated, use `workers.celery.persistence.persistentVolumeClaimRetentionPolicy` instead)
     persistentVolumeClaimRetentionPolicy: ~
     # persistentVolumeClaimRetentionPolicy:
     #   whenDeleted: Delete
     #   whenScaled: Delete
 
     # Volume size for Airflow Celery worker StatefulSet
+    # (deprecated, use `workers.celery.persistence.size` instead)
     size: 100Gi
 
     # If using a custom storageClass, pass name ref to all StatefulSets here
+    # (deprecated, use `workers.celery.persistence.storageClassName` instead)
     storageClassName:
 
     # Execute init container to chown log directory.
     # This is currently only needed in kind, due to usage
     # of local-path provisioner.
+    # (deprecated, use `workers.celery.persistence.fixPermissions` instead)
     fixPermissions: false
 
     # Annotations to add to Airflow Celery worker volumes
+    # (deprecated, use `workers.celery.persistence.annotations` instead)
     annotations: {}
 
     # Detailed default security context for persistence on container level
+    # (deprecated, use `workers.celery.persistence.securityContexts` instead)
     securityContexts:
+      # (deprecated, use `workers.celery.persistence.securityContexts.container` instead)
       container: {}
 
   # Kerberos sidecar configuration for Airflow Celery workers and pods created with pod-template-file
@@ -1060,6 +1068,35 @@ workers:
       # Annotations to add to worker kubernetes service account.
       annotations: {}
 
+    # Persistence volume configuration for Airflow Celery workers
+    persistence:
+      # Enable persistent volumes
+      enabled: true
+
+      # This policy determines whether PVCs should be deleted when StatefulSet is scaled down or removed
+      persistentVolumeClaimRetentionPolicy: ~
+      # persistentVolumeClaimRetentionPolicy:
+      #   whenDeleted: Delete
+      #   whenScaled: Delete
+
+      # Volume size for Airflow Celery worker StatefulSet
+      size: 100Gi
+
+      # If using a custom storageClass, pass name ref to all StatefulSets here
+      storageClassName:
+
+      # Execute init container to chown log directory.
+      # This is currently only needed in kind, due to usage
+      # of local-path provisioner.
+      fixPermissions: false
+
+      # Annotations to add to Airflow Celery worker volumes
+      annotations: {}
+
+      # Detailed default security context for persistence on container level
+      securityContexts:
+        container: {}
+
   kubernetes:
     # Command to use in pod-template-file (templated)
     command: ~
@@ -1089,23 +1126,55 @@ scheduler:
   #    hostnames:
   #      - "foo.remote"
 
-  # If the scheduler stops heartbeating for 5 minutes (5*60s) kill the
-  # scheduler and let Kubernetes restart it
+  # Liveness probe kills the scheduler pod if it stops heartbeating for 5 minutes (5*60s)
+  # Supports full Kubernetes probe configuration: exec (command), httpGet, tcpSocket, grpc
   livenessProbe:
+    enabled: true
     initialDelaySeconds: 10
     timeoutSeconds: 20
     failureThreshold: 5
     periodSeconds: 60
     command: ~
+    # Alternative probe types (mutually exclusive with command):
+    # httpGet:
+    #   path: /health
+    #   port: 8974
+    #   scheme: HTTP
+    # tcpSocket:
+    #   port: 8793
+    # grpc:
+    #   port: 50051
 
-  # Wait for at most 1 minute (6*10s) for the scheduler container to startup.
-  # livenessProbe kicks in after the first successful startupProbe
+  # Readiness probe for traffic routing decisions. Disabled by default since
+  # scheduler typically doesn't receive external traffic, but useful for custom setups.
+  # Supports the same probe types as livenessProbe.
+  readinessProbe:
+    enabled: false
+    initialDelaySeconds: 10
+    timeoutSeconds: 20
+    failureThreshold: 5
+    periodSeconds: 60
+    command: ~
+    # httpGet:
+    #   path: /health
+    #   port: 8974
+    # tcpSocket:
+    #   port: 8793
+
+  # Startup probe gives the scheduler time to initialize before liveness checks begin.
+  # Waits up to 1 minute (6*10s) for the container to become ready.
   startupProbe:
+    enabled: true
     initialDelaySeconds: 0
     failureThreshold: 6
     periodSeconds: 10
     timeoutSeconds: 20
     command: ~
+    # httpGet:
+    #   path: /health
+    #   port: 8974
+    # tcpSocket:
+    #   port: 8793
 
   # Airflow 2.0 allows users to run multiple schedulers,
   # However this feature is only recommended for MySQL 8+ and Postgres


### PR DESCRIPTION
## What this PR does

Extends the Airflow Scheduler's probe configuration to support the complete Kubernetes probe specification. Previously, the scheduler only accepted basic timing parameters and exec commands, which blocked users from configuring TCP socket checks, HTTP endpoints, or gRPC health probes.

## Why we need this

The current schema is overly restrictive compared to other chart components. When users try to set `tcpSocket`, `httpGet`, or even add a `readinessProbe`, they hit validation errors like:
