### PR TITLE
Move ``AirflowOptionalProviderFeatureException`` to task sdk

### DIFF
--- a/airflow-core/newsfragments/54505.significant.rst
+++ b/airflow-core/newsfragments/54505.significant.rst
@@ -26,6 +26,7 @@ proxies that emit ``DeprecatedImportWarning`` so Dag authors can migrate before 
 - ``DagRunTriggerException`` and ``DownstreamTasksSkipped``
 - ``AirflowDagCycleException`` and ``AirflowInactiveAssetInInletOrOutletException``
 - ``ParamValidationError``, ``DuplicateTaskIdFound``, ``TaskAlreadyInTaskGroup``, ``TaskNotFound``, ``XComNotFound``
+- ``AirflowOptionalProviderFeatureException``
 
 **Backward compatibility:**
 

--- a/airflow-core/src/airflow/exceptions.py
+++ b/airflow-core/src/airflow/exceptions.py
@@ -34,6 +34,7 @@ try:
     from airflow.sdk.exceptions import (
         AirflowException,
         AirflowNotFoundException,
+        AirflowOptionalProviderFeatureException as AirflowOptionalProviderFeatureException,
         AirflowRescheduleException as AirflowRescheduleException,
         AirflowTimetableInvalid as AirflowTimetableInvalid,
         TaskNotFound as TaskNotFound,
@@ -68,6 +69,9 @@ except ModuleNotFoundError:
             cls = self.__class__
             return f"{cls.__module__}.{cls.__name__}", (), {"reschedule_date": self.reschedule_date}
 
+    class AirflowOptionalProviderFeatureException(AirflowException):  # type: ignore[no-redef]
+        """Raise by providers when imports are missing for optional provider features."""
+
 
 class AirflowBadRequest(AirflowException):
     """Raise when the application or server cannot handle the request."""
@@ -77,10 +81,6 @@ class AirflowBadRequest(AirflowException):
 
 class InvalidStatsNameException(AirflowException):
     """Raise when name of the stats is invalid."""
-
-
-class AirflowOptionalProviderFeatureException(AirflowException):
-    """Raise by providers when imports are missing for optional provider features."""
 
 
 class AirflowInternalRuntimeError(BaseException):

--- a/task-sdk/src/airflow/sdk/exceptions.py
+++ b/task-sdk/src/airflow/sdk/exceptions.py
@@ -47,6 +47,10 @@ class AirflowException(Exception):
         return f"{cls.__module__}.{cls.__name__}", (str(self),), {}
 
 
+class AirflowOptionalProviderFeatureException(AirflowException):
+    """Raise by providers when imports are missing for optional provider features."""
+
+
 class AirflowNotFoundException(AirflowException):
     """Raise when the requested object/resource is not available in the system."""
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Precursor to: https://github.com/apache/airflow/pull/60218/
Related / addendum to: https://github.com/apache/airflow/pull/54505

`AirflowOptionalProviderFeatureException` is an exception that is needed for the provider discovery and task execution flow, and belongs in SDK for proper architectural separation between core and task sdk.

### Usages of this exception

1. Airflow Startup: during provider discovery
   - Raised by providers when optional dependencies are missing during import
   - Caught by `_correctness_check()` in `providers_manager`
   - Allows provider to startup with features excluded

2. Runtime: during task execution
   - Raised when task code calls methods requiring optional dependencies
   - Caught by generic `AirflowException` handler in `task_runner.py`
   - Task fails with clear error message
 

### Why task sdk?

With client-server separation, providers will depend only on `task-sdk` and not `airflow-core`, so the idea is that when providers raise this exception, the task SDK catches it during runtime (via `AirflowException` inheritance which is in task sdk) and discovery piece is handled in https://github.com/apache/airflow/pull/60218/


### Backward Compatibility

Similar to https://github.com/apache/airflow/pull/54505, backcompat is built into core for discovery piece but for providers piece I will follow up with a PR that adds it to https://github.com/astronomer/airflow/blob/main/providers/common/compat/src/airflow/providers/common/compat/sdk.py#L239 and providers consume from there: `from airflow.providers.common.compat.sdk import AirflowOptionalProviderFeatureException`

This enables providers to work seamlessly across Airflow 2.x and 3.x.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
