### PR TITLE
Docs: Clarify ingress settings for Airflow 2 vs 3 in values.yaml

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -149,7 +149,7 @@ ingress:
   # (deprecated - use ingress.web.enabled, ingress.apiServer.enabled and ingress.flower.enabled)
   enabled: ~
 
-  # Configs for the Ingress of the API Server
+  # Configs for the Ingress of the API Server (Airflow 3+)
   apiServer:
     # Enable API Server ingress resource
     enabled: false
@@ -193,7 +193,7 @@ ingress:
     # Http paths to add to the API Server Ingress after the default path
     succeedingPaths: []
 
-  # Configs for the Ingress of the web Service
+  # Configs for the Ingress of the web Service (Airflow 2.x)
   web:
     # Enable web ingress resource
     enabled: false


### PR DESCRIPTION
This PR updates [chart/values.yaml](cci:7://file:///e:/Vighnesh/git/airflow/chart/values.yaml:0:0-0:0) to explicitly clarify the versioning support for Ingress configurations:

- `ingress.web`: Only used for **Airflow 2.x** (Webserver).
- `ingress.apiServer`: Only used for **Airflow 3+** (API Server).

This clarifies usage for users deploying Helm charts across different Airflow versions and prevents confusion when `ingress.web` values are ignored in Airflow 3 setups.

**Related Issue:**
closes: #53611

## Was generative AI tooling used to co-author this PR?

- [ ] Yes