### PR TITLE
Made WinRMOperator deferrable

### DIFF
--- a/providers/microsoft/winrm/provider.yaml
+++ b/providers/microsoft/winrm/provider.yaml
@@ -83,6 +83,11 @@ hooks:
     python-modules:
       - airflow.providers.microsoft.winrm.hooks.winrm
 
+triggers:
+  - integration-name: Windows Remote Management (WinRM)
+    python-modules:
+      - airflow.providers.microsoft.winrm.triggers.winrm
+
 connection-types:
   - hook-class-name: airflow.providers.microsoft.winrm.hooks.winrm.WinRMHook
     connection-type: winrm

--- a/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/get_provider_info.py
+++ b/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/get_provider_info.py
@@ -47,6 +47,12 @@ def get_provider_info():
                 "python-modules": ["airflow.providers.microsoft.winrm.hooks.winrm"],
             }
         ],
+        "triggers": [
+            {
+                "integration-name": "Windows Remote Management (WinRM)",
+                "python-modules": ["airflow.providers.microsoft.winrm.triggers.winrm"],
+            }
+        ],
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.microsoft.winrm.hooks.winrm.WinRMHook",

--- a/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/operators/winrm.py
+++ b/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/operators/winrm.py
@@ -17,13 +17,19 @@
 # under the License.
 from __future__ import annotations
 
+import base64
 import logging
+import warnings
 from base64 import b64encode
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from contextlib import suppress
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.common.compat.sdk import AirflowException, BaseOperator, conf
 from airflow.providers.microsoft.winrm.hooks.winrm import WinRMHook
+from airflow.providers.microsoft.winrm.triggers.winrm import WinRMCommandOutputTrigger
 
 if TYPE_CHECKING:
     from airflow.sdk import Context
@@ -46,9 +52,14 @@ class WinRMOperator(BaseOperator):
     :param ps_path: path to powershell, `powershell` for v5.1- and `pwsh` for v6+.
         If specified, it will execute the command as powershell script.
     :param output_encoding: the encoding used to decode stout and stderr
-    :param timeout: timeout for executing the command.
+    :param max_output_chunks: Maximum number of stdout/stderr chunks to keep in a rolling buffer to prevent
+        excessive memory usage for long-running commands in deferrable mode, defaults to 100.
+    :param timeout: timeout for executing the command, defaults to 10.
+    :param poll_interval: How often, in seconds, the trigger should poll the output command of the launched command,
+        defaults to 1.
     :param expected_return_code: expected return code value(s) of command.
     :param working_directory: specify working directory.
