### PR TITLE
Add `skipKubernetesEnvVars` option for all components in chart to prevent env var conflicts and UI exposure

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -174,8 +174,10 @@ If release name contains chart name it will be used as a full name.
   - name: {{ $config.name }}
     value: {{ $config.value | quote }}
     {{- if or (contains "KubernetesExecutor" $.Values.executor) (contains "LocalKubernetesExecutor" $.Values.executor) (contains "CeleryKubernetesExecutor" $.Values.executor) }}
+    {{- if not $config.skipKubernetesEnvVars }}
   - name: AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__{{ $config.name }}
     value: {{ $config.value | quote }}
+    {{- end }}
     {{- end }}
   {{- end }}
   # Dynamically created secret envs

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2657,6 +2657,11 @@
                         "additionalProperties": false
                     }
                 },
+                "skipKubernetesEnvVars": {
+                    "description": "Skip automatically creating AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__ prefixed env vars for workers when using KubernetesExecutor. These prefixed vars are exposed in the Airflow web UI config page, which can be a security concern for sensitive values. Use top-level 'env' or 'config.kubernetes_environment_variables' if you need these prefixed vars.",
+                    "type": "boolean",
+                    "default": false
+                },
                 "volumeClaimTemplates": {
                     "description": "Specify additional volume claim template for Airflow Celery workers.",
                     "type": "array",
@@ -3726,6 +3731,11 @@
                         ],
                         "additionalProperties": false
                     }
+                },
+                "skipKubernetesEnvVars": {
+                    "description": "Skip automatically creating AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__ prefixed env vars for scheduler when using KubernetesExecutor. These prefixed vars are exposed in the Airflow web UI config page, which can be a security concern for sensitive values. Use top-level 'env' or 'config.kubernetes_environment_variables' if you need these prefixed vars.",
+                    "type": "boolean",
+                    "default": false
                 }
             }
         },
@@ -4294,6 +4304,11 @@
                         ],
                         "additionalProperties": false
                     }
+                },
+                "skipKubernetesEnvVars": {
+                    "description": "Skip automatically creating AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__ prefixed env vars for triggerer when using KubernetesExecutor. These prefixed vars are exposed in the Airflow web UI config page, which can be a security concern for sensitive values. Use top-level 'env' or 'config.kubernetes_environment_variables' if you need these prefixed vars.",
+                    "type": "boolean",
+                    "default": false
                 },
                 "keda": {
                     "description": "KEDA configuration.",
@@ -4864,6 +4879,11 @@
                         ],
                         "additionalProperties": false
                     }
+                },
+                "skipKubernetesEnvVars": {
+                    "description": "Skip automatically creating AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__ prefixed env vars for dag processor when using KubernetesExecutor. These prefixed vars are exposed in the Airflow web UI config page, which can be a security concern for sensitive values. Use top-level 'env' or 'config.kubernetes_environment_variables' if you need these prefixed vars.",
+                    "type": "boolean",
+                    "default": false
                 }
             }
         },
@@ -5269,6 +5289,11 @@
                         ],
                         "additionalProperties": false
                     }
+                },
+                "skipKubernetesEnvVars": {
+                    "description": "Skip automatically creating AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__ prefixed env vars for create user job when using KubernetesExecutor. These prefixed vars are exposed in the Airflow web UI config page, which can be a security concern for sensitive values. Use top-level 'env' or 'config.kubernetes_environment_variables' if you need these prefixed vars.",
+                    "type": "boolean",
+                    "default": false
                 }
             }
         },
@@ -6326,6 +6351,11 @@
                         ],
                         "additionalProperties": false
                     }
+                },
+                "skipKubernetesEnvVars": {
+                    "description": "Skip automatically creating AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__ prefixed env vars for API server when using KubernetesExecutor. These prefixed vars are exposed in the Airflow web UI config page, which can be a security concern for sensitive values. Use top-level 'env' or 'config.kubernetes_environment_variables' if you need these prefixed vars.",
+                    "type": "boolean",
+                    "default": false
                 }
             }
         },
