### PR TITLE
Refactor opensearch, elasticsearch, amazon to use SQLA2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -489,17 +489,21 @@ repos:
             ^airflow-core/tests/unit/dag_processing/test_processor.py$|
             ^airflow-core/tests/unit/dag_processing/test_collection\.py$|
             ^dev/airflow_perf/scheduler_dag_execution_timing.py$|
+            ^providers/amazon/tests/system/amazon/aws/example_kinesis_analytics.py$|
+            ^providers/amazon/tests/unit/amazon/aws/transfers/test_s3_to_sql.py$|
             ^providers/celery/.*\.py$|
             ^providers/cncf/kubernetes/.*\.py$|
             ^providers/databricks/.*\.py$|
             ^providers/edge3/.*\.py$|
+            ^providers/elasticsearch/src/airflow/providers/elasticsearch/log/es_task_handler.py$|
             ^providers/mysql/.*\.py$|
             ^providers/openlineage/.*\.py$|
-            ^providers/google/src/airflow/providers/google/cloud/triggers/dataproc\.py$|
+            ^providers/opensearch/src/airflow/providers/opensearch/log/os_task_handler.py$|
             ^providers/google/src/airflow/providers/google/cloud/triggers/bigquery\.py$|
+            ^providers/google/src/airflow/providers/google/cloud/triggers/dataproc\.py$|
+            ^providers/google/tests/system/google/gcp_api_client_helpers\.py$|
             ^providers/google/tests/unit/google/cloud/utils/gcp_authenticator\.py$|
             ^providers/google/tests/unit/google/marketing_platform/operators/test_campaign_manager\.py$|
-            ^providers/google/tests/system/google/gcp_api_client_helpers\.py$|
             ^providers/standard/tests/unit/standard/operators/test_latest_only_operator\.py$|
             ^providers/standard/tests/unit/standard/operators/test_trigger_dagrun\.py$|
             ^providers/standard/tests/unit/standard/operators/test_weekday\.py$|

--- a/providers/amazon/tests/system/amazon/aws/example_kinesis_analytics.py
+++ b/providers/amazon/tests/system/amazon/aws/example_kinesis_analytics.py
@@ -22,6 +22,7 @@ import random
 from datetime import datetime
 
 import boto3
+from sqlalchemy import select
 
 from airflow import settings
 from airflow.models import Connection
@@ -189,7 +190,7 @@ def copy_jar_to_s3(bucket: str):
         if settings.Session is None:
             raise RuntimeError("Session not configured. Call configure_orm() first.")
         session = settings.Session()
-        conn_to_details = session.query(Connection).filter(Connection.conn_id == conn_id).first()
+        conn_to_details = session.scalar(select(Connection).where(Connection.conn_id == conn_id))
         session.delete(conn_to_details)
         session.commit()
 

--- a/providers/amazon/tests/unit/amazon/aws/transfers/test_s3_to_sql.py
+++ b/providers/amazon/tests/unit/amazon/aws/transfers/test_s3_to_sql.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
-from sqlalchemy import or_
+from sqlalchemy import delete, or_
 
 from airflow import models
 from airflow.providers.amazon.aws.transfers.s3_to_sql import S3ToSqlOperator
@@ -119,8 +119,8 @@ class TestS3ToSqlTransfer:
 
     def teardown_method(self):
         with create_session() as session:
-            (
-                session.query(models.Connection)
-                .filter(or_(models.Connection.conn_id == "s3_test", models.Connection.conn_id == "sql_test"))
-                .delete()
+            session.execute(
+                delete(models.Connection).where(
+                    or_(models.Connection.conn_id == "s3_test", models.Connection.conn_id == "sql_test")
+                )
             )

--- a/providers/elasticsearch/src/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/providers/elasticsearch/src/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -37,6 +37,7 @@ import elasticsearch
 import pendulum
 from elasticsearch import helpers
 from elasticsearch.exceptions import NotFoundError
+from sqlalchemy import select
 
 from airflow.models.dagrun import DagRun
 from airflow.providers.common.compat.module_loading import import_string
@@ -98,15 +99,13 @@ def _ensure_ti(ti: TaskInstanceKey | TaskInstance, session) -> TaskInstance:
 
     if not isinstance(ti, TaskInstanceKey):
         return ti
-    val = (
-        session.query(TaskInstance)
-        .filter(
+    val = session.scalar(
+        select(TaskInstance).where(
             TaskInstance.task_id == ti.task_id,
             TaskInstance.dag_id == ti.dag_id,
             TaskInstance.run_id == ti.run_id,
             TaskInstance.map_index == ti.map_index,
         )
-        .one_or_none()
     )
     if isinstance(val, TaskInstance):
         val.try_number = ti.try_number

--- a/providers/opensearch/src/airflow/providers/opensearch/log/os_task_handler.py
+++ b/providers/opensearch/src/airflow/providers/opensearch/log/os_task_handler.py
@@ -31,6 +31,7 @@ from urllib.parse import urlparse
 import pendulum
 from opensearchpy import OpenSearch
 from opensearchpy.exceptions import NotFoundError
+from sqlalchemy import select
 
 from airflow.models import DagRun
 from airflow.providers.common.compat.module_loading import import_string
@@ -85,15 +86,13 @@ def _ensure_ti(ti: TaskInstanceKey | TaskInstance, session) -> TaskInstance:
 
     if not isinstance(ti, TaskInstanceKey):
         return ti
-    val = (
-        session.query(TaskInstance)
-        .filter(
+    val = session.scalar(
+        select(TaskInstance).where(
             TaskInstance.task_id == ti.task_id,
             TaskInstance.dag_id == ti.dag_id,
             TaskInstance.run_id == ti.run_id,
             TaskInstance.map_index == ti.map_index,
         )
-        .one_or_none()
     )
     if isinstance(val, TaskInstance):
         val.try_number = ti.try_number


### PR DESCRIPTION
related: #59402

Migrate deprecated SQLAlchemy Query object usage to SQLAlchemy 2.0 style in:
- `providers/amazon/tests/system/amazon/aws/example_kinesis_analytics.py`
- `providers/amazon/tests/unit/amazon/aws/transfers/test_s3_to_sql.py`
- `providers/elasticsearch/src/airflow/providers/elasticsearch/log/es_task_handler.py`
- `providers/opensearch/src/airflow/providers/opensearch/log/os_task_handler.py`

---
^ Add meaningful description above
Read the Pull Request Guidelines for more information.
In case of fundamental code changes, an Airflow Improvement Proposal (AIP) is needed.
In case of a new dependency, check compliance with the ASF 3rd Party License Policy.
In case of backwards incompatible changes please leave a note in a newsfragment file, named {pr_number}.significant.rst or {issue_number}.significant.rst, in airflow-core/newsfragments.

