### PR TITLE
fix: Remove explicit bg color from active filter buttons

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/DataTable/ToggleTableDisplay.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DataTable/ToggleTableDisplay.tsx
@@ -34,7 +34,6 @@ export const ToggleTableDisplay = ({ display, setDisplay }: Props) => {
     <ButtonGroup attached colorPalette="brand" pb={2} size="sm" variant="outline">
       <IconButton
         aria-label={translate("toggleCardView")}
-        bg={display === "card" ? "colorPalette.muted" : undefined}
         onClick={() => setDisplay("card")}
         title={translate("toggleCardView")}
         variant={display === "card" ? "solid" : "outline"}
@@ -43,7 +42,6 @@ export const ToggleTableDisplay = ({ display, setDisplay }: Props) => {
       </IconButton>
       <IconButton
         aria-label={translate("toggleTableView")}
-        bg={display === "table" ? "colorPalette.muted" : undefined}
         onClick={() => setDisplay("table")}
         title={translate("toggleTableView")}
         variant={display === "table" ? "solid" : "outline"}

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/FavoriteFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/FavoriteFilter.tsx
@@ -33,7 +33,6 @@ export const FavoriteFilter = ({ onFavoriteChange, showFavorites }: Props) => {
   return (
     <ButtonGroup attached size="sm" variant="outline">
       <Button
-        bg={currentValue === "all" ? "colorPalette.muted" : undefined}
         colorPalette="brand"
         onClick={onFavoriteChange}
         value="all"
@@ -42,7 +41,6 @@ export const FavoriteFilter = ({ onFavoriteChange, showFavorites }: Props) => {
         {translate("filters.favorite.all")}
       </Button>
       <Button
-        bg={currentValue === "true" ? "colorPalette.muted" : undefined}
         colorPalette="brand"
         onClick={onFavoriteChange}
         value="true"
@@ -54,7 +52,6 @@ export const FavoriteFilter = ({ onFavoriteChange, showFavorites }: Props) => {
         {translate("filters.favorite.favorite")}
       </Button>
       <Button
-        bg={currentValue === "false" ? "colorPalette.muted" : undefined}
         colorPalette="brand"
         onClick={onFavoriteChange}
         value="false"

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/PausedFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/PausedFilter.tsx
@@ -33,7 +33,6 @@ export const PausedFilter = ({ defaultShowPaused, onPausedChange, showPaused }: 
   return (
     <ButtonGroup attached size="sm" variant="outline">
       <Button
-        bg={currentValue === "all" ? "colorPalette.muted" : undefined}
         colorPalette="brand"
         onClick={onPausedChange}
         value="all"
@@ -42,7 +41,6 @@ export const PausedFilter = ({ defaultShowPaused, onPausedChange, showPaused }: 
         {translate("filters.paused.all")}
       </Button>
       <Button
-        bg={currentValue === "false" ? "colorPalette.muted" : undefined}
         colorPalette="brand"
         onClick={onPausedChange}
         value="false"
@@ -51,7 +49,6 @@ export const PausedFilter = ({ defaultShowPaused, onPausedChange, showPaused }: 
         {translate("filters.paused.active")}
       </Button>
       <Button
-        bg={currentValue === "true" ? "colorPalette.muted" : undefined}
         colorPalette="brand"
         onClick={onPausedChange}
         value="true"

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/StateFilters.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/StateFilters.tsx
@@ -45,17 +45,10 @@ export const StateFilters = ({
 
   return (
     <ButtonGroup attached size="sm" variant="outline">
-      <Button
-        bg={isAll ? "colorPalette.muted" : undefined}
-        colorPalette="brand"
-        onClick={onStateChange}
-        value="all"
-        variant={isAll ? "solid" : "outline"}
-      >
+      <Button colorPalette="brand" onClick={onStateChange} value="all" variant={isAll ? "solid" : "outline"}>
         {translate("dags:filters.paused.all")}
       </Button>
       <Button
-        bg={isFailed ? "colorPalette.muted" : undefined}
         colorPalette="brand"
         data-testid="dags-failed-filter"
         onClick={onStateChange}
@@ -66,7 +59,6 @@ export const StateFilters = ({
         {translate("common:states.failed")}
       </Button>
       <Button
-        bg={isQueued ? "colorPalette.muted" : undefined}
         colorPalette="brand"
         data-testid="dags-queued-filter"
         onClick={onStateChange}
@@ -77,7 +69,6 @@ export const StateFilters = ({
         {translate("common:states.queued")}
       </Button>
       <Button
-        bg={isRunning ? "colorPalette.muted" : undefined}
         colorPalette="brand"
         data-testid="dags-running-filter"
         onClick={onStateChange}
@@ -88,7 +79,6 @@ export const StateFilters = ({
         {translate("common:states.running")}
       </Button>
       <Button
-        bg={isSuccess ? "colorPalette.muted" : undefined}
         colorPalette="brand"
         data-testid="dags-success-filter"
         onClick={onStateChange}
@@ -99,7 +89,6 @@ export const StateFilters = ({
         {translate("common:states.success")}
       </Button>
       <Button
-        bg={needsReview ? "colorPalette.muted" : undefined}
         colorPalette="brand"
         data-testid="dags-needs-review-filter"
         onClick={onStateChange}


### PR DESCRIPTION
In light mode, the active button was rendered with colorPalette.muted, causing the button color to appear washed out.

Since the solid variant already provides sufficient visual distinction for the active state, 
the additional muted background override has been removed.

I had only been looking at dark mode, but once I checked light mode, the issue became noticeable 😅


## Before
<img width="2168" height="1397" alt="image" src="https://github.com/user-attachments/assets/d9afb18f-7aba-499c-8a31-73277dc8a6f0" />


## After
<img width="2168" height="1397" alt="image" src="https://github.com/user-attachments/assets/02670095-7a3f-4e3a-9916-888f3e0fc9c6" />


<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

## Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
