### PR TITLE
Simplify metric names construction in BaseExecutor emit_metrics

### DIFF
--- a/airflow-core/src/airflow/executors/base_executor.py
+++ b/airflow-core/src/airflow/executors/base_executor.py
@@ -275,9 +275,12 @@ class BaseExecutor(LoggingMixin):
         self.log.debug("Calling the %s sync method", self.__class__)
         self.sync()
 
-    @staticmethod
-    def _get_metric_name(metric_base_name: str, metric_suffix: str | None = None) -> str:
-        return f"{metric_base_name}.{metric_suffix}" if metric_suffix else metric_base_name
+    def _get_metric_name(self, metric_base_name: str) -> str:
+        return (
+            f"{metric_base_name}.{self.__class__.__name__}"
+            if len(ExecutorLoader.get_executor_names()) > 1
+            else metric_base_name
+        )
 
     def _emit_metrics(self, open_slots, num_running_tasks, num_queued_tasks):
         """
@@ -289,13 +292,10 @@ class BaseExecutor(LoggingMixin):
         If only one executor is configured, the metric names will not be changed.
         """
         name = self.__class__.__name__
-        multiple_executors_configured = len(ExecutorLoader.get_executor_names()) > 1
 
-        metric_suffix = name if multiple_executors_configured else None
-
-        open_slots_metric_name = self._get_metric_name("executor.open_slots", metric_suffix)
-        queued_tasks_metric_name = self._get_metric_name("executor.queued_tasks", metric_suffix)
-        running_tasks_metric_name = self._get_metric_name("executor.running_tasks", metric_suffix)
+        open_slots_metric_name = self._get_metric_name("executor.open_slots")
+        queued_tasks_metric_name = self._get_metric_name("executor.queued_tasks")
+        running_tasks_metric_name = self._get_metric_name("executor.running_tasks")
 
         span = Trace.get_current_span()
         if span.is_recording():


### PR DESCRIPTION
Simplifying few conditions :)

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
