### PR TITLE
Bugfix: SQL not rendered in Rendered Templates view 

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1004,16 +1004,44 @@ def _serialize_template_field(template_field: Any, name: str) -> str | dict | li
 def _serialize_rendered_fields(task: AbstractOperator) -> dict[str, JsonValue]:
     from airflow.sdk._shared.secrets_masker import redact
 
-    rendered_fields = {}
+    rendered_fields: dict[str, JsonValue] = {}
     for field in task.template_fields:
         value = getattr(task, field)
         serialized = _serialize_template_field(value, field)
         # Redact secrets in the task process itself before sending to API server
         # This ensures that the secrets those are registered via mask_secret() on workers / dag processor are properly masked
         # on the UI.
-        rendered_fields[field] = redact(serialized, field)
+        redacted = redact(serialized, field)
+        rendered_fields[field] = TypeAdapter(JsonValue).validate_python(redacted)
 
-    return rendered_fields  # type: ignore[return-value] # Convince mypy that this is OK since we pass JsonValue to redact, so it will return the same
+    renderers = getattr(task, "template_fields_renderers", {})
+    for renderer_path in renderers:
+        if "." not in renderer_path:
+            continue
+
+        base_field, _, remainder = renderer_path.partition(".")
+        if base_field not in task.template_fields:
+            continue
+
+        base_value = getattr(task, base_field, None)
+        if base_value is None:
+            continue
+
+        current = base_value
+        for key in remainder.split("."):
+            if isinstance(current, dict):
+                current = current.get(key)
+            else:
+                current = getattr(current, key, None)
+            if current is None:
+                break
+
+        if current is not None:
+            serialized = _serialize_template_field(current, renderer_path)
+            redacted = redact(serialized, renderer_path)
+            rendered_fields[renderer_path] = TypeAdapter(JsonValue).validate_python(redacted)
+
+    return rendered_fields
 
 
 def _build_asset_profiles(lineage_objects: list) -> Iterator[AssetProfile]:

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -2702,6 +2702,78 @@ class TestRuntimeTaskInstance:
             == '[{"name": "var1", "value": "This is a test phrase.", "value_from": null}, {"name": "var2", "value": "***", "value_from": null}, {"name": "var3", "value": "***", "value_from": null}]'
         )
 
+    def test_nested_template_field_renderer_respects_redaction(
+        self, create_runtime_ti, mock_supervisor_comms
+    ):
+        """
+        Ensure nested template_fields_renderers paths still serialize
+        and redact correctly.
+        """
+
+        class CustomOperator(BaseOperator):
+            template_fields = ("config",)
+            template_fields_renderers = {"config.nested.secret": "json"}
+
+            def __init__(self, config, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.config = config
+
+            def execute(self, context):
+                pass
+
+        config = {"nested": {"secret": "top_secret"}}
+
+        task = CustomOperator(
+            task_id="nested_redact_test",
+            config=config,
+        )
+
+        runtime_ti = create_runtime_ti(task=task)
+
+        with mock.patch(
+            "airflow.sdk._shared.secrets_masker.redact",
+            side_effect=lambda val, _: f"MASKED:{val}",
+        ):
+            run(runtime_ti, context=runtime_ti.get_template_context(), log=mock.MagicMock())
+
+        assert any(
+            "config.nested.secret" in call.kwargs.get("msg").rendered_fields
+            for call in mock_supervisor_comms.send.mock_calls
+            if hasattr(call.kwargs.get("msg"), "rendered_fields")
+        )
+
+    def test_rendered_fields_validates_json_value_types(self, create_runtime_ti, mock_supervisor_comms):
+        """
+        Ensure validated JSON-compatible types are preserved after redaction.
+        """
+
+        class CustomOperator(BaseOperator):
+            template_fields = ("data",)
+
+            def __init__(self, data, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.data = data
+
+            def execute(self, context):
+                pass
+
+        complex_value = {"key": [1, 2, {"nested": "value"}]}
+
+        task = CustomOperator(task_id="json_validation_test", data=complex_value)
+        runtime_ti = create_runtime_ti(task=task)
+
+        with mock.patch(
+            "airflow.sdk._shared.secrets_masker.redact",
+            side_effect=lambda val, _: val,
+        ):
+            run(runtime_ti, context=runtime_ti.get_template_context(), log=mock.MagicMock())
+
+        assert any(
+            call.kwargs.get("msg").rendered_fields["data"] == complex_value
+            for call in mock_supervisor_comms.send.mock_calls
+            if hasattr(call.kwargs.get("msg"), "rendered_fields")
+        )
+
 
 class TestXComAfterTaskExecution:
     @pytest.mark.parametrize(


### PR DESCRIPTION
This PR resolves the issue of not rendering SQL (other also like bash command) in the Rendered Templates tab in the specific Task.

Fixes : https://github.com/apache/airflow/issues/60589

### **What is happening currently ?**

Rendered Template fields are generated inside the task runner after jinja rendering and then sent to the API server to be stored in the RTIF table.

The task runner only serialized the top-level template fields defined on the operator(for ex - configuration)
Nested renderer paths (such as configuration.query.query) were not extracted or sent. 

As a result The RTIF model and UI were functioning correctly, but the required data never reached them.

### **What changed made** 

The task runner logic si updated to corrrectly capture rendered template values after rendering and senfd them to the API server.
Becuase the UI is data driven, it immediately began displaying the correct rendered templates with proper title and syntax, without any changes in teh UI code.

Image after fixing this issue 

<img width="1297" height="694" alt="Screenshot from 2026-01-18 12-23-18" src="https://github.com/user-attachments/assets/702db139-6d4a-4eb0-a0d8-470edd9f08f0" />


<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
