### PR TITLE
Fix breeze start-airflow mprocs output interference

### DIFF
--- a/scripts/ci/prek/compile_ui_assets_dev.py
+++ b/scripts/ci/prek/compile_ui_assets_dev.py
@@ -94,9 +94,8 @@ if __name__ == "__main__":
             stdout=f,
             stderr=subprocess.STDOUT,
         )
-        subprocess.run(
+        subprocess.Popen(
             ["pnpm", "dev"],
-            check=True,
             cwd=os.fspath(SIMPLE_AUTH_MANAGER_UI_DIRECTORY),
             env=env,
             stdout=f,


### PR DESCRIPTION
Run the dev UI hook without blocking start-airflow so other process output remains readable.


https://github.com/user-attachments/assets/fbf97caf-817c-4a9a-9645-20cb5dcc7fb4

I'm not very sure of this change but worked for me cc @potiuk 