### PR TITLE
Refactor moving executors property from job to scheduler runner

### DIFF
--- a/airflow-core/src/airflow/jobs/job.py
+++ b/airflow-core/src/airflow/jobs/job.py
@@ -33,7 +33,6 @@ from airflow._shared.observability.metrics.stats import Stats
 from airflow._shared.timezones import timezone
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
-from airflow.executors.executor_loader import ExecutorLoader
 from airflow.listeners.listener import get_listener_manager
 from airflow.models.base import ID_LEN, Base
 from airflow.observability.trace import DebugTrace, add_debug_span
@@ -59,8 +58,6 @@ class JobState(str, Enum):
 
 if TYPE_CHECKING:
     from sqlalchemy.orm.session import Session
-
-    from airflow.executors.base_executor import BaseExecutor
 
 
 def _resolve_dagrun_model():
@@ -137,12 +134,10 @@ class Job(Base, LoggingMixin):
     Only makes sense for SchedulerJob.
     """
 
-    def __init__(self, executor: BaseExecutor | None = None, heartrate=None, **kwargs):
+    def __init__(self, heartrate=None, **kwargs):
         # Save init parameters as DB fields
         self.heartbeat_failed = False
         self.hostname = get_hostname()
-        if executor:
-            self.executors = [executor]
         self.start_date = timezone.utcnow()
         self.latest_heartbeat = timezone.utcnow()
         self.previous_heartbeat = None
@@ -155,14 +150,6 @@ class Job(Base, LoggingMixin):
         except Exception:
             self.log.exception("error calling listener")
         super().__init__(**kwargs)
-
-    @property
-    def executor(self):
-        return self.executors[0]
-
-    @cached_property
-    def executors(self):
-        return ExecutorLoader.init_executors()
 
     @cached_property
     def heartrate(self) -> float:

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -66,6 +66,7 @@ from airflow.configuration import conf
 from airflow.dag_processing.bundles.base import BundleUsageTrackingManager
 from airflow.exceptions import DagNotFound
 from airflow.executors import workloads
+from airflow.executors.executor_loader import ExecutorLoader
 from airflow.jobs.base_job_runner import BaseJobRunner
 from airflow.jobs.job import Job, JobState, perform_heartbeat
 from airflow.models import Deadline, Log
@@ -247,6 +248,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         num_runs: int = conf.getint("scheduler", "num_runs"),
         scheduler_idle_sleep_time: float = conf.getfloat("scheduler", "scheduler_idle_sleep_time"),
         log: Logger | None = None,
+        executors: list[BaseExecutor] | None = None,
     ):
         super().__init__(job)
         self.num_runs = num_runs
@@ -264,6 +266,9 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             key="num_stuck_in_queued_retries",
             fallback=2,
         )
+
+        self.executors: list[BaseExecutor] = executors if executors else ExecutorLoader.init_executors()
+        self.executor: BaseExecutor = self.executors[0]
 
         if self._enable_tracemalloc:
             import tracemalloc
@@ -427,7 +432,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
         self.log.info("%s\n%s received, printing debug\n%s", "-" * 80, sig_name, "-" * 80)
 
-        for executor in self.job.executors:
+        for executor in self.executors:
             self.log.info("Debug dump for the executor %s", executor)
             executor.debug_dump()
             self.log.info("-" * 80)
@@ -646,7 +651,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
             executor_slots_available: dict[ExecutorName, int] = {}
             # First get a mapping of executor names to slots they have available
-            for executor in self.job.executors:
+            for executor in self.executors:
                 if TYPE_CHECKING:
                     # All executors should have a name if they are initted from the executor_loader.
                     # But we need to check for None to make mypy happy.
@@ -962,7 +967,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         # it. However, with multiple executors, any of which can run up to core.parallelism TIs individually,
         # we need to make sure in the scheduler now that we don't schedule more than core.parallelism totally
         # across all executors.
-        num_occupied_slots = sum([executor.slots_occupied for executor in self.job.executors])
+        num_occupied_slots = sum([executor.slots_occupied for executor in self.executors])
         parallelism = conf.getint("core", "parallelism")
         if self.job.max_tis_per_query == 0:
             max_tis = parallelism - num_occupied_slots
@@ -1304,7 +1309,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             self.log.debug("Using DatabaseCallbackSink as callback sink.")
             callback_sink = DatabaseCallbackSink()
 
-            for executor in self.job.executors:
+            for executor in self.executors:
                 executor.job_id = self.job.id
                 executor.callback_sink = callback_sink
                 executor.start()
@@ -1331,7 +1336,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             self.log.exception("Exception when executing SchedulerJob._run_scheduler_loop")
             raise
         finally:
-            for executor in self.job.executors:
+            for executor in self.executors:
                 try:
                     executor.end()
                 except Exception:
@@ -1600,7 +1605,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             self._remove_unreferenced_triggers,
         )
 
-        if any(x.is_local for x in self.job.executors):
+        if any(x.is_local for x in self.executors):
             bundle_cleanup_mgr = BundleUsageTrackingManager()
             check_interval = conf.getint(
                 section="dag_processor",
@@ -1636,17 +1641,17 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 # Heartbeat all executors, even if they're not receiving new tasks this loop. It will be
                 # either a no-op, or they will check-in on currently running tasks and send out new
                 # events to be processed below.
-                for executor in self.job.executors:
+                for executor in self.executors:
                     executor.heartbeat()
 
                 with create_session() as session:
                     num_finished_events = 0
-                    for executor in self.job.executors:
+                    for executor in self.executors:
                         num_finished_events += self._process_executor_events(
                             executor=executor, session=session
                         )
 
-                for executor in self.job.executors:
+                for executor in self.executors:
                     try:
                         with create_session() as session:
                             self._process_task_event_logs(executor._task_event_logs, session)
@@ -1761,7 +1766,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             # END: schedule TIs
 
             # Attempt to schedule even if some executors are full but not all.
-            total_free_executor_slots = sum([executor.slots_available for executor in self.job.executors])
+            total_free_executor_slots = sum([executor.slots_available for executor in self.executors])
             if total_free_executor_slots <= 0:
                 # We know we can't do anything here, so don't even try!
                 self.log.debug("All executors are full, skipping critical section")
@@ -2448,7 +2453,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         callback: DagCallbackRequest | None = None,
     ) -> None:
         if callback:
-            self.job.executor.send_callback(callback)
+            self.executor.send_callback(callback)
         else:
             self.log.debug("callback is empty")
 
@@ -2940,7 +2945,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 "stable/core-concepts/tasks.html#task-instance-heartbeat-timeout)",
                 request,
             )
-            self.job.executor.send_callback(request)
+            self.executor.send_callback(request)
             executor = self._try_to_load_executor(
                 ti, session, team_name=dag_id_to_team_name.get(ti.dag_id, NOTSET)
             )
@@ -3177,21 +3182,21 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         if ti.executor is None:
             if not team_name:
                 # No team is specified, so just use the global default executor
-                executor = self.job.executor
+                executor = self.executor
             else:
                 # We do have a team, so we need to find the default executor for that team
-                for _executor in self.job.executors:
+                for _executor in self.executors:
                     # First executor that resolves should be the default for that team
                     if _executor.team_name == team_name:
                         executor = _executor
                         break
                 else:
                     # No executor found for that team, fall back to global default
-                    executor = self.job.executor
+                    executor = self.executor
         else:
             # An executor is specified on the TaskInstance (as a str), so we need to find it in the list of executors
-            for _executor in self.job.executors:
-                if ti.executor in (_executor.name.alias, _executor.name.module_path):
+            for _executor in self.executors:
+                if _executor.name and ti.executor in (_executor.name.alias, _executor.name.module_path):
                     # The executor must either match the team or be global (i.e. team_name is None)
                     if team_name and _executor.team_name == team_name or _executor.team_name is None:
                         executor = _executor

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -28,7 +28,7 @@ from datetime import timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest import mock
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pendulum
@@ -52,6 +52,7 @@ from airflow.executors.base_executor import BaseExecutor
 from airflow.executors.executor_constants import MOCK_EXECUTOR
 from airflow.executors.executor_loader import ExecutorLoader
 from airflow.executors.executor_utils import ExecutorName
+from airflow.executors.local_executor import LocalExecutor
 from airflow.jobs.job import Job, run_job
 from airflow.jobs.scheduler_job_runner import SchedulerJobRunner
 from airflow.models.asset import (
@@ -310,15 +311,15 @@ class TestSchedulerJob:
         default_executor.queue_workload.__func__ = BaseExecutor.queue_workload
         second_executor.queue_workload.__func__ = BaseExecutor.queue_workload
 
-        with mock.patch("airflow.jobs.job.Job.executors", new_callable=PropertyMock) as executors_mock:
+        with mock.patch("airflow.executors.executor_loader.ExecutorLoader.init_executors") as executors_mock:
             executors_mock.return_value = [default_executor, second_executor]
             yield [default_executor, second_executor]
 
     @pytest.fixture
     def mock_executor(self, mock_executors):
         default_executor = mock_executors[0]
-        with mock.patch("airflow.jobs.job.Job.executors", new_callable=PropertyMock) as executors_mock:
-            executors_mock.return_value = [default_executor]
+        with mock.patch("airflow.executors.executor_loader.ExecutorLoader.init_executors") as loader_mock:
+            loader_mock.return_value = mock_executors
             yield default_executor
 
     def test_is_alive(self):
@@ -341,23 +342,35 @@ class TestSchedulerJob:
         scheduler_job.latest_heartbeat = timezone.utcnow() - datetime.timedelta(seconds=10)
         assert not scheduler_job.is_alive(), "Completed jobs even with recent heartbeat should not be alive"
 
+    @patch("airflow.jobs.scheduler_job_runner.ExecutorLoader.get_default_executor")
+    @patch("airflow.jobs.scheduler_job_runner.ExecutorLoader.init_executors")
+    def test_executor_loaded_in_scheduler_job(self, mock_init_executors, mock_default_executor):
+        mock_local_executor = LocalExecutor()
+        mock_default_executor.return_value = mock_local_executor
+        mock_init_executors.return_value = [mock_local_executor]
+
+        scheduler_job = SchedulerJobRunner(Job())
+
+        assert scheduler_job.executor == mock_local_executor
+        assert scheduler_job.executors == [mock_local_executor]
+
     @pytest.mark.parametrize(
         "heartrate",
         [10, 5],
     )
     def test_heartrate(self, heartrate):
         with conf_vars({("scheduler", "scheduler_heartbeat_sec"): str(heartrate)}):
-            scheduler_job = Job(executor=self.null_exec)
-            _ = SchedulerJobRunner(job=scheduler_job)
+            scheduler_job = Job()
+            _ = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
             assert scheduler_job.heartrate == heartrate
 
     def test_no_orphan_process_will_be_left(self):
         current_process = psutil.Process()
         old_children = current_process.children(recursive=True)
-        scheduler_job = Job(
-            executor=MockExecutor(do_update=False),
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(
+            job=scheduler_job, num_runs=1, executors=[MockExecutor(do_update=False)]
         )
-        self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=1)
         run_job(scheduler_job, execute_callable=self.job_runner._execute)
 
         # Remove potential noise created by previous tests.
@@ -380,8 +393,8 @@ class TestSchedulerJob:
         executor = MockExecutor(do_update=False)
         task_callback = mock.MagicMock(spec=TaskCallbackRequest)
         mock_task_callback.return_value = task_callback
-        scheduler_job = Job(executor=executor)
-        self.job_runner = SchedulerJobRunner(scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[executor])
         ti1.state = State.QUEUED
         session.merge(ti1)
         session.commit()
@@ -391,7 +404,7 @@ class TestSchedulerJob:
         self.job_runner._process_executor_events(executor=executor, session=session)
         ti1.refresh_from_db(session=session)
         assert ti1.state == State.FAILED
-        scheduler_job.executor.callback_sink.send.assert_not_called()
+        self.job_runner.executor.callback_sink.send.assert_not_called()
 
         # ti in success state
         ti1.state = State.SUCCESS
@@ -402,7 +415,7 @@ class TestSchedulerJob:
         self.job_runner._process_executor_events(executor=executor, session=session)
         ti1.refresh_from_db(session=session)
         assert ti1.state == State.SUCCESS
-        scheduler_job.executor.callback_sink.send.assert_not_called()
+        self.job_runner.executor.callback_sink.send.assert_not_called()
         mock_stats_incr.assert_has_calls(
             [
                 mock.call(
@@ -456,8 +469,8 @@ class TestSchedulerJob:
         executor = MockExecutor(do_update=False)
         task_callback = mock.MagicMock(spec=TaskCallbackRequest)
         mock_task_callback.return_value = task_callback
-        scheduler_job = Job(executor=executor)
-        job_runner = SchedulerJobRunner(scheduler_job)
+        scheduler_job = Job()
+        job_runner = SchedulerJobRunner(scheduler_job, executors=[executor])
 
         # Simulate executor reporting task completion (this triggers the bug scenario)
         executor.event_buffer[ti1.key] = State.SUCCESS, None
@@ -493,8 +506,8 @@ class TestSchedulerJob:
         executor = MockExecutor(do_update=False)
         task_callback = mock.MagicMock(spec=TaskCallbackRequest)
         mock_task_callback.return_value = task_callback
-        scheduler_job = Job(executor=executor)
-        self.job_runner = SchedulerJobRunner(scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(scheduler_job, executors=[executor])
 
         session = settings.Session()
         with dag_maker(dag_id=dag_id, fileloc="/test_path1/"):
@@ -508,8 +521,8 @@ class TestSchedulerJob:
         executor = MockExecutor(do_update=False)
         task_callback = mock.MagicMock()
         mock_task_callback.return_value = task_callback
-        scheduler_job = Job(executor=executor)
-        self.job_runner = SchedulerJobRunner(scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(scheduler_job, executors=[executor])
         ti1.state = State.QUEUED
         session.merge(ti1)
         session.commit()
@@ -519,7 +532,7 @@ class TestSchedulerJob:
         self.job_runner._process_executor_events(executor=executor, session=session)
         ti1.refresh_from_db(session=session)
         assert ti1.state == State.UP_FOR_RETRY
-        scheduler_job.executor.callback_sink.send.assert_not_called()
+        self.job_runner.executor.callback_sink.send.assert_not_called()
 
         # ti in success state
         ti1.state = State.SUCCESS
@@ -530,7 +543,7 @@ class TestSchedulerJob:
         self.job_runner._process_executor_events(executor=executor, session=session)
         ti1.refresh_from_db(session=session)
         assert ti1.state == State.SUCCESS
-        scheduler_job.executor.callback_sink.send.assert_not_called()
+        self.job_runner.executor.callback_sink.send.assert_not_called()
         mock_stats_incr.assert_has_calls(
             [
                 mock.call(
@@ -561,8 +574,8 @@ class TestSchedulerJob:
         task_callback = mock.MagicMock()
         mock_task_callback.return_value = task_callback
         executor = MockExecutor(do_update=False)
-        scheduler_job = Job(executor=executor)
-        self.job_runner = SchedulerJobRunner(scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(scheduler_job, executors=[executor])
 
         ti1.state = State.QUEUED
         session.merge(ti1)
@@ -585,8 +598,8 @@ class TestSchedulerJob:
             context_from_server=mock.ANY,
             task_callback_type=TaskInstanceState.FAILED,
         )
-        scheduler_job.executor.callback_sink.send.assert_called_once_with(task_callback)
-        scheduler_job.executor.callback_sink.reset_mock()
+        self.job_runner.executor.callback_sink.send.assert_called_once_with(task_callback)
+        self.job_runner.executor.callback_sink.reset_mock()
         mock_stats_incr.assert_any_call(
             "scheduler.tasks.killed_externally",
             tags={
@@ -610,8 +623,8 @@ class TestSchedulerJob:
         executor = MockExecutor(do_update=False)
         task_callback = mock.MagicMock()
         mock_task_callback.return_value = task_callback
-        scheduler_job = Job(executor=executor)
-        self.job_runner = SchedulerJobRunner(scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(scheduler_job, executors=[executor])
         self.job_runner.scheduler_dag_bag = mock.MagicMock()
         self.job_runner.scheduler_dag_bag.get_dag_for_run.side_effect = Exception("failed")
 
@@ -642,10 +655,10 @@ class TestSchedulerJob:
         executor = MockExecutor(do_update=False)
         task_callback = mock.MagicMock()
         mock_task_callback.return_value = task_callback
-        scheduler_job = Job(executor=executor)
+        scheduler_job = Job()
         session.add(scheduler_job)
         session.flush()
-        self.job_runner = SchedulerJobRunner(scheduler_job)
+        self.job_runner = SchedulerJobRunner(scheduler_job, executors=[executor])
 
         # ti is queued with another try number - do not fail it
         ti1.state = State.QUEUED
@@ -659,7 +672,7 @@ class TestSchedulerJob:
         self.job_runner._process_executor_events(executor=executor, session=session)
         ti1.refresh_from_db(session=session)
         assert ti1.state == State.QUEUED
-        scheduler_job.executor.callback_sink.send.assert_not_called()
+        self.job_runner.executor.callback_sink.send.assert_not_called()
 
         # ti is queued by another scheduler - do not fail it
         ti1.state = State.QUEUED
@@ -672,7 +685,7 @@ class TestSchedulerJob:
         self.job_runner._process_executor_events(executor=executor, session=session)
         ti1.refresh_from_db(session=session)
         assert ti1.state == State.QUEUED
-        scheduler_job.executor.callback_sink.send.assert_not_called()
+        self.job_runner.executor.callback_sink.send.assert_not_called()
 
         # ti is queued by this scheduler but it is handed back to the executor - do not fail it
         ti1.state = State.QUEUED
@@ -686,7 +699,7 @@ class TestSchedulerJob:
         self.job_runner._process_executor_events(executor=executor, session=session)
         ti1.refresh_from_db(session=session)
         assert ti1.state == State.QUEUED
-        scheduler_job.executor.callback_sink.send.assert_not_called()
+        self.job_runner.executor.callback_sink.send.assert_not_called()
         mock_stats_incr.assert_not_called()
 
     @pytest.mark.usefixtures("testing_dag_bundle")
@@ -727,8 +740,8 @@ class TestSchedulerJob:
         session.flush()
 
         executor = MockExecutor(do_update=False)
-        scheduler_job = Job(executor=executor)
-        self.job_runner = SchedulerJobRunner(scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(scheduler_job, executors=[executor])
 
         ti1 = dr.get_task_instance("dummy_task")
         ti1.state = State.QUEUED
@@ -744,8 +757,8 @@ class TestSchedulerJob:
         assert ti1.state == State.FAILED
 
         # Verify callback was created with asset event data
-        scheduler_job.executor.callback_sink.send.assert_called_once()
-        callback_request = scheduler_job.executor.callback_sink.send.call_args.args[0]
+        self.job_runner.executor.callback_sink.send.assert_called_once()
+        callback_request = self.job_runner.executor.callback_sink.send.call_args.args[0]
         assert callback_request.context_from_server is not None
         assert len(callback_request.context_from_server.dag_run.consumed_asset_events) == 1
         assert callback_request.context_from_server.dag_run.consumed_asset_events[0].asset.uri == asset1.uri
@@ -794,8 +807,8 @@ class TestSchedulerJob:
         session.flush()
 
         executor = MockExecutor(do_update=False)
-        scheduler_job = Job(executor=executor)
-        self.job_runner = SchedulerJobRunner(scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(scheduler_job, executors=[executor])
 
         ti1 = dr.get_task_instance("dummy_task")
         if TYPE_CHECKING:
@@ -895,7 +908,7 @@ class TestSchedulerJob:
         session.flush()
 
         executor = MockExecutor()
-        scheduler_job = Job(executor=executor)
+        scheduler_job = Job()
         with mock.patch("airflow.executors.executor_loader.ExecutorLoader.load_executor") as loader_mock:
             loader_mock.return_value = executor
             self.job_runner = SchedulerJobRunner(job=scheduler_job)
@@ -945,8 +958,8 @@ class TestSchedulerJob:
         with dag_maker(dag_id=dag_id):
             task1 = EmptyOperator(task_id=task_id_1)
 
-        scheduler_job = Job(executor=self.null_exec)
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(scheduler_job, executors=[self.null_exec])
         session = settings.Session()
 
         dr1 = dag_maker.create_dagrun(run_type=DagRunType.BACKFILL_JOB)
@@ -970,14 +983,14 @@ class TestSchedulerJob:
         self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=1)
         self.job_runner._execute()
 
-        assert isinstance(scheduler_job.executor.callback_sink, DatabaseCallbackSink)
+        assert isinstance(self.job_runner.executor.callback_sink, DatabaseCallbackSink)
 
     def test_setup_callback_sink_standalone_dag_processor_multiple_executors(self, mock_executors):
         scheduler_job = Job()
         self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=1)
         self.job_runner._execute()
 
-        for executor in scheduler_job.executors:
+        for executor in self.job_runner.executors:
             assert isinstance(executor.callback_sink, DatabaseCallbackSink)
 
     def test_executor_start_called(self, mock_executors):
@@ -985,8 +998,8 @@ class TestSchedulerJob:
         self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=1)
         self.job_runner._execute()
 
-        scheduler_job.executor.start.assert_called_once()
-        for executor in scheduler_job.executors:
+        self.job_runner.executor.start.assert_called_once()
+        for executor in self.job_runner.executors:
             executor.start.assert_called_once()
 
     def test_executor_job_id_assigned(self, mock_executors, configure_testing_dag_bundle):
@@ -995,8 +1008,8 @@ class TestSchedulerJob:
             self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=1)
             self.job_runner._execute()
 
-            assert scheduler_job.executor.job_id == scheduler_job.id
-            for executor in scheduler_job.executors:
+            assert self.job_runner.executor.job_id == scheduler_job.id
+            for executor in self.job_runner.executors:
                 assert executor.job_id == scheduler_job.id
 
     def test_executor_heartbeat(self, mock_executors, configure_testing_dag_bundle):
@@ -1005,7 +1018,7 @@ class TestSchedulerJob:
             self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=1)
             self.job_runner._execute()
 
-            for executor in scheduler_job.executors:
+            for executor in self.job_runner.executors:
                 executor.heartbeat.assert_called_once()
 
     def test_executor_events_processed(self, mock_executors, configure_testing_dag_bundle):
@@ -1014,7 +1027,7 @@ class TestSchedulerJob:
             self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=1)
             self.job_runner._execute()
 
-            for executor in scheduler_job.executors:
+            for executor in self.job_runner.executors:
                 executor.get_event_buffer.assert_called_once()
 
     @patch("traceback.extract_stack")
@@ -1023,7 +1036,7 @@ class TestSchedulerJob:
         self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=1)
         self.job_runner._debug_dump(1, mock.MagicMock())
 
-        for executor in scheduler_job.executors:
+        for executor in self.job_runner.executors:
             executor.debug_dump.assert_called_once()
 
         patch_traceback_extract_stack.assert_called()
@@ -1308,9 +1321,9 @@ class TestSchedulerJob:
         b_tis_in_executor = [ti for ti in executor_to_tis.get(mock_executors[1], []) if ti.dag_id == "dag_b"]
         assert len(b_tis_in_executor) == 2
 
-        # Global task should go to the default executor (scheduler_job.executor)
+        # Global task should go to the default executor (self.job_runner.executor)
         global_tis_in_executor = [
-            ti for ti in executor_to_tis.get(scheduler_job.executor, []) if ti.dag_id == "dag_global"
+            ti for ti in executor_to_tis.get(self.job_runner.executor, []) if ti.dag_id == "dag_global"
         ]
         assert len(global_tis_in_executor) == 1
 
@@ -1338,10 +1351,10 @@ class TestSchedulerJob:
     )
     def test_max_active_tasks_per_dr_limit_applied_in_task_query(self, dag_maker, mock_executors):
         scheduler_job = Job()
-        scheduler_job.executor.parallelism = 100
-        scheduler_job.executor.slots_available = 70
         scheduler_job.max_tis_per_query = 100
         self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        self.job_runner.executor.slots_available = 70
+        self.job_runner.executor.parallelism = 100
         session = settings.Session()
 
         session.add(Pool(pool="test_pool1", slots=64, description="with_slots1", include_deferred=False))
@@ -1419,7 +1432,7 @@ class TestSchedulerJob:
             # Use `_executable_task_instances_to_queued` because it returns a list of TIs
             # while `_critical_section_enqueue_task_instances` just returns the number of the TIs.
             queued_tis = self.job_runner._executable_task_instances_to_queued(
-                max_tis=scheduler_job.executor.slots_available, session=session
+                max_tis=self.job_runner.executor.slots_available, session=session
             )
             count += len(queued_tis)
             iterations += 1
@@ -1455,10 +1468,10 @@ class TestSchedulerJob:
     )
     def test_max_active_tasks_per_dr_limit_partial_capacity(self, dag_maker, mock_executors):
         scheduler_job = Job()
-        scheduler_job.executor.parallelism = 100
-        scheduler_job.executor.slots_available = 70
         scheduler_job.max_tis_per_query = 100
         self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        self.job_runner.executor.parallelism = 100
+        self.job_runner.executor.slots_available = 70
         session = settings.Session()
 
         session.add(Pool(pool="test_pool1", slots=64, description="with_slots1", include_deferred=False))
@@ -1477,7 +1490,7 @@ class TestSchedulerJob:
         )
 
         queued_tis = self.job_runner._executable_task_instances_to_queued(
-            max_tis=scheduler_job.executor.slots_available, session=session
+            max_tis=self.job_runner.executor.slots_available, session=session
         )
 
         assert queued_tis is not None
@@ -1504,10 +1517,10 @@ class TestSchedulerJob:
     )
     def test_max_active_tasks_per_dr_limit_starvation_filter_ordering(self, dag_maker, mock_executors):
         scheduler_job = Job()
-        scheduler_job.executor.parallelism = 100
-        scheduler_job.executor.slots_available = 50
         scheduler_job.max_tis_per_query = 100
         self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        self.job_runner.executor.parallelism = 100
+        self.job_runner.executor.slots_available = 50
         session = settings.Session()
 
         # Add 2 pools, one starved and one with available slots.
@@ -1527,7 +1540,7 @@ class TestSchedulerJob:
         )
 
         queued_tis = self.job_runner._executable_task_instances_to_queued(
-            max_tis=scheduler_job.executor.slots_available, session=session
+            max_tis=self.job_runner.executor.slots_available, session=session
         )
 
         assert queued_tis is not None
@@ -1900,8 +1913,8 @@ class TestSchedulerJob:
 
         executor = MockExecutor(do_update=True)
 
-        scheduler_job = Job(executor=executor)
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(scheduler_job, executors=[executor])
         session = settings.Session()
 
         dr1 = dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED)
@@ -2252,15 +2265,15 @@ class TestSchedulerJob:
         with dag_maker(dag_id=dag_id, start_date=DEFAULT_DATE, session=session):
             task1 = EmptyOperator(task_id=task_id_1)
 
-        scheduler_job = Job(executor=self.null_exec)
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
 
         dr1 = dag_maker.create_dagrun()
         ti1 = dr1.get_task_instance(task1.task_id, session)
 
         with patch.object(BaseExecutor, "queue_workload") as mock_queue_workload:
             self.job_runner._enqueue_task_instances_with_queued_state(
-                [ti1], executor=scheduler_job.executor, session=session
+                [ti1], executor=self.job_runner.executor, session=session
             )
 
         assert mock_queue_workload.called
@@ -2286,7 +2299,7 @@ class TestSchedulerJob:
 
         with patch.object(BaseExecutor, "queue_workload") as mock_queue_workload:
             self.job_runner._enqueue_task_instances_with_queued_state(
-                [ti], executor=scheduler_job.executor, session=session
+                [ti], executor=self.job_runner.executor, session=session
             )
         session.flush()
         ti.refresh_from_db(session=session)
@@ -2301,8 +2314,8 @@ class TestSchedulerJob:
         with dag_maker(dag_id=dag_id, start_date=DEFAULT_DATE, session=session):
             task1 = EmptyOperator(task_id=task_id_1)
 
-        scheduler_job = Job(executor=self.null_exec)
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
 
         dr1 = dag_maker.create_dagrun()
         ti = dr1.get_task_instance(task1.task_id, session)
@@ -2314,7 +2327,7 @@ class TestSchedulerJob:
         with patch.object(BaseExecutor, "queue_workload") as mock_queue_workload:
             with caplog.at_level("WARNING", logger="airflow.jobs.scheduler_job_runner"):
                 self.job_runner._enqueue_task_instances_with_queued_state(
-                    [ti], executor=scheduler_job.executor, session=session
+                    [ti], executor=self.job_runner.executor, session=session
                 )
 
         mock_queue_workload.assert_not_called()
@@ -2553,14 +2566,14 @@ class TestSchedulerJob:
             session.flush()
 
         scheduler_job.max_tis_per_query = 8
-        scheduler_job.executor.slots_available = 2  # Limit only the default executor to 2 slots.
+        self.job_runner.executor.slots_available = 2  # Limit only the default executor to 2 slots.
         # Check that we don't "overfill" an executor when the max tis per query is larger than slots
         # available. Of the 8 tasks returned by the query, the default executor will only take 2 and the
         # secondary executor will take 4 (since only 4 of the 8 TIs in the result will be for that executor)
         res = self.job_runner._critical_section_enqueue_task_instances(session)
         assert res == 6
 
-        scheduler_job.executor.slots_available = 6  # The default executor has more slots freed now and
+        self.job_runner.executor.slots_available = 6  # The default executor has more slots freed now and
         # will take the other two TIs.
         res = self.job_runner._critical_section_enqueue_task_instances(session)
         assert res == 2
@@ -2597,8 +2610,8 @@ class TestSchedulerJob:
             ti2.state = State.SCHEDULED
             session.flush()
         scheduler_job.max_tis_per_query = 0
-        scheduler_job.executor.parallelism = 32
-        scheduler_job.executor.slots_available = 31
+        self.job_runner.executor.parallelism = 32
+        self.job_runner.executor.slots_available = 31
 
         res = self.job_runner._critical_section_enqueue_task_instances(session)
         # 20 dag runs * 2 tasks each = 40, but limited by number of slots available
@@ -2803,8 +2816,8 @@ class TestSchedulerJob:
         dag_run = dag_maker.create_dagrun(run_id="test_run", state=DagRunState.RUNNING)
 
         mock_executor = MagicMock()
-        scheduler_job = Job(executor=mock_executor)
-        self.job_runner = SchedulerJobRunner(scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(scheduler_job, executors=[mock_executor])
 
         ti = dag_run.get_task_instance(task_id="task", session=session)
         ti.state = TaskInstanceState.RUNNING
@@ -3018,14 +3031,13 @@ class TestSchedulerJob:
         ti.state = State.QUEUED
         ti.queued_dttm = timezone.utcnow() - timedelta(minutes=15)
         session.commit()
-        from airflow.executors.local_executor import LocalExecutor
 
         assert "revoke_task" in BaseExecutor.__dict__
         # this is just verifying that LocalExecutor is good enough for this test
         # in that it does not implement revoke_task
         assert "revoke_task" not in LocalExecutor.__dict__
-        scheduler_job = Job(executor=LocalExecutor())
-        job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=0)
+        scheduler_job = Job()
+        job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=0, executors=[LocalExecutor()])
         job_runner._task_queued_timeout = 300
         job_runner._handle_tasks_stuck_in_queued()
 
@@ -3036,7 +3048,7 @@ class TestSchedulerJob:
         scheduler_job = Job()
         self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=1)
         run_job(scheduler_job, execute_callable=self.job_runner._execute)
-        scheduler_job.executor.end.assert_called_once()
+        self.job_runner.executor.end.assert_called_once()
 
     def test_executor_end_called_multiple_executors(self, mock_executors):
         """
