### PR TITLE
fix(edge3): Resolve edge worker 405 error by deferring table creation to FastAPI startup

### DIFF
--- a/providers/edge3/src/airflow/providers/edge3/worker_api/app.py
+++ b/providers/edge3/src/airflow/providers/edge3/worker_api/app.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+from collections.abc import AsyncGenerator, Callable
 from pathlib import Path
 
 from fastapi import FastAPI
@@ -28,7 +29,9 @@ from airflow.providers.edge3.worker_api.routes.ui import ui_router
 from airflow.providers.edge3.worker_api.routes.worker import worker_router
 
 
-def create_edge_worker_api_app() -> FastAPI:
+def create_edge_worker_api_app(
+    lifespan: Callable[[FastAPI], AsyncGenerator[None, None]] | None = None,
+) -> FastAPI:
     """Create FastAPI app for edge worker API."""
     edge_worker_api_app = FastAPI(
         title="Airflow Edge Worker API",
@@ -40,6 +43,7 @@ def create_edge_worker_api_app() -> FastAPI:
             "All endpoints under ``/edge_worker/ui`` are used by UI and can be accessed with normal authentication. "
             "Please assume UI endpoints to change and not be stable."
         ),
+        lifespan=lifespan,
     )
 
     edge_worker_api_app.include_router(jobs_router, prefix="/v1")

--- a/providers/edge3/src/airflow/providers/edge3/worker_api/app.py
+++ b/providers/edge3/src/airflow/providers/edge3/worker_api/app.py
@@ -16,8 +16,8 @@
 # under the License.
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator, Callable
 from pathlib import Path
+from typing import Any
 
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
@@ -30,7 +30,7 @@ from airflow.providers.edge3.worker_api.routes.worker import worker_router
 
 
 def create_edge_worker_api_app(
-    lifespan: Callable[[FastAPI], AsyncGenerator[None, None]] | None = None,
+    lifespan: Any = None,
 ) -> FastAPI:
     """Create FastAPI app for edge worker API."""
     edge_worker_api_app = FastAPI(


### PR DESCRIPTION
**Closes:** #60261

## Summary

This PR fixes the intermittent `405 Method Not Allowed` error that edge workers encounter during startup in high-concurrency environments (e.g., 8 API servers × 64 worker processes).

## Root Cause

The edge executor plugin was acquiring a global database lock (`DBLocks.MIGRATIONS`) **at class definition time** (plugin import) to create tables. When many API server processes started simultaneously, they all competed for the same lock, causing:

1. `psycopg2.errors.LockNotAvailable` errors on lock timeout
2. Plugin import failures → edge worker endpoints not registered
3. Edge workers receiving `405 Method Not Allowed` for `/edge_worker/v1/worker/`

## Solution
- Moved table creation from plugin import time to a **FastAPI startup event**
- Plugin import no longer blocks on database operations
- Added retry mechanism (5 attempts) for lock acquisition
- Exponential backoff with jitter to avoid thundering herd
- Proper logging for debugging
- Check if tables exist **before** attempting to acquire lock
- Skip lock entirely during normal operation (tables already exist)
- Double-check pattern after lock acquisition to handle race conditions