### PR TITLE
Add support for `parquetOptions` in GCSToBigQueryOperator 

### DIFF
--- a/airflow-core/newsfragments/60876.improvement.rst
+++ b/airflow-core/newsfragments/60876.improvement.rst
@@ -1,0 +1,1 @@
+The ``GCSToBigQueryOperator`` parameter ``src_fmt_configs`` now supports ``parquetOptions``.

--- a/airflow-core/newsfragments/60876.improvement.rst
+++ b/airflow-core/newsfragments/60876.improvement.rst
@@ -1,1 +1,0 @@
-The ``GCSToBigQueryOperator`` parameter ``src_fmt_configs`` now supports ``parquetOptions``.

--- a/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -544,7 +544,11 @@ class GCSToBigQueryOperator(BaseOperator):
             "allowJaggedRows": self.allow_jagged_rows,
             "encoding": self.encoding,
         }
-        src_fmt_to_param_mapping = {"CSV": "csvOptions", "GOOGLE_SHEETS": "googleSheetsOptions"}
+        src_fmt_to_param_mapping = {
+            "CSV": "csvOptions",
+            "GOOGLE_SHEETS": "googleSheetsOptions",
+            "PARQUET": "parquetOptions",
+        }
         src_fmt_to_configs_mapping = {
             "csvOptions": [
                 "allowJaggedRows",
@@ -557,6 +561,7 @@ class GCSToBigQueryOperator(BaseOperator):
                 "columnNameCharacterMap",
             ],
             "googleSheetsOptions": ["skipLeadingRows"],
+            "parquetOptions": ["enumAsString", "enableListInference", "mapTargetType"],
         }
         if self.source_format in src_fmt_to_param_mapping:
             valid_configs = src_fmt_to_configs_mapping[src_fmt_to_param_mapping[self.source_format]]
@@ -687,7 +692,17 @@ class GCSToBigQueryOperator(BaseOperator):
             "ORC": ["autodetect"],
         }
 
+        # Some source formats have nested configuration options which are not available
+        # at the top level of the load configuration.
+        src_fmt_to_param_mapping = {"PARQUET": "parquetOptions"}
+        src_fmt_to_nested_configs_mapping = {
+            "parquetOptions": ["enumAsString", "enableListInference", "mapTargetType"],
+        }
+
         valid_configs = src_fmt_to_configs_mapping[self.source_format]
+
+        src_fmt_param = src_fmt_to_param_mapping.get(self.source_format)
+        valid_nested_configs = src_fmt_to_nested_configs_mapping[src_fmt_param] if src_fmt_param else None
 
         # if following fields are not specified in src_fmt_configs,
         # honor the top-level params for backward-compatibility
@@ -701,7 +716,12 @@ class GCSToBigQueryOperator(BaseOperator):
         }
 
         self.src_fmt_configs = self._validate_src_fmt_configs(
-            self.source_format, self.src_fmt_configs, valid_configs, backward_compatibility_configs
+            self.source_format,
+            self.src_fmt_configs,
+            valid_configs,
+            backward_compatibility_configs,
+            src_fmt_param,
+            valid_nested_configs,
         )
 
         self.configuration["load"].update(self.src_fmt_configs)
@@ -716,29 +736,50 @@ class GCSToBigQueryOperator(BaseOperator):
         src_fmt_configs: dict,
         valid_configs: list[str],
         backward_compatibility_configs: dict | None = None,
+        src_fmt_param: str | None = None,
+        valid_nested_configs: list[str] | None = None,
     ) -> dict:
         """
-        Validate the given src_fmt_configs against a valid configuration for the source format.
+        Validate and format the given src_fmt_configs against a valid configuration for the source format.
 
         Adds the backward compatibility config to the src_fmt_configs.
+
+        Adds nested source format configurations if valid_nested_configs is provided.
 
         :param source_format: File format to export.
         :param src_fmt_configs: Configure optional fields specific to the source format.
         :param valid_configs: Valid configuration specific to the source format
         :param backward_compatibility_configs: The top-level params for backward-compatibility
+        :param src_fmt_param: The source format parameter for nested configurations.
+        Required when valid_nested_configs is provided.
+        :param valid_nested_configs: Valid nested configuration specific to the source format.
         """
