### PR TITLE
Improve DAG processor performance when sorting by mtime

### DIFF
--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -102,6 +102,7 @@ class DagFileStat:
     last_duration: float | None = None
     run_count: int = 0
     last_num_of_db_queries: int = 0
+    last_mtime: float | None = None
 
 
 @dataclass(frozen=True)
@@ -989,8 +990,28 @@ class DagFileProcessorManager(LoggingMixin):
 
     def _resort_file_queue(self):
         if self._file_parsing_sort_mode == "modified_time" and self._file_queue:
-            files, _ = self._sort_by_mtime(self._file_queue)
-            self._file_queue = deque(files)
+            files_with_mtime: dict[DagFileInfo, float] = {}
+            mtime_changed = False
+
+            for file in list(self._file_queue):
+                try:
+                    mtime = os.path.getmtime(file.absolute_path)
+                    files_with_mtime[file] = mtime
+                    stat = self._file_stats[file]
+                    if stat.last_mtime != mtime:
+                        mtime_changed = True
+                        stat.last_mtime = mtime
+                except FileNotFoundError:
+                    self.log.warning("Skipping processing of missing file: %s", file)
+                    self._file_stats.pop(file, None)
+                    mtime_changed = True  # Queue structure changed
+
+            if not mtime_changed:
+                return  # No changes, skip sorting
+
+            # Sort by mtime descending and rebuild queue
+            sorted_files = [f for f, _ in sorted(files_with_mtime.items(), key=itemgetter(1), reverse=True)]
+            self._file_queue = deque(sorted_files)
 
     def _sort_by_mtime(self, files: Iterable[DagFileInfo]):
         files_with_mtime: dict[DagFileInfo, float] = {}

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -998,9 +998,10 @@ class DagFileProcessorManager(LoggingMixin):
                     mtime = os.path.getmtime(file.absolute_path)
                     files_with_mtime[file] = mtime
                     stat = self._file_stats.get(file)
-                    if stat and stat.last_mtime != mtime:
+                    if stat is None or stat.last_mtime != mtime:
                         mtime_changed = True
-                        stat.last_mtime = mtime
+                        if stat:
+                            stat.last_mtime = mtime
                 except FileNotFoundError:
                     self.log.warning("Skipping processing of missing file: %s", file)
                     self._file_stats.pop(file, None)

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -997,7 +997,7 @@ class DagFileProcessorManager(LoggingMixin):
                 try:
                     mtime = os.path.getmtime(file.absolute_path)
                     files_with_mtime[file] = mtime
-                    stat = self._file_stats[file]
+                    stat = self._file_stats.get(file)
                     if stat.last_mtime != mtime:
                         mtime_changed = True
                         stat.last_mtime = mtime

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -998,7 +998,7 @@ class DagFileProcessorManager(LoggingMixin):
                     mtime = os.path.getmtime(file.absolute_path)
                     files_with_mtime[file] = mtime
                     stat = self._file_stats.get(file)
-                    if stat.last_mtime != mtime:
+                    if stat and stat.last_mtime != mtime:
                         mtime_changed = True
                         stat.last_mtime = mtime
                 except FileNotFoundError:

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -997,11 +997,10 @@ class DagFileProcessorManager(LoggingMixin):
                 try:
                     mtime = os.path.getmtime(file.absolute_path)
                     files_with_mtime[file] = mtime
-                    stat = self._file_stats.get(file)
-                    if stat is None or stat.last_mtime != mtime:
+                    stat = self._file_stats[file]  # Creates entry via defaultdict if missing
+                    if stat.last_mtime != mtime:
                         mtime_changed = True
-                        if stat:
-                            stat.last_mtime = mtime
+                        stat.last_mtime = mtime
                 except FileNotFoundError:
                     self.log.warning("Skipping processing of missing file: %s", file)
                     self._file_stats.pop(file, None)

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -389,7 +389,7 @@ class TestDagFileProcessorManager:
         assert list(manager._file_queue) == [file_2, file_1]
 
     @conf_vars({("dag_processor", "file_parsing_sort_mode"): "modified_time"})
-    @mock.patch("airflow.utils.file.os.path.getmtime", new=mock_get_mtime)
+    @mock.patch("airflow.dag_processing.manager.os.path.getmtime", new=mock_get_mtime)
     def test_resort_file_queue_by_mtime(self):
         """
         Check that existing files in the queue are re-sorted by mtime when calling _resort_file_queue,
@@ -417,7 +417,7 @@ class TestDagFileProcessorManager:
         assert list(manager._file_queue) == [dag_files[1], dag_files[0]]
 
     @conf_vars({("dag_processor", "file_parsing_sort_mode"): "modified_time"})
-    @mock.patch("airflow.utils.file.os.path.getmtime", new=mock_get_mtime)
+    @mock.patch("airflow.dag_processing.manager.os.path.getmtime", new=mock_get_mtime)
     def test_resort_file_queue_skips_sort_when_mtimes_unchanged(self):
         # Prepare some files with mtimes
         files_with_mtime = [


### PR DESCRIPTION
When file_parsing_sort_mode is set to "modified_time", the DAG processor previously re-sorted the entire file queue on every bundle refresh, even when no file modification times had changed.

This change caches the last seen modification time for each file in DagFileStat and skips the sort entirely when no mtimes have changed since the last check.

A follow up on https://github.com/apache/airflow/pull/60003