### PR TITLE
Improve Dags Filter UI

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/DataTable/ToggleTableDisplay.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DataTable/ToggleTableDisplay.tsx
@@ -34,7 +34,6 @@ export const ToggleTableDisplay = ({ display, setDisplay }: Props) => {
     <ButtonGroup attached colorPalette="brand" pb={2} size="sm" variant="outline">
       <IconButton
         aria-label={translate("toggleCardView")}
-        bg={display === "card" ? "colorPalette.solid" : undefined}
         onClick={() => setDisplay("card")}
         title={translate("toggleCardView")}
         variant={display === "card" ? "solid" : "outline"}
@@ -43,7 +42,6 @@ export const ToggleTableDisplay = ({ display, setDisplay }: Props) => {
       </IconButton>
       <IconButton
         aria-label={translate("toggleTableView")}
-        bg={display === "table" ? "colorPalette.solid" : undefined}
         onClick={() => setDisplay("table")}
         title={translate("toggleTableView")}
         variant={display === "table" ? "solid" : "outline"}

--- a/airflow-core/src/airflow/ui/src/components/DataTable/ToggleTableDisplay.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DataTable/ToggleTableDisplay.tsx
@@ -34,7 +34,7 @@ export const ToggleTableDisplay = ({ display, setDisplay }: Props) => {
     <ButtonGroup attached colorPalette="brand" pb={2} size="sm" variant="outline">
       <IconButton
         aria-label={translate("toggleCardView")}
-        bg={display === "card" ? "colorPalette.muted" : undefined}
+        bg={display === "card" ? "colorPalette.solid" : undefined}
         onClick={() => setDisplay("card")}
         title={translate("toggleCardView")}
         variant={display === "card" ? "solid" : "outline"}
@@ -43,7 +43,7 @@ export const ToggleTableDisplay = ({ display, setDisplay }: Props) => {
       </IconButton>
       <IconButton
         aria-label={translate("toggleTableView")}
-        bg={display === "table" ? "colorPalette.muted" : undefined}
+        bg={display === "table" ? "colorPalette.solid" : undefined}
         onClick={() => setDisplay("table")}
         title={translate("toggleTableView")}
         variant={display === "table" ? "solid" : "outline"}

--- a/airflow-core/src/airflow/ui/src/components/ui/ButtonGroupToggle.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ui/ButtonGroupToggle.test.tsx
@@ -1,0 +1,88 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { BaseWrapper } from "src/utils/Wrapper";
+
+import { ButtonGroupToggle } from "./ButtonGroupToggle";
+
+describe("ButtonGroupToggle", () => {
+  const options = [
+    { label: "All", value: "all" },
+    { label: "Active", value: "active" },
+    { label: "Paused", value: "paused" },
+  ];
+
+  it("renders all options", () => {
+    render(<ButtonGroupToggle onChange={vi.fn()} options={options} value="all" />, {
+      wrapper: BaseWrapper,
+    });
+
+    expect(screen.getByText("All")).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.getByText("Paused")).toBeInTheDocument();
+  });
+
+  it("calls onChange when clicking a button", () => {
+    const onChange = vi.fn();
+
+    render(<ButtonGroupToggle onChange={onChange} options={options} value="all" />, {
+      wrapper: BaseWrapper,
+    });
+
+    fireEvent.click(screen.getByText("Active"));
+
+    expect(onChange).toHaveBeenCalledWith("active");
+  });
+
+  it("renders disabled options", () => {
+    const optionsWithDisabled = [
+      { label: "All", value: "all" },
+      { disabled: true, label: "Disabled", value: "disabled" },
+    ];
+
+    render(<ButtonGroupToggle onChange={vi.fn()} options={optionsWithDisabled} value="all" />, {
+      wrapper: BaseWrapper,
+    });
+
+    expect(screen.getByText("Disabled")).toBeDisabled();
+  });
+
+  it("supports render function labels", () => {
+    const optionsWithRenderFn = [
+      { label: "All", value: "all" },
+      {
+        label: (isSelected: boolean) => (isSelected ? "Selected!" : "Not Selected"),
+        value: "toggle",
+      },
+    ];
+
+    const { rerender } = render(
+      <ButtonGroupToggle onChange={vi.fn()} options={optionsWithRenderFn} value="all" />,
+      { wrapper: BaseWrapper },
+    );
+
+    expect(screen.getByText("Not Selected")).toBeInTheDocument();
+
+    rerender(<ButtonGroupToggle onChange={vi.fn()} options={optionsWithRenderFn} value="toggle" />);
+
+    expect(screen.getByText("Selected!")).toBeInTheDocument();
+  });
+});

--- a/airflow-core/src/airflow/ui/src/components/ui/ButtonGroupToggle.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ui/ButtonGroupToggle.tsx
@@ -1,0 +1,60 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import type { ButtonGroupProps } from "@chakra-ui/react";
+import { Button, ButtonGroup } from "@chakra-ui/react";
+import type { ReactNode } from "react";
+
+export type ButtonGroupOption<T extends string = string> = {
+  readonly disabled?: boolean;
+  readonly label: ((isSelected: boolean) => ReactNode) | ReactNode;
+  readonly value: T;
+};
+
+type ButtonGroupToggleProps<T extends string = string> = {
+  readonly onChange: (value: T) => void;
+  readonly options: Array<ButtonGroupOption<T>>;
+  readonly value: T;
+} & Omit<ButtonGroupProps, "onChange">;
+
+export const ButtonGroupToggle = <T extends string = string>({
+  onChange,
+  options,
+  value,
+  ...rest
+}: ButtonGroupToggleProps<T>) => (
+  <ButtonGroup attached colorPalette="brand" size="sm" variant="outline" {...rest}>
+    {options.map((option) => {
+      const isSelected = option.value === value;
+      const label = typeof option.label === "function" ? option.label(isSelected) : option.label;
+
+      return (
+        <Button
+          bg={isSelected ? "colorPalette.solid" : undefined}
+          disabled={option.disabled}
+          key={option.value}
+          onClick={() => onChange(option.value)}
+          value={option.value}
+          variant={isSelected ? "solid" : "outline"}
+        >
+          {label}
+        </Button>
+      );
+    })}
+  </ButtonGroup>
+);

--- a/airflow-core/src/airflow/ui/src/components/ui/ButtonGroupToggle.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ui/ButtonGroupToggle.tsx
@@ -45,7 +45,6 @@ export const ButtonGroupToggle = <T extends string = string>({
 
       return (
         <Button
-          bg={isSelected ? "colorPalette.solid" : undefined}
           disabled={option.disabled}
           key={option.value}
           onClick={() => onChange(option.value)}

--- a/airflow-core/src/airflow/ui/src/components/ui/index.ts
+++ b/airflow-core/src/airflow/ui/src/components/ui/index.ts
@@ -33,3 +33,4 @@ export * from "./Popover";
 export * from "./Checkbox";
 export * from "./ResetButton";
 export * from "./InputWithAddon";
+export * from "./ButtonGroupToggle";

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/DagsFilters.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/DagsFilters.tsx
@@ -16,17 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Flex } from "@chakra-ui/react";
+import { HStack } from "@chakra-ui/react";
 import type { MultiValue } from "chakra-react-select";
 import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 
 import { useTableURLState } from "src/components/DataTable/useTableUrlState";
-import { ResetButton } from "src/components/ui";
 import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searchParams";
 import { useConfig } from "src/queries/useConfig";
 import { useDagTagsInfinite } from "src/queries/useDagTagsInfinite";
-import { getFilterCount } from "src/utils/filterUtils";
 
 import { FavoriteFilter } from "./FavoriteFilter";
 import { PausedFilter } from "./PausedFilter";
@@ -142,18 +140,6 @@ export const DagsFilters = () => {
     setSearchParams(searchParams);
   };
 
-  const onClearFilters = () => {
-    searchParams.delete(PAUSED_PARAM);
-    searchParams.delete(FAVORITE_PARAM);
-    searchParams.delete(NEEDS_REVIEW_PARAM);
-    searchParams.delete(LAST_DAG_RUN_STATE_PARAM);
-    searchParams.delete(TAGS_PARAM);
-    searchParams.delete(TAGS_MATCH_MODE_PARAM);
-
-    setSearchParams(searchParams);
-    setPattern("");
-  };
-
   const handleTagModeChange = ({ checked }: { checked: boolean }) => {
     const mode = checked ? "all" : "any";
 
@@ -161,52 +147,37 @@ export const DagsFilters = () => {
     setSearchParams(searchParams);
   };
 
-  const filterCount = getFilterCount({
-    needsReview,
-    selectedTags,
-    showFavorites,
-    showPaused,
-    state,
-  });
-
   return (
-    <Flex flexWrap="wrap" gap={4} justifyContent="space-between">
-      <Flex alignItems="center" flexWrap="wrap" gap={4}>
-        <StateFilters
-          isAll={isAll}
-          isFailed={isFailed}
-          isQueued={isQueued}
-          isRunning={isRunning}
-          isSuccess={isSuccess}
-          needsReview={needsReview === "true"}
-          onStateChange={handleStateChange}
-        />
-        <PausedFilter
-          defaultShowPaused={defaultShowPaused}
-          onPausedChange={handlePausedChange}
-          showPaused={showPaused}
-        />
-        <Box maxWidth="300px">
-          <TagFilter
-            onMenuScrollToBottom={() => {
-              void fetchNextPage();
-            }}
-            onMenuScrollToTop={() => {
-              void fetchPreviousPage();
-            }}
-            onSelectTagsChange={handleSelectTagsChange}
-            onTagModeChange={handleTagModeChange}
-            onUpdate={setPattern}
-            selectedTags={selectedTags}
-            tagFilterMode={tagFilterMode}
-            tags={data?.pages.flatMap((dagResponse) => dagResponse.tags) ?? []}
-          />
-        </Box>
-        <FavoriteFilter onFavoriteChange={handleFavoriteChange} showFavorites={showFavorites} />
-      </Flex>
-      <Box>
-        <ResetButton filterCount={filterCount} onClearFilters={onClearFilters} />
-      </Box>
-    </Flex>
+    <HStack flexWrap="wrap" gap={2} justifyContent="space-between">
+      <StateFilters
+        isAll={isAll}
+        isFailed={isFailed}
+        isQueued={isQueued}
+        isRunning={isRunning}
+        isSuccess={isSuccess}
+        needsReview={needsReview === "true"}
+        onStateChange={handleStateChange}
+      />
+      <PausedFilter
+        defaultShowPaused={defaultShowPaused}
+        onPausedChange={handlePausedChange}
+        showPaused={showPaused}
+      />
+      <TagFilter
+        onMenuScrollToBottom={() => {
+          void fetchNextPage();
+        }}
+        onMenuScrollToTop={() => {
+          void fetchPreviousPage();
+        }}
+        onSelectTagsChange={handleSelectTagsChange}
+        onTagModeChange={handleTagModeChange}
+        onUpdate={setPattern}
+        selectedTags={selectedTags}
+        tagFilterMode={tagFilterMode}
+        tags={data?.pages.flatMap((dagResponse) => dagResponse.tags) ?? []}
+      />
+      <FavoriteFilter onFavoriteChange={handleFavoriteChange} showFavorites={showFavorites} />
+    </HStack>
   );
 };

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/FavoriteFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/FavoriteFilter.tsx
@@ -16,55 +16,52 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Button, ButtonGroup, Icon } from "@chakra-ui/react";
+import { Icon } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 import { FiStar } from "react-icons/fi";
 
+import { ButtonGroupToggle } from "src/components/ui/ButtonGroupToggle";
+
+type FavoriteValue = "all" | "false" | "true";
+
 type Props = {
-  readonly onFavoriteChange: React.MouseEventHandler<HTMLButtonElement>;
-  readonly showFavorites: string | null;
+  readonly onChange: (value: FavoriteValue) => void;
+  readonly value: FavoriteValue;
 };
 
-export const FavoriteFilter = ({ onFavoriteChange, showFavorites }: Props) => {
+const StarIcon = ({ filled, isSelected }: { readonly filled: boolean; readonly isSelected: boolean }) => (
+  <Icon asChild color={isSelected ? "brand.contrast" : "brand.solid"}>
+    <FiStar style={filled ? { fill: "currentColor" } : undefined} />
+  </Icon>
+);
+
+const renderFavoriteLabel =
+  (text: string, filled: boolean) =>
+  (isSelected: boolean): React.ReactNode => (
+    <>
+      <StarIcon filled={filled} isSelected={isSelected} />
+      {text}
+    </>
+  );
+
+export const FavoriteFilter = ({ onChange, value }: Props) => {
   const { t: translate } = useTranslation("dags");
 
-  const currentValue = showFavorites ?? "all";
-
   return (
-    <ButtonGroup attached size="sm" variant="outline">
-      <Button
-        bg={currentValue === "all" ? "colorPalette.solid" : undefined}
-        colorPalette="brand"
-        onClick={onFavoriteChange}
-        value="all"
-        variant={currentValue === "all" ? "solid" : "outline"}
-      >
-        {translate("filters.favorite.all")}
-      </Button>
-      <Button
-        bg={currentValue === "true" ? "colorPalette.solid" : undefined}
-        colorPalette="brand"
-        onClick={onFavoriteChange}
-        value="true"
-        variant={currentValue === "true" ? "solid" : "outline"}
-      >
-        <Icon asChild color={currentValue === "true" ? "brand.contrast" : "brand.solid"}>
-          <FiStar style={{ fill: "currentColor" }} />
-        </Icon>
-        {translate("filters.favorite.favorite")}
-      </Button>
-      <Button
-        bg={currentValue === "false" ? "colorPalette.solid" : undefined}
-        colorPalette="brand"
-        onClick={onFavoriteChange}
-        value="false"
-        variant={currentValue === "false" ? "solid" : "outline"}
-      >
-        <Icon asChild color={currentValue === "false" ? "brand.contrast" : "brand.solid"}>
-          <FiStar />
-        </Icon>
-        {translate("filters.favorite.unfavorite")}
-      </Button>
-    </ButtonGroup>
+    <ButtonGroupToggle<FavoriteValue>
+      onChange={onChange}
+      options={[
+        { label: translate("filters.favorite.all"), value: "all" },
+        {
+          label: renderFavoriteLabel(translate("filters.favorite.favorite"), true),
+          value: "true",
+        },
+        {
+          label: renderFavoriteLabel(translate("filters.favorite.unfavorite"), false),
+          value: "false",
+        },
+      ]}
+      value={value}
+    />
   );
 };

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/FavoriteFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/FavoriteFilter.tsx
@@ -33,7 +33,7 @@ export const FavoriteFilter = ({ onFavoriteChange, showFavorites }: Props) => {
   return (
     <ButtonGroup attached size="sm" variant="outline">
       <Button
-        bg={currentValue === "all" ? "colorPalette.muted" : undefined}
+        bg={currentValue === "all" ? "colorPalette.solid" : undefined}
         colorPalette="brand"
         onClick={onFavoriteChange}
         value="all"
@@ -42,25 +42,25 @@ export const FavoriteFilter = ({ onFavoriteChange, showFavorites }: Props) => {
         {translate("filters.favorite.all")}
       </Button>
       <Button
-        bg={currentValue === "true" ? "colorPalette.muted" : undefined}
+        bg={currentValue === "true" ? "colorPalette.solid" : undefined}
         colorPalette="brand"
         onClick={onFavoriteChange}
         value="true"
         variant={currentValue === "true" ? "solid" : "outline"}
       >
-        <Icon asChild color="brand.solid">
+        <Icon asChild color={currentValue === "true" ? "brand.contrast" : "brand.solid"}>
           <FiStar style={{ fill: "currentColor" }} />
         </Icon>
         {translate("filters.favorite.favorite")}
       </Button>
       <Button
-        bg={currentValue === "false" ? "colorPalette.muted" : undefined}
+        bg={currentValue === "false" ? "colorPalette.solid" : undefined}
         colorPalette="brand"
         onClick={onFavoriteChange}
         value="false"
         variant={currentValue === "false" ? "solid" : "outline"}
       >
-        <Icon asChild color="fg.muted">
+        <Icon asChild color={currentValue === "false" ? "brand.contrast" : "brand.solid"}>
           <FiStar />
         </Icon>
         {translate("filters.favorite.unfavorite")}

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/PausedFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/PausedFilter.tsx
@@ -33,7 +33,7 @@ export const PausedFilter = ({ defaultShowPaused, onPausedChange, showPaused }: 
   return (
     <ButtonGroup attached size="sm" variant="outline">
       <Button
-        bg={currentValue === "all" ? "colorPalette.muted" : undefined}
+        bg={currentValue === "all" ? "colorPalette.solid" : undefined}
         colorPalette="brand"
         onClick={onPausedChange}
         value="all"
@@ -42,7 +42,7 @@ export const PausedFilter = ({ defaultShowPaused, onPausedChange, showPaused }: 
         {translate("filters.paused.all")}
       </Button>
       <Button
-        bg={currentValue === "false" ? "colorPalette.muted" : undefined}
+        bg={currentValue === "false" ? "colorPalette.solid" : undefined}
         colorPalette="brand"
         onClick={onPausedChange}
         value="false"
@@ -51,7 +51,7 @@ export const PausedFilter = ({ defaultShowPaused, onPausedChange, showPaused }: 
         {translate("filters.paused.active")}
       </Button>
       <Button
-        bg={currentValue === "true" ? "colorPalette.muted" : undefined}
+        bg={currentValue === "true" ? "colorPalette.solid" : undefined}
         colorPalette="brand"
         onClick={onPausedChange}
         value="true"

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/RequiredActionFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/RequiredActionFilter.tsx
@@ -16,25 +16,33 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { Button } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
+import { LuUserRoundPen } from "react-icons/lu";
 
-import { ButtonGroupToggle } from "src/components/ui";
-
-type PausedValue = "all" | "false" | "true";
+import { StateBadge } from "src/components/StateBadge";
 
 type Props = {
-  readonly onChange: (value: PausedValue) => void;
-  readonly value: PausedValue;
+  readonly needsReview: boolean;
+  readonly onToggle: () => void;
 };
 
-export const PausedFilter = ({ onChange, value }: Props) => {
-  const { t: translate } = useTranslation("dags");
+export const RequiredActionFilter = ({ needsReview, onToggle }: Props) => {
+  const { t: translate } = useTranslation("hitl");
 
-  const options = [
-    { label: translate("filters.paused.all"), value: "all" as const },
-    { label: translate("filters.paused.active"), value: "false" as const },
-    { label: translate("filters.paused.paused"), value: "true" as const },
-  ];
-
-  return <ButtonGroupToggle<PausedValue> onChange={onChange} options={options} value={value} />;
+  return (
+    <Button
+      bg={needsReview ? "colorPalette.solid" : undefined}
+      colorPalette="brand"
+      data-testid="dags-needs-review-filter"
+      onClick={onToggle}
+      size="sm"
+      variant={needsReview ? "solid" : "outline"}
+    >
+      <StateBadge colorPalette="deferred">
+        <LuUserRoundPen />
+      </StateBadge>
+      {translate("requiredAction_other")}
+    </Button>
+  );
 };

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/RequiredActionFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/RequiredActionFilter.tsx
@@ -32,7 +32,6 @@ export const RequiredActionFilter = ({ needsReview, onToggle }: Props) => {
 
   return (
     <Button
-      bg={needsReview ? "colorPalette.solid" : undefined}
       colorPalette="brand"
       data-testid="dags-needs-review-filter"
       onClick={onToggle}

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/StateFilters.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/StateFilters.tsx
@@ -46,7 +46,7 @@ export const StateFilters = ({
   return (
     <ButtonGroup attached size="sm" variant="outline">
       <Button
-        bg={isAll ? "colorPalette.muted" : undefined}
+        bg={isAll ? "colorPalette.solid" : undefined}
         colorPalette="brand"
         onClick={onStateChange}
         value="all"
@@ -55,7 +55,7 @@ export const StateFilters = ({
         {translate("dags:filters.paused.all")}
       </Button>
       <Button
-        bg={isFailed ? "colorPalette.muted" : undefined}
+        bg={isFailed ? "colorPalette.solid" : undefined}
         colorPalette="brand"
         data-testid="dags-failed-filter"
         onClick={onStateChange}
@@ -66,7 +66,7 @@ export const StateFilters = ({
         {translate("common:states.failed")}
       </Button>
       <Button
-        bg={isQueued ? "colorPalette.muted" : undefined}
+        bg={isQueued ? "colorPalette.solid" : undefined}
         colorPalette="brand"
         data-testid="dags-queued-filter"
         onClick={onStateChange}
@@ -77,7 +77,7 @@ export const StateFilters = ({
         {translate("common:states.queued")}
       </Button>
       <Button
-        bg={isRunning ? "colorPalette.muted" : undefined}
+        bg={isRunning ? "colorPalette.solid" : undefined}
         colorPalette="brand"
         data-testid="dags-running-filter"
         onClick={onStateChange}
@@ -88,7 +88,7 @@ export const StateFilters = ({
         {translate("common:states.running")}
       </Button>
       <Button
-        bg={isSuccess ? "colorPalette.muted" : undefined}
+        bg={isSuccess ? "colorPalette.solid" : undefined}
         colorPalette="brand"
         data-testid="dags-success-filter"
         onClick={onStateChange}
@@ -99,7 +99,7 @@ export const StateFilters = ({
         {translate("common:states.success")}
       </Button>
       <Button
-        bg={needsReview ? "colorPalette.muted" : undefined}
+        bg={needsReview ? "colorPalette.solid" : undefined}
         colorPalette="brand"
         data-testid="dags-needs-review-filter"
         onClick={onStateChange}

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/StateFilters.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/StateFilters.tsx
@@ -16,101 +16,60 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Button, ButtonGroup } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
-import { LuUserRoundPen } from "react-icons/lu";
 
 import { StateBadge } from "src/components/StateBadge";
+import { ButtonGroupToggle, type ButtonGroupOption } from "src/components/ui/ButtonGroupToggle";
+
+type StateValue = "all" | "failed" | "queued" | "running" | "success";
 
 type Props = {
-  readonly isAll: boolean;
-  readonly isFailed: boolean;
-  readonly isQueued: boolean;
-  readonly isRunning: boolean;
-  readonly isSuccess: boolean;
-  readonly needsReview: boolean;
-  readonly onStateChange: React.MouseEventHandler<HTMLButtonElement>;
+  readonly onChange: (value: StateValue) => void;
+  readonly value: StateValue;
 };
 
-export const StateFilters = ({
-  isAll,
-  isFailed,
-  isQueued,
-  isRunning,
-  isSuccess,
-  needsReview,
-  onStateChange,
-}: Props) => {
-  const { t: translate } = useTranslation(["dags", "common", "hitl"]);
+export const StateFilters = ({ onChange, value }: Props) => {
+  const { t: translate } = useTranslation(["dags", "common"]);
 
-  return (
-    <ButtonGroup attached size="sm" variant="outline">
-      <Button
-        bg={isAll ? "colorPalette.solid" : undefined}
-        colorPalette="brand"
-        onClick={onStateChange}
-        value="all"
-        variant={isAll ? "solid" : "outline"}
-      >
-        {translate("dags:filters.paused.all")}
-      </Button>
-      <Button
-        bg={isFailed ? "colorPalette.solid" : undefined}
-        colorPalette="brand"
-        data-testid="dags-failed-filter"
-        onClick={onStateChange}
-        value="failed"
-        variant={isFailed ? "solid" : "outline"}
-      >
-        <StateBadge state="failed" />
-        {translate("common:states.failed")}
-      </Button>
-      <Button
-        bg={isQueued ? "colorPalette.solid" : undefined}
-        colorPalette="brand"
-        data-testid="dags-queued-filter"
-        onClick={onStateChange}
-        value="queued"
-        variant={isQueued ? "solid" : "outline"}
-      >
-        <StateBadge state="queued" />
-        {translate("common:states.queued")}
-      </Button>
-      <Button
-        bg={isRunning ? "colorPalette.solid" : undefined}
-        colorPalette="brand"
-        data-testid="dags-running-filter"
-        onClick={onStateChange}
-        value="running"
-        variant={isRunning ? "solid" : "outline"}
-      >
-        <StateBadge state="running" />
-        {translate("common:states.running")}
-      </Button>
-      <Button
-        bg={isSuccess ? "colorPalette.solid" : undefined}
-        colorPalette="brand"
-        data-testid="dags-success-filter"
-        onClick={onStateChange}
-        value="success"
-        variant={isSuccess ? "solid" : "outline"}
-      >
-        <StateBadge state="success" />
-        {translate("common:states.success")}
-      </Button>
-      <Button
-        bg={needsReview ? "colorPalette.solid" : undefined}
-        colorPalette="brand"
-        data-testid="dags-needs-review-filter"
-        onClick={onStateChange}
-        value="needs_review"
-        variant={needsReview ? "solid" : "outline"}
-      >
-        <StateBadge colorPalette="deferred">
-          <LuUserRoundPen />
-        </StateBadge>
-        {translate("hitl:requiredAction_other")}
-      </Button>
-    </ButtonGroup>
-  );
+  const options: Array<ButtonGroupOption<StateValue>> = [
+    { label: translate("dags:filters.paused.all"), value: "all" },
+    {
+      label: (
+        <>
+          <StateBadge state="failed" />
+          {translate("common:states.failed")}
+        </>
+      ),
+      value: "failed",
+    },
+    {
+      label: (
+        <>
+          <StateBadge state="queued" />
+          {translate("common:states.queued")}
+        </>
+      ),
+      value: "queued",
+    },
+    {
+      label: (
+        <>
+          <StateBadge state="running" />
+          {translate("common:states.running")}
+        </>
+      ),
+      value: "running",
+    },
+    {
+      label: (
+        <>
+          <StateBadge state="success" />
+          {translate("common:states.success")}
+        </>
+      ),
+      value: "success",
+    },
+  ];
+
+  return <ButtonGroupToggle<StateValue> onChange={onChange} options={options} value={value} />;
 };

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/TagFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/TagFilter.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Field, HStack, Text } from "@chakra-ui/react";
+import { Box, Field, HStack, Text } from "@chakra-ui/react";
 import { Select as ReactSelect, type MultiValue } from "chakra-react-select";
 import { useTranslation } from "react-i18next";
 
@@ -46,7 +46,7 @@ export const TagFilter = ({
   const { t: translate } = useTranslation("common");
 
   return (
-    <>
+    <Box maxWidth="300px" minWidth="64px">
       <Field.Root>
         <ReactSelect
           aria-label={translate("table.filterByTag")}
@@ -106,6 +106,6 @@ export const TagFilter = ({
           </Text>
         </HStack>
       )}
-    </>
+    </Box>
   );
 };

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.test.tsx
@@ -26,12 +26,12 @@ describe("Dag Filters", () => {
   it("Filter by selected last run state", async () => {
     render(<AppWrapper initialEntries={["/dags"]} />);
 
-    await waitFor(() => expect(screen.getByTestId("dags-success-filter")).toBeInTheDocument());
-    await waitFor(() => screen.getByTestId("dags-success-filter").click());
+    await waitFor(() => expect(screen.getByText("states.success")).toBeInTheDocument());
+    await waitFor(() => screen.getByText("states.success").click());
     await waitFor(() => expect(screen.getByText("tutorial_taskflow_api_success")).toBeInTheDocument());
 
-    await waitFor(() => expect(screen.getByTestId("dags-failed-filter")).toBeInTheDocument());
-    await waitFor(() => screen.getByTestId("dags-failed-filter").click());
+    await waitFor(() => expect(screen.getByText("states.failed")).toBeInTheDocument());
+    await waitFor(() => screen.getByText("states.failed").click());
     await waitFor(() => expect(screen.getByText("tutorial_taskflow_api_failed")).toBeInTheDocument());
   });
 });


### PR DESCRIPTION
Follow up from https://github.com/apache/airflow/pull/60298

Make a single ButtonGroupToggle component we can use in many place

Make the DagsFilters component wrap on smaller screens

Changed the selected colors to use `colorPalette.solid` to make it more visible on dark and light modes.

Moved the Required Actions as a separate on/off button because it isn't actually filtering by state

Removed Reset Filters button. I feel like with the filters being more noticeable that a button showing up and changing the page's format got in the way more than it helps.

<img width="1046" height="489" alt="Screenshot 2026-01-09 at 12 52 49 PM" src="https://github.com/user-attachments/assets/52bfd70c-6d79-42ef-9011-ac00c8856a84" />


### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

Generated-by: [Cursor] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
