### PR TITLE
Support PR: Add TTL-enabled LRU cache for StatsD metrics aggregation

### DIFF
--- a/chart/newsfragments/51792.significant.rst
+++ b/chart/newsfragments/51792.significant.rst
@@ -2,9 +2,9 @@ StatsD metrics aggregation now supports configurable TTL-enabled LRU cache to pr
 
 The Helm Chart now includes new configuration options for StatsD aggregation management:
 
-* ``statsd.cacheType`` - Enable TTL-enabled ``lru`` cache or ``random`` cache for metrics aggregation (default: ``lru``)
-* ``statsd.cacheSize`` - Maximum number of metrics to cache (default: ``1000``)
-* ``statsd.ttl`` - Time-to-live for cached metrics in seconds (``0s`` is TTL disabled) (default: ``0s``)
+* ``statsd.cache.type`` - Enable TTL-enabled ``lru`` cache or ``random`` cache for metrics aggregation (default: ``lru``)
+* ``statsd.cache.size`` - Maximum number of metrics to cache (default: 1000)
+* ``statsd.cache.ttl`` - Time-to-live for cached metrics in seconds (``0s`` is TTL disabled) (default: ``0s``)
 
 This feature addresses uncontrolled memory growth in StatsD daemons by automatically cleaning up stale or unused metric entries. When enabled, the cache uses both LRU (Least Recently Used) eviction and TTL (Time To Live) expiration to manage memory usage effectively.
 

--- a/chart/newsfragments/51792.significant.rst
+++ b/chart/newsfragments/51792.significant.rst
@@ -8,4 +8,4 @@ The Helm Chart now includes new configuration options for StatsD aggregation man
 
 This feature addresses uncontrolled memory growth in StatsD daemons by automatically cleaning up stale or unused metric entries. When enabled, the cache uses both LRU (Least Recently Used) eviction and TTL (Time To Live) expiration to manage memory usage effectively.
 
-To maintain backward compatibility, the values are kept default values from ``StatsD`` Users experiencing memory growth issues with StatsD can enable this feature by setting ``statsd.cache: true`` in their Helm values.
+To maintain backward compatibility, the default behaviour remains unchanged. Users experiencing memory growth issues with StatsD can enable this feature by setting ``statsd.cache: true`` in their Helm values.

--- a/chart/newsfragments/51792.significant.rst
+++ b/chart/newsfragments/51792.significant.rst
@@ -1,6 +1,6 @@
 StatsD metrics aggregation now supports configurable TTL-enabled LRU cache to prevent memory growth in long-running daemons.
 
-The Helm chart now includes new configuration options for StatsD aggregation management:
+The Helm Chart now includes new configuration options for StatsD aggregation management:
 
 * ``statsd.cacheType`` - Enable TTL-enabled ``lru`` cache or ``random`` cache for metrics aggregation (default: ``lru``)
 * ``statsd.cacheSize`` - Maximum number of metrics to cache (default: ``1000``)

--- a/chart/newsfragments/51792.significant.rst
+++ b/chart/newsfragments/51792.significant.rst
@@ -1,0 +1,11 @@
+StatsD metrics aggregation now supports configurable TTL-enabled LRU cache to prevent memory growth in long-running daemons. 
+
+The Helm chart now includes new configuration options for StatsD aggregation management:
+
+* ``statsd.cacheType`` - Enable TTL-enabled ``lru`` cache ot ``random`` cache for metrics aggregation (default: ``lru``)
+* ``statsd.cacheSize`` - Maximum number of metrics to cache (default: ``1000``)
+* ``statsd.ttl`` - Time-to-live for cached metrics in seconds (``0s`` is TTL disabled) (default: ``0s``)
+
+This feature addresses uncontrolled memory growth in StatsD daemons by automatically cleaning up stale or unused metric entries. When enabled, the cache uses both LRU (Least Recently Used) eviction and TTL (Time To Live) expiration to manage memory usage effectively.
+
+To maintain backward compatibility, the values are kept default values from ``StatsD`` Users experiencing memory growth issues with StatsD can enable this feature by setting ``statsd.cache: true`` in their Helm values.

--- a/chart/newsfragments/51792.significant.rst
+++ b/chart/newsfragments/51792.significant.rst
@@ -2,7 +2,7 @@ StatsD metrics aggregation now supports configurable TTL-enabled LRU cache to pr
 
 The Helm chart now includes new configuration options for StatsD aggregation management:
 
-* ``statsd.cacheType`` - Enable TTL-enabled ``lru`` cache ot ``random`` cache for metrics aggregation (default: ``lru``)
+* ``statsd.cacheType`` - Enable TTL-enabled ``lru`` cache or ``random`` cache for metrics aggregation (default: ``lru``)
 * ``statsd.cacheSize`` - Maximum number of metrics to cache (default: ``1000``)
 * ``statsd.ttl`` - Time-to-live for cached metrics in seconds (``0s`` is TTL disabled) (default: ``0s``)
 

--- a/chart/newsfragments/51792.significant.rst
+++ b/chart/newsfragments/51792.significant.rst
@@ -1,4 +1,4 @@
-StatsD metrics aggregation now supports configurable TTL-enabled LRU cache to prevent memory growth in long-running daemons. 
+StatsD metrics aggregation now supports configurable TTL-enabled LRU cache to prevent memory growth in long-running daemons.
 
 The Helm chart now includes new configuration options for StatsD aggregation management:
 

--- a/chart/templates/configmaps/statsd-configmap.yaml
+++ b/chart/templates/configmaps/statsd-configmap.yaml
@@ -49,4 +49,8 @@ data:
         {{- toYaml .Values.statsd.extraMappings | nindent 6 }}
       {{- end }}
     {{- end }}
+    {{- if .Values.statsd.cache.ttl }}
+    defaults:
+      ttl: {{ .Values.statsd.cache.ttl }}
+    {{- end }}
 {{- end }}

--- a/chart/templates/statsd/statsd-deployment.yaml
+++ b/chart/templates/statsd/statsd-deployment.yaml
@@ -62,7 +62,7 @@ spec:
         component: statsd
         release: {{ .Release.Name }}
         {{- if or .Values.labels .Values.statsd.labels }}
-        {{- mustMerge .Values.statsd.labels .Values.labels | toYaml | nindent 8 }}
+          {{- mustMerge .Values.statsd.labels .Values.labels | toYaml | nindent 8 }}
         {{- end }}
       {{- if or .Values.statsd.extraMappings .Values.statsd.podAnnotations }}
       annotations:
@@ -97,20 +97,20 @@ spec:
           {{- end }}
           args:
           {{- if .Values.statsd.cache.size }}
-          - "--statsd.cache-size={{ .Values.statsd.cache.size }}"
+            - "--statsd.cache-size={{ .Values.statsd.cache.size }}"
           {{- end }}
-          {{- if .Values.statsd.cache.type }}
-          - "--statsd.cache-type={{ .Values.statsd.cache.type }}"
+            {{- if .Values.statsd.cache.type }}
+            - "--statsd.cache-type={{ .Values.statsd.cache.type }}"
           {{- end }}
           {{- if .Values.statsd.cache.ttl }}
-          - "--ttl={{ .Values.statsd.cache.ttl }}"
+            - "--ttl={{ .Values.statsd.cache.ttl }}"
           {{- end }}
           {{- if .Values.statsd.args }}
           {{- range $arg := .Values.statsd.args }}
-          - {{ $arg | quote }}
+            - {{ $arg | quote }}
           {{- end }}
           {{- else }}
