### PR TITLE
Adding Airflow generic version for Breeze installations for Airflow

### DIFF
--- a/dev/README_RELEASE_PROVIDERS.md
+++ b/dev/README_RELEASE_PROVIDERS.md
@@ -1015,8 +1015,10 @@ pip install apache-airflow-providers-<provider>==<VERSION>rc<X>
 
 ### Installing with Breeze
 
+You can use any Airflow 3.X.Y version, like 3.2.0, to install specific version for testing, using breeze.
+
 ```shell
-breeze start-airflow --use-airflow-version 3.1.3 --python 3.10 --backend postgres \
+breeze start-airflow --use-airflow-version 3.X.Y --python 3.10 --backend postgres \
     --load-example-dags --load-default-connections
 ```
 

--- a/dev/README_RELEASE_PROVIDERS.md
+++ b/dev/README_RELEASE_PROVIDERS.md
@@ -1018,7 +1018,7 @@ pip install apache-airflow-providers-<provider>==<VERSION>rc<X>
 You can use any Airflow 3.X.Y version, like 3.2.0, to install specific version for testing, using breeze.
 
 ```shell
-breeze start-airflow --use-airflow-version 3.X.Y --python 3.10 --backend postgres \
+breeze start-airflow --use-airflow-version 3.1.3 --python 3.10 --backend postgres \
     --load-example-dags --load-default-connections
 ```
 


### PR DESCRIPTION
This PR enhances details in steps to Verify the release candidate by Contributors as mentioned in link below to show that the Airflow version to be installed via Breeze is generic and not hardcoded to a specific value. https://github.com/apache/airflow/blob/main/dev/README_RELEASE_PROVIDERS.md#verify-the-release-candidate-by-contributo

This helps showcase to contributors that older versions can be tested for backward compatibility as well.

##### Was generative AI tooling used to co-author this PR?

No