### PR TITLE
Remove redundant try/except blocks in Bigtable operators

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/operators/bigtable.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/bigtable.py
@@ -164,24 +164,20 @@ class BigtableCreateInstanceOperator(GoogleCloudBaseOperator, BigtableValidation
             )
             BigtableInstanceLink.persist(context=context)
             return
-        try:
-            hook.create_instance(
-                project_id=self.project_id,
-                instance_id=self.instance_id,
-                main_cluster_id=self.main_cluster_id,
-                main_cluster_zone=self.main_cluster_zone,
-                replica_clusters=self.replica_clusters,
-                instance_display_name=self.instance_display_name,
-                instance_type=self.instance_type,
-                instance_labels=self.instance_labels,
-                cluster_nodes=self.cluster_nodes,
-                cluster_storage_type=self.cluster_storage_type,
-                timeout=self.timeout,
-            )
-            BigtableInstanceLink.persist(context=context)
-        except google.api_core.exceptions.GoogleAPICallError as e:
-            self.log.error("An error occurred. Exiting.")
-            raise e
+        hook.create_instance(
+            project_id=self.project_id,
+            instance_id=self.instance_id,
+            main_cluster_id=self.main_cluster_id,
+            main_cluster_zone=self.main_cluster_zone,
+            replica_clusters=self.replica_clusters,
+            instance_display_name=self.instance_display_name,
+            instance_type=self.instance_type,
+            instance_labels=self.instance_labels,
+            cluster_nodes=self.cluster_nodes,
+            cluster_storage_type=self.cluster_storage_type,
+            timeout=self.timeout,
+        )
+        BigtableInstanceLink.persist(context=context)
 
 
 class BigtableUpdateInstanceOperator(GoogleCloudBaseOperator, BigtableValidationMixin):
@@ -263,19 +259,15 @@ class BigtableUpdateInstanceOperator(GoogleCloudBaseOperator, BigtableValidation
         if not instance:
             raise AirflowException(f"Dependency: instance '{self.instance_id}' does not exist.")
 
-        try:
-            hook.update_instance(
-                project_id=self.project_id,
-                instance_id=self.instance_id,
-                instance_display_name=self.instance_display_name,
-                instance_type=self.instance_type,
-                instance_labels=self.instance_labels,
-                timeout=self.timeout,
-            )
-            BigtableInstanceLink.persist(context=context)
-        except google.api_core.exceptions.GoogleAPICallError as e:
-            self.log.error("An error occurred. Exiting.")
-            raise e
+        hook.update_instance(
+            project_id=self.project_id,
+            instance_id=self.instance_id,
+            instance_display_name=self.instance_display_name,
+            instance_type=self.instance_type,
+            instance_labels=self.instance_labels,
+            timeout=self.timeout,
+        )
+        BigtableInstanceLink.persist(context=context)
 
 
 class BigtableDeleteInstanceOperator(GoogleCloudBaseOperator, BigtableValidationMixin):
@@ -339,9 +331,6 @@ class BigtableDeleteInstanceOperator(GoogleCloudBaseOperator, BigtableValidation
                 self.instance_id,
                 self.project_id,
             )
-        except google.api_core.exceptions.GoogleAPICallError as e:
-            self.log.error("An error occurred. Exiting.")
-            raise e
 
 
 class BigtableCreateTableOperator(GoogleCloudBaseOperator, BigtableValidationMixin):
@@ -534,9 +523,6 @@ class BigtableDeleteTableOperator(GoogleCloudBaseOperator, BigtableValidationMix
         except google.api_core.exceptions.NotFound:
             # It's OK if table doesn't exists.
             self.log.info("The table '%s' no longer exists. Consider it as deleted", self.table_id)
-        except google.api_core.exceptions.GoogleAPICallError as e:
-            self.log.error("An error occurred. Exiting.")
-            raise e
 
 
 class BigtableUpdateClusterOperator(GoogleCloudBaseOperator, BigtableValidationMixin):
@@ -620,6 +606,3 @@ class BigtableUpdateClusterOperator(GoogleCloudBaseOperator, BigtableValidationM
             raise AirflowException(
                 f"Dependency: cluster '{self.cluster_id}' does not exist for instance '{self.instance_id}'."
             )
-        except google.api_core.exceptions.GoogleAPICallError as e:
-            self.log.error("An error occurred. Exiting.")
-            raise e


### PR DESCRIPTION
Related: #60687

### Summary
Removed redundant `try/except` blocks in Bigtable operators that only logged and re-raised exceptions without adding extra handling.
Behavior-changing handlers for example `NotFound`, `AlreadyExists` were preserved.
