### PR TITLE
Add UvicornMonitor for zero-downtime API server worker recycling

### DIFF
--- a/airflow-core/docs/administration-and-deployment/web-stack.rst
+++ b/airflow-core/docs/administration-and-deployment/web-stack.rst
@@ -57,3 +57,45 @@ separately. This might be useful for scaling them independently or for deploying
    airflow api-server --apps core
    # serve only the Execution API Server
    airflow api-server --apps execution
+
+Worker Recycling
+----------------
+
+Long-running API server workers can accumulate memory over time. To address this,
+Airflow supports rolling worker restarts that periodically recycle workers while
+maintaining zero downtime.
+
+When enabled via :ref:`config:api__worker_refresh_interval`, the API server spawns
+new workers and health-checks them *before* killing old workers, ensuring continuous
+availability.
+
+.. code-block:: ini
+
+   [api]
+   # Recycle workers every 30 minutes (1800 seconds)
+   worker_refresh_interval = 1800
+   # Number of workers to refresh at a time
+   worker_refresh_batch_size = 1
+
+Or via environment variables:
+
+.. code-block:: bash
+
+   export AIRFLOW__API__WORKER_REFRESH_INTERVAL=1800
+   airflow api-server --workers 2
+
+The rolling restart pattern works as follows:
+
+1. Spawn ``worker_refresh_batch_size`` new workers (via ``SIGTTIN`` signal)
+2. Wait for new workers to pass health checks
+3. Kill the same number of old workers (via ``SIGTTOU`` signal)
+4. If new workers fail health checks, roll back by killing the new workers
+
+This ensures at least the expected number of healthy workers are always available.
+
+.. note::
+
+   When running with ``--workers 1``, uvicorn operates in single-process mode without a
+   process supervisor. Rolling restarts still work but briefly scale up to 2 workers
+   during the refresh cycle to enable signal-based worker management. For true zero-downtime
+   with no capacity changes, use ``--workers 2`` or more.

--- a/airflow-core/newsfragments/60919.significant.rst
+++ b/airflow-core/newsfragments/60919.significant.rst
@@ -1,0 +1,44 @@
+Add ``UvicornMonitor`` for zero-downtime API server worker recycling
+
+The API server now supports rolling worker restarts via ``worker_refresh_interval`` configuration,
+providing feature parity with Airflow 2's ``GunicornMonitor``. This addresses memory accumulation
+in long-running API server workers by periodically recycling them while maintaining zero downtime.
+
+**Why this matters:**
+
+In Airflow 3, the API server switched from Gunicorn to uvicorn. Uvicorn's built-in
+``limit_max_requests`` causes brief downtime because new workers spawn *after* old ones die.
+With multiple workers, this creates a service gap where requests can fail.
+
+**How it works:**
+
+The ``UvicornMonitor`` uses uvicorn's signal-based worker management (SIGTTIN/SIGTTOU) to perform
+rolling restarts: new workers are spawned and health-checked *before* old workers are killed,
+ensuring continuous availability.
+
+**New configuration options:**
+
+.. code-block:: ini
+
+    [api]
+    # Seconds between rolling worker refreshes (0 = disabled, default)
+    worker_refresh_interval = 1800
+
+    # Number of workers to refresh at a time
+    worker_refresh_batch_size = 1
+
+**Example usage:**
+
+To enable worker recycling every 30 minutes:
+
+.. code-block:: bash
+
+    export AIRFLOW__API__WORKER_REFRESH_INTERVAL=1800
+    airflow api-server --workers 2
+
+**Note on single-worker mode:**
+
+When running with ``--workers 1``, uvicorn operates in single-process mode without a supervisor.
+Rolling restarts still work but briefly scale up to 2 workers during the refresh cycle to enable
+the multiprocess signal handling. For true zero-downtime with no capacity changes, use
+``--workers 2`` or more.

