### PR TITLE
Fix TaskSDK unit test config file path handling for installed packages and monorepo

### DIFF
--- a/task-sdk/src/airflow/sdk/configuration.py
+++ b/task-sdk/src/airflow/sdk/configuration.py
@@ -149,14 +149,7 @@ class AirflowSDKConfigParser(_SharedAirflowConfigParser):
         The SDK does not expand template variables (FERNET_KEY, JWT_SECRET_KEY, etc.) because it does not use
         the config fields that require expansion.
         """
-        unit_test_config_file = (
-            pathlib.Path(__file__).parent.parent.parent.parent.parent
-            / "airflow-core"
-            / "src"
-            / "airflow"
-            / "config_templates"
-            / "unit_tests.cfg"
-        )
+        unit_test_config_file = pathlib.Path(_default_config_file_path("unit_tests.cfg"))
         unit_test_config = unit_test_config_file.read_text()
         self.remove_all_read_configurations()
         with StringIO(unit_test_config) as test_config_file:


### PR DESCRIPTION
## Why

When using `breeze shell --use-airflow-version owner:repo/branch --mount-sources providers-and-tests` and run `pytest` directly in the shell, I encounter the following error:


```
ERROR providers/standard/tests/unit/standard/operators/test_trigger_dagrun.py - FileNotFoundError: [Errno 2] No such file or directory: '/usr/python/lib/airflow-core/src/airflow/config_templates/unit_tests.cfg'
``` 

<details>
  <summary>Full traceback:</summary>

```
============================================================================================ ERRORS ============================================================================================
___________________________________________________ ERROR collecting providers/standard/tests/unit/standard/operators/test_trigger_dagrun.py ___________________________________________________
providers/standard/tests/unit/standard/operators/test_trigger_dagrun.py:29: in <module>
    from airflow.models.dag import DagModel
/usr/python/lib/python3.10/site-packages/airflow/models/dag.py:55: in <module>
    from airflow.models.dagrun import DagRun
/usr/python/lib/python3.10/site-packages/airflow/models/dagrun.py:74: in <module>
    from airflow.sdk.definitions.deadline import DeadlineReference
/usr/python/lib/python3.10/site-packages/airflow/sdk/definitions/deadline.py:25: in <module>
    from airflow.sdk.serde import deserialize, serialize
/usr/python/lib/python3.10/site-packages/airflow/sdk/serde/__init__.py:34: in <module>
    from airflow.sdk.configuration import conf
/usr/python/lib/python3.10/site-packages/airflow/sdk/configuration.py:264: in __getattr__
    val = initialize_config()
/usr/python/lib/python3.10/site-packages/airflow/sdk/configuration.py:258: in initialize_config
    airflow_config_parser.load_test_config()
/usr/python/lib/python3.10/site-packages/airflow/sdk/configuration.py:173: in load_test_config
    unit_test_config = unit_test_config_file.read_text()
/usr/python/lib/python3.10/pathlib.py:1134: in read_text
    with self.open(mode='r', encoding=encoding, errors=errors) as f:
/usr/python/lib/python3.10/pathlib.py:1119: in open
    return self._accessor.open(self, mode, buffering, encoding, errors,
E   FileNotFoundError: [Errno 2] No such file or directory: '/usr/python/lib/airflow-core/src/airflow/config_templates/unit_tests.cfg'
=================================================================================== short test summary info ====================================================================================
ERROR providers/standard/tests/unit/standard/operators/test_trigger_dagrun.py - FileNotFoundError: [Errno 2] No such file or directory: '/usr/python/lib/airflow-core/src/airflow/config_templates/unit_tests.cfg'
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
================================================================================= 1 warning, 1 error in 2.08s ==================================================================================
```

</details>



The SDK's `load_test_config()` method was using an incorrect path calculation to locate `unit_tests.cfg`, which only worked in the monorepo structure. When the SDK is installed as a package in `site-packages`, the path resolution failed because it assumed the monorepo directory structure.
## What

We updated `load_test_config()` to use the same dual-path resolution pattern as `_default_config_file_path()`:

https://github.com/apache/airflow/blob/8a94a43a80cc41068894f5ae6e153a4bf254a2d4/task-sdk/src/airflow/sdk/configuration.py#L36-L58