### PR TITLE
Ensure only one dag entry is displayed in dags list output case of dags with multiple serialized dags.

### DIFF
--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -390,7 +390,7 @@ def dag_list_dags(args, session: Session = NEW_SESSION) -> None:
             dags_list.extend(list(dagbag.dags.values()))
             dagbag_import_errors += len(dagbag.import_errors)
     else:
-        dags_list.extend(cast("DAG", sm.dag) for sm in session.scalars(select(SerializedDagModel)))
+        dags_list.extend(cast("DAG", dag) for dag in SerializedDagModel.read_all_dags().values())
         pie_stmt = select(func.count()).select_from(ParseImportError)
         if args.bundle_name:
             pie_stmt = pie_stmt.where(ParseImportError.bundle_name.in_(args.bundle_name))


### PR DESCRIPTION
When a dag has multiple serialized dag entries due to dag versioning ensure only one entry is displayed in the `airflow dags list` per dag.

closes: #60594

##### Was generative AI tooling used to co-author this PR?

No

