### PR TITLE
Use minimal hashes to decide whether to update or create new versions

### DIFF
--- a/airflow-core/src/airflow/models/serialized_dag.py
+++ b/airflow-core/src/airflow/models/serialized_dag.py
@@ -382,9 +382,6 @@ class SerializedDagModel(Base):
         "doc_json",
         "doc_yaml",
         "doc_rst",
-        # Scheduling
-        "start_date",
-        "end_date",
         # Template metadata (not actual values)
         "template_fields",
         "template_ext",
@@ -397,9 +394,6 @@ class SerializedDagModel(Base):
         # Display/documentation
         "description",
         "doc_md",
-        # Scheduling
-        "start_date",
-        "end_date",
         # Config
         "render_template_as_native_obj",
         # Location (can change without affecting logic)

--- a/airflow-core/tests/unit/models/test_dagcode.py
+++ b/airflow-core/tests/unit/models/test_dagcode.py
@@ -163,7 +163,7 @@ class TestDagCode:
 
         assert result.source_code is not None
 
-        example_dag.doc_md = "new doc"
+        example_dag.tags.add("new_doc")
         with patch("airflow.models.dagcode.DagCode.get_code_from_file") as mock_code:
             mock_code.return_value = "# dummy code"
             sync_dag_to_db(example_dag, session=session)


### PR DESCRIPTION
While the main dag_hash remains, this adds a minimal hashing for deciding
whether to create a new serialized dag version or update an existing
serialized dag entry. This helps control the serialized dag churn with
dynamic dags

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
