### PR TITLE
Explicitly set table ordering

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/DataTable/DataTable.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DataTable/DataTable.tsx
@@ -129,7 +129,7 @@ export const DataTable = <TData,>({
     onStateChange: handleStateChange,
     rowCount: total,
     // We need to manually set the sort toggle buttons for undefined values
-    sortDescFirst: true,
+    sortDescFirst: false,
     state: { ...initialState, columnVisibility },
     ...rest,
   });

--- a/airflow-core/src/airflow/ui/src/components/DataTable/DataTable.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DataTable/DataTable.tsx
@@ -128,6 +128,8 @@ export const DataTable = <TData,>({
     onColumnVisibilityChange: setColumnVisibility,
     onStateChange: handleStateChange,
     rowCount: total,
+    // We need to manually set the sort toggle buttons for undefined values
+    sortDescFirst: true,
     state: { ...initialState, columnVisibility },
     ...rest,
   });

--- a/airflow-core/src/airflow/ui/src/components/DataTable/TableList.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DataTable/TableList.tsx
@@ -56,24 +56,13 @@ export const TableList = <TData,>({ allowFiltering, renderSubComponent, table }:
                   rightIcon = <TiArrowUnsorted aria-label={translate("sortedUnsorted")} />;
                 }
 
-                // Custom sort toggle: unsorted -> asc -> desc -> unsorted
-                const handleSortClick = () => {
-                  if (sort === false) {
-                    column.toggleSorting(false);
-                  } else if (sort === "asc") {
-                    column.toggleSorting(true);
-                  } else {
-                    column.clearSorting();
-                  }
-                };
-
                 return (
                   <Table.ColumnHeader colSpan={colSpan} key={id} whiteSpace="nowrap">
                     {isPlaceholder ? undefined : (
                       <Button
                         aria-label={translate("sort")}
                         disabled={!canSort}
-                        onClick={handleSortClick}
+                        onClick={column.getToggleSortingHandler()}
                         variant="plain"
                       >
                         {text}

--- a/airflow-core/src/airflow/ui/src/components/DataTable/TableList.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DataTable/TableList.tsx
@@ -59,13 +59,10 @@ export const TableList = <TData,>({ allowFiltering, renderSubComponent, table }:
                 // Custom sort toggle: unsorted -> asc -> desc -> unsorted
                 const handleSortClick = () => {
                   if (sort === false) {
-                    // Currently unsorted -> sort ascending
                     column.toggleSorting(false);
                   } else if (sort === "asc") {
-                    // Currently ascending -> sort descending
                     column.toggleSorting(true);
                   } else {
-                    // Currently descending -> clear sort
                     column.clearSorting();
                   }
                 };

--- a/airflow-core/src/airflow/ui/src/components/DataTable/TableList.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DataTable/TableList.tsx
@@ -56,13 +56,27 @@ export const TableList = <TData,>({ allowFiltering, renderSubComponent, table }:
                   rightIcon = <TiArrowUnsorted aria-label={translate("sortedUnsorted")} />;
                 }
 
+                // Custom sort toggle: unsorted -> asc -> desc -> unsorted
+                const handleSortClick = () => {
+                  if (sort === false) {
+                    // Currently unsorted -> sort ascending
+                    column.toggleSorting(false);
+                  } else if (sort === "asc") {
+                    // Currently ascending -> sort descending
+                    column.toggleSorting(true);
+                  } else {
+                    // Currently descending -> clear sort
+                    column.clearSorting();
+                  }
+                };
+
                 return (
                   <Table.ColumnHeader colSpan={colSpan} key={id} whiteSpace="nowrap">
                     {isPlaceholder ? undefined : (
                       <Button
                         aria-label={translate("sort")}
                         disabled={!canSort}
-                        onClick={column.getToggleSortingHandler()}
+                        onClick={handleSortClick}
                         variant="plain"
                       >
                         {text}

--- a/airflow-core/src/airflow/ui/src/pages/DagRuns.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagRuns.tsx
@@ -209,7 +209,7 @@ export const DagRuns = () => {
 
   const refetchInterval = useAutoRefresh({});
 
-  const { data, error, isFetching, isLoading } = useDagRunServiceGetDagRuns(
+  const { data, error, isLoading } = useDagRunServiceGetDagRuns(
     {
       confContains: confContains !== null && confContains !== "" ? confContains : undefined,
       dagId: dagId ?? "~",
@@ -248,7 +248,6 @@ export const DagRuns = () => {
         data={data?.dag_runs ?? []}
         errorMessage={<ErrorAlert error={error} />}
         initialState={tableURLState}
-        isFetching={isFetching}
         isLoading={isLoading}
         modelName="common:dagRun"
         onStateChange={setTableURLState}

--- a/airflow-core/src/airflow/ui/src/pages/DagRuns.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagRuns.tsx
@@ -209,7 +209,7 @@ export const DagRuns = () => {
 
   const refetchInterval = useAutoRefresh({});
 
-  const { data, error, isLoading } = useDagRunServiceGetDagRuns(
+  const { data, error, isFetching, isLoading } = useDagRunServiceGetDagRuns(
     {
       confContains: confContains !== null && confContains !== "" ? confContains : undefined,
       dagId: dagId ?? "~",
@@ -232,6 +232,7 @@ export const DagRuns = () => {
     },
     undefined,
     {
+      placeholderData: (prev) => prev,
       refetchInterval: (query) =>
         query.state.data?.dag_runs.some((run) => isStatePending(run.state)) ? refetchInterval : false,
     },
@@ -247,6 +248,7 @@ export const DagRuns = () => {
         data={data?.dag_runs ?? []}
         errorMessage={<ErrorAlert error={error} />}
         initialState={tableURLState}
+        isFetching={isFetching}
         isLoading={isLoading}
         modelName="common:dagRun"
         onStateChange={setTableURLState}

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
@@ -257,7 +257,7 @@ export const TaskInstances = () => {
 
   const refetchInterval = useAutoRefresh({});
 
-  const { data, error, isFetching, isLoading } = useTaskInstanceServiceGetTaskInstances(
+  const { data, error, isLoading } = useTaskInstanceServiceGetTaskInstances(
     {
       dagId: dagId ?? "~",
       dagIdPattern: filteredDagIdPattern ?? undefined,
@@ -307,7 +307,6 @@ export const TaskInstances = () => {
         data={data?.task_instances ?? []}
         errorMessage={<ErrorAlert error={error} />}
         initialState={tableURLState}
-        isFetching={isFetching}
         isLoading={isLoading}
         modelName="common:taskInstance"
         onStateChange={setTableURLState}

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
@@ -235,7 +235,7 @@ export const TaskInstances = () => {
   });
   const { pagination, sorting } = tableURLState;
   const [sort] = sorting;
-  const orderBy = sort ? [`${sort.desc ? "-" : ""}${sort.id}`] : ["-start_date", "-run_after"];
+  const orderBy = sort ? [`${sort.desc ? "-" : ""}${sort.id}`] : ["-run_after"];
 
   const filteredState = searchParams.getAll(STATE_PARAM);
   const filteredDagVersion = searchParams.get(DAG_VERSION_PARAM);

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
@@ -235,7 +235,7 @@ export const TaskInstances = () => {
   });
   const { pagination, sorting } = tableURLState;
   const [sort] = sorting;
-  const orderBy = sort ? [`${sort.desc ? "-" : ""}${sort.id}`] : ["-run_after"];
+  const orderBy = sort ? [`${sort.desc ? "-" : ""}${sort.id}`] : ["-start_date", "-run_after"];
 
   const filteredState = searchParams.getAll(STATE_PARAM);
   const filteredDagVersion = searchParams.get(DAG_VERSION_PARAM);

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
@@ -257,7 +257,7 @@ export const TaskInstances = () => {
 
   const refetchInterval = useAutoRefresh({});
 
-  const { data, error, isLoading } = useTaskInstanceServiceGetTaskInstances(
+  const { data, error, isFetching, isLoading } = useTaskInstanceServiceGetTaskInstances(
     {
       dagId: dagId ?? "~",
       dagIdPattern: filteredDagIdPattern ?? undefined,
@@ -286,6 +286,7 @@ export const TaskInstances = () => {
     },
     undefined,
     {
+      placeholderData: (prev) => prev,
       refetchInterval: (query) =>
         query.state.data?.task_instances.some((ti) => isStatePending(ti.state)) ? refetchInterval : false,
     },
@@ -306,6 +307,7 @@ export const TaskInstances = () => {
         data={data?.task_instances ?? []}
         errorMessage={<ErrorAlert error={error} />}
         initialState={tableURLState}
+        isFetching={isFetching}
         isLoading={isLoading}
         modelName="common:taskInstance"
         onStateChange={setTableURLState}


### PR DESCRIPTION
The sort handler for tansStack/table was inconsistent with when it cycled between sort states if it had a default value. Implementing it ourselves makes sure it always appears.

Closes https://github.com/apache/airflow/issues/60576


Also, added add a placeholder data of the previous data to prevent the whole table from showing a loading page when a user does change the sorting.

##### Was generative AI tooling used to co-author this PR?

- [ ] 


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
