### PR TITLE
Add zh-TW translation for triggerAgainWithConfig 

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/components.json
@@ -135,6 +135,7 @@
         "title": "已觸發 Dag 執行"
       }
     },
+    "triggerAgainWithConfig": "使用此設定再次觸發",
     "unpause": "觸發時取消暫停 {{dagDisplayName}}"
   },
   "trimText": {


### PR DESCRIPTION
## Description:                                                             
  Add Traditional Chinese (zh-TW) translation for the new                  
  `triggerAgainWithConfig` key added in #56406.                            
                                                                           
  - `"triggerAgainWithConfig": "使用此設定再次觸發"`    
  
<img width="237" height="133" alt="截圖 2026-01-16 下午4 30 28" src="https://github.com/user-attachments/assets/0e245dd1-2acc-43a5-ac87-6ae41a11c373" />
