### PR TITLE
fix: Add AirflowRunFacet to AF3 tasks with externally changed state

### DIFF
--- a/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
@@ -1085,6 +1085,7 @@ class TestOpenLineageListenerAirflow3:
             listener, task_instance = _create_listener_and_task_instance()
             # Now you can use listener and task_instance in your tests to simulate their interaction.
         """
+        from airflow.sdk.definitions.dag import DAG
 
         if not runtime_ti:
             # TaskInstance is used when on API server (when listener gets called about manual state change)
@@ -1097,15 +1098,27 @@ class TestOpenLineageListenerAirflow3:
                 )
             else:
                 task_instance = TaskInstance(task=MagicMock(), dag_version_id=uuid7())
+
+            dag = DAG(
+                dag_id="dag_id_from_dag_not_ti",
+                description="Test DAG Description",
+                tags=["tag1", "tag2"],
+            )
+            task = EmptyOperator(
+                task_id="task_id_from_task_not_ti", dag=dag, owner="task_owner", doc_md="TASK Description"
+            )
+
             task_instance.dag_run = DagRun()
             task_instance.dag_run.dag_id = "dag_id_from_dagrun_and_not_ti"
             task_instance.dag_run.run_id = "dag_run_run_id"
             task_instance.dag_run.clear_number = 0
             task_instance.dag_run.logical_date = timezone.datetime(2020, 1, 1, 1, 1, 1)
             task_instance.dag_run.run_after = timezone.datetime(2020, 1, 1, 1, 1, 1)
+            task_instance.dag_run.data_interval_start = timezone.datetime(2020, 1, 1, 1, 1, 1)
+            task_instance.dag_run.data_interval_end = timezone.datetime(2020, 1, 1, 1, 1, 1)
             task_instance.dag_run.state = DagRunState.RUNNING
-            task_instance.task = None
-            task_instance.dag = None
+            task_instance.task = task  # type: ignore[assignment]  # For testing we'll avoid serialization
+            task_instance.dag = dag
             task_instance.task_id = "task_id"
             task_instance.dag_id = "dag_id"
             task_instance.try_number = 1
@@ -1119,7 +1132,6 @@ class TestOpenLineageListenerAirflow3:
                 TaskInstance as SdkTaskInstance,
                 TIRunContext,
             )
-            from airflow.sdk.definitions.dag import DAG
             from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
 
             dag = DAG(
@@ -1447,6 +1459,7 @@ class TestOpenLineageListenerAirflow3:
     @mock.patch("airflow.providers.openlineage.plugins.adapter.OpenLineageAdapter.emit")
     @mock.patch("airflow.providers.openlineage.conf.debug_mode", return_value=True)
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_debug_facet")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_run_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_task_parent_run_facet")
     @mock.patch(
         "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
@@ -1454,6 +1467,7 @@ class TestOpenLineageListenerAirflow3:
     def test_adapter_fail_task_is_called_with_proper_arguments_for_db_task_instance_model(
         self,
         mock_get_task_parent_run_facet,
+        mock_get_airflow_run_facet,
         mock_debug_facet,
         mock_debug_mode,
         mock_emit,
@@ -1467,6 +1481,7 @@ class TestOpenLineageListenerAirflow3:
         time_machine.move_to(timezone.datetime(2023, 1, 3, 13, 1, 1), tick=False)
 
         listener, task_instance = self._create_listener_and_task_instance(runtime_ti=False)
+        mock_get_airflow_run_facet.return_value = {"airflow": 3}
         mock_get_task_parent_run_facet.return_value = {"parent": 4}
         mock_debug_facet.return_value = {"debug": "packages"}
 
@@ -1483,14 +1498,15 @@ class TestOpenLineageListenerAirflow3:
             job_name="dag_id.task_id",
             run_id="2020-01-01T01:01:01+00:00.dag_id.task_id.1.-1",
             task=OperatorLineage(),
-            nominal_start_time=None,
-            nominal_end_time=None,
-            tags=None,
-            owners=None,
-            job_description=None,
-            job_description_type=None,
+            nominal_start_time="2020-01-01T01:01:01+00:00",
+            nominal_end_time="2020-01-01T01:01:01+00:00",
+            tags={"tag1", "tag2"},
+            owners=["task_owner"],
+            job_description="TASK Description",
+            job_description_type="text/markdown",
             run_facets={
                 "parent": 4,
+                "airflow": 3,
                 "debug": "packages",
             },
             error=err,
@@ -1645,6 +1661,7 @@ class TestOpenLineageListenerAirflow3:
         time_machine.move_to(timezone.datetime(2023, 1, 3, 13, 1, 1), tick=False)
 
         listener, task_instance = self._create_listener_and_task_instance(runtime_ti=False)
+        delattr(task_instance, "task")  # Test api server path, where task is not available
         mock_get_task_parent_run_facet.return_value = {"parent": 4}
         mock_debug_facet.return_value = {"debug": "packages"}
 
@@ -1661,8 +1678,8 @@ class TestOpenLineageListenerAirflow3:
             job_name="dag_id.task_id",
             run_id="2020-01-01T01:01:01+00:00.dag_id.task_id.1.-1",
             task=OperatorLineage(),
-            nominal_start_time=None,
-            nominal_end_time=None,
+            nominal_start_time="2020-01-01T01:01:01+00:00",
+            nominal_end_time="2020-01-01T01:01:01+00:00",
             tags=None,
             owners=None,
             job_description=None,
@@ -1851,6 +1868,7 @@ class TestOpenLineageListenerAirflow3:
         time_machine.move_to(timezone.datetime(2023, 1, 3, 13, 1, 1), tick=False)
 
         listener, task_instance = self._create_listener_and_task_instance(runtime_ti=False)
+        delattr(task_instance, "task")  # Test api server path, where task is not available
         mock_get_task_parent_run_facet.return_value = {"parent": 4}
         mock_debug_facet.return_value = {"debug": "packages"}
 
@@ -1867,8 +1885,8 @@ class TestOpenLineageListenerAirflow3:
             job_name="dag_id.task_id",
             run_id="2020-01-01T01:01:01+00:00.dag_id.task_id.1.-1",
             task=OperatorLineage(),
-            nominal_start_time=None,
-            nominal_end_time=None,
+            nominal_start_time="2020-01-01T01:01:01+00:00",
+            nominal_end_time="2020-01-01T01:01:01+00:00",
             tags=None,
             owners=None,
             job_description=None,


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

There is still one case in Airflow 3, where the `_on_task_instance_*` listener method is being called on scheduler and as a result, is using DB TaskInstance model instead of `RuntimeTaskInstance`. The call is [here](https://github.com/apache/airflow/blob/c58bdfca4b740fce2ee76f34b738c9b3b7307498/airflow-core/src/airflow/jobs/scheduler_job_runner.py#L1146), when external task state change is being handled, the `ti.fetch_handle_failure_context` is calling `get_listener_manager().hook.on_task_instance_failed`. Currently, for complete/fail listener methods, for DB TaskInstance model, we're calling the `_on_task_instance_manual_state_change` path, which is generally correct, as it does not call any user code (as opposed to `_on_task_instance_success` and `_on_task_instance_failed` that may call user custom run facets function and operator OL method). So to correctly handle this scheduler call, I've kept it as manual state change (we should maybe rename it to external, but it's still relevant) and I just added some checks that will create airflowrunfacet in that scenario, since we have all the models there (we still don't on api server). Added appropriate comments and tests.

So TLDR; when task state is externally changed the event will be emitted from scheduler as it is now but with additional AirflowRunFacet when possible.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