-          - "--statsd.mapping-config=/etc/statsd-exporter/mappings.yml"
+            - "--statsd.mapping-config=/etc/statsd-exporter/mappings.yml"
           {{- end }}
           resources: {{- toYaml .Values.statsd.resources | nindent 12 }}
           {{- with .Values.statsd.env }}

--- a/chart/templates/statsd/statsd-deployment.yaml
+++ b/chart/templates/statsd/statsd-deployment.yaml
@@ -62,13 +62,13 @@ spec:
         component: statsd
         release: {{ .Release.Name }}
         {{- if or .Values.labels .Values.statsd.labels }}
-          {{- mustMerge .Values.statsd.labels .Values.labels | toYaml | nindent 8 }}
+        {{- mustMerge .Values.statsd.labels .Values.labels | toYaml | nindent 8 }}
         {{- end }}
       {{- if or .Values.statsd.extraMappings .Values.statsd.podAnnotations }}
       annotations:
         checksum/statsd-config: {{ include (print $.Template.BasePath "/configmaps/statsd-configmap.yaml") . | sha256sum }}
         {{- if .Values.statsd.podAnnotations }}
-          {{- toYaml .Values.statsd.podAnnotations | nindent 8 }}
+        {{- toYaml .Values.statsd.podAnnotations | nindent 8 }}
         {{- end }}
       {{- end }}
     spec:
@@ -97,18 +97,18 @@ spec:
           {{- end }}
           args:
           {{- if .Values.statsd.cache.size }}
-            - "--statsd.cache-size={{ .Values.statsd.cache.size }}"
+          - "--statsd.cache-size={{ .Values.statsd.cache.size }}"
           {{- end }}
           {{- if .Values.statsd.cache.type }}
-            - "--statsd.cache-type={{ .Values.statsd.cache.type }}"
+          - "--statsd.cache-type={{ .Values.statsd.cache.type }}"
           {{- end }}
           {{- if .Values.statsd.cache.ttl }}
-            - "--ttl={{ .Values.statsd.cache.ttl }}"
+          - "--ttl={{ .Values.statsd.cache.ttl }}"
           {{- end }}
           {{- if .Values.statsd.args }}
-            {{- range $arg := .Values.statsd.args }}
-            - {{ $arg | quote }}
-            {{- end }}
+          {{- range $arg := .Values.statsd.args }}
+          - {{ $arg | quote }}
+          {{- end }}
           {{- else }}
           - "--statsd.mapping-config=/etc/statsd-exporter/mappings.yml"
           {{- end }}

--- a/chart/templates/statsd/statsd-deployment.yaml
+++ b/chart/templates/statsd/statsd-deployment.yaml
@@ -96,15 +96,15 @@ spec:
           lifecycle: {{- tpl (toYaml $containerLifecycleHooks) . | nindent 12 }}
           {{- end }}
           args:
-            {{- if .Values.statsd.cacheSize }}
-            - "--statsd.cache-size={{ .Values.statsd.cacheSize }}"
-            {{- end }}
-            {{- if .Values.statsd.cacheType }}
-            - "--statsd.cache-type={{ .Values.statsd.cacheType }}"
-            {{- end }}
-            {{- if .Values.statsd.ttl }}
-            - "--ttl={{ .Values.statsd.ttl }}"
-            {{- end }}
+          {{- if .Values.statsd.cache.size }}
+            - "--statsd.cache-size={{ .Values.statsd.cache.size }}"
+          {{- end }}
+          {{- if .Values.statsd.cache.type }}
+            - "--statsd.cache-type={{ .Values.statsd.cache.type }}"
+          {{- end }}
+          {{- if .Values.statsd.cache.ttl }}
+            - "--ttl={{ .Values.statsd.cache.ttl }}"
+          {{- end }}
           {{- if .Values.statsd.args }}
             {{- range $arg := .Values.statsd.args }}
             - {{ $arg | quote }}

--- a/chart/templates/statsd/statsd-deployment.yaml
+++ b/chart/templates/statsd/statsd-deployment.yaml
@@ -105,7 +105,7 @@ spec:
           {{- end }}
             - "--statsd.cache-size={{ .Values.statsd.cacheSize | default 1000 }}"
             - "--statsd.cache-type={{ .Values.statsd.cacheType | default `lru` }}"
-            - "--ttl={{ .Values.statsd.ttl | default '0s' }}"
+            - "--ttl={{ .Values.statsd.ttl }}"
           resources: {{- toYaml .Values.statsd.resources | nindent 12 }}
           {{- with .Values.statsd.env }}
           env: {{- toYaml . | nindent 12 }}

--- a/chart/templates/statsd/statsd-deployment.yaml
+++ b/chart/templates/statsd/statsd-deployment.yaml
@@ -100,9 +100,9 @@ spec:
           {{- else}}
           args:
             - "--statsd.mapping-config=/etc/statsd-exporter/mappings.yml"
-            - "--statsd.cache-size={{ default 1000 .Values.statsd.cacheSize }}"
-            - "--statsd.cache-type={{ default 'lru' .Values.statsd.cacheType }}"
-            - "--ttl={{ default '0s' .Values.statsd.ttl }}"
+            - "--statsd.cache-size={{ .Values.statsd.cacheSize }}"
+            - "--statsd.cache-type={{ .Values.statsd.cacheType }}"
+            - "--ttl={{ .Values.statsd.ttl }}"
           {{- end }}
           resources: {{- toYaml .Values.statsd.resources | nindent 12 }}
           {{- with .Values.statsd.env }}

--- a/chart/templates/statsd/statsd-deployment.yaml
+++ b/chart/templates/statsd/statsd-deployment.yaml
@@ -105,7 +105,7 @@ spec:
           {{- end }}
             - "--statsd.cache-size={{ .Values.statsd.cacheSize | default 1000 }}"
             - "--statsd.cache-type={{ .Values.statsd.cacheType | default `lru` }}"
-            - "--ttl={{ .Values.statsd.ttl | default '0s'}}"
+            - "--ttl={{ .Values.statsd.ttl | default 0s}}"
           resources: {{- toYaml .Values.statsd.resources | nindent 12 }}
           {{- with .Values.statsd.env }}
           env: {{- toYaml . | nindent 12 }}

--- a/chart/templates/statsd/statsd-deployment.yaml
+++ b/chart/templates/statsd/statsd-deployment.yaml
@@ -102,9 +102,6 @@ spec:
             {{- if .Values.statsd.cache.type }}
             - "--statsd.cache-type={{ .Values.statsd.cache.type }}"
           {{- end }}
-          {{- if .Values.statsd.cache.ttl }}
-            - "--ttl={{ .Values.statsd.cache.ttl }}"
-          {{- end }}
           {{- if .Values.statsd.args }}
           {{- range $arg := .Values.statsd.args }}
             - {{ $arg | quote }}

--- a/chart/templates/statsd/statsd-deployment.yaml
+++ b/chart/templates/statsd/statsd-deployment.yaml
@@ -103,8 +103,8 @@ spec:
           {{- else }}
             - "--statsd.mapping-config=/etc/statsd-exporter/mappings.yml"
           {{- end }}
-            - "--statsd.cache-size={{ .Values.statsd.cacheSize | default 1000 }}"
-            - "--statsd.cache-type={{ .Values.statsd.cacheType | default `lru` }}"
+            - "--statsd.cache-size={{ .Values.statsd.cacheSize }}"
+            - "--statsd.cache-type={{ .Values.statsd.cacheType }}"
             - "--ttl={{ .Values.statsd.ttl }}"
           resources: {{- toYaml .Values.statsd.resources | nindent 12 }}
           {{- with .Values.statsd.env }}

