### PR TITLE
Add get_db_manager to executors and auto-discovery through ExecutorLoader

### DIFF
--- a/airflow-core/src/airflow/executors/base_executor.py
+++ b/airflow-core/src/airflow/executors/base_executor.py
@@ -155,6 +155,19 @@ class BaseExecutor(LoggingMixin):
     name: None | ExecutorName = None
     callback_sink: BaseCallbackSink | None = None
 
+    @staticmethod
+    def get_db_manager() -> str | None:
+        """
+        Return the DB manager class path for this executor, if any.
+
+        Override this method in executor subclasses that require their own
+        database tables to be managed during db operations like reset/migrate.
+
+        Returns:
+            str | None: Full module path to the DB manager class, or None if not needed.
+        """
+        return None
+
     @cached_property
     def jwt_generator(self) -> JWTGenerator:
         from airflow.api_fastapi.auth.tokens import (

--- a/airflow-core/src/airflow/utils/db_manager.py
+++ b/airflow-core/src/airflow/utils/db_manager.py
@@ -191,9 +191,9 @@ class RunDBManager(LoggingMixin):
                         if executor_db_manager and executor_db_manager not in managers:
                             managers.append(executor_db_manager)
                 except Exception:
-                    self.log.debug("Could not load DB manager from executor %s", executor_name)
+                    self.log.warning("Could not load DB manager from executor %s", executor_name)
         except Exception:
-            self.log.debug("Could not load executor DB managers")
+            self.log.warning("Could not load executor DB managers")
         for module in managers:
             manager = import_string(module)
             self._managers.append(manager)

--- a/airflow-core/tests/unit/executors/test_base_executor.py
+++ b/airflow-core/tests/unit/executors/test_base_executor.py
@@ -403,6 +403,29 @@ def test_repr():
     assert repr(executor) == "BaseExecutor(parallelism=10, team_name='teamA')"
 
 
+def test_get_db_manager_default_returns_none():
+    """Test that BaseExecutor.get_db_manager() returns None by default."""
+    assert BaseExecutor.get_db_manager() is None
+
+
+def test_get_db_manager_subclass_override():
+    """Test that executor subclasses can override get_db_manager()."""
+
+    class CustomExecutor(BaseExecutor):
+        @staticmethod
+        def get_db_manager():
+            return "airflow.providers.custom.db_manager.CustomDBManager"
+
+    assert CustomExecutor.get_db_manager() == "airflow.providers.custom.db_manager.CustomDBManager"
+
+
+def test_get_db_manager_callable_from_class_and_instance():
+    """Test that get_db_manager() can be called from both class and instance."""
+    executor = BaseExecutor()
+    assert BaseExecutor.get_db_manager() is None
+    assert executor.get_db_manager() is None
+
+
 @mock.patch.dict("os.environ", {}, clear=True)
 class TestExecutorConf:
     """Test ExecutorConf shim class that provides team-specific configuration access."""

--- a/airflow-core/tests/unit/utils/test_db_manager.py
+++ b/airflow-core/tests/unit/utils/test_db_manager.py
@@ -90,3 +90,204 @@ class TestBaseDBManager:
         with pytest.raises(TypeError):
             # Ensure the old kwarg name is not accepted anymore
             manager.downgrade(to_version="1.2.3")  # type: ignore[call-arg]
+
+
+class TestRunDBManager:
+    """Tests for RunDBManager executor DB manager discovery."""
+
+    @mock.patch("airflow.executors.executor_loader.ExecutorLoader.get_executor_names")
+    @mock.patch("airflow.executors.executor_loader.ExecutorLoader.import_executor_cls")
+    def test_rundbmanager_discovers_executor_db_managers(self, mock_import_executor, mock_get_names, session):
+        """Test that RunDBManager discovers and loads executor DB managers."""
+        from airflow.utils.db_manager import RunDBManager
+
+        # Mock executor with DB manager
+        class MockExecutor:
+            @staticmethod
+            def get_db_manager():
+                return "mock.executor.db.Manager"
+
+        mock_get_names.return_value = ["MockExecutor"]
+        mock_import_executor.return_value = (MockExecutor, None)
+
+        with mock.patch("airflow.utils.db_manager.import_string") as mock_import_string:
+            manager = RunDBManager()
+            assert manager is not None
+
+            mock_get_names.assert_called_once_with(validate_teams=False)
+            mock_import_executor.assert_called_once_with("MockExecutor")
+            mock_import_string.assert_any_call("mock.executor.db.Manager")
+
+    @mock.patch("airflow.executors.executor_loader.ExecutorLoader.get_executor_names")
+    @mock.patch("airflow.executors.executor_loader.ExecutorLoader.import_executor_cls")
+    def test_rundbmanager_discovers_multiple_executor_db_managers(
+        self, mock_import_executor, mock_get_names, session
+    ):
+        """Test discovery of DB managers from multiple executors."""
+        from airflow.utils.db_manager import RunDBManager
+
+        class Executor1:
+            @staticmethod
+            def get_db_manager():
+                return "executor1.db.Manager"
+
+        class Executor2:
+            @staticmethod
+            def get_db_manager():
+                return "executor2.db.Manager"
+
+        mock_get_names.return_value = ["Executor1", "Executor2"]
+        mock_import_executor.side_effect = [
+            (Executor1, None),
+            (Executor2, None),
+        ]
+
+        with mock.patch("airflow.utils.db_manager.import_string") as mock_import_string:
+            manager = RunDBManager()
+            assert manager is not None
+
+            assert mock_import_executor.call_count == 2
+            assert mock_import_string.call_count >= 2
+
+    @mock.patch("airflow.executors.executor_loader.ExecutorLoader.get_executor_names")
+    @mock.patch("airflow.executors.executor_loader.ExecutorLoader.import_executor_cls")
+    def test_rundbmanager_handles_executor_without_db_manager(
+        self, mock_import_executor, mock_get_names, session
+    ):
+        """Test that executors without get_db_manager() are skipped gracefully."""
+        from airflow.utils.db_manager import RunDBManager
+
+        class LegacyExecutor:
+            pass  # No get_db_manager method
+
+        mock_get_names.return_value = ["LegacyExecutor"]
+        mock_import_executor.return_value = (LegacyExecutor, None)
+
+        # Should not raise an exception
+        manager = RunDBManager()
+        assert manager is not None
+
+    @mock.patch("airflow.executors.executor_loader.ExecutorLoader.get_executor_names")
+    @mock.patch("airflow.executors.executor_loader.ExecutorLoader.import_executor_cls")
+    def test_rundbmanager_handles_executor_db_manager_none(
+        self, mock_import_executor, mock_get_names, session
+    ):
+        """Test that executors returning None from get_db_manager() are handled."""
+        from airflow.executors.base_executor import BaseExecutor
+        from airflow.utils.db_manager import RunDBManager
+
+        class ExecutorWithoutDB(BaseExecutor):
+            @staticmethod
+            def get_db_manager():
+                return None
+
+        mock_get_names.return_value = ["ExecutorWithoutDB"]
+        mock_import_executor.return_value = (ExecutorWithoutDB, None)
+
+        with mock.patch("airflow.utils.db_manager.import_string") as mock_import_string:
+            manager = RunDBManager()
+            assert manager is not None
+
+            # import_string should not be called for None values
+            # Only auth manager import should happen
+            assert mock_import_string.call_count <= 1
+
+    @mock.patch("airflow.executors.executor_loader.ExecutorLoader.get_executor_names")
+    @mock.patch("airflow.executors.executor_loader.ExecutorLoader.import_executor_cls")
+    def test_rundbmanager_prevents_duplicate_db_managers(self, mock_import_executor, mock_get_names, session):
+        """Test that duplicate DB manager paths are not added multiple times."""
+        from airflow.utils.db_manager import RunDBManager
+
+        class Executor1:
+            @staticmethod
+            def get_db_manager():
+                return "shared.db.Manager"
+
+        class Executor2:
+            @staticmethod
+            def get_db_manager():
+                return "shared.db.Manager"  # Same as Executor1
+
+        mock_get_names.return_value = ["Executor1", "Executor2"]
+        mock_import_executor.side_effect = [
+            (Executor1, None),
+            (Executor2, None),
+        ]
+
+        with mock.patch("airflow.utils.db_manager.import_string") as mock_import_string:
+            manager = RunDBManager()
+            assert manager is not None
+
+            # Should only import the shared manager once
+            shared_manager_calls = [
+                call for call in mock_import_string.call_args_list if "shared.db.Manager" in str(call)
+            ]
+            assert len(shared_manager_calls) == 1
+
+    @mock.patch("airflow.executors.executor_loader.ExecutorLoader.get_executor_names")
+    @mock.patch("airflow.executors.executor_loader.ExecutorLoader.import_executor_cls")
+    def test_rundbmanager_handles_executor_import_error(self, mock_import_executor, mock_get_names, session):
+        """Test graceful handling when executor import fails."""
+        from airflow.utils.db_manager import RunDBManager
+
+        mock_get_names.return_value = ["BrokenExecutor"]
+        mock_import_executor.side_effect = Exception("Import failed")
+
+        # Should not raise an exception, just skip the broken executor
+        manager = RunDBManager()
+        assert manager is not None
+
+    @mock.patch("airflow.executors.executor_loader.ExecutorLoader.get_executor_names")
+    def test_rundbmanager_handles_get_executor_names_error(self, mock_get_names, session):
+        """Test graceful handling when get_executor_names fails."""
+        from airflow.utils.db_manager import RunDBManager
+
+        mock_get_names.side_effect = Exception("Config error")
+
+        # Should not raise an exception, just skip executor DB manager discovery
+        manager = RunDBManager()
+        assert manager is not None
+
+    @mock.patch("airflow.api_fastapi.app.create_auth_manager")
+    @mock.patch("airflow.executors.executor_loader.ExecutorLoader.get_executor_names")
+    @mock.patch("airflow.executors.executor_loader.ExecutorLoader.import_executor_cls")
+    def test_rundbmanager_integrates_auth_and_executor_managers(
+        self, mock_import_executor, mock_get_names, mock_auth_manager, session
+    ):
+        """Test that both auth manager and executor DB managers are loaded."""
+        from airflow.utils.db_manager import RunDBManager
+
+        # Mock auth manager with DB manager
+        mock_auth = mock.Mock()
+        mock_auth.get_db_manager.return_value = "auth.db.Manager"
+        mock_auth_manager.return_value = mock_auth
+
+        # Mock executor with DB manager
+        class CustomExecutor:
+            @staticmethod
+            def get_db_manager():
+                return "executor.db.Manager"
+
+        mock_get_names.return_value = ["CustomExecutor"]
+        mock_import_executor.return_value = (CustomExecutor, None)
+
+        with mock.patch("airflow.utils.db_manager.import_string") as mock_import_string:
+            manager = RunDBManager()
+            assert manager is not None
+
+            # Should import both auth and executor managers
+            calls = [str(call) for call in mock_import_string.call_args_list]
+            assert any("auth.db.Manager" in call for call in calls)
+            assert any("executor.db.Manager" in call for call in calls)
+
+    @mock.patch("airflow.executors.executor_loader.ExecutorLoader.get_executor_names")
+    def test_rundbmanager_skips_team_validation(self, mock_get_names, session):
+        """Test that RunDBManager calls get_executor_names with validate_teams=False."""
+        from airflow.utils.db_manager import RunDBManager
+
+        mock_get_names.return_value = []
+
+        manager = RunDBManager()
+        assert manager is not None
+
+        mock_get_names.assert_called_once_with(validate_teams=False)


### PR DESCRIPTION
Extends the get_db_manager() pattern from auth managers to executors, allowing executor providers to register database managers for automatic lifecycle operations during db reset/migrate.

Currently, only auth managers can register DB managers via get_db_manager(). Executors that require database tables (like EdgeExecutor) have no way to participate in database lifecycle operations. When a user configures AIRFLOW__CORE__EXECUTOR=EdgeExecutor, the edge tables should automatically be managed. The core changes enable this auto-discovery through ExecutorLoader.

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
Claude Code (Sonnet 4.5)