@@ -3045,23 +3057,25 @@ class TestSchedulerJob:
         scheduler_job = Job()
         self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=1)
         run_job(scheduler_job, execute_callable=self.job_runner._execute)
-        scheduler_job.executor.end.assert_called_once()
-        for executor in scheduler_job.executors:
+        self.job_runner.executor.end.assert_called_once()
+        for executor in self.job_runner.executors:
             executor.end.assert_called_once()
 
     def test_cleanup_methods_all_called(self):
         """
         Test to make sure all cleanup methods are called when the scheduler loop has an exception
         """
-        scheduler_job = Job(executor=mock.MagicMock(slots_available=8))
-        self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=1)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(
+            job=scheduler_job, num_runs=1, executors=[mock.MagicMock(slots_available=8)]
+        )
         self.job_runner._run_scheduler_loop = mock.MagicMock(side_effect=RuntimeError("oops"))
-        scheduler_job.executor.end = mock.MagicMock(side_effect=RuntimeError("triple oops"))
+        self.job_runner.executor.end = mock.MagicMock(side_effect=RuntimeError("triple oops"))
 
         with pytest.raises(RuntimeError, match="oops"):
             run_job(scheduler_job, execute_callable=self.job_runner._execute)
 
-        scheduler_job.executor.end.assert_called_once()
+        self.job_runner.executor.end.assert_called_once()
 
     def test_cleanup_methods_all_called_multiple_executors(self, mock_executors):
         """
@@ -3071,12 +3085,12 @@ class TestSchedulerJob:
 
         self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=1)
         self.job_runner._run_scheduler_loop = mock.MagicMock(side_effect=RuntimeError("oops"))
-        scheduler_job.executor.end = mock.MagicMock(side_effect=RuntimeError("triple oops"))
+        self.job_runner.executor.end = mock.MagicMock(side_effect=RuntimeError("triple oops"))
 
         with pytest.raises(RuntimeError, match="oops"):
             run_job(scheduler_job, execute_callable=self.job_runner._execute)
 
-        for executor in scheduler_job.executors:
+        for executor in self.job_runner.executors:
             executor.end.assert_called_once()
 
     def test_queued_dagruns_stops_creating_when_max_active_is_reached(self, dag_maker, session):
@@ -3084,8 +3098,8 @@ class TestSchedulerJob:
         with dag_maker(max_active_runs=10) as dag:
             EmptyOperator(task_id="mytask")
 
-        scheduler_job = Job(executor=self.null_exec)
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
 
         orm_dag = session.get(DagModel, dag.dag_id)
         assert orm_dag is not None
@@ -3110,8 +3124,8 @@ class TestSchedulerJob:
         """
         Test that when creating runs once max_active_runs is reached the runs does not stick
         """
-        scheduler_job = Job(executor=self.null_exec)
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
 
         # Use catchup=True to ensure proper run creation behavior after max_active_runs is no longer reached
         with dag_maker(max_active_runs=1, session=session, catchup=True) as dag:
@@ -3436,8 +3450,8 @@ class TestSchedulerJob:
         dr = dag_maker.create_dagrun(start_date=timezone.utcnow() - datetime.timedelta(days=1))
         # check that next_dagrun is dr.logical_date
         dag_maker.dag_model.next_dagrun == dr.logical_date
-        scheduler_job = Job(executor=self.null_exec)
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
 
         self.job_runner._schedule_dag_run(dr, session)
         session.flush()
@@ -3471,8 +3485,8 @@ class TestSchedulerJob:
         ) as dag:
             EmptyOperator(task_id="dummy")
 
-        scheduler_job = Job(executor=self.null_exec)
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
 
         dr = dag_maker.create_dagrun()
         ti = dr.get_task_instance("dummy", session)
@@ -3496,7 +3510,7 @@ class TestSchedulerJob:
         )
 
         # Verify dag failure callback request is sent to file processor
-        scheduler_job.executor.callback_sink.send.assert_called_once_with(expected_callback)
+        self.job_runner.executor.callback_sink.send.assert_called_once_with(expected_callback)
         session.rollback()
         session.close()
 
@@ -3521,8 +3535,8 @@ class TestSchedulerJob:
         dag_listener.clear()
         listener_manager(dag_listener)
 
-        scheduler_job = Job(executor=self.null_exec)
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
 
         dr = dag_maker.create_dagrun()
 
@@ -3548,10 +3562,10 @@ class TestSchedulerJob:
         ) as dag:
             EmptyOperator(task_id="empty")
 
-        scheduler_job = Job(executor=self.null_exec)
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
 
-        scheduler_job.executor.callback_sink = DatabaseCallbackSink()
+        self.job_runner.executor.callback_sink = DatabaseCallbackSink()
 
         dr = dag_maker.create_dagrun(start_date=DEFAULT_DATE)
 
@@ -3703,8 +3717,8 @@ class TestSchedulerJob:
 
         executor = MockExecutor(do_update=False)
 
-        scheduler_job = Job(executor=executor)
-        self.job_runner = SchedulerJobRunner(scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(scheduler_job, executors=[executor])
 
         session = settings.Session()
         dr = dag_maker.create_dagrun()
@@ -3794,8 +3808,8 @@ class TestSchedulerJob:
         for idx, state in enumerate(ti_states):
             dr.task_instances[idx].state = state
         session.commit()
-        scheduler_job = Job(executor=self.null_exec)
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
 
         self.job_runner._do_scheduling(session)
         assert (
@@ -3842,8 +3856,9 @@ class TestSchedulerJob:
             scheduler_dag.clear()
             assert scheduler_dag.start_date > datetime.datetime.now(timezone.utc)
 
-            scheduler_job = Job(executor=self.null_exec)
-            self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=1)
+            scheduler_job = Job()
+            self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=1, executors=[self.null_exec])
+
             run_job(scheduler_job, execute_callable=self.job_runner._execute)
 
             # zero tasks ran
@@ -3869,8 +3884,9 @@ class TestSchedulerJob:
             assert len(session.scalars(select(TaskInstance).where(TaskInstance.dag_id == dag_id)).all()) == 1
             session.commit()
 
-            scheduler_job = Job(executor=self.null_exec)
-            self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=1)
+            scheduler_job = Job()
+            self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=1, executors=[self.null_exec])
+
             run_job(scheduler_job, execute_callable=self.job_runner._execute)
 
             # still one task
@@ -3900,8 +3916,9 @@ class TestSchedulerJob:
 
         sync_bag_to_db(dagbag, "testing", None)
 
-        scheduler_job = Job(executor=self.null_exec)
-        self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=3)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=3, executors=[self.null_exec])
+
         run_job(scheduler_job, execute_callable=self.job_runner._execute)
 
         session = settings.Session()
@@ -3939,8 +3956,9 @@ class TestSchedulerJob:
 
         sync_bag_to_db(dagbag, "testing", None)
 
-        scheduler_job = Job(executor=self.null_exec)
-        self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=3)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=3, executors=[self.null_exec])
+
         run_job(scheduler_job, execute_callable=self.job_runner._execute)
 
         session = settings.Session()
@@ -3978,8 +3996,9 @@ class TestSchedulerJob:
                 raise ValueError(f"could not find dag {dag_id}")
             create_scheduler_dag(dag).clear()
 
-        scheduler_job = Job(executor=self.null_exec)
-        self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=1)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=1, executors=[self.null_exec])
+
         run_job(scheduler_job, execute_callable=self.job_runner._execute)
 
         # zero tasks ran
@@ -4383,8 +4402,8 @@ class TestSchedulerJob:
             # Use a empty file since the above mock will return the
             # expected DAGs. Also specify only a single file so that it doesn't
             # try to schedule the above DAG repeatedly.
-            scheduler_job = Job(executor=executor)
-            self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=1)
+            scheduler_job = Job()
+            self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=1, executors=[executor])
 
             scheduler_job.heartrate = 0
             # Since the DAG is not in the directory watched by scheduler job,
@@ -4670,8 +4689,9 @@ class TestSchedulerJob:
         with dag_maker(schedule="0 0 * * *"):
             EmptyOperator(task_id="dummy")
 
-        scheduler_job = Job(executor=self.null_exec)
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
+
         with patch("airflow.models.dag.DagModel.calculate_dagrun_date_fields") as mock_calc:
             self.job_runner._create_dag_runs(dag_models=[dag_maker.dag_model], session=session)
         assert mock_calc.called
@@ -4701,8 +4721,8 @@ class TestSchedulerJob:
         with dag_maker(schedule="0 0 * * *"):
             EmptyOperator(task_id="dummy")
 
-        scheduler_job = Job(executor=self.null_exec)
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
         self.job_runner._create_dag_runs(dag_models=[dag_maker.dag_model], session=session)
         kwargs = mock_create.call_args.kwargs
         # todo: AIP-76 let's add partition_date to dag run
@@ -4749,8 +4769,9 @@ class TestSchedulerJob:
         )
 
         session.flush()
-        scheduler_job = Job(executor=self.null_exec)
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
 
         # ensure terminal state; otherwise the run type is moot
         run.state = DagRunState.FAILED
@@ -4781,8 +4802,8 @@ class TestSchedulerJob:
 
         dag_model = dag_maker.dag_model
 
-        scheduler_job = Job(executor=self.null_exec)
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
 
         with create_session() as session:
             self.job_runner._create_dag_runs([dag_model], session)
@@ -4855,8 +4876,8 @@ class TestSchedulerJob:
         )
         session.flush()
 
-        scheduler_job = Job(executor=self.null_exec)
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
 
         with create_session() as session:
             self.job_runner._create_dagruns_for_dags(session, session)
@@ -4949,8 +4970,8 @@ class TestSchedulerJob:
         )
         session.flush()
 
-        scheduler_job = Job(executor=self.null_exec)
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
 
         with create_session() as session:
             self.job_runner._create_dagruns_for_dags(session, session)
@@ -5044,8 +5065,8 @@ class TestSchedulerJob:
 
         dag_model = dag_maker.dag_model
 
-        scheduler_job = Job(executor=self.null_exec)
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
 
         self.job_runner._create_dag_runs([dag_model], session)
         self.job_runner._start_queued_dagruns(session)
@@ -5086,8 +5107,8 @@ class TestSchedulerJob:
         assert custom_task.operator_extra_links
 
         session = settings.Session()
-        scheduler_job = Job(executor=self.null_exec)
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
         self.job_runner._do_scheduling(session=session)
         self.job_runner._start_queued_dagruns(session)
         session.flush()
@@ -5109,8 +5130,8 @@ class TestSchedulerJob:
                 task_id="dummy",
             )
 
-        scheduler_job = Job(executor=self.null_exec)
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
 
         caplog.set_level("FATAL")
         caplog.clear()
@@ -5144,8 +5165,8 @@ class TestSchedulerJob:
         with dag_maker(dag_id="test_scheduler_create_dag_runs_deserialization_error"):
             EmptyOperator(task_id="dummy")
 
-        scheduler_job = Job(executor=self.null_exec)
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
 
         caplog.set_level("FATAL")
         caplog.clear()
@@ -5189,8 +5210,8 @@ class TestSchedulerJob:
         assert dag_model.next_dagrun_data_interval_start == DEFAULT_DATE
         assert dag_model.next_dagrun_data_interval_end == DEFAULT_DATE + timedelta(minutes=1)
 
-        scheduler_job = Job(executor=MockExecutor(do_update=False))
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[MockExecutor(do_update=False)])
 
         # Verify a DagRun is created with the correct dates
         # when Scheduler._do_scheduling is run in the Scheduler Loop
@@ -5265,8 +5286,8 @@ class TestSchedulerJob:
 
         assert get_last_dagrun(dag.dag_id, session) == dagrun
 
-        scheduler_job = Job(executor=self.null_exec)
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
 
         # Test that this does not raise any error
         self.job_runner._create_dag_runs([dag_model], session)
@@ -5320,8 +5341,8 @@ class TestSchedulerJob:
             triggered_by=DagRunTriggeredByType.TEST,
         )
 
-        scheduler_job = Job(executor=self.null_exec)
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
 
         my_dag = session.get(DagModel, dag.dag_id)
         self.job_runner._create_dag_runs([my_dag], session)
@@ -5362,8 +5383,8 @@ class TestSchedulerJob:
         )
 
         executor = MockExecutor(do_update=False)
-        scheduler_job = Job(executor=executor)
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[executor])
 
         with mock.patch("airflow.executors.executor_loader.ExecutorLoader.load_executor") as loader_mock:
             # The executor is mocked, so cannot be loaded/imported. Mock load_executor and return the
@@ -5386,8 +5407,8 @@ class TestSchedulerJob:
         # Explicitly set catchup=True as test specifically expects historical dates to be respected
         with dag_maker(max_active_runs=1, catchup=True):
             EmptyOperator(task_id="task")
-        scheduler_job = Job(executor=MockExecutor(do_update=False))
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[MockExecutor(do_update=False)])
 
         assert session.scalar(select(func.count()).select_from(DagRun)) == 0
         query, _ = DagModel.dags_needing_dagruns(session)
@@ -5455,8 +5476,8 @@ class TestSchedulerJob:
             # Need to use something that doesn't immediately get marked as success by the scheduler
             BashOperator(task_id="task", bash_command="true")
 
-        scheduler_job = Job(executor=self.null_exec)
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
 
         query, _ = DagModel.dags_needing_dagruns(session)
         query.all()
@@ -5569,8 +5590,8 @@ class TestSchedulerJob:
         for _ in range(9):
             dr = dag_maker.create_dagrun_after(dr, run_type=DagRunType.SCHEDULED, state=State.QUEUED)
 
-        scheduler_job = Job(executor=MockExecutor(do_update=False))
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[MockExecutor(do_update=False)])
 
         self.job_runner._start_queued_dagruns(session)
         session.flush()
@@ -5610,8 +5631,8 @@ class TestSchedulerJob:
         for _ in range(9):
             dr = dag_maker.create_dagrun_after(dr, run_type=DagRunType.SCHEDULED, state=State.QUEUED)
 
-        scheduler_job = Job(executor=MockExecutor(do_update=False))
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[MockExecutor(do_update=False)])
 
         self.job_runner._start_queued_dagruns(session)
         session.flush()
@@ -5703,8 +5724,8 @@ class TestSchedulerJob:
         for _ in range(2):
             dr = dag_maker.create_dagrun_after(dr, run_type=DagRunType.SCHEDULED, state=State.QUEUED)
 
-        scheduler_job = Job(executor=MockExecutor(do_update=False))
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[MockExecutor(do_update=False)])
 
         self.job_runner._start_queued_dagruns(session)
         session.flush()
@@ -5789,8 +5810,8 @@ class TestSchedulerJob:
             )
             return dag1_non_b_running, dag1_b_running, total_running_count
 
-        scheduler_job = Job(executor=MockExecutor(do_update=False))
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[MockExecutor(do_update=False)])
 
         from_date = pendulum.parse("2021-01-01")
         to_date = pendulum.parse("2021-01-06")
@@ -5901,8 +5922,8 @@ class TestSchedulerJob:
             )
             return dag1_non_b_running, dag1_b_running, total_running_count
 
-        scheduler_job = Job(executor=MockExecutor(do_update=False))
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[MockExecutor(do_update=False)])
 
         from_date = pendulum.parse("2021-01-01")
         to_date = pendulum.parse("2021-01-06")
@@ -6004,8 +6025,8 @@ class TestSchedulerJob:
             )
             return dag1_non_b_running, dag1_b_running, total_running_count
 
-        scheduler_job = Job(executor=MockExecutor(do_update=False))
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[MockExecutor(do_update=False)])
 
         from_date = pendulum.parse("2021-01-01")
         to_date = pendulum.parse("2021-01-06")
@@ -6149,8 +6170,8 @@ class TestSchedulerJob:
             )
             return dag1_non_b_running, dag1_b_running, total_running_count
 
-        scheduler_job = Job(executor=MockExecutor(do_update=False))
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[MockExecutor(do_update=False)])
 
         from_date = pendulum.parse("2021-01-01")
         to_date = pendulum.parse("2021-01-06")
@@ -6226,8 +6247,8 @@ class TestSchedulerJob:
         )
         assert queued_count == 5
 
-        scheduler_job = Job(executor=MockExecutor(do_update=False))
-        job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        job_runner = SchedulerJobRunner(job=scheduler_job, executors=[MockExecutor(do_update=False)])
 
         # Simulate another scheduler holding the lock by returning empty from _lock_backfills
         with patch.object(job_runner, "_lock_backfills", return_value={}):
@@ -6278,8 +6299,8 @@ class TestSchedulerJob:
                 logical_date=date,
             )
             date = dr.logical_date + timedelta(hours=1)
-        scheduler_job = Job(executor=MockExecutor(do_update=False))
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[MockExecutor(do_update=False)])
 
         self.job_runner._start_queued_dagruns(session)
         session.flush()
@@ -6373,8 +6394,8 @@ class TestSchedulerJob:
             )
             date = dr.logical_date + timedelta(hours=1)
 
-        scheduler_job = Job(executor=MockExecutor(do_update=False))
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[MockExecutor(do_update=False)])
 
         dag_version = DagVersion.get_latest_version(dag_id=dag.dag_id)
         ti = create_task_instance(task=task1, run_id=dr1_running.run_id, dag_version_id=dag_version.id)
@@ -6811,7 +6832,7 @@ class TestSchedulerJob:
 
     def test_find_and_purge_task_instances_without_heartbeats_nothing(self):
         executor = MockExecutor(do_update=False)
-        scheduler_job = Job(executor=executor)
+        scheduler_job = Job()
         with mock.patch("airflow.executors.executor_loader.ExecutorLoader.load_executor") as loader_mock:
             loader_mock.return_value = executor
             self.job_runner = SchedulerJobRunner(scheduler_job)
@@ -6838,7 +6859,7 @@ class TestSchedulerJob:
         )
 
         executor = MockExecutor()
-        scheduler_job = Job(executor=executor)
+        scheduler_job = Job()
         with mock.patch("airflow.executors.executor_loader.ExecutorLoader.load_executor") as loader_mock:
             loader_mock.return_value = executor
             self.job_runner = SchedulerJobRunner(job=scheduler_job)
@@ -6908,8 +6929,8 @@ class TestSchedulerJob:
             data_interval=data_interval,
         )
 
-        scheduler_job = Job(executor=MockExecutor())
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[MockExecutor()])
 
         # We will provision 2 tasks so we can check we only find task instance heartbeat timeouts from this scheduler
         tasks_to_setup = ["branching", "run_this_first"]
@@ -7022,7 +7043,6 @@ class TestSchedulerJob:
     @pytest.mark.parametrize("dag_id", ["test_mapped_classic", "test_mapped_taskflow"])
     def test_mapped_dag(self, dag_id, session, testing_dag_bundle):
         """End-to-end test of a simple mapped dag"""
-        from airflow.executors.local_executor import LocalExecutor
 
         dagbag = DagBag(dag_folder=TEST_DAGS_FOLDER, include_examples=False)
         sync_bag_to_db(dagbag, "testing", None)
@@ -7046,8 +7066,8 @@ class TestSchedulerJob:
 
         executor = LocalExecutor()
 
-        job = Job(executor=executor)
-        self.job_runner = SchedulerJobRunner(job=job)
+        job = Job()
+        self.job_runner = SchedulerJobRunner(job=job, executors=[executor])
         self.run_scheduler_until_dagrun_terminal()
 
         dr.refresh_from_db(session)
@@ -7140,8 +7160,8 @@ class TestSchedulerJob:
         ) as dag:
             EmptyOperator(task_id="dummy")
 
-        scheduler_job = Job(executor=self.null_exec)
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
 
         self.job_runner._create_dag_runs([dag_maker.dag_model], session)
         self.job_runner._start_queued_dagruns(session)
@@ -7194,8 +7214,8 @@ class TestSchedulerJob:
 
         assert scheduled_run.state == State.RUNNING
 
-        scheduler_job = Job(executor=self.null_exec)
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
 
         self.job_runner._update_dag_run_state_for_paused_dags(session=session)
         session.flush()
@@ -7235,8 +7255,8 @@ class TestSchedulerJob:
 
         assert backfill_run.state == State.RUNNING
 
-        scheduler_job = Job(executor=self.null_exec)
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
 
         self.job_runner._update_dag_run_state_for_paused_dags(session=session)
         session.flush()
@@ -7521,8 +7541,8 @@ class TestSchedulerJob:
         dag_run = dag_maker.create_dagrun(run_id="test_run", state=DagRunState.RUNNING)
 
         mock_executor = MagicMock()
-        scheduler_job = Job(executor=mock_executor)
-        self.job_runner = SchedulerJobRunner(scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(scheduler_job, executors=[mock_executor])
 
         # Create a task instance that appears to be running but hasn't heartbeat
         ti = dag_run.get_task_instance(task_id="test_task")
@@ -7565,8 +7585,8 @@ class TestSchedulerJob:
         ti = dr.get_task_instance(task_id="t1")
 
         executor = MockExecutor(do_update=False)
-        scheduler_job = Job(executor=executor)
-        self.job_runner = SchedulerJobRunner(scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(scheduler_job, executors=[executor])
 
         ti.state = State.QUEUED
         session.merge(ti)
@@ -7577,8 +7597,8 @@ class TestSchedulerJob:
 
         self.job_runner._process_executor_events(executor=executor, session=session)
 
-        scheduler_job.executor.callback_sink.send.assert_called()
-        request = scheduler_job.executor.callback_sink.send.call_args[0][0]
+        self.job_runner.executor.callback_sink.send.assert_called()
+        request = self.job_runner.executor.callback_sink.send.call_args[0][0]
         assert isinstance(request, TaskCallbackRequest)
         assert request.task_callback_type == expected
 
@@ -7598,8 +7618,8 @@ class TestSchedulerJob:
         # Mock the executor to simulate a task failure
         mock_executor = MagicMock(spec=BaseExecutor)
         mock_executor.has_task = mock.MagicMock(return_value=False)
-        scheduler_job = Job(executor=mock_executor)
-        self.job_runner = SchedulerJobRunner(scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(scheduler_job, executors=[mock_executor])
 
         # Simulate executor reporting task as failed
         executor_event = {ti.key: (TaskInstanceState.FAILED, None)}
@@ -7639,8 +7659,8 @@ class TestSchedulerJob:
         session.commit()
 
         mock_executor = MagicMock()
-        scheduler_job = Job(executor=mock_executor)
-        self.job_runner = SchedulerJobRunner(scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[mock_executor])
 
         callback_req = self.job_runner._schedule_dag_run(dag_run, session)
 
@@ -7666,8 +7686,8 @@ class TestSchedulerJob:
         session.commit()
 
         mock_executor = MagicMock()
-        scheduler_job = Job(executor=mock_executor)
-        self.job_runner = SchedulerJobRunner(scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(scheduler_job, executors=[mock_executor])
 
         self.job_runner._start_queued_dagruns(session)
 
@@ -7697,8 +7717,8 @@ class TestSchedulerJob:
         session.commit()
 
         mock_executor = MagicMock()
-        scheduler_job = Job(executor=mock_executor)
-        self.job_runner = SchedulerJobRunner(scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(scheduler_job, executors=[mock_executor])
 
         self.job_runner._schedule_dag_run(dag_run, session)
 
@@ -7711,8 +7731,8 @@ class TestSchedulerJob:
     @mock.patch("airflow.models.Deadline.handle_miss")
     def test_process_expired_deadlines(self, mock_handle_miss, session, dag_maker):
         """Verify all expired and unhandled deadlines (and only those) are processed by the scheduler."""
-        scheduler_job = Job(executor=MockExecutor())
-        self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=1)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=1, executors=[MockExecutor()])
 
         past_date = timezone.utcnow() - timedelta(minutes=5)
         future_date = timezone.utcnow() + timedelta(minutes=5)
@@ -7797,8 +7817,8 @@ class TestSchedulerJob:
     @mock.patch("airflow.models.Deadline.handle_miss")
     def test_process_expired_deadlines_no_deadlines_found(self, mock_handle_miss, session):
         """Test handling when there are no deadlines to process."""
-        scheduler_job = Job(executor=MockExecutor())
-        self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=1)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=1, executors=[MockExecutor()])
 
         self.job_runner._execute()
 
@@ -7984,7 +8004,7 @@ class TestSchedulerJob:
         result = self.job_runner._try_to_load_executor(ti, session)
 
         # Should return the global default executor (first executor in Job)
-        assert result == scheduler_job.executor
+        assert result == self.job_runner.executor
 
     @conf_vars({("core", "multi_team"): "true"})
     def test_multi_team_try_to_load_executor_no_explicit_executor_with_team(
@@ -8328,7 +8348,7 @@ class TestSchedulerJob:
 
             # Should use legacy logic without calling team resolution
             mock_team_resolve.assert_not_called()
-            assert result1 == scheduler_job.executor  # Default for no explicit executor
+            assert result1 == self.job_runner.executor  # Default for no explicit executor
             assert result2 == mock_executors[1]  # Matched by executor name
 
 
@@ -8392,8 +8412,8 @@ def test_schedule_dag_run_with_upstream_skip(dag_maker, session):
 
         # Create a SerializedDAG (which will have max_active_runs=1)
         # This simulates the SerializedDAG being created/updated from the DAG file
-        scheduler_job = Job(executor=self.null_exec)
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
         self.job_runner._create_dag_runs([dag_model], session)
 
         # Verify SerializedDAG has max_active_runs=1
@@ -8537,9 +8557,11 @@ class TestSchedulerJobQueriesCount:
                 for ti in dr.get_task_instances():
                     ti.set_state(state=State.SCHEDULED)
 
-            scheduler_job = Job(executor=MockExecutor(do_update=False))
+            scheduler_job = Job()
             scheduler_job.heartbeat = mock.MagicMock()
-            self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=1)
+            self.job_runner = SchedulerJobRunner(
+                job=scheduler_job, num_runs=1, executors=[MockExecutor(do_update=False)]
+            )
 
             with assert_queries_count(expected_query_count, margin=15):
                 with mock.patch.object(
@@ -8615,9 +8637,11 @@ class TestSchedulerJobQueriesCount:
             dagbag = DagBag(dag_folder=ELASTIC_DAG_FILE, include_examples=False)
             sync_bag_to_db(dagbag, "testing", None)
 
-            scheduler_job = Job(job_type=SchedulerJobRunner.job_type, executor=MockExecutor(do_update=False))
+            scheduler_job = Job(job_type=SchedulerJobRunner.job_type)
             scheduler_job.heartbeat = mock.MagicMock()
-            self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=1)
+            self.job_runner = SchedulerJobRunner(
+                job=scheduler_job, num_runs=1, executors=[MockExecutor(do_update=False)]
+            )
 
             failures = []  # Collects assertion errors and report all of them at the end.
             message = "Expected {expected_count} query, but got {current_count} located at:"
@@ -8649,7 +8673,7 @@ def test_mark_backfills_completed(dag_maker, session):
     )
     session.expunge_all()
     runner = SchedulerJobRunner(
-        job=Job(job_type=SchedulerJobRunner.job_type, executor=MockExecutor(do_update=False))
+        job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
     )
     runner._mark_backfills_complete()
     b = session.get(Backfill, b.id)
@@ -8784,7 +8808,7 @@ def test_partitioned_dag_run_with_customized_mapper(
         session.commit()
 
     runner = SchedulerJobRunner(
-        job=Job(job_type=SchedulerJobRunner.job_type, executor=MockExecutor(do_update=False))
+        job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
     )
 
     with dag_maker(dag_id="asset-event-producer", schedule=None, session=session) as dag:
@@ -8858,7 +8882,7 @@ def test_consumer_dag_listen_to_two_partitioned_asset(
 
     # Check whether we are ready to create Dag run for "asset-event-consumer"
     runner = SchedulerJobRunner(
-        job=Job(job_type=SchedulerJobRunner.job_type, executor=MockExecutor(do_update=False))
+        job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
     )
 
     apdr = _produce_and_register_asset_event(
@@ -8935,7 +8959,7 @@ def test_consumer_dag_listen_to_two_partitioned_asset_with_key_1_mapper(
 
     # Check whether we are ready to create Dag run for "asset-event-consumer"
     runner = SchedulerJobRunner(
-        job=Job(job_type=SchedulerJobRunner.job_type, executor=MockExecutor(do_update=False))
+        job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
     )
 
     with custom_partition_mapper_patch():

--- a/dev/airflow_perf/scheduler_dag_execution_timing.py
+++ b/dev/airflow_perf/scheduler_dag_execution_timing.py
@@ -280,8 +280,8 @@ def main(num_runs, repeat, pre_create_dag_runs, executor_class, dag_ids):
     ShortCircuitExecutor = get_executor_under_test(executor_class)
 
     executor = ShortCircuitExecutor(dag_ids_to_watch=dag_ids, num_runs=num_runs)
-    scheduler_job = Job(executor=executor)
-    job_runner = SchedulerJobRunner(job=scheduler_job, dag_ids=dag_ids)
+    scheduler_job = Job()
+    job_runner = SchedulerJobRunner(job=scheduler_job, executors=[executor], dag_ids=dag_ids)
     executor.job_runner = job_runner
 
     total_tasks = sum(len(dag.tasks) for dag in dags)
@@ -304,8 +304,8 @@ def main(num_runs, repeat, pre_create_dag_runs, executor_class, dag_ids):
                 for dag in dags:
                     reset_dag(dag, session)
             executor.reset(dag_ids)
-            scheduler_job = Job(executor=executor)
-            job_runner = SchedulerJobRunner(job=scheduler_job, dag_ids=dag_ids)
+            scheduler_job = Job()
+            job_runner = SchedulerJobRunner(job=scheduler_job, executors=[executor], dag_ids=dag_ids)
             executor.scheduler_job = scheduler_job
 
         gc.disable()


### PR DESCRIPTION
discussed: https://github.com/apache/airflow/discussions/58143 in 3
Move the `executors` property from the base `Job` class to the `SchedulerJobRunner` subclass.

Rationale for refactoring:
- The `executors` property is only used by scheduler jobs, both conceptually and in practice across the codebase.
- Implementing executor-related logic in the `Job` class (a database model) violates separation of concerns.
- Moving this property to the subclass encapsulates executor logic where it belongs and prevents unnecessary access from other job types.
- This change maintains backward compatibility with no modifications to existing behavior.


<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
