### PR TITLE
Change leftover import error path record to relative path

### DIFF
--- a/airflow-core/src/airflow/dag_processing/processor.py
+++ b/airflow-core/src/airflow/dag_processing/processor.py
@@ -255,7 +255,7 @@ def _serialize_dags(
             dagbag_import_error_traceback_depth = conf.getint(
                 "core", "dagbag_import_error_traceback_depth", fallback=None
             )
-            serialization_import_errors[dag.fileloc] = traceback.format_exc(
+            serialization_import_errors[dag.relative_fileloc] = traceback.format_exc(
                 limit=-dagbag_import_error_traceback_depth
             )
     return serialized_dags, serialization_import_errors

--- a/airflow-core/src/airflow/dag_processing/processor.py
+++ b/airflow-core/src/airflow/dag_processing/processor.py
@@ -255,7 +255,9 @@ def _serialize_dags(
             dagbag_import_error_traceback_depth = conf.getint(
                 "core", "dagbag_import_error_traceback_depth", fallback=None
             )
-            serialization_import_errors[dag.relative_fileloc] = traceback.format_exc(
+            # Use relative_fileloc if available, fall back to fileloc
+            error_path = dag.relative_fileloc or dag.fileloc
+            serialization_import_errors[error_path] = traceback.format_exc(
                 limit=-dagbag_import_error_traceback_depth
             )
     return serialized_dags, serialization_import_errors

--- a/airflow-core/tests/unit/dag_processing/test_dagbag.py
+++ b/airflow-core/tests/unit/dag_processing/test_dagbag.py
@@ -539,7 +539,6 @@ class TestDagBag:
         # One file should have a duplicate DAG error - file order is not guaranteed
         assert len(dagbag.import_errors) == 1
         error_path = next(iter(dagbag.import_errors.keys()))
-        breakpoint()
 
         # The error key should be a relative path (not absolute)
         # and of any of the two test files

--- a/airflow-core/tests/unit/dag_processing/test_dagbag.py
+++ b/airflow-core/tests/unit/dag_processing/test_dagbag.py
@@ -533,15 +533,21 @@ class TestDagBag:
             bundle_name="test_bundle",
         )
 
-        # First file should load successfully
+        # The DAG should load successfully from one file
         assert "my_flow" in dagbag.dags
 
-        # The import error for the second file (duplicate DAG ID) should use relative path
-        expected_relative_path = "testfile2.py"
-        assert expected_relative_path in dagbag.import_errors
-        # Absolute path should NOT be a key
+        # One file should have a duplicate DAG error - file order is not guaranteed
+        assert len(dagbag.import_errors) == 1
+        error_path = next(iter(dagbag.import_errors.keys()))
+        breakpoint()
+
+        # The error key should be a relative path (not absolute)
+        # and of any of the two test files
+        assert error_path in ("testfile1.py", "testfile2.py")
+        # Absolute paths should NOT be keys
+        assert os.fspath(path1) not in dagbag.import_errors
         assert os.fspath(path2) not in dagbag.import_errors
-        assert "AirflowDagDuplicatedIdException" in dagbag.import_errors[expected_relative_path]
+        assert "AirflowDagDuplicatedIdException" in dagbag.import_errors[error_path]
 
     def test_zip_skip_log(self, caplog, test_zip_path):
         """


### PR DESCRIPTION
These too should use relative paths for import error

