### PR TITLE
dag_processing: initialize versioned bundles for callbacks (#52040)

### DIFF
--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -48,6 +48,7 @@ from airflow._shared.observability.metrics.stats import Stats
 from airflow._shared.timezones import timezone
 from airflow.api_fastapi.execution_api.app import InProcessExecutionAPI
 from airflow.configuration import conf
+from airflow.dag_processing.bundles.base import BundleUsageTrackingManager
 from airflow.dag_processing.bundles.manager import DagBundlesManager
 from airflow.dag_processing.collection import update_dag_parsing_results_in_db
 from airflow.dag_processing.processor import DagFileParsingResult, DagFileProcessorProcess
@@ -175,6 +176,9 @@ class DagFileProcessorManager(LoggingMixin):
     parsing_cleanup_interval: float = attrs.field(
         factory=_config_int_factory("scheduler", "parsing_cleanup_interval")
     )
+    stale_bundle_cleanup_interval: float = attrs.field(
+        factory=_config_int_factory("dag_processor", "stale_bundle_cleanup_interval")
+    )
     _file_process_interval: float = attrs.field(
         factory=_config_int_factory("dag_processor", "min_file_process_interval")
     )
@@ -183,6 +187,7 @@ class DagFileProcessorManager(LoggingMixin):
     )
 
     _last_deactivate_stale_dags_time: float = attrs.field(default=0, init=False)
+    _last_stale_bundle_cleanup_time: float = attrs.field(default=0, init=False)
     print_stats_interval: float = attrs.field(
         factory=_config_int_factory("dag_processor", "print_stats_interval")
     )
@@ -299,6 +304,20 @@ class DagFileProcessorManager(LoggingMixin):
             self.deactivate_stale_dags(last_parsed=last_parsed)
             self._last_deactivate_stale_dags_time = time.monotonic()
 
