### PR TITLE
Remove deprecated options from old sections to prevent duplication and ensure sensitive flags are applied correctly

### DIFF
--- a/shared/configuration/src/airflow_shared/configuration/parser.py
+++ b/shared/configuration/src/airflow_shared/configuration/parser.py
@@ -1444,6 +1444,20 @@ class AirflowConfigParser(ConfigParser):
         else:
             self._filter_by_source(config_sources, display_source, self._get_secret_option)
 
+        # Remove deprecated options from old sections to avoid duplication
+        # Only remove if new option exists in the new section
+        inversed_deprecated = self.inversed_deprecated_options
+        for (old_section, old_key), (new_section, new_key) in inversed_deprecated.items():
+            old_section_dict = config_sources.get(old_section)
+            new_section_dict = config_sources.get(new_section)
+            if not (old_section_dict and old_key in old_section_dict):
+                continue
+            if not (new_section_dict and new_key in new_section_dict):
+                continue
+            del old_section_dict[old_key]
+            if not old_section_dict:
+                del config_sources[old_section]
+
         if not display_sensitive:
             # This ensures the ones from config file is hidden too
             # if they are not provided through env, cmd and secret


### PR DESCRIPTION
# Related Issue
Issue: https://github.com/apache/airflow/issues/60668

# Summary
Removes deprecated configuration options from old sections when displaying config via `as_dict()` to prevent duplication and ensure sensitive flags are properly applied.

# Problem

When displaying configuration in the Airflow web UI, deprecated options (e.g., `core.sql_alchemy_conn`) were shown alongside their new counterparts (e.g., `database.sql_alchemy_conn`), causing:
1. Duplicate entries in the configs screen
2. Potential sensitive information exposure, as deprecated options in old sections may not have sensitive flags properly applied

# Solution

Added logic in `as_dict()` to filter out deprecated options from old sections when the same option exists in the new section, ensuring only the new section's configuration (with proper sensitive handling) is displayed.


<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)
- Cursor

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