+    :param deferrable: Run operator in the deferrable mode
     """
 
     template_fields: Sequence[str] = (
@@ -66,9 +77,12 @@ class WinRMOperator(BaseOperator):
         command: str | None = None,
         ps_path: str | None = None,
         output_encoding: str = "utf-8",
-        timeout: int = 10,
+        max_output_chunks: int = 100,
+        timeout: int | timedelta | None = None,
+        poll_interval: int | timedelta | None = None,
         expected_return_code: int | list[int] | range = 0,
         working_directory: str | None = None,
+        deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -78,37 +92,91 @@ class WinRMOperator(BaseOperator):
         self.command = command
         self.ps_path = ps_path
         self.output_encoding = output_encoding
-        self.timeout = timeout
+        self.max_output_chunks = max_output_chunks
+        if timeout is not None:
+            warnings.warn(
+                "timeout is deprecated and will be removed. Please use execution_timeout instead.",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
+            )
+            self.execution_timeout = (
+                timedelta(seconds=timeout) if not isinstance(timeout, timedelta) else timeout
+            )
+        self.poll_interval = (
+            poll_interval.total_seconds()
+            if isinstance(poll_interval, timedelta)
+            else poll_interval
+            if poll_interval is not None
+            else 1.0
+        )
         self.expected_return_code = expected_return_code
         self.working_directory = working_directory
+        self.deferrable = deferrable
+
+    @property
+    def hook(self) -> WinRMHook:
+        if not self.winrm_hook:
+            if self.ssh_conn_id:
+                self.log.info("Hook not found, creating...")
+                self.winrm_hook = WinRMHook(ssh_conn_id=self.ssh_conn_id, remote_host=self.remote_host)
+            else:
+                raise AirflowException("Cannot operate without winrm_hook.")
+
+        return self.winrm_hook
 
     def execute(self, context: Context) -> list | str:
-        if self.ssh_conn_id and not self.winrm_hook:
-            self.log.info("Hook not found, creating...")
-            self.winrm_hook = WinRMHook(ssh_conn_id=self.ssh_conn_id)
-
-        if not self.winrm_hook:
-            raise AirflowException("Cannot operate without winrm_hook or ssh_conn_id.")
-
-        if self.remote_host is not None:
-            self.winrm_hook.remote_host = self.remote_host
-
         if not self.command:
             raise AirflowException("No command specified so nothing to execute here.")
 
-        return_code, stdout_buffer, stderr_buffer = self.winrm_hook.run(
+        if self.deferrable:
+            if not self.hook.ssh_conn_id:
+                raise AirflowException("Cannot operate in deferrable mode without ssh_conn_id.")
+
+            shell_id, command_id = self.hook.run_command(
+                command=self.command,
+                ps_path=self.ps_path,
+                working_directory=self.working_directory,
+            )
+            return self.defer(
+                trigger=WinRMCommandOutputTrigger(
+                    ssh_conn_id=self.hook.ssh_conn_id,
+                    shell_id=shell_id,
+                    command_id=command_id,
+                    output_encoding=self.output_encoding,
+                    return_output=self.do_xcom_push,
+                    max_output_chunks=self.max_output_chunks,
+                    poll_interval=self.poll_interval,
+                ),
+                method_name=self.execute_complete.__name__,
+                timeout=self.execution_timeout,
+            )
+
+        return_code, stdout_buffer, stderr_buffer = self.hook.run(
             command=self.command,
             ps_path=self.ps_path,
             output_encoding=self.output_encoding,
             return_output=self.do_xcom_push,
             working_directory=self.working_directory,
         )
+        return self.evaluate_result(return_code, stdout_buffer, stderr_buffer)
 
-        success = False
-        if isinstance(self.expected_return_code, int):
-            success = return_code == self.expected_return_code
-        elif isinstance(self.expected_return_code, list) or isinstance(self.expected_return_code, range):
-            success = return_code in self.expected_return_code
+    def validate_return_code(self, return_code: int | None) -> bool:
+        if return_code is not None:
+            if isinstance(self.expected_return_code, int):
+                return return_code == self.expected_return_code
+            if isinstance(self.expected_return_code, list) or isinstance(self.expected_return_code, range):
+                return return_code in self.expected_return_code
+        return False
+
+    def evaluate_result(
+        self,
+        return_code: int | None,
+        stdout_buffer: list[bytes],
+        stderr_buffer: list[bytes],
+    ) -> Any:
+        success = self.validate_return_code(return_code)
+
+        self.log.debug("success: %s", success)
 
         if success:
             # returning output if do_xcom_push is set
@@ -122,3 +190,40 @@ class WinRMOperator(BaseOperator):
         stderr_output = b"".join(stderr_buffer).decode(self.output_encoding)
         error_msg = f"Error running cmd: {self.command}, return code: {return_code}, error: {stderr_output}"
         raise AirflowException(error_msg)
+
+    def _decode(self, output: str) -> bytes:
+        decoded_output = base64.standard_b64decode(output)
+        self.hook.log_output(decoded_output, output_encoding=self.output_encoding)
+        return decoded_output
+
+    def execute_complete(
+        self,
+        context: Context,
+        event: dict[Any, Any],
+    ) -> Any:
+        """
+        Execute callback when WinRMCommandOutputTrigger finishes execution.
+
+        This method gets executed automatically when WinRMCommandOutputTrigger completes its execution.
+        """
+        status = event.get("status")
+
+        if status == "error":
+            raise AirflowException(f"Trigger failed: {event.get('message')}")
+
+        return_code = event.get("return_code")
+
+        self.log.info("%s completed with %s", self.task_id, status)
+
+        stdout = [self._decode(output) for output in event.get("stdout", [])]
+        stderr = [self._decode(output) for output in event.get("stderr", [])]
+
+        try:
+            return self.evaluate_result(return_code, stdout, stderr)
+        finally:
+            conn = self.hook.get_conn()
+            if conn:
+                with suppress(Exception):
+                    conn.cleanup_command(event["shell_id"], event["command_id"])
+                with suppress(Exception):
+                    conn.close_shell(event["shell_id"])

--- a/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/triggers/__init__.py
+++ b/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/triggers/__init__.py
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/triggers/winrm.py
+++ b/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/triggers/winrm.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Hook for winrm remote execution."""
+"""Trigger for winrm remote execution."""
 
 from __future__ import annotations
 