@@ -7109,6 +7139,11 @@
                         ],
                         "additionalProperties": false
                     }
+                },
+                "skipKubernetesEnvVars": {
+                    "description": "Skip automatically creating AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__ prefixed env vars for webserver when using KubernetesExecutor. These prefixed vars are exposed in the Airflow web UI config page, which can be a security concern for sensitive values. Use top-level 'env' or 'config.kubernetes_environment_variables' if you need these prefixed vars.",
+                    "type": "boolean",
+                    "default": false
                 }
             }
         },
@@ -7673,6 +7708,11 @@
                         ],
                         "additionalProperties": false
                     }
+                },
+                "skipKubernetesEnvVars": {
+                    "description": "Skip automatically creating AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__ prefixed env vars for flower when using KubernetesExecutor. These prefixed vars are exposed in the Airflow web UI config page, which can be a security concern for sensitive values. Use top-level 'env' or 'config.kubernetes_environment_variables' if you need these prefixed vars.",
+                    "type": "boolean",
+                    "default": false
                 }
             }
         },
@@ -9541,6 +9581,11 @@
                         "additionalProperties": false
                     }
                 },
+                "skipKubernetesEnvVars": {
+                    "description": "Skip automatically creating AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__ prefixed env vars for cleanup when using KubernetesExecutor. These prefixed vars are exposed in the Airflow web UI config page, which can be a security concern for sensitive values. Use top-level 'env' or 'config.kubernetes_environment_variables' if you need these prefixed vars.",
+                    "type": "boolean",
+                    "default": false
+                },
                 "failedJobsHistoryLimit": {
                     "description": "The failed jobs history limit specifies the number of failed jobs to retain.",
                     "type": [
@@ -9880,6 +9925,11 @@
                         ],
                         "additionalProperties": false
                     }
