### PR TITLE
Optimize template field serialization/SDM for efficiency

### DIFF
--- a/airflow-core/src/airflow/models/serialized_dag.py
+++ b/airflow-core/src/airflow/models/serialized_dag.py
@@ -340,10 +340,8 @@ class SerializedDagModel(Base):
         dag_data = dag.data
         self.dag_hash = SerializedDagModel.hash(dag_data)
 
-        # partially ordered json data
-        dag_data_json = json.dumps(dag_data, sort_keys=True).encode("utf-8")
-
         if _COMPRESS_SERIALIZED_DAGS:
+            dag_data_json = json.dumps(dag_data, sort_keys=True).encode("utf-8")
             self._data = None
             self._data_compressed = zlib.compress(dag_data_json)
         else:


### PR DESCRIPTION
- Avoid json.dumps() when only checking JSON compatibility.
- Normalize tuples/dicts in a single pass and centralize truncation logic.
- Only build json bytes for compressed dags


---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)
Used claude-4.5-opus-high