--- a/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/triggers/winrm.py
+++ b/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/triggers/winrm.py
@@ -1,0 +1,147 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Hook for winrm remote execution."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from collections import deque
+from collections.abc import AsyncIterator
+from functools import cached_property
+from typing import TYPE_CHECKING, Any
+
+from airflow.providers.microsoft.winrm.hooks.winrm import WinRMHook
+from airflow.triggers.base import BaseTrigger, TriggerEvent
+
+if TYPE_CHECKING:
+    from winrm import Protocol
+
+
+class WinRMCommandOutputTrigger(BaseTrigger):
+    """
+    A trigger that polls the command output executed by the WinRMHook.
+
+    This trigger avoids blocking a worker when using the WinRMOperator in deferred mode.
+
+    The behavior of this trigger is as follows:
+    - poll the command output from the shell launched by WinRM,
+    - if command not done then sleep and retry,
+    - when command done then return the output.
+
+    :param ssh_conn_id: connection id from airflow Connections from where
+        all the required parameters can be fetched like username and password,
+        though priority is given to the params passed during init.
+    :param shell_id: The shell id on the remote machine.
+    :param command_id: The command id executed on the remote machine.
+    :param output_encoding: the encoding used to decode stout and stderr, defaults to utf-8.
+    :param return_output: Whether to accumulate and return the stdout or not, defaults to True.
+    :param poll_interval: How often, in seconds, the trigger should poll the output command of the launched command,
+        defaults to 1.
+    :param max_output_chunks: Maximum number of stdout/stderr chunks to keep in a rolling buffer to prevent
+        excessive memory usage for long-running commands, defaults to 100.
+    """
+
+    def __init__(
+        self,
+        ssh_conn_id: str,
+        shell_id: str,
+        command_id: str,
+        output_encoding: str = "utf-8",
+        return_output: bool = True,
+        poll_interval: float = 1,
+        max_output_chunks: int = 100,
+    ) -> None:
+        super().__init__()
+        self.ssh_conn_id = ssh_conn_id
+        self.shell_id = shell_id
+        self.command_id = command_id
+        self.output_encoding = output_encoding
+        self.return_output = return_output
+        self.poll_interval = poll_interval
+        self._stdout: deque[str] = deque(maxlen=max_output_chunks)
+        self._stderr: deque[str] = deque(maxlen=max_output_chunks)
+
+    def serialize(self) -> tuple[str, dict[str, Any]]:
+        """Serialize WinRMCommandOutputTrigger arguments and classpath."""
+        return (
+            f"{self.__class__.__module__}.{self.__class__.__name__}",
+            {
+                "ssh_conn_id": self.ssh_conn_id,
+                "shell_id": self.shell_id,
+                "command_id": self.command_id,
+                "output_encoding": self.output_encoding,
+                "return_output": self.return_output,
+                "poll_interval": self.poll_interval,
+                "max_output_chunks": self._stdout.maxlen,
+            },
+        )
+
+    @cached_property
+    def hook(self) -> WinRMHook:
+        return WinRMHook(ssh_conn_id=self.ssh_conn_id)
+
+    async def get_command_output(self, conn: Protocol) -> tuple[bytes, bytes, int | None, bool]:
+        from asgiref.sync import sync_to_async
+
+        return await sync_to_async(self.hook.get_command_output)(conn, self.shell_id, self.command_id)
+
+    async def run(self) -> AsyncIterator[TriggerEvent]:
+        command_done: bool = False
+
+        try:
+            conn = await self.hook.get_async_conn()
+            while not command_done:
+                (
+                    stdout,
+                    stderr,
+                    return_code,
+                    command_done,
+                ) = await self.get_command_output(conn)
+
+                if self.return_output and stdout:
+                    self._stdout.append(base64.standard_b64encode(stdout).decode(self.output_encoding))
+                if stderr:
+                    self._stderr.append(base64.standard_b64encode(stderr).decode(self.output_encoding))
+
+                if not command_done:
+                    await asyncio.sleep(self.poll_interval)
+                    continue
+
+                yield TriggerEvent(
+                    {
+                        "status": "success",
+                        "shell_id": self.shell_id,
+                        "command_id": self.command_id,
+                        "return_code": return_code,
+                        "stdout": list(self._stdout),
+                        "stderr": list(self._stderr),
+                    }
+                )
+                return
+        except Exception as e:
+            self.log.exception("An error occurred: %s", e)
+            yield TriggerEvent(
+                {
+                    "status": "error",
+                    "shell_id": self.shell_id,
+                    "command_id": self.command_id,
+                    "message": str(e),
+                }
+            )
+            return

