### PR TITLE
Fix mypy checks in CI to also run for scripts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -903,7 +903,7 @@ repos:
         stages: ['manual']
         name: Run mypy for dev (manual)
         language: python
-        entry: ./scripts/ci/prek/mypy_folder.py dev
+        entry: ./scripts/ci/prek/mypy_folder.py dev scripts
         pass_filenames: false
         files: ^.*\.py$
         require_serial: true

--- a/scripts/ci/prek/check_secrets_search_path_sync.py
+++ b/scripts/ci/prek/check_secrets_search_path_sync.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import ast
 import sys
 from pathlib import Path
+from types import EllipsisType
 
 AIRFLOW_ROOT = Path(__file__).parents[3].resolve()
 CORE_SECRETS_FILE = AIRFLOW_ROOT / "airflow-core" / "src" / "airflow" / "secrets" / "base_secrets.py"
@@ -29,7 +30,9 @@ SDK_SECRETS_FILE = (
 )
 
 
-def extract_from_file(file_path: Path, constant_name: str) -> list[str] | None:
+def extract_from_file(
+    file_path: Path, constant_name: str
+) -> list[str | bytes | int | float | complex | EllipsisType | None] | None:
     """Extract a list constant value from a Python file using AST parsing."""
     try:
         with open(file_path) as f:

--- a/scripts/ci/prek/check_shared_distributions_usage.py
+++ b/scripts/ci/prek/check_shared_distributions_usage.py
@@ -348,7 +348,7 @@ def get_all_shared_modules(shared_dir: Path) -> list[str]:
     Get all shared module names from the shared/ directory.
     Returns list of package names like 'apache-airflow-shared-configuration'.
     """
-    shared_modules = []
+    shared_modules: list[str] = []
     if not shared_dir.exists():
         return shared_modules
 
@@ -495,7 +495,7 @@ def ensure_shared_in_workspace_and_dev(main_pyproject_path: Path, shared_dir: Pa
     Also ensures they are sorted alphabetically.
     Returns list of errors if any.
     """
-    errors = []
+    errors: list[str] = []
     shared_modules = get_all_shared_modules(shared_dir)
 
     if not shared_modules:

--- a/scripts/ci/prek/mypy_folder.py
+++ b/scripts/ci/prek/mypy_folder.py
@@ -47,6 +47,7 @@ ALLOWED_FOLDERS = [
     "airflow-core",
     *[f"providers/{provider_id.replace('.', '/')}" for provider_id in get_all_provider_ids()],
     "dev",
+    "scripts",
     "devel-common",
     "task-sdk",
     "airflow-ctl",


### PR DESCRIPTION
Mypy Checks in CI have not been run on "scripts" folder - only on dev folder and if a mypy error creeped-in, it remained undetected unless someone run `pre-push` mypy check that instead of folders run it on individual files.

This PR fixes the errors that creeped in and fixes the CI so that mypy-dev also checks scripts.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
