### PR TITLE
Fix flaky test_execution test

### DIFF
--- a/airflow-core/tests/unit/executors/test_local_executor.py
+++ b/airflow-core/tests/unit/executors/test_local_executor.py
@@ -78,7 +78,6 @@ class TestLocalExecutor:
 
         executor.end()
 
-    @skip_spawn_mp_start
     @mock.patch("airflow.sdk.execution_time.supervisor.supervise")
     def test_execution(self, mock_supervise):
         success_tis = [
@@ -101,8 +100,12 @@ class TestLocalExecutor:
         fail_ti = success_tis[0].model_copy(update={"id": uuid7(), "task_id": "failure"})
 
         # We just mock both styles here, only one will be hit though
+        has_failed_once = False
+
         def fake_supervise(ti, **kwargs):
-            if ti.id == fail_ti.id:
+            nonlocal has_failed_once
+            if ti.id == fail_ti.id and not has_failed_once:
+                has_failed_once = True
                 raise RuntimeError("fake failure")
             return 0
 


### PR DESCRIPTION
### Why: 
The `test_execution` test is flaky due to a race condition. When the worker raises the intended `RuntimeError`, it crashes, causing the LocalExecutor to immediately respawn a new worker to maintain parallelism.

This creates an infinite crash-and-respawn loop if the new worker picks up the failing task again. As a result, `executor.end()` hangs (times out) because it cannot successfully join the processes while new ones are constantly being spawned.

### How: 
I introduced a `has_failed_once` flag to ensure the worker raises the `RuntimeError` only once. Subsequent executions will return successfully. This prevents the infinite respawn loop, allowing the worker to shut down gracefully and `executor.end()` to finish without timing out.


closes: #45329 

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] No (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
