### PR TITLE
Fix task-level audit logs missing SUCCESS/RUNNING events in Airflow 3.1.x

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -779,6 +779,8 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 )
                 .execution_options(synchronize_session=False)
             )
+            # add queue events to audit log
+            session.add_all([Log(event=TaskInstanceState.QUEUED, task_instance=ti) for ti in executable_tis])
 
             for ti in executable_tis:
                 ti.emit_state_change_metric(TaskInstanceState.QUEUED)

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -34,6 +34,7 @@ from airflow.api_fastapi.execution_api.app import lifespan
 from airflow.exceptions import AirflowSkipException
 from airflow.models import RenderedTaskInstanceFields, TaskReschedule, Trigger
 from airflow.models.asset import AssetActive, AssetAliasModel, AssetEvent, AssetModel
+from airflow.models.log import Log
 from airflow.models.taskinstance import TaskInstance
 from airflow.models.taskinstancehistory import TaskInstanceHistory
 from airflow.providers.standard.operators.empty import EmptyOperator
@@ -44,6 +45,7 @@ from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import (
     clear_db_assets,
     clear_db_dags,
+    clear_db_logs,
     clear_db_runs,
     clear_db_serialized_dags,
     clear_rendered_ti_fields,
@@ -130,11 +132,13 @@ class TestTIRunState:
         clear_db_runs()
         clear_db_serialized_dags()
         clear_db_dags()
+        clear_db_logs()
 
     def teardown_method(self):
         clear_db_runs()
         clear_db_serialized_dags()
         clear_db_dags()
+        clear_db_logs()
 
     @pytest.mark.parametrize(
         ("max_tries", "should_retry"),
@@ -848,15 +852,68 @@ class TestTIRunState:
         assert dag_run["run_id"] == "test"
         assert dag_run["state"] == "running"
 
+    def test_ti_run_inserts_audit_log(
+        self,
+        client,
+        session,
+        create_task_instance,
+        time_machine,
+    ):
+        """Test that calling ti_run inserts an audit log entry for the task instance RUNNING state."""
+        instant_str = "2026-01-16T12:00:00Z"
+        instant = timezone.parse(instant_str)
+        time_machine.move_to(instant, tick=False)
+
+        ti = create_task_instance(
+            task_id="test_ti_run_inserts_audit_log_running",
+            state=State.QUEUED,
+            dagrun_state=DagRunState.RUNNING,
+            session=session,
+            start_date=instant,
+        )
+        session.commit()
+
+        response = client.patch(
+            f"/execution/task-instances/{ti.id}/run",
+            json={
+                "state": "running",
+                "hostname": "test-hostname",
+                "unixname": "test-user",
+                "pid": 100,
+                "start_date": instant_str,
+            },
+        )
+
+        assert response.status_code == 200
+
+        # Query for the audit log entry
+        log_entry = session.scalar(
+            select(Log).where(
+                Log.dag_id == ti.dag_id,
+                Log.task_id == ti.task_id,
+                Log.run_id == ti.run_id,
+                Log.event == TaskInstanceState.RUNNING.value,
+            )
+        )
+
+        assert log_entry is not None, "Audit log entry should be inserted for RUNNING state"
+        assert log_entry.dag_id == ti.dag_id
+        assert log_entry.task_id == ti.task_id
+        assert log_entry.run_id == ti.run_id
+        assert log_entry.map_index == ti.map_index
+        assert log_entry.try_number == ti.try_number
+
 
 class TestTIUpdateState:
     def setup_method(self):
         clear_db_assets()
         clear_db_runs()
+        clear_db_logs()
 
     def teardown_method(self):
         clear_db_assets()
         clear_db_runs()
+        clear_db_logs()
 
     @pytest.mark.parametrize(
         ("state", "end_date", "expected_state"),
@@ -1118,8 +1175,12 @@ class TestTIUpdateState:
             mock.patch(
                 "airflow.api_fastapi.common.db.common.Session.execute",
                 side_effect=[
-                    mock.Mock(one=lambda: ("running", 1, 0, "dag")),  # First call returns "queued"
-                    mock.Mock(one=lambda: ("running", 1, 0, "dag")),  # Second call returns "queued"
+                    mock.Mock(
+                        one=lambda: ("running", 1, 0, "dag", "task_id", "run_id", -1)
+                    ),  # First call returns "queued"
+                    mock.Mock(
+                        one=lambda: ("running", 1, 0, "dag", "task_id", "run_id", -1)
+                    ),  # Second call returns "queued"
                     SQLAlchemyError("Database error"),  # Last call raises an error
                 ],
             ),
@@ -1515,6 +1576,100 @@ class TestTIUpdateState:
         session.expire_all()
         ti1 = session.get(TaskInstance, ti1.id)
         assert ti1.state == State.FAILED
+
+    @pytest.mark.parametrize(
+        "terminal_state",
+        [
+            pytest.param(State.SUCCESS, id=State.SUCCESS),
+            pytest.param(State.FAILED, id=State.FAILED),
+            pytest.param(State.SKIPPED, id=State.SKIPPED),
+        ],
+    )
+    def test_ti_update_state_inserts_audit_log_for_terminal_states(
+        self,
+        client,
+        session,
+        create_task_instance,
+        terminal_state,
+    ):
+        """Test that calling ti_update_state inserts an audit log entry for the terminal state."""
+        ti = create_task_instance(
+            task_id=f"test_ti_update_state_inserts_audit_log_{terminal_state}",
+            state=State.RUNNING,  # Must be RUNNING to transition to terminal state
+            start_date=DEFAULT_START_DATE,
+        )
+        session.commit()
+
+        response = client.patch(
+            f"/execution/task-instances/{ti.id}/state",
+            json={
+                "state": terminal_state,
+                "end_date": DEFAULT_END_DATE.isoformat(),
+            },
+        )
+
+        assert response.status_code == 204
+
+        # Query for the audit log entry
+        log_entry = session.scalar(
+            select(Log).where(
+                Log.dag_id == ti.dag_id,
+                Log.task_id == ti.task_id,
+                Log.run_id == ti.run_id,
+                Log.event == terminal_state,
+            )
+        )
+
+        assert log_entry is not None, f"Audit log entry should be inserted for {terminal_state} state"
+        assert log_entry.dag_id == ti.dag_id
+        assert log_entry.task_id == ti.task_id
+        assert log_entry.run_id == ti.run_id
+        assert log_entry.map_index == ti.map_index
+        assert log_entry.try_number == ti.try_number
+
+    def test_ti_update_state_inserts_audit_log_for_deferred_state(
+        self,
+        client,
+        session,
+        create_task_instance,
+    ):
+        """Test that calling ti_update_state for deferred state inserts an audit log entry."""
+        ti = create_task_instance(
+            task_id="test_ti_update_state_inserts_audit_log_deferred",
+            state=State.RUNNING,
+            start_date=DEFAULT_START_DATE,
+        )
+        session.commit()
+
+        response = client.patch(
+            f"/execution/task-instances/{ti.id}/state",
+            json={
+                "state": "deferred",
+                "trigger_kwargs": {"moment": "2026-01-16T00:00:00Z"},
+                "trigger_timeout": "P1D",
+                "classpath": "my-classpath",
+                "next_method": "execute_callback",
+            },
+        )
+
+        assert response.status_code == 204
+
+        # Query for the audit log entry
+        log_entry = session.scalar(
+            select(Log).where(
+                Log.dag_id == ti.dag_id,
+                Log.task_id == ti.task_id,
+                Log.run_id == ti.run_id,
+                Log.event == TaskInstanceState.DEFERRED.value,
+            )
+        )
+
+        assert log_entry is not None, "Audit log entry should be inserted for DEFERRED state"
+        assert log_entry.dag_id == ti.dag_id
+        assert log_entry.task_id == ti.task_id
+        assert log_entry.run_id == ti.run_id
+        assert log_entry.map_index == ti.map_index
+        assert log_entry.try_number == ti.try_number
 
 
 class TestTISkipDownstream:

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -852,20 +852,20 @@ class TestTIRunState:
         assert dag_run["run_id"] == "test"
         assert dag_run["state"] == "running"
 
-    def test_ti_run_inserts_audit_log(
+    def test_ti_run_creates_audit_log_entry(
         self,
         client,
         session,
         create_task_instance,
         time_machine,
     ):
-        """Test that calling ti_run inserts an audit log entry for the task instance RUNNING state."""
+        """Test that calling ti_run creates an audit log entry for the task instance RUNNING state."""
         instant_str = "2026-01-16T12:00:00Z"
         instant = timezone.parse(instant_str)
         time_machine.move_to(instant, tick=False)
 
         ti = create_task_instance(
-            task_id="test_ti_run_inserts_audit_log_running",
+            task_id="test_ti_run_creates_audit_log_running",
             state=State.QUEUED,
             dagrun_state=DagRunState.RUNNING,
             session=session,
@@ -886,8 +886,7 @@ class TestTIRunState:
 
         assert response.status_code == 200
 
-        # Query for the audit log entry
-        log_entry = session.scalar(
+        audit_log_entry = session.scalar(
             select(Log).where(
                 Log.dag_id == ti.dag_id,
                 Log.task_id == ti.task_id,
@@ -896,12 +895,12 @@ class TestTIRunState:
             )
         )
 
-        assert log_entry is not None, "Audit log entry should be inserted for RUNNING state"
-        assert log_entry.dag_id == ti.dag_id
-        assert log_entry.task_id == ti.task_id
-        assert log_entry.run_id == ti.run_id
-        assert log_entry.map_index == ti.map_index
-        assert log_entry.try_number == ti.try_number
+        assert audit_log_entry is not None, "Audit log entry should be inserted for RUNNING state"
+        assert audit_log_entry.dag_id == ti.dag_id
+        assert audit_log_entry.task_id == ti.task_id
+        assert audit_log_entry.run_id == ti.run_id
+        assert audit_log_entry.map_index == ti.map_index
+        assert audit_log_entry.try_number == ti.try_number
 
 
 class TestTIUpdateState:
@@ -1585,17 +1584,17 @@ class TestTIUpdateState:
             pytest.param(State.SKIPPED, id=State.SKIPPED),
         ],
     )
-    def test_ti_update_state_inserts_audit_log_for_terminal_states(
+    def test_ti_update_state_creates_audit_log_for_terminal_states(
         self,
         client,
         session,
         create_task_instance,
         terminal_state,
     ):
-        """Test that calling ti_update_state inserts an audit log entry for the terminal state."""
+        """Test that calling ti_update_state creates an audit log entry for the terminal state."""
         ti = create_task_instance(
-            task_id=f"test_ti_update_state_inserts_audit_log_{terminal_state}",
-            state=State.RUNNING,  # Must be RUNNING to transition to terminal state
+            task_id=f"test_ti_update_state_creates_audit_log_{terminal_state}",
+            state=State.RUNNING,
             start_date=DEFAULT_START_DATE,
         )
         session.commit()
@@ -1610,8 +1609,7 @@ class TestTIUpdateState:
 
         assert response.status_code == 204
 
-        # Query for the audit log entry
-        log_entry = session.scalar(
+        audit_log_entry = session.scalar(
             select(Log).where(
                 Log.dag_id == ti.dag_id,
                 Log.task_id == ti.task_id,
@@ -1620,22 +1618,22 @@ class TestTIUpdateState:
             )
         )
 
-        assert log_entry is not None, f"Audit log entry should be inserted for {terminal_state} state"
-        assert log_entry.dag_id == ti.dag_id
-        assert log_entry.task_id == ti.task_id
-        assert log_entry.run_id == ti.run_id
-        assert log_entry.map_index == ti.map_index
-        assert log_entry.try_number == ti.try_number
+        assert audit_log_entry is not None, f"Audit log entry should be inserted for {terminal_state} state"
+        assert audit_log_entry.dag_id == ti.dag_id
+        assert audit_log_entry.task_id == ti.task_id
+        assert audit_log_entry.run_id == ti.run_id
+        assert audit_log_entry.map_index == ti.map_index
+        assert audit_log_entry.try_number == ti.try_number
 
-    def test_ti_update_state_inserts_audit_log_for_deferred_state(
+    def test_ti_update_state_creates_audit_log_for_deferred_state(
         self,
         client,
         session,
         create_task_instance,
     ):
-        """Test that calling ti_update_state for deferred state inserts an audit log entry."""
+        """Test that calling ti_update_state for deferred state creates an audit log entry."""
         ti = create_task_instance(
-            task_id="test_ti_update_state_inserts_audit_log_deferred",
+            task_id="test_ti_update_state_creates_audit_log_deferred",
             state=State.RUNNING,
             start_date=DEFAULT_START_DATE,
         )
@@ -1654,8 +1652,7 @@ class TestTIUpdateState:
 
         assert response.status_code == 204
 
-        # Query for the audit log entry
-        log_entry = session.scalar(
+        audit_log_entry = session.scalar(
             select(Log).where(
                 Log.dag_id == ti.dag_id,
                 Log.task_id == ti.task_id,
@@ -1664,12 +1661,12 @@ class TestTIUpdateState:
             )
         )
 
-        assert log_entry is not None, "Audit log entry should be inserted for DEFERRED state"
-        assert log_entry.dag_id == ti.dag_id
-        assert log_entry.task_id == ti.task_id
-        assert log_entry.run_id == ti.run_id
-        assert log_entry.map_index == ti.map_index
-        assert log_entry.try_number == ti.try_number
+        assert audit_log_entry is not None, "Audit log entry should be inserted for DEFERRED state"
+        assert audit_log_entry.dag_id == ti.dag_id
+        assert audit_log_entry.task_id == ti.task_id
+        assert audit_log_entry.run_id == ti.run_id
+        assert audit_log_entry.map_index == ti.map_index
+        assert audit_log_entry.try_number == ti.try_number
 
 
 class TestTISkipDownstream:

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -104,6 +104,7 @@ from tests_common.test_utils.db import (
     clear_db_deadline,
     clear_db_import_errors,
     clear_db_jobs,
+    clear_db_logs,
     clear_db_pools,
     clear_db_runs,
     clear_db_teams,
@@ -201,6 +202,7 @@ def _clean_db():
     clear_db_pools()
     clear_db_import_errors()
     clear_db_jobs()
+    clear_db_logs()
     clear_db_assets()
     clear_db_deadline()
     clear_db_callbacks()
@@ -999,6 +1001,43 @@ class TestSchedulerJob:
         assert len(queued_tis) == 2
         assert {x.key for x in queued_tis} == {ti_non_backfill.key, ti_backfill.key}
         session.rollback()
+
+    def test_executable_task_instances_to_queued_creates_audit_log(self, dag_maker, session):
+        """Test that queuing tasks creates audit log entries."""
+        dag_id = "SchedulerJobTest.test_executable_task_instances_to_queued_creates_audit_log"
+        task_id = "dummy"
+
+        with dag_maker(dag_id=dag_id, session=session):
+            EmptyOperator(task_id=task_id)
+
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+
+        dr = dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED)
+        ti = dr.get_task_instance(task_id, session)
+        ti.state = State.SCHEDULED
+        session.merge(ti)
+        session.flush()
+
+        # Queue the task
+        queued_tis = self.job_runner._executable_task_instances_to_queued(max_tis=8, session=session)
+        session.flush()
+
+        assert len(queued_tis) == 1
+
+        # Verify audit log was created
+        audit_log_entry = session.scalar(
+            select(Log).where(
+                Log.dag_id == dag_id,
+                Log.task_id == task_id,
+                Log.event == TaskInstanceState.QUEUED.value,
+            )
+        )
+
+        assert audit_log_entry is not None, "Audit log entry should be created for QUEUED state"
+        assert audit_log_entry.dag_id == ti.dag_id
+        assert audit_log_entry.task_id == ti.task_id
+        assert audit_log_entry.run_id == ti.run_id
 
     def test_find_executable_task_instances_pool(self, dag_maker):
         dag_id = "SchedulerJobTest.test_find_executable_task_instances_pool"


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

closes: #58381 

### Summary

The audit logging doesn't seem to capture events for task lifecycle state transitions including running and success. As mentioned in the [document](https://airflow.apache.org/docs/apache-airflow/stable/security/audit_logs.html#scope-of-audit-logging), it should capture system-generated events including "task lifecycle state transitions (queued, running, success, failed)". As mentioned in the issue, task-level success and running events were logged in Airflow 2.10.x.

In Airflow 3, task state is set to `running` through the execution API endpoint `/{task_instance_id}/run` (`ti_run`), and task state update is handled the endpoint `/{task_instance_id}/state` (`ti_update_state`). The logic to insert log entry seems missing when updating task instance states.

To log the state transition events, we need to write logs into DB through when the two functions is processing the state update. However, if we would also want to cover the "queue" event, we need to add similar logic in the function below:
https://github.com/apache/airflow/blob/06fbabb26e826fe2fc79399333b8bff503b458c1/airflow-core/src/airflow/jobs/scheduler_job_runner.py#L412-L426

### Current (Basic) Approach

Since both `ti_run` and `ti_update_state` already execute a SELECT query at the start to fetch task metadata, The audit log entry is constructed through `TaskInstanceKey` by copying the data from the query result with an updated state. As this insert operation is done through the same `session`, if I understand correctly, this operation is atomic and can ensure consistency between the actual task state and audit log.

### Some Issues

1. There are some inconsistency in audit logs between Airflow 2 and Airflow 3 when implementing in this way. For example, `logical_date` field is empty. In `ti_run`, this could probably be collected from the DAG Run query, but in `ti_update_state` extra query is required. Also, `owner` field is empty if it is not explicitly passed. `extra` field need to be explicitly constructed but only `hostname` is available.
2. In scheduler job, there is `TaskInstance` object available which contains `logical_date`. This is more ideal as the log is more closer to what are in Airflow 2's audit log, but similarly still need to construct the `extra` field. To make the logging behavior similar to the one we have in scheduler require extra query to construct those information.

The logging behavior is kind of different now based on where the insert is implemented. Thinking about a way to make this implementation more unified and ensure consistency between actual task state and log entry.

### Current Implementation
```bash
breeze start-airflow --python 3.12 --backend postgres --db-reset --load-example-dags
```
<img width="1302" height="203" alt="Screenshot from 2026-01-17 01-28-44" src="https://github.com/user-attachments/assets/443afd3a-68ad-4530-99c0-041a5574c3ce" />

### Airflow 2 Audit Log
```bash
breeze start-airflow --use-airflow-version 2.10.5 --python 3.12 --backend postgres --db-reset --load-example-dags
```
<img width="1409" height="240" alt="Screenshot from 2026-01-17 01-36-59" src="https://github.com/user-attachments/assets/58e27599-2a42-4410-b12f-d8e0cb346475" />

> Notice that the `queued` event is not logged.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

Generated-by: [Antigravity, Claude Opus 4.5] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

1. The test cases are generated by the tool and reviewed/refined through comparing with existing test implementation pattern
2. All relevant static checks have been run and the generated test cases have been run/tested locally

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
