### PR TITLE
Fix memray error handlings to avoid hiding unrelated errors

### DIFF
--- a/airflow-core/src/airflow/utils/memray_utils.py
+++ b/airflow-core/src/airflow/utils/memray_utils.py
@@ -69,15 +69,14 @@ def enable_memray_trace(component: MemrayTraceComponents) -> Callable[[Callable[
                     return func(*args, **kwargs)
             except ImportError as error:
                 # Silently fall back to running without tracking
-                log.warning(
-                    "ImportError memray.Tracker: %s in %s, please check the memray is installed",
-                    error.msg,
-                    component.value,
-                )
-                return func(*args, **kwargs)
-            except Exception as exception:
-                log.warning("Fail to apply memray.Tracker in %s, error: %s", component.value, exception)
-                return func(*args, **kwargs)
+                if "memray" in str(error):
+                    log.warning(
+                        "ImportError memray.Tracker: %s in %s, please check the memray is installed",
+                        error.msg,
+                        component.value,
+                    )
+                    return func(*args, **kwargs)
+                raise error
 
         return wrapper
 

--- a/airflow-core/tests/unit/utils/test_memray_utils.py
+++ b/airflow-core/tests/unit/utils/test_memray_utils.py
@@ -163,15 +163,3 @@ class TestEnableMemrayTrackErrorHandling:
 
             self.mock_function.assert_called_once_with("arg1")
             assert result == "test_result"
-
-    @conf_vars({("profiling", "memray_trace_components"): "scheduler,api,dag_processor"})
-    def test_graceful_fallback_on_exception(self):
-        """
-        Verify graceful degradation when exception occurs
-        """
-        with patch("memray.Tracker", side_effect=RuntimeError("Failed to initialize tracker")):
-            decorated_function = enable_memray_trace(MemrayTraceComponents.dag_processor)(self.mock_function)
-            result = decorated_function("arg1")
-
-            self.mock_function.assert_called_once_with("arg1")
-            assert result == "test_result"


### PR DESCRIPTION
I'm submitting a PR because error handling needs to be modified in the previously worked on memray integration.
https://github.com/apache/airflow/pull/56821

I discovered that due to this exception, errors unrelated to memray were being ignored. I removed that part and changed the importError section in more detail.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