--- a/chart/templates/statsd/statsd-deployment.yaml
+++ b/chart/templates/statsd/statsd-deployment.yaml
@@ -95,7 +95,6 @@ spec:
           {{- if $containerLifecycleHooks }}
           lifecycle: {{- tpl (toYaml $containerLifecycleHooks) . | nindent 12 }}
           {{- end }}
-          {{- if .Values.statsd.args }}
           args:
           {{- if .Values.statsd.args }}
             {{- range $arg := .Values.statsd.args }}

--- a/chart/templates/statsd/statsd-deployment.yaml
+++ b/chart/templates/statsd/statsd-deployment.yaml
@@ -96,15 +96,21 @@ spec:
           lifecycle: {{- tpl (toYaml $containerLifecycleHooks) . | nindent 12 }}
           {{- end }}
           args:
+            {{- if .Values.statsd.cacheSize }}
+            - "--statsd.cache-size={{ .Values.statsd.cacheSize }}"
+            {{- end }}
+            {{- if .Values.statsd.cacheType }}
+            - "--statsd.cache-type={{ .Values.statsd.cacheType }}"
+            {{- end }}
+            {{- if .Values.statsd.ttl }}
+            - "--ttl={{ .Values.statsd.ttl }}"
+            {{- end }}
           {{- if .Values.statsd.args }}
             {{- range $arg := .Values.statsd.args }}
             - {{ $arg | quote }}
             {{- end }}
           {{- else }}
-            - "--statsd.mapping-config=/etc/statsd-exporter/mappings.yml"
-            - "--statsd.cache-size={{ .Values.statsd.cacheSize }}"
-            - "--statsd.cache-type={{ .Values.statsd.cacheType }}"
-            - "--ttl={{ .Values.statsd.ttl }}"
+          - "--statsd.mapping-config=/etc/statsd-exporter/mappings.yml"
           {{- end }}
           resources: {{- toYaml .Values.statsd.resources | nindent 12 }}
           {{- with .Values.statsd.env }}

--- a/chart/templates/statsd/statsd-deployment.yaml
+++ b/chart/templates/statsd/statsd-deployment.yaml
@@ -105,7 +105,7 @@ spec:
           {{- end }}
             - "--statsd.cache-size={{ .Values.statsd.cacheSize | default 1000 }}"
             - "--statsd.cache-type={{ .Values.statsd.cacheType | default `lru` }}"
-            - "--ttl={{ .Values.statsd.ttl | default 0s}}"
+            - "--ttl={{ .Values.statsd.ttl | default '0s' }}"
           resources: {{- toYaml .Values.statsd.resources | nindent 12 }}
           {{- with .Values.statsd.env }}
           env: {{- toYaml . | nindent 12 }}

--- a/chart/templates/statsd/statsd-deployment.yaml
+++ b/chart/templates/statsd/statsd-deployment.yaml
@@ -102,10 +102,10 @@ spec:
             {{- end }}
           {{- else }}
             - "--statsd.mapping-config=/etc/statsd-exporter/mappings.yml"
-          {{- end }}
             - "--statsd.cache-size={{ .Values.statsd.cacheSize }}"
             - "--statsd.cache-type={{ .Values.statsd.cacheType }}"
             - "--ttl={{ .Values.statsd.ttl }}"
+          {{- end }}
           resources: {{- toYaml .Values.statsd.resources | nindent 12 }}
           {{- with .Values.statsd.env }}
           env: {{- toYaml . | nindent 12 }}

--- a/chart/templates/statsd/statsd-deployment.yaml
+++ b/chart/templates/statsd/statsd-deployment.yaml
@@ -96,14 +96,17 @@ spec:
           lifecycle: {{- tpl (toYaml $containerLifecycleHooks) . | nindent 12 }}
           {{- end }}
           {{- if .Values.statsd.args }}
-          args: {{ tpl (toYaml .Values.statsd.args) . | nindent 12 }}
-          {{- else}}
           args:
+          {{- if .Values.statsd.args }}
+            {{- range $arg := .Values.statsd.args }}
+            - {{ $arg | quote }}
+            {{- end }}
+          {{- else }}
             - "--statsd.mapping-config=/etc/statsd-exporter/mappings.yml"
+          {{- end }}
             - "--statsd.cache-size={{ .Values.statsd.cacheSize }}"
             - "--statsd.cache-type={{ .Values.statsd.cacheType }}"
             - "--ttl={{ .Values.statsd.ttl }}"
-          {{- end }}
           resources: {{- toYaml .Values.statsd.resources | nindent 12 }}
           {{- with .Values.statsd.env }}
           env: {{- toYaml . | nindent 12 }}

--- a/chart/templates/statsd/statsd-deployment.yaml
+++ b/chart/templates/statsd/statsd-deployment.yaml
@@ -103,9 +103,9 @@ spec:
           {{- else }}
             - "--statsd.mapping-config=/etc/statsd-exporter/mappings.yml"
           {{- end }}
-            - "--statsd.cache-size={{ .Values.statsd.cacheSize }}"
-            - "--statsd.cache-type={{ .Values.statsd.cacheType }}"
-            - "--ttl={{ .Values.statsd.ttl }}"
+            - "--statsd.cache-size={{ .Values.statsd.cacheSize | default 1000 }}"
+            - "--statsd.cache-type={{ .Values.statsd.cacheType | default 'lru' }}"
+            - "--ttl={{ .Values.statsd.ttl | default '0s'}}"
           resources: {{- toYaml .Values.statsd.resources | nindent 12 }}
           {{- with .Values.statsd.env }}
           env: {{- toYaml . | nindent 12 }}

--- a/chart/templates/statsd/statsd-deployment.yaml
+++ b/chart/templates/statsd/statsd-deployment.yaml
@@ -104,7 +104,7 @@ spec:
             - "--statsd.mapping-config=/etc/statsd-exporter/mappings.yml"
           {{- end }}
             - "--statsd.cache-size={{ .Values.statsd.cacheSize | default 1000 }}"
-            - "--statsd.cache-type={{ .Values.statsd.cacheType | default 'lru' }}"
+            - "--statsd.cache-type={{ .Values.statsd.cacheType | default `lru` }}"
             - "--ttl={{ .Values.statsd.ttl | default '0s'}}"
           resources: {{- toYaml .Values.statsd.resources | nindent 12 }}
           {{- with .Values.statsd.env }}

--- a/chart/templates/statsd/statsd-deployment.yaml
+++ b/chart/templates/statsd/statsd-deployment.yaml
@@ -100,6 +100,9 @@ spec:
           {{- else}}
           args:
             - "--statsd.mapping-config=/etc/statsd-exporter/mappings.yml"
+            - "--statsd.cache-size={{ default 1000 .Values.statsd.cacheSize }}"
+            - "--statsd.cache-type={{ default 'lru' .Values.statsd.cacheType }}"
+            - "--ttl={{ default '0s' .Values.statsd.ttl }}"
           {{- end }}
           resources: {{- toYaml .Values.statsd.resources | nindent 12 }}
           {{- with .Values.statsd.env }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -7751,6 +7751,21 @@
                     "type": "boolean",
                     "default": true
                 },
