### PR TITLE
Improve typing in Fab

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_endpoints/user_endpoint.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_endpoints/user_endpoint.py
@@ -120,7 +120,9 @@ def post_user() -> APIResponse:
         raise BadRequest(detail=detail)
 
     if not roles_to_add:  # No roles provided, use the F.A.B's default registered user role.
-        roles_to_add.append(security_manager.find_role(security_manager.auth_user_registration_role))
+        r = security_manager.find_role(security_manager.auth_user_registration_role)
+        if r:
+            roles_to_add.append(r)
 
     user = security_manager.add_user(role=roles_to_add, **data)
     if not user:

--- a/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
@@ -272,13 +272,13 @@ class FabAuthManager(BaseAuthManager[User]):
     def is_logged_in(self) -> bool:
         """Return whether the user is logged in."""
         user = self.get_user()
-        return (
+        return bool(
             self.appbuilder
             and self.appbuilder.app.config.get("AUTH_ROLE_PUBLIC", None)
             or (not user.is_anonymous and user.is_active)
         )
 
-    def create_token(self, headers: dict[str, str], body: dict[str, Any]) -> User:
+    def create_token(self, headers: dict[str, str], body: dict[str, Any]) -> User | None:
         """
         Create a new token from a payload.
 


### PR DESCRIPTION
While I was hunting for a bug in OAuth I realized that the typing of Python code in Fab is... missing in most part. This PR adds more typing hints to the providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py - and as a consequence I found a lot of warnings and mypy errors alongside which I needed to fix to make tests and mypy happy again.

Not sure whether my type fixes are introducing some kind of breaking changes... but I assume Fab is "not a kind of public API"? Therefore would merge only based on an expert review like @vincbeck or @potiuk

---

##### Was generative AI tooling used to co-author this PR?

- [ ] No (please specify the tool below)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
