### PR TITLE
(feat): add HTTP request customization parameters to `SnowflakeSqlApiHook`

### DIFF
--- a/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake_sql_api.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake_sql_api.py
@@ -477,14 +477,10 @@ class SnowflakeSqlApiHook(SnowflakeHook):
             for attempt in Retrying(**self.retry_config):  # type: ignore
                 with attempt:
                     if method.upper() in ("GET", "POST"):
-                        response = session.request(
-                            method=method.lower(),
-                            url=url,
-                            headers=headers,
-                            params=params,
-                            json=json,
-                            timeout=self.http_timeout_seconds,
-                        )
+                        request_kwargs = dict(method=method.lower(), url=url, headers=headers, params=params, json=json)
+                        if self.http_timeout_seconds is not None:
+                            request_kwargs["timeout"] = self.http_timeout_seconds
+                        response = session.request(**request_kwargs)
                     else:
                         raise ValueError(f"Unsupported HTTP method: {method}")
                     response.raise_for_status()

--- a/providers/snowflake/tests/unit/snowflake/hooks/test_snowflake_sql_api.py
+++ b/providers/snowflake/tests/unit/snowflake/hooks/test_snowflake_sql_api.py
@@ -1472,7 +1472,7 @@ class TestSnowflakeSqlApiHook:
 
         assert mock_cancel_execution.call_count == 3
         mock_cancel_execution.assert_has_calls([call("query-1"), call("query-2"), call("query-3")])
-        
+
     def test_make_api_call_passes_timeout_to_requests(self, mock_requests):
         hook = SnowflakeSqlApiHook(snowflake_conn_id="test_conn", http_timeout_seconds=12)
 


### PR DESCRIPTION
### Summary
This PR enhances the Snowflake SQL API hook by consistently applying the http_timeout_seconds parameter to both synchronous and asynchronous HTTP requests. 
Also it updates retry logic to consider asyncio.TimeoutError retryable.

---

##### Was generative AI tooling used to co-author this PR?

- [X] No (please specify the tool below)

---
Details
1. Propagate http_timeout_seconds to requests.Session.request(...) in _make_api_call_with_retries.
2. Configure aiohttp.ClientSession with ClientTimeout(total=...) when http_timeout_seconds is provided.
3. Expand _should_retry_on_error to treat asyncio.TimeoutError as retryable.
4. Refactor request kwargs construction to reduce duplication and centralize timeout behavior.

---
Tests
- Verified timeout propagation for synchronous HTTP requests.
- Checked that async ClientSession is configured with the expected timeout.
- Ensured async requests are retried on timeout errors.

Sync retry behavior is already extensively covered by existing tests..
So, this PR adds coverage for timeout propagation and async timeout retries.
