### PR TITLE
docs:clarify relationship between Context and template context

### DIFF
--- a/airflow-core/docs/templates-ref.rst
+++ b/airflow-core/docs/templates-ref.rst
@@ -22,6 +22,10 @@ Templates reference
 
 Variables, macros and filters can be used in templates (see the :ref:`concepts:jinja-templating` section)
 
+The variables listed on this page are provided via Airflow's execution-time context.
+
+When using the Task SDK, the same execution-time context is also available programmatically via the :class:`airflow.sdk.Context` object.
+
 The following come for free out of the box with Airflow.
 Additional custom macros can be added globally through :doc:`administration-and-deployment/plugins`, or at a Dag level through the
 ``DAG.user_defined_macros`` argument.

--- a/task-sdk/docs/api.rst
+++ b/task-sdk/docs/api.rst
@@ -162,6 +162,13 @@ Execution Time Components
 
 .. autoapiclass:: airflow.sdk.Context
 
+The ``Context`` object represents the execution-time context available to tasks.
+It corresponds to the same context that is exposed to Jinja templates during task execution.
+
+For a complete list of available context variables (such as ``dag_run``,
+``task_instance``, ``logical_date``, etc.), see the
+:ref:`Templates reference <templates-ref>`.
+
 .. rubric:: Logging
 
 .. autofunction:: airflow.sdk.log.mask_secret


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes 

Generated-by: ChatGPT following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---
This PR clarifies the relationship between Airflow’s execution-time template context and the Task SDK Context object.

### What is changed
- Added a short explanatory note in the templates reference to explain that the listed variables are provided via the execution-time context
- Added a cross-reference to airflow.sdk.Context for users working with the Task SDK

### Why this is needed
The Context API documentation does not currently explain how it relates to the template context described in the templates reference, which can be confusing for users moving between templating and Task SDK usage.

This change improves discoverability without duplicating documentation.

Closes: #60476