+    def _cleanup_stale_bundle_versions(self):
+        if self.stale_bundle_cleanup_interval <= 0:
+            return
+        now = time.monotonic()
+        elapsed_time_since_cleanup = now - self._last_stale_bundle_cleanup_time
+        if elapsed_time_since_cleanup < self.stale_bundle_cleanup_interval:
+            return
+        try:
+            BundleUsageTrackingManager().remove_stale_bundle_versions()
+        except Exception:
+            self.log.exception("Error removing stale bundle versions")
+        finally:
+            self._last_stale_bundle_cleanup_time = now
+
     @provide_session
     def deactivate_stale_dags(
         self,
@@ -374,6 +393,7 @@ class DagFileProcessorManager(LoggingMixin):
             for callback in self._fetch_callbacks():
                 self._add_callback_to_queue(callback)
             self._scan_stale_dags()
+            self._cleanup_stale_bundle_versions()
             DagWarning.purge_inactive_dag_warnings()
 
             # Update number of loop iteration.
@@ -491,6 +511,16 @@ class DagFileProcessorManager(LoggingMixin):
             # Bundle no longer configured
             self.log.error("Bundle %s no longer configured, skipping callback", request.bundle_name)
             return None
+        if bundle.supports_versioning and request.bundle_version:
+            try:
+                bundle.initialize()
+            except Exception:
+                self.log.exception(
+                    "Error initializing bundle %s version %s for callback, skipping",
+                    request.bundle_name,
+                    request.bundle_version,
+                )
+                return None
 
         file_info = DagFileInfo(
             rel_path=Path(request.filepath),

--- a/airflow-core/src/airflow/dag_processing/processor.py
+++ b/airflow-core/src/airflow/dag_processing/processor.py
@@ -35,6 +35,7 @@ from airflow.callbacks.callback_requests import (
     TaskCallbackRequest,
 )
 from airflow.configuration import conf
+from airflow.dag_processing.bundles.base import BundleVersionLock
 from airflow.dag_processing.dagbag import BundleDagBag, DagBag
 from airflow.sdk.exceptions import TaskNotFound
 from airflow.sdk.execution_time.comms import (
@@ -287,12 +288,16 @@ def _execute_callbacks(
 ) -> None:
     for request in callback_requests:
         log.debug("Processing Callback Request", request=request.to_json())
-        if isinstance(request, TaskCallbackRequest):
-            _execute_task_callbacks(dagbag, request, log)
-        elif isinstance(request, DagCallbackRequest):
-            _execute_dag_callbacks(dagbag, request, log)
-        elif isinstance(request, EmailRequest):
-            _execute_email_callbacks(dagbag, request, log)
+        with BundleVersionLock(
+            bundle_name=request.bundle_name,
+            bundle_version=request.bundle_version,
+        ):
+            if isinstance(request, TaskCallbackRequest):
+                _execute_task_callbacks(dagbag, request, log)
+            elif isinstance(request, DagCallbackRequest):
+                _execute_dag_callbacks(dagbag, request, log)
+            elif isinstance(request, EmailRequest):
+                _execute_email_callbacks(dagbag, request, log)
 
 
 def _execute_dag_callbacks(dagbag: DagBag, request: DagCallbackRequest, log: FilteringBoundLogger) -> None:

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -593,6 +593,20 @@ class TestDagFileProcessorManager:
         # SerializedDagModel gives history about Dags
         assert serialized_dag_count == 1
 
+    @mock.patch("airflow.dag_processing.manager.BundleUsageTrackingManager")
+    def test_cleanup_stale_bundle_versions_interval(self, mock_bundle_manager):
+        manager = DagFileProcessorManager(max_runs=1)
+        manager.stale_bundle_cleanup_interval = 10
+
+        manager._last_stale_bundle_cleanup_time = time.monotonic() - 20
+        manager._cleanup_stale_bundle_versions()
+        mock_bundle_manager.return_value.remove_stale_bundle_versions.assert_called_once()
+
+        mock_bundle_manager.return_value.remove_stale_bundle_versions.reset_mock()
+        manager._last_stale_bundle_cleanup_time = time.monotonic()
+        manager._cleanup_stale_bundle_versions()
+        mock_bundle_manager.return_value.remove_stale_bundle_versions.assert_not_called()
+
     def test_kill_timed_out_processors_kill(self):
         manager = DagFileProcessorManager(max_runs=1, processor_timeout=5)
         # Set start_time to ensure timeout occurs: start_time = current_time - (timeout + 1) = always (timeout + 1) seconds
@@ -1137,6 +1151,28 @@ class TestDagFileProcessorManager:
             # And removed from the queue
             assert dag1_path not in manager._callback_to_execute
             assert dag2_path not in manager._callback_to_execute
+
+    @mock.patch("airflow.dag_processing.manager.DagBundlesManager")
+    def test_add_callback_initializes_versioned_bundle(self, mock_bundle_manager):
+        manager = DagFileProcessorManager(max_runs=1)
+        bundle = MagicMock()
+        bundle.supports_versioning = True
+        bundle.path = Path("/tmp/bundle")
+        mock_bundle_manager.return_value.get_bundle.return_value = bundle
+
+        request = DagCallbackRequest(
+            filepath="file1.py",
+            dag_id="dag1",
+            run_id="run1",
+            is_failure_callback=False,
+            bundle_name="testing",
+            bundle_version="some_commit_hash",
+            msg=None,
+        )
+
+        manager._add_callback_to_queue(request)
+
+        bundle.initialize.assert_called_once()
 
     def test_dag_with_assets(self, session, configure_testing_dag_bundle):
         """'Integration' test to ensure that the assets get parsed and stored correctly for parsed dags."""

--- a/airflow-core/tests/unit/dag_processing/test_processor.py
+++ b/airflow-core/tests/unit/dag_processing/test_processor.py
@@ -669,15 +669,17 @@ def test_import_error_updates_timestamps(session):
 
 class TestExecuteCallbacks:
     def test_execute_callbacks_locks_bundle_version(self):
-        callbacks = [DagCallbackRequest(
-            filepath="test.py",
-            dag_id="test_dag",
-            run_id="test_run",
-            bundle_name="testing",
-            bundle_version="some_commit_hash",
-            is_failure_callback=False,
-            msg=None,
-        )]
+        callbacks = [
+            DagCallbackRequest(
+                filepath="test.py",
+                dag_id="test_dag",
+                run_id="test_run",
+                bundle_name="testing",
+                bundle_version="some_commit_hash",
+                is_failure_callback=False,
+                msg=None,
+            )
+        ]
         log = MagicMock(spec=FilteringBoundLogger)
         dagbag = MagicMock(spec=DagBag)
 

--- a/airflow-core/tests/unit/dag_processing/test_processor.py
+++ b/airflow-core/tests/unit/dag_processing/test_processor.py
@@ -685,7 +685,7 @@ class TestExecuteCallbacks:
             patch("airflow.dag_processing.processor.BundleVersionLock") as mock_lock,
             patch("airflow.dag_processing.processor._execute_dag_callbacks") as mock_execute,
         ):
-            _execute_callbacks(dagbag, [request], log)
+            _execute_callbacks(dagbag, callbacks, log)
 
         mock_lock.assert_called_once_with(bundle_name="testing", bundle_version="some_commit_hash")
         mock_lock.return_value.__enter__.assert_called_once()

--- a/airflow-core/tests/unit/dag_processing/test_processor.py
+++ b/airflow-core/tests/unit/dag_processing/test_processor.py
@@ -669,7 +669,7 @@ def test_import_error_updates_timestamps(session):
 
 class TestExecuteCallbacks:
     def test_execute_callbacks_locks_bundle_version(self):
-        request = DagCallbackRequest(
+        callbacks = [DagCallbackRequest(
             filepath="test.py",
             dag_id="test_dag",
             run_id="test_run",

--- a/airflow-core/tests/unit/dag_processing/test_processor.py
+++ b/airflow-core/tests/unit/dag_processing/test_processor.py
@@ -678,8 +678,8 @@ class TestExecuteCallbacks:
             is_failure_callback=False,
             msg=None,
         )]
-        log = structlog.get_logger()
-        dagbag = MagicMock()
+        log = MagicMock(spec=FilteringBoundLogger)
+        dagbag = MagicMock(spec=DagBag)
 
         with (
             patch("airflow.dag_processing.processor.BundleVersionLock") as mock_lock,
@@ -690,7 +690,7 @@ class TestExecuteCallbacks:
         mock_lock.assert_called_once_with(bundle_name="testing", bundle_version="some_commit_hash")
         mock_lock.return_value.__enter__.assert_called_once()
         mock_lock.return_value.__exit__.assert_called_once()
-        mock_execute.assert_called_once_with(dagbag, request, log)
+        mock_execute.assert_called_once_with(dagbag, callbacks[0], log)
 
 
 class TestExecuteDagCallbacks:

--- a/airflow-core/tests/unit/dag_processing/test_processor.py
+++ b/airflow-core/tests/unit/dag_processing/test_processor.py
@@ -677,7 +677,7 @@ class TestExecuteCallbacks:
             bundle_version="some_commit_hash",
             is_failure_callback=False,
             msg=None,
-        )
+        )]
         log = structlog.get_logger()
         dagbag = MagicMock()
 

--- a/airflow-core/tests/unit/dag_processing/test_processor.py
+++ b/airflow-core/tests/unit/dag_processing/test_processor.py
@@ -56,6 +56,7 @@ from airflow.dag_processing.processor import (
     DagFileProcessorProcess,
     ToDagProcessor,
     ToManager,
+    _execute_callbacks,
     _execute_dag_callbacks,
     _execute_email_callbacks,
     _execute_task_callbacks,
@@ -664,6 +665,32 @@ def test_import_error_updates_timestamps(session):
     assert stat.last_finish_time == finish_time
     assert stat.run_count == 3
     assert stat.import_errors == 1
+
+
+class TestExecuteCallbacks:
+    def test_execute_callbacks_locks_bundle_version(self):
+        request = DagCallbackRequest(
+            filepath="test.py",
+            dag_id="test_dag",
+            run_id="test_run",
+            bundle_name="testing",
+            bundle_version="some_commit_hash",
+            is_failure_callback=False,
+            msg=None,
+        )
+        log = structlog.get_logger()
+        dagbag = MagicMock()
+
+        with (
+            patch("airflow.dag_processing.processor.BundleVersionLock") as mock_lock,
+            patch("airflow.dag_processing.processor._execute_dag_callbacks") as mock_execute,
+        ):
+            _execute_callbacks(dagbag, [request], log)
+
+        mock_lock.assert_called_once_with(bundle_name="testing", bundle_version="some_commit_hash")
+        mock_lock.return_value.__enter__.assert_called_once()
+        mock_lock.return_value.__exit__.assert_called_once()
+        mock_execute.assert_called_once_with(dagbag, request, log)
 
 
 class TestExecuteDagCallbacks:


### PR DESCRIPTION
Closes: #52040

# Why

1. Original issue:
When using GitDagBundle with `supports_versioning=True`, Airflow DAG Processor fails to execute DAG callbacks because it cannot find the materialized code under `versions/<commit_hash>/`.
2. Additional concern:
The DAG processor should honor `stale_bundle_cleanup_*` to avoid accumulating versioned bundles.

# How

1. Initialize versioned bundles in `_add_callback_to_queue`.
2. Wrap callback execution in `BundleVersionLock` to update usage and avoid cleanup races.
3. Add `_cleanup_stale_bundle_versions` in `DagFileProcessorManager._run_parsing_loop` to periodically check and remove stale bundle versions.

# What

Before the fixes, `_execute_dag_callbacks` raised errors and the callback logs did not appear in the DAG processor logs.

Here is my remote dag repo: https://github.com/nailo2c/my_repo/blob/main/example_git_bundle_success_dag.py

<img width="1279" height="230" alt="issue-52040-reproduce-1" src="https://github.com/user-attachments/assets/9e6c5572-223c-47bb-8e58-7035c7a86090" />

<img width="1323" height="77" alt="issue-52040-reproduce-2" src="https://github.com/user-attachments/assets/3380aef2-9223-4000-aeb0-b989f7610f43" /> 

<br><br>

After the fixes, `_execute_dag_callbacks` completes without errors, and callbacks continue to work after committing new versions.

```console
aaron.chen@Aarons-MacBook-Air-3 airflow_2 % kubectl exec -n airflow airflow-dag-processor-fd9f96f64-nzc7h -c dag-processor -- grep -R "SUCCESS CALLBACK" /opt/airflow/logs/dag_processor
/opt/airflow/logs/dag_processor/2026-01-17/git_bundle/example_git_bundle_success_dag.py.log:{"timestamp":"2026-01-17T18:47:18.871227Z","level":"warning","event":">>> SUCCESS CALLBACK TRIGGERED VERSION 2 <<<","logger":"root","filename":"example_git_bundle_success_dag.py","lineno":7}
/opt/airflow/logs/dag_processor/2026-01-17/git_bundle/example_git_bundle_success_dag.py.log:{"timestamp":"2026-01-17T19:32:06.676855Z","level":"warning","event":">>> SUCCESS CALLBACK TRIGGERED VERSION 3 <<<","logger":"root","filename":"example_git_bundle_success_dag.py","lineno":7}
```

Both `on_success_callback` and `on_failure_callback` behave as expected.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)
GPT 5.2

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
