### PR TITLE
Fix TaskInstance.get_dagrun returning None in task_instance_mutation_hook

### DIFF
--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -1005,7 +1005,10 @@ class TaskInstance(Base, LoggingMixin):
         :return: DagRun
         """
         info: Any = inspect(self)
-        if info.attrs.dag_run.loaded_value is not NO_VALUE:
+        # If dag_run is loaded and not None, return it.
+        # In early lifecycle phases (e.g. task_instance_mutation_hook),
+        # dag_run may be marked as loaded but still be None.
+        if info.attrs.dag_run.loaded_value is not NO_VALUE and self.dag_run is not None:            
             if getattr(self, "task", None) is not None:
                 if TYPE_CHECKING:
                     assert self.task

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/powerbi.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/powerbi.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin
 from airflow.providers.common.compat.sdk import AirflowException
 from airflow.providers.microsoft.azure.hooks.msgraph import KiotaRequestAdapterHook
-\
+
 
 
 if TYPE_CHECKING:
@@ -284,3 +284,4 @@ class PowerBIHook(KiotaRequestAdapterHook):
             },
             method="DELETE",
         )
+

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/powerbi.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/powerbi.py
@@ -295,8 +295,3 @@ class PowerBIHook(KiotaRequestAdapterHook):
             },
             method="DELETE",
         )
-
-
-
-
-

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/powerbi.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/powerbi.py
@@ -22,6 +22,8 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin
 from airflow.providers.common.compat.sdk import AirflowException
 from airflow.providers.microsoft.azure.hooks.msgraph import KiotaRequestAdapterHook
+from io import BytesIO
+from typing import Any
 
 if TYPE_CHECKING:
     from msgraph_core import APIVersion
@@ -91,19 +93,36 @@ class PowerBIHook(KiotaRequestAdapterHook):
             host="https://api.powerbi.com",
             scopes=["https://analysis.windows.net/powerbi/api/.default"],
             api_version=api_version,
-        )
+        )  
         
-    async def run(self, url: str, **kwargs):
+    async def run(
+        self,
+        url: str = "",
+        response_type: str | None = None,
+        path_parameters: dict[str, Any] | None = None,
+        method: str = "GET",
+        query_parameters: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        data: dict[str, Any] | str | BytesIO | None = None,
+    ):
         """
         Execute a Power BI REST API request.
-
+    
         Ensures relative Power BI endpoints are expanded to full URLs.
         """
         if not url.startswith(("http://", "https://")):
             url = urljoin(self.POWERBI_API_BASE_URL, url)
-
-        return await super().run(url=url, **kwargs)
-        
+    
+        return await super().run(
+            url=url,
+            response_type=response_type,
+            path_parameters=path_parameters,
+            method=method,
+            query_parameters=query_parameters,
+            headers=headers,
+            data=data,
+        )
+    
     @classmethod
     def get_connection_form_widgets(cls) -> dict[str, Any]:
         """Return connection widgets to add to connection form."""
@@ -281,6 +300,7 @@ class PowerBIHook(KiotaRequestAdapterHook):
             },
             method="DELETE",
         )
+
 
 
 

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/powerbi.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/powerbi.py
@@ -23,8 +23,6 @@ from urllib.parse import urljoin
 from airflow.providers.common.compat.sdk import AirflowException
 from airflow.providers.microsoft.azure.hooks.msgraph import KiotaRequestAdapterHook
 
-
-
 if TYPE_CHECKING:
     from msgraph_core import APIVersion
 
@@ -284,4 +282,5 @@ class PowerBIHook(KiotaRequestAdapterHook):
             },
             method="DELETE",
         )
+
 

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/powerbi.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/powerbi.py
@@ -25,8 +25,7 @@ from airflow.providers.microsoft.azure.hooks.msgraph import KiotaRequestAdapterH
 
 if TYPE_CHECKING:
     from msgraph_core import APIVersion
-
-
+    
 class PowerBIDatasetRefreshFields(Enum):
     """Power BI refresh dataset details."""
 
@@ -282,5 +281,6 @@ class PowerBIHook(KiotaRequestAdapterHook):
             },
             method="DELETE",
         )
+
 
 

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/powerbi.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/powerbi.py
@@ -35,7 +35,6 @@ class PowerBIDatasetRefreshFields(Enum):
     STATUS = "status"
     ERROR = "error"
 
-
 class PowerBIDatasetRefreshStatus:
     """Power BI refresh dataset statuses."""
 
@@ -47,18 +46,14 @@ class PowerBIDatasetRefreshStatus:
     TERMINAL_STATUSES = {FAILED, COMPLETED}
     FAILURE_STATUSES = {FAILED, DISABLED}
 
-
 class PowerBIDatasetRefreshException(AirflowException):
     """An exception that indicates a dataset refresh failed to complete."""
-
 
 class PowerBIWorkspaceListException(AirflowException):
     """An exception that indicates a failure in getting the list of groups (workspaces)."""
 
-
 class PowerBIDatasetListException(AirflowException):
     """An exception that indicates a failure in getting the list of datasets."""
-
 
 class PowerBIHook(KiotaRequestAdapterHook):
     """
