### PR TITLE
Fix importlib import in shared plugins manager

### DIFF
--- a/shared/plugins_manager/src/airflow_shared/plugins_manager/plugins_manager.py
+++ b/shared/plugins_manager/src/airflow_shared/plugins_manager/plugins_manager.py
@@ -19,6 +19,7 @@
 
 from __future__ import annotations
 
+import importlib
 import inspect
 import logging
 import os
@@ -214,7 +215,6 @@ def _load_plugins_from_plugin_directory(
 
     if load_examples:
         log.debug("Note: Loading plugins from examples as well: %s", plugins_folder)
-        import importlib
 
         example_plugins = importlib.import_module(example_plugins_module)
         example_plugins_folder = next(iter(example_plugins.__path__))


### PR DESCRIPTION
This was only being imported if load_examples was on.

Before:

```
Traceback (most recent call last):
  File "/Users/jedc/github/airflow/airflow-core/src/airflow/_shared/plugins_manager/plugins_manager.py", line 234, in _load_plugins_from_plugin_directory
    loader = importlib.machinery.SourceFileLoader(mod_name, file_path)
             ^^^^^^^^^
UnboundLocalError: cannot access local variable 'importlib' where it is not associated with a value
```