### PR TITLE
Fix missing templating in API server extraInitContainers

### DIFF
--- a/chart/templates/api-server/api-server-deployment.yaml
+++ b/chart/templates/api-server/api-server-deployment.yaml
@@ -151,7 +151,7 @@ spec:
             {{- end }}
         {{- end }}
         {{- if .Values.apiServer.extraInitContainers }}
-          {{- toYaml .Values.apiServer.extraInitContainers | nindent 8 }}
+          {{- tpl (toYaml .Values.apiServer.extraInitContainers) . | nindent 8 }}
         {{- end }}
       containers:
         - name: api-server


### PR DESCRIPTION
The apiServer.extraInitContainers configuration was documented as templated in values.yaml but the template did not use the tpl function, preventing Helm templating from working correctly.

This change wraps the toYaml expression with tpl, making it consistent with all other workloads (scheduler, webserver, triggerer, workers, dag-processor, and jobs).

Fixes #60780

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: GitHub Copilot following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)