--- a/providers/microsoft/winrm/tests/unit/microsoft/winrm/hooks/test_winrm.py
+++ b/providers/microsoft/winrm/tests/unit/microsoft/winrm/hooks/test_winrm.py
@@ -21,13 +21,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from airflow.providers.common.compat.sdk import AirflowException
+from airflow.providers.common.compat.sdk import AirflowException, Connection
 from airflow.providers.microsoft.winrm.hooks.winrm import WinRMHook
-
-try:
-    from airflow.sdk import Connection  # type: ignore
-except ImportError:
-    from airflow.models import Connection  # type: ignore
 
 
 class TestWinRMHook:

--- a/providers/microsoft/winrm/tests/unit/microsoft/winrm/operators/test_winrm.py
+++ b/providers/microsoft/winrm/tests/unit/microsoft/winrm/operators/test_winrm.py
@@ -19,23 +19,28 @@ from __future__ import annotations
 
 from base64 import b64encode
 from unittest import mock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from airflow.providers.common.compat.sdk import AirflowException
+from airflow.providers.microsoft.winrm.hooks.winrm import WinRMHook
 from airflow.providers.microsoft.winrm.operators.winrm import WinRMOperator
+from airflow.triggers.base import TriggerEvent
+
+from tests_common.test_utils.operators.run_deferrable import execute_operator
 
 
 class TestWinRMOperator:
     def test_no_winrm_hook_no_ssh_conn_id(self):
-        op = WinRMOperator(task_id="test_task_id", winrm_hook=None, ssh_conn_id=None)
-        exception_msg = "Cannot operate without winrm_hook or ssh_conn_id."
+        op = WinRMOperator(task_id="test_task_id", winrm_hook=None, ssh_conn_id=None, command="not_empty")
+        exception_msg = "Cannot operate without winrm_hook."
         with pytest.raises(AirflowException, match=exception_msg):
             op.execute(None)
 
-    @mock.patch("airflow.providers.microsoft.winrm.operators.winrm.WinRMHook")
-    def test_no_command(self, mock_hook):
-        op = WinRMOperator(task_id="test_task_id", winrm_hook=mock_hook, command=None)
+    def test_no_command(self):
+        winrm_hook = WinRMHook(transport="ntml", remote_host="localhost", password="secret")
+        op = WinRMOperator(task_id="test_task_id", winrm_hook=winrm_hook, command=None)
         exception_msg = "No command specified so nothing to execute here."
         with pytest.raises(AirflowException, match=exception_msg):
             op.execute(None)
@@ -84,11 +89,7 @@ class TestWinRMOperator:
             expected_return_code=expected_return_code,
         )
 
