### PR TITLE
Add jscheffl for K8s provider as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,9 +9,6 @@
 # DAG Parsing
 /airflow-core/src/airflow/dag_processing @jedcunningham @ephraimbuddy
 
-# Kubernetes
-/providers/cncf/kubernetes/ @dstandish @jedcunningham
-
 # Helm Chart
 /chart/ @jedcunningham @hussein-awala @jscheffl
 
@@ -51,7 +48,7 @@ airflow-core/src/airflow/ui/public/i18n/locales/he/ @shahar1 @romsharon98 # +@De
 airflow-core/src/airflow/ui/public/i18n/locales/hi/ @vatsrahul1001
 airflow-core/src/airflow/ui/public/i18n/locales/hu/ @jscheffl @potiuk # +@majorosdonat
 airflow-core/src/airflow/ui/public/i18n/locales/it/ @bbovenzi # + @aoelvp94
-airflow-core/src/airflow/ui/public/i18n/locales/ja/  @uranusjr @sekikn # + @rsanda
+airflow-core/src/airflow/ui/public/i18n/locales/ja/ @uranusjr @sekikn # + @rsanda
 airflow-core/src/airflow/ui/public/i18n/locales/ko/ @choo121600 # + @kgw7401 @onestn @noeunkim
 airflow-core/src/airflow/ui/public/i18n/locales/nl/ @BasPH # + @DjVinnii
 airflow-core/src/airflow/ui/public/i18n/locales/pl/ @potiuk @mobuchowski # + @kacpermuda
@@ -89,7 +86,7 @@ airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/ @Lee-W @jason810496 @guan
 /providers/amazon/ @o-nikolas
 /providers/apache/iceberg/ @Fokko
 /providers/celery/ @hussein-awala @dheerajturaga
-/providers/cncf/kubernetes @jedcunningham @hussein-awala
+/providers/cncf/kubernetes @jedcunningham @hussein-awala @scheffl
 /providers/common/messaging/ @vincbeck
 /providers/dbt/cloud/ @josh-fell
 /providers/edge3/ @jscheffl @dheerajturaga
@@ -116,10 +113,10 @@ Dockerfile.ci @potiuk @ashb @gopidesupavan @amoghrajesh @jscheffl @bugraoz93 @ka
 /airflow-e2e-tests/ @potiuk @ashb @gopidesupavan @amoghrajesh @jscheffl @bugraoz93 @kaxil @jason810496
 
 # Task SDK integration tests
-/task-sdk-integration-tests/ @potiuk @ashb @gopidesupavan @amoghrajesh @jscheffl @bugraoz93 @kaxil @jason810496
+/task-sdk-integration-tests/ @potiuk @ashb @gopidesupavan @amoghrajesh @bugraoz93 @kaxil @jason810496
 
 # airflowctl integration tests
-/airflow-ctl-tests/ @potiuk @ashb @gopidesupavan @amoghrajesh @jscheffl @bugraoz93 @kaxil @jason810496
+/airflow-ctl-tests/ @potiuk @ashb @gopidesupavan @amoghrajesh @bugraoz93 @kaxil @jason810496
 
 # Issue triage process
 # ISSUE_TRIAGE_PROCESS.rst


### PR DESCRIPTION
@vikramkoka asked me to support K8s provider as close to Helm chart as I was reviewing a couple of PRs anyway. Try to join in there... with a bit of reduced capacity as already some other obligations. But willing to help working off backlog.

To compensate removing myself from some integration tests, I assume there are sufficient active contributors.

Note to @dstandish I saw a redundant definition for K8s provider with your name but file is parsed top-down, last match wins. So the entry in line 13 was not effective. If you still want to be in, add yourself to line 89 please!

FYI @jedcunningham 

##### Was generative AI tooling used to co-author this PR?

- [ ] Noooooo (please specify the tool below)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
