### PR TITLE
Execution API: document RTIF endpoint

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -689,9 +689,11 @@ def ti_heartbeat(
 @ti_id_router.put(
     "/{task_instance_id}/rtif",
     status_code=status.HTTP_201_CREATED,
-    # TODO: Add description to the operation
-    # TODO: Add Operation ID to control the function name in the OpenAPI spec
-    # TODO: Do we need to use create_openapi_http_exception_doc here?
+    operation_id="put_rtif",
+    summary="Set Rendered Task Instance Fields",
+    description="Store the rendered task instance fields (RTIF) for a task instance. "
+    "These are the template fields after Jinja rendering has been applied. "
+    "Called by the worker after task execution begins.",
     responses={
         status.HTTP_404_NOT_FOUND: {"description": "Task Instance not found"},
         HTTP_422_UNPROCESSABLE_CONTENT: {


### PR DESCRIPTION
The RTIF endpoint is called by workers to store rendered fields, but the OpenAPI spec lacked a stable operation_id and human-readable summary/description. Adding metadata improves spec clarity for client generation and discovery without changing behavior.

Test plan: not run (OpenAPI metadata only).

## Was generative AI tooling used to co-author this PR?

- [X] Yes (OpenAI Codex (GPT-5))

Generated-by: OpenAI Codex (GPT-5) following https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions
