### PR TITLE
Fix out-of-memory errors during UI build

### DIFF
--- a/airflow-core/src/airflow/ui/CONTRIBUTING.md
+++ b/airflow-core/src/airflow/ui/CONTRIBUTING.md
@@ -19,6 +19,16 @@
 
 # Contributing to the UI
 
+## System Requirements
+
+Building the UI requires at least 8GB of system RAM (6GB available).
+
+If you encounter out-of-memory errors during the build, you can increase Node.js heap size:
+
+```bash
+export NODE_OPTIONS="--max-old-space-size=8192"
+```
+
 ## Quick Start
 
 With Breeze:

--- a/contributing-docs/15_node_environment_setup.rst
+++ b/contributing-docs/15_node_environment_setup.rst
@@ -32,6 +32,21 @@ Adding the ``--dev-mode`` flag will automatically run the vite dev server for ho
 
 In certain WSL environments, you will need to set ``CHOKIDAR_USEPOLLING=true`` in your environment variables for hot reloading to work.
 
+System Requirements
+-------------------
+
+Building the Airflow UI requires at least 8GB of system RAM (6GB available).
+
+By default, the build process allocates 4GB of heap memory to Node.js. If you encounter
+out-of-memory errors during the build, you can increase this by setting the ``NODE_OPTIONS``
+environment variable:
+
+.. code-block:: bash
+
+    # Increase to 8GB
+    export NODE_OPTIONS="--max-old-space-size=8192"
+    breeze start-airflow
+
 pnpm commands
 -------------
 

--- a/scripts/ci/prek/compile_ui_assets.py
+++ b/scripts/ci/prek/compile_ui_assets.py
@@ -71,6 +71,9 @@ def compile_assets(ui_directory: Path, hash_file: Path):
         shutil.rmtree(dist_directory, ignore_errors=True)
     env = os.environ.copy()
     env["FORCE_COLOR"] = "true"
+    # Allow users to override via NODE_OPTIONS, default to 4GB if not set
+    if "NODE_OPTIONS" not in env:
+        env["NODE_OPTIONS"] = "--max-old-space-size=4096"
     for try_num in range(3):
         print(f"### Trying to install yarn dependencies: attempt: {try_num + 1} ###")
         result = subprocess.run(


### PR DESCRIPTION
Set default Node.js heap size to 4GB for UI builds and document system requirements. Users can override via NODE_OPTIONS environment variable.

When running breeze start-airflow, the UI build process was failing with:
  - Error: FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
  - Root cause: Vite build process was running out of memory during the UI compilation
  - Default Node.js heap size: ~2GB (on 64-bit systems), which was insufficient

```
  <--- JS stacktrace --->

  FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```