### PR TITLE
Improve error handling in edge worker on 405

### DIFF
--- a/providers/edge3/src/airflow/providers/edge3/cli/worker.py
+++ b/providers/edge3/src/airflow/providers/edge3/cli/worker.py
@@ -269,7 +269,8 @@ class EdgeWorker:
             logger.error(str(e))
             raise SystemExit(str(e))
         except ClientResponseError as e:
-            if e.status == HTTPStatus.NOT_FOUND:
+            # Note: Method not allowed is raised by FastAPI if the API is not enabled (not 404)
+            if e.status in {HTTPStatus.NOT_FOUND, HTTPStatus.METHOD_NOT_ALLOWED}:
                 raise SystemExit(
                     "Error: API endpoint is not ready, please set [edge] api_enabled=True. Or check if the URL is correct to your deployment."
                 )


### PR DESCRIPTION
Airflow 3 / FastAPI return HTTP 405 if API endpoint is not existing or URL is "wrong", not a HTTP 404.

* related: #60261 - note: does not close!

## Was generative AI tooling used to co-author this PR?

- [ ] Nope