### PR TITLE
Exclude mysql-connector-python 9.6.0 version

### DIFF
--- a/providers/mysql/docs/index.rst
+++ b/providers/mysql/docs/index.rst
@@ -104,7 +104,7 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.12.0``
 ``apache-airflow-providers-common-sql``     ``>=1.20.0``
 ``mysqlclient``                             ``>=2.2.5; sys_platform != "darwin"``
-``mysql-connector-python``                  ``>=9.1.0``
+``mysql-connector-python``                  ``>=9.1.0,!=9.6.0``
 ``aiomysql``                                ``>=0.2.0``
 ==========================================  =====================================
 

--- a/providers/mysql/pyproject.toml
+++ b/providers/mysql/pyproject.toml
@@ -65,7 +65,11 @@ dependencies = [
     # Install and compile, and it's really only used by MySQL provider, so we can skip it on MacOS
     # Instead, if someone attempts to use it on MacOS, they will get explanatory error on how to install it
     'mysqlclient>=2.2.5; sys_platform != "darwin"',
-    'mysql-connector-python>=9.1.0',
+    # MySQL Connector/Python package from Oracle version 9.6.0 has been badly published to PyPI
+    # and it misses both sdist and wheel distributions for Python 3.12, 3.13, 3.14 making it impossible
+    # to install on these Python versions. We need to exclude this version until Oracle
+    # fixes the issue. Issue raised: https://bugs.mysql.com/bug.php?id=119736
+    'mysql-connector-python>=9.1.0,!=9.6.0',
     "aiomysql>=0.2.0",
 ]
 


### PR DESCRIPTION
MySQL Connector/Python package from Oracle version 9.6.0 has been badly published to PyPI and it misses both sdist and wheel distributions for Python 3.12, 3.13, 3.14 making it impossible to install on these Python versions. We need to exclude this version until Oracle fixes the issue. Issue raised: https://bugs.mysql.com/bug.php?id=119736

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
