### PR TITLE
Fix Simple Auth Manager UI dev server not starting in breeze

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/run_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_utils.py
@@ -448,13 +448,16 @@ def _run_compile_internally(
 
     env = os.environ.copy()
     if dev:
-        return run_command(
-            command_to_execute,
-            check=False,
-            no_output_dump_on_exception=True,
-            text=True,
-            env=env,
-        )
+        with open(UI_ASSET_OUT_DEV_MODE_FILE, "w") as output_file:
+            return run_command(
+                command_to_execute,
+                check=False,
+                no_output_dump_on_exception=True,
+                text=True,
+                env=env,
+                stderr=subprocess.STDOUT,
+                stdout=output_file,
+            )
     compile_lock.parent.mkdir(parents=True, exist_ok=True)
     compile_lock.unlink(missing_ok=True)
     try:

--- a/scripts/ci/prek/compile_ui_assets_dev.py
+++ b/scripts/ci/prek/compile_ui_assets_dev.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import os
+import signal
 import subprocess
 import sys
 from pathlib import Path
@@ -79,10 +80,9 @@ if __name__ == "__main__":
             stderr=subprocess.STDOUT,
         )
 
-    subprocess.run(
+    subprocess.Popen(
         ["pnpm", "dev"],
         cwd=os.fspath(UI_DIRECTORY),
-        check=True,
         env=env,
         stdout=open(UI_ASSET_OUT_DEV_MODE_FILE, "a"),
         stderr=subprocess.STDOUT,
@@ -104,3 +104,7 @@ if __name__ == "__main__":
         stdout=open(SIMPLE_AUTH_MANAGER_UI_ASSET_OUT_DEV_MODE_FILE, "a"),
         stderr=subprocess.STDOUT,
     )
+
+    # Keep script alive so child processes stay in the same process group.
+    # When breeze exits, kill_process_group() will terminate all processes together.
+    signal.pause()


### PR DESCRIPTION
## Problem
Second Vite dev server (Simple Auth Manager UI) never starts in breeze dev mode
<img width="2168" height="1402" alt="image" src="https://github.com/user-attachments/assets/6d461b00-1eaa-4236-94f9-6c820ba1abf6" />

<img width="789" height="418" alt="image" src="https://github.com/user-attachments/assets/c8c3419b-f741-4eb7-8bf5-a4cf363edcb7" />


## Change
- Change `subprocess.run` --> `subprocess.Popen` for the first pnpm dev
- Add `signal.pause()` to keep the script alive so child processes stay in the same process group


<img width="768" height="500" alt="Screenshot 2026-01-22 at 5 51 56 PM" src="https://github.com/user-attachments/assets/18f5ddd8-744b-4ca2-a974-9c887e1f763f" />

https://github.com/user-attachments/assets/d40582a2-bf78-4369-ad9f-567eb707c5eb



closes: #60930

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: [claude] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
