### PR TITLE
Add uv sync --no-dev before provider YAML checks

### DIFF
--- a/scripts/in_container/run_provider_yaml_files_check.py
+++ b/scripts/in_container/run_provider_yaml_files_check.py
@@ -25,6 +25,7 @@ import json
 import os
 import pathlib
 import platform
+import subprocess
 import sys
 import textwrap
 import warnings
@@ -33,8 +34,6 @@ from collections.abc import Callable, Iterable
 from enum import Enum
 from functools import cache
 from typing import Any
-
-import subprocess
 
 import jsonschema
 import yaml
@@ -117,7 +116,7 @@ def sync_dependencies_without_dev() -> None:
         capture_output=True,
         text=True,
         cwd=AIRFLOW_ROOT_PATH,
-        check = False
+        check=False,
     )
     if result.returncode != 0:
         console.print(f"[red]Failed to remove dev dependencies: {result.stderr}[/]")

--- a/scripts/in_container/run_provider_yaml_files_check.py
+++ b/scripts/in_container/run_provider_yaml_files_check.py
@@ -718,6 +718,7 @@ def check_providers_have_all_documentation_files(yaml_files: dict[str, dict]):
 
 
 if __name__ == "__main__":
+    sync_dependencies_without_dev()
     ProvidersManager().initialize_providers_configuration()
     architecture = Architecture.get_current()
     console.print(f"Verifying packages on {architecture} architecture. Platform: {platform.machine()}.")

--- a/scripts/in_container/run_provider_yaml_files_check.py
+++ b/scripts/in_container/run_provider_yaml_files_check.py
@@ -117,6 +117,7 @@ def sync_dependencies_without_dev() -> None:
         capture_output=True,
         text=True,
         cwd=AIRFLOW_ROOT_PATH,
+        check = False
     )
     if result.returncode != 0:
         console.print(f"[red]Failed to remove dev dependencies: {result.stderr}[/]")

--- a/scripts/in_container/run_provider_yaml_files_check.py
+++ b/scripts/in_container/run_provider_yaml_files_check.py
@@ -118,9 +118,12 @@ def sync_dependencies_without_dev() -> None:
         cwd=AIRFLOW_ROOT_PATH,
     )
     if result.returncode != 0:
-        console.print(f"[yellow]Warning: uv sync --no-dev failed:[/]\n{result.stderr}")
-    else:
-        console.print("[green]Successfully synchronized without dev dependencies[/]")
+        console.print(f"[red]Failed to remove dev dependencies: {result.stderr}[/]")
+        sys.exit(1)
+
+    console.print("[green]Successfully synchronized without dev dependencies[/]")
+    if result.stdout:
+        console.print(result.stdout)
 
 
 def _filepath_to_module(filepath: pathlib.Path | str) -> str:

--- a/scripts/in_container/run_provider_yaml_files_check.py
+++ b/scripts/in_container/run_provider_yaml_files_check.py
@@ -38,6 +38,7 @@ import subprocess
 
 import jsonschema
 import yaml
+from jsonpath_ng.ext import parse
 from rich.console import Console
 from tabulate import tabulate
 
@@ -687,8 +688,6 @@ def check_unique_provider_name(yaml_files: dict[str, dict]) -> tuple[int, int]:
 
 @run_check(f"Checking providers are mentioned in {PROVIDER_ISSUE_TEMPLATE_PATH}")
 def check_providers_are_mentioned_in_issue_template(yaml_files: dict[str, dict]):
-    from jsonpath_ng.ext import parse
-
     num_errors = 0
     num_providers = 0
     prefix_len = len("apache-airflow-providers-")


### PR DESCRIPTION
**What change does this PR introduce?**

Strips dev dependencies before running provider YAML validation checks by running `uv sync --no-dev --all-packages`.

**Why is this change needed?**

Currently, the provider YAML check runs with all dependencies installed, including dev dependencies. This can mask issues where provider code has optional cross-provider dependencies that aren't handled properly (missing try/except blocks for optional imports). By stripping dev dependencies first, we create an environment closer to production and can detect these issues during CI.

**Related issue(s)**

closes: #60662

**Changes**

- Added `sync_dependencies_without_dev()` function that runs `uv sync --no-dev --all-packages` before provider checks
- Function is called at the start of the main execution before any validation runs

**Testing**

- Ran `uv sync --no-dev --all-packages` in breeze container to strip dev dependencies
- Verified providers and their dependencies (including `jsonpath-ng` from amazon provider) remain installed
- Executed `python scripts/in_container/run_provider_yaml_files_check.py`
- All provider checks passed with 0 errors

## Gen-AI Assisted Contribution

Claude AI was consulted for guidance on Airflow's codebase structure and assistance with resolving CI failures. Core implementation and testing were done independently.