+                },
+                "skipKubernetesEnvVars": {
+                    "description": "Skip automatically creating AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__ prefixed env vars for database cleanup when using KubernetesExecutor. These prefixed vars are exposed in the Airflow web UI config page, which can be a security concern for sensitive values. Use top-level 'env' or 'config.kubernetes_environment_variables' if you need these prefixed vars.",
+                    "type": "boolean",
+                    "default": false
                 },
                 "failedJobsHistoryLimit": {
                     "description": "The failed jobs history limit specifies the number of failed jobs to retain.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1019,6 +1019,29 @@ workers:
   # Additional env variable configuration for Airflow Celery workers and pods created with pod-template-file
   env: []
 
+  # Skip automatically creating AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__ prefixed env vars
+  # for workers when using KubernetesExecutor.
+  #
+  # When you add environment variables to the 'env' array above (e.g., workers.env, scheduler.env,
+  # apiServer.env, etc.), and KubernetesExecutor is enabled, Airflow automatically creates an
+  # additional environment variable with the prefix AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__
+  # for each env var you define. For example, if you add 'MY_API_KEY' to env, Airflow will also
+  # create 'AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__MY_API_KEY'. These prefixed env vars are
+  # used by KubernetesExecutor to pass environment variables to dynamically created task pods.
+  #
+  # However, these automatically generated environment variables are exposed in the Airflow web UI
+  # config page, which can be a security concern if your env vars contain sensitive information
+  # (API keys, passwords, tokens, etc.). Setting this to true prevents the automatic creation
+  # of these prefixed env vars, ensuring sensitive values are not exposed in the UI.
+  #
+  # If you need AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__ prefixed env vars for KubernetesExecutor
+  # task pods, you can either use the top-level 'env' configuration or the
+  # 'config.kubernetes_environment_variables' section instead of component-specific env arrays
+  # (e.g., workers.env, scheduler.env, apiServer.env).
+  #
+  # Default is false to maintain backward compatibility with existing deployments.
+  skipKubernetesEnvVars: false
+
   # Additional volume claim templates for Airflow Celery workers
   volumeClaimTemplates: []
   # Comment out the above and uncomment the section below to enable it.
@@ -1401,6 +1424,29 @@ scheduler:
 
   env: []
 
+  # Skip automatically creating AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__ prefixed env vars
+  # for workers when using KubernetesExecutor.
+  #
+  # When you add environment variables to the 'env' array above (e.g., workers.env, scheduler.env,
+  # apiServer.env, etc.), and KubernetesExecutor is enabled, Airflow automatically creates an
+  # additional environment variable with the prefix AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__
+  # for each env var you define. For example, if you add 'MY_API_KEY' to env, Airflow will also
+  # create 'AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__MY_API_KEY'. These prefixed env vars are
+  # used by KubernetesExecutor to pass environment variables to dynamically created task pods.
+  #
+  # However, these automatically generated environment variables are exposed in the Airflow web UI
+  # config page, which can be a security concern if your env vars contain sensitive information
+  # (API keys, passwords, tokens, etc.). Setting this to true prevents the automatic creation
+  # of these prefixed env vars, ensuring sensitive values are not exposed in the UI.
+  #
+  # If you need AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__ prefixed env vars for KubernetesExecutor
+  # task pods, you can either use the top-level 'env' configuration or the
+  # 'config.kubernetes_environment_variables' section instead of component-specific env arrays
+  # (e.g., workers.env, scheduler.env, apiServer.env).
+  #
+  # Default is false to maintain backward compatibility with existing deployments.
+  skipKubernetesEnvVars: false
+
 # Airflow create user job settings
 createUserJob:
   # Whether the create user job should be created
@@ -1511,6 +1557,29 @@ createUserJob:
   applyCustomEnv: true
 
   env: []
+
+  # Skip automatically creating AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__ prefixed env vars
+  # for workers when using KubernetesExecutor.
+  #
+  # When you add environment variables to the 'env' array above (e.g., workers.env, scheduler.env,
+  # apiServer.env, etc.), and KubernetesExecutor is enabled, Airflow automatically creates an
+  # additional environment variable with the prefix AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__
+  # for each env var you define. For example, if you add 'MY_API_KEY' to env, Airflow will also
+  # create 'AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__MY_API_KEY'. These prefixed env vars are
+  # used by KubernetesExecutor to pass environment variables to dynamically created task pods.
+  #
+  # However, these automatically generated environment variables are exposed in the Airflow web UI
+  # config page, which can be a security concern if your env vars contain sensitive information
+  # (API keys, passwords, tokens, etc.). Setting this to true prevents the automatic creation
+  # of these prefixed env vars, ensuring sensitive values are not exposed in the UI.
+  #
+  # If you need AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__ prefixed env vars for KubernetesExecutor
+  # task pods, you can either use the top-level 'env' configuration or the
+  # 'config.kubernetes_environment_variables' section instead of component-specific env arrays
+  # (e.g., workers.env, scheduler.env, apiServer.env).
+  #
+  # Default is false to maintain backward compatibility with existing deployments.
+  skipKubernetesEnvVars: false
 
   resources: {}
   #  limits:
@@ -1634,6 +1703,29 @@ apiServer:
   args: ["bash", "-c", "exec airflow api-server"]
   allowPodLogReading: true
   env: []
+
+  # Skip automatically creating AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__ prefixed env vars
+  # for workers when using KubernetesExecutor.
+  #
+  # When you add environment variables to the 'env' array above (e.g., workers.env, scheduler.env,
+  # apiServer.env, etc.), and KubernetesExecutor is enabled, Airflow automatically creates an
+  # additional environment variable with the prefix AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__
+  # for each env var you define. For example, if you add 'MY_API_KEY' to env, Airflow will also
+  # create 'AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__MY_API_KEY'. These prefixed env vars are
+  # used by KubernetesExecutor to pass environment variables to dynamically created task pods.
+  #
+  # However, these automatically generated environment variables are exposed in the Airflow web UI
+  # config page, which can be a security concern if your env vars contain sensitive information
+  # (API keys, passwords, tokens, etc.). Setting this to true prevents the automatic creation
+  # of these prefixed env vars, ensuring sensitive values are not exposed in the UI.
+  #
+  # If you need AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__ prefixed env vars for KubernetesExecutor
+  # task pods, you can either use the top-level 'env' configuration or the
+  # 'config.kubernetes_environment_variables' section instead of component-specific env arrays
+  # (e.g., workers.env, scheduler.env, apiServer.env).
+  #
+  # Default is false to maintain backward compatibility with existing deployments.
+  skipKubernetesEnvVars: false
 
   # Allow Horizontal Pod Autoscaler (HPA) configuration for apiServer. (optional)
   # HPA automatically scales the number of apiServer pods based on observed metrics.
@@ -2036,6 +2128,29 @@ webserver:
 
   env: []
 
+  # Skip automatically creating AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__ prefixed env vars
+  # for workers when using KubernetesExecutor.
+  #
+  # When you add environment variables to the 'env' array above (e.g., workers.env, scheduler.env,
+  # apiServer.env, etc.), and KubernetesExecutor is enabled, Airflow automatically creates an
+  # additional environment variable with the prefix AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__
+  # for each env var you define. For example, if you add 'MY_API_KEY' to env, Airflow will also
+  # create 'AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__MY_API_KEY'. These prefixed env vars are
+  # used by KubernetesExecutor to pass environment variables to dynamically created task pods.
+  #
+  # However, these automatically generated environment variables are exposed in the Airflow web UI
+  # config page, which can be a security concern if your env vars contain sensitive information
+  # (API keys, passwords, tokens, etc.). Setting this to true prevents the automatic creation
+  # of these prefixed env vars, ensuring sensitive values are not exposed in the UI.
+  #
+  # If you need AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__ prefixed env vars for KubernetesExecutor
+  # task pods, you can either use the top-level 'env' configuration or the
+  # 'config.kubernetes_environment_variables' section instead of component-specific env arrays
+  # (e.g., workers.env, scheduler.env, apiServer.env).
+  #
+  # Default is false to maintain backward compatibility with existing deployments.
+  skipKubernetesEnvVars: false
+
 # Airflow Triggerer Config
 triggerer:
   enabled: true
@@ -2225,6 +2340,29 @@ triggerer:
       container: {}
 
   env: []
+
+  # Skip automatically creating AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__ prefixed env vars
+  # for workers when using KubernetesExecutor.
+  #
+  # When you add environment variables to the 'env' array above (e.g., workers.env, scheduler.env,
+  # apiServer.env, etc.), and KubernetesExecutor is enabled, Airflow automatically creates an
+  # additional environment variable with the prefix AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__
+  # for each env var you define. For example, if you add 'MY_API_KEY' to env, Airflow will also
+  # create 'AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__MY_API_KEY'. These prefixed env vars are
+  # used by KubernetesExecutor to pass environment variables to dynamically created task pods.
+  #
+  # However, these automatically generated environment variables are exposed in the Airflow web UI
+  # config page, which can be a security concern if your env vars contain sensitive information
+  # (API keys, passwords, tokens, etc.). Setting this to true prevents the automatic creation
+  # of these prefixed env vars, ensuring sensitive values are not exposed in the UI.
+  #
+  # If you need AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__ prefixed env vars for KubernetesExecutor
+  # task pods, you can either use the top-level 'env' configuration or the
+  # 'config.kubernetes_environment_variables' section instead of component-specific env arrays
+  # (e.g., workers.env, scheduler.env, apiServer.env).
+  #
+  # Default is false to maintain backward compatibility with existing deployments.
+  skipKubernetesEnvVars: false
 
   # Allow KEDA autoscaling.
   keda:
@@ -2424,6 +2562,29 @@ dagProcessor:
   # Environment variables to add to dag processor container
   env: []
 
+  # Skip automatically creating AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__ prefixed env vars
+  # for workers when using KubernetesExecutor.
+  #
+  # When you add environment variables to the 'env' array above (e.g., workers.env, scheduler.env,
+  # apiServer.env, etc.), and KubernetesExecutor is enabled, Airflow automatically creates an
+  # additional environment variable with the prefix AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__
+  # for each env var you define. For example, if you add 'MY_API_KEY' to env, Airflow will also
+  # create 'AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__MY_API_KEY'. These prefixed env vars are
+  # used by KubernetesExecutor to pass environment variables to dynamically created task pods.
+  #
+  # However, these automatically generated environment variables are exposed in the Airflow web UI
+  # config page, which can be a security concern if your env vars contain sensitive information
+  # (API keys, passwords, tokens, etc.). Setting this to true prevents the automatic creation
+  # of these prefixed env vars, ensuring sensitive values are not exposed in the UI.
+  #
+  # If you need AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__ prefixed env vars for KubernetesExecutor
+  # task pods, you can either use the top-level 'env' configuration or the
+  # 'config.kubernetes_environment_variables' section instead of component-specific env arrays
+  # (e.g., workers.env, scheduler.env, apiServer.env).
+  #
+  # Default is false to maintain backward compatibility with existing deployments.
+  skipKubernetesEnvVars: false
+
 # Flower settings
 flower:
   # Enable flower.
@@ -2570,6 +2731,29 @@ flower:
   # Labels specific to flower objects and pods
   labels: {}
   env: []
+
+  # Skip automatically creating AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__ prefixed env vars
+  # for workers when using KubernetesExecutor.
+  #
+  # When you add environment variables to the 'env' array above (e.g., workers.env, scheduler.env,
+  # apiServer.env, etc.), and KubernetesExecutor is enabled, Airflow automatically creates an
+  # additional environment variable with the prefix AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__
+  # for each env var you define. For example, if you add 'MY_API_KEY' to env, Airflow will also
+  # create 'AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__MY_API_KEY'. These prefixed env vars are
+  # used by KubernetesExecutor to pass environment variables to dynamically created task pods.
+  #
+  # However, these automatically generated environment variables are exposed in the Airflow web UI
+  # config page, which can be a security concern if your env vars contain sensitive information
+  # (API keys, passwords, tokens, etc.). Setting this to true prevents the automatic creation
+  # of these prefixed env vars, ensuring sensitive values are not exposed in the UI.
+  #
+  # If you need AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__ prefixed env vars for KubernetesExecutor
+  # task pods, you can either use the top-level 'env' configuration or the
+  # 'config.kubernetes_environment_variables' section instead of component-specific env arrays
+  # (e.g., workers.env, scheduler.env, apiServer.env).
+  #
+  # Default is false to maintain backward compatibility with existing deployments.
+  skipKubernetesEnvVars: false
 
 # StatsD settings
 statsd:
@@ -3108,6 +3292,29 @@ cleanup:
   #  runAsGroup: 0
   env: []
 
+  # Skip automatically creating AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__ prefixed env vars
+  # for workers when using KubernetesExecutor.
+  #
+  # When you add environment variables to the 'env' array above (e.g., workers.env, scheduler.env,
+  # apiServer.env, etc.), and KubernetesExecutor is enabled, Airflow automatically creates an
+  # additional environment variable with the prefix AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__
+  # for each env var you define. For example, if you add 'MY_API_KEY' to env, Airflow will also
+  # create 'AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__MY_API_KEY'. These prefixed env vars are
+  # used by KubernetesExecutor to pass environment variables to dynamically created task pods.
+  #
+  # However, these automatically generated environment variables are exposed in the Airflow web UI
+  # config page, which can be a security concern if your env vars contain sensitive information
+  # (API keys, passwords, tokens, etc.). Setting this to true prevents the automatic creation
+  # of these prefixed env vars, ensuring sensitive values are not exposed in the UI.
+  #
+  # If you need AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__ prefixed env vars for KubernetesExecutor
+  # task pods, you can either use the top-level 'env' configuration or the
+  # 'config.kubernetes_environment_variables' section instead of component-specific env arrays
+  # (e.g., workers.env, scheduler.env, apiServer.env).
+  #
+  # Default is false to maintain backward compatibility with existing deployments.
+  skipKubernetesEnvVars: false
+
   # Detailed default security context for cleanup for container level
   securityContexts:
     pod: {}
@@ -3192,6 +3399,29 @@ databaseCleanup:
     annotations: {}
 
   env: []
+
+  # Skip automatically creating AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__ prefixed env vars
+  # for workers when using KubernetesExecutor.
+  #
+  # When you add environment variables to the 'env' array above (e.g., workers.env, scheduler.env,
+  # apiServer.env, etc.), and KubernetesExecutor is enabled, Airflow automatically creates an
+  # additional environment variable with the prefix AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__
+  # for each env var you define. For example, if you add 'MY_API_KEY' to env, Airflow will also
+  # create 'AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__MY_API_KEY'. These prefixed env vars are
+  # used by KubernetesExecutor to pass environment variables to dynamically created task pods.
+  #
+  # However, these automatically generated environment variables are exposed in the Airflow web UI
+  # config page, which can be a security concern if your env vars contain sensitive information
+  # (API keys, passwords, tokens, etc.). Setting this to true prevents the automatic creation
+  # of these prefixed env vars, ensuring sensitive values are not exposed in the UI.
+  #
+  # If you need AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__ prefixed env vars for KubernetesExecutor
+  # task pods, you can either use the top-level 'env' configuration or the
+  # 'config.kubernetes_environment_variables' section instead of component-specific env arrays
+  # (e.g., workers.env, scheduler.env, apiServer.env).
+  #
+  # Default is false to maintain backward compatibility with existing deployments.
+  skipKubernetesEnvVars: false
 
   # Detailed default security context for database cleanup for container level
   securityContexts:


### PR DESCRIPTION
## Related PR
- Related Issue: https://github.com/apache/airflow/issues/60668
- This addresses concerns raised in PR #60750 by providing a non-breaking alternative.

## Summary

This PR adds the `skipKubernetesEnvVars` option to all Airflow components (workers, scheduler, apiServer, webserver, triggerer, dagProcessor, flower, cleanup, databaseCleanup, createUserJob) as an alternative solution to address the breaking change introduced in PR #60750.

## Problem

When using KubernetesExecutor, Airflow automatically creates `AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__` prefixed environment variables for each env var defined in component-specific `env` arrays (e.g., `workers.env`, `scheduler.env`, `apiServer.env`). These automatically generated environment variables are exposed in the Airflow web UI config page, which poses a security risk when env vars contain sensitive information such as API keys, passwords, or tokens (Like below image).
<img width="783" height="58" alt="image" src="https://github.com/user-attachments/assets/b10781f8-4d9b-4ba6-9910-49289afbe90c" />

Additionally, this automatic behavior can cause unexpected conflicts. When users add environment variables to component-specific arrays like `scheduler.env`, they expect those variables to only apply to the scheduler component. However, the automatically generated `AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__` prefixed variables are propagated to worker pods created by KubernetesExecutor, potentially causing conflicts or unintended behavior when the same variable names exist in different components.

## Solution

This PR introduces a `skipKubernetesEnvVars` boolean option (default: `false`) for each component that allows users to prevent the automatic creation of these prefixed env vars. When set to `true`, sensitive values will not be exposed in the UI while maintaining backward compatibility.

For users who still need `AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__` prefixed env vars for KubernetesExecutor task pods, they can use:
- The top-level `env` configuration, or
- The `config.kubernetes_environment_variables` section

instead of component-specific env arrays.

## Changes

- Added `skipKubernetesEnvVars` option and comprehensive documentation to `values.yaml` for all components
- Added `skipKubernetesEnvVars` schema definitions to `values.schema.json` for all components

## Backward Compatibility

The default value is `false`, ensuring backward compatibility with existing deployments. Users must explicitly set `skipKubernetesEnvVars: true` to enable this security feature.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)
- Cursor 

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
