### PR TITLE
AIP-67 - Multi Team: Assert executors support multi team

### DIFF
--- a/airflow-core/src/airflow/executors/base_executor.py
+++ b/airflow-core/src/airflow/executors/base_executor.py
@@ -143,6 +143,7 @@ class BaseExecutor(LoggingMixin):
     active_spans = ThreadSafeDict()
 
     supports_ad_hoc_ti_run: bool = False
+    supports_multi_team: bool = False
     sentry_integration: str = ""
 
     is_local: bool = False

--- a/airflow-core/src/airflow/executors/executor_loader.py
+++ b/airflow-core/src/airflow/executors/executor_loader.py
@@ -360,6 +360,13 @@ class ExecutorLoader:
             executor_cls, import_source = cls.import_executor_cls(_executor_name)
             log.debug("Loading executor %s from %s", _executor_name, import_source.value)
             if _executor_name.team_name:
+                # Validate that team executors support multi-team functionality
+                if not executor_cls.supports_multi_team:
+                    raise AirflowConfigException(
+                        f"Executor {_executor_name.module_path} does not support multi-team functionality "
+                        f"but was configured for team '{_executor_name.team_name}'. "
+                        f"Only executors with supports_multi_team=True can be used as team executors."
+                    )
                 executor = executor_cls(team_name=_executor_name.team_name)
             else:
                 executor = executor_cls()

--- a/airflow-core/src/airflow/executors/local_executor.py
+++ b/airflow-core/src/airflow/executors/local_executor.py
@@ -153,6 +153,7 @@ class LocalExecutor(BaseExecutor):
     is_local: bool = True
     is_mp_using_fork: bool = multiprocessing.get_start_method() == "fork"
 
+    supports_multi_team: bool = True
     serve_logs: bool = True
 
     activity_queue: SimpleQueue[workloads.All | None]

--- a/airflow-core/tests/unit/executors/test_base_executor.py
+++ b/airflow-core/tests/unit/executors/test_base_executor.py
@@ -54,6 +54,10 @@ def test_is_production_default_value():
     assert BaseExecutor.is_production
 
 
+def test_supports_multi_team_default_value():
+    assert not BaseExecutor.supports_multi_team
+
+
 def test_invalid_slotspool():
     with pytest.raises(ValueError, match="parallelism is set to 0 or lower"):
         BaseExecutor(0)

--- a/airflow-core/tests/unit/executors/test_executor_loader.py
+++ b/airflow-core/tests/unit/executors/test_executor_loader.py
@@ -684,3 +684,74 @@ class TestExecutorLoader:
                     match=r"Global executors must be specified before team-based executors",
                 ):
                     executor_loader.ExecutorLoader._get_team_executor_configs()
+
+    def test_team_executor_with_multi_team_support_loads_successfully(self):
+        """Test that executors with supports_multi_team=True load successfully for teams."""
+        with conf_vars({("core", "executor"): "LocalExecutor"}):
+            executor = executor_loader.ExecutorLoader.load_executor(
+                ExecutorName(
+                    module_path="airflow.executors.local_executor.LocalExecutor",
+                    alias="LocalExecutor",
+                    team_name="team_a",
+                )
+            )
+            assert executor.team_name == "team_a"
+            assert executor.supports_multi_team is True
+
+    def test_team_executor_without_multi_team_support_fails(self):
+        """Test that executors without supports_multi_team fail when configured for teams."""
+        # Mock the executor class to have supports_multi_team = False
+        with (
+            conf_vars({("core", "executor"): "LocalExecutor"}),
+            mock.patch("airflow.executors.local_executor.LocalExecutor") as mock_executor_cls,
+        ):
+            # Set the class attribute to False
+            mock_executor_cls.supports_multi_team = False
+            mock_executor_cls.__name__ = "LocalExecutor"
+
+            with pytest.raises(
+                AirflowConfigException,
+                match=r".*does not support multi-team functionality.*",
+            ):
+                executor_loader.ExecutorLoader.load_executor(
+                    ExecutorName(
+                        module_path="airflow.executors.local_executor.LocalExecutor",
+                        alias="LocalExecutor",
+                        team_name="team_a",
+                    )
+                )
+
+    def test_global_executor_works_regardless_of_multi_team_support(self):
+        """Test that global executors work regardless of supports_multi_team value."""
+        # Test with an executor that supports multi-team (LocalExecutor)
+        with conf_vars({("core", "executor"): "LocalExecutor"}):
+            executor = executor_loader.ExecutorLoader.load_executor(
+                ExecutorName(
+                    module_path="airflow.executors.local_executor.LocalExecutor",
+                    alias="LocalExecutor",
+                    team_name=None,
+                )
+            )
+            assert executor.team_name is None
+            assert executor.supports_multi_team is True
+
+        # Test with a mocked executor that doesn't support multi-team
+        with (
+            conf_vars({("core", "executor"): "LocalExecutor"}),
+            mock.patch("airflow.executors.local_executor.LocalExecutor") as mock_executor_cls,
+        ):
+            mock_executor_cls.supports_multi_team = False
+            mock_executor_instance = mock.MagicMock()
+            mock_executor_instance.supports_multi_team = False
+            mock_executor_instance.team_name = None
+            mock_executor_cls.return_value = mock_executor_instance
+
+            executor = executor_loader.ExecutorLoader.load_executor(
+                ExecutorName(
+                    module_path="airflow.executors.local_executor.LocalExecutor",
+                    alias="LocalExecutor",
+                    team_name=None,
+                )
+            )
+            assert executor.team_name is None
+            assert executor.supports_multi_team is False

--- a/airflow-core/tests/unit/executors/test_local_executor.py
+++ b/airflow-core/tests/unit/executors/test_local_executor.py
@@ -58,6 +58,9 @@ class TestLocalExecutor:
     def test_is_local_default_value(self):
         assert LocalExecutor.is_local
 
+    def test_supports_multi_team(self):
+        assert LocalExecutor.supports_multi_team
+
     def test_serve_logs_default_value(self):
         assert LocalExecutor.serve_logs
 

--- a/providers/amazon/src/airflow/providers/amazon/aws/executors/ecs/ecs_executor.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/executors/ecs/ecs_executor.py
@@ -90,6 +90,8 @@ class AwsEcsExecutor(BaseExecutor):
      Airflow TaskInstance's executor_config.
     """
 
+    supports_multi_team: bool = True
+
     # AWS limits the maximum number of ARNs in the describe_tasks function.
     DESCRIBE_TASKS_BATCH_SIZE = 99
 

--- a/providers/amazon/tests/unit/amazon/aws/executors/ecs/test_ecs_executor.py
+++ b/providers/amazon/tests/unit/amazon/aws/executors/ecs/test_ecs_executor.py
@@ -378,6 +378,9 @@ class TestEcsExecutorTask:
 class TestAwsEcsExecutor:
     """Tests the AWS ECS Executor."""
 
+    def test_supports_multi_team(self):
+        assert AwsEcsExecutor.supports_multi_team
+
     @mock.patch("airflow.providers.amazon.aws.executors.ecs.ecs_executor.AwsEcsExecutor.change_state")
     def test_execute(self, change_state_mock, mock_airflow_key, mock_executor, mock_cmd):
         """Test execution from end-to-end."""


### PR DESCRIPTION
If the user is trying to configure a particular executor for a multi team use, ensure the executor itself supports this.

Includes changes and tests in core airflow and also the two executors that support multi team so far.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)
Cline w/  Claude Sonnet 4.5

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
