### PR TITLE
Fix DAG state reverting from failed to success when manually marked as failed (#57061)

### DIFF
--- a/airflow-core/src/airflow/api/common/mark_tasks.py
+++ b/airflow-core/src/airflow/api/common/mark_tasks.py
@@ -339,7 +339,7 @@ def set_dag_run_state_to_failed(
 
     if commit:
         for ti in pending_normal_tis:
-            ti.set_state(TaskInstanceState.SKIPPED)
+            ti.set_state(TaskInstanceState.UPSTREAM_FAILED)
 
         # Mark the dag run to failed if there is no pending teardown (else this would not be scheduled later).
         if not any(dag.task_dict[ti.task_id].is_teardown for ti in (running_tis + pending_tis)):

--- a/airflow-core/tests/unit/api/common/test_mark_tasks.py
+++ b/airflow-core/tests/unit/api/common/test_mark_tasks.py
@@ -52,7 +52,7 @@ def test_set_dag_run_state_to_failed(dag_maker: DagMaker[SerializedDAG]):
     assert len(updated_tis) == 2
     task_dict = {ti.task_id: ti for ti in updated_tis}
     assert task_dict["running"].state == TaskInstanceState.FAILED
-    assert task_dict["pending"].state == TaskInstanceState.SKIPPED
+    assert task_dict["pending"].state == TaskInstanceState.UPSTREAM_FAILED
     assert "teardown" not in task_dict
 
 


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---
 ## Summary

  closes:  #57061

  When a user manually marks a running DAG as failed, the DAG state briefly shows "failed" but then reverts to "success". This happens because pending tasks are marked as `SKIPPED`, which is in `success_states`, causing the scheduler's `update_state()` to recalculate the DAG as successful.

  ## Solution

  Change pending tasks from `SKIPPED` to `UPSTREAM_FAILED` when manually failing a DAG. This is semantically correct (tasks didn't run because their upstream was failed) and keeps the DAG in `FAILED` state since `UPSTREAM_FAILED` is in `failed_states`.

## Question for Maintainers

  The `dagrun_timeout` handling in `scheduler_job_runner.py:2149` uses the same pattern - marking unfinished tasks as `SKIPPED` when a DAG times out:

 Should this also be changed to UPSTREAM_FAILED for consistency? Or should that be a separate issue/PR?

  ```python
  if dag_run.start_date < timezone.utcnow() - dag.dagrun_timeout:
      dag_run.set_state(DagRunState.FAILED)
      for task_instance in unfinished_task_instances:
          task_instance.state = TaskInstanceState.SKIPPED  # Same issue?
```

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
