### PR TITLE
Update universal-pathlib to `>=0.3.8` and use upath.extensions.ProxyUPath

### DIFF
--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -144,7 +144,7 @@ dependencies = [
     "termcolor>=3.0.0",
     "typing-extensions>=4.14.1",
     # https://github.com/apache/airflow/issues/56369 , rework universal-pathlib usage
-    "universal-pathlib>=0.2.6,<0.3.0",
+    "universal-pathlib>=0.3.8",
     "uuid6>=2024.7.10",
     "apache-airflow-task-sdk<1.3.0,>=1.2.0",
     # pre-installed providers

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1,5 +1,6 @@
 aarch
 abc
+AbstractFileSystem
 accessor
 AccessSecretVersionResponse
 accountmaking
@@ -736,6 +737,7 @@ fqdn
 frontend
 fs
 fsGroup
+fsspec
 fullname
 func
 Fundera

--- a/task-sdk/src/airflow/sdk/io/path.py
+++ b/task-sdk/src/airflow/sdk/io/path.py
@@ -199,11 +199,11 @@ class ObjectStoragePath(ProxyUPath):
         return self.rename(target)
 
     @classmethod
-    def cwd(cls) -> Self:  # type: ignore[override]
+    def cwd(cls) -> Self:
         return cls._from_upath(UPath.cwd())
 
     @classmethod
-    def home(cls) -> Self:  # type: ignore[override]
+    def home(cls) -> Self:
         return cls._from_upath(UPath.home())
 
     # EXTENDED OPERATIONS
@@ -443,6 +443,6 @@ class ObjectStoragePath(ProxyUPath):
 
     def __str__(self):
         conn_id = self.storage_options.get("conn_id")
-        if self._protocol and conn_id:
-            return f"{self._protocol}://{conn_id}@{self.path}"
+        if self.protocol and conn_id:
+            return f"{self.protocol}://{conn_id}@{self.path}"
         return super().__str__()

--- a/task-sdk/src/airflow/sdk/io/path.py
+++ b/task-sdk/src/airflow/sdk/io/path.py
@@ -372,6 +372,7 @@ class ObjectStoragePath(ProxyUPath):
 
         :param target_dir: Destination directory
         :param recursive: If True, copy directories recursively.
+
         kwargs: Additional keyword arguments to be passed to the underlying implementation.
         """
         if isinstance(target_dir, str):
@@ -410,7 +411,9 @@ class ObjectStoragePath(ProxyUPath):
         Move file(s) from this path into another directory.
 
         :param target_dir: Destination directory
-        :param recursive: If True, move directories recursively.
+        :param recursive: bool
+                         If True, move directories recursively.
+
         kwargs: Additional keyword arguments to be passed to the underlying implementation.
         """
         if isinstance(target_dir, str):

--- a/task-sdk/tests/task_sdk/io/test_path.py
+++ b/task-sdk/tests/task_sdk/io/test_path.py
@@ -262,7 +262,11 @@ class TestLocalPath:
         o1 = ObjectStoragePath(f"file://{target}")
         o2 = ObjectStoragePath(f"file://{tmp_path.as_posix()}")
         o3 = ObjectStoragePath(f"file:///{uuid.uuid4()}")
-        assert o1.relative_to(o2) == o1
+        # relative_to returns the relative path from o2 to o1
+        relative = o1.relative_to(o2)
+        # The relative path should be the basename (uuid) of the target
+        expected_relative = target.split("/")[-1]
+        assert str(relative) == expected_relative
         with pytest.raises(ValueError, match="is not in the subpath of"):
             o1.relative_to(o3)
 

--- a/task-sdk/tests/task_sdk/io/test_path.py
+++ b/task-sdk/tests/task_sdk/io/test_path.py
@@ -70,10 +70,13 @@ def test_home():
 def test_lazy_load():
     o = ObjectStoragePath("file:///tmp/foo")
     with pytest.raises(AttributeError):
-        assert o._fs_cached
+        assert o.__wrapped__._fs_cached
 
+    # ObjectStoragePath overrides .fs and provides cached filesystems via the STORE_CACHE
     assert o.fs is not None
-    assert o._fs_cached
+
+    with pytest.raises(AttributeError):
+        assert o.__wrapped__._fs_cached
     # Clear the cache to avoid side effects in other tests below
     _STORE_CACHE.clear()
 


### PR DESCRIPTION
Closes #56369 

This PR updates airflow's `ObjectStoragePath` class to be compatible with universal-pathlib `>=0.3.8`. It now uses `upath.extensions.ProxyUPath` as a base class, to avoid using the now deprecated `_protocol_dispatch = False` mechanism for class API extensions.

Also `pathlib.Path` added `.copy`, `.copy_into`, `.move`, and `.move_into` methods in 3.14, which means the ObjectStoragePath behavior for these is now different from standard pathlib, which defaults to recursive copies for directories and returns the target path.

Cheers,
Andreas ☺️ 