### PR TITLE
AIP-67 - Multi Team: Validate that global executors come before team executors in config

### DIFF
--- a/airflow-core/src/airflow/executors/executor_loader.py
+++ b/airflow-core/src/airflow/executors/executor_loader.py
@@ -249,6 +249,21 @@ class ExecutorLoader:
                 "'CeleryExecutor;team1=LocalExecutor' instead of 'team1=CeleryExecutor;team2=LocalExecutor')."
             )
 
+        # Validate that global executors come before team executors
+        seen_team_executor = False
+        for team_name, _ in configs:
+            if team_name is not None:
+                seen_team_executor = True
+            elif seen_team_executor:
+                # Found a global executor after we've already seen a team executor
+                raise AirflowConfigException(
+                    "Global executors must be specified before team-based executors. "
+                    "Current configuration has team executors before global executors. "
+                    "Please reorder your configuration so that all global executors (those without a team prefix) "
+                    "appear before any team-based executors (e.g., 'CeleryExecutor;team1=LocalExecutor' "
+                    "instead of 'team1=CeleryExecutor;LocalExecutor')."
+                )
+
         # Validate that all team names exist in the database (excluding None for global configs)
         team_names_to_validate = {team_name for team_name in seen_teams if team_name is not None}
         if team_names_to_validate and validate_teams:

--- a/airflow-core/tests/unit/executors/test_executor_loader.py
+++ b/airflow-core/tests/unit/executors/test_executor_loader.py
@@ -657,3 +657,30 @@ class TestExecutorLoader:
                 mock_get_team_names.return_value = {"team_a"}
                 executor_loader.ExecutorLoader.get_executor_names()
                 mock_get_team_names.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "executor_config",
+        [
+            "team_a=CeleryExecutor;LocalExecutor",
+            "team_a=CeleryExecutor;team_b=LocalExecutor;CeleryExecutor",
+            "team_a=CeleryExecutor;=LocalExecutor",
+            "team_a=CeleryExecutor;team_b=LocalExecutor;=CeleryExecutor,KubernetesExecutor",
+            "CeleryExecutor,team_a=CeleryExecutor;=LocalExecutor",
+        ],
+    )
+    def test_team_executors_before_global_executors_should_fail(self, executor_config):
+        """Test that configurations with team executors before global executors fail validation.
+
+        Global executors must always be specified before any team-based executors.
+        This ensures the default executor (first in config) is always global.
+        """
+        with (
+            mock.patch.object(executor_loader.ExecutorLoader, "block_use_of_multi_team"),
+            mock.patch.object(executor_loader.ExecutorLoader, "_validate_teams_exist_in_database"),
+        ):
+            with conf_vars({("core", "executor"): executor_config, ("core", "multi_team"): "True"}):
+                with pytest.raises(
+                    AirflowConfigException,
+                    match=r"Global executors must be specified before team-based executors",
+                ):
+                    executor_loader.ExecutorLoader._get_team_executor_configs()


### PR DESCRIPTION
Add validation to ensure global executors are specified before any team executors, since we do not want them to be the default global executor.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

## Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Cline

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
