### PR TITLE
Fix `TypeError: unhashable type: 'dict'` in Asset.__hash__()

### DIFF
--- a/task-sdk/src/airflow/sdk/definitions/asset/__init__.py
+++ b/task-sdk/src/airflow/sdk/definitions/asset/__init__.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import operator
 import os
@@ -378,7 +379,7 @@ class Asset(os.PathLike, BaseAsset):
 
     def __hash__(self):
         f = attrs.filters.include(*attrs.fields_dict(Asset))
-        return hash(attrs.asdict(self, filter=f))
+        return hash(json.dumps(attrs.asdict(self, filter=f), sort_keys=True))
 
     @property
     def normalized_uri(self) -> str | None:

--- a/task-sdk/tests/task_sdk/definitions/test_asset.py
+++ b/task-sdk/tests/task_sdk/definitions/test_asset.py
@@ -192,6 +192,19 @@ def test_not_equal_when_different_uri():
     assert asset1 != asset2
 
 
+def test_hash_for_same_uri():
+    asset1 = Asset(uri="s3://example/asset")
+    asset2 = Asset(uri="s3://example/asset")
+
+    assert hash(asset1) == hash(asset2)
+
+
+def test_hash_for_different_uri():
+    asset1 = Asset(uri="s3://bucket1/data1")
+    asset2 = Asset(uri="s3://bucket2/data2")
+    assert hash(asset1) != hash(asset2)
+
+
 asset1 = Asset(uri="s3://bucket1/data1", name="asset-1")
 asset2 = Asset(uri="s3://bucket2/data2", name="asset-2")
 asset3 = Asset(uri="s3://bucket3/data3", name="asset-3")


### PR DESCRIPTION
## What change does this PR introduce?
  - Fixes the method `airflow.sdk.definitions.asset.Asset.__hash__()` in task-sdk which was attempting to hash a dictionary directly, causing a `TypeError`.
  - The current implementation attempts to hash a dictionary directly, which is not allowed in Python since dictionaries are mutable and unhashable. This prevents Asset objects from being used in sets or as dictionary keys, which is inconsistent with the `__eq__` implementation.

## Changes
- Modified `__hash__` to serialize the attrs dictionary to JSON string using `json.dumps(sort_keys=True)` before hashing.
  - Applied the same pattern used in the codebase for hashing dictionaries:
    - Similar to airflow/triggers/base.py:147 which uses json.dumps() to serialize kwargs before hashing.
    - Similar to airflow/providers/standard/operators/python.py:834-836 which uses json.dumps(hash_dict, sort_keys=True) to create a hashable string.

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
