### PR TITLE
Decouple task sdk from airflow core for remote logging

### DIFF
--- a/airflow-core/src/airflow/logging/remote.py
+++ b/airflow-core/src/airflow/logging/remote.py
@@ -17,42 +17,6 @@
 
 from __future__ import annotations
 
-import os
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from airflow._shared.logging.remote import RemoteLogIO, RemoteLogStreamIO
 
-if TYPE_CHECKING:
-    import structlog.typing
-
-    from airflow.sdk.types import RuntimeTaskInstanceProtocol as RuntimeTI
-    from airflow.utils.log.file_task_handler import LogResponse, StreamingLogResponse
-
-
-class RemoteLogIO(Protocol):
-    """Interface for remote task loggers."""
-
-    @property
-    def processors(self) -> tuple[structlog.typing.Processor, ...]: ...
-
-    """
-    List of structlog processors to install in the task write path.
-
-    This is useful if a remote logging provider wants to either transform the structured log messages as they
-    are being written to a file, or if you want to upload messages as they are generated.
-    """
-
-    def upload(self, path: os.PathLike | str, ti: RuntimeTI) -> None:
-        """Upload the given log path to the remote storage."""
-        ...
-
-    def read(self, relative_path: str, ti: RuntimeTI) -> LogResponse:
-        """Read logs from the given remote log path."""
-        ...
-
-
-@runtime_checkable
-class RemoteLogStreamIO(RemoteLogIO, Protocol):
-    """Interface for remote task loggers with stream-based read support."""
-
-    def stream(self, relative_path: str, ti: RuntimeTI) -> StreamingLogResponse:
-        """Stream-based read interface for reading logs from the given remote log path."""
-        ...
+__all__ = ["RemoteLogIO", "RemoteLogStreamIO"]

--- a/airflow-core/src/airflow/utils/log/file_task_handler.py
+++ b/airflow-core/src/airflow/utils/log/file_task_handler.py
@@ -51,6 +51,13 @@ if TYPE_CHECKING:
 
     from requests import Response
 
+    from airflow._shared.logging.remote import (
+        LogMessages,
+        LogResponse,
+        LogSourceInfo,
+        RawLogStream,
+        StreamingLogResponse,
+    )
     from airflow.executors.base_executor import BaseExecutor
     from airflow.models.taskinstance import TaskInstance
     from airflow.models.taskinstancehistory import TaskInstanceHistory
@@ -66,17 +73,6 @@ Assuming 50 characters per line, an offset of 10,000,000 can represent approxima
 HEAP_DUMP_SIZE = 5000
 HALF_HEAP_DUMP_SIZE = HEAP_DUMP_SIZE // 2
 
