### PR TITLE
Add filename display to DAG Code tab for easier file identification

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
@@ -36,7 +36,6 @@
   },
   "code": {
     "bundleUrl": "Bundle Url",
-    "fileLocation": "File:",
     "noCode": "No Code Found",
     "parseDuration": "Parse Duration:",
     "parsedAt": "Parsed at:"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
@@ -36,6 +36,7 @@
   },
   "code": {
     "bundleUrl": "Bundle Url",
+    "fileLocation": "File:",
     "noCode": "No Code Found",
     "parseDuration": "Parse Duration:",
     "parsedAt": "Parsed at:"

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
@@ -248,7 +248,7 @@ export const Code = () => {
       {isDiffMode ? (
         <Box dir="ltr" height="full">
           {dag?.fileloc !== undefined && (
-            <FileLocation fileloc={dag.fileloc} relativeFileloc={dag.relative_fileloc} variant="tab" />
+            <FileLocation fileloc={dag.fileloc} relativeFileloc={dag.relative_fileloc} />
           )}
           <CodeDiffViewer
             modifiedCode={
@@ -275,7 +275,7 @@ export const Code = () => {
           height="full"
         >
           {dag?.fileloc !== undefined && (
-            <FileLocation fileloc={dag.fileloc} relativeFileloc={dag.relative_fileloc} variant="tab" />
+            <FileLocation fileloc={dag.fileloc} relativeFileloc={dag.relative_fileloc} />
           )}
           <Editor
             language="python"

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
@@ -16,6 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
+/* eslint-disable max-lines */
 import { Box, Button, Heading, HStack, Link, VStack } from "@chakra-ui/react";
 import Editor, { type EditorProps } from "@monaco-editor/react";
 import { useState } from "react";
@@ -143,9 +145,6 @@ export const Code = () => {
     <Box h="100%" overflow="hidden">
       <HStack justifyContent="space-between" mt={2}>
         <HStack gap={5}>
-          {dag?.fileloc !== undefined && (
-            <FileLocation fileloc={dag.fileloc} relativeFileloc={dag.relative_fileloc} />
-          )}
           {dag?.last_parsed_time !== undefined && (
             <Heading as="h4" fontSize="14px" size="md">
               {translate("code.parsedAt")} <Time datetime={dag.last_parsed_time} />
@@ -248,6 +247,9 @@ export const Code = () => {
 
       {isDiffMode ? (
         <Box dir="ltr" height="full">
+          {dag?.fileloc !== undefined && (
+            <FileLocation fileloc={dag.fileloc} relativeFileloc={dag.relative_fileloc} variant="tab" />
+          )}
           <CodeDiffViewer
             modifiedCode={
               codeError?.status === 404 && !Boolean(code?.content)
@@ -272,6 +274,9 @@ export const Code = () => {
           fontSize="14px"
           height="full"
         >
+          {dag?.fileloc !== undefined && (
+            <FileLocation fileloc={dag.fileloc} relativeFileloc={dag.relative_fileloc} variant="tab" />
+          )}
           <Editor
             language="python"
             options={editorOptions}

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Button, Heading, HStack, Link, VStack } from "@chakra-ui/react";
+import { Box, Button, Code as CodeText, Heading, HStack, Link, VStack } from "@chakra-ui/react";
 import Editor, { type EditorProps } from "@monaco-editor/react";
 import { useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
@@ -34,7 +34,7 @@ import type { DAGSourceResponse } from "openapi/requests/types.gen";
 import { DagVersionSelect } from "src/components/DagVersionSelect";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import Time from "src/components/Time";
-import { ClipboardRoot, ClipboardButton, Tooltip } from "src/components/ui";
+import { ClipboardRoot, ClipboardButton, ClipboardIconButton, Tooltip } from "src/components/ui";
 import { ProgressBar } from "src/components/ui";
 import { useColorMode } from "src/context/colorMode";
 import useSelectedVersion from "src/hooks/useSelectedVersion";
@@ -43,6 +43,16 @@ import { renderDuration } from "src/utils";
 
 import { CodeDiffViewer } from "./CodeDiffViewer";
 import { VersionCompareSelect } from "./VersionCompareSelect";
+
+const getDisplayFilename = (fileloc: string, relativeFileloc: string | null): string => {
+  if (relativeFileloc) {
+    return relativeFileloc;
+  }
+  // Fallback: extract filename from full path
+  const parts = fileloc.split('/');
+
+  return parts[parts.length - 1] || fileloc;
+};
 
 export const Code = () => {
   const { t: translate } = useTranslation(["dag", "common"]);
@@ -142,6 +152,25 @@ export const Code = () => {
     <Box h="100%" overflow="hidden">
       <HStack justifyContent="space-between" mt={2}>
         <HStack gap={5}>
+          {dag?.fileloc !== undefined && (
+            <HStack gap={1}>
+              <Heading as="h4" fontSize="14px" size="md">
+                {translate("code.fileLocation")}
+              </Heading>
+              <Tooltip
+                closeDelay={100}
+                content={dag.fileloc}
+                openDelay={100}
+              >
+                <CodeText fontSize="14px" wordBreak="break-word">
+                  {getDisplayFilename(dag.fileloc, dag.relative_fileloc)}
+                </CodeText>
+              </Tooltip>
+              <ClipboardRoot value={dag.fileloc}>
+                <ClipboardIconButton size="2xs" />
+              </ClipboardRoot>
+            </HStack>
+          )}
           {dag?.last_parsed_time !== undefined && (
             <Heading as="h4" fontSize="14px" size="md">
               {translate("code.parsedAt")} <Time datetime={dag.last_parsed_time} />

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Button, Code as CodeText, Heading, HStack, Link, VStack } from "@chakra-ui/react";
+import { Box, Button, Heading, HStack, Link, VStack } from "@chakra-ui/react";
 import Editor, { type EditorProps } from "@monaco-editor/react";
 import { useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
@@ -34,7 +34,7 @@ import type { DAGSourceResponse } from "openapi/requests/types.gen";
 import { DagVersionSelect } from "src/components/DagVersionSelect";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import Time from "src/components/Time";
-import { ClipboardRoot, ClipboardButton, ClipboardIconButton, Tooltip } from "src/components/ui";
+import { ClipboardRoot, ClipboardButton, Tooltip } from "src/components/ui";
 import { ProgressBar } from "src/components/ui";
 import { useColorMode } from "src/context/colorMode";
 import useSelectedVersion from "src/hooks/useSelectedVersion";
@@ -42,17 +42,8 @@ import { useConfig } from "src/queries/useConfig";
 import { renderDuration } from "src/utils";
 
 import { CodeDiffViewer } from "./CodeDiffViewer";
+import { FileLocation } from "./FileLocation";
 import { VersionCompareSelect } from "./VersionCompareSelect";
-
-const getDisplayFilename = (fileloc: string, relativeFileloc: string | null): string => {
-  if (relativeFileloc) {
-    return relativeFileloc;
-  }
-  // Fallback: extract filename from full path
-  const parts = fileloc.split('/');
-
-  return parts[parts.length - 1] || fileloc;
-};
 
 export const Code = () => {
   const { t: translate } = useTranslation(["dag", "common"]);
@@ -153,23 +144,7 @@ export const Code = () => {
       <HStack justifyContent="space-between" mt={2}>
         <HStack gap={5}>
           {dag?.fileloc !== undefined && (
-            <HStack gap={1}>
-              <Heading as="h4" fontSize="14px" size="md">
-                {translate("code.fileLocation")}
-              </Heading>
-              <Tooltip
-                closeDelay={100}
-                content={dag.fileloc}
-                openDelay={100}
-              >
-                <CodeText fontSize="14px" wordBreak="break-word">
-                  {getDisplayFilename(dag.fileloc, dag.relative_fileloc)}
-                </CodeText>
-              </Tooltip>
-              <ClipboardRoot value={dag.fileloc}>
-                <ClipboardIconButton size="2xs" />
-              </ClipboardRoot>
-            </HStack>
+            <FileLocation fileloc={dag.fileloc} relativeFileloc={dag.relative_fileloc} />
           )}
           {dag?.last_parsed_time !== undefined && (
             <Heading as="h4" fontSize="14px" size="md">

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Code/FileLocation.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Code/FileLocation.tsx
@@ -1,0 +1,51 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Code, Heading, HStack } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
+
+import { ClipboardIconButton, ClipboardRoot, Tooltip } from "src/components/ui";
+
+type FileLocationProps = {
+  readonly fileloc: string;
+  readonly relativeFileloc: string | null;
+};
+
+export const FileLocation = ({ fileloc, relativeFileloc }: FileLocationProps) => {
+  const { t: translate } = useTranslation("dag");
+  const displayFilename =
+    relativeFileloc !== null && relativeFileloc !== ""
+      ? relativeFileloc
+      : (fileloc.split("/").at(-1) ?? fileloc);
+
+  return (
+    <HStack gap={1}>
+      <Heading as="h4" fontSize="14px" size="md">
+        {translate("code.fileLocation")}
+      </Heading>
+      <Tooltip closeDelay={100} content={fileloc} openDelay={100}>
+        <Code fontSize="14px" wordBreak="break-word">
+          {displayFilename}
+        </Code>
+      </Tooltip>
+      <ClipboardRoot value={fileloc}>
+        <ClipboardIconButton size="2xs" />
+      </ClipboardRoot>
+    </HStack>
+  );
+};

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Code/FileLocation.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Code/FileLocation.tsx
@@ -16,61 +16,40 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Code, Heading, HStack } from "@chakra-ui/react";
-import { useTranslation } from "react-i18next";
+import { Box, Code, HStack } from "@chakra-ui/react";
 
 import { ClipboardIconButton, ClipboardRoot, Tooltip } from "src/components/ui";
 
 type FileLocationProps = {
   readonly fileloc: string;
   readonly relativeFileloc: string | null;
-  readonly variant?: "inline" | "tab";
 };
 
-export const FileLocation = ({ fileloc, relativeFileloc, variant = "tab" }: FileLocationProps) => {
-  const { t: translate } = useTranslation("dag");
+export const FileLocation = ({ fileloc, relativeFileloc }: FileLocationProps) => {
   const displayFilename =
     relativeFileloc !== null && relativeFileloc !== ""
       ? relativeFileloc
       : (fileloc.split("/").at(-1) ?? fileloc);
 
-  if (variant === "tab") {
-    return (
-      <Box
-        bg="bg.subtle"
-        borderBottomWidth={1}
-        borderColor="border.emphasized"
-        borderTopRadius={8}
-        px={3}
-        py={1}
-      >
-        <HStack gap={2}>
-          <Tooltip closeDelay={100} content={fileloc} openDelay={100}>
-            <Code fontSize="13px" wordBreak="break-word">
-              {displayFilename}
-            </Code>
-          </Tooltip>
-          <ClipboardRoot value={fileloc}>
-            <ClipboardIconButton size="2xs" />
-          </ClipboardRoot>
-        </HStack>
-      </Box>
-    );
-  }
-
   return (
-    <HStack gap={1}>
-      <Heading as="h4" fontSize="14px" size="md">
-        {translate("code.fileLocation")}
-      </Heading>
-      <Tooltip closeDelay={100} content={fileloc} openDelay={100}>
-        <Code fontSize="14px" wordBreak="break-word">
-          {displayFilename}
-        </Code>
-      </Tooltip>
-      <ClipboardRoot value={fileloc}>
-        <ClipboardIconButton size="2xs" />
-      </ClipboardRoot>
-    </HStack>
+    <Box
+      bg="bg.subtle"
+      borderBottomWidth={1}
+      borderColor="border.emphasized"
+      borderTopRadius={8}
+      px={3}
+      py={1}
+    >
+      <HStack gap={2}>
+        <Tooltip closeDelay={100} content={fileloc} openDelay={100}>
+          <Code fontSize="13px" wordBreak="break-word">
+            {displayFilename}
+          </Code>
+        </Tooltip>
+        <ClipboardRoot value={fileloc}>
+          <ClipboardIconButton size="2xs" />
+        </ClipboardRoot>
+      </HStack>
+    </Box>
   );
 };

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Code/FileLocation.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Code/FileLocation.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Code, Heading, HStack } from "@chakra-ui/react";
+import { Box, Code, Heading, HStack } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 
 import { ClipboardIconButton, ClipboardRoot, Tooltip } from "src/components/ui";
@@ -24,14 +24,39 @@ import { ClipboardIconButton, ClipboardRoot, Tooltip } from "src/components/ui";
 type FileLocationProps = {
   readonly fileloc: string;
   readonly relativeFileloc: string | null;
+  readonly variant?: "inline" | "tab";
 };
 
-export const FileLocation = ({ fileloc, relativeFileloc }: FileLocationProps) => {
+export const FileLocation = ({ fileloc, relativeFileloc, variant = "tab" }: FileLocationProps) => {
   const { t: translate } = useTranslation("dag");
   const displayFilename =
     relativeFileloc !== null && relativeFileloc !== ""
       ? relativeFileloc
       : (fileloc.split("/").at(-1) ?? fileloc);
+
+  if (variant === "tab") {
+    return (
+      <Box
+        bg="bg.subtle"
+        borderBottomWidth={1}
+        borderColor="border.emphasized"
+        borderTopRadius={8}
+        px={3}
+        py={1}
+      >
+        <HStack gap={2}>
+          <Tooltip closeDelay={100} content={fileloc} openDelay={100}>
+            <Code fontSize="13px" wordBreak="break-word">
+              {displayFilename}
+            </Code>
+          </Tooltip>
+          <ClipboardRoot value={fileloc}>
+            <ClipboardIconButton size="2xs" />
+          </ClipboardRoot>
+        </HStack>
+      </Box>
+    );
+  }
 
   return (
     <HStack gap={1}>


### PR DESCRIPTION
Users can now see the DAG file location in the Code tab, with a tooltip showing the full path and a clipboard button to copy it.

<img width="2944" height="1240" alt="image" src="https://github.com/user-attachments/assets/972c1118-a289-449d-964f-7927f598f494" />


##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
Claude Code (Sonnet 4.5)