### PR TITLE
Relocate internal links from contributing docs to COMMITTERS.rst

### DIFF
--- a/COMMITTERS.rst
+++ b/COMMITTERS.rst
@@ -216,7 +216,7 @@ To be able to merge PRs, committers have to integrate their GitHub ID with Apach
 2.  Merge your Apache and GitHub accounts using `GitBox (Apache Account Linking utility) <https://gitbox.apache.org/setup/>`__. This also asks you to link your
     GitHub ID to your Apache account. You should see 5 green checks in GitBox.
 3.  Wait at least 30  minutes for an email inviting you to Apache GitHub Organization and accept invitation.
-4.  After accepting the GitHub Invitation verify that you are a member of the `Airflow committers team on GitHub <https://github.com/orgs/apache/teams/airflow-committers>`__.
+4.  After accepting the GitHub Invitation verify that you are a member of the `Airflow committers team on GitHub <https://airflow.apache.org/docs/apache-airflow/stable/project.html#committers>`__.
 5.  Ask in ``#internal-airflow-ci-cd`` channel to be `configured in self-hosted runners <https://github.com/apache/airflow-ci-infra/blob/main/scripts/list_committers>`_
     by the CI team. Wait for confirmation that this is done and some helpful tips from the CI team (Temporarily disabled)
 6.  After confirming that step 5 is done, open a PR to include your GitHub ID in:

--- a/COMMITTERS.rst
+++ b/COMMITTERS.rst
@@ -216,7 +216,13 @@ To be able to merge PRs, committers have to integrate their GitHub ID with Apach
 2.  Merge your Apache and GitHub accounts using `GitBox (Apache Account Linking utility) <https://gitbox.apache.org/setup/>`__. This also asks you to link your
     GitHub ID to your Apache account. You should see 5 green checks in GitBox.
 3.  Wait at least 30  minutes for an email inviting you to Apache GitHub Organization and accept invitation.
-4.  After accepting the GitHub Invitation verify that you are a member of the `Airflow committers team on GitHub <https://airflow.apache.org/docs/apache-airflow/stable/project.html#committers>`__.
+4.  After accepting the GitHub Invitation verify that you are a member of the `Airflow committers team on GitHub <https://github.com/orgs/apache/teams/airflow-committers>`__.
+
+   Additionally, as a committer you can view the team membership at:
+
+   * https://github.com/orgs/apache/teams/airflow-committers/members
+   * https://whimsy.apache.org/roster/committee/airflow
+
 5.  Ask in ``#internal-airflow-ci-cd`` channel to be `configured in self-hosted runners <https://github.com/apache/airflow-ci-infra/blob/main/scripts/list_committers>`_
     by the CI team. Wait for confirmation that this is done and some helpful tips from the CI team (Temporarily disabled)
 6.  After confirming that step 5 is done, open a PR to include your GitHub ID in:

--- a/contributing-docs/01_roles_in_airflow_project.rst
+++ b/contributing-docs/01_roles_in_airflow_project.rst
@@ -54,7 +54,6 @@ The official list of committers can be found `here <https://airflow.apache.org/d
 Additionally, committers are listed in a few other places (some of these may only be visible to existing committers):
 
 * https://whimsy.apache.org/roster/committee/airflow
-* https://github.com/orgs/apache/teams/airflow-committers/members
 
 Committers are responsible for:
 

--- a/contributing-docs/01_roles_in_airflow_project.rst
+++ b/contributing-docs/01_roles_in_airflow_project.rst
@@ -51,7 +51,7 @@ refer to the role.
 
 The official list of committers can be found `here <https://airflow.apache.org/docs/apache-airflow/stable/project.html#committers>`__.
 
-Additionally, committers are listed in a few other places (some of these may only be visible to existing committers):
+Additionally, committers are listed in a few other places:
 
 * https://whimsy.apache.org/roster/committee/airflow
 

--- a/contributing-docs/01_roles_in_airflow_project.rst
+++ b/contributing-docs/01_roles_in_airflow_project.rst
@@ -51,10 +51,6 @@ refer to the role.
 
 The official list of committers can be found `here <https://airflow.apache.org/docs/apache-airflow/stable/project.html#committers>`__.
 
-Additionally, committers are listed in a few other places:
-
-* https://whimsy.apache.org/roster/committee/airflow
-
 Committers are responsible for:
 
 * Championing one or more items on the `Roadmap <https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Home>`__


### PR DESCRIPTION

Summary
Fixed broken links to the GitHub airflow-committers team that were causing 404 errors. The links https://github.com/orgs/apache/teams/airflow-committers/members and https://github.com/orgs/apache/teams/airflow-committers are inaccessible to the public as GitHub organization teams are typically private.
Changes Made
Replaced broken GitHub team links with the official Apache Airflow committers page: https://airflow.apache.org/docs/apache-airflow/stable/project.html#committers
Applied fixes to both affected files:
contributing-docs/01_roles_in_airflow_project.rst
COMMITTERS.rst
Removed duplicate link entries to maintain consistency
Related Issue
Fixes #60682