### PR TITLE
Improve insert content when generate docker file

### DIFF
--- a/scripts/ci/prek/inline_scripts_in_docker.py
+++ b/scripts/ci/prek/inline_scripts_in_docker.py
@@ -35,7 +35,7 @@ def insert_content(file_path: Path, content: list[str], header: str, footer: str
             replacing = False
         if not replacing:
             result.append(line)
-        file_path.write_text("".join(result))
+    file_path.write_text("".join(result))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What
When inserting scripts into Dockerfiles, the file write function is currently called inside a loop, causing the file to be written line by line.

## Proposal
Move the file write operation outside the loop so the content is written only once. This reduces unnecessary I/O operations and improves execution time.