### PR TITLE
fix:#60447 document fix

### DIFF
--- a/airflow-core/docs/administration-and-deployment/listeners.rst
+++ b/airflow-core/docs/administration-and-deployment/listeners.rst
@@ -21,6 +21,14 @@ Listeners
 You can write listeners to enable Airflow to notify you when events happen.
 `Pluggy <https://pluggy.readthedocs.io/en/stable/>`__ powers these listeners.
 
+.. note::
+
+    As of Airflow 3.x, the listeners functionality has been moved to a shared library
+    to support client-server separation and improve the architecture. The core
+    functionality remains the same, but the internal implementation now resides
+    in ``airflow._shared.listeners`` while maintaining backward compatibility
+    through the existing import paths.
+
 .. warning::
 
     Listeners are an advanced feature of Airflow. They are not isolated from the Airflow components they run in, and
@@ -131,7 +139,13 @@ Usage
 To create a listener:
 
 - import ``airflow.listeners.hookimpl``
-- implement the ``hookimpls`` for events that you'd like to generate notifications
+- implement the ``hookimpls`` for events that you\'d like to generate notifications
+
+.. note::
+
+    The listeners functionality has been moved to a shared library to support client-server separation.
+    The core listener infrastructure is now available from ``airflow._shared.listeners`` but is still
+    accessible through the same import paths for backward compatibility.
 
 Airflow defines the specification as `hookspec <https://github.com/apache/airflow/tree/main/airflow-core/src/airflow/listeners/spec>`__. Your implementation must accept the same named parameters as defined in hookspec. If you don't use the same parameters as hookspec, Pluggy throws an error when you try to use your plugin. But you don't need to implement every method. Many listeners only implement one method, or a subset of methods.
 

--- a/airflow-core/docs/administration-and-deployment/plugins.rst
+++ b/airflow-core/docs/administration-and-deployment/plugins.rst
@@ -41,6 +41,14 @@ organizations have different stacks and different needs. Using Airflow
 plugins can be a way for companies to customize their Airflow installation
 to reflect their ecosystem.
 
+.. note::
+
+    As of Airflow 3.x, the plugins manager has been moved to a shared library
+    to support client-server separation and improve the architecture. The core
+    functionality remains the same, but the internal implementation now resides
+    in ``airflow._shared.plugins_manager`` while maintaining backward compatibility
+    through the existing import paths.
+
 Plugins can be used as an easy way to write, share and activate new sets of
 features.
 
@@ -112,6 +120,12 @@ To create a plugin you will need to derive the
 you want to plug into Airflow. Here's what the class you need to derive
 looks like:
 
+.. note::
+
+    The plugins manager functionality has been moved to a shared library to support client-server separation.
+    The core plugin infrastructure is now available from ``airflow._shared.plugins_manager`` but is still
+    accessible through the same import paths for backward compatibility.
+
 
 .. code-block:: python
 
@@ -161,6 +175,12 @@ looks like:
         # TaskInstance state changes. Listeners are python modules.
         listeners = []
 
+        # A list of hook lineage reader classes that can be used for reading lineage information from a hook.
+        hook_lineage_readers = []
+
+        # A list of priority weight strategy classes that can be used for calculating tasks weight priority.
+        priority_weight_strategies = []
+
 You can derive it by inheritance (please refer to the example below). In the example, all options have been
 defined as class attributes, but you can also define them as properties if you need to perform
 additional initialization. Please note ``name`` inside this class must be specified.
@@ -192,6 +212,7 @@ definitions in Airflow.
 .. code-block:: python
 
     # This is the class you derive to create a plugin
+    # Note: AirflowPlugin is now available from shared library
     from airflow.plugins_manager import AirflowPlugin
 
     from fastapi import FastAPI

--- a/contributing-docs/12_provider_distributions.rst
+++ b/contributing-docs/12_provider_distributions.rst
@@ -159,6 +159,11 @@ having to manage and install providers separately, you can easily run tests for 
 and when you run Airflow from the ``main`` sources, all community providers are
 automatically available for you.
 
+.. note::
+
+    The providers manager functionality remains in the core but has been enhanced to support shared
+    library architecture. Providers are still discovered through the same mechanisms as before.
+
 The capabilities of the community-managed providers are the same as the third-party ones. When
 the providers are installed from PyPI, they provide the entry-point containing the metadata as described
 in the previous chapter. However when they are locally developed, together with Airflow, the mechanism


### PR DESCRIPTION
Fix: Documentation updates for shared library moves (#60447)
Problem
The meta-issue #60447 tracks documentation updates needed for three critical components that have been moved to shared libraries in Airflow 3.x:
plugins_manager  -> airflow._shared.plugins_manager
listeners ->  airflow._shared.listeners
providers_manager ->  enhanced to support shared library architecture
Solution
Updated documentation to reflect the new physical locations of these components while maintaining clarity about backward compatibility:
plugins.rst: Added notes about the shared library move, updated import paths with backward compatibility notice, and included missing plugin attributes (hook_lineage_readers, priority_weight_strategies)
listeners.rst: Added information about the move to shared library, client-server separation benefits, and architecture improvements
provider_distributions.rst: Enhanced documentation about providers manager changes to support shared library architecture