@@ -300,6 +295,7 @@ class PowerBIHook(KiotaRequestAdapterHook):
             },
             method="DELETE",
         )
+
 
 
 

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/powerbi.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/powerbi.py
@@ -19,9 +19,11 @@ from __future__ import annotations
 
 from enum import Enum
 from typing import TYPE_CHECKING, Any
-
+from urllib.parse import urljoin
 from airflow.providers.common.compat.sdk import AirflowException
 from airflow.providers.microsoft.azure.hooks.msgraph import KiotaRequestAdapterHook
+\
+
 
 if TYPE_CHECKING:
     from msgraph_core import APIVersion
@@ -76,6 +78,7 @@ class PowerBIHook(KiotaRequestAdapterHook):
     conn_name_attr: str = "conn_id"
     default_conn_name: str = "powerbi_default"
     hook_name: str = "Power BI"
+    POWERBI_API_BASE_URL = "https://api.powerbi.com/v1.0/"
 
     def __init__(
         self,
@@ -92,7 +95,18 @@ class PowerBIHook(KiotaRequestAdapterHook):
             scopes=["https://analysis.windows.net/powerbi/api/.default"],
             api_version=api_version,
         )
+        
+    async def run(self, url: str, **kwargs):
+        """
+        Execute a Power BI REST API request.
 
+        Ensures relative Power BI endpoints are expanded to full URLs.
+        """
+        if not url.startswith(("http://", "https://")):
+            url = urljoin(self.POWERBI_API_BASE_URL, url)
+
+        return await super().run(url=url, **kwargs)
+        
     @classmethod
     def get_connection_form_widgets(cls) -> dict[str, Any]:
         """Return connection widgets to add to connection form."""

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_powerbi.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_powerbi.py
@@ -213,3 +213,42 @@ class TestPowerBIHook:
             },
             method="DELETE",
         )
+
+    @pytest.mark.asyncio
+    async def test_run_expands_relative_powerbi_url(self, powerbi_hook):
+        """Relative Power BI URLs should be expanded to full REST API URLs."""
+
+        with mock.patch.object(
+            KiotaRequestAdapterHook,
+            "run",
+            new_callable=mock.AsyncMock,
+        ) as mock_run:
+            mock_run.return_value = {}
+
+            await powerbi_hook.run(url="myorg/groups")
+
+            mock_run.assert_awaited_once()
+            called_url = mock_run.call_args.kwargs["url"]
+
+            assert called_url == "https://api.powerbi.com/v1.0/myorg/groups"
+
+    @pytest.mark.asyncio
+    async def test_run_does_not_modify_absolute_url(self, powerbi_hook):
+        """Absolute URLs should not be modified by PowerBIHook.run."""
+
+        absolute_url = "https://api.powerbi.com/v1.0/myorg/groups"
+
+        with mock.patch.object(
+            KiotaRequestAdapterHook,
+            "run",
+            new_callable=mock.AsyncMock,
+        ) as mock_run:
+            mock_run.return_value = {}
+
+            await powerbi_hook.run(url=absolute_url)
+
+            mock_run.assert_awaited_once()
+            called_url = mock_run.call_args.kwargs["url"]
+
+            assert called_url == absolute_url
+


### PR DESCRIPTION
Fixes #60610

TaskInstance.get_dagrun() could return None when the dag_run relationship
was marked as loaded but unset, which occurs in early lifecycle phases such as
task_instance_mutation_hook.

This change ensures the DagRun is fetched from the database in that case,
restoring access to DagRun.conf without altering lifecycle semantics.
