### PR TITLE
Revert Fix breeze start-airflow mprocs output interference #60652

### DIFF
--- a/scripts/ci/prek/compile_ui_assets_dev.py
+++ b/scripts/ci/prek/compile_ui_assets_dev.py
@@ -79,9 +79,10 @@ if __name__ == "__main__":
             stderr=subprocess.STDOUT,
         )
 
-    subprocess.Popen(
+    subprocess.run(
         ["pnpm", "dev"],
         cwd=os.fspath(UI_DIRECTORY),
+        check=True,
         env=env,
         stdout=open(UI_ASSET_OUT_DEV_MODE_FILE, "a"),
         stderr=subprocess.STDOUT,


### PR DESCRIPTION
After this change, UI is blank and vite dev server is not reachable.

This fixes it locally for me, I suppose something is not working correctly with https://github.com/apache/airflow/pull/60652. 

(I tried rebuilding images, removing UI artifacts, etc... nothing helped, so I assume this is not a local setup problem)