+                "cacheSize": {
+                    "description": "Maximum number of metric mappings to cache in memory. Higher values improve performance for frequently used metrics but consume more memory.",
+                    "type": "integer",
+                    "default": 1000
+                },
+                "cacheType": {
+                    "description": "Cache eviction strategy for metric mappings. `lru` (Least Recently Used) evicts oldest accessed items, 'random' evicts randomly selected items.",
+                    "type": "string",
+                    "default": "lru"
+                },
+                "ttl": {
+                    "description": "Time-to-live for cached metric mappings. Determines how long mappings remain in cache before expiring. Set to '0s' to disable expiration.",
+                    "type": "string",
+                    "default": "0s"
+                },
                 "revisionHistoryLimit": {
                     "description": "Number of old replicasets to retain.",
                     "type": [

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -595,17 +595,17 @@
                         "cacheSize": {
                             "description": "Add cache size for your statsD deployment.",
                             "type": "integer",
-                            "default": false
+                            "default": true
                         },
                         "cacheType": {
                             "description": "Add cache type for your statsD deployment (lru/random).",
                             "type": "string",
-                            "default": false
+                            "default": true
                         },
                         "ttl": {
                             "description": "Configure Time TO Live time for StatsD Metrics.",
                             "type": "string",
-                            "default": false
+                            "default": true
                         },
                         "annotations": {
                             "description": "Annotations for the statsd Ingress.",

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -592,21 +592,6 @@
                             "type": "boolean",
                             "default": false
                         },
-                        "cacheSize": {
-                            "description": "Add cache size for your statsD deployment.",
-                            "type": "integer",
-                            "default": 1000
-                        },
-                        "cacheType": {
-                            "description": "Add cache type for your statsD deployment (lru/random).",
-                            "type": "string",
-                            "default": "lru"
-                        },
-                        "ttl": {
-                            "description": "Configure Time TO Live time for StatsD Metrics.",
-                            "type": "string",
-                            "default": "0s"
-                        },
                         "annotations": {
                             "description": "Annotations for the statsd Ingress.",
                             "type": "object",

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -592,6 +592,21 @@
                             "type": "boolean",
                             "default": false
                         },
+                        "cacheSize": {
+                            "description": "Add cache size for your statsD deployment.",
+                            "type": "integer",
+                            "default": false
+                        },
+                        "cacheType": {
+                            "description": "Add cache type for your statsD deployment (lru/random).",
+                            "type": "string",
+                            "default": false
+                        },
+                        "ttl": {
+                            "description": "Configure Time TO Live time for StatsD Metrics.",
+                            "type": "string",
+                            "default": false
+                        },
                         "annotations": {
                             "description": "Annotations for the statsd Ingress.",
                             "type": "object",

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -595,17 +595,17 @@
                         "cacheSize": {
                             "description": "Add cache size for your statsD deployment.",
                             "type": "integer",
-                            "default": true
+                            "default": 1000
                         },
                         "cacheType": {
                             "description": "Add cache type for your statsD deployment (lru/random).",
                             "type": "string",
-                            "default": true
+                            "default": "lru"
                         },
                         "ttl": {
                             "description": "Configure Time TO Live time for StatsD Metrics.",
                             "type": "string",
-                            "default": true
+                            "default": "0s"
                         },
                         "annotations": {
                             "description": "Annotations for the statsd Ingress.",

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -7751,20 +7751,27 @@
                     "type": "boolean",
                     "default": true
                 },
-                "cacheSize": {
-                    "description": "Maximum number of metric mappings to cache in memory. Higher values improve performance for frequently used metrics but consume more memory.",
-                    "type": "integer",
-                    "default": 1000
-                },
-                "cacheType": {
-                    "description": "Cache eviction strategy for metric mappings. `lru` (Least Recently Used) evicts oldest accessed items, 'random' evicts randomly selected items.",
-                    "type": "string",
-                    "default": "lru"
-                },
-                "ttl": {
-                    "description": "Time-to-live for cached metric mappings. Determines how long mappings remain in cache before expiring. Set to '0s' to disable expiration.",
-                    "type": "string",
-                    "default": "0s"
+                "cache": {
+                    "description": "StatsD cache configuration.",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "size": {
+                            "description": "Maximum number of metric mappings to cache in memory. Higher values improve performance for frequently used metrics but consume more memory.",
+                            "type": "integer",
+                            "default": 1000
+                        },
+                        "type": {
+                            "description": "Cache eviction strategy for metric mappings. `lru` (Least Recently Used) evicts oldest accessed items, 'random' evicts randomly selected items.",
+                            "type": "string",
+                            "default": "lru"
+                        },
+                        "ttl": {
+                            "description": "Time-to-live for cached metric mappings. Determines how long mappings remain in cache before expiring. Set to '0s' to disable expiration.",
+                            "type": "string",
+                            "default": "0s"
+                        }
+                    }
                 },
                 "revisionHistoryLimit": {
                     "description": "Number of old replicasets to retain.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -283,9 +283,9 @@ ingress:
     # supply your own array here; if set, all below flag-specific values
     # (mappingConfig, cacheSize, cacheType, ttl) are ignored.
     # args:
-    #   - "--statsd.cache-size=500"
-    #   - "--statsd.cache-type=random"
-    #   - "--ttl=10m"
+    #  - "--statsd.cache-size=1000"
+    #  - "--statsd.cache-type=random"
+    #  - "--ttl=10m"
     # -------------------------------------------------------------------
 
     # Path in the container to the mapping config file.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -303,7 +303,7 @@ ingress:
     cacheType: lru
 
     # Per‐metric time‐to‐live. When set to a non‐zero duration, any metric
-    # series that hasn’t received an update in this interval will be dropped
+    # series that hasn't received an update in this interval will be dropped
     # from the exported /metrics output.
     # Format: Go duration string (e.g. "30s", "5m", "1h")
     # Default: "0s" (disabled, never expires)

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -279,6 +279,36 @@ ingress:
     # Enable web ingress resource
     enabled: false
 
+    # If you ever need to fully override the entire args list, you can
+    # supply your own array here; if set, all below flag-specific values
+    # (mappingConfig, cacheSize, cacheType, ttl) are ignored.
+    # args:
+    #   - "--statsd.cache-size=500"
+    #   - "--statsd.cache-type=random"
+    #   - "--ttl=10m"
+    # -------------------------------------------------------------------
+
+    # Path in the container to the mapping config file.
+
+    # Maximum number of metric‐mapping entries to keep in cache.
+    # When you send more distinct metric names than this, older entries
+    # will be evicted according to cacheType.
+    # Default: 1000
+    cacheSize: 1000
+
+    # Metrics Eviction policy for the mapping cache.
+    #   - lru    → Least‐Recently‐Used eviction
+    #   - random → Random eviction
+    # Default: lru
+    cacheType: lru
+
+    # Per‐metric time‐to‐live. When set to a non‐zero duration, any metric
+    # series that hasn’t received an update in this interval will be dropped
+    # from the exported /metrics output.
+    # Format: Go duration string (e.g. "30s", "5m", "1h")
+    # Default: "0s" (disabled, never expires)
+    ttl: "0s"
+
     # Annotations for the statsd Ingress
     annotations: {}
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2608,16 +2608,16 @@ statsd:
   # Arguments for StatsD exporter command.
   args: ["--statsd.mapping-config=/etc/statsd-exporter/mappings.yml"]
 
-      # If you ever need to fully override the entire args list, you can
-    # supply your own array here; if set, all below flag-specific values
-    # (mappingConfig, cache-size, cache-type, ttl) are ignored.
-    # args:
-    #  - "--statsd.cache-size=1000"
-    #  - "--statsd.cache-type=random"
-    #  - "--ttl=10m"
-    # -------------------------------------------------------------------
+  # If you ever need to fully override the entire args list, you can
+  # supply your own array here; if set, all below flag-specific values
+  # (mappingConfig, cache-size, cache-type, ttl) are ignored.
+  # args:
+  #  - "--statsd.cache-size=1000"
+  #  - "--statsd.cache-type=random"
+  #  - "--ttl=10m"
+  # -------------------------------------------------------------------
 
-    # Path in the container to the mapping config file.
+  # Path in the container to the mapping config file.
 
   cache:
     # Maximum number of metric‐mapping entries to keep in cache.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -279,36 +279,6 @@ ingress:
     # Enable web ingress resource
     enabled: false
 
-    # If you ever need to fully override the entire args list, you can
-    # supply your own array here; if set, all below flag-specific values
-    # (mappingConfig, cacheSize, cacheType, ttl) are ignored.
-    # args:
-    #  - "--statsd.cache-size=1000"
-    #  - "--statsd.cache-type=random"
-    #  - "--ttl=10m"
-    # -------------------------------------------------------------------
-
-    # Path in the container to the mapping config file.
-
-    # Maximum number of metric‐mapping entries to keep in cache.
-    # When you send more distinct metric names than this, older entries
-    # will be evicted according to cacheType.
-    # Default: 1000
-    cacheSize: 1000
-
-    # Metrics Eviction policy for the mapping cache.
-    #   - lru    → Least‐Recently‐Used eviction
-    #   - random → Random eviction
-    # Default: lru
-    cacheType: lru
-
-    # Per‐metric time‐to‐live. When set to a non‐zero duration, any metric
-    # series that hasn't received an update in this interval will be dropped
-    # from the exported /metrics output.
-    # Format: Go duration string (e.g. "30s", "5m", "1h")
-    # Default: "0s" (disabled, never expires)
-    ttl: "0s"
-
     # Annotations for the statsd Ingress
     annotations: {}
 
@@ -2637,6 +2607,37 @@ statsd:
 
   # Arguments for StatsD exporter command.
   args: ["--statsd.mapping-config=/etc/statsd-exporter/mappings.yml"]
+
+      # If you ever need to fully override the entire args list, you can
+    # supply your own array here; if set, all below flag-specific values
+    # (mappingConfig, cache-size, cache-type, ttl) are ignored.
+    # args:
+    #  - "--statsd.cache-size=1000"
+    #  - "--statsd.cache-type=random"
+    #  - "--ttl=10m"
+    # -------------------------------------------------------------------
+
+    # Path in the container to the mapping config file.
+
+  cache:
+    # Maximum number of metric‐mapping entries to keep in cache.
+    # When you send more distinct metric names than this, older entries
+    # will be evicted according to cacheType.
+    # Default: 1000
+    size: 1000
+
+    # Metrics Eviction policy for the mapping cache.
+    #   - lru    → Least‐Recently‐Used eviction
+    #   - random → Random eviction
+    # Default: lru
+    type: lru
+
+    # Per‐metric time‐to‐live. When set to a non‐zero duration, any metric
+    # series that hasn't received an update in this interval will be dropped
+    # from the exported /metrics output.
+    # Format: Go duration string (e.g. "30s", "5m", "1h")
+    # Default: "0s" (disabled, never expires)
+    ttl: "0s"
 
   # Annotations to add to the StatsD Deployment.
   annotations: {}

--- a/helm-tests/tests/helm_tests/airflow_core/test_api_server.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_api_server.py
@@ -131,7 +131,7 @@ class TestAPIServerDeployment:
                         {
                             "name": "TEST_ENV_3",
                             "valueFrom": {"secretKeyRef": {"name": "test-secret", "key": "test-key"}},
-                        }
+                        },
                     ],
                 },
             },

