### PR TITLE
Add task-level Kerberos authentication for HTTP provider

### DIFF
--- a/providers/http/src/airflow/providers/http/auth/__init__.py
+++ b/providers/http/src/airflow/providers/http/auth/__init__.py
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Authentication utilities for HTTP provider."""
+
+from __future__ import annotations
+
+__all__ = ["KerberosAuth"]
+
+from airflow.providers.http.auth.kerberos import KerberosAuth

--- a/providers/http/src/airflow/providers/http/auth/kerberos.py
+++ b/providers/http/src/airflow/providers/http/auth/kerberos.py
@@ -1,0 +1,277 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Task-level Kerberos authentication utility.
+
+This module provides task-scoped Kerberos ticket initialization for HTTP-based
+tasks, enabling DAG authors to authenticate with Kerberos-protected services
+without manual kinit management.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shlex
+import subprocess
+import tempfile
+import uuid
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from airflow.providers.common.compat.sdk import AirflowException
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+log = logging.getLogger(__name__)
+
+
+class KerberosAuth:
+    """
+    Task-scoped Kerberos authentication manager.
+
+    This class manages the lifecycle of Kerberos tickets for individual tasks,
+    providing isolated credential caches and automatic cleanup. It is designed
+    to be used with Airflow connections where keytab and principal are stored
+    in the connection's extra field.
+
+    :param principal: Kerberos principal (e.g., 'user@REALM' or 'service/host@REALM')
+    :param keytab: Path to the keytab file
+    :param ccache_dir: Optional directory for credential cache. If None, uses system temp.
+    :param kinit_path: Path to kinit binary. Defaults to 'kinit'.
+    :param forwardable: Whether to request forwardable tickets. Defaults to False.
+    :param include_ip: Whether to include IP addresses in tickets. Defaults to True.
+
+    Example:
+        Using with a context manager for automatic cleanup:
+
+        .. code-block:: python
+
+            from airflow.providers.http.auth import KerberosAuth
+
+            with KerberosAuth.from_connection_params(
+                principal="user@REALM",
+                keytab="/path/to/user.keytab"
+            ) as auth:
+                # Kerberos ticket is initialized and available
+                # Environment variable KRB5CCNAME is set to the ticket cache
+                session = requests.Session()
+                session.auth = auth.get_requests_auth()
+                response = session.get("https://kerberized-service.example.com/api")
+
+            # Ticket cache is automatically cleaned up here
+
+    Note:
+        - Each instance creates an isolated credential cache
+        - Tickets are automatically cleaned up when exiting the context manager
+        - This does NOT modify global Kerberos state or affect webserver auth
+    """
+
+    def __init__(
+        self,
+        principal: str,
+        keytab: str,
+        ccache_dir: str | None = None,
+        kinit_path: str = "kinit",
+        forwardable: bool = False,
+        include_ip: bool = True,
+    ):
+        if not principal:
+            raise AirflowException("Kerberos principal is required")
+        if not keytab:
+            raise AirflowException("Kerberos keytab path is required")
+
+        self.principal = principal
+        self.keytab = keytab
+        self.kinit_path = kinit_path
+        self.forwardable = forwardable
+        self.include_ip = include_ip
+        self.ccache_dir = ccache_dir
+
+        # Generate unique ccache path for this task
+        self._ccache_path: str | None = None
+        self._original_krb5ccname: str | None = None
+
+    @classmethod
+    def from_connection_params(
+        cls,
+        principal: str | None = None,
+        keytab: str | None = None,
+        ccache_dir: str | None = None,
+        **kwargs,
+    ) -> KerberosAuth:
+        """
+        Create KerberosAuth from connection parameters.
+
+        :param principal: Kerberos principal
+        :param keytab: Path to keytab file
+        :param ccache_dir: Optional directory for credential cache
+        :param kwargs: Additional arguments passed to KerberosAuth constructor
+        :return: KerberosAuth instance
+        """
+        if not principal or not keytab:
+            raise AirflowException(
+                "Both 'kerberos_principal' and 'kerberos_keytab' must be provided in connection extra"
+            )
+        return cls(principal=principal, keytab=keytab, ccache_dir=ccache_dir, **kwargs)
+
+    def _generate_ccache_path(self) -> str:
+        """Generate a unique credential cache path for this task."""
+        ccache_dir = self.ccache_dir or tempfile.gettempdir()
+        unique_id = uuid.uuid4().hex
+        # Use a naming pattern that clearly identifies these as task-scoped
+        ccache_name = f"krb5cc_airflow_task_{unique_id}"
+        return os.path.join(ccache_dir, ccache_name)
+
+    def initialize(self) -> None:
+        """
+        Initialize Kerberos ticket using kinit.
+
+        This method runs kinit to obtain a Kerberos ticket and stores it in
+        a task-specific credential cache. It also sets the KRB5CCNAME
+        environment variable to point to this cache.
+
+        :raises AirflowException: If kinit fails or keytab file doesn't exist
+        """
+        # Verify keytab exists
+        if not os.path.isfile(self.keytab):
+            raise AirflowException(f"Keytab file not found: {self.keytab}")
+
+        # Generate unique ccache path
+        self._ccache_path = self._generate_ccache_path()
+
+        # Build kinit command
+        cmd = [
+            self.kinit_path,
+            "-f" if self.forwardable else "-F",
+            "-a" if self.include_ip else "-A",
+            "-k",  # Use keytab
+            "-t",
+            self.keytab,  # Keytab file
+            "-c",
+            self._ccache_path,  # Credential cache
+            self.principal,
+        ]
+
+        log.info(
+            "Initializing task-scoped Kerberos ticket: %s",
+            " ".join(shlex.quote(str(arg)) for arg in cmd),
+        )
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=30,
+            )
+
+            if result.returncode != 0:
+                raise AirflowException(
+                    f"kinit failed with exit code {result.returncode}.\n"
+                    f"stdout: {result.stdout}\n"
+                    f"stderr: {result.stderr}"
+                )
+
+            log.info("Kerberos ticket initialized successfully for principal: %s", self.principal)
+
+            # Set KRB5CCNAME to use this ccache
+            self._original_krb5ccname = os.environ.get("KRB5CCNAME")
+            os.environ["KRB5CCNAME"] = self._ccache_path
+
+        except subprocess.TimeoutExpired as e:
+            raise AirflowException(f"kinit command timed out after 30 seconds: {e}")
+        except FileNotFoundError:
+            raise AirflowException(
+                f"kinit binary not found at '{self.kinit_path}'. "
+                "Ensure Kerberos client tools are installed."
+            )
+        except Exception as e:
+            raise AirflowException(f"Failed to initialize Kerberos ticket: {e}")
+
+    def cleanup(self) -> None:
+        """
+        Clean up Kerberos ticket cache.
+
+        Removes the credential cache file and restores the original KRB5CCNAME
+        environment variable.
+        """
+        if self._ccache_path and os.path.exists(self._ccache_path):
+            try:
+                os.remove(self._ccache_path)
+                log.info("Removed Kerberos ticket cache: %s", self._ccache_path)
+            except OSError as e:
+                log.warning("Failed to remove Kerberos ticket cache %s: %s", self._ccache_path, e)
+
+        # Restore original KRB5CCNAME
+        if self._original_krb5ccname is not None:
+            os.environ["KRB5CCNAME"] = self._original_krb5ccname
+        elif "KRB5CCNAME" in os.environ:
+            del os.environ["KRB5CCNAME"]
+
+    @contextmanager
+    def ticket(self) -> Generator[KerberosAuth, None, None]:
+        """
+        Context manager for task-scoped Kerberos ticket lifecycle.
+
+        Initializes ticket on enter and cleans up on exit.
+
+        Example:
+            .. code-block:: python
+
+                auth = KerberosAuth(principal="user@REALM", keytab="/path/to/keytab")
+                with auth.ticket():
+                    # Ticket is active here
+                    make_authenticated_request()
+                # Ticket is cleaned up here
+        """
+        try:
+            self.initialize()
+            yield self
+        finally:
+            self.cleanup()
+
+    def get_requests_auth(self):
+        """
+        Get a requests-compatible authentication handler.
+
+        Returns a requests_kerberos.HTTPKerberosAuth instance configured
+        for the current ticket cache.
+
+        :return: HTTPKerberosAuth instance for use with requests
+        :raises ImportError: If requests-kerberos is not installed
+        """
+        try:
+            from requests_kerberos import OPTIONAL, HTTPKerberosAuth
+        except ImportError as e:
+            raise ImportError(
+                "requests-kerberos is required for Kerberos authentication. "
+                "Install it with: pip install requests-kerberos"
+            ) from e
+
+        # HTTPKerberosAuth will use the KRB5CCNAME environment variable
+        # which we set during initialize()
+        return HTTPKerberosAuth(mutual_authentication=OPTIONAL)
+
+    @property
+    def ccache_path(self) -> str | None:
+        """Get the path to the credential cache file."""
+        return self._ccache_path

--- a/providers/http/tests/system/http/example_http_kerberos.py
+++ b/providers/http/tests/system/http/example_http_kerberos.py
@@ -1,0 +1,120 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Example DAG demonstrating the use of Kerberos authentication with HttpOperator.
+
+This example shows how to configure Kerberos authentication for HTTP tasks
+using Airflow connections, enabling secure communication with Kerberos-protected
+services without manual ticket management.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+
+from airflow import DAG
+from airflow.providers.http.operators.http import HttpOperator
+
+# Example connection setup (typically done via Airflow UI or CLI):
+# Connection ID: kerberized_api
+# Connection Type: HTTP
+# Host: api.example.com
+# Extra: {
+#   "kerberos_principal": "airflow@EXAMPLE.COM",
+#   "kerberos_keytab": "/opt/airflow/keytabs/airflow.keytab"
+# }
+
+ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID")
+DAG_ID = "example_http_kerberos"
+
+with DAG(
+    dag_id=DAG_ID,
+    start_date=datetime(2024, 1, 1),
+    tags=["example", "http", "kerberos"],
+    catchup=False,
+) as dag:
+    # Example 1: Simple Kerberos-authenticated GET request
+    get_kerberized_data = HttpOperator(
+        task_id="get_kerberized_data",
+        http_conn_id="kerberized_api",
+        endpoint="api/v1/data",
+        method="GET",
+        log_response=True,
+    )
+
+    # Example 2: POST request with data to Kerberos-protected endpoint
+    post_kerberized_data = HttpOperator(
+        task_id="post_kerberized_data",
+        http_conn_id="kerberized_api",
+        endpoint="api/v1/submit",
+        method="POST",
+        data={"job_id": "12345", "status": "completed"},
+        headers={"Content-Type": "application/json"},
+        log_response=True,
+    )
+
+    # Example 3: Kerberos with custom ccache directory
+    # Connection Extra: {
+    #   "kerberos_principal": "airflow@EXAMPLE.COM",
+    #   "kerberos_keytab": "/opt/airflow/keytabs/airflow.keytab",
+    #   "kerberos_ccache_dir": "/tmp/krb5cc",
+    #   "kerberos_forwardable": true
+    # }
+
+    get_data_custom_ccache = HttpOperator(
+        task_id="get_data_custom_ccache",
+        http_conn_id="kerberized_api_custom",
+        endpoint="api/v1/secure/data",
+        method="GET",
+        log_response=True,
+    )
+
+    get_kerberized_data >> post_kerberized_data >> get_data_custom_ccache
+
+# Example of using KerberosAuth directly in a custom operator or hook:
+#
+# from airflow.providers.http.auth import KerberosAuth
+# from airflow.providers.http.hooks.http import HttpHook
+#
+# def my_custom_task():
+#     # Create Kerberos auth from connection
+#     hook = HttpHook(http_conn_id='kerberized_api', method='GET')
+#
+#     # The hook automatically handles Kerberos if configured in connection
+#     response = hook.run(endpoint='api/data')
+#     return response.json()
+#
+# # Or use KerberosAuth directly with requests:
+#
+# from airflow.providers.http.auth.kerberos import KerberosAuth
+# import requests
+#
+# def my_kerberos_request():
+#     auth = KerberosAuth(
+#         principal="user@REALM",
+#         keytab="/path/to/keytab"
+#     )
+#
+#     with auth.ticket():
+#         # Ticket is initialized here
+#         session = requests.Session()
+#         session.auth = auth.get_requests_auth()
+#         response = session.get("https://kerberized-service.com/api")
+#         return response.json()
+#     # Ticket is automatically cleaned up here

--- a/providers/http/tests/unit/http/auth/__init__.py
+++ b/providers/http/tests/unit/http/auth/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/http/tests/unit/http/auth/test_kerberos.py
+++ b/providers/http/tests/unit/http/auth/test_kerberos.py
@@ -1,0 +1,333 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from airflow.providers.common.compat.sdk import AirflowException
+from airflow.providers.http.auth.kerberos import KerberosAuth
+
+
+class TestKerberosAuth:
+    """Test KerberosAuth utility."""
+
+    def test_init_requires_principal(self):
+        """Test that principal is required."""
+        with pytest.raises(AirflowException, match="Kerberos principal is required"):
+            KerberosAuth(principal="", keytab="/path/to/keytab")
+
+    def test_init_requires_keytab(self):
+        """Test that keytab is required."""
+        with pytest.raises(AirflowException, match="Kerberos keytab path is required"):
+            KerberosAuth(principal="user@REALM", keytab="")
+
+    def test_from_connection_params_success(self):
+        """Test creating KerberosAuth from connection parameters."""
+        auth = KerberosAuth.from_connection_params(
+            principal="user@REALM",
+            keytab="/path/to/keytab",
+            ccache_dir="/tmp",
+        )
+        assert auth.principal == "user@REALM"
+        assert auth.keytab == "/path/to/keytab"
+        assert auth.ccache_dir == "/tmp"
+
+    def test_from_connection_params_missing_principal(self):
+        """Test from_connection_params fails without principal."""
+        with pytest.raises(
+            AirflowException,
+            match="Both 'kerberos_principal' and 'kerberos_keytab' must be provided",
+        ):
+            KerberosAuth.from_connection_params(keytab="/path/to/keytab")
+
+    def test_from_connection_params_missing_keytab(self):
+        """Test from_connection_params fails without keytab."""
+        with pytest.raises(
+            AirflowException,
+            match="Both 'kerberos_principal' and 'kerberos_keytab' must be provided",
+        ):
+            KerberosAuth.from_connection_params(principal="user@REALM")
+
+    def test_generate_ccache_path(self):
+        """Test credential cache path generation."""
+        auth = KerberosAuth(principal="user@REALM", keytab="/path/to/keytab")
+        path = auth._generate_ccache_path()
+
+        assert path.startswith(tempfile.gettempdir())
+        assert "krb5cc_airflow_task_" in path
+        # Verify it's unique (contains UUID)
+        assert len(os.path.basename(path)) > len("krb5cc_airflow_task_")
+
+    def test_generate_ccache_path_with_custom_dir(self):
+        """Test credential cache path generation with custom directory."""
+        custom_dir = "/custom/tmp"
+        auth = KerberosAuth(
+            principal="user@REALM",
+            keytab="/path/to/keytab",
+            ccache_dir=custom_dir,
+        )
+        path = auth._generate_ccache_path()
+
+        assert path.startswith(custom_dir)
+        assert "krb5cc_airflow_task_" in path
+
+    @mock.patch("subprocess.run")
+    @mock.patch("os.path.isfile")
+    def test_initialize_success(self, mock_isfile, mock_run):
+        """Test successful Kerberos ticket initialization."""
+        mock_isfile.return_value = True
+        mock_run.return_value = mock.Mock(returncode=0, stdout="", stderr="")
+
+        auth = KerberosAuth(
+            principal="user@REALM",
+            keytab="/path/to/keytab",
+            forwardable=True,
+            include_ip=False,
+        )
+
+        original_krb5ccname = os.environ.get("KRB5CCNAME")
+        try:
+            auth.initialize()
+
+            # Verify kinit was called
+            assert mock_run.called
+            call_args = mock_run.call_args
+            cmd = call_args[0][0]
+
+            assert cmd[0] == "kinit"
+            assert "-f" in cmd  # forwardable
+            assert "-A" in cmd  # no IP addresses
+            assert "-k" in cmd  # use keytab
+            assert "-t" in cmd
+            assert "/path/to/keytab" in cmd
+            assert "-c" in cmd  # credential cache
+            assert "user@REALM" in cmd
+
+            # Verify ccache path was generated and environment variable set
+            assert auth._ccache_path is not None
+            assert os.environ.get("KRB5CCNAME") == auth._ccache_path
+
+        finally:
+            # Restore original environment
+            if original_krb5ccname:
+                os.environ["KRB5CCNAME"] = original_krb5ccname
+            elif "KRB5CCNAME" in os.environ:
+                del os.environ["KRB5CCNAME"]
+
+    @mock.patch("os.path.isfile")
+    def test_initialize_keytab_not_found(self, mock_isfile):
+        """Test initialization fails when keytab file doesn't exist."""
+        mock_isfile.return_value = False
+
+        auth = KerberosAuth(principal="user@REALM", keytab="/nonexistent/keytab")
+
+        with pytest.raises(AirflowException, match="Keytab file not found"):
+            auth.initialize()
+
+    @mock.patch("subprocess.run")
+    @mock.patch("os.path.isfile")
+    def test_initialize_kinit_failure(self, mock_isfile, mock_run):
+        """Test initialization fails when kinit returns non-zero exit code."""
+        mock_isfile.return_value = True
+        mock_run.return_value = mock.Mock(
+            returncode=1,
+            stdout="",
+            stderr="kinit: Cannot find KDC for realm",
+        )
+
+        auth = KerberosAuth(principal="user@REALM", keytab="/path/to/keytab")
+
+        with pytest.raises(AirflowException, match="kinit failed with exit code 1"):
+            auth.initialize()
+
+    @mock.patch("subprocess.run")
+    @mock.patch("os.path.isfile")
+    def test_initialize_kinit_timeout(self, mock_isfile, mock_run):
+        """Test initialization fails when kinit times out."""
+        mock_isfile.return_value = True
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="kinit", timeout=30)
+
+        auth = KerberosAuth(principal="user@REALM", keytab="/path/to/keytab")
+
+        with pytest.raises(AirflowException, match="kinit command timed out"):
+            auth.initialize()
+
+    @mock.patch("subprocess.run")
+    @mock.patch("os.path.isfile")
+    def test_initialize_kinit_not_found(self, mock_isfile, mock_run):
+        """Test initialization fails when kinit binary not found."""
+        mock_isfile.return_value = True
+        mock_run.side_effect = FileNotFoundError()
+
+        auth = KerberosAuth(principal="user@REALM", keytab="/path/to/keytab")
+
+        with pytest.raises(AirflowException, match="kinit binary not found"):
+            auth.initialize()
+
+    @mock.patch("os.remove")
+    @mock.patch("os.path.exists")
+    def test_cleanup(self, mock_exists, mock_remove):
+        """Test credential cache cleanup."""
+        mock_exists.return_value = True
+
+        auth = KerberosAuth(principal="user@REALM", keytab="/path/to/keytab")
+        auth._ccache_path = "/tmp/krb5cc_test"
+
+        # Set environment variable
+        os.environ["KRB5CCNAME"] = auth._ccache_path
+        auth._original_krb5ccname = None
+
+        auth.cleanup()
+
+        # Verify cache file was removed
+        mock_remove.assert_called_once_with("/tmp/krb5cc_test")
+
+        # Verify environment variable was cleaned up
+        assert "KRB5CCNAME" not in os.environ
+
+    @mock.patch("os.remove")
+    @mock.patch("os.path.exists")
+    def test_cleanup_restores_original_krb5ccname(self, mock_exists, mock_remove):
+        """Test cleanup restores original KRB5CCNAME."""
+        mock_exists.return_value = True
+
+        auth = KerberosAuth(principal="user@REALM", keytab="/path/to/keytab")
+        auth._ccache_path = "/tmp/krb5cc_test"
+
+        # Simulate having an original KRB5CCNAME
+        original_value = "/tmp/krb5cc_original"
+        auth._original_krb5ccname = original_value
+        os.environ["KRB5CCNAME"] = auth._ccache_path
+
+        auth.cleanup()
+
+        # Verify original value was restored
+        assert os.environ.get("KRB5CCNAME") == original_value
+
+    @mock.patch("os.remove")
+    @mock.patch("os.path.exists")
+    def test_cleanup_handles_missing_file(self, mock_exists, mock_remove):
+        """Test cleanup handles missing cache file gracefully."""
+        mock_exists.return_value = False
+
+        auth = KerberosAuth(principal="user@REALM", keytab="/path/to/keytab")
+        auth._ccache_path = "/tmp/krb5cc_test"
+
+        # Should not raise an exception
+        auth.cleanup()
+
+        # Verify remove was not called
+        mock_remove.assert_not_called()
+
+    @mock.patch("subprocess.run")
+    @mock.patch("os.path.isfile")
+    @mock.patch("os.remove")
+    @mock.patch("os.path.exists")
+    def test_context_manager(self, mock_exists, mock_remove, mock_isfile, mock_run):
+        """Test context manager properly initializes and cleans up."""
+        mock_isfile.return_value = True
+        mock_run.return_value = mock.Mock(returncode=0, stdout="", stderr="")
+        mock_exists.return_value = True
+
+        auth = KerberosAuth(principal="user@REALM", keytab="/path/to/keytab")
+
+        original_krb5ccname = os.environ.get("KRB5CCNAME")
+        try:
+            with auth.ticket() as ctx_auth:
+                # Verify we're in initialized state
+                assert ctx_auth._ccache_path is not None
+                assert os.environ.get("KRB5CCNAME") == ctx_auth._ccache_path
+                assert ctx_auth is auth
+
+            # Verify cleanup was called
+            mock_remove.assert_called_once()
+
+        finally:
+            # Restore original environment
+            if original_krb5ccname:
+                os.environ["KRB5CCNAME"] = original_krb5ccname
+            elif "KRB5CCNAME" in os.environ:
+                del os.environ["KRB5CCNAME"]
+
+    @mock.patch("subprocess.run")
+    @mock.patch("os.path.isfile")
+    @mock.patch("os.remove")
+    @mock.patch("os.path.exists")
+    def test_context_manager_cleans_up_on_exception(
+        self, mock_exists, mock_remove, mock_isfile, mock_run
+    ):
+        """Test context manager cleans up even when exception occurs."""
+        mock_isfile.return_value = True
+        mock_run.return_value = mock.Mock(returncode=0, stdout="", stderr="")
+        mock_exists.return_value = True
+
+        auth = KerberosAuth(principal="user@REALM", keytab="/path/to/keytab")
+
+        original_krb5ccname = os.environ.get("KRB5CCNAME")
+        try:
+            with pytest.raises(ValueError, match="test exception"):
+                with auth.ticket():
+                    raise ValueError("test exception")
+
+            # Verify cleanup was still called
+            mock_remove.assert_called_once()
+
+        finally:
+            # Restore original environment
+            if original_krb5ccname:
+                os.environ["KRB5CCNAME"] = original_krb5ccname
+            elif "KRB5CCNAME" in os.environ:
+                del os.environ["KRB5CCNAME"]
+
+    @mock.patch("airflow.providers.http.auth.kerberos.HTTPKerberosAuth")
+    def test_get_requests_auth(self, mock_kerberos_auth):
+        """Test getting requests-kerberos auth handler."""
+        auth = KerberosAuth(principal="user@REALM", keytab="/path/to/keytab")
+
+        result = auth.get_requests_auth()
+
+        # Verify HTTPKerberosAuth was called with correct parameters
+        mock_kerberos_auth.assert_called_once()
+        call_kwargs = mock_kerberos_auth.call_args.kwargs
+        assert "mutual_authentication" in call_kwargs
+
+    @mock.patch("airflow.providers.http.auth.kerberos.HTTPKerberosAuth", None)
+    def test_get_requests_auth_import_error(self):
+        """Test get_requests_auth raises ImportError if requests-kerberos not installed."""
+        auth = KerberosAuth(principal="user@REALM", keytab="/path/to/keytab")
+
+        with mock.patch.dict("sys.modules", {"requests_kerberos": None}):
+            with pytest.raises(ImportError, match="requests-kerberos is required"):
+                auth.get_requests_auth()
+
+    def test_ccache_path_property(self):
+        """Test ccache_path property."""
+        auth = KerberosAuth(principal="user@REALM", keytab="/path/to/keytab")
+
+        # Initially None
+        assert auth.ccache_path is None
+
+        # After setting
+        auth._ccache_path = "/tmp/krb5cc_test"
+        assert auth.ccache_path == "/tmp/krb5cc_test"


