### PR TITLE
Grey out trigger button on API 403

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -31,7 +31,7 @@ import { DEFAULT_DATETIME_FORMAT } from "src/utils/datetimeUtils";
 
 import ConfigForm from "../ConfigForm";
 import { DateTimeInput } from "../DateTimeInput";
-import { ErrorAlert } from "../ErrorAlert";
+import { ErrorAlert, type ExpandedApiError } from "../ErrorAlert";
 import { Checkbox } from "../ui/Checkbox";
 import { RadioCardItem, RadioCardRoot } from "../ui/RadioCard";
 import TriggerDAGAdvancedOptions from "./TriggerDAGAdvancedOptions";
@@ -258,7 +258,12 @@ const TriggerDAGForm = ({
           <Button
             colorPalette="brand"
             disabled={
-              Boolean(errors.conf) || Boolean(errors.date) || formError || isPending || dataIntervalInvalid
+              Boolean(errors.conf) ||
+              Boolean(errors.date) ||
+              formError ||
+              isPending ||
+              dataIntervalInvalid ||
+              (Boolean(errorTrigger) && (errorTrigger as ExpandedApiError).status === 403)
             }
             onClick={() => void handleSubmit(onSubmit)()}
           >


### PR DESCRIPTION
Follow up: https://github.com/apache/airflow/pull/58016, https://github.com/apache/airflow/pull/60473

We should only grey out the button on 'api server error 403 permission denied' as it's unlikely to change live (https://github.com/apache/airflow/issues/57966). As mentioned in Brent PR, we don't want all 'server' side errors to block resubmission of the form.