+        valid_src_fmt_configs = {}
+
         if backward_compatibility_configs is None:
             backward_compatibility_configs = {}
 
         for k, v in backward_compatibility_configs.items():
             if k not in src_fmt_configs and k in valid_configs:
-                src_fmt_configs[k] = v
+                valid_src_fmt_configs[k] = v
 
-        for k in src_fmt_configs:
-            if k not in valid_configs:
-                raise ValueError(f"{k} is not a valid src_fmt_configs for type {source_format}.")
+        if valid_nested_configs is not None:
+            if src_fmt_param is not None:
+                valid_src_fmt_configs[src_fmt_param] = {}
+            else:
+                raise ValueError("src_fmt_param is required when valid_nested_configs is provided.")
 
-        return src_fmt_configs
+        valid_nested_configs = valid_nested_configs or []
+        for k, v in src_fmt_configs.items():
+            if k in valid_configs:
+                valid_src_fmt_configs[k] = v
+            else:
+                if k in valid_nested_configs:
+                    valid_src_fmt_configs[src_fmt_param][k] = v
+                else:
+                    raise ValueError(f"{k} is not a valid src_fmt_configs for type {source_format}.")
+
+        return valid_src_fmt_configs
 
     def _cleanse_time_partitioning(
         self, destination_dataset_table: str | None, time_partitioning_in: dict | None

--- a/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -763,21 +763,22 @@ class GCSToBigQueryOperator(BaseOperator):
             if k not in src_fmt_configs and k in valid_configs:
                 valid_src_fmt_configs[k] = v
 
-        if valid_nested_configs is not None:
-            if src_fmt_param is not None:
-                valid_src_fmt_configs[src_fmt_param] = {}
-            else:
+        if valid_nested_configs is None:
+            valid_nested_configs = []
+
+        if valid_nested_configs:
+            if src_fmt_param is None:
                 raise ValueError("src_fmt_param is required when valid_nested_configs is provided.")
 
-        valid_nested_configs = valid_nested_configs or []
+            valid_src_fmt_configs[src_fmt_param] = {}
+
         for k, v in src_fmt_configs.items():
             if k in valid_configs:
                 valid_src_fmt_configs[k] = v
+            elif k in valid_nested_configs:
+                valid_src_fmt_configs[src_fmt_param][k] = v
             else:
-                if k in valid_nested_configs:
-                    valid_src_fmt_configs[src_fmt_param][k] = v
-                else:
-                    raise ValueError(f"{k} is not a valid src_fmt_configs for type {source_format}.")
+                raise ValueError(f"{k} is not a valid src_fmt_configs for type {source_format}.")
 
         return valid_src_fmt_configs
 

--- a/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_bigquery.py
@@ -1682,6 +1682,102 @@ class TestGCSToBigQueryOperator:
                 },
             )
 
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
+    def test_external_table_should_accept_parquet_format(self, hook):
+        hook.return_value.insert_job.side_effect = [
+            MagicMock(job_id=REAL_JOB_ID, error_result=False),
+            REAL_JOB_ID,
+        ]
+        hook.return_value.generate_job_id.return_value = REAL_JOB_ID
+        hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
+
+        operator = GCSToBigQueryOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            source_objects=TEST_SOURCE_OBJECTS,
+            destination_project_dataset_table=TEST_EXPLICIT_DEST,
+            schema_fields=SCHEMA_FIELDS,
+            write_disposition=WRITE_DISPOSITION,
+            external_table=True,
+            project_id=JOB_PROJECT_ID,
+            source_format="PARQUET",
+        )
+
+        operator.execute(context=MagicMock())
+
+        hook.return_value.create_table.assert_called_once_with(
+            exists_ok=True,
+            location=None,
+            project_id=JOB_PROJECT_ID,
+            dataset_id=DATASET,
+            table_id=TABLE,
+            table_resource={
+                "tableReference": {
+                    "projectId": PROJECT_ID,
+                    "datasetId": DATASET,
+                    "tableId": TABLE,
+                },
+                "externalDataConfiguration": {
+                    "autodetect": True,
+                    "sourceFormat": "PARQUET",
+                    "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS}"],
+                    "compression": "NONE",
+                    "ignoreUnknownValues": False,
+                    "schema": {"fields": SCHEMA_FIELDS},
+                },
+                "labels": {},
+            },
+        )
+
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
+    def test_without_external_table_should_accept_parquet_format(self, hook):
+        hook.return_value.insert_job.side_effect = [
+            MagicMock(job_id=REAL_JOB_ID, error_result=False),
+            REAL_JOB_ID,
+        ]
+        hook.return_value.generate_job_id.return_value = REAL_JOB_ID
+        hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
+        operator = GCSToBigQueryOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            source_objects=TEST_SOURCE_OBJECTS,
+            write_disposition=WRITE_DISPOSITION,
+            destination_project_dataset_table=TEST_EXPLICIT_DEST,
+            external_table=False,
+            project_id=JOB_PROJECT_ID,
+            source_format="PARQUET",
+        )
+
+        operator.execute(context=MagicMock())
+
+        calls = [
+            call(
+                configuration={
+                    "load": {
+                        "autodetect": True,
+                        "createDisposition": "CREATE_IF_NEEDED",
+                        "destinationTable": {
+                            "projectId": "test-project",
+                            "datasetId": "dataset",
+                            "tableId": "table",
+                        },
+                        "sourceFormat": "PARQUET",
+                        "sourceUris": ["gs://test-bucket/test/objects/test.csv"],
+                        "writeDisposition": "WRITE_TRUNCATE",
+                        "ignoreUnknownValues": False,
+                    }
+                },
+                job_id=REAL_JOB_ID,
+                location=None,
+                nowait=True,
+                project_id=JOB_PROJECT_ID,
+                retry=DEFAULT_RETRY,
+                timeout=None,
+            )
+        ]
+
+        hook.return_value.insert_job.assert_has_calls(calls)
+
 
 @pytest.fixture
 def create_task_instance(create_task_instance_of_operator, session):

