### PR TITLE
Remove redundant try/except blocks in `BigtableDeleteInstanceOperator`

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/hooks/bigtable.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/bigtable.py
@@ -251,11 +251,9 @@ class BigtableHook(GoogleBaseHook):
         """
         instance = self.get_instance(instance_id=instance_id, project_id=project_id)
         if instance is None:
-            self.log.warning("Instance '%s' does not exist in project '%s'. Exiting", instance_id, project_id)
-
-        else:
-            table = instance.table(table_id=table_id)
-            table.delete()
+            raise RuntimeError(f"Instance {instance_id} did not exist; unable to delete table {table_id}")
+        table = instance.table(table_id=table_id)
+        table.delete()
 
     @staticmethod
     def update_cluster(instance: Instance, cluster_id: str, nodes: int) -> None:

--- a/providers/google/src/airflow/providers/google/cloud/hooks/bigtable.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/bigtable.py
@@ -251,9 +251,11 @@ class BigtableHook(GoogleBaseHook):
         """
         instance = self.get_instance(instance_id=instance_id, project_id=project_id)
         if instance is None:
-            raise RuntimeError(f"Instance {instance_id} did not exist; unable to delete table {table_id}")
-        table = instance.table(table_id=table_id)
-        table.delete()
+            self.log.warning("Instance '%s' does not exist in project '%s'. Exiting", instance_id, project_id)
+
+        else:
+            table = instance.table(table_id=table_id)
+            table.delete()
 
     @staticmethod
     def update_cluster(instance: Instance, cluster_id: str, nodes: int) -> None:

--- a/providers/google/src/airflow/providers/google/cloud/operators/bigtable.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/bigtable.py
@@ -331,17 +331,7 @@ class BigtableDeleteInstanceOperator(GoogleCloudBaseOperator, BigtableValidation
             gcp_conn_id=self.gcp_conn_id,
             impersonation_chain=self.impersonation_chain,
         )
-        try:
-            hook.delete_instance(project_id=self.project_id, instance_id=self.instance_id)
-        except google.api_core.exceptions.NotFound:
-            self.log.info(
-                "The instance '%s' does not exist in project '%s'. Consider it as deleted",
-                self.instance_id,
-                self.project_id,
-            )
-        except google.api_core.exceptions.GoogleAPICallError as e:
-            self.log.error("An error occurred. Exiting.")
-            raise e
+        hook.delete_instance(project_id=self.project_id, instance_id=self.instance_id)
 
 
 class BigtableCreateTableOperator(GoogleCloudBaseOperator, BigtableValidationMixin):

--- a/providers/google/src/airflow/providers/google/cloud/operators/bigtable.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/bigtable.py
@@ -511,22 +511,11 @@ class BigtableDeleteTableOperator(GoogleCloudBaseOperator, BigtableValidationMix
             gcp_conn_id=self.gcp_conn_id,
             impersonation_chain=self.impersonation_chain,
         )
-        instance = hook.get_instance(project_id=self.project_id, instance_id=self.instance_id)
-        if not instance:
-            raise AirflowException(f"Dependency: instance '{self.instance_id}' does not exist.")
-
-        try:
-            hook.delete_table(
-                project_id=self.project_id,
-                instance_id=self.instance_id,
-                table_id=self.table_id,
-            )
-        except google.api_core.exceptions.NotFound:
-            # It's OK if table doesn't exists.
-            self.log.info("The table '%s' no longer exists. Consider it as deleted", self.table_id)
-        except google.api_core.exceptions.GoogleAPICallError as e:
-            self.log.error("An error occurred. Exiting.")
-            raise e
+        hook.delete_table(
+            project_id=self.project_id,
+            instance_id=self.instance_id,
+            table_id=self.table_id,
+        )
 
 
 class BigtableUpdateClusterOperator(GoogleCloudBaseOperator, BigtableValidationMixin):

--- a/providers/google/tests/unit/google/cloud/operators/test_bigtable.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_bigtable.py
@@ -596,7 +596,6 @@ class TestBigtableInstanceDelete:
             impersonation_chain=IMPERSONATION_CHAIN,
         )
 
