### PR TITLE
Fix unset of new workers.celery values

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2698,7 +2698,10 @@
                     "properties": {
                         "replicas": {
                             "description": "Number of Airflow Celery workers.",
-                            "type": "integer",
+                            "type": [
+                                "integer",
+                                "null"
+                            ],
                             "default": 1
                         },
                         "revisionHistoryLimit": {
@@ -2743,27 +2746,42 @@
                             "properties": {
                                 "enabled": {
                                     "description": "Enable liveness probe for Airflow Celery workers.",
-                                    "type": "boolean",
+                                    "type": [
+                                        "boolean",
+                                        "null"
+                                    ],
                                     "default": true
                                 },
                                 "initialDelaySeconds": {
                                     "description": "Number of seconds after the container has started before liveness probes are initiated.",
-                                    "type": "integer",
+                                    "type": [
+                                        "integer",
+                                        "null"
+                                    ],
                                     "default": 10
                                 },
                                 "timeoutSeconds": {
                                     "description": "Number of seconds after which the probe times out. Minimum value is 1 seconds.",
-                                    "type": "integer",
+                                    "type": [
+                                        "integer",
+                                        "null"
+                                    ],
                                     "default": 20
                                 },
                                 "failureThreshold": {
                                     "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Minimum value is 1.",
-                                    "type": "integer",
+                                    "type": [
+                                        "integer",
+                                        "null"
+                                    ],
                                     "default": 5
                                 },
                                 "periodSeconds": {
                                     "description": "How often (in seconds) to perform the probe. Minimum value is 1.",
-                                    "type": "integer",
+                                    "type": [
+                                        "integer",
+                                        "null"
+                                    ],
                                     "default": 60
                                 },
                                 "command": {
@@ -2863,7 +2881,10 @@
                             "properties": {
                                 "enabled": {
                                     "description": "Enable persistent volumes.",
-                                    "type": "boolean",
+                                    "type": [
+                                        "boolean",
+                                        "null"
+                                    ],
                                     "default": true
                                 },
                                 "persistentVolumeClaimRetentionPolicy": {
@@ -2872,7 +2893,10 @@
                                 },
                                 "size": {
                                     "description": "Volume size for Airflow Celery worker StatefulSet.",
-                                    "type": "string",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
                                     "default": "100Gi"
                                 },
                                 "storageClassName": {
@@ -2885,7 +2909,10 @@
                                 },
                                 "fixPermissions": {
                                     "description": "Execute init container to chown log directory. This is currently only needed in kind, due to usage of local-path provisioner.",
-                                    "type": "boolean",
+                                    "type": [
+                                        "boolean",
+                                        "null"
+                                    ],
                                     "default": false
                                 },
                                 "annotations": {


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

related: #28880

There is a difference between running it locally and in Helm tests. I have some idea why, but I need to dig deeper into what and why. As 1.19 is getting close, this PR aims to make sure that newsfragments related to unsetting new `workers.celery` values are correct.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