--- a/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_bigquery.py
@@ -1724,6 +1724,60 @@ class TestGCSToBigQueryOperator:
                     "compression": "NONE",
                     "ignoreUnknownValues": False,
                     "schema": {"fields": SCHEMA_FIELDS},
+                    "parquetOptions": {},
+                },
+                "labels": {},
+            },
+        )
+
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
+    def test_external_table_should_accept_parquet_format_and_options(self, hook):
+        hook.return_value.insert_job.side_effect = [
+            MagicMock(job_id=REAL_JOB_ID, error_result=False),
+            REAL_JOB_ID,
+        ]
+        hook.return_value.generate_job_id.return_value = REAL_JOB_ID
+        hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
+
+        operator = GCSToBigQueryOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            source_objects=TEST_SOURCE_OBJECTS,
+            destination_project_dataset_table=TEST_EXPLICIT_DEST,
+            schema_fields=SCHEMA_FIELDS,
+            write_disposition=WRITE_DISPOSITION,
+            external_table=True,
+            project_id=JOB_PROJECT_ID,
+            source_format="PARQUET",
+            src_fmt_configs={
+                "enableListInference": True,
+            },
+        )
+
+        operator.execute(context=MagicMock())
+
+        hook.return_value.create_table.assert_called_once_with(
+            exists_ok=True,
+            location=None,
+            project_id=JOB_PROJECT_ID,
+            dataset_id=DATASET,
+            table_id=TABLE,
+            table_resource={
+                "tableReference": {
+                    "projectId": PROJECT_ID,
+                    "datasetId": DATASET,
+                    "tableId": TABLE,
+                },
+                "externalDataConfiguration": {
+                    "autodetect": True,
+                    "sourceFormat": "PARQUET",
+                    "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS}"],
+                    "compression": "NONE",
+                    "ignoreUnknownValues": False,
+                    "schema": {"fields": SCHEMA_FIELDS},
+                    "parquetOptions": {
+                        "enableListInference": True,
+                    },
                 },
                 "labels": {},
             },
@@ -1765,6 +1819,62 @@ class TestGCSToBigQueryOperator:
                         "sourceUris": ["gs://test-bucket/test/objects/test.csv"],
                         "writeDisposition": "WRITE_TRUNCATE",
                         "ignoreUnknownValues": False,