-        # Should NOT raise
         op.execute(None)
 
         mock_hook.return_value.delete_instance.assert_called_once_with(

--- a/providers/google/tests/unit/google/cloud/operators/test_bigtable.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_bigtable.py
@@ -654,6 +654,10 @@ class TestBigtableTableDelete:
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
+
+        mock_hook.return_value.delete_table.side_effect = mock.Mock(
+            side_effect=google.api_core.exceptions.NotFound("Table not found.")
+        )
         op.execute(None)
         mock_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
@@ -672,6 +676,10 @@ class TestBigtableTableDelete:
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
+
+        mock_hook.return_value.delete_table.side_effect = mock.Mock(
+            side_effect=google.api_core.exceptions.NotFound("Table not found.")
+        )
         op.execute(None)
         mock_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
@@ -679,6 +687,53 @@ class TestBigtableTableDelete:
         )
         mock_hook.return_value.delete_table.assert_called_once_with(
             project_id=None, instance_id=INSTANCE_ID, table_id=TABLE_ID
+        )
+
+    @mock.patch("airflow.providers.google.cloud.operators.bigtable.BigtableHook")
+    def test_deleting_table_when_instance_doesnt_exists(self, mock_hook):
+        op = BigtableDeleteTableOperator(
+            project_id=PROJECT_ID,
+            instance_id=INSTANCE_ID,
+            table_id=TABLE_ID,
+            task_id="id",
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
+
+        mock_hook.return_value.get_instance.return_value = None
+        with pytest.raises(AirflowException) as ctx:
+            op.execute(None)
+        err = ctx.value
+        assert str(err) == f"Dependency: instance '{INSTANCE_ID}' does not exist."
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
+        mock_hook.return_value.delete_table.assert_not_called()
+
+    @mock.patch("airflow.providers.google.cloud.operators.bigtable.BigtableHook")
+    def test_different_error_reraised(self, mock_hook):
+        op = BigtableDeleteTableOperator(
+            project_id=PROJECT_ID,
+            instance_id=INSTANCE_ID,
+            table_id=TABLE_ID,
+            task_id="id",
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
+        mock_hook.return_value.delete_table.side_effect = mock.Mock(
+            side_effect=google.api_core.exceptions.GoogleAPICallError("error")
+        )
+
+        with pytest.raises(google.api_core.exceptions.GoogleAPICallError):
+            op.execute(None)
+
+        mock_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
+        mock_hook.return_value.delete_table.assert_called_once_with(
+            project_id=PROJECT_ID, instance_id=INSTANCE_ID, table_id=TABLE_ID
         )
 
 

--- a/providers/google/tests/unit/google/cloud/operators/test_bigtable.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_bigtable.py
@@ -654,10 +654,6 @@ class TestBigtableTableDelete:
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
-
-        mock_hook.return_value.delete_table.side_effect = mock.Mock(
-            side_effect=google.api_core.exceptions.NotFound("Table not found.")
-        )
         op.execute(None)
         mock_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
@@ -676,10 +672,6 @@ class TestBigtableTableDelete:
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
-
-        mock_hook.return_value.delete_table.side_effect = mock.Mock(
-            side_effect=google.api_core.exceptions.NotFound("Table not found.")
-        )
         op.execute(None)
         mock_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
@@ -687,53 +679,6 @@ class TestBigtableTableDelete:
         )
         mock_hook.return_value.delete_table.assert_called_once_with(
             project_id=None, instance_id=INSTANCE_ID, table_id=TABLE_ID
-        )
-
-    @mock.patch("airflow.providers.google.cloud.operators.bigtable.BigtableHook")
-    def test_deleting_table_when_instance_doesnt_exists(self, mock_hook):
-        op = BigtableDeleteTableOperator(
-            project_id=PROJECT_ID,
-            instance_id=INSTANCE_ID,
-            table_id=TABLE_ID,
-            task_id="id",
-            gcp_conn_id=GCP_CONN_ID,
-            impersonation_chain=IMPERSONATION_CHAIN,
-        )
-
-        mock_hook.return_value.get_instance.return_value = None
-        with pytest.raises(AirflowException) as ctx:
-            op.execute(None)
-        err = ctx.value
-        assert str(err) == f"Dependency: instance '{INSTANCE_ID}' does not exist."
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID,
-            impersonation_chain=IMPERSONATION_CHAIN,
-        )
-        mock_hook.return_value.delete_table.assert_not_called()
-
-    @mock.patch("airflow.providers.google.cloud.operators.bigtable.BigtableHook")
-    def test_different_error_reraised(self, mock_hook):
-        op = BigtableDeleteTableOperator(
-            project_id=PROJECT_ID,
-            instance_id=INSTANCE_ID,
-            table_id=TABLE_ID,
-            task_id="id",
-            gcp_conn_id=GCP_CONN_ID,
-            impersonation_chain=IMPERSONATION_CHAIN,
-        )
-        mock_hook.return_value.delete_table.side_effect = mock.Mock(
-            side_effect=google.api_core.exceptions.GoogleAPICallError("error")
-        )
-
-        with pytest.raises(google.api_core.exceptions.GoogleAPICallError):
-            op.execute(None)
-
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID,
-            impersonation_chain=IMPERSONATION_CHAIN,
-        )
-        mock_hook.return_value.delete_table.assert_called_once_with(
-            project_id=PROJECT_ID, instance_id=INSTANCE_ID, table_id=TABLE_ID
         )
 
 

