### PR TITLE
Execution API: document RTIF endpoint

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -633,9 +633,11 @@ def ti_heartbeat(
 @ti_id_router.put(
     "/{task_instance_id}/rtif",
     status_code=status.HTTP_201_CREATED,
-    # TODO: Add description to the operation
-    # TODO: Add Operation ID to control the function name in the OpenAPI spec
-    # TODO: Do we need to use create_openapi_http_exception_doc here?
+    operation_id="put_rtif",
+    summary="Set Rendered Task Instance Fields",
+    description="Store the rendered task instance fields (RTIF) for a task instance. "
+    "These are the template fields after Jinja rendering has been applied. "
+    "Called by the worker after task execution begins.",
     responses={
         status.HTTP_404_NOT_FOUND: {"description": "Task Instance not found"},
         HTTP_422_UNPROCESSABLE_CONTENT: {


### PR DESCRIPTION
## Why
The Execution API spec lacks OpenAPI metadata for the RTIF endpoint, which makes client generation and discovery harder. This change documents the endpoint; runtime behavior is unchanged.

## Tests
Not run (metadata-only change).

## Follow-ups
- #60463 Validate map_index range when creating task instances via CLI
- #60464 Improve executor callback log file template
- #60465 Remove ui_color/ui_fgcolor from SerializedBaseOperator
- #60466 Decide whether ui_color/ui_fgcolor are needed in SerializedTaskGroup
- #60467 Consider create_openapi_http_exception_doc for RTIF endpoint
