### PR TITLE
Fix logout flow in Keycloak auth manager

### DIFF
--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/openapi/v2-keycloak-auth-manager-generated.yaml
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/openapi/v2-keycloak-auth-manager-generated.yaml
@@ -45,9 +45,6 @@ paths:
           content:
             application/json:
               schema: {}
-      security:
-      - OAuth2PasswordBearer: []
-      - HTTPBearer: []
   /auth/logout_callback:
     get:
       tags:
@@ -106,8 +103,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPExceptionResponse'
-        '401':
-          description: Unauthorized
+        '403':
+          description: Forbidden
           content:
             application/json:
               schema:
@@ -143,8 +140,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPExceptionResponse'
-        '401':
-          description: Unauthorized
+        '403':
+          description: Forbidden
           content:
             application/json:
               schema:

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/routes/token.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/routes/token.py
@@ -37,7 +37,7 @@ token_router = AirflowRouter(tags=["KeycloakAuthManagerToken"])
 @token_router.post(
     "/token",
     status_code=status.HTTP_201_CREATED,
-    responses=create_openapi_http_exception_doc([status.HTTP_400_BAD_REQUEST, status.HTTP_401_UNAUTHORIZED]),
+    responses=create_openapi_http_exception_doc([status.HTTP_400_BAD_REQUEST, status.HTTP_403_FORBIDDEN]),
 )
 def create_token(body: TokenBody) -> TokenResponse:
     token = body.root.create_token(
@@ -49,7 +49,7 @@ def create_token(body: TokenBody) -> TokenResponse:
 @token_router.post(
     "/token/cli",
     status_code=status.HTTP_201_CREATED,
-    responses=create_openapi_http_exception_doc([status.HTTP_400_BAD_REQUEST, status.HTTP_401_UNAUTHORIZED]),
+    responses=create_openapi_http_exception_doc([status.HTTP_400_BAD_REQUEST, status.HTTP_403_FORBIDDEN]),
 )
 def create_token_cli(body: TokenPasswordBody) -> TokenResponse:
     token = body.create_token(

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/services/token.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/services/token.py
@@ -37,7 +37,7 @@ def create_token_for(
         tokens = client.token(username, password)
     except KeycloakAuthenticationError:
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,
             detail="Invalid credentials",
         )
 
@@ -77,7 +77,7 @@ def create_client_credentials_token(
         tokens = client.token(grant_type="client_credentials")
     except KeycloakAuthenticationError:
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+            status_code=status.HTTP_403_FORBIDDEN,
             detail="Client credentials authentication failed",
         )
 

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/routes/test_login.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/routes/test_login.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from unittest.mock import ANY, Mock, patch
 
-from keycloak import KeycloakPostError
+import pytest
 
 from airflow.api_fastapi.app import AUTH_MANAGER_FASTAPI_APP_PREFIX
 from airflow.providers.keycloak.auth_manager.user import KeycloakAuthManagerUser
@@ -45,6 +45,7 @@ class TestLoginRouter:
         mock_keycloak_client.token.return_value = {
             "access_token": "access_token",
             "refresh_token": "refresh_token",
+            "id_token": "id_token",
         }
         mock_keycloak_client.userinfo.return_value = {
             "sub": "sub",
@@ -73,43 +74,35 @@ class TestLoginRouter:
         assert "location" in response.headers
         assert "_token" in response.cookies
         assert response.cookies["_token"] == token
+        assert response.cookies["_id_token"] == "id_token"
 
     def test_login_callback_without_code(self, client):
         response = client.get(AUTH_MANAGER_FASTAPI_APP_PREFIX + "/login_callback")
         assert response.status_code == 400
 
+    @pytest.mark.parametrize(
+        ("id_token", "logout_callback_url"),
+        [
+            (None, "http://testserver/auth/logout_callback"),
+            (
+                "id_token",
+                "logout_url?post_logout_redirect_uri=http://testserver/auth/logout_callback&id_token_hint=id_token",
+            ),
+        ],
+    )
     @patch("airflow.providers.keycloak.auth_manager.routes.login.KeycloakAuthManager.get_keycloak_client")
-    def test_logout(self, mock_get_keycloak_client, client):
+    def test_logout(self, mock_get_keycloak_client, id_token, logout_callback_url, client):
         mock_keycloak_client = Mock()
         mock_keycloak_client.well_known.return_value = {"end_session_endpoint": "logout_url"}
-        mock_keycloak_client.refresh_token.return_value = {"id_token": "id_token"}
         mock_get_keycloak_client.return_value = mock_keycloak_client
-        response = client.get(AUTH_MANAGER_FASTAPI_APP_PREFIX + "/logout", follow_redirects=False)
+        response = client.get(
+            AUTH_MANAGER_FASTAPI_APP_PREFIX + "/logout",
+            cookies={"_id_token": id_token},
+            follow_redirects=False,
+        )
         assert response.status_code == 307
         assert "location" in response.headers
-        assert (
-            response.headers["location"]
-            == "logout_url?post_logout_redirect_uri=http://testserver/auth/logout_callback&id_token_hint=id_token"
-        )
-        mock_keycloak_client.refresh_token.assert_called_once_with("refresh_token")
-
-    @patch("airflow.providers.keycloak.auth_manager.routes.login.KeycloakAuthManager.get_keycloak_client")
-    def test_logout_when_keycloak_client_raises_keycloak_post_error(self, mock_get_keycloak_client, client):
-        mock_keycloak_client = Mock()
-        mock_keycloak_client.well_known.return_value = {"end_session_endpoint": "logout_url"}
-        mock_keycloak_client.refresh_token.side_effect = KeycloakPostError(
-            response_code=400,
-            response_body=b'{"error":"invalid_grant","error_description":"Token is not active"}',
-        )
-        mock_get_keycloak_client.return_value = mock_keycloak_client
-        response = client.get(AUTH_MANAGER_FASTAPI_APP_PREFIX + "/logout", follow_redirects=False)
-        assert response.status_code == 307
-        assert "location" in response.headers
-        assert (
-            response.headers["location"]
-            == "logout_url?post_logout_redirect_uri=http://testserver/auth/logout_callback"
-        )
-        mock_keycloak_client.refresh_token.assert_called_once_with("refresh_token")
+        assert response.headers["location"] == logout_callback_url
 
     @patch("airflow.providers.keycloak.auth_manager.routes.login.get_auth_manager")
     def test_refresh_token(self, mock_get_auth_manager, client):

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/services/test_token.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/services/test_token.py
@@ -131,5 +131,5 @@ class TestTokenService:
         with pytest.raises(fastapi.exceptions.HTTPException) as exc_info:
             create_client_credentials_token(client_id=test_client_id, client_secret=test_client_secret)
 
-        assert exc_info.value.status_code == 401
+        assert exc_info.value.status_code == 403
         assert "Client credentials authentication failed" in exc_info.value.detail


### PR DESCRIPTION
Related #59359.

The current logout flow with Keycloak auth manager has a bug, you must have an active session in order to logout, which should not be. I update the flow to use the id token we are now saving when logging in as separate cookie.

I also update the HTTP code when invalid credentials are entered, it should be 403 and not 401.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

No

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