--- a/providers/google/tests/unit/google/cloud/operators/test_bigtable.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_bigtable.py
@@ -584,7 +584,10 @@ class TestBigtableInstanceDelete:
         mock_hook.assert_not_called()
 
     @mock.patch("airflow.providers.google.cloud.operators.bigtable.BigtableHook")
-    def test_deleting_instance_that_doesnt_exists(self, mock_hook):
+    def test_delete_instance_when_instance_missing_does_not_fail(self, mock_hook):
+        # Simulate hook handling missing instance gracefully
+        mock_hook.return_value.delete_instance.return_value = None
+
         op = BigtableDeleteInstanceOperator(
             project_id=PROJECT_ID,
             instance_id=INSTANCE_ID,
@@ -592,58 +595,10 @@ class TestBigtableInstanceDelete:
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
-        mock_hook.return_value.delete_instance.side_effect = mock.Mock(
-            side_effect=google.api_core.exceptions.NotFound("Instance not found.")
-        )
+
+        # Should NOT raise
         op.execute(None)
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID,
-            impersonation_chain=IMPERSONATION_CHAIN,
-        )
-        mock_hook.return_value.delete_instance.assert_called_once_with(
-            project_id=PROJECT_ID, instance_id=INSTANCE_ID
-        )
 
-    @mock.patch("airflow.providers.google.cloud.operators.bigtable.BigtableHook")
-    def test_deleting_instance_that_doesnt_exists_empty_project_id(self, mock_hook):
-        op = BigtableDeleteInstanceOperator(
-            instance_id=INSTANCE_ID,
-            task_id="id",
-            gcp_conn_id=GCP_CONN_ID,
-            impersonation_chain=IMPERSONATION_CHAIN,
-        )
-        mock_hook.return_value.delete_instance.side_effect = mock.Mock(
-            side_effect=google.api_core.exceptions.NotFound("Instance not found.")
-        )
-        op.execute(None)
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID,
-            impersonation_chain=IMPERSONATION_CHAIN,
-        )
-        mock_hook.return_value.delete_instance.assert_called_once_with(
-            project_id=None, instance_id=INSTANCE_ID
-        )
-
-    @mock.patch("airflow.providers.google.cloud.operators.bigtable.BigtableHook")
-    def test_different_error_reraised(self, mock_hook):
-        op = BigtableDeleteInstanceOperator(
-            project_id=PROJECT_ID,
-            instance_id=INSTANCE_ID,
-            task_id="id",
-            gcp_conn_id=GCP_CONN_ID,
-            impersonation_chain=IMPERSONATION_CHAIN,
-        )
-        mock_hook.return_value.delete_instance.side_effect = mock.Mock(
-            side_effect=google.api_core.exceptions.GoogleAPICallError("error")
-        )
-
-        with pytest.raises(google.api_core.exceptions.GoogleAPICallError):
-            op.execute(None)
-
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID,
-            impersonation_chain=IMPERSONATION_CHAIN,
-        )
         mock_hook.return_value.delete_instance.assert_called_once_with(
             project_id=PROJECT_ID, instance_id=INSTANCE_ID
         )


### PR DESCRIPTION
Fix #60687 
Have Checked the Code and Modified accordingly also checked when the instance is not available to delete it should not log an error(Idempotent).

Tested Working Fine from My Side