### PR TITLE
Bump upper limit on kubernetes library version

### DIFF
--- a/providers/cncf/kubernetes/docs/index.rst
+++ b/providers/cncf/kubernetes/docs/index.rst
@@ -115,7 +115,7 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.10.1``
 ``asgiref``                                 ``>=3.5.2``
 ``cryptography``                            ``>=41.0.0,<46.0.0``
-``kubernetes``                              ``>=32.0.0,<35.0.0``
+``kubernetes``                              ``>=35.0.0,<36.0.0``
 ``urllib3``                                 ``>=2.1.0,!=2.6.0``
 ``kubernetes_asyncio``                      ``>=32.0.0,<35.0.0``
 ==========================================  ====================

--- a/providers/cncf/kubernetes/pyproject.toml
+++ b/providers/cncf/kubernetes/pyproject.toml
@@ -72,7 +72,7 @@ dependencies = [
     # limiting minimum airflow version supported in cncf.kubernetes provider, due to the
     # potential breaking changes in Airflow Core as well (kubernetes is added as extra, so Airflow
     # core is not hard-limited via install-requirements, only by extra).
-    "kubernetes>=32.0.0,<35.0.0",
+    "kubernetes>=35.0.0,<36.0.0",
     # Urllib 2.6.0 breaks kubernetes client because kubernetes client uses deprecated in 2.0.0 and
     # removed in 2.6.0 `getheaders()` call (instead of `headers` property.
     # Tracked in https://github.com/kubernetes-client/python/issues/2477


### PR DESCRIPTION
Kubernetes client release 35.0.0 happened 2 days ago, and it removed the limit on urllib3 https://github.com/kubernetes-client/python/issues/2477 so it should be possible to upgrade it (unlike 34.* version that had urllib <2.4.0 - pretty old version).

We should bump the upper limit to <36.0.0 to test it.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
