### PR TITLE
Adds a "private_key" alternative extra field to GitHub connection

### DIFF
--- a/providers/github/docs/connections/github.rst
+++ b/providers/github/docs/connections/github.rst
@@ -52,6 +52,7 @@ GitHub App authentication
 You can authenticate using a GitHub App installation by setting the extra field of your connection, instead of using a token.
 
 - ``key_path``: Path to the private key file used for GitHub App authentication.
+- ``private_key``: The private key content used for GitHub App authentication. (alternative to ``key_path``)
 - ``app_id``: The application ID.
 - ``installation_id``: The ID of the app installation.
 - ``token_permissions``: A dictionary of permissions. - Properties of permissions - https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#create-an-installation-access-token-for-an-app
@@ -62,6 +63,20 @@ Example "extras" field:
 
     {
       "key_path": "FAKE_KEY.pem",
+      "app_id": "123456s",
+      "installation_id": 123456789,
+      "token_permissions": {
+        "issues":"write",
+        "contents":"read"
+      }
+    }
+
+Example with embedded private key:
+
+.. code-block:: json
+
+    {
+      "private_key": "-----BEGIN+PRIVATE+KEY-----%0AM...%0A-----END+PRIVATE+KEY-----",
       "app_id": "123456s",
       "installation_id": 123456789,
       "token_permissions": {

--- a/providers/github/src/airflow/providers/github/hooks/github.py
+++ b/providers/github/src/airflow/providers/github/hooks/github.py
@@ -64,8 +64,13 @@ class GithubHook(BaseHook):
                     raise ValueError("Unrecognised key file: expected a .pem private key")
                 with open(key_path) as key_file:
                     private_key = key_file.read()
+            elif key := extras.get("private_key"):
+                private_key = key
+
             else:
-                raise ValueError("No key_path provided for GitHub App authentication.")
+                raise ValueError(
+                    "Neither key_path nor private_key are provided for GitHub App authentication."
+                )
 
             app_id = extras.get("app_id")
             installation_id = extras.get("installation_id")


### PR DESCRIPTION
This PR adds support for GitHub App private keys stored directly in connections (e.g. in AWS Secrets Manager).

`private_key` field is an alternative to `key_path`.

This is a followup for https://github.com/apache/airflow/pull/54812.

* related: #39457


