### PR TITLE
Handling the job cancel in case of timeouts

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/triggers/base.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/triggers/base.py
@@ -162,7 +162,7 @@ class AwsBaseWaiterTrigger(BaseTrigger):
             )
             yield TriggerEvent({"status": "success", self.return_key: self.return_value})
 
-    async def cancel(self):
+    async def cleanup(self):
         hook = self.hook()
         async with await hook.get_async_conn() as client:
             if not self.cancel_waiter_names:

--- a/providers/amazon/src/airflow/providers/amazon/aws/triggers/emr.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/triggers/emr.py
@@ -174,6 +174,7 @@ class EmrContainerTrigger(AwsBaseWaiterTrigger):
             waiter_delay=waiter_delay,
             waiter_max_attempts=waiter_max_attempts,
             aws_conn_id=aws_conn_id,
+            cancel_waiter_names=["container_job_cancel", "container_job_complete"],
         )
 
     def hook(self) -> AwsGenericHook:

--- a/providers/amazon/src/airflow/providers/amazon/aws/waiters/emr-containers.json
+++ b/providers/amazon/src/airflow/providers/amazon/aws/waiters/emr-containers.json
@@ -25,6 +25,18 @@
                     "state": "failure"
                 }
             ]
+        },
+        "container_job_cancel": {
+            "operation": "CancelJobRun",
+            "delay": 30,
+            "maxAttempts": 60,
+            "acceptors": [
+                {
+                    "matcher": "status",
+                    "expected": "200",
+                    "state": "success"
+                }
+            ]
         }
     }
 }


### PR DESCRIPTION
Resolves https://github.com/apache/airflow/issues/60517
The timeouts for the deferred operators are not handled properly. This fixes the by implementing the cleanup method.