### PR TITLE
Use log_level for root logger instead of hardcoded INFO level

### DIFF
--- a/shared/logging/src/airflow_shared/logging/structlog.py
+++ b/shared/logging/src/airflow_shared/logging/structlog.py
@@ -554,7 +554,7 @@ def configure_logging(
     )
     config["root"] = {
         "handlers": ["default"],
-        "level": "INFO",
+        "level": log_level.upper(),
         "propagate": True,
     }
 

--- a/shared/logging/tests/logging/test_structlog.py
+++ b/shared/logging/tests/logging/test_structlog.py
@@ -367,3 +367,16 @@ def test_logger_filtering(structlog_config, levels):
         [other.logger] Hello key1=value4
         [my.logger.sub] Hello key1=value5
         """)
+
+
+def test_logger_respects_configured_level(structlog_config):
+    with structlog_config(
+        colors=False,
+        log_format="[%(name)s] %(message)s",
+        log_level="DEBUG",
+    ) as sio:
+        my_logger = logging.getLogger("my_logger")
+        my_logger.debug("Debug message")
+
+    written = sio.getvalue()
+    assert "[my_logger] Debug message\n" in written


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---
In the `configure_logging` function, the root logger level is hard coded to INFO. Since the user defined loggers inherit from the root, it wouldn't pick up the DEBUG level even if AIRFLOW__LOGGING__LOGGING_LEVEL=DEBUG is set.
Based on the conversation in #59634, it seems like it shouldn't be hard coded but I wasn't entirely sure if that was the conclusion. 

related: #58965
##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
