### PR TITLE
Skip metadata DB check in KubernetesExecutor worker pods

### DIFF
--- a/scripts/docker/entrypoint_prod.sh
+++ b/scripts/docker/entrypoint_prod.sh
@@ -283,9 +283,16 @@ readonly CONNECTION_CHECK_SLEEP_TIME
 
 create_system_user_if_missing
 set_pythonpath_for_root_user
+
 if [[ "${CONNECTION_CHECK_MAX_COUNT}" -gt "0" ]]; then
-    wait_for_airflow_db
+    case "$1" in
+        scheduler|dag-processor|api-server|triggerer)
+            wait_for_airflow_db
+            ;;
+    esac
 fi
+
+
 
 if [[ -n "${_AIRFLOW_DB_UPGRADE=}" ]] || [[ -n "${_AIRFLOW_DB_MIGRATE=}" ]] ; then
     migrate_db


### PR DESCRIPTION
This PR fixes an issue where KubernetesExecutor worker pods attempt to
connect directly to the metadata database during startup.

In Airflow 3.x, worker pods are expected to communicate via the API server
and should not require direct metadata DB access.

This change adds a minimal conditional guard to skip the metadata DB
availability check when running inside a KubernetesExecutor worker pod.

- Single-file change
- No behavior change for scheduler, webserver, or other executors
- No configuration changes

Closes #60271
