### PR TITLE
Add workers.celery.podManagementPolicy field

### DIFF
--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -332,6 +332,14 @@ DEPRECATION WARNING:
 
 {{- end }}
 
+{{- if not (empty .Values.workers.podManagementPolicy) }}
+
+ DEPRECATION WARNING:
+    `workers.podManagementPolicy` has been renamed to `workers.celery.podManagementPolicy`.
+    Please change your values as support for the old name will be dropped in a future release.
+
+{{- end }}
+
 {{ if (semverCompare ">=3.0.0" .Values.airflowVersion) }}
 #####################################################
 #  WARNING: You should set a static API secret key  #

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -76,8 +76,8 @@ spec:
       tier: airflow
       component: worker
       release: {{ .Release.Name }}
-  {{- if and $persistence .Values.workers.podManagementPolicy }}
-  podManagementPolicy: {{ .Values.workers.podManagementPolicy }}
+  {{- if and $persistence (or .Values.workers.celery.podManagementPolicy .Values.workers.podManagementPolicy) }}
+  podManagementPolicy: {{ .Values.workers.celery.podManagementPolicy | default .Values.workers.podManagementPolicy }}
   {{- end }}
   {{- if and $persistence (or .Values.workers.celery.updateStrategy .Values.workers.updateStrategy) }}
   updateStrategy: {{- toYaml (.Values.workers.celery.updateStrategy | default .Values.workers.updateStrategy) | nindent 4 }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1725,7 +1725,7 @@
                     "default": null
                 },
                 "podManagementPolicy": {
-                    "description": "Specifies the policy for managing pods within the Airflow Celery worker. Only applicable to StatefulSet.",
+                    "description": "Specifies the policy for managing pods within the Airflow Celery worker (deprecated, use `workers.celery.podManagementPolicy` instead). Only applicable to StatefulSet.",
                     "type": [
                         "null",
                         "string"
@@ -2681,6 +2681,18 @@
                                     "maxUnavailable": "50%"
                                 }
                             }
+                        },
+                        "podManagementPolicy": {
+                            "description": "Specifies the policy for managing pods within the Airflow Celery worker. Only applicable to StatefulSet.",
+                            "type": [
+                                "null",
+                                "string"
+                            ],
+                            "default": null,
+                            "enum": [
+                                "OrderedReady",
+                                "Parallel"
+                            ]
                         },
                         "serviceAccount": {
                             "description": "Create ServiceAccount.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -687,7 +687,8 @@ workers:
       maxUnavailable: "50%"
 
   # Allow relaxing ordering guarantees for Airflow Celery worker while preserving its uniqueness and identity
-  # podManagementPolicy: Parallel
+  # (deprecated, use `workers.celery.podManagementPolicy` instead)
+  # podManagementPolicy: ~
 
   # When not set, the values defined in the global securityContext will
   # be used in Airflow Celery workers and pod-template-file
@@ -1064,6 +1065,10 @@ workers:
       rollingUpdate:
         maxSurge: "100%"
         maxUnavailable: "50%"
+
+    # Allow relaxing ordering guarantees for Airflow Celery worker
+    # while preserving its uniqueness and identity
+    # podManagementPolicy: ~
 
     # Create ServiceAccount for Airflow Celery workers
     serviceAccount:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -688,7 +688,7 @@ workers:
 
   # Allow relaxing ordering guarantees for Airflow Celery worker while preserving its uniqueness and identity
   # (deprecated, use `workers.celery.podManagementPolicy` instead)
-  # podManagementPolicy: ~
+  # podManagementPolicy: Parallel
 
   # When not set, the values defined in the global securityContext will
   # be used in Airflow Celery workers and pod-template-file
@@ -1068,7 +1068,7 @@ workers:
 
     # Allow relaxing ordering guarantees for Airflow Celery worker
     # while preserving its uniqueness and identity
-    # podManagementPolicy: ~
+    # podManagementPolicy: Parallel
 
     # Create ServiceAccount for Airflow Celery workers
     serviceAccount:


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

related: https://github.com/apache/airflow/issues/28880

This PR introduces a new `workers.celery.podManagementPolicy` command and deprecates the old `workers.podManagementPolicy` command (as it was only applicable to Celery workers).

## Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
