### PR TITLE
Increase retry interval and maximum retries for remote logging tests

### DIFF
--- a/airflow-e2e-tests/tests/airflow_e2e_tests/remote_log_tests/test_remote_logging.py
+++ b/airflow-e2e-tests/tests/airflow_e2e_tests/remote_log_tests/test_remote_logging.py
@@ -29,8 +29,8 @@ class TestRemoteLogging:
     airflow_client = AirflowClient()
     dag_id = "example_xcom_test"
     task_count = 6
-    retry_interval_in_seconds = 1
-    max_retries = 5
+    retry_interval_in_seconds = 5
+    max_retries = 12
 
     def test_dag_unpause(self):
         self.airflow_client.un_pause_dag(


### PR DESCRIPTION
## Why

The ‎⁠`TestRemoteLogging.test_remote_logging_s3⁠ test` has been flaky recently. Based on the traceback, some logs were still uploading while the test had already started asserting the expected number of logs.

For example: https://github.com/apache/airflow/actions/runs/21033617855/job/60479030954?pr=60585

<details>

  <summary>Full traceback:</summary>

```
Failed: Expected at least 6 log files in S3 bucket test-airflow-logs, but found 5 objects: ['dag_id=example_xcom_test/run_id=manual__2026-01-15T14:27:11.507649+00:00/task_id=bash_push/attempt=1.log', 'dag_id=example_xcom_test/run_id=manual__2026-01-15T14:27:11.507649+00:00/task_id=pull_value_from_bash_push/attempt=1.log', 'dag_id=example_xcom_test/run_id=manual__2026-01-15T14:27:11.507649+00:00/task_id=puller/attempt=1.log', 'dag_id=example_xcom_test/run_id=manual__2026-01-15T14:27:11.507649+00:00/task_id=push/attempt=1.log', 'dag_id=example_xcom_test/run_id=manual__2026-01-15T14:27:11.507649+00:00/task_id=push_by_returning/attempt=1.log']. 
E           List Objects Response: {'ResponseMetadata': {'RequestId': '565861a9-475f-48f2-a27c-5cea80822c1e', 'HostId': 's9lzHYrFp76ZVxRcpX9+5cjAnEH2ROuNkd2BHfIa6UkFVdtjf5mKR3/eTPFvsiP/XV/VLi31234=', 'HTTPStatusCode': 200, 'HTTPHeaders': {'server': 'TwistedWeb/24.3.0', 'date': 'Thu, 15 Jan 2026 14:27:26 GMT', 'content-type': 'application/xml', 'content-length': '2240', 'x-amz-request-id': '565861a9-475f-48f2-a27c-5cea80822c1e', 'x-amz-id-2': 's9lzHYrFp76ZVxRcpX9+5cjAnEH2ROuNkd2BHfIa6UkFVdtjf5mKR3/eTPFvsiP/XV/VLi31234=', 'x-localstack': 'true'}, 'RetryAttempts': 0}, 'IsTruncated': False, 'Contents': [{'Key': 'dag_id=example_xcom_test/run_id=manual__2026-01-15T14:27:11.507649+00:00/task_id=bash_push/attempt=1.log', 'LastModified': datetime.datetime(2026, 1, 15, 14, 27, 19, tzinfo=tzlocal()), 'ETag': '"2c1f06d3a1201cfb6aecd92ccfdf378e"', 'ChecksumAlgorithm': ['CRC32'], 'ChecksumType': 'FULL_OBJECT', 'Size': 4109, 'StorageClass': 'STANDARD'}, {'Key': 'dag_id=example_xcom_test/run_id=manual__2026-01-15T14:27:11.507649+00:00/task_id=pull_value_from_bash_push/attempt=1.log', 'LastModified': datetime.datetime(2026, 1, 15, 14, 27, 26, tzinfo=tzlocal()), 'ETag': '"bc7ec94ee1b40801ea7b7a6994ee70b9"', 'ChecksumAlgorithm': ['CRC32'], 'ChecksumType': 'FULL_OBJECT', 'Size': 2299, 'StorageClass': 'STANDARD'}, {'Key': 'dag_id=example_xcom_test/run_id=manual__2026-01-15T14:27:11.507649+00:00/task_id=puller/attempt=1.log', 'LastModified': datetime.datetime(2026, 1, 15, 14, 27, 26, tzinfo=tzlocal()), 'ETag': '"a40fd4e657a3777b7bb094c1d01204db"', 'ChecksumAlgorithm': ['CRC32'], 'ChecksumType': 'FULL_OBJECT', 'Size': 1937, 'StorageClass': 'STANDARD'}, {'Key': 'dag_id=example_xcom_test/run_id=manual__2026-01-15T14:27:11.507649+00:00/task_id=push/attempt=1.log', 'LastModified': datetime.datetime(2026, 1, 15, 14, 27, 19, tzinfo=tzlocal()), 'ETag': '"8adb669bf7a5bf88f906e043fc4fa848"', 'ChecksumAlgorithm': ['CRC32'], 'ChecksumType': 'FULL_OBJECT', 'Size': 1933, 'StorageClass': 'STANDARD'}, {'Key': 'dag_id=example_xcom_test/run_id=manual__2026-01-15T14:27:11.507649+00:00/task_id=push_by_returning/attempt=1.log', 'LastModified': datetime.datetime(2026, 1, 15, 14, 27, 19, tzinfo=tzlocal()), 'ETag': '"50a2f32cbc28f0e87c65da4e3cc2a408"', 'ChecksumAlgorithm': ['CRC32'], 'ChecksumType': 'FULL_OBJECT', 'Size': 2763, 'StorageClass': 'STANDARD'}], 'Name': 'test-airflow-logs', 'Prefix': '', 'MaxKeys': 1000, 'EncodingType': 'url', 'KeyCount': 5}
```


</details>

## What

Increase the retry threshold from "5 times per second" (5 seconds total) to "12 times per 5 seconds" (one minute total).