### PR TITLE
go-sdk: Fix execution API URL config key to use nested format

### DIFF
--- a/go-sdk/README.md
+++ b/go-sdk/README.md
@@ -52,26 +52,26 @@ Since Go is a compiled language (putting aside projects such as [YAEGI](https://
   These config values need tweaking, especially the ports and secrets. The ports are the default assuming
   airflow is running locally via `airflow standalone`.
 
-  ```toml
-  [edge]
-  api_url = "http://0.0.0.0:8080/"
+  ```yaml
+  edge:
+    api_url: "http://0.0.0.0:8080/"
 
-  [execution]
-  api_url = "http://0.0.0.0:8080/execution"
+  execution:
+    api_url: "http://0.0.0.0:8080/execution/"
 
-  [api_auth]
-  # This needs to match the value from the same setting in your API server for Edge API to function
-  secret_key = "hPDU4Yi/wf5COaWiqeI3g=="
+  api_auth:
+    # This needs to match the value from the same setting in your API server for Edge API to function
+    secret_key: "hPDU4Yi/wf5COaWiqeI3g=="
 
-  [bundles]
-  # Which folder to look in for pre-compiled bundle binaries
-  folder = "./bin"
+  bundles:
+    # Which folder to look in for pre-compiled bundle binaries
+    folder: "./bin"
 
-  [logging]
-  # Where to write task logs to
-  base_log_folder = "./logs"
-  # Secret key matching airflow API server config, to only allow log requests from there.
-  secret_key = "u0ZDb2ccINAbhzNmvYzclw=="
+  logging:
+    # Where to write task logs to
+    base_log_folder: "./logs"
+    # Secret key matching airflow API server config, to only allow log requests from there.
+    secret_key: "u0ZDb2ccINAbhzNmvYzclw=="
   ```
 
   You can also set these options via environment variables of `AIRFLOW__${section}_${key}`, for example `AIRFLOW__API_AUTH__SECRET_KEY`.

--- a/go-sdk/bundle/bundlev1/bundlev1server/impl/plugin.go
+++ b/go-sdk/bundle/bundlev1/bundlev1server/impl/plugin.go
@@ -178,8 +178,8 @@ func (g *server) executeTask(ctx context.Context, executeTask *proto.ExecuteTask
 	w := worker.NewWithBundle(dagBundle, slog.Default())
 
 	hclog.Default().
-		Warn("Does viper work", "url", viper.GetString("execution-api-url"), "env", os.Getenv("AIRFLOW__EXECUTION_API_URL"))
-	w, err = w.WithServer(viper.GetString("execution-api-url"))
+		Warn("Does viper work", "url", viper.GetString("execution.api_url"), "env", os.Getenv("AIRFLOW__EXECUTION__API_URL"))
+	w, err = w.WithServer(viper.GetString("execution.api_url"))
 	if err != nil {
 		slog.ErrorContext(ctx, "Error setting ExecutionAPI server for worker", "err", err)
 		return err


### PR DESCRIPTION
(Found this issue when I was playing with `go-sdk` for some inspirations)

The bundle plugin was using viper key `'execution-api-url'` but the config file (`go-sdk.yaml`) uses nested YAML format `'execution.api_url'` matching the pattern used by other config sections (`edge.api_url`, `api_auth.secret_key`).

This caused the plugin to fail silently when `execution.api_url` was set in `go-sdk.yaml` because viper couldn't find the incorrectly-named key (I had to add a line `execution-api-url: xxx` in `go-sdk.yaml` as a workaround).

This PR fixes this issue. Also fixed the `README.md` to use YAML syntax instead of TOML (the doc mentioned it should be a YAML).

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
