### PR TITLE
i18n(zh-TW): add missing translations

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/common.json
@@ -159,15 +159,6 @@
     "placeholder": "新增筆記...",
     "taskInstance": "任務實例筆記"
   },
-  "pools": {
-    "deferred": "已延後",
-    "open": "開放",
-    "pools_one": "資源池",
-    "pools_other": "資源池",
-    "queued": "排隊中",
-    "running": "執行中",
-    "scheduled": "已排程"
-  },
   "reset": "重置",
   "runId": "執行 ID",
   "runTypes": {
@@ -207,6 +198,7 @@
     "failed": "失敗",
     "no_status": "無狀態",
     "none": "無狀態",
+    "open": "開放",
     "planned": "已計劃",
     "queued": "排隊中",
     "removed": "已移除",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/components.json
@@ -10,6 +10,7 @@
     "maxRuns": "活躍執行數上限",
     "missingAndErroredRuns": "遺漏和錯誤的執行",
     "missingRuns": "遺漏的執行",
+    "permissionDenied": "試跑失敗：使用者沒有建立回填的權限。",
     "reprocessBehavior": "重新處理行為",
     "run": "執行回填",
     "selectDescription": "為指定的日期範圍補上 Dag 執行",
@@ -111,6 +112,13 @@
   "sortedUnsorted": "未排序",
   "taskTries": "任務嘗試次數",
   "taskTryPlaceholder": "任務嘗試數",
+  "team": {
+    "selector": {
+      "helperText": "選填，限制僅供特定團隊使用。",
+      "label": "團隊",
+      "placeHolder": "選擇團隊"
+    }
+  },
   "toggleCardView": "顯示卡片視圖",
   "toggleTableView": "顯示表格視圖",
   "triggerDag": {
@@ -135,6 +143,7 @@
         "title": "已觸發 Dag 執行"
       }
     },
+    "triggerAgainWithConfig": "使用此配置再次觸發",
     "unpause": "觸發時取消暫停 {{dagDisplayName}}"
   },
   "trimText": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/components.json
@@ -10,7 +10,7 @@
     "maxRuns": "活躍執行數上限",
     "missingAndErroredRuns": "遺漏和錯誤的執行",
     "missingRuns": "遺漏的執行",
-    "permissionDenied": "試跑失敗：使用者沒有建立回填的權限。",
+    "permissionDenied": "試執行失敗：使用者沒有建立回填的權限。",
     "reprocessBehavior": "重新處理行為",
     "run": "執行回填",
     "selectDescription": "為指定的日期範圍補上 Dag 執行",


### PR DESCRIPTION
Added missing zh-TW translations
### Before:
<img width="941" height="892" alt="image" src="https://github.com/user-attachments/assets/17ddde16-e013-4db9-b25d-1ad8dc88bec6" />

### After:
<img width="955" height="598" alt="image" src="https://github.com/user-attachments/assets/f14f3ba3-fbab-45f1-b951-7772e9e950f0" />

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