--- a/helm-tests/tests/helm_tests/airflow_core/test_api_server.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_api_server.py
@@ -124,8 +124,14 @@ class TestAPIServerDeployment:
                 "apiServer": {
                     "env": [
                         {"name": "TEST_ENV_1", "value": "test_env_1"},
-                        {"name": "TEST_ENV_2", "value": "test_env_2"},
-                        {"name": "TEST_ENV_3", "value": "test_env_3"},
+                        {
+                            "name": "TEST_ENV_2",
+                            "valueFrom": {"configMapKeyRef": {"name": "test-config", "key": "test-key"}},
+                        },
+                        {
+                            "name": "TEST_ENV_3",
+                            "valueFrom": {"secretKeyRef": {"name": "test-secret", "key": "test-key"}},
+                        }
                     ],
                 },
             },
@@ -134,8 +140,14 @@ class TestAPIServerDeployment:
 
         env_result = jmespath.search("spec.template.spec.containers[0].env", docs[0])
         assert {"name": "TEST_ENV_1", "value": "test_env_1"} in env_result
-        assert {"name": "TEST_ENV_2", "value": "test_env_2"} in env_result
-        assert {"name": "TEST_ENV_3", "value": "test_env_3"} in env_result
+        assert {
+            "name": "TEST_ENV_2",
+            "valueFrom": {"configMapKeyRef": {"name": "test-config", "key": "test-key"}},
+        } in env_result
+        assert {
+            "name": "TEST_ENV_3",
+            "valueFrom": {"secretKeyRef": {"name": "test-secret", "key": "test-key"}},
+        } in env_result
 
     def test_should_add_extra_volume_and_extra_volume_mount(self):
         docs = render_chart(

--- a/helm-tests/tests/helm_tests/airflow_core/test_api_server.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_api_server.py
@@ -124,14 +124,8 @@ class TestAPIServerDeployment:
                 "apiServer": {
                     "env": [
                         {"name": "TEST_ENV_1", "value": "test_env_1"},
-                        {
-                            "name": "TEST_ENV_2",
-                            "valueFrom": {"configMapKeyRef": {"name": "test-config", "key": "test-key"}},
-                        },
-                        {
-                            "name": "TEST_ENV_3",
-                            "valueFrom": {"secretKeyRef": {"name": "test-secret", "key": "test-key"}},
-                        },
+                        {"name": "TEST_ENV_2", "value": "test_env_2"},
+                        {"name": "TEST_ENV_3", "value": "test_env_3"},
                     ],
                 },
             },

--- a/helm-tests/tests/helm_tests/airflow_core/test_api_server.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_api_server.py
@@ -124,8 +124,8 @@ class TestAPIServerDeployment:
                 "apiServer": {
                     "env": [
                         {"name": "TEST_ENV_1", "value": "test_env_1"},
-                        {"name": "TEST_ENV_2", "value": "test_env_2"},
-                        {"name": "TEST_ENV_3", "value": "test_env_3"},
+                        {"name": "TEST_ENV_2", "valueFrom": {"configMapKeyRef": {"name": "test-config", "key": "test-key"}}},
+                        {"name": "TEST_ENV_3", "valueFrom": {"secretKeyRef": {"name": "test-secret", "key": "test-key"}}},
                     ],
                 },
             },

--- a/helm-tests/tests/helm_tests/airflow_core/test_api_server.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_api_server.py
@@ -124,8 +124,8 @@ class TestAPIServerDeployment:
                 "apiServer": {
                     "env": [
                         {"name": "TEST_ENV_1", "value": "test_env_1"},
-                        {"name": "TEST_ENV_2", "valueFrom": {"configMapKeyRef": {"name": "test-config", "key": "test-key"}}},
-                        {"name": "TEST_ENV_3", "valueFrom": {"secretKeyRef": {"name": "test-secret", "key": "test-key"}}},
+                        {"name": "TEST_ENV_2", "value": "test_env_2"},
+                        {"name": "TEST_ENV_3", "value": "test_env_3"},
                     ],
                 },
             },
