### PR TITLE
Fix/sensitive extra fields required

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Iterable, Mapping
-from typing import Annotated
+from typing import Annotated, Any
 
 from pydantic import Field, field_validator
 from pydantic_core.core_schema import ValidationInfo
@@ -137,7 +137,7 @@ class ConnectionHookMetaData(BaseModel):
         )
 
         if has_param_spec_structure:
-            redacted_extra_fields = {}
+            redacted_extra_fields: dict[str, Any] = {}
             for field_name, field_spec in v.items():
                 if isinstance(field_spec, dict) and "value" in field_spec and "schema" in field_spec:
                     if should_hide_value_for_key(field_name) and field_spec.get("value") is not None:
@@ -149,8 +149,9 @@ class ConnectionHookMetaData(BaseModel):
                 else:
                     # Not a param spec structure, apply redact by default
                     redacted_extra_fields[field_name] = redact(field_spec)
+
             return redacted_extra_fields
-            
+
         # For simple dictionary structures, use the standard redact function
         return redact(v)
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
@@ -147,7 +147,7 @@ class ConnectionHookMetaData(BaseModel):
                         # Not sensitive or no value, keep as is
                         redacted_extra_fields[field_name] = field_spec
                 else:
-                    # Not a param spec structure, keep as is
+                    # Not a param spec structure, apply redact by default
                     redacted_extra_fields[field_name] = redact(field_spec)
             return redacted_extra_fields
         # For simple dictionary structures, use the standard redact function

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
@@ -150,9 +150,8 @@ class ConnectionHookMetaData(BaseModel):
                     # Not a param spec structure, keep as is
                     redacted_extra_fields[field_name] = field_spec
             return redacted_extra_fields
-        else:
-            # For simple dictionary structures, use the standard redact function
-            return redact(v)
+        # For simple dictionary structures, use the standard redact function
+        return redact(v)
 
 
 # Request Models

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
@@ -148,7 +148,7 @@ class ConnectionHookMetaData(BaseModel):
                         redacted_extra_fields[field_name] = field_spec
                 else:
                     # Not a param spec structure, keep as is
-                    redacted_extra_fields[field_name] = field_spec
+                    redacted_extra_fields[field_name] = redact(field_spec)
             return redacted_extra_fields
         # For simple dictionary structures, use the standard redact function
         return redact(v)

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
@@ -150,6 +150,7 @@ class ConnectionHookMetaData(BaseModel):
                     # Not a param spec structure, apply redact by default
                     redacted_extra_fields[field_name] = redact(field_spec)
             return redacted_extra_fields
+            
         # For simple dictionary structures, use the standard redact function
         return redact(v)
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_connections.py
@@ -58,6 +58,48 @@ class TestHookMetaData:
                 },
                 {"secret_key": "***", "extra_fields": "test-extra_fields", "password": "***"},
             ),
+            (
+                {
+                    "auth_type": {
+                        "value": "oauth2",
+                        "schema": {
+                            "type": ["string", "null"],
+                            "title": "Auth Type",
+                        },
+                        "description": "Authentication type: 'basic' (default) | 'oauth2'",
+                        "source": None,
+                    },
+                    "access_token": {  # sensitive field
+                        "value": "oauth2-bearer-token",
+                        "schema": {
+                            "type": ["string", "null"],  # Optional field
+                            "title": "Access Token",
+                        },
+                        "description": "OAuth 2 bearer (one-hour).",
+                        "source": None,
+                    },
+                },
+                {
+                    "auth_type": {
+                        "value": "oauth2",
+                        "schema": {
+                            "type": ["string", "null"],
+                            "title": "Auth Type",
+                        },
+                        "description": "Authentication type: 'basic' (default) | 'oauth2'",
+                        "source": None,
+                    },
+                    "access_token": {  # sensitive field - masked but schema.type preserved
+                        "value": "***",
+                        "schema": {
+                            "type": ["string", "null"],  # Should be preserved
+                            "title": "***",
+                        },
+                        "description": "***",
+                        "source": None,
+                    },
+                },
+            ),
         ],
     )
     @pytest.mark.enable_redact

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_connections.py
@@ -89,13 +89,13 @@ class TestHookMetaData:
                         "description": "Authentication type: 'basic' (default) | 'oauth2'",
                         "source": None,
                     },
-                    "access_token": {  # sensitive field - masked but schema.type preserved
+                    "access_token": {  # sensitive field - only value masked, schema.type preserved
                         "value": "***",
                         "schema": {
                             "type": ["string", "null"],  # Should be preserved
-                            "title": "***",
+                            "title": "Access Token",  # Preserved
                         },
-                        "description": "***",
+                        "description": "OAuth 2 bearer (one-hour).",  # Preserved
                         "source": None,
                     },
                 },


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

closes: #60370

Fixes an issue where sensitive fields in connection `extra_fields` were incorrectly marked as "required" in the UI after redaction. The `redact()` function was masking the entire param spec structure, including `schema.type`, which the frontend uses to determine if a field is optional.

## Problem

When sensitive fields (e.g., `proxy`, `access_token`, `password`) in connection `extra_fields` were redacted, the `schema.type` field was also masked. The frontend's `isRequired()` logic relies on `schema.type` to determine optionality:
- If `schema.type` includes `"null"` (e.g., `["string", "null"]`), the field is optional
- If `schema.type` is a single type (e.g., `"string"`), the field is required

When `schema.type` was masked to `"***"`, the frontend could not determine that the field was optional, causing it to be incorrectly marked as required.

### Before
<img width="764" height="621" alt="image" src="https://github.com/user-attachments/assets/5970d67a-31b1-4023-bb5f-00b372a90f40" />


### After
<img width="778" height="651" alt="image" src="https://github.com/user-attachments/assets/da6a2df8-618c-4e83-ba1c-685ab0efb818" />



## Solution

Modified the `redact_extra_fields` validator in `ConnectionHookMetaData` to handle param spec structures (result of `SerializedParam.dump()`) differently from simple dictionary structures:

1. **For param spec structures**: Mask only the `value` field for sensitive fields while preserving `schema.type`, `schema.title`, and `description`. This ensures that:
   - Sensitive values are properly masked
   - `schema.type` is preserved so the frontend can determine field optionality
   - UI display texts (`schema.title`, `description`) remain visible

2. **For simple dictionary structures**: Use the standard `redact()` function as before

This approach is simpler and more targeted than applying `redact()` to everything and then restoring `schema.type`. Only the actual sensitive data (the `value`) is masked, while all metadata needed for proper UI rendering is preserved.

**Why not modify `redact()` directly?**

The `redact()` function is a shared utility used throughout Airflow for masking sensitive data in various contexts. Modifying it directly would affect all usages of the function, which may not be desirable. Instead, we chose to handle the specific case of `param_dump` structures in the `redact_extra_fields` validator, which is the appropriate place for connection-specific redaction logic. This approach:
- Preserves the existing behavior of `redact()` for all other use cases
- Keeps the fix localized to the connection metadata API where the issue occurs
- Maintains backward compatibility with existing code that relies on `redact()`

## Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