-        should_task_succeed = False
-        if isinstance(expected_return_code, int):
-            should_task_succeed = real_return_code == expected_return_code
-        elif isinstance(expected_return_code, list) or isinstance(expected_return_code, range):
-            should_task_succeed = real_return_code in expected_return_code
+        should_task_succeed = op.validate_return_code(real_return_code)
 
         if should_task_succeed:
             execute_result = op.execute(None)
@@ -104,3 +105,40 @@ class TestWinRMOperator:
             exception_msg = f"Error running cmd: {command}, return code: {real_return_code}, error: KO"
             with pytest.raises(AirflowException, match=exception_msg):
                 op.execute(None)
+
+    @mock.patch("airflow.providers.microsoft.winrm.operators.winrm.WinRMHook")
+    @mock.patch("airflow.providers.microsoft.winrm.triggers.winrm.WinRMHook")
+    def test_execute_deferrable_success(self, mock_operator_hook, mock_trigger_hook):
+        mock_hook_instance = MagicMock(spec=WinRMHook)
+        mock_hook_instance.ssh_conn_id = "winrm_default"
+        mock_operator_hook.return_value = mock_hook_instance
+        mock_trigger_hook.return_value = mock_hook_instance
+        mock_conn = MagicMock()
+        mock_hook_instance.get_async_conn = AsyncMock(return_value=mock_conn)
+        mock_hook_instance.get_conn.return_value = mock_conn
+        mock_hook_instance.get_command_output.return_value = (b"hello", b"", 0, True)
+        mock_hook_instance.run_command.return_value = (
+            "043E496C-A9E5-4284-AFCC-78A90E2BCB65",
+            "E4C36903-E59F-43AB-9374-ABA87509F46D",
+        )
+
+        operator = WinRMOperator(
+            task_id="test_task",
+            winrm_hook=mock_hook_instance,
+            command="dir",
+            deferrable=True,
+        )
+
+        result, events = execute_operator(operator)
+
+        assert len(events) == 1
+        assert isinstance(events[0], TriggerEvent)
+        assert events[0].payload == {
+            "command_id": "E4C36903-E59F-43AB-9374-ABA87509F46D",
+            "return_code": 0,
+            "shell_id": "043E496C-A9E5-4284-AFCC-78A90E2BCB65",
+            "status": "success",
+            "stderr": [],
+            "stdout": ["aGVsbG8="],
+        }
+        assert result == "aGVsbG8="

