### PR TITLE
Change starlette import to fastapi

### DIFF
--- a/airflow-core/docs/howto/custom-view-plugin.rst
+++ b/airflow-core/docs/howto/custom-view-plugin.rst
@@ -118,7 +118,7 @@ Create an Airflow plugin that serves your React application:
 
     from pathlib import Path
     from fastapi import FastAPI
-    from starlette.staticfiles import StaticFiles
+    from fastapi.staticfiles import StaticFiles
     import mimetypes
 
     from airflow.plugins_manager import AirflowPlugin

--- a/airflow-core/src/airflow/api_fastapi/app.py
+++ b/airflow-core/src/airflow/api_fastapi/app.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
 
 from fastapi import FastAPI
-from starlette.routing import Mount
+from fastapi.routing import Mount
 
 from airflow.api_fastapi.common.dagbag import create_dag_bag
 from airflow.api_fastapi.core_api.app import (

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/routes/login.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/routes/login.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 from fastapi import Depends, Request, status
-from starlette.responses import RedirectResponse
+from fastapi.responses import RedirectResponse
 
 from airflow.api_fastapi.auth.managers.base_auth_manager import COOKIE_NAME_JWT_TOKEN
 from airflow.api_fastapi.auth.managers.simple.datamodels.login import LoginBody, LoginResponse

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
@@ -28,11 +28,10 @@ from json import JSONDecodeError
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TextIO
 
-from fastapi import FastAPI
-from starlette.requests import Request
-from starlette.responses import HTMLResponse
-from starlette.staticfiles import StaticFiles
-from starlette.templating import Jinja2Templates
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
 from termcolor import colored
 
 from airflow.api_fastapi.app import AUTH_MANAGER_FASTAPI_APP_PREFIX

--- a/airflow-core/src/airflow/api_fastapi/compat.py
+++ b/airflow-core/src/airflow/api_fastapi/compat.py
@@ -16,11 +16,13 @@
 # under the License.
 from __future__ import annotations
 
+from fastapi import status
+
+# HTTP_422_UNPROCESSABLE_CONTENT was added in Starlette 0.29.0 (renamed from HTTP_422_UNPROCESSABLE_ENTITY)
+# We need to support older versions that only have HTTP_422_UNPROCESSABLE_ENTITY
 try:
-    from starlette.status import HTTP_422_UNPROCESSABLE_CONTENT
-except ImportError:
-    from starlette.status import (  # type: ignore[no-redef]
-        HTTP_422_UNPROCESSABLE_ENTITY as HTTP_422_UNPROCESSABLE_CONTENT,
-    )
+    HTTP_422_UNPROCESSABLE_CONTENT = status.HTTP_422_UNPROCESSABLE_CONTENT
+except AttributeError:
+    HTTP_422_UNPROCESSABLE_CONTENT = status.HTTP_422_UNPROCESSABLE_ENTITY  # type: ignore[attr-defined]
 
 __all__ = ["HTTP_422_UNPROCESSABLE_CONTENT"]

--- a/airflow-core/src/airflow/api_fastapi/compat.py
+++ b/airflow-core/src/airflow/api_fastapi/compat.py
@@ -18,8 +18,11 @@ from __future__ import annotations
 
 from fastapi import status
 
-# HTTP_422_UNPROCESSABLE_CONTENT was added in Starlette 0.29.0 (renamed from HTTP_422_UNPROCESSABLE_ENTITY)
-# We need to support older versions that only have HTTP_422_UNPROCESSABLE_ENTITY
+# HTTP_422_UNPROCESSABLE_CONTENT was added in Starlette 0.48.0, replacing HTTP_422_UNPROCESSABLE_ENTITY
+# to align with RFC 9110 (HTTP Semantics). We need to support older versions for "Low dep tests".
+# Refs:
+#   - https://www.starlette.io/release-notes/
+#   - https://www.rfc-editor.org/rfc/rfc9110#status.422
 try:
     HTTP_422_UNPROCESSABLE_CONTENT = status.HTTP_422_UNPROCESSABLE_CONTENT
 except AttributeError:

--- a/airflow-core/src/airflow/api_fastapi/compat.py
+++ b/airflow-core/src/airflow/api_fastapi/compat.py
@@ -19,7 +19,12 @@ from __future__ import annotations
 from fastapi import status
 
 # HTTP_422_UNPROCESSABLE_CONTENT was added in Starlette 0.48.0, replacing HTTP_422_UNPROCESSABLE_ENTITY
-# to align with RFC 9110 (HTTP Semantics). We need to support older versions for "Low dep tests".
+# to align with RFC 9110 (HTTP Semantics).
+#
+# FastAPI 0.128.0 (our minimum version) requires starlette>=0.40.0. With "Low dep tests"
+# (uv sync --resolution lowest-direct), starlette 0.40.0 is installed, which only has
+# HTTP_422_UNPROCESSABLE_ENTITY. So we need this fallback for backward compatibility.
+#
 # Refs:
 #   - https://www.starlette.io/release-notes/
 #   - https://www.rfc-editor.org/rfc/rfc9110#status.422

--- a/airflow-core/src/airflow/api_fastapi/core_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/app.py
@@ -22,13 +22,12 @@ import sys
 import warnings
 from pathlib import Path
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
-from starlette.requests import Request
-from starlette.responses import HTMLResponse, JSONResponse
-from starlette.staticfiles import StaticFiles
-from starlette.templating import Jinja2Templates
+from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
 
 from airflow.api_fastapi.auth.tokens import get_signing_key
 from airflow.configuration import conf

--- a/providers/amazon/src/airflow/providers/amazon/aws/auth_manager/routes/login.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/auth_manager/routes/login.py
@@ -21,9 +21,8 @@ import logging
 from typing import Any
 
 import anyio
-from fastapi import HTTPException, Request
-from starlette import status
-from starlette.responses import RedirectResponse
+from fastapi import HTTPException, Request, status
+from fastapi.responses import RedirectResponse
 
 from airflow.api_fastapi.app import (
     AUTH_MANAGER_FASTAPI_APP_PREFIX,

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/routes/login.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/routes/login.py
@@ -18,10 +18,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import Body
-from starlette import status
-from starlette.requests import Request  # noqa: TC002
-from starlette.responses import RedirectResponse
+from fastapi import Body, Request, status
+from fastapi.responses import RedirectResponse
 
 from airflow.api_fastapi.app import get_auth_manager
 from airflow.api_fastapi.auth.managers.base_auth_manager import COOKIE_NAME_JWT_TOKEN

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/services/login.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/services/login.py
@@ -18,8 +18,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from starlette import status
-from starlette.exceptions import HTTPException
+from fastapi import HTTPException, status
 
 from airflow.configuration import conf
 from airflow.providers.fab.auth_manager.api_fastapi.datamodels.login import LoginResponse

--- a/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
@@ -24,11 +24,11 @@ from urllib.parse import urljoin
 
 from connexion import FlaskApi
 from fastapi import FastAPI
+from fastapi.middleware.wsgi import WSGIMiddleware
 from flask import Blueprint, current_app, g
 from flask_appbuilder.const import AUTH_LDAP
 from sqlalchemy import select
 from sqlalchemy.orm import Session, joinedload
-from starlette.middleware.wsgi import WSGIMiddleware
 
 from airflow.api_fastapi.app import AUTH_MANAGER_FASTAPI_APP_PREFIX
 from airflow.api_fastapi.auth.managers.base_auth_manager import BaseAuthManager

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_login.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_login.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from unittest.mock import ANY, MagicMock, patch
 
 import pytest
-from starlette.exceptions import HTTPException
+from fastapi import HTTPException
 
 from airflow.providers.fab.auth_manager.api_fastapi.services.login import FABAuthManagerLogin
 

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/routes/login.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/routes/login.py
@@ -21,7 +21,7 @@ import logging
 from typing import Annotated, cast
 
 from fastapi import Depends, Request
-from starlette.responses import HTMLResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, RedirectResponse
 
 from airflow.api_fastapi.app import get_auth_manager
 from airflow.api_fastapi.auth.managers.base_auth_manager import COOKIE_NAME_JWT_TOKEN

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/routes/token.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/routes/token.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import logging
 
-from starlette import status
+from fastapi import status
 
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/services/token.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/services/token.py
@@ -17,9 +17,8 @@
 
 from __future__ import annotations
 
-from fastapi import HTTPException
+from fastapi import HTTPException, status
 from keycloak import KeycloakAuthenticationError
-from starlette import status
 
 from airflow.api_fastapi.app import get_auth_manager
 from airflow.providers.common.compat.sdk import conf


### PR DESCRIPTION
# Description
This PR change `starlette` import to `fastapi`, `fastapi` re-export `starlette` dependencies for convenience and consistency, we should use it if possible.

However, the following starlette imports must remain because FastAPI does not re-export these modules:

## `BaseHTTPMiddleware`

**Why**: FastAPI intentionally does not re-export `BaseHTTPMiddleware`. There is no `fastapi.middleware.base` module.

**References**:
- https://github.com/fastapi/fastapi/discussions/8541 - Request to add `BaseHTTPMiddleware` to FastAPI was answered with: *"Is there a particular reason you don't just import it directly from Starlette, since FastAPI depends on Starlette?"* (marked as accepted answer)
- https://fastapi.tiangolo.com/advanced/middleware/ - FastAPI only re-exports specific middlewares (HTTPSRedirect, TrustedHost, GZip, WSGI, CORS), not `BaseHTTPMiddleware`.

---

* related: https://github.com/apache/airflow/pull/57199#discussion_r2463178216, #58127 (this PR is stale)


## Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: [Cursor, Claude] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---
