### PR TITLE
Add team selector in variable form

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/AddVariableButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/AddVariableButton.tsx
@@ -39,6 +39,7 @@ const AddVariableButton = ({ disabled }: Props) => {
   const initialVariableValue: VariableBody = {
     description: "",
     key: "",
+    team_name: "",
     value: "",
   };
 

--- a/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/EditVariableButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/EditVariableButton.tsx
@@ -50,6 +50,7 @@ const EditVariableButton = ({ disabled, variable }: Props) => {
   const initialVariableValue: VariableBody = {
     description: variable.description ?? "",
     key: variable.key,
+    team_name: variable.team_name ?? "",
     value: formatValue(variable.value),
   };
   const { editVariable, error, isPending, setError } = useEditVariable(initialVariableValue, {

--- a/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/VariableForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/VariableForm.tsx
@@ -22,10 +22,13 @@ import { useTranslation } from "react-i18next";
 import { FiSave } from "react-icons/fi";
 
 import { ErrorAlert } from "src/components/ErrorAlert";
+import { TeamSelector } from "src/components/TeamSelector.tsx";
+import { useConfig } from "src/queries/useConfig.tsx";
 
 export type VariableBody = {
   description: string | undefined;
   key: string;
+  team_name: string;
   value: string;
 };
 
@@ -58,6 +61,7 @@ const VariableForm = ({ error, initialVariable, isPending, manageMutate, setErro
     defaultValues: initialVariable,
     mode: "onChange",
   });
+  const multiTeamEnabled = Boolean(useConfig("multi_team"));
 
   const onSubmit = (data: VariableBody) => {
     manageMutate(data);
@@ -125,6 +129,8 @@ const VariableForm = ({ error, initialVariable, isPending, manageMutate, setErro
           </Field.Root>
         )}
       />
+
+      {multiTeamEnabled ? <TeamSelector control={control} /> : undefined}
 
       <ErrorAlert error={error} />
 

--- a/airflow-core/src/airflow/ui/src/queries/useAddVariable.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useAddVariable.ts
@@ -63,6 +63,7 @@ export const useAddVariable = ({ onSuccessConfirm }: { onSuccessConfirm: () => v
       requestBody: {
         description: parsedDescription,
         key: variableRequestBody.key,
+        team_name: variableRequestBody.team_name,
         value: variableRequestBody.value,
       },
     });


### PR DESCRIPTION
Similar to #60237 but for variables.

Add a dropdown in the variable form to select the team if the multi team mode is enabled.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
