### PR TITLE
Remove API error from disabling submit

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -231,12 +231,7 @@ const TriggerDAGForm = ({
           <Button
             colorPalette="brand"
             disabled={
-              Boolean(errors.conf) ||
-              Boolean(errors.date) ||
-              formError ||
-              isPending ||
-              Boolean(errorTrigger) ||
-              dataIntervalInvalid
+              Boolean(errors.conf) || Boolean(errors.date) || formError || isPending || dataIntervalInvalid
             }
             onClick={() => void handleSubmit(onSubmit)()}
           >


### PR DESCRIPTION
Prevent an API error from disabling the trigger dag form.

If you submitted once and then got an error. You had to close the modal and restart. You couldn't just change the erroring field. (ex: type an invalid custom run id, get an error, you can't submit even after editing the run id)

Ideally, we would have better error messages that we can map onto a specific field and only remove the disabling once that change was made. Maybe in the future.

### Was generative AI tooling used to co-author this PR?

No

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
