### PR TITLE
Fix ui get dags permission endpoint for user without dag run permissions

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/dags.py
@@ -78,7 +78,6 @@ dags_router = AirflowRouter(prefix="/dags", tags=["DAG"])
     response_model_exclude_none=True,
     dependencies=[
         Depends(requires_access_dag(method="GET")),
-        Depends(requires_access_dag("GET", DagAccessEntity.RUN)),
     ],
     operation_id="get_dags_ui",
 )


### PR DESCRIPTION
The problem: 
A user that lacks permissions on 'dag runs' cannot see the list dags in the UI at all.

At first I considered simply filtering the 'recent_dag_runs' in the response based on the `read on DagRun` permissions. So you wouldn't get a 403, but just an empty list of 'recent runs' for each dags returned. Most likely updating the `readable_dag_runs_filter` to take into consideration the `access entity`. This propagate down to auth manager implementation since we need to be able to pass AccessEntity to `get_authorized_dag_ids`. The base implementation is fine, the fab auth manager overriding is a problem. Also this will bring backward compatibility issues (core will try to pass an extra argument to the provider, which can be missing on older version). I dropped this idea.

Another option is to simply inline a call in the for loop to filter dag runs based on runs permissions, something like:
```python
    for row in recent_dag_runs:
        is_authorized_runs = get_auth_manager().is_authorized_dag(
            method="GET",
            access_entity=DagAccessEntity.RUN,
            details=DagDetails(id=dag_id, team_name=DagModel.get_team_name(row.dag_id, session=session)),
            user=user,
        )
        
        if not is_authorized_runs:
            continue
```

But since there are possibly a lot of runs in the `recent_dag_runs` object and this adds multiple db queries (get_team, and then is_authorized_dag), that could possibly explode the number of db request.


**The approach I opted for is much simpler.** This just considers that having "Dag" access on a dag, gives you the permissions to see a 'summary' representation of the recent Runs associated to the Dag. The endpoint returns nested `DAGRunLightResponse` which is a really light representation of a Run. (Btw it is already king the case because having access to all dags, but only to a particular dag runs will still return the full reponse with all recent runs of all dags, that's because get_authorized_dag_ids don't handle access entity).