### PR TITLE
add operator-level render_template_as_native_obj override

### DIFF
--- a/airflow-core/newsfragments/60619.significant.rst
+++ b/airflow-core/newsfragments/60619.significant.rst
@@ -1,0 +1,22 @@
+Add operator-level ``render_template_as_native_obj`` override
+
+Operators can now override the DAG-level ``render_template_as_native_obj`` setting,
+enabling fine-grained control over whether templates are rendered as native Python
+types or strings on a per-task basis. Set ``render_template_as_native_obj=True`` or
+``False`` on any operator to override the DAG setting, or leave as ``None`` (default)
+to inherit from the DAG.
+
+* Types of change
+
+  * [ ] Dag changes
+  * [ ] Config changes
+  * [ ] API changes
+  * [ ] CLI changes
+  * [x] Behaviour changes
+  * [ ] Plugin changes
+  * [ ] Dependency changes
+  * [ ] Code interface changes
+
+* Migration rules needed
+
+  * None - this is a new optional feature with backwards-compatible defaults

--- a/airflow-core/src/airflow/serialization/definitions/baseoperator.py
+++ b/airflow-core/src/airflow/serialization/definitions/baseoperator.py
@@ -213,6 +213,7 @@ class SerializedBaseOperator(DAGNode):
                 "pool_slots",
                 "priority_weight",
                 "queue",
+                "render_template_as_native_obj",
                 "resources",
                 "retries",
                 "retry_delay",

--- a/airflow-core/src/airflow/serialization/definitions/baseoperator.py
+++ b/airflow-core/src/airflow/serialization/definitions/baseoperator.py
@@ -121,6 +121,7 @@ class SerializedBaseOperator(DAGNode):
     priority_weight: int = 1
     queue: str = "default"
 
+    render_template_as_native_obj: bool | None = None
     resources: dict[str, Any] | None = None
     retries: int = 0
     retry_delay: datetime.timedelta = datetime.timedelta(seconds=300)

--- a/airflow-core/src/airflow/serialization/schema.json
+++ b/airflow-core/src/airflow/serialization/schema.json
@@ -322,6 +322,7 @@
         "_expand_input_attr": { "type": "string" },
         "map_index_template": { "type": "string" },
         "allow_nested_operators": { "type": "boolean", "default": true },
+        "render_template_as_native_obj": { "anyOf": [{"type": "boolean"}, {"type": "null"}], "default": null },
         "inlets": {"type":  "array", "default": []},
         "outlets": {"type":  "array", "default": []},
         "has_on_execute_callback": {"type": "boolean", "default": false},

--- a/airflow-core/tests/unit/serialization/test_dag_serialization.py
+++ b/airflow-core/tests/unit/serialization/test_dag_serialization.py
@@ -1568,6 +1568,7 @@ class TestStringifiedDAGs:
             "pool_slots": 1,
             "priority_weight": 1,
             "queue": "default",
+            "render_template_as_native_obj": None,
             "resources": None,
             "retries": 0,
             "retry_delay": timedelta(0, 300),

--- a/task-sdk/src/airflow/sdk/bases/operator.py
+++ b/task-sdk/src/airflow/sdk/bases/operator.py
@@ -818,6 +818,10 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
                     dag=dag,
                 )
                 hello_world_task.execute(context)