-# These types are similar, but have distinct names to make processing them less error prone
-LogMessages: TypeAlias = list[str]
-"""The legacy format of log messages before 3.0.4"""
-LogSourceInfo: TypeAlias = list[str]
-"""Information _about_ the log fetching process for display to a user"""
-RawLogStream: TypeAlias = Generator[str, None, None]
-"""Raw log stream, containing unparsed log lines."""
-LogResponse: TypeAlias = tuple[LogSourceInfo, LogMessages | None]
-"""Legacy log response, containing source information and log messages."""
-StreamingLogResponse: TypeAlias = tuple[LogSourceInfo, list[RawLogStream]]
-"""Streaming log response, containing source information, stream of log lines."""
 StructuredLogStream: TypeAlias = Generator["StructuredLogMessage", None, None]
 """Structured log stream, containing structured log messages."""
 LogHandlerOutputStream: TypeAlias = (

--- a/providers/amazon/tests/unit/amazon/aws/log/test_cloudwatch_task_handler.py
+++ b/providers/amazon/tests/unit/amazon/aws/log/test_cloudwatch_task_handler.py
@@ -108,9 +108,7 @@ class TestCloudRemoteLogIO:
 
             # Set up the right chain of processors so the event looks like we want for our full test
             if AIRFLOW_V_3_2_PLUS:
-                monkeypatch.setattr(
-                    airflow.logging_config._ActiveLoggingConfig, "remote_task_log", self.subject
-                )
+                airflow.sdk.log._ActiveLoggingConfig.set(self.subject, None)
             else:
                 monkeypatch.setattr(airflow.logging_config, "REMOTE_TASK_LOG", self.subject)
             try:

--- a/shared/logging/src/airflow_shared/logging/remote.py
+++ b/shared/logging/src/airflow_shared/logging/remote.py
@@ -1,0 +1,96 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Callable
+from importlib import import_module
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    import structlog.typing
+
+    # Use Any for forward references to avoid importing concrete types
+    RuntimeTI = Any  # Type alias for RuntimeTaskInstance protocol
+    LogResponse = tuple[Any, Any]  # Type alias for (messages, logs)
+    StreamingLogResponse = tuple[Any, Any]  # Type alias for streaming response
+
+log = logging.getLogger(__name__)
+
+
+class RemoteLogIO(Protocol):
+    """Interface for remote task loggers."""
+
+    @property
+    def processors(self) -> tuple[structlog.typing.Processor, ...]:
+        """
+        List of structlog processors to install in the task write path.
+
+        This is useful if a remote logging provider wants to either transform
+        the structured log messages as they are being written to a file, or if
+        you want to upload messages as they are generated.
+        """
+        ...
+
+    def upload(self, path: os.PathLike | str, ti: RuntimeTI) -> None:
+        """Upload the given log path to the remote storage."""
+        ...
+
+    def read(self, relative_path: str, ti: RuntimeTI) -> LogResponse:
+        """Read logs from the given remote log path."""
+        ...
+
+
+@runtime_checkable
+class RemoteLogStreamIO(RemoteLogIO, Protocol):
+    """Interface for remote task loggers with stream-based read support."""
+
+    def stream(self, relative_path: str, ti: RuntimeTI) -> StreamingLogResponse:
+        """Stream-based read interface for reading logs from the given remote log path."""
+        ...
+
+
+def discover_remote_log_handler(
+    logging_class_path: str,
+    fallback_path: str,
+    import_string: Callable[[str], Any],
+) -> tuple[RemoteLogIO | None, str | None]:
+    """Discover and load the remote log handler from a logging config module."""
+    # Sometimes we end up with `""` as the value!
+    logging_class_path = logging_class_path or fallback_path
+
+    try:
+        logging_config = import_string(logging_class_path)
+
+        # Make sure that the variable is in scope
+        if not isinstance(logging_config, dict):
+            return None, None
+
+        modpath = logging_class_path.rsplit(".", 1)[0]
+        mod = import_module(modpath)
+
+        # Load remote logging configuration from the custom module
+        remote_task_log = getattr(mod, "REMOTE_TASK_LOG", None)
+        default_remote_conn_id = getattr(mod, "DEFAULT_REMOTE_CONN_ID", None)
+
+        return remote_task_log, default_remote_conn_id
+
+    except Exception as err:
+        log.info("Remote task logs will not be available due to an error: %s", err)
+        return None, None

--- a/shared/logging/src/airflow_shared/logging/remote.py
+++ b/shared/logging/src/airflow_shared/logging/remote.py
@@ -17,21 +17,20 @@
 
 from __future__ import annotations
 
-import logging
 import os
 from collections.abc import Callable
 from importlib import import_module
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
-if TYPE_CHECKING:
-    import structlog.typing
+import structlog
 
+if TYPE_CHECKING:
     # Use Any for forward references to avoid importing concrete types
     RuntimeTI = Any  # Type alias for RuntimeTaskInstance protocol
     LogResponse = tuple[Any, Any]  # Type alias for (messages, logs)
     StreamingLogResponse = tuple[Any, Any]  # Type alias for streaming response
 
-log = logging.getLogger(__name__)
+log = structlog.getLogger(__name__)
 
 
 class RemoteLogIO(Protocol):

--- a/shared/logging/src/airflow_shared/logging/remote.py
+++ b/shared/logging/src/airflow_shared/logging/remote.py
@@ -18,17 +18,26 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Generator
 from importlib import import_module
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, TypeAlias, runtime_checkable
 
 import structlog
 
+LogMessages: TypeAlias = list[str]
+"""The legacy format of log messages before 3.0.4"""
+LogSourceInfo: TypeAlias = list[str]
+"""Information about the log fetching process for display to a user"""
+RawLogStream: TypeAlias = Generator[str, None, None]
+"""Raw log stream, containing unparsed log lines"""
+LogResponse: TypeAlias = tuple[LogSourceInfo, LogMessages | None]
+"""Legacy log response, containing source information and log messages"""
+StreamingLogResponse: TypeAlias = tuple[LogSourceInfo, list[RawLogStream]]
+"""Streaming log response, containing source information, stream of log lines"""
+
 if TYPE_CHECKING:
-    # Use Any for forward references to avoid importing concrete types
-    RuntimeTI = Any  # Type alias for RuntimeTaskInstance protocol
-    LogResponse = tuple[Any, Any]  # Type alias for (messages, logs)
-    StreamingLogResponse = tuple[Any, Any]  # Type alias for streaming response
+    # RuntimeTI is only needed for type checking to avoid circular imports
+    from airflow.sdk.types import RuntimeTaskInstanceProtocol as RuntimeTI
 
 log = structlog.getLogger(__name__)
 

--- a/shared/logging/tests/logging/test_remote.py
+++ b/shared/logging/tests/logging/test_remote.py
@@ -1,0 +1,168 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest import mock
+
+from airflow_shared.logging.remote import RemoteLogStreamIO, discover_remote_log_handler
+
+
+class DummyRemoteLogIO:
+    @property
+    def processors(self):
+        return ()
+
+    def upload(self, path, ti):
+        pass
+
+    def read(self, relative_path, ti):
+        return ([], [])
+
+
+class TestDiscoverRemoteLogHandler:
+    def test_discovers_handler_and_conn_id(self):
+        handler = DummyRemoteLogIO()
+        config = {"version": 1}
+
+        mock_module = mock.MagicMock()
+        mock_module.REMOTE_TASK_LOG = handler
+        mock_module.DEFAULT_REMOTE_CONN_ID = "aws_default"
+
+        with mock.patch("airflow_shared.logging.remote.import_module", return_value=mock_module):
+            result_handler, result_conn = discover_remote_log_handler(
+                "airflow.config_templates.airflow_local_settings.DEFAULT_LOGGING_CONFIG",
+                "fallback_path",
+                lambda path: config,
+            )
+
+        assert result_handler is handler
+        assert result_conn == "aws_default"
+
+    def test_uses_fallback_when_no_logging_class_path(self):
+        handler = DummyRemoteLogIO()
+        config = {"version": 1}
+
+        mock_module = mock.MagicMock()
+        mock_module.REMOTE_TASK_LOG = handler
+        mock_module.DEFAULT_REMOTE_CONN_ID = None
+
+        with mock.patch("airflow_shared.logging.remote.import_module", return_value=mock_module):
+            result_handler, _ = discover_remote_log_handler(
+                "",
+                "fallback_path",
+                lambda path: config,
+            )
+
+        assert result_handler is handler
+
+    def test_returns_none_when_no_remote_task_log(self):
+        config = {"version": 1}
+
+        with mock.patch(
+            "airflow_shared.logging.remote.import_module",
+            side_effect=ModuleNotFoundError(
+                "airflow.config_templates.airflow_local_settings.DEFAULT_LOGGING_CONFIG"
+            ),
+        ):
+            result_handler, result_conn = discover_remote_log_handler(
+                "airflow.config_templates.airflow_local_settings.DEFAULT_LOGGING_CONFIG",
+                "fallback_path",
+                lambda path: config,
+            )
+
+        assert result_handler is None
+        assert result_conn is None
+
+    def test_conn_id_optional(self):
+        handler = DummyRemoteLogIO()
+        config = {"version": 1}
+
+        mock_module = mock.MagicMock()
+        mock_module.REMOTE_TASK_LOG = handler
+        mock_module.DEFAULT_REMOTE_CONN_ID = None
+
+        with mock.patch("airflow_shared.logging.remote.import_module", return_value=mock_module):
+            result_handler, result_conn = discover_remote_log_handler(
+                "airflow.config_templates.airflow_local_settings.DEFAULT_LOGGING_CONFIG",
+                "fallback_path",
+                lambda path: config,
+            )
+
+        assert result_handler is handler
+        assert result_conn is None
+
+    def test_handles_import_error(self):
+        def import_error(path):
+            raise ImportError("No module named 'nonexistent'")
+
+        result_handler, result_conn = discover_remote_log_handler(
+            "nonexistent",
+            "fallback_path",
+            import_error,
+        )
+
+        assert result_handler is None
+        assert result_conn is None
+
+    def test_handles_module_loading_error(self):
+        config = {"version": 1}
+
+        with mock.patch(
+            "airflow_shared.logging.remote.import_module", side_effect=RuntimeError("Failed to load")
+        ):
+            result_handler, result_conn = discover_remote_log_handler(
+                "airflow.config_templates.airflow_local_settings.DEFAULT_LOGGING_CONFIG",
+                "fallback_path",
+                lambda path: config,
+            )
+
+        assert result_handler is None
+        assert result_conn is None
+
+
+class TestRemoteLogIOProtocol:
+    def test_dummy_implements_protocol(self):
+        handler = DummyRemoteLogIO()
+
+        assert hasattr(handler, "processors")
+        assert hasattr(handler, "upload")
+        assert hasattr(handler, "read")
+        assert callable(handler.upload)
+        assert callable(handler.read)
+
+    def test_stream_io_protocol_runtime_check(self):
+        class StreamHandler:
+            @property
+            def processors(self):
+                return ()
+
+            def upload(self, path, ti):
+                pass
+
+            def read(self, relative_path, ti):
+                return ([], [])
+
+            def stream(self, relative_path, ti):
+                return ([], [])
+
+        handler = StreamHandler()
+        assert isinstance(handler, RemoteLogStreamIO)
+
+    def test_non_stream_handler_not_stream_io(self):
+        handler = DummyRemoteLogIO()
+        assert not isinstance(handler, RemoteLogStreamIO)

--- a/shared/observability/pyproject.toml
+++ b/shared/observability/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 
 dependencies = [
     "pendulum>=3.1.0",
+    "pygtrie>=2.5.0",
     "structlog>=25.4.0",
     "methodtools>=0.4.7",
 ]

--- a/task-sdk/src/airflow/sdk/configuration.py
+++ b/task-sdk/src/airflow/sdk/configuration.py
@@ -155,8 +155,6 @@ class AirflowSDKConfigParser(_SharedAirflowConfigParser):
         if default_config is not None:
             self._update_defaults_from_string(default_config)
 
-        self.expand_all_configuration_values()
-
     def expand_all_configuration_values(self):
         """Expand all configuration values using SDK-specific expansion variables."""
         all_vars = get_sdk_expansion_variables()

--- a/task-sdk/src/airflow/sdk/configuration.py
+++ b/task-sdk/src/airflow/sdk/configuration.py
@@ -77,13 +77,14 @@ def create_default_config_parser(configuration_description: dict[str, dict[str, 
     """
     Create default config parser based on configuration description.
 
-    This is a simplified version that doesn't expand variables (SDK doesn't need
-    Core-specific expansion variables like SECRET_KEY, FERNET_KEY, etc.).
+    This version expands {AIRFLOW_HOME} in default values but not other
+    Core-specific expansion variables (SECRET_KEY, FERNET_KEY, etc.).
 
     :param configuration_description: configuration description from config.yml
     :return: Default Config Parser with default values
     """
     parser = ConfigParser()
+    all_vars = get_sdk_expansion_variables()
     for section, section_desc in configuration_description.items():
         parser.add_section(section)
         options = section_desc["options"]
@@ -94,8 +95,24 @@ def create_default_config_parser(configuration_description: dict[str, dict[str, 
                 if is_template or not isinstance(default_value, str):
                     parser.set(section, key, str(default_value))
                 else:
-                    parser.set(section, key, default_value)
+                    try:
+                        parser.set(section, key, default_value.format(**all_vars))
+                    except (KeyError, ValueError):
+                        parser.set(section, key, default_value)
     return parser
+
+
+def get_sdk_expansion_variables() -> dict[str, Any]:
+    """
+    Get variables available for config value expansion in SDK.
+
+    SDK only needs AIRFLOW_HOME for expansion. Core specific variables
+    (FERNET_KEY, JWT_SECRET_KEY, etc.) are not needed in the SDK.
+    """
+    airflow_home = os.environ.get("AIRFLOW_HOME", os.path.expanduser("~/airflow"))
+    return {
+        "AIRFLOW_HOME": airflow_home,
+    }
 
 
 def get_airflow_config() -> str:
@@ -138,6 +155,21 @@ class AirflowSDKConfigParser(_SharedAirflowConfigParser):
         if default_config is not None:
             self._update_defaults_from_string(default_config)
 
+        self.expand_all_configuration_values()
+
+    def expand_all_configuration_values(self):
+        """Expand all configuration values using SDK-specific expansion variables."""
+        all_vars = get_sdk_expansion_variables()
+        for section in self.sections():
+            for key, value in self.items(section):
+                if value is not None:
+                    if self.has_option(section, key):
+                        self.remove_option(section, key)
+                    if self.is_template(section, key) or not isinstance(value, str):
+                        self.set(section, key, value)
+                    else:
+                        self.set(section, key, value.format(**all_vars))
+
     def load_test_config(self):
         """
         Use the test configuration instead of Airflow defaults.
@@ -154,6 +186,9 @@ class AirflowSDKConfigParser(_SharedAirflowConfigParser):
         self.remove_all_read_configurations()
         with StringIO(unit_test_config) as test_config_file:
             self.read_file(test_config_file)
+
+        self.expand_all_configuration_values()
+
         log.info("Unit test configuration loaded from 'unit_tests.cfg'")
 
     def remove_all_read_configurations(self):

--- a/task-sdk/src/airflow/sdk/configuration.py
+++ b/task-sdk/src/airflow/sdk/configuration.py
@@ -166,7 +166,11 @@ class AirflowSDKConfigParser(_SharedAirflowConfigParser):
                     if self.is_template(section, key) or not isinstance(value, str):
                         self.set(section, key, value)
                     else:
-                        self.set(section, key, value.format(**all_vars))
+                        try:
+                            self.set(section, key, value.format(**all_vars))
+                        except (KeyError, ValueError, IndexError):
+                            # Leave unexpanded if variable not available
+                            self.set(section, key, value)
 
     def load_test_config(self):
         """

--- a/task-sdk/src/airflow/sdk/log.py
+++ b/task-sdk/src/airflow/sdk/log.py
@@ -33,11 +33,19 @@ from pydantic import JsonValue  # noqa: TC002
 if TYPE_CHECKING:
     from structlog.typing import EventDict, FilteringBoundLogger, Processor
 
-    from airflow.logging_config import RemoteLogIO
+    from airflow.sdk._shared.logging.remote import RemoteLogIO
     from airflow.sdk.types import Logger, RuntimeTaskInstanceProtocol as RuntimeTI
 
 
 from airflow.sdk._shared.secrets_masker import redact
+
+
+class _ActiveLoggingConfig:
+    """Internal class to track active logging configuration."""
+
+    logging_config_loaded = False
+    remote_task_log: RemoteLogIO | None = None
+    default_remote_conn_id: str | None = None
 
 
 class _WarningsInterceptor:
@@ -161,10 +169,8 @@ def init_log_file(local_relative_path: str) -> Path:
 
     Any directories that are missing are created with the right permission bits.
     """
-    # TODO: Over time, providers should use SDK's conf only. Verify and make changes to ensure we're aligned with that aim here?
-    # Currently using Core's conf for remote logging consistency.
-    from airflow.configuration import conf
     from airflow.sdk._shared.logging import init_log_file
+    from airflow.sdk.configuration import conf
 
     new_file_permissions = int(
         conf.get("logging", "file_task_handler_new_file_permissions", fallback="0o664"),
@@ -185,23 +191,39 @@ def init_log_file(local_relative_path: str) -> Path:
     )
 
 
-def load_remote_log_handler() -> RemoteLogIO | None:
-    from airflow.logging_config import get_remote_task_log
+def _load_logging_config() -> None:
+    """Load and cache the remote logging configuration from SDK config."""
+    from airflow.sdk._shared.logging.remote import discover_remote_log_handler
+    from airflow.sdk._shared.module_loading import import_string
+    from airflow.sdk.configuration import conf
 
-    return get_remote_task_log()
+    fallback = "airflow.config_templates.airflow_local_settings.DEFAULT_LOGGING_CONFIG"
+    logging_class_path = conf.get("logging", "logging_config_class", fallback=fallback)
+    _ActiveLoggingConfig.logging_config_loaded = True
+
+    # Load remote logging configuration using shared discovery logic
+    remote_task_log, default_remote_conn_id = discover_remote_log_handler(
+        logging_class_path, fallback, import_string
+    )
+    _ActiveLoggingConfig.remote_task_log = remote_task_log
+    _ActiveLoggingConfig.default_remote_conn_id = default_remote_conn_id
+
+
+def load_remote_log_handler() -> RemoteLogIO | None:
+    if not _ActiveLoggingConfig.logging_config_loaded:
+        _load_logging_config()
+    return _ActiveLoggingConfig.remote_task_log
 
 
 def load_remote_conn_id() -> str | None:
-    # TODO: Over time, providers should use SDK's conf only. Verify and make changes to ensure we're aligned with that aim here?
-    # Currently using Core's conf for remote logging consistency.
-    from airflow.configuration import conf
+    from airflow.sdk.configuration import conf
 
     if conn_id := conf.get("logging", "remote_log_conn_id", fallback=None):
         return conn_id
 
-    from airflow.logging_config import get_default_remote_conn_id
-
-    return get_default_remote_conn_id()
+    if not _ActiveLoggingConfig.logging_config_loaded:
+        _load_logging_config()
+    return _ActiveLoggingConfig.default_remote_conn_id
 
 
 def relative_path_from_logger(logger) -> Path | None:
@@ -218,9 +240,7 @@ def relative_path_from_logger(logger) -> Path | None:
         # Logging to stdout, or something odd about this logger, don't try to upload!
         return None
 
-    # TODO: Over time, providers should use SDK's conf only. Verify and make changes to ensure we're aligned with that aim here?
-    # Currently using Core's conf for remote logging consistency
-    from airflow.configuration import conf
+    from airflow.sdk.configuration import conf
 
     base_log_folder = conf.get("logging", "base_log_folder")
     return Path(fname).relative_to(base_log_folder)

--- a/task-sdk/src/airflow/sdk/log.py
+++ b/task-sdk/src/airflow/sdk/log.py
@@ -47,6 +47,13 @@ class _ActiveLoggingConfig:
     remote_task_log: RemoteLogIO | None = None
     default_remote_conn_id: str | None = None
 
+    @classmethod
+    def set(cls, remote_task_log: RemoteLogIO | None, default_remote_conn_id: str | None) -> None:
+        """Set remote logging configuration."""
+        cls.remote_task_log = remote_task_log
+        cls.default_remote_conn_id = default_remote_conn_id
+        cls.logging_config_loaded = True
+
 
 class _WarningsInterceptor:
     """A class to hold the reference to the original warnings.showwarning function."""
@@ -199,14 +206,12 @@ def _load_logging_config() -> None:
 
     fallback = "airflow.config_templates.airflow_local_settings.DEFAULT_LOGGING_CONFIG"
     logging_class_path = conf.get("logging", "logging_config_class", fallback=fallback)
-    _ActiveLoggingConfig.logging_config_loaded = True
 
     # Load remote logging configuration using shared discovery logic
     remote_task_log, default_remote_conn_id = discover_remote_log_handler(
         logging_class_path, fallback, import_string
     )
-    _ActiveLoggingConfig.remote_task_log = remote_task_log
-    _ActiveLoggingConfig.default_remote_conn_id = default_remote_conn_id
+    _ActiveLoggingConfig.set(remote_task_log, default_remote_conn_id)
 
 
 def load_remote_log_handler() -> RemoteLogIO | None:

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -2748,6 +2748,7 @@ def test_remote_logging_conn(remote_logging, remote_conn, expected_env, monkeypa
     # This test is a little bit overly specific to how the logging is currently configured :/
     monkeypatch.delitem(sys.modules, "airflow.logging_config")
     monkeypatch.delitem(sys.modules, "airflow.config_templates.airflow_local_settings", raising=False)
+    monkeypatch.delitem(sys.modules, "airflow.sdk.log", raising=False)
 
     def handle_request(request: httpx.Request) -> httpx.Response:
         return httpx.Response(
@@ -2827,6 +2828,7 @@ def test_remote_logging_conn_sets_process_context(monkeypatch, mocker):
 
     monkeypatch.delitem(sys.modules, "airflow.logging_config")
     monkeypatch.delitem(sys.modules, "airflow.config_templates.airflow_local_settings", raising=False)
+    monkeypatch.delitem(sys.modules, "airflow.sdk.log", raising=False)
 
     conn_id = "s3_conn_logs"
     conn_uri = "aws:///?region_name=us-east-1"


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
Used Cursor with Claude Sonnet 4.5, mostly for tests

---

### Problem

task-sdk had several imports from airflow-core for remote logging, for instance
- `from airflow.logging_config import RemoteLogIO, get_remote_task_log, get_default_remote_conn_id`
- `from airflow.configuration import conf` (used atleast 4 times in `log.py`)

Due to this coupling,  client-server separation is difficult where task sdk dfoesn't import from core airflow.

### Proposal

To the existing shared library (`logging`), I am adding utilities containing the remote logging protocols and discovery logic. Both core and sdk now use this shared code, but each uses its own configuration source (conf)

For context as to what's being moved:

- The `RemoteLogIO` and `RemoteLogStreamIO` protocols define the interface that S3, GCS, CloudWatch and other remote log handlers implement. These protocols are now in the shared library where both core and sdk (and providers) can reference them.

- The discovery logic that found and was responsible for loading the remote log handler from the logging config module is extracted into a helper `discover_remote_log_handler()` function. This function takes the config paths and import function as parameters, so core and sdk can each inject their own config.

### Summary of changes

Airflow core's: `airflow/logging/remote.py` is just a backcompat shim now that re-exports from the shared library. The `logging_config.py` module uses the shared discovery function instead of it's earlier logic.

For task-sdk, `sdk/log.py` gets its own `_ActiveLoggingConfig` class and discovery logic exports. All imports from core are replaced with sdk or shared imports. The earlier TODO's are removed too.


### Impact on remote logging

No breaking changes. 

- Provider remote log handlers work unchanged, same configuration mechanism, same connection ID options. 
- The difference is internal - task processes now use sdk's config instead of core's/

### For confidence, entire testing flow is here:

1. Run breeze with localstack integration after setting these env vars:

```shell
export AIRFLOW__LOGGING__REMOTE_LOGGING=true
export AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER=s3://test-airflow-logs
export AIRFLOW__LOGGING__REMOTE_LOG_CONN_ID=aws_default
export AIRFLOW__LOGGING__DELETE_LOCAL_LOGS=false
export AIRFLOW_CONN_AWS_DEFAULT=aws://test:test@?endpoint_url=http://localstack:4566&region_name=us-east-1
```

`breeze start-airflow --integration localstack`

2. Create a simple dag like this one:
```python
from datetime import datetime
from airflow.sdk import DAG
from airflow.providers.standard.operators.python import PythonOperator


def test_logging():
    import logging
    logger = logging.getLogger(__name__)

    logger.info("Testing remote logging with LocalStack")
    logger.warning("This should appear in S3")

    for i in range(5):
        logger.info(f"Log message {i}")

    print("Print statement test")


with DAG(
    "test_remote_logging",
    start_date=datetime(2024, 1, 1),
    schedule=None,
    catchup=False,
) as dag:
    PythonOperator(
        task_id="log_test",
        python_callable=test_logging,
    )

```

3. Trigger the dag and observe the logs
<img width="2559" height="1189" alt="image" src="https://github.com/user-attachments/assets/f94b9896-7490-47ca-8bcb-3480c8d70507" />

4. Check in localstack logs for requests:

<img width="1722" height="1018" alt="image" src="https://github.com/user-attachments/assets/d8de3dc4-57f1-422e-b0ee-8a49eea3131d" />


5. Check logs on localstack container using `awslocal` too

<img width="1722" height="1018" alt="image" src="https://github.com/user-attachments/assets/95e249b5-3823-4396-a719-f6a7ff7ce694" />


NOTE:

While I was at it, I realised that sdk conf didn't have support for expansion variables like `AIRFLOW_HOME` leading to remote log tests failing with:

```python
Failed: Expected at least 6 log files in S3 bucket test-airflow-logs, but found 0 objects: []
```

This was because `AIRFLOW_HOME` was not being expanded:
```
DEBUG upload_to_remote(): raw_logger=<BytesLogger(file=<_io.BufferedWriter name='{AIRFLOW_HOME}/logs/dag_id=example_xcom_test/...'>>
```

Fixed in 43319c3086


* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