@@ -134,14 +134,8 @@ class TestAPIServerDeployment:
 
         env_result = jmespath.search("spec.template.spec.containers[0].env", docs[0])
         assert {"name": "TEST_ENV_1", "value": "test_env_1"} in env_result
-        assert {
-            "name": "TEST_ENV_2",
-            "valueFrom": {"configMapKeyRef": {"name": "test-config", "key": "test-key"}},
-        } in env_result
-        assert {
-            "name": "TEST_ENV_3",
-            "valueFrom": {"secretKeyRef": {"name": "test-secret", "key": "test-key"}},
-        } in env_result
+        assert {"name": "TEST_ENV_2", "value": "test_env_2"} in env_result
+        assert {"name": "TEST_ENV_3", "value": "test_env_3"} in env_result
 
     def test_should_add_extra_volume_and_extra_volume_mount(self):
         docs = render_chart(

--- a/helm-tests/tests/helm_tests/other/test_statsd.py
+++ b/helm-tests/tests/helm_tests/other/test_statsd.py
@@ -34,12 +34,10 @@ class TestStatsd:
                         "--statsd.cache-size=1000",
                         "--statsd.cache-type=lru",
                         "--ttl=0s",
-                    ]
+                    ],
                 }
             },
-            show_only=[
-                "templates/statsd/statsd-deployment.yaml"
-            ]
+            show_only=["templates/statsd/statsd-deployment.yaml"]
         )
 
         assert jmespath.search("metadata.name", docs[0]) == "release-name-statsd"
@@ -56,7 +54,14 @@ class TestStatsd:
             "readOnly": True,
         } in jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
 
-        expected_args = ["--statsd.mapping-config=/etc/statsd-exporter/mappings.yml"]
+        expected_args = [                                                              
+                    '--statsd.cache-size=1000',                                  
+                    '--statsd.cache-type=lru',                                   
+                    '--ttl=0s',                                                  
+                    '--statsd.cache-size=',                                      
+                    '--statsd.cache-type=',                                      
+                    '--ttl=',                                                    
+                    ]
         assert expected_args == jmespath.search("spec.template.spec.containers[0].args", docs[0])
 
     def test_should_add_volume_and_volume_mount_when_exist_extra_mappings(self):

--- a/helm-tests/tests/helm_tests/other/test_statsd.py
+++ b/helm-tests/tests/helm_tests/other/test_statsd.py
@@ -26,7 +26,10 @@ class TestStatsd:
     """Tests statsd."""
 
     def test_should_create_statsd_default(self):
-        docs = render_chart(show_only=["templates/statsd/statsd-deployment.yaml"])
+        docs = render_chart(show_only=['templates/statsd/statsd-deployment.yaml',
+                                       '--statsd.cache-size=1000',                                  
+                                       '--statsd.cache-type=lru',                                   
+                                       '--ttl='])
 
         assert jmespath.search("metadata.name", docs[0]) == "release-name-statsd"
 

--- a/helm-tests/tests/helm_tests/other/test_statsd.py
+++ b/helm-tests/tests/helm_tests/other/test_statsd.py
@@ -26,10 +26,14 @@ class TestStatsd:
     """Tests statsd."""
 
     def test_should_create_statsd_default(self):
-        docs = render_chart(show_only=['templates/statsd/statsd-deployment.yaml',
-                                       '--statsd.cache-size=1000',                                  
-                                       '--statsd.cache-type=lru',                                   
-                                       '--ttl='])
+        docs = render_chart(
+            show_only=[
+                'templates/statsd/statsd-deployment.yaml',
+                '--statsd.cache-size=1000',                                  
+                '--statsd.cache-type=lru',                                   
+                '--ttl=0s'
+            ]
+        )
 
         assert jmespath.search("metadata.name", docs[0]) == "release-name-statsd"
 

--- a/helm-tests/tests/helm_tests/other/test_statsd.py
+++ b/helm-tests/tests/helm_tests/other/test_statsd.py
@@ -27,7 +27,7 @@ class TestStatsd:
 
     def test_should_create_statsd_default(self):
         docs = render_chart(
-            values={"statsd": {"enabled": True, "cacheSize": 1000, "cacheType": "lru", "ttl": "0s"}},
+            values={"statsd": {"enabled": True, "cache": {"size": 1000, "type": "lru", "ttl": "0s"}}},
             show_only=["templates/statsd/statsd-deployment.yaml"],
         )
 
@@ -328,7 +328,7 @@ class TestStatsd:
             "--statsd.mapping-config=/custom/path",
          ]
         docs = render_chart(
-            values={"statsd": {"enabled": True, "args": args, "cacheSize": 0, "cacheType": "", "ttl": ""}},
+            values={"statsd": {"enabled": True, "args": args, "cache": {"size": 0, "type": "", "ttl": ""}}},
             show_only=["templates/statsd/statsd-deployment.yaml"],
         )
 

--- a/helm-tests/tests/helm_tests/other/test_statsd.py
+++ b/helm-tests/tests/helm_tests/other/test_statsd.py
@@ -320,7 +320,7 @@ class TestStatsd:
         assert mappings_yml_obj["mappings"][0]["name"] == "airflow_pool_queued_slots"
 
     def test_statsd_args_can_be_overridden(self):