--- a/airflow-core/src/airflow/cli/commands/uvicorn_monitor.py
+++ b/airflow-core/src/airflow/cli/commands/uvicorn_monitor.py
@@ -1,0 +1,241 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Monitor uvicorn workers and perform rolling restarts for zero-downtime worker recycling."""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import sys
+import time
+import urllib.error
+import urllib.request
+
+import psutil
+
+log = logging.getLogger(__name__)
+
+
+class UvicornMonitor:
+    """
+    Monitors uvicorn workers and performs rolling restarts.
+
+    This class provides zero-downtime worker recycling for the API server by using
+    uvicorn's SIGTTIN/SIGTTOU signals to dynamically manage worker processes.
+
+    Rolling restart pattern:
+    [n / n] ──TTIN──> [n+bs / n+bs] ──health check──> [n+bs ready] ──TTOU──> [n / n]
+
+    This ensures zero-downtime because new workers are ready BEFORE old ones are killed.
+
+    :param uvicorn_parent_pid: PID of the uvicorn parent process to monitor
+    :param num_workers_expected: Expected number of worker processes
+    :param worker_refresh_interval: Seconds between worker refresh cycles (0 to disable)
+    :param worker_refresh_batch_size: Number of workers to refresh at a time
+    :param health_check_url: URL to check for worker health before killing old workers
+    """
+
+    def __init__(
+        self,
+        uvicorn_parent_pid: int,
+        num_workers_expected: int,
+        worker_refresh_interval: int,
+        worker_refresh_batch_size: int,
+        health_check_url: str,
+    ):
+        self.uvicorn_parent_proc = psutil.Process(uvicorn_parent_pid)
+        self.num_workers_expected = num_workers_expected
+        self.worker_refresh_interval = worker_refresh_interval
+        self.worker_refresh_batch_size = worker_refresh_batch_size
+        self.health_check_url = health_check_url
+        self._last_refresh_time = time.monotonic()
+
+    def _get_num_workers_running(self) -> int:
+        """Return the number of currently running worker processes."""
+        try:
+            return len(self.uvicorn_parent_proc.children())
+        except psutil.NoSuchProcess:
+            return 0
+
+    def _get_worker_pids(self) -> list[int]:
+        """Return list of current worker PIDs."""
+        try:
+            return [child.pid for child in self.uvicorn_parent_proc.children()]
+        except psutil.NoSuchProcess:
+            return []
+
+    def _spawn_new_workers(self, count: int) -> tuple[bool, list[int]]:
+        """
+        Spawn new worker processes by sending SIGTTIN signals.
+
+        :param count: Number of workers to spawn
+        :return: Tuple of (success, list of new worker PIDs)
+        """
+        pids_before = set(self._get_worker_pids())
+        log.debug("Spawning %d new workers (current PIDs: %s)", count, sorted(pids_before))
+        try:
+            for _ in range(count):
+                self.uvicorn_parent_proc.send_signal(signal.SIGTTIN)
+        except psutil.NoSuchProcess:
+            log.error("Uvicorn parent process died during worker spawn")
+            return False, []
+
+        # Wait for new workers to appear
+        target = len(pids_before) + count
+        if not self._wait_for_workers(target, wait_for_increase=True, timeout=30):
+            return False, []
+
+        pids_after = set(self._get_worker_pids())
+        new_pids = sorted(pids_after - pids_before)
+        log.info("Spawned new workers: PIDs %s", new_pids)
+        return True, new_pids
+
+    def _kill_old_workers(self, count: int, pids_to_kill: list[int]) -> bool:
+        """
+        Kill specific old worker processes by sending SIGTERM directly to them.
+
+        We send SIGTERM directly to specific PIDs instead of using SIGTTOU because
+        SIGTTOU lets uvicorn choose which worker to kill (often the newest one),
+        which defeats the purpose of rolling restart.
+
+        :param count: Number of workers to kill
+        :param pids_to_kill: Specific PIDs of old workers to kill
+        :return: True if successful, False on error
+        """
+        pids = pids_to_kill[:count]
+        log.info("Killing old workers: PIDs %s", pids)
+        for pid in pids:
+            try:
+                os.kill(pid, signal.SIGTERM)
+            except OSError as e:
+                log.warning("Failed to kill worker PID %d: %s", pid, e)
+        # Wait for worker count to decrease
+        self._wait_for_workers(self.num_workers_expected, wait_for_increase=False, timeout=30)
+        return True
+
+    def _wait_for_workers(self, target: int, wait_for_increase: bool, timeout: int = 30) -> bool:
+        """
+        Wait for worker count to reach target.
+
+        :param target: Target number of workers
+        :param wait_for_increase: If True, wait for >= target; if False, wait for <= target
+        :param timeout: Maximum time to wait in seconds
+        :return: True if target reached, False if timed out
+        """
+        start = time.monotonic()
+        while True:
+            current = self._get_num_workers_running()
+            if wait_for_increase and current >= target:
+                return True
+            if not wait_for_increase and current <= target:
+                return True
+            if time.monotonic() - start > timeout:
+                log.warning(
+                    "Timeout waiting for workers: target=%d, current=%d, wait_for_increase=%s",
+                    target,
+                    current,
+                    wait_for_increase,
+                )
+                return False
+            time.sleep(0.5)
+        return True
+
+    def _wait_until_healthy(self, timeout: int = 120) -> bool:
+        """
+        Wait until the health check endpoint responds successfully.
+
+        :param timeout: Maximum time to wait in seconds
+        :return: True if healthy, False if timed out
+        """
+        start = time.monotonic()
+        while time.monotonic() - start < timeout:
+            try:
+                request = urllib.request.Request(self.health_check_url, method="GET")
+                with urllib.request.urlopen(request, timeout=5) as response:
+                    if response.status == 200:
+                        log.debug("Health check passed")
+                        return True
+            except (urllib.error.URLError, OSError) as e:
+                log.debug("Health check failed: %s", e)
+            time.sleep(1)
+        log.warning("Health check timed out after %d seconds", timeout)
+        return False
+
+    def _refresh_workers(self) -> None:
+        """
+        Perform a rolling restart of workers.
+
+        This spawns new workers first, waits for them to be healthy,
+        then kills the old workers to ensure zero-downtime.
+        """
+        batch_size = min(self.worker_refresh_batch_size, self.num_workers_expected)
+        pids_before = self._get_worker_pids()
+        log.info("Starting worker refresh: current workers PIDs %s", pids_before)
+
+        success, new_pids = self._spawn_new_workers(batch_size)
+        if not success:
+            # Parent process died, will be caught by main loop
+            self._last_refresh_time = time.monotonic()
+            return
+
+        # Wait for new workers to be healthy before killing old ones
+        log.info("Waiting for health check before killing old workers...")
+        if self._wait_until_healthy():
+            self._kill_old_workers(batch_size, pids_before)
+            log.info(
+                "Worker refresh completed: new PIDs %s replaced old PIDs %s",
+                new_pids,
+                pids_before[:batch_size],
+            )
+        else:
+            log.warning("New workers not healthy, rolling back by killing new workers")
+            # Try to restore original worker count by killing the new workers
+            try:
+                for _ in range(batch_size):
+                    self.uvicorn_parent_proc.send_signal(signal.SIGTTOU)
+                self._wait_for_workers(self.num_workers_expected, wait_for_increase=False, timeout=30)
+            except psutil.NoSuchProcess:
+                pass
+
+        self._last_refresh_time = time.monotonic()
+
+    def start(self) -> None:
+        """
+        Start the monitor loop.
+
+        This runs indefinitely, checking if workers need to be refreshed
+        and performing rolling restarts when necessary.
+        """
+        log.info(
+            "Starting UvicornMonitor: refresh_interval=%d, batch_size=%d, workers=%d",
+            self.worker_refresh_interval,
+            self.worker_refresh_batch_size,
+            self.num_workers_expected,
+        )
+
+        while True:
+            if not self.uvicorn_parent_proc.is_running():
+                log.error("Uvicorn parent process died, exiting monitor")
+                sys.exit(1)
+
+            if self.worker_refresh_interval > 0:
+                elapsed = time.monotonic() - self._last_refresh_time
+                if elapsed >= self.worker_refresh_interval:
+                    self._refresh_workers()
+
+            time.sleep(1)

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1446,6 +1446,24 @@ api:
       type: string
       example: ~
       default: "False"
+    worker_refresh_interval:
+      description: |
+        Number of seconds between rolling worker refreshes for the API server.
+        When enabled, workers are periodically restarted using a rolling restart
+        pattern (new workers spawn before old ones are killed) to prevent memory
+        accumulation while maintaining zero downtime. Set to 0 to disable.
+      version_added: 3.2.0
+      type: integer
+      example: ~
+      default: "0"
+    worker_refresh_batch_size:
+      description: |
+        Number of workers to refresh at a time during rolling restarts.
+        Only used when worker_refresh_interval > 0.
+      version_added: 3.2.0
+      type: integer
+      example: ~
+      default: "1"
     base_url:
       description: |
         The base url of the API server. Airflow cannot guess what domain or CNAME you are using.

--- a/airflow-core/tests/unit/cli/commands/test_uvicorn_monitor.py
+++ b/airflow-core/tests/unit/cli/commands/test_uvicorn_monitor.py
@@ -1,0 +1,323 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for UvicornMonitor."""
+
+from __future__ import annotations
+
+import signal
+import urllib.error
+from unittest import mock
+
+import psutil
+import pytest
+
+from airflow.cli.commands.uvicorn_monitor import UvicornMonitor
+
+# Store reference to real psutil.Process for use in specs before patching
+_RealProcess = psutil.Process
+
+
+class TestUvicornMonitor:
+    """Test cases for UvicornMonitor class."""
+
+    @pytest.fixture
+    def mock_process(self):
+        """Create a mock psutil.Process with proper spec."""
+        with mock.patch("psutil.Process", autospec=True) as mock_process_class:
+            mock_proc = mock.MagicMock(spec=_RealProcess)
+            mock_proc.is_running.return_value = True
+            mock_proc.children.return_value = [mock.MagicMock(spec=_RealProcess, pid=1001)]
+            mock_process_class.return_value = mock_proc
+            yield mock_proc
+
+    def test_init(self, mock_process):
+        """Test UvicornMonitor initialization."""
+        monitor = UvicornMonitor(
+            uvicorn_parent_pid=1234,
+            num_workers_expected=2,
+            worker_refresh_interval=60,
+            worker_refresh_batch_size=1,
+            health_check_url="http://localhost:8080/api/v2/version",
+        )
+
+        assert monitor.num_workers_expected == 2
+        assert monitor.worker_refresh_interval == 60
+        assert monitor.worker_refresh_batch_size == 1
+        assert monitor.health_check_url == "http://localhost:8080/api/v2/version"
+
+    def test_get_num_workers_running(self, mock_process):
+        """Test _get_num_workers_running returns correct count."""
+        mock_process.children.return_value = [
+            mock.MagicMock(spec=_RealProcess, pid=1001),
+            mock.MagicMock(spec=_RealProcess, pid=1002),
+        ]
+
+        monitor = UvicornMonitor(
+            uvicorn_parent_pid=1234,
+            num_workers_expected=2,
+            worker_refresh_interval=60,
+            worker_refresh_batch_size=1,
+            health_check_url="http://localhost:8080/api/v2/version",
+        )
+
+        assert monitor._get_num_workers_running() == 2
+
+    def test_get_worker_pids(self, mock_process):
+        """Test _get_worker_pids returns list of PIDs."""
+        mock_process.children.return_value = [
+            mock.MagicMock(spec=_RealProcess, pid=1001),
+            mock.MagicMock(spec=_RealProcess, pid=1002),
+        ]
+
+        monitor = UvicornMonitor(
+            uvicorn_parent_pid=1234,
+            num_workers_expected=2,
+            worker_refresh_interval=60,
+            worker_refresh_batch_size=1,
+            health_check_url="http://localhost:8080/api/v2/version",
+        )
+
+        assert monitor._get_worker_pids() == [1001, 1002]
+
+    def test_get_num_workers_running_no_such_process(self, mock_process):
+        """Test _get_num_workers_running handles NoSuchProcess."""
+        mock_process.children.side_effect = psutil.NoSuchProcess(1234)
+
+        monitor = UvicornMonitor(
+            uvicorn_parent_pid=1234,
+            num_workers_expected=2,
+            worker_refresh_interval=60,
+            worker_refresh_batch_size=1,
+            health_check_url="http://localhost:8080/api/v2/version",
+        )
+
+        assert monitor._get_num_workers_running() == 0
+
+    def test_spawn_new_workers_sends_sigttin(self, mock_process):
+        """Test _spawn_new_workers sends SIGTTIN signals."""
+        # Initially 2 workers, after spawn should be 3
+        mock_process.children.side_effect = [
+            [mock.MagicMock(spec=_RealProcess, pid=1001), mock.MagicMock(spec=_RealProcess, pid=1002)],
+            [mock.MagicMock(spec=_RealProcess, pid=1001), mock.MagicMock(spec=_RealProcess, pid=1002)],
+            [
+                mock.MagicMock(spec=_RealProcess, pid=1001),
+                mock.MagicMock(spec=_RealProcess, pid=1002),
+                mock.MagicMock(spec=_RealProcess, pid=1003),
+            ],
+            [
+                mock.MagicMock(spec=_RealProcess, pid=1001),
+                mock.MagicMock(spec=_RealProcess, pid=1002),
+                mock.MagicMock(spec=_RealProcess, pid=1003),
+            ],
+        ]
+
+        monitor = UvicornMonitor(
+            uvicorn_parent_pid=1234,
+            num_workers_expected=2,
+            worker_refresh_interval=60,
+            worker_refresh_batch_size=1,
+            health_check_url="http://localhost:8080/api/v2/version",
+        )
+
+        success, new_pids = monitor._spawn_new_workers(1)
+
+        assert success is True
+        assert new_pids == [1003]
+        mock_process.send_signal.assert_called_with(signal.SIGTTIN)
+
+    @mock.patch("os.kill")
+    def test_kill_old_workers_sends_sigterm_to_specific_pids(self, mock_kill, mock_process):
+        """Test _kill_old_workers sends SIGTERM to specific old worker PIDs."""
+        # Start with 3 workers, after kill should be 2
+        mock_process.children.side_effect = [
+            [mock.MagicMock(spec=_RealProcess, pid=p) for p in [1001, 1002, 1003]],
+            [mock.MagicMock(spec=_RealProcess, pid=p) for p in [1002, 1003]],
+        ]
+
+        monitor = UvicornMonitor(
+            uvicorn_parent_pid=1234,
+            num_workers_expected=2,
+            worker_refresh_interval=60,
+            worker_refresh_batch_size=1,
+            health_check_url="http://localhost:8080/api/v2/version",
+        )
+
+        monitor._kill_old_workers(1, [1001, 1002, 1003])
+
+        # Should send SIGTERM to the specific old worker PID (1001), not SIGTTOU to parent
+        mock_kill.assert_called_with(1001, signal.SIGTERM)
+
+    def test_wait_for_workers_increase_success(self, mock_process):
+        """Test _wait_for_workers returns True when target reached (increase)."""
+        mock_process.children.return_value = [
+            mock.MagicMock(spec=_RealProcess, pid=1001),
+            mock.MagicMock(spec=_RealProcess, pid=1002),
+        ]
+
+        monitor = UvicornMonitor(
+            uvicorn_parent_pid=1234,
+            num_workers_expected=2,
+            worker_refresh_interval=60,
+            worker_refresh_batch_size=1,
+            health_check_url="http://localhost:8080/api/v2/version",
+        )
+
+        result = monitor._wait_for_workers(2, wait_for_increase=True, timeout=1)
+        assert result is True
+
+    def test_wait_for_workers_decrease_success(self, mock_process):
+        """Test _wait_for_workers returns True when target reached (decrease)."""
+        mock_process.children.return_value = [
+            mock.MagicMock(spec=_RealProcess, pid=1001),
+            mock.MagicMock(spec=_RealProcess, pid=1002),
+        ]
+
+        monitor = UvicornMonitor(
+            uvicorn_parent_pid=1234,
+            num_workers_expected=2,
+            worker_refresh_interval=60,
+            worker_refresh_batch_size=1,
+            health_check_url="http://localhost:8080/api/v2/version",
+        )
+
+        result = monitor._wait_for_workers(2, wait_for_increase=False, timeout=1)
+        assert result is True
+
+    @mock.patch("time.monotonic")
+    @mock.patch("time.sleep")
+    def test_wait_for_workers_timeout(self, mock_sleep, mock_monotonic, mock_process):
+        """Test _wait_for_workers returns False on timeout."""
+        mock_process.children.return_value = [mock.MagicMock(spec=_RealProcess, pid=1001)]
+        mock_monotonic.side_effect = [0, 0, 31, 32]
+
+        monitor = UvicornMonitor(
+            uvicorn_parent_pid=1234,
+            num_workers_expected=2,
+            worker_refresh_interval=60,
+            worker_refresh_batch_size=1,
+            health_check_url="http://localhost:8080/api/v2/version",
+        )
+
+        result = monitor._wait_for_workers(2, wait_for_increase=True, timeout=30)
+        assert result is False
+
+    @mock.patch("urllib.request.urlopen")
+    def test_wait_until_healthy_success(self, mock_urlopen, mock_process):
+        """Test _wait_until_healthy returns True on successful response."""
+        mock_response = mock.MagicMock()
+        mock_response.status = 200
+        mock_response.__enter__ = mock.MagicMock(return_value=mock_response)
+        mock_response.__exit__ = mock.MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        monitor = UvicornMonitor(
+            uvicorn_parent_pid=1234,
+            num_workers_expected=2,
+            worker_refresh_interval=60,
+            worker_refresh_batch_size=1,
+            health_check_url="http://localhost:8080/api/v2/version",
+        )
+
+        result = monitor._wait_until_healthy(timeout=1)
+        assert result is True
+
+    @mock.patch("time.monotonic")
+    @mock.patch("time.sleep")
+    @mock.patch("urllib.request.urlopen")
+    def test_wait_until_healthy_timeout(self, mock_urlopen, mock_sleep, mock_monotonic, mock_process):
+        """Test _wait_until_healthy returns False on timeout."""
+        mock_urlopen.side_effect = urllib.error.URLError("Connection refused")
+        mock_monotonic.side_effect = [0, 0, 121, 122]
+
+        monitor = UvicornMonitor(
+            uvicorn_parent_pid=1234,
+            num_workers_expected=2,
+            worker_refresh_interval=60,
+            worker_refresh_batch_size=1,
+            health_check_url="http://localhost:8080/api/v2/version",
+        )
+
+        result = monitor._wait_until_healthy(timeout=120)
+        assert result is False
+
+    @mock.patch("os.kill")
+    @mock.patch("urllib.request.urlopen")
+    @mock.patch("time.monotonic")
+    def test_refresh_workers_successful(self, mock_monotonic, mock_urlopen, mock_kill, mock_process):
+        """Test _refresh_workers completes successfully."""
+        mock_monotonic.return_value = 0
+
+        # Mock health check success
+        mock_response = mock.MagicMock()
+        mock_response.status = 200
+        mock_response.__enter__ = mock.MagicMock(return_value=mock_response)
+        mock_response.__exit__ = mock.MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        # Set up worker count transitions with PIDs
+        call_count = [0]
+
+        def children_side_effect():
+            call_count[0] += 1
+            if call_count[0] <= 2:
+                # Initial: 2 workers
+                return [mock.MagicMock(spec=_RealProcess, pid=p) for p in [1001, 1002]]
+            if call_count[0] <= 5:
+                # After spawn: 3 workers
+                return [mock.MagicMock(spec=_RealProcess, pid=p) for p in [1001, 1002, 1003]]
+            # After kill: 2 workers
+            return [mock.MagicMock(spec=_RealProcess, pid=p) for p in [1002, 1003]]
+
+        mock_process.children.side_effect = children_side_effect
+
+        monitor = UvicornMonitor(
+            uvicorn_parent_pid=1234,
+            num_workers_expected=2,
+            worker_refresh_interval=60,
+            worker_refresh_batch_size=1,
+            health_check_url="http://localhost:8080/api/v2/version",
+        )
+
+        monitor._refresh_workers()
+
+        # Should have sent SIGTTIN to spawn new worker
+        assert any(call[0][0] == signal.SIGTTIN for call in mock_process.send_signal.call_args_list)
+        # Should have sent SIGTERM directly to old worker PID (1001)
+        mock_kill.assert_called_with(1001, signal.SIGTERM)
+
+    def test_refresh_workers_batch_size_limited_to_workers(self, mock_process):
+        """Test _refresh_workers limits batch_size to num_workers_expected."""
+        mock_process.children.return_value = [mock.MagicMock(spec=_RealProcess, pid=1001)]
+
+        with mock.patch.object(
+            UvicornMonitor, "_spawn_new_workers", return_value=(True, [1002])
+        ) as mock_spawn:
+            with mock.patch.object(UvicornMonitor, "_wait_until_healthy", return_value=True):
+                with mock.patch.object(UvicornMonitor, "_kill_old_workers"):
+                    with mock.patch("time.monotonic", return_value=0):
+                        monitor = UvicornMonitor(
+                            uvicorn_parent_pid=1234,
+                            num_workers_expected=1,  # Only 1 worker
+                            worker_refresh_interval=60,
+                            worker_refresh_batch_size=5,  # Batch size larger than workers
+                            health_check_url="http://localhost:8080/api/v2/version",
+                        )
+
+                        monitor._refresh_workers()
+
+                        # Should have been limited to 1 (min of batch_size and num_workers)
+                        mock_spawn.assert_called_once_with(1)


