### PR TITLE
feat: add depth filter to TaskStreamFilter in UI

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
@@ -120,7 +120,13 @@
       "clearFilter": "Clear Filter",
       "clickTask": "Click a task to select it as the filter root",
       "depth": "Depth",
+      "direction": "Direction",
       "label": "Filter",
+      "mode": "Mode",
+      "modes": {
+        "static": "Static",
+        "traverse": "Traverse"
+      },
       "options": {
         "both": "Both upstream & downstream",
         "downstream": "Downstream",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
@@ -119,6 +119,7 @@
       "activeFilter": "Active filter",
       "clearFilter": "Clear Filter",
       "clickTask": "Click a task to select it as the filter root",
+      "depth": "Depth",
       "label": "Filter",
       "options": {
         "both": "Both upstream & downstream",

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/Gantt.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/Gantt.tsx
@@ -37,7 +37,7 @@ import dayjs from "dayjs";
 import { useDeferredValue } from "react";
 import { Bar } from "react-chartjs-2";
 import { useTranslation } from "react-i18next";
-import { useParams, useNavigate, useLocation } from "react-router-dom";
+import { useParams, useNavigate, useLocation, useSearchParams } from "react-router-dom";
 
 import { useTaskInstanceServiceGetTaskInstances } from "openapi/queries";
 import type { DagRunState, DagRunType } from "openapi/requests/types.gen";
@@ -83,6 +83,7 @@ const MIN_BAR_WIDTH = 10;
 
 export const Gantt = ({ dagRunState, limit, runType, triggeringUser }: Props) => {
   const { dagId = "", groupId: selectedGroupId, runId = "", taskId: selectedTaskId } = useParams();
+  const [searchParams] = useSearchParams();
   const { openGroupIds } = useOpenGroups();
   const deferredOpenGroupIds = useDeferredValue(openGroupIds);
   const { t: translate } = useTranslation("common");
@@ -91,6 +92,12 @@ export const Gantt = ({ dagRunState, limit, runType, triggeringUser }: Props) =>
   const { hoveredTaskId, setHoveredTaskId } = useHover();
   const navigate = useNavigate();
   const location = useLocation();
+
+  const filterRoot = searchParams.get("root") ?? undefined;
+  const includeUpstream = searchParams.get("upstream") === "true";
+  const includeDownstream = searchParams.get("downstream") === "true";
+  const depthParam = searchParams.get("depth");
+  const depth = depthParam ? parseInt(depthParam, 10) : undefined;
 
   // Corresponds to border, brand.emphasized, and brand.muted
   const [
@@ -114,7 +121,11 @@ export const Gantt = ({ dagRunState, limit, runType, triggeringUser }: Props) =>
   });
   const { data: dagStructure, isLoading: structureLoading } = useGridStructure({
     dagRunState,
+    depth,
+    includeDownstream,
+    includeUpstream,
     limit,
+    root: filterRoot,
     runType,
     triggeringUser,
   });

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/Gantt.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/Gantt.tsx
@@ -97,7 +97,7 @@ export const Gantt = ({ dagRunState, limit, runType, triggeringUser }: Props) =>
   const includeUpstream = searchParams.get("upstream") === "true";
   const includeDownstream = searchParams.get("downstream") === "true";
   const depthParam = searchParams.get("depth");
-  const depth = depthParam ? parseInt(depthParam, 10) : undefined;
+  const depth = depthParam !== null && depthParam !== "" ? parseInt(depthParam, 10) : undefined;
 
   // Corresponds to border, brand.emphasized, and brand.muted
   const [

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Graph/Graph.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Graph/Graph.tsx
@@ -69,7 +69,7 @@ export const Graph = () => {
   const includeUpstream = searchParams.get("upstream") === "true";
   const includeDownstream = searchParams.get("downstream") === "true";
   const depthParam = searchParams.get("depth");
-  const depth = depthParam ? parseInt(depthParam, 10) : undefined;
+  const depth = depthParam !== null && depthParam !== "" ? parseInt(depthParam, 10) : undefined;
 
   const hasActiveFilter = includeUpstream || includeDownstream;
 

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Graph/Graph.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Graph/Graph.tsx
@@ -68,6 +68,8 @@ export const Graph = () => {
   const filterRoot = searchParams.get("root") ?? undefined;
   const includeUpstream = searchParams.get("upstream") === "true";
   const includeDownstream = searchParams.get("downstream") === "true";
+  const depthParam = searchParams.get("depth");
+  const depth = depthParam ? parseInt(depthParam, 10) : undefined;
 
   const hasActiveFilter = includeUpstream || includeDownstream;
 
@@ -90,6 +92,7 @@ export const Graph = () => {
   const { data: graphData = { edges: [], nodes: [] } } = useStructureServiceStructureData(
     {
       dagId,
+      depth,
       externalDependencies: dependencies === "immediate",
       includeDownstream,
       includeUpstream,

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Grid.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Grid.tsx
@@ -69,7 +69,7 @@ export const Grid = ({ dagRunState, limit, runType, showGantt, triggeringUser }:
   const includeUpstream = searchParams.get("upstream") === "true";
   const includeDownstream = searchParams.get("downstream") === "true";
   const depthParam = searchParams.get("depth");
-  const depth = depthParam ? parseInt(depthParam, 10) : undefined;
+  const depth = depthParam !== null && depthParam !== "" ? parseInt(depthParam, 10) : undefined;
 
   const { data: gridRuns, isLoading } = useGridRuns({ dagRunState, limit, runType, triggeringUser });
 

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Grid.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Grid.tsx
@@ -68,8 +68,8 @@ export const Grid = ({ dagRunState, limit, runType, showGantt, triggeringUser }:
   const filterRoot = searchParams.get("root") ?? undefined;
   const includeUpstream = searchParams.get("upstream") === "true";
   const includeDownstream = searchParams.get("downstream") === "true";
-  const depth = searchParams.get("depth") ?? undefined;
-
+  const depthParam = searchParams.get("depth");
+  const depth = depthParam ? parseInt(depthParam, 10) : undefined;
 
   const { data: gridRuns, isLoading } = useGridRuns({ dagRunState, limit, runType, triggeringUser });
 

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Grid.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Grid.tsx
@@ -68,6 +68,8 @@ export const Grid = ({ dagRunState, limit, runType, showGantt, triggeringUser }:
   const filterRoot = searchParams.get("root") ?? undefined;
   const includeUpstream = searchParams.get("upstream") === "true";
   const includeDownstream = searchParams.get("downstream") === "true";
+  const depth = searchParams.get("depth") ?? undefined;
+
 
   const { data: gridRuns, isLoading } = useGridRuns({ dagRunState, limit, runType, triggeringUser });
 
@@ -85,6 +87,7 @@ export const Grid = ({ dagRunState, limit, runType, showGantt, triggeringUser }:
 
   const { data: dagStructure } = useGridStructure({
     dagRunState,
+    depth,
     hasActiveRun: gridRuns?.some((dr) => isStatePending(dr.state)),
     includeDownstream,
     includeUpstream,

--- a/airflow-core/src/airflow/ui/src/layouts/Details/TaskStreamFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/TaskStreamFilter.tsx
@@ -25,7 +25,7 @@ import { useParams, useSearchParams } from "react-router-dom";
 import { Menu } from "src/components/ui/Menu";
 
 export const TaskStreamFilter = () => {
-  const { t: translate } = useTranslation(["components", "dag"]);
+  const { t: translate } = useTranslation(["common", "components", "dag"]);
   const { taskId: currentTaskId } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -199,7 +199,7 @@ export const TaskStreamFilter = () => {
                 onKeyDown={(event) => {
                   event.stopPropagation();
                 }}
-                placeholder="All"
+                placeholder={translate("common:expression.all")}
                 size="sm"
                 type="number"
                 value={depth ?? ""}

--- a/airflow-core/src/airflow/ui/src/layouts/Details/TaskStreamFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/TaskStreamFilter.tsx
@@ -201,7 +201,8 @@ export const TaskStreamFilter = () => {
                 disabled={currentTaskId === undefined || !hasActiveFilter}
                 min={0}
                 onChange={(e) => {
-                  const value = e.target.value;
+                  const {value} = e.target;
+
                   buildFilterSearch(includeUpstream, includeDownstream, filterRoot, value);
                 }}
                 onKeyDown={(e) => {

--- a/airflow-core/src/airflow/ui/src/layouts/Details/TaskStreamFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/TaskStreamFilter.tsx
@@ -66,6 +66,7 @@ export const TaskStreamFilter = () => {
       searchParams.set("root", root);
     } else {
       searchParams.delete("root");
+      searchParams.delete("mode");
     }
 
     if (newDepth !== undefined && newDepth !== "" && (upstream || downstream)) {

--- a/airflow-core/src/airflow/ui/src/layouts/Details/TaskStreamFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/TaskStreamFilter.tsx
@@ -16,13 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Button, Input, Portal, Separator, Text, VStack } from "@chakra-ui/react";
+import { Button, ButtonGroup, Input, Portal, Separator, Text, VStack } from "@chakra-ui/react";
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { FiChevronDown, FiFilter } from "react-icons/fi";
 import { useParams, useSearchParams } from "react-router-dom";
 
-import { ButtonGroupToggle } from "src/components/ui/ButtonGroupToggle";
 import { Menu } from "src/components/ui/Menu";
 
 export const TaskStreamFilter = () => {
@@ -125,26 +124,6 @@ export const TaskStreamFilter = () => {
 
             <Separator my={2} />
 
-            {/* Mode Section */}
-            <VStack align="stretch" gap={2} width="100%">
-              <Text fontSize="xs" fontWeight="semibold">
-                {translate("dag:panel.taskStreamFilter.mode")}
-              </Text>
-              <ButtonGroupToggle<"static" | "traverse">
-                onChange={(value) => {
-                  searchParams.set("mode", value);
-                  setSearchParams(searchParams);
-                }}
-                options={[
-                  { disabled: !hasActiveFilter, label: translate("dag:panel.taskStreamFilter.modes.static"), value: "static" },
-                  { disabled: !hasActiveFilter, label: translate("dag:panel.taskStreamFilter.modes.traverse"), value: "traverse" },
-                ]}
-                value={mode as "static" | "traverse"}
-              />
-            </VStack>
-
-            <Separator my={2} />
-
             {/* Direction Section */}
             <VStack align="stretch" gap={2} width="100%">
               <Text fontSize="xs" fontWeight="semibold">
@@ -153,7 +132,7 @@ export const TaskStreamFilter = () => {
               <VStack align="stretch" gap={1} width="100%">
                 <Button
                   color={activeUpstream ? "white" : undefined}
-                  colorPalette={activeUpstream ? "blue" : "gray"}
+                  colorPalette={activeUpstream ? "brand" : "gray"}
                   disabled={currentTaskId === undefined}
                   justifyContent="flex-start"
                   onClick={() => buildFilterSearch(true, false, currentTaskId, depth)}
@@ -172,7 +151,7 @@ export const TaskStreamFilter = () => {
 
                 <Button
                   color={activeDownstream ? "white" : undefined}
-                  colorPalette={activeDownstream ? "blue" : "gray"}
+                  colorPalette={activeDownstream ? "brand" : "gray"}
                   disabled={currentTaskId === undefined}
                   justifyContent="flex-start"
                   onClick={() => buildFilterSearch(false, true, currentTaskId, depth)}
@@ -191,7 +170,7 @@ export const TaskStreamFilter = () => {
 
                 <Button
                   color={bothActive ? "white" : undefined}
-                  colorPalette={bothActive ? "blue" : "gray"}
+                  colorPalette={bothActive ? "brand" : "gray"}
                   disabled={currentTaskId === undefined}
                   justifyContent="flex-start"
                   onClick={() => buildFilterSearch(true, true, currentTaskId, depth)}
@@ -232,6 +211,39 @@ export const TaskStreamFilter = () => {
                 type="number"
                 value={depth ?? ""}
               />
+            </VStack>
+
+            <Separator my={2} />
+
+            {/* Mode Section */}
+            <VStack align="stretch" gap={2} width="100%">
+              <Text fontSize="xs" fontWeight="semibold">
+                {translate("dag:panel.taskStreamFilter.mode")}
+              </Text>
+              <ButtonGroup attached colorPalette="brand" size="sm" variant="outline" width="100%">
+                <Button
+                  disabled={!hasActiveFilter}
+                  flex="1"
+                  onClick={() => {
+                    searchParams.set("mode", "static");
+                    setSearchParams(searchParams);
+                  }}
+                  variant={mode === "static" ? "solid" : "outline"}
+                >
+                  {translate("dag:panel.taskStreamFilter.modes.static")}
+                </Button>
+                <Button
+                  disabled={!hasActiveFilter}
+                  flex="1"
+                  onClick={() => {
+                    searchParams.set("mode", "traverse");
+                    setSearchParams(searchParams);
+                  }}
+                  variant={mode === "traverse" ? "solid" : "outline"}
+                >
+                  {translate("dag:panel.taskStreamFilter.modes.traverse")}
+                </Button>
+              </ButtonGroup>
             </VStack>
 
             <Separator my={2} />

--- a/airflow-core/src/airflow/ui/src/layouts/Details/TaskStreamFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/TaskStreamFilter.tsx
@@ -43,13 +43,26 @@ export const TaskStreamFilter = () => {
 
   // In traverse mode, update the root when the selected task changes
   useEffect(() => {
-    if (mode === "traverse" && hasActiveFilter && currentTaskId && currentTaskId !== filterRoot) {
+    if (
+      mode === "traverse" &&
+      hasActiveFilter &&
+      currentTaskId !== undefined &&
+      currentTaskId !== "" &&
+      currentTaskId !== filterRoot
+    ) {
       searchParams.set("root", currentTaskId);
       setSearchParams(searchParams, { replace: true });
     }
   }, [currentTaskId, mode, hasActiveFilter, filterRoot, searchParams, setSearchParams]);
 
-  const buildFilterSearch = (upstream: boolean, downstream: boolean, root?: string, newDepth?: string) => {
+  const buildFilterSearch = (options: {
+    depth?: string;
+    downstream: boolean;
+    root?: string;
+    upstream: boolean;
+  }) => {
+    const { depth: newDepth, downstream, root, upstream } = options;
+
     if (upstream) {
       searchParams.set("upstream", "true");
     } else {
@@ -136,11 +149,13 @@ export const TaskStreamFilter = () => {
                   colorPalette={activeUpstream ? "brand" : "gray"}
                   disabled={currentTaskId === undefined}
                   justifyContent="flex-start"
-                  onClick={() => buildFilterSearch(true, false, currentTaskId, depth)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault();
-                      buildFilterSearch(true, false, currentTaskId, depth);
+                  onClick={() =>
+                    buildFilterSearch({ depth, downstream: false, root: currentTaskId, upstream: true })
+                  }
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") {
+                      event.preventDefault();
+                      buildFilterSearch({ depth, downstream: false, root: currentTaskId, upstream: true });
                     }
                   }}
                   size="sm"
@@ -155,11 +170,13 @@ export const TaskStreamFilter = () => {
                   colorPalette={activeDownstream ? "brand" : "gray"}
                   disabled={currentTaskId === undefined}
                   justifyContent="flex-start"
-                  onClick={() => buildFilterSearch(false, true, currentTaskId, depth)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault();
-                      buildFilterSearch(false, true, currentTaskId, depth);
+                  onClick={() =>
+                    buildFilterSearch({ depth, downstream: true, root: currentTaskId, upstream: false })
+                  }
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") {
+                      event.preventDefault();
+                      buildFilterSearch({ depth, downstream: true, root: currentTaskId, upstream: false });
                     }
                   }}
                   size="sm"
@@ -174,11 +191,13 @@ export const TaskStreamFilter = () => {
                   colorPalette={bothActive ? "brand" : "gray"}
                   disabled={currentTaskId === undefined}
                   justifyContent="flex-start"
-                  onClick={() => buildFilterSearch(true, true, currentTaskId, depth)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault();
-                      buildFilterSearch(true, true, currentTaskId, depth);
+                  onClick={() =>
+                    buildFilterSearch({ depth, downstream: true, root: currentTaskId, upstream: true })
+                  }
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") {
+                      event.preventDefault();
+                      buildFilterSearch({ depth, downstream: true, root: currentTaskId, upstream: true });
                     }
                   }}
                   size="sm"
@@ -200,13 +219,18 @@ export const TaskStreamFilter = () => {
               <Input
                 disabled={currentTaskId === undefined || !hasActiveFilter}
                 min={0}
-                onChange={(e) => {
-                  const {value} = e.target;
+                onChange={(event) => {
+                  const { value } = event.target;
 
-                  buildFilterSearch(includeUpstream, includeDownstream, filterRoot, value);
+                  buildFilterSearch({
+                    depth: value,
+                    downstream: includeDownstream,
+                    root: filterRoot,
+                    upstream: includeUpstream,
+                  });
                 }}
-                onKeyDown={(e) => {
-                  e.stopPropagation();
+                onKeyDown={(event) => {
+                  event.stopPropagation();
                 }}
                 placeholder="All"
                 size="sm"
@@ -253,7 +277,14 @@ export const TaskStreamFilter = () => {
             {hasActiveFilter && filterRoot !== undefined ? (
               <Menu.Item asChild value="clear">
                 <Button
-                  onClick={() => buildFilterSearch(false, false)}
+                  onClick={() =>
+                    buildFilterSearch({
+                      depth: undefined,
+                      downstream: false,
+                      root: undefined,
+                      upstream: false,
+                    })
+                  }
                   size="sm"
                   variant="outline"
                   width="100%"

--- a/airflow-core/src/airflow/ui/src/layouts/Details/TaskStreamFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/TaskStreamFilter.tsx
@@ -62,32 +62,31 @@ export const TaskStreamFilter = () => {
     upstream: boolean;
   }) => {
     const { depth: newDepth, downstream, root, upstream } = options;
+    const hasDirection = upstream || downstream;
+    const hasRoot = root !== undefined && root !== "";
+    const hasDepth = newDepth !== undefined && newDepth !== "";
 
     if (upstream) {
       searchParams.set("upstream", "true");
     } else {
       searchParams.delete("upstream");
     }
-
     if (downstream) {
       searchParams.set("downstream", "true");
     } else {
       searchParams.delete("downstream");
     }
-
-    if (root !== undefined && root !== "" && (upstream || downstream)) {
+    if (hasRoot && hasDirection) {
       searchParams.set("root", root);
     } else {
       searchParams.delete("root");
       searchParams.delete("mode");
     }
-
-    if (newDepth !== undefined && newDepth !== "" && (upstream || downstream)) {
+    if (hasDepth && hasDirection) {
       searchParams.set("depth", newDepth);
     } else {
       searchParams.delete("depth");
     }
-
     setSearchParams(searchParams);
   };
 
@@ -144,68 +143,36 @@ export const TaskStreamFilter = () => {
                 {translate("dag:panel.taskStreamFilter.direction")}
               </Text>
               <VStack align="stretch" gap={1} width="100%">
-                <Button
-                  color={activeUpstream ? "white" : undefined}
-                  colorPalette={activeUpstream ? "brand" : "gray"}
-                  disabled={currentTaskId === undefined}
-                  justifyContent="flex-start"
-                  onClick={() =>
-                    buildFilterSearch({ depth, downstream: false, root: currentTaskId, upstream: true })
-                  }
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter" || event.key === " ") {
-                      event.preventDefault();
-                      buildFilterSearch({ depth, downstream: false, root: currentTaskId, upstream: true });
-                    }
-                  }}
-                  size="sm"
-                  variant={activeUpstream ? "solid" : "ghost"}
-                  width="100%"
-                >
-                  {translate("dag:panel.taskStreamFilter.options.upstream")}
-                </Button>
+                {[
+                  { active: activeUpstream, down: false, key: "upstream", label: "upstream", up: true },
+                  { active: activeDownstream, down: true, key: "downstream", label: "downstream", up: false },
+                  { active: bothActive, down: true, key: "both", label: "both", up: true },
+                ].map(({ active, down, key, label, up }) => {
+                  const onClick = () =>
+                    buildFilterSearch({ depth, downstream: down, root: currentTaskId, upstream: up });
 
-                <Button
-                  color={activeDownstream ? "white" : undefined}
-                  colorPalette={activeDownstream ? "brand" : "gray"}
-                  disabled={currentTaskId === undefined}
-                  justifyContent="flex-start"
-                  onClick={() =>
-                    buildFilterSearch({ depth, downstream: true, root: currentTaskId, upstream: false })
-                  }
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter" || event.key === " ") {
-                      event.preventDefault();
-                      buildFilterSearch({ depth, downstream: true, root: currentTaskId, upstream: false });
-                    }
-                  }}
-                  size="sm"
-                  variant={activeDownstream ? "solid" : "ghost"}
-                  width="100%"
-                >
-                  {translate("dag:panel.taskStreamFilter.options.downstream")}
-                </Button>
-
-                <Button
-                  color={bothActive ? "white" : undefined}
-                  colorPalette={bothActive ? "brand" : "gray"}
-                  disabled={currentTaskId === undefined}
-                  justifyContent="flex-start"
-                  onClick={() =>
-                    buildFilterSearch({ depth, downstream: true, root: currentTaskId, upstream: true })
-                  }
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter" || event.key === " ") {
-                      event.preventDefault();
-                      buildFilterSearch({ depth, downstream: true, root: currentTaskId, upstream: true });
-                    }
-                  }}
-                  size="sm"
-                  variant={bothActive ? "solid" : "ghost"}
-                  width="100%"
-                >
-                  {translate("dag:panel.taskStreamFilter.options.both")}
-                </Button>
+                  return (
+                    <Button
+                      color={active ? "white" : undefined}
+                      colorPalette={active ? "brand" : "gray"}
+                      disabled={currentTaskId === undefined}
+                      justifyContent="flex-start"
+                      key={key}
+                      onClick={onClick}
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter" || event.key === " ") {
+                          event.preventDefault();
+                          onClick();
+                        }
+                      }}
+                      size="sm"
+                      variant={active ? "solid" : "ghost"}
+                      width="100%"
+                    >
+                      {translate(`dag:panel.taskStreamFilter.options.${label}`)}
+                    </Button>
+                  );
+                })}
               </VStack>
             </VStack>
 

--- a/airflow-core/src/airflow/ui/src/queries/useGridStructure.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useGridStructure.ts
@@ -24,6 +24,7 @@ import { useAutoRefresh } from "src/utils";
 
 export const useGridStructure = ({
   dagRunState,
+  depth,
   hasActiveRun,
   includeDownstream,
   includeUpstream,
@@ -33,6 +34,7 @@ export const useGridStructure = ({
   triggeringUser,
 }: {
   dagRunState?: DagRunState | undefined;
+  depth?: number | undefined;
   hasActiveRun?: boolean;
   includeDownstream?: boolean;
   includeUpstream?: boolean;
@@ -48,6 +50,7 @@ export const useGridStructure = ({
   const { data: dagStructure, ...rest } = useGridServiceGetDagStructure(
     {
       dagId,
+      depth,
       includeDownstream,
       includeUpstream,
       limit,


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

## Context
This PR adds the ability for a user to filter the stream of tasks given a certain depth. It builds further upon the recent implementation of allowing to retrieve a partial dag from a root with a given depth in core and the API.

* closes: #58450

## Example
An example of what the menu will look like is given here:
<img width="1713" height="1050" alt="image" src="https://github.com/user-attachments/assets/3396b3d4-e72c-49cf-b07a-7bc4f563f525" />

## UX Changes
What's changed is that we now allow for the setting of a depth parameter. In which the user will only see an X amount of tasks away from the `root`. 

The idea of having this depth was to allow the user to traverse the graph a bit easier, which is useful when the DAGs get complex, to understand how tasks are related to one another. However, with a static filter, the depth parameter will require a lot of clicks from the user. At the same time, we don't want to get rid of the static filter, because it's useful to check some task information without necessarily altering the current view of the graph/grid (If the filter is not static, selecting another task will make that task the `root` in the filter and completely alter the view, making retrieving task logs a more intrusive operation). 

In order to get the best in each scenario, I introduce a mode for Task Stream filtering. A user can then specify themself whether they want to "traverse" the DAG, or investigate the "static" view. 

Happy to discuss whether this makes sense, or how it can be improved!

## Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Claude Sonnet 4.5

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