+                        "parquetOptions": {},
+                    }
+                },
+                job_id=REAL_JOB_ID,
+                location=None,
+                nowait=True,
+                project_id=JOB_PROJECT_ID,
+                retry=DEFAULT_RETRY,
+                timeout=None,
+            )
+        ]
+
+        hook.return_value.insert_job.assert_has_calls(calls)
+
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
+    def test_without_external_table_should_accept_parquet_format_and_options(self, hook):
+        hook.return_value.insert_job.side_effect = [
+            MagicMock(job_id=REAL_JOB_ID, error_result=False),
+            REAL_JOB_ID,
+        ]
+        hook.return_value.generate_job_id.return_value = REAL_JOB_ID
+        hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
+        operator = GCSToBigQueryOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            source_objects=TEST_SOURCE_OBJECTS,
+            write_disposition=WRITE_DISPOSITION,
+            destination_project_dataset_table=TEST_EXPLICIT_DEST,
+            external_table=False,
+            project_id=JOB_PROJECT_ID,
+            source_format="PARQUET",
+            src_fmt_configs={
+                "enableListInference": True,
+            },
+        )
+
+        operator.execute(context=MagicMock())
+
+        calls = [
+            call(
+                configuration={
+                    "load": {
+                        "autodetect": True,
+                        "createDisposition": "CREATE_IF_NEEDED",
+                        "destinationTable": {
+                            "projectId": "test-project",
+                            "datasetId": "dataset",
+                            "tableId": "table",
+                        },
+                        "sourceFormat": "PARQUET",
+                        "sourceUris": ["gs://test-bucket/test/objects/test.csv"],
+                        "writeDisposition": "WRITE_TRUNCATE",
+                        "ignoreUnknownValues": False,
+                        "parquetOptions": {
+                            "enableListInference": True,
+                        },
                     }
                 },
                 job_id=REAL_JOB_ID,


### PR DESCRIPTION
## Description

Add support for `parquetOptions` in GCSToBigQueryOperator `src_fmt_configs`.

My team has a lot of workflows that involve loading parquet in gcs to bigquery using airflow. By default (without [parquetOptions.enable_list_inference](https://docs.cloud.google.com/python/docs/reference/bigquery/latest/google.cloud.bigquery.format_options.ParquetOptions#google_cloud_bigquery_format_options_ParquetOptions_enable_list_inference)) parquet lists get loaded to bigquery as `STRUCT<list ARRAY<STRUCT<element $TYPE>>>`. This nested struct is cumbersome to use for querying and analysis.

With the `enable_list_inference` flag, the same parquet list is loaded simply as `ARRAY<$TYPE>` which is much easier to work with.

This PR adds support for passing `enableListInference` as one of the options in `src_fmt_configs` when the source format is `PARQUET`. This works both for the external table code path as well as the bq load code path.

## Testing

- [x] Added unit tests covering new behavior
- [x] Ran all unit tests for the operator
- [ ] Run `providers/google/tests/system/google/cloud/gcs/example_gcs_to_bigquery.py` (haven't managed to get this running yet)
  -  These currently don't work without commenting out all the openlineage stuff [slack](https://apache-airflow.slack.com/archives/C06K9Q5G2UA/p1769355582519179?thread_ts=1767106487.419719&cid=C06K9Q5G2UA). I can get it working if this is a requirement, but wondering if my own test (see below) suffices.
- [x] Created a custom dag to exercise the behavior and ran it in the breeze environment (see results below)

Without `enableListInference`:

```
    gcs_to_bq_task = GCSToBigQueryOperator(
        task_id="gcs_to_bigquery_parquet_no_options",
        bucket="<my_bucket>",
        source_objects=["<my_parquet_file_with_list"],
        destination_project_dataset_table="<my_table>",
        source_format="PARQUET",
        write_disposition="WRITE_TRUNCATE",
    )
```

Produces:
<img width="712" height="128" alt="image" src="https://github.com/user-attachments/assets/641597fb-00c3-4082-9fc1-a3db4fbbf151" />


With `enableListInference`:

```
    gcs_to_bq_task = GCSToBigQueryOperator(
        task_id="gcs_to_bigquery_parquet_no_options",
        bucket="<my_bucket>",
        source_objects=["<my_parquet_file_with_list"],
        destination_project_dataset_table="<my_table>",
        source_format="PARQUET",
        write_disposition="WRITE_TRUNCATE",
        src_fmt_configs={"enableListInference": True},
    )
```

produces:

<img width="712" height="46" alt="image" src="https://github.com/user-attachments/assets/78f3b6f3-5ce3-4024-97ee-aa6949b6ef4e" />

And likewise for the external table case which i also tested.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: Claude Sonnet 4.5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

GenAI tooling was used only for code review and discussion, no lines of code in the PR were written or directly copied from Claude.

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