### PR DESCRIPTION
Alternate/complement to https://github.com/apache/airflow/pull/60804

## Why

API server workers accumulate memory over time. Airflow 2 had `GunicornMonitor` with rolling restarts - spawn new workers, health check them, then kill old ones. This was lost when we switched to uvicorn.

Uvicorn's built-in `limit_max_requests` doesn't help here - it kills old workers *before* spawning new ones, causing downtime.

## What

New `UvicornMonitor` class that does rolling restarts:

```
[n workers] → spawn batch → [n + batch workers] → health check → kill old batch → [n workers]
```

Enabled via config:
```ini
[api]
worker_refresh_interval = 1800  # seconds, 0 = disabled (default)
worker_refresh_batch_size = 1
```

## Gotchas (vs GunicornMonitor)

**Single-worker mode**: Gunicorn always uses master/worker architecture even with `workers=1` (master + 1 worker), so signals always work. Uvicorn with `workers=1` runs in single-process mode with no supervisor, so SIGTTIN/SIGTTOU are ignored. Workaround: start with 2 workers and scale down after startup. Works, but briefly has 2 workers during refresh cycles.

**Uvicorn kills newest worker, not oldest**: Gunicorn kills the oldest worker on SIGTTOU (`workers.pop(0)` sorted by age). Uvicorn kills the newest (`processes.pop()` - LIFO). This would kill our fresh healthy workers instead of the old ones. Fixed by sending SIGTERM directly to specific old PIDs instead of using SIGTTOU.

**No memory sharing between workers**: Unlike Gunicorn (which uses preload + fork for copy-on-write memory sharing), uvicorn's multiprocess mode spawns independent workers that each load everything separately. This means:

- Each worker has its own copy of all loaded modules, configurations, and cached data
- Total memory usage scales linearly with worker count (N workers = ~N× memory)

This is an inherent limitation of uvicorn's multiprocessing approach vs gunicorn's preload+fork model.

## Testing

```bash
# Start API server with worker recycling enabled
export AIRFLOW__API__WORKER_REFRESH_INTERVAL=60
airflow api-server --workers 2

# Watch logs for rolling restart messages:
# "Starting worker refresh: current workers PIDs [1001, 1002]"
# "Spawned new workers: PIDs [1003]"
# "Killing old workers: PIDs [1001]"
# "Worker refresh completed: new PIDs [1003] replaced old PIDs [1001]"
```

## Related

- Uvicorn multiprocess docs: https://www.uvicorn.org/deployment/#built-in