### PR TITLE
Fix N+1 query: add joinedload for asset in ``dags_needing_dagruns()``

### DIFF
--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -630,7 +630,12 @@ class DagModel(Base):
 
         # this loads all the ADRQ records.... may need to limit num dags
         adrq_by_dag: dict[str, list[AssetDagRunQueue]] = defaultdict(list)
-        for adrq in session.scalars(select(AssetDagRunQueue).options(joinedload(AssetDagRunQueue.dag_model))):
+        for adrq in session.scalars(
+            select(AssetDagRunQueue).options(
+                joinedload(AssetDagRunQueue.dag_model),
+                joinedload(AssetDagRunQueue.asset),
+            )
+        ):
             if adrq.dag_model.asset_expression is None:
                 # The dag referenced does not actually depend on an asset! This
                 # could happen if the dag DID depend on an asset at some point,


### PR DESCRIPTION
Add `joinedload(AssetDagRunQueue.asset)` to avoid N+1 when accessing `adrq.asset` in the dag_statuses dict comprehension.

**Before:** 14 queries (10 extra for N+1 on `adrq.asset`)
**After:** 4 queries

Test uses `session.expire_all()` to clear identity map before counting queries.