### PR TITLE
Fix lambda executor max attempts config

### DIFF
--- a/providers/amazon/docs/changelog.rst
+++ b/providers/amazon/docs/changelog.rst
@@ -25,6 +25,7 @@
 
 Changelog
 ---------
+* ``Rename ''max_run_task_attempts'' to ''max_invoke_attempts'' in AWS Lambda Executor (#60666)``
 
 9.20.0
 ......

--- a/providers/amazon/provider.yaml
+++ b/providers/amazon/provider.yaml
@@ -1074,7 +1074,7 @@ config:
         type: boolean
         example: "True"
         default: "True"
-      max_run_task_attempts:
+      max_invoke_attempts:
         description: |
           The maximum number of times the Lambda Executor should attempt to start an Airflow task.
         version_added: "9.9.0"

--- a/providers/amazon/src/airflow/providers/amazon/aws/executors/aws_lambda/utils.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/executors/aws_lambda/utils.py
@@ -59,7 +59,7 @@ class AllLambdaConfigKeys(InvokeLambdaKwargsConfigKeys):
 
     AWS_CONN_ID = "conn_id"
     CHECK_HEALTH_ON_STARTUP = "check_health_on_startup"
-    MAX_INVOKE_ATTEMPTS = "max_run_task_attempts"
+    MAX_INVOKE_ATTEMPTS = "max_invoke_attempts"
     REGION_NAME = "region_name"
     QUEUE_URL = "queue_url"
     DLQ_URL = "dead_letter_queue_url"

--- a/providers/amazon/src/airflow/providers/amazon/get_provider_info.py
+++ b/providers/amazon/src/airflow/providers/amazon/get_provider_info.py
@@ -1207,7 +1207,7 @@ def get_provider_info():
                         "example": "True",
                         "default": "True",
                     },
-                    "max_run_task_attempts": {
+                    "max_invoke_attempts": {
                         "description": "The maximum number of times the Lambda Executor should attempt to start an Airflow task.\n",
                         "version_added": "9.9.0",
                         "type": "integer",


### PR DESCRIPTION
The documentation and even most of the code properly refers to the config as `max_invoke_attempts` but the config name itself (which was read from Airflow config/env) was using the wrong config name (`max_run_task_attempts` which comes from the ECS executor)

#### Note: The Lambda Executor is still in alpha/experimental mode. So we are able to make this breaking change. However, this config is not often used, so it should be fairly low impact as well.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
