### PR TITLE
Mark pending-response PRs stale after 7 days

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,6 +29,7 @@ jobs:
   stale:
     runs-on: ["ubuntu-22.04"]
     steps:
+      # Handle all PRs (45-day stale) and pending-response issues (14-day stale)
       - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639  # v9.1.0
         with:
           stale-pr-message: >
@@ -37,7 +38,7 @@ jobs:
             for your contributions.
           days-before-pr-stale: 45
           days-before-pr-close: 5
-          exempt-pr-labels: 'pinned,security'
+          exempt-pr-labels: 'pinned,security,pending-response'
           only-issue-labels: 'pending-response'
           remove-stale-when-updated: true
           days-before-issue-stale: 14
@@ -48,3 +49,20 @@ jobs:
             activity occurs from the issue author.
           close-issue-message: >
             This issue has been closed because it has not received response from the issue author.
+      # Handle PRs with pending-response label (7-day stale, faster response expected)
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639  # v9.1.0
+        with:
+          only-pr-labels: 'pending-response'
+          days-before-pr-stale: 7
+          days-before-pr-close: 7
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because the author has not
+            responded to a request for more information. It will be closed in 7 days if no further
+            activity occurs. Thank you for your contributions.
+          close-pr-message: >
+            This pull request has been closed because the author has not responded to a request
+            for more information.
+          labels-to-remove-when-unstale: 'pending-response,stale'
+          remove-stale-when-updated: true
+          days-before-issue-stale: -1
+          days-before-issue-close: -1


### PR DESCRIPTION
PRs with the pending-response label now go stale after 7 days instead of 45 days. When the author responds or pushes, the pending-response and stale labels are automatically removed.

As discussed on the dev list, we have gathered a good number of PRs where PR author hasn't responded. 

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
