### PR TITLE
Fix: Enable descending sort for Start Date in Task Instances view

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
@@ -154,7 +154,9 @@ const taskInstanceColumns = ({
       ) : (
         <Time datetime={original.start_date} />
       ),
+    enableSorting: true,
     header: translate("startDate"),
+    id: "start_date",
   },
   {
     accessorKey: "end_date",


### PR DESCRIPTION
### Description
This PR addresses issue #60576. 

Currently, the Start Date column in the Task Instances view does not toggle to a descending sort when clicked. It only toggles between unsorted and ascending. This behavior is misleading because the backend correctly supports descending sort (verified by manually adding ?sort=-start_date to the URL).

The issue was caused by the missing explicit id in the column definition, which prevented TanStack Table from correctly mapping the sorting state for the complex cell renderer used in the Start Date column.

#### Changes introduced:
`TaskInstances.tsx`: Added an explicit `id: "start_date"` to the column definition to ensure proper state mapping during sorting toggles.

`TaskInstances.tsx`: Added `enableSorting: true` to the Start Date column to ensure the full sorting cycle (**Ascending -> Descending -> None**) is active.


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