+    :param render_template_as_native_obj: If True, uses a Jinja ``NativeEnvironment``
+        to render templates as native Python types. If False, a Jinja
+        ``Environment`` is used to render templates as string values.
+        If None (default), inherits from the DAG setting.
     """
 
     task_id: str
@@ -874,6 +878,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
     _task_display_name: str | None = None
     logger_name: str | None = None
     allow_nested_operators: bool = True
+    render_template_as_native_obj: bool | None = None
 
     is_setup: bool = False
     is_teardown: bool = False
@@ -1029,6 +1034,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         task_display_name: str | None = None,
         logger_name: str | None = None,
         allow_nested_operators: bool = True,
+        render_template_as_native_obj: bool | None = None,
         **kwargs: Any,
     ):
         # Note: Metaclass handles passing in the Dag/TaskGroup from active context manager, if any
@@ -1155,6 +1161,8 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         self._task_display_name = task_display_name
 
         self.allow_nested_operators = allow_nested_operators
+
+        self.render_template_as_native_obj = render_template_as_native_obj
 
         self._logger_name = logger_name
 

--- a/task-sdk/src/airflow/sdk/definitions/_internal/abstractoperator.py
+++ b/task-sdk/src/airflow/sdk/definitions/_internal/abstractoperator.py
@@ -251,8 +251,26 @@ class AbstractOperator(Templater, DAGNode):
     #   _render
     def get_template_env(self, dag: DAG | None = None) -> jinja2.Environment:
         """Get the template environment for rendering templates."""
+        from airflow.sdk.definitions._internal.templater import create_template_env
+
         if dag is None:
             dag = self.get_dag()
+        # Check if the operator has an explicit native rendering preference
+        render_op_template_as_native_obj = getattr(self, "render_template_as_native_obj", None)
+        if render_op_template_as_native_obj is not None:
+            if dag:
+                # Use dag's template settings (searchpath, macros, filters, etc.)
+                return create_template_env(
+                    native=render_op_template_as_native_obj,
+                    searchpath=[dag.folder] + (dag.template_searchpath or []),
+                    template_undefined=dag.template_undefined,
+                    jinja_environment_kwargs=dag.jinja_environment_kwargs,
+                    user_defined_macros=dag.user_defined_macros,
+                    user_defined_filters=dag.user_defined_filters,
+                )
+            # No dag context available, use minimal template env
+            return create_template_env(native=render_op_template_as_native_obj)
+        # No operator-level override, delegate to parent class
         return super().get_template_env(dag=dag)
 
     def _render(self, template, context, dag: DAG | None = None):

--- a/task-sdk/src/airflow/sdk/definitions/_internal/abstractoperator.py
+++ b/task-sdk/src/airflow/sdk/definitions/_internal/abstractoperator.py
@@ -260,9 +260,12 @@ class AbstractOperator(Templater, DAGNode):
         if render_op_template_as_native_obj is not None:
             if dag:
                 # Use dag's template settings (searchpath, macros, filters, etc.)
+                searchpath = [dag.folder]
+                if dag.template_searchpath:
+                    searchpath += dag.template_searchpath
                 return create_template_env(
                     native=render_op_template_as_native_obj,
-                    searchpath=[dag.folder] + (dag.template_searchpath or []),
+                    searchpath=searchpath,
                     template_undefined=dag.template_undefined,
                     jinja_environment_kwargs=dag.jinja_environment_kwargs,
                     user_defined_macros=dag.user_defined_macros,

--- a/task-sdk/src/airflow/sdk/definitions/dag.py
+++ b/task-sdk/src/airflow/sdk/definitions/dag.py
@@ -775,36 +775,22 @@ class DAG:
 
     def get_template_env(self, *, force_sandboxed: bool = False) -> jinja2.Environment:
         """Build a Jinja2 environment."""
-        from airflow.sdk.definitions._internal.templater import NativeEnvironment, SandboxedEnvironment
+        from airflow.sdk.definitions._internal.templater import create_template_env
 
         # Collect directories to search for template files
         searchpath = [self.folder]
         if self.template_searchpath:
             searchpath += self.template_searchpath
 
-        # Default values (for backward compatibility)
-        jinja_env_options = {
-            "loader": jinja2.FileSystemLoader(searchpath),
-            "undefined": self.template_undefined,
-            "extensions": ["jinja2.ext.do"],
-            "cache_size": 0,
-        }
-        if self.jinja_environment_kwargs:
-            jinja_env_options.update(self.jinja_environment_kwargs)
-        env: jinja2.Environment
-        if self.render_template_as_native_obj and not force_sandboxed:
-            env = NativeEnvironment(**jinja_env_options)
-        else:
-            env = SandboxedEnvironment(**jinja_env_options)
-
-        # Add any user defined items. Safe to edit globals as long as no templates are rendered yet.
-        # http://jinja.pocoo.org/docs/2.10/api/#jinja2.Environment.globals
-        if self.user_defined_macros:
-            env.globals.update(self.user_defined_macros)
-        if self.user_defined_filters:
-            env.filters.update(self.user_defined_filters)
-
-        return env
+        use_native = self.render_template_as_native_obj and not force_sandboxed
+        return create_template_env(
+            native=use_native,
+            searchpath=searchpath,
+            template_undefined=self.template_undefined,
+            jinja_environment_kwargs=self.jinja_environment_kwargs,
+            user_defined_macros=self.user_defined_macros,
+            user_defined_filters=self.user_defined_filters,
+        )
 
     def set_dependency(self, upstream_task_id, downstream_task_id):
         """Set dependency between two tasks that already have been added to the Dag using add_task()."""

--- a/task-sdk/src/airflow/sdk/definitions/mappedoperator.py
+++ b/task-sdk/src/airflow/sdk/definitions/mappedoperator.py
@@ -694,6 +694,14 @@ class MappedOperator(AbstractOperator):
     def allow_nested_operators(self) -> bool:
         return bool(self.partial_kwargs.get("allow_nested_operators"))
 
+    @property
+    def render_template_as_native_obj(self) -> bool | None:
+        return self.partial_kwargs.get("render_template_as_native_obj")
+
+    @render_template_as_native_obj.setter
+    def render_template_as_native_obj(self, value: bool | None) -> None:
+        self.partial_kwargs["render_template_as_native_obj"] = value
+
     def get_dag(self) -> DAG | None:
         """Implement Operator."""
         return self.dag

--- a/task-sdk/tests/task_sdk/definitions/test_mappedoperator.py
+++ b/task-sdk/tests/task_sdk/definitions/test_mappedoperator.py
@@ -723,6 +723,7 @@ def test_mapped_xcom_push_skipped_tasks(create_runtime_ti, mock_supervisor_comms
         ("on_skipped_callback", [], [id]),
         ("inlets", ["a"], ["b"]),
         ("outlets", ["a"], ["b"]),
+        ("render_template_as_native_obj", True, False),
     ],
 )
 def test_setters(setter_name: str, old_value: object, new_value: object) -> None:


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

This PR adds the ability for individual operators to override the DAG-level `render_template_as_native_obj` setting, enabling fine-grained control over template rendering behavior on a per-task basis.

As discussed in https://github.com/apache/airflow/discussions/30266, users have encountered situations where they need mixed template rendering behavior within the same DAG, and it is one I've had to navigate multiple times myself.

Currently, `render_template_as_native_obj` can only be set at the DAG level, which means all tasks in a DAG must use the same template rendering behavior. This can be limiting when you need some tasks to receive native Python types while others need string values.

Usage:
```python3
with DAG("example", render_template_as_native_obj=False):
    # This task renders templates as strings (inherits from DAG)
    task1 = PythonOperator(task_id="string_task", ...)
    
    # This task renders templates as native Python types (overrides DAG)
    task2 = PythonOperator(
        task_id="native_task",
        render_template_as_native_obj=True,
        ...
    )
    
    # Works with mapped operators too
    mapped = PythonOperator.partial(
        task_id="mapped_native",
        render_template_as_native_obj=True,
    ).expand(...)
```

If there are specific reasons why this approach shouldn't be taken, I'd love to hear the feedback. Otherwise, I'm hoping to move this discussion forward as it would be a nice to have!

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
