### PR TITLE
Fix missing fastavro after PR #60732

### DIFF
--- a/providers/databricks/pyproject.toml
+++ b/providers/databricks/pyproject.toml
@@ -97,6 +97,7 @@ dependencies = [
     "apache-airflow-providers-google>=10.24.0"
 ]
 "avro" = [
+    "fastavro>=1.9.0",
     'fastavro>=1.10.0;python_version>="3.12"'  # Need to pin to this version for Python 3.13 compatibility
 ]
 


### PR DESCRIPTION
Fixes missing fastavro after pinning for Python 3.13 - see https://github.com/apache/airflow/pull/60732/changes#r2703191481

Thansk @Dev-iL for ping!

---

##### Was generative AI tooling used to co-author this PR?

- [ ] No (please specify the tool below)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
