### PR TITLE
Revert exclusion of deltalake 1.3.1 as aarch64 binaries are available now

### DIFF
--- a/contributing-docs/testing/unit_tests.rst
+++ b/contributing-docs/testing/unit_tests.rst
@@ -1365,8 +1365,8 @@ to figure out one of the problems:
         "apache-airflow-providers-common-sql",
         "apache-airflow-providers-fab",
         # Additional devel dependencies (do not remove this line and add extra development dependencies)
-        # Limit deltalake to avoid issue with missing linux ARM wheels: https://github.com/delta-io/delta-rs/issues/4041
-        "deltalake>=1.1.3,!=1.3.0,!=1.3.1",
+        # Need to exclude 1.3.0 due to missing aarch64 binaries, fixed with 1.3.1++
+        "deltalake>=1.1.3,!=1.3.0",
         "apache-airflow-providers-microsoft-azure",
     ]
 

--- a/providers/databricks/pyproject.toml
+++ b/providers/databricks/pyproject.toml
@@ -103,8 +103,8 @@ dev = [
     "apache-airflow-providers-common-sql",
     "apache-airflow-providers-openlineage",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
-    # Limit deltalake to avoid issue with missing linux ARM wheels: https://github.com/delta-io/delta-rs/issues/4041
-    "deltalake>=1.1.3,!=1.3.0,!=1.3.1",
+    # Need to exclude 1.3.0 due to missing aarch64 binaries, fixed with 1.3.1++
+    "deltalake>=1.1.3,!=1.3.0",
     "apache-airflow-providers-fab>=2.2.0; python_version < '3.13'",
     "apache-airflow-providers-microsoft-azure",
     "apache-airflow-providers-common-sql[pandas,polars]",


### PR DESCRIPTION
As aarch64 binaries are re-generated for 1.3.1 we can remove the limit. Also deltalake 1.3.2 was released with also aarch64. So https://github.com/delta-io/delta-rs/issues/4041 is really resolved.

##### Was generative AI tooling used to co-author this PR?

- [ ] Nö (please specify the tool below)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
