### PR TITLE
Add template.significant.rst to towncrier ignore list

### DIFF
--- a/airflow-core/newsfragments/config.toml
+++ b/airflow-core/newsfragments/config.toml
@@ -18,7 +18,7 @@
 name = "Airflow"
 filename = "../RELEASE_NOTES.rst"
 underlines = ["-", '^']
-ignore = ["config.toml"]
+ignore = ["config.toml", "template.significant.rst"]
 
 [[tool.towncrier.type]]
 directory = "significant"


### PR DESCRIPTION
template.significant.rst is not meant to be deleted by towncrier build command. Adding it as ignored so it's not deleted going forward


