### PR TITLE
Git provider should require common-compat >=1.12.0

### DIFF
--- a/providers/git/docs/index.rst
+++ b/providers/git/docs/index.rst
@@ -96,7 +96,7 @@ The minimum Apache Airflow version supported by this provider distribution is ``
 PIP package                                 Version required
 ==========================================  ==================
 ``apache-airflow``                          ``>=3.0.0``
-``apache-airflow-providers-common-compat``  ``>=1.10.1``
+``apache-airflow-providers-common-compat``  ``>=1.12.0``
 ``GitPython``                               ``>=3.1.44``
 ==========================================  ==================
 

--- a/providers/git/pyproject.toml
+++ b/providers/git/pyproject.toml
@@ -59,7 +59,7 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=3.0.0",
-    "apache-airflow-providers-common-compat>=1.10.1", # use next version
+    "apache-airflow-providers-common-compat>=1.12.0",
     "GitPython>=3.1.44",
 ]
 

--- a/providers/git/pyproject.toml
+++ b/providers/git/pyproject.toml
@@ -59,7 +59,7 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=3.0.0",
-    "apache-airflow-providers-common-compat>=1.10.1",
+    "apache-airflow-providers-common-compat>=1.10.1", # use next version
     "GitPython>=3.1.44",
 ]
 


### PR DESCRIPTION
Using git provider 0.2.1 with common.compat <1.12 causes issues in dag callbacks

