### PR TITLE
Increase MySQL healthcheck timeouts to reduce CI flakiness

### DIFF
--- a/scripts/ci/docker-compose/backend-mysql.yml
+++ b/scripts/ci/docker-compose/backend-mysql.yml
@@ -37,8 +37,8 @@ services:
     healthcheck:
       test: ["CMD", "mysqladmin", "status", "-h", "localhost", "-u", "root"]
       interval: 10s
-      timeout: 10s
-      start_period: 30s
+      timeout: 15s
+      start_period: 60s
       retries: 5
     restart: "on-failure"
     command: [


### PR DESCRIPTION
Increase MySQL healthcheck timeouts to reduce [CI](https://github.com/apache/airflow/actions/runs/20853764603/job/59916058085) flakiness.

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
