### PR TITLE
Refactor Bigtable Delete Instance Operator to remove redundant try/excep…

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,11 @@
+Closes: #60687
+
+This PR removes redundant `try/except` blocks in `BigtableDeleteInstanceOperator` in `airflow/providers/google/cloud/operators/bigtable.py`.
+
+The underlying `BigtableHook.delete_instance` method already handles the case where the instance does not exist by logging a warning. Therefore, catching `NotFound` in the operator was unnecessary and duplicated logic.
+
+I have also:
+- Updated the unit tests in `providers/google/tests/unit/google/cloud/operators/test_bigtable.py` to remove tests that specifically enforced this redundant exception handling.
+- Corrected the docstring in `airflow/providers/google/cloud/hooks/bigtable.py` which incorrectly stated that `delete_instance` raises `NotFound`.
+
+Generated-by: Antigravity (Google DeepMind)

--- a/providers/google/src/airflow/providers/google/cloud/hooks/bigtable.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/bigtable.py
@@ -87,8 +87,7 @@ class BigtableHook(GoogleBaseHook):
         """
         Delete the specified Cloud Bigtable instance.
 
-        Raises google.api_core.exceptions.NotFound if the Cloud Bigtable instance does
-        not exist.
+        If the Cloud Bigtable instance does not exist, it logs a warning.
 
         :param project_id: Optional, Google Cloud project ID where the
             BigTable exists. If set to None or missing,

--- a/providers/google/src/airflow/providers/google/cloud/operators/bigtable.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/bigtable.py
@@ -331,17 +331,7 @@ class BigtableDeleteInstanceOperator(GoogleCloudBaseOperator, BigtableValidation
             gcp_conn_id=self.gcp_conn_id,
             impersonation_chain=self.impersonation_chain,
         )
-        try:
-            hook.delete_instance(project_id=self.project_id, instance_id=self.instance_id)
-        except google.api_core.exceptions.NotFound:
-            self.log.info(
-                "The instance '%s' does not exist in project '%s'. Consider it as deleted",
-                self.instance_id,
-                self.project_id,
-            )
-        except google.api_core.exceptions.GoogleAPICallError as e:
-            self.log.error("An error occurred. Exiting.")
-            raise e
+        hook.delete_instance(project_id=self.project_id, instance_id=self.instance_id)
 
 
 class BigtableCreateTableOperator(GoogleCloudBaseOperator, BigtableValidationMixin):

--- a/providers/google/tests/unit/google/cloud/operators/test_bigtable.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_bigtable.py
@@ -584,47 +584,6 @@ class TestBigtableInstanceDelete:
         mock_hook.assert_not_called()
 
     @mock.patch("airflow.providers.google.cloud.operators.bigtable.BigtableHook")
-    def test_deleting_instance_that_doesnt_exists(self, mock_hook):
-        op = BigtableDeleteInstanceOperator(
-            project_id=PROJECT_ID,
-            instance_id=INSTANCE_ID,
-            task_id="id",
-            gcp_conn_id=GCP_CONN_ID,
-            impersonation_chain=IMPERSONATION_CHAIN,
-        )
-        mock_hook.return_value.delete_instance.side_effect = mock.Mock(
-            side_effect=google.api_core.exceptions.NotFound("Instance not found.")
-        )
-        op.execute(None)
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID,
-            impersonation_chain=IMPERSONATION_CHAIN,
-        )
-        mock_hook.return_value.delete_instance.assert_called_once_with(
-            project_id=PROJECT_ID, instance_id=INSTANCE_ID
-        )
-
-    @mock.patch("airflow.providers.google.cloud.operators.bigtable.BigtableHook")
-    def test_deleting_instance_that_doesnt_exists_empty_project_id(self, mock_hook):
-        op = BigtableDeleteInstanceOperator(
-            instance_id=INSTANCE_ID,
-            task_id="id",
-            gcp_conn_id=GCP_CONN_ID,
-            impersonation_chain=IMPERSONATION_CHAIN,
-        )
-        mock_hook.return_value.delete_instance.side_effect = mock.Mock(
-            side_effect=google.api_core.exceptions.NotFound("Instance not found.")
-        )
-        op.execute(None)
-        mock_hook.assert_called_once_with(
-            gcp_conn_id=GCP_CONN_ID,
-            impersonation_chain=IMPERSONATION_CHAIN,
-        )
-        mock_hook.return_value.delete_instance.assert_called_once_with(
-            project_id=None, instance_id=INSTANCE_ID
-        )
-
-    @mock.patch("airflow.providers.google.cloud.operators.bigtable.BigtableHook")
     def test_different_error_reraised(self, mock_hook):
         op = BigtableDeleteInstanceOperator(
             project_id=PROJECT_ID,


### PR DESCRIPTION
This PR removes redundant `try/except` blocks in `BigtableDeleteInstanceOperator` in `airflow/providers/google/cloud/operators/bigtable.py`.

The underlying `BigtableHook.delete_instance` method already handles the case where the instance does not exist by logging a warning. Therefore, catching `NotFound` in the operator was unnecessary and duplicated logic.

I have also:
- Updated the unit tests in `providers/google/tests/unit/google/cloud/operators/test_bigtable.py` to remove tests that specifically enforced this redundant exception handling.
- Corrected the docstring in `airflow/providers/google/cloud/hooks/bigtable.py` which incorrectly stated that `delete_instance` raises `NotFound`.

Generated-by: Antigravity (Google DeepMind)