--- a/providers/microsoft/winrm/tests/unit/microsoft/winrm/triggers/__init__.py
+++ b/providers/microsoft/winrm/tests/unit/microsoft/winrm/triggers/__init__.py
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/microsoft/winrm/tests/unit/microsoft/winrm/triggers/test_winrm.py
+++ b/providers/microsoft/winrm/tests/unit/microsoft/winrm/triggers/test_winrm.py
@@ -1,0 +1,85 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import asyncio
+import base64
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from airflow.providers.microsoft.winrm.triggers.winrm import WinRMCommandOutputTrigger
+from airflow.triggers.base import TriggerEvent
+
+
+class TestWinRMCommandOutputTrigger:
+    def test_serialize(self):
+        trigger = WinRMCommandOutputTrigger(
+            ssh_conn_id="ssh_conn_id",
+            shell_id="043E496C-A9E5-4284-AFCC-78A90E2BCB65",
+            command_id="E4C36903-E59F-43AB-9374-ABA87509F46D",
+            output_encoding="utf-8",
+            return_output=True,
+            poll_interval=10,
+            max_output_chunks=100,
+        )
+
+        actual = trigger.serialize()
+
+        assert isinstance(actual, tuple)
+        assert actual[0] == f"{WinRMCommandOutputTrigger.__module__}.{WinRMCommandOutputTrigger.__name__}"
+        assert actual[1] == {
+            "ssh_conn_id": "ssh_conn_id",
+            "shell_id": "043E496C-A9E5-4284-AFCC-78A90E2BCB65",
+            "command_id": "E4C36903-E59F-43AB-9374-ABA87509F46D",
+            "output_encoding": "utf-8",
+            "return_output": True,
+            "poll_interval": 10,
+            "max_output_chunks": 100,
+        }
+
+    @pytest.mark.asyncio
+    @patch("airflow.providers.microsoft.winrm.triggers.winrm.WinRMHook")
+    async def test_run(self, mock_hook):
+        trigger = WinRMCommandOutputTrigger(
+            ssh_conn_id="ssh_conn_id",
+            shell_id="043E496C-A9E5-4284-AFCC-78B5717DF4D73",
+            command_id="78CE100B-04FD-4EE2-8DAF-0751795661BB",
+            poll_interval=1,
+        )
+
+        mock_hook_instance = MagicMock()
+        mock_hook.return_value = mock_hook_instance
+        mock_conn = MagicMock()
+        mock_hook_instance.get_async_conn = AsyncMock(return_value=mock_conn)
+        mock_hook_instance.get_conn.return_value = mock_conn
+        mock_hook_instance.get_command_output.return_value = (b"hello", b"", 0, True)
+
+        with patch.object(asyncio, "sleep", return_value=None):
+            events = [event async for event in trigger.run()]
+
+        assert len(events) == 1
+        event = events[0]
+        assert isinstance(event, TriggerEvent)
+
+        payload = event.payload
+        assert payload["status"] == "success"
+        assert payload["shell_id"] == "043E496C-A9E5-4284-AFCC-78B5717DF4D73"
+        assert payload["command_id"] == "78CE100B-04FD-4EE2-8DAF-0751795661BB"
+        assert payload["return_code"] == 0
+        assert base64.b64decode(payload["stdout"][0]) == b"hello"
+        assert not payload["stderr"]


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: [#60330](https://github.com/apache/airflow/pull/60330)
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

**Motivation**

Recently, we encountered an issue where TaskInstances were being prematurely killed by the scheduler.

We initially tried the fix proposed in PR [#60330](https://github.com/apache/airflow/pull/60330) made by @ephraimbuddy, but unfortunately this did not help in our case. After further investigation, we discovered that this behaviour only occurred in DAGs using the WinRMOperator.

**Problem**

We use the WinRMOperator to launch remote processes on Windows servers. Some of these processes can take a significant amount of time to complete.

The root cause is that the WinRMOperator currently performs polling synchronously inside the worker, via the run method of WinRMHook. This has several drawbacks:

- The worker is blocked while waiting for the remote command to complete.
- Long-running polling increases the risk of scheduler heartbeats being missed.
- This can lead to TaskInstances being marked as failed or killed prematurely.

Overall, this is not an efficient or scalable execution model in Airflow.

**Solution**

This PR refactors the WinRMOperator to support deferrable execution.

When deferrable=True:

- The worker is only responsible for launching the remote command on the Windows server.
- The operator retrieves the shell_id and command_id from the WinRM session.
- Polling for command output and the final result_code is deferred to a new WinRMCommandTrigger.
- The triggerer performs this polling asynchronously, freeing the worker immediately.

This aligns the WinRMOperator with Airflow’s recommended architecture for long-running or polling-based operations.

**Benefits**

Workers are no longer blocked by long-running WinRM commands.

- Polling is handled asynchronously by the triggerer.
- Prevents scheduler-induced task termination for long-running WinRM jobs.
- Improves scalability and resource utilization.
- Matches the deferrable operator pattern used across Airflow providers.

**Example Usage**

```
WinRMOperator(
    task_id="run_job",
    ssh_conn_id="ssh.winrm",
    command="python C:\\Temp\\python_scripts\\job_trigger.py -j TEST",
    pool="winrm",
    poll_interval=10,
    execution_timeout=timedelta(minutes=360),  # Avoid infinite polling if something goes wrong
    deferrable=True,
)
```

**Conclussion**

With this refactoring in place, we no longer experience TaskInstances being prematurely killed. Polling is handled asynchronously by the triggerer, which is the preferred and more robust approach for this type of workload in Airflow and we don't block workers for polling unnecessarily.

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
