### PR TITLE
Respect maximum page limit in API

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/common/parameters.py
+++ b/airflow-core/src/airflow/api_fastapi/common/parameters.py
@@ -42,6 +42,7 @@ from airflow._shared.timezones import timezone
 from airflow.api_fastapi.compat import HTTP_422_UNPROCESSABLE_CONTENT
 from airflow.api_fastapi.core_api.base import OrmClause
 from airflow.api_fastapi.core_api.security import GetUserDep
+from airflow.configuration import conf
 from airflow.models import Base
 from airflow.models.asset import (
     AssetAliasModel,
@@ -102,8 +103,8 @@ class LimitFilter(BaseParam[NonNegativeInt]):
         return select.limit(self.value)
 
     @classmethod
-    def depends(cls, limit: NonNegativeInt = 50) -> LimitFilter:
-        return cls().set_value(limit)
+    def depends(cls, limit: NonNegativeInt = conf.getint("api", "page_size")) -> LimitFilter:
+        return cls().set_value(min(limit, conf.getint("api", "maximum_page_limit")))
 
 
 class OffsetFilter(BaseParam[NonNegativeInt]):


### PR DESCRIPTION
We should respect the `maximum_page_limit` as a safety to prevent request with a big limit from overloading the server.

If the client specifies a limit that is bigger than the `maximum_page_limit` specified in the conf, the limit will be retained.


Note: while working on that, I realised we have two similar options `api.page_size` and `api.fallback_page_limit`. I'll open a follow up PR to deprecate `page_size` and use `fallback_page_limit` instead since it's already the standard in providers too.