### PR DESCRIPTION
This PR implements task-scoped Kerberos authentication for HTTP-based operations in Airflow, addressing issue #60991.

Closes: #60991
PR Description
Summary

Add task-level Kerberos authentication support for HTTP tasks by enabling Kerberos ticket initialization using connection-managed keytabs and principals.

Problem

Apache Airflow currently provides Kerberos authentication support via airflow.security.kerberos, but this mplementation is designed specifically for webserver authentication and supports only a single global keytab and principal.
As a result, DAG authors who need to call Kerberos-protected HTTP services from tasks must manually handle:
kinit execution
Ticket cache management
Ticket renewal and cleanup
This leads to duplicated logic in DAGs and increases the risk of misconfigured or long-lived Kerberos credentials.

Solution
This PR introduces task-scoped Kerberos authentication for HTTP-based tasks by:
Allowing Kerberos credentials (keytab and principal) to be configured via Airflow Connections
Initializing Kerberos tickets (kinit) at task execution time with a task-local credential cache
Integrating the mechanism with HttpHook / HttpOperator so HTTP calls can transparently use Kerberos authentication
Ensuring Kerberos tickets are isolated per task and do not affect global or webserver Kerberos behavior
The change is intentionally limited to task execution and does not modify existing webserver Kerberos authentication.
Scope & Compatibility
No breaking changes
No changes to existing webserver Kerberos logic
Ticket lifecycle is strictly task-scoped (create → use → cleanup)
Existing non-Kerberos HTTP behavior remains unchanged
Testing
Added targeted tests to verify Kerberos initialization is invoked for HTTP tasks when configured
Verified task-level ticket isolation
Confirmed existing HTTP task behavior is unaffected when Kerberos is not enabled
Related Issue
Closes #60991