### PR TITLE
Remove non-logic redundant selection and query in FAB

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -739,11 +739,6 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         return current_app.config["AUTH_REMOTE_USER_ENV_VAR"]
 
     @property
-    def auth_username_ci(self):
-        """Get the auth username for CI."""
-        return current_app.config.get("AUTH_USERNAME_CI", True)
-
-    @property
     def auth_user_registration(self):
         """Will user self registration be allowed."""
         return current_app.config["AUTH_USER_REGISTRATION"]
@@ -1435,12 +1430,6 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         """Find user by username or email."""
         if username:
             try:
-                if self.auth_username_ci:
-                    return self.session.scalars(
-                        select(self.user_model).where(
-                            func.lower(self.user_model.username) == func.lower(username)
-                        )
-                    ).one_or_none()
                 return self.session.scalars(
                     select(self.user_model).where(
                         func.lower(self.user_model.username) == func.lower(username)


### PR DESCRIPTION
While I was working on some auth stuff I saw this code and stumbled over it... had been even reworked during SQLA2 adjustements but can not find in git history why the query is the same independent of the if statement in `find_user()`. Also no test is relying on this so I propose to clean this up. (I would even see a risk if something is different based on a AUTH_USERNAME_CI flag.
Code is like this since at least 3 years.

I propose to delete ... except if @vincbeck has an expert opinion.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