-        args = ["--some-arg=foo", "--statsd.cache-size=foo", "--statsd.cache-type=foo", "--ttl=foo"]
+        args = ["--some-arg=foo", "--statsd.cache-size=", "--statsd.cache-type=", "--ttl="]
         docs = render_chart(
             values={"statsd": {"enabled": True, "args": args}},
             show_only=["templates/statsd/statsd-deployment.yaml"],

--- a/helm-tests/tests/helm_tests/other/test_statsd.py
+++ b/helm-tests/tests/helm_tests/other/test_statsd.py
@@ -313,7 +313,7 @@ class TestStatsd:
         assert mappings_yml_obj["mappings"][0]["name"] == "airflow_pool_queued_slots"
 
     def test_statsd_args_can_be_overridden(self):
-        args = ["--some-arg=foo"]
+        args = ["--some-arg=foo",'--statsd.cache-size=foo', '--statsd.cache-type=foo', '--ttl=foo']
         docs = render_chart(
             values={"statsd": {"enabled": True, "args": args}},
             show_only=["templates/statsd/statsd-deployment.yaml"],

--- a/helm-tests/tests/helm_tests/other/test_statsd.py
+++ b/helm-tests/tests/helm_tests/other/test_statsd.py
@@ -28,10 +28,10 @@ class TestStatsd:
     def test_should_create_statsd_default(self):
         docs = render_chart(
             show_only=[
-                'templates/statsd/statsd-deployment.yaml',
-                '--statsd.cache-size=1000',                                  
-                '--statsd.cache-type=lru',                                   
-                '--ttl=0s'
+                "templates/statsd/statsd-deployment.yaml",
+                "--statsd.cache-size=1000",                                  
+                "--statsd.cache-type=lru",                                   
+                "--ttl=0s"
             ]
         )
 
@@ -320,7 +320,7 @@ class TestStatsd:
         assert mappings_yml_obj["mappings"][0]["name"] == "airflow_pool_queued_slots"
 
     def test_statsd_args_can_be_overridden(self):
-        args = ["--some-arg=foo", "--statsd.cache-size=", "--statsd.cache-type=", "--ttl="]
+        args = ["--some-arg=foo", "--statsd.cache-size=1000", "--statsd.cache-type=lru", "--ttl=0s"]
         docs = render_chart(
             values={"statsd": {"enabled": True, "args": args}},
             show_only=["templates/statsd/statsd-deployment.yaml"],

--- a/helm-tests/tests/helm_tests/other/test_statsd.py
+++ b/helm-tests/tests/helm_tests/other/test_statsd.py
@@ -46,7 +46,7 @@ class TestStatsd:
             "--statsd.mapping-config=/etc/statsd-exporter/mappings.yml",
             "--statsd.cache-size=1000",
             "--statsd.cache-type=lru",
-            "--ttl="
+            "--ttl=",
         ]
         assert expected_args == jmespath.search("spec.template.spec.containers[0].args", docs[0])
 
@@ -318,9 +318,9 @@ class TestStatsd:
         assert mappings_yml_obj["mappings"][0]["name"] == "airflow_pool_queued_slots"
 
     def test_statsd_args_can_be_overridden(self):
-        args = ["--some-arg=foo","--statsd.cache-size=foo", "--statsd.cache-type=foo", "--ttl=foo"]
+        args = ["--some-arg=foo", "--statsd.cache-size=foo", "--statsd.cache-type=foo", "--ttl=foo"]
         docs = render_chart(
-            values={"statsd": {"enabled": True, "args": args, "useDefaultArgs": False}},
+            values={"statsd": {"enabled": True, "args": args}},
             show_only=["templates/statsd/statsd-deployment.yaml"],
         )
 

--- a/helm-tests/tests/helm_tests/other/test_statsd.py
+++ b/helm-tests/tests/helm_tests/other/test_statsd.py
@@ -27,15 +27,8 @@ class TestStatsd:
 
     def test_should_create_statsd_default(self):
         docs = render_chart(
-            values={
-                "statsd": {
-                    "enabled": True,
-                    "cacheSize": 1000,
-                    "cacheType": "lru", 
-                    "ttl": "0s"
-                }
-            },
-            show_only=["templates/statsd/statsd-deployment.yaml"]
+            values={"statsd": {"enabled": True, "cacheSize": 1000, "cacheType": "lru", "ttl": "0s"}},
+            show_only=["templates/statsd/statsd-deployment.yaml"],
         )
 
         assert jmespath.search("metadata.name", docs[0]) == "release-name-statsd"
@@ -328,12 +321,14 @@ class TestStatsd:
         assert mappings_yml_obj["mappings"][0]["name"] == "airflow_pool_queued_slots"
 
     def test_statsd_args_can_be_overridden(self):
-        args = ["--statsd.cache-size=",
-                "--statsd.cache-type=",
-                "--ttl=",
-                "--statsd.mapping-config=/custom/path"]
+        args = [
+            "--statsd.cache-size=",
+            "--statsd.cache-type=",
+            "--ttl=",
+            "--statsd.mapping-config=/custom/path",
+         ]
         docs = render_chart(
-            values={"statsd": {"enabled": True, "args": args,  "cacheSize": 0, "cacheType": "", "ttl": ""}},
+            values={"statsd": {"enabled": True, "args": args, "cacheSize": 0, "cacheType": "", "ttl": ""}},
             show_only=["templates/statsd/statsd-deployment.yaml"],
         )
 
@@ -341,7 +336,7 @@ class TestStatsd:
             "--statsd.cache-size=",
             "--statsd.cache-type=",
             "--ttl=",
-            "--statsd.mapping-config=/custom/path"
+            "--statsd.mapping-config=/custom/path",
         ]
 
         assert jmespath.search("spec.template.spec.containers[0].args", docs[0]) == expected_args

--- a/helm-tests/tests/helm_tests/other/test_statsd.py
+++ b/helm-tests/tests/helm_tests/other/test_statsd.py
@@ -27,11 +27,18 @@ class TestStatsd:
 
     def test_should_create_statsd_default(self):
         docs = render_chart(
+            values={
+                "statsd": {
+                    "enabled": True,
+                    "args": [
+                        "--statsd.cache-size=1000",
+                        "--statsd.cache-type=lru",
+                        "--ttl=0s",
+                    ]
+                }
+            },
             show_only=[
-                "templates/statsd/statsd-deployment.yaml",
-                "--statsd.cache-size=1000",                                  
-                "--statsd.cache-type=lru",                                   
-                "--ttl=0s"
+                "templates/statsd/statsd-deployment.yaml"
             ]
         )
 
@@ -437,6 +444,16 @@ class TestStatsdIngress:
         )
 
         assert jmespath.search("spec.rules[0].http.paths[0].backend.service", docs[0]) == {
+            "name": "release-name-statsd",
+            "port": {"name": "statsd-scrape"},
+        }
+        assert jmespath.search("spec.rules[0].http.paths[0].path", docs[0]) == "/metrics"
+        assert jmespath.search("spec.rules[0].host", docs[0]) == "some-host"
+        assert jmespath.search("spec.tls[0]", docs[0]) == {
+            "hosts": ["some-host"],
+            "secretName": "some-secret",
+        }
+        assert jmespath.search("spec.ingressClassName", docs[0]) == "ingress-class"
             "name": "release-name-statsd",
             "port": {"name": "statsd-scrape"},
         }

--- a/helm-tests/tests/helm_tests/other/test_statsd.py
+++ b/helm-tests/tests/helm_tests/other/test_statsd.py
@@ -454,13 +454,3 @@ class TestStatsdIngress:
             "secretName": "some-secret",
         }
         assert jmespath.search("spec.ingressClassName", docs[0]) == "ingress-class"
-            "name": "release-name-statsd",
-            "port": {"name": "statsd-scrape"},
-        }
-        assert jmespath.search("spec.rules[0].http.paths[0].path", docs[0]) == "/metrics"
-        assert jmespath.search("spec.rules[0].host", docs[0]) == "some-host"
-        assert jmespath.search("spec.tls[0]", docs[0]) == {
-            "hosts": ["some-host"],
-            "secretName": "some-secret",
-        }
-        assert jmespath.search("spec.ingressClassName", docs[0]) == "ingress-class"

--- a/helm-tests/tests/helm_tests/other/test_statsd.py
+++ b/helm-tests/tests/helm_tests/other/test_statsd.py
@@ -326,7 +326,7 @@ class TestStatsd:
             "--statsd.cache-type=",
             "--ttl=",
             "--statsd.mapping-config=/custom/path",
