### PR TITLE
fix(fab): Align ORM column sizes with migration definitions

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/models/__init__.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/models/__init__.py
@@ -235,14 +235,14 @@ class User(Model, BaseUser):
         Sequence("ab_user_id_seq", start=1, increment=1, minvalue=1, cycle=False),
         primary_key=True,
     )
-    first_name: Mapped[str] = mapped_column(String(64), nullable=False)
-    last_name: Mapped[str] = mapped_column(String(64), nullable=False)
+    first_name: Mapped[str] = mapped_column(String(256), nullable=False)
+    last_name: Mapped[str] = mapped_column(String(256), nullable=False)
     username: Mapped[str] = mapped_column(
         String(512).with_variant(String(512, collation="NOCASE"), "sqlite"), unique=True, nullable=False
     )
     password: Mapped[str | None] = mapped_column(String(256))
     active: Mapped[bool | None] = mapped_column(Boolean, default=True)
-    email: Mapped[str] = mapped_column(String(320), unique=True, nullable=False)
+    email: Mapped[str] = mapped_column(String(512), unique=True, nullable=False)
     last_login: Mapped[datetime.datetime | None] = mapped_column(DateTime, nullable=True)
     login_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
     fail_login_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
@@ -349,13 +349,13 @@ class RegisterUser(Model):
         Sequence("ab_register_user_id_seq", start=1, increment=1, minvalue=1, cycle=False),
         primary_key=True,
     )
-    first_name: Mapped[str] = mapped_column(String(64), nullable=False)
-    last_name: Mapped[str] = mapped_column(String(64), nullable=False)
+    first_name: Mapped[str] = mapped_column(String(256), nullable=False)
+    last_name: Mapped[str] = mapped_column(String(256), nullable=False)
     username: Mapped[str] = mapped_column(
         String(512).with_variant(String(512, collation="NOCASE"), "sqlite"), unique=True, nullable=False
     )
     password: Mapped[str | None] = mapped_column(String(256))
-    email: Mapped[str] = mapped_column(String(320), unique=True, nullable=False)
+    email: Mapped[str] = mapped_column(String(512), unique=True, nullable=False)
     registration_date: Mapped[datetime.datetime | None] = mapped_column(
         DateTime, default=lambda: datetime.datetime.now(), nullable=True
     )


### PR DESCRIPTION
This PR try to fixes the inconsistency between ORM model definitions and Alembic migration definitions in the FAB provider
* closes: #60863 

## Problem

When FAB 5 support was added , `db.create_all()` was introduced in `create_db_from_orm()`.
This causes tables to be created using ORM metadata instead of migrations when initializing a fresh database.

The ORM defines different column sizes than the migration:

  | Column | ORM | Migration |
  |--------|-----|-----------|
  | `ab_user.first_name` | String(64) | String(256) |
  | `ab_user.last_name` | String(64) | String(256) |
  | `ab_user.email` | String(320) | String(512) |

## This PR

Align the ORM column definitions to match the migration definitions.

I understand there might be alternative approaches to solve this issue (like modifying `create_db_from_orm()` to run migrations instead of using ORM metadata), but I believe aligning the ORM with the migration is the simplest and most straightforward fix.(not sure...)

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