-         ]
+        ]
         docs = render_chart(
             values={"statsd": {"enabled": True, "args": args, "cache": {"size": 0, "type": "", "ttl": ""}}},
             show_only=["templates/statsd/statsd-deployment.yaml"],

--- a/helm-tests/tests/helm_tests/other/test_statsd.py
+++ b/helm-tests/tests/helm_tests/other/test_statsd.py
@@ -30,7 +30,7 @@ class TestStatsd:
             values={
                 "statsd": {
                     "enabled": True,
-                    "cacheSize": "1000",
+                    "cacheSize": 1000,
                     "cacheType": "lru", 
                     "ttl": "0s"
                 }
@@ -53,10 +53,10 @@ class TestStatsd:
         } in jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
 
         expected_args = [
-            "--statsd.mapping-config=/etc/statsd-exporter/mappings.yml",
             "--statsd.cache-size=1000",
             "--statsd.cache-type=lru",
-            "--ttl=0s"
+            "--ttl=0s",
+            "--statsd.mapping-config=/etc/statsd-exporter/mappings.yml",
         ]
         assert expected_args == jmespath.search("spec.template.spec.containers[0].args", docs[0])
 
@@ -328,13 +328,23 @@ class TestStatsd:
         assert mappings_yml_obj["mappings"][0]["name"] == "airflow_pool_queued_slots"
 
     def test_statsd_args_can_be_overridden(self):
-        args = ["--statsd.mapping-config=/custom/path"]
+        args = ["--statsd.cache-size=",
+                "--statsd.cache-type=",
+                "--ttl=",
+                "--statsd.mapping-config=/custom/path"]
         docs = render_chart(
-            values={"statsd": {"enabled": True, "args": args}},
+            values={"statsd": {"enabled": True, "args": args,  "cacheSize": 0, "cacheType": "", "ttl": ""}},
             show_only=["templates/statsd/statsd-deployment.yaml"],
         )
 
-        assert jmespath.search("spec.template.spec.containers[0].args", docs[0]) == args
+        expected_args = [
+            "--statsd.cache-size=",
+            "--statsd.cache-type=",
+            "--ttl=",
+            "--statsd.mapping-config=/custom/path"
+        ]
+
+        assert jmespath.search("spec.template.spec.containers[0].args", docs[0]) == expected_args
 
     def test_should_add_component_specific_annotations(self):
         docs = render_chart(

--- a/helm-tests/tests/helm_tests/other/test_statsd.py
+++ b/helm-tests/tests/helm_tests/other/test_statsd.py
@@ -42,8 +42,13 @@ class TestStatsd:
             "readOnly": True,
         } in jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
 
-        default_args = ["--statsd.mapping-config=/etc/statsd-exporter/mappings.yml"]
-        assert default_args == jmespath.search("spec.template.spec.containers[0].args", docs[0])
+        expected_args = [
+            "--statsd.mapping-config=/etc/statsd-exporter/mappings.yml",
+            "--statsd.cache-size=1000",
+            "--statsd.cache-type=lru",
+            "--ttl="
+        ]
+        assert expected_args == jmespath.search("spec.template.spec.containers[0].args", docs[0])
 
     def test_should_add_volume_and_volume_mount_when_exist_extra_mappings(self):
         extra_mapping = {
@@ -313,9 +318,9 @@ class TestStatsd:
         assert mappings_yml_obj["mappings"][0]["name"] == "airflow_pool_queued_slots"
 
     def test_statsd_args_can_be_overridden(self):
-        args = ["--some-arg=foo",'--statsd.cache-size=foo', '--statsd.cache-type=foo', '--ttl=foo']
+        args = ["--some-arg=foo","--statsd.cache-size=foo", "--statsd.cache-type=foo", "--ttl=foo"]
         docs = render_chart(
-            values={"statsd": {"enabled": True, "args": args}},
+            values={"statsd": {"enabled": True, "args": args, "useDefaultArgs": False}},
             show_only=["templates/statsd/statsd-deployment.yaml"],
         )
 

--- a/helm-tests/tests/helm_tests/other/test_statsd.py
+++ b/helm-tests/tests/helm_tests/other/test_statsd.py
@@ -217,7 +217,7 @@ class TestStatsd:
             },
             show_only=["templates/statsd/statsd-deployment.yaml"],
         )
-        assert jmespath.search("spec.template.spec.containers[0].rezzsources.limits.memory", docs[0]) == "128Mi"
+        assert jmespath.search("spec.template.spec.containers[0].resources.limits.memory", docs[0]) == "128Mi"
         assert (
             jmespath.search("spec.template.spec.containers[0].resources.requests.memory", docs[0]) == "169Mi"
         )

--- a/helm-tests/tests/helm_tests/other/test_statsd.py
+++ b/helm-tests/tests/helm_tests/other/test_statsd.py
@@ -30,11 +30,9 @@ class TestStatsd:
             values={
                 "statsd": {
                     "enabled": True,
-                    "args": [
-                        "--statsd.cache-size=1000",
-                        "--statsd.cache-type=lru",
-                        "--ttl=0s",
-                    ],
+                    "cacheSize": "1000",
+                    "cacheType": "lru", 
+                    "ttl": "0s"
                 }
             },
             show_only=["templates/statsd/statsd-deployment.yaml"]
@@ -54,14 +52,12 @@ class TestStatsd:
             "readOnly": True,
         } in jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
 
-        expected_args = [                                                              
-                    '--statsd.cache-size=1000',                                  
-                    '--statsd.cache-type=lru',                                   
-                    '--ttl=0s',                                                  
-                    '--statsd.cache-size=',                                      
-                    '--statsd.cache-type=',                                      
-                    '--ttl=',                                                    
-                    ]
+        expected_args = [
+            "--statsd.mapping-config=/etc/statsd-exporter/mappings.yml",
+            "--statsd.cache-size=1000",
+            "--statsd.cache-type=lru",
+            "--ttl=0s"
+        ]
         assert expected_args == jmespath.search("spec.template.spec.containers[0].args", docs[0])
 
     def test_should_add_volume_and_volume_mount_when_exist_extra_mappings(self):
@@ -221,7 +217,7 @@ class TestStatsd:
             },
             show_only=["templates/statsd/statsd-deployment.yaml"],
         )
-        assert jmespath.search("spec.template.spec.containers[0].resources.limits.memory", docs[0]) == "128Mi"
+        assert jmespath.search("spec.template.spec.containers[0].rezzsources.limits.memory", docs[0]) == "128Mi"
         assert (
             jmespath.search("spec.template.spec.containers[0].resources.requests.memory", docs[0]) == "169Mi"
         )
@@ -332,7 +328,7 @@ class TestStatsd:
         assert mappings_yml_obj["mappings"][0]["name"] == "airflow_pool_queued_slots"
 
     def test_statsd_args_can_be_overridden(self):
-        args = ["--some-arg=foo", "--statsd.cache-size=1000", "--statsd.cache-type=lru", "--ttl=0s"]
+        args = ["--statsd.mapping-config=/custom/path"]
         docs = render_chart(
             values={"statsd": {"enabled": True, "args": args}},
             show_only=["templates/statsd/statsd-deployment.yaml"],

--- a/helm-tests/tests/helm_tests/other/test_statsd.py
+++ b/helm-tests/tests/helm_tests/other/test_statsd.py
@@ -42,12 +42,7 @@ class TestStatsd:
             "readOnly": True,
         } in jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
 
-        expected_args = [
-            "--statsd.mapping-config=/etc/statsd-exporter/mappings.yml",
-            "--statsd.cache-size=1000",
-            "--statsd.cache-type=lru",
-            "--ttl=",
-        ]
+        expected_args = ["--statsd.mapping-config=/etc/statsd-exporter/mappings.yml"]
         assert expected_args == jmespath.search("spec.template.spec.containers[0].args", docs[0])
 
     def test_should_add_volume_and_volume_mount_when_exist_extra_mappings(self):


### PR DESCRIPTION
# Overview

We are eagerly looking forward to seeing this PR merged https://github.com/apache/airflow/pull/51792 from  @shubham36deshpande. We would like to help bring this PR over the finish line, as we are currently facing this exact issue in our deployment and need to use it. As we do not have access to his repo we opened a new PR.

We noticed @jscheffl comment in the PR regarding the missing TTL parameter and found this parameter in the defaults section of the config mapping. In response, we have added a commit to the branch that includes the parameter in the config mapping of the StatsD deployment.

Thanks  @shubham36deshpande for finding this topic.