### PR TITLE
Fix airflow-ctl-tests files not triggering pre-commit integration tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -948,6 +948,16 @@ repos:
           ^airflow-core/src/airflow/api_fastapi/core_api/datamodels/.*\.py$|
           ^airflow-core/src/airflow/api_fastapi/auth/managers/simple/(datamodels|routes|services|openapi)/.*\.py$
         require_serial: true
+      - id: check-airflowctl-command-coverage
+        name: Check airflowctl CLI command test coverage
+        entry: ./scripts/ci/prek/check_airflowctl_command_coverage.py
+        language: python
+        pass_filenames: false
+        files:
+          (?x)
+          ^airflow-ctl/src/airflowctl/api/operations\.py$|
+          ^airflow-ctl-tests/tests/airflowctl_tests/.*\.py$|
+          ^scripts/ci/prek/check_airflowctl_command_coverage\.py$
         ## ONLY ADD PREK HOOKS HERE THAT REQUIRE CI IMAGE
       - id: check-contextmanager-class-decorators
         name: Check for problematic context manager class decorators

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -948,16 +948,6 @@ repos:
           ^airflow-core/src/airflow/api_fastapi/core_api/datamodels/.*\.py$|
           ^airflow-core/src/airflow/api_fastapi/auth/managers/simple/(datamodels|routes|services|openapi)/.*\.py$
         require_serial: true
-      - id: check-airflowctl-command-coverage
-        name: Check airflowctl CLI command test coverage
-        entry: ./scripts/ci/prek/check_airflowctl_command_coverage.py
-        language: python
-        pass_filenames: false
-        files:
-          (?x)
-          ^airflow-ctl/src/airflowctl/api/operations\.py$|
-          ^airflow-ctl-tests/tests/airflowctl_tests/.*\.py$|
-          ^scripts/ci/prek/check_airflowctl_command_coverage\.py$
         ## ONLY ADD PREK HOOKS HERE THAT REQUIRE CI IMAGE
       - id: check-contextmanager-class-decorators
         name: Check for problematic context manager class decorators

--- a/airflow-ctl-tests/.pre-commit-config.yaml
+++ b/airflow-ctl-tests/.pre-commit-config.yaml
@@ -19,37 +19,14 @@ default_stages: [pre-commit, pre-push]
 minimum_prek_version: '0.2.0'
 default_language_version:
   python: python3
-  node: 22.19.0
-  golang: 1.24.0
 repos:
   - repo: local
     hooks:
-      - id: mypy-airflow-ctl
-        stages: ['pre-push']
-        name: Run mypy for airflow-ctl
-        language: python
-        entry: ../scripts/ci/prek/mypy.py
-        files:
-          (?x)
-          ^src/airflowctl/.*\.py$|
-          ^tests/.*\.py$
-        exclude: .*generated.py
-        require_serial: true
-      - id: mypy-airflow-ctl
-        stages: ['manual']
-        name: Run mypy for airflow-ctl (manual)
-        language: python
-        entry: ../scripts/ci/prek/mypy_folder.py airflow-ctl
-        pass_filenames: false
-        files: ^.*\.py$
-        require_serial: true
-      - id: generate-airflowctl-help-images
-        name: Generate SVG from Airflow CTL Commands
-        entry: ../scripts/ci/prek/capture_airflowctl_help.py
+      - id: check-airflowctl-command-coverage
+        name: Check airflowctl CLI command test coverage
+        entry: ../scripts/ci/prek/check_airflowctl_command_coverage.py
         language: python
         pass_filenames: false
         files:
           (?x)
-          ^src/airflowctl/ctl/cli_config.py$|
-          ^src/airflowctl/api/operations.py$|
-          ^src/airflowctl/ctl/commands/.*\.py$
+          ^tests/airflowctl_tests/.*\.py$

--- a/airflow-ctl/.pre-commit-config.yaml
+++ b/airflow-ctl/.pre-commit-config.yaml
@@ -53,3 +53,11 @@ repos:
           ^src/airflowctl/ctl/cli_config.py$|
           ^src/airflowctl/api/operations.py$|
           ^src/airflowctl/ctl/commands/.*\.py$
+      - id: check-airflowctl-command-coverage
+        name: Check airflowctl CLI command test coverage
+        entry: ../scripts/ci/prek/check_airflowctl_command_coverage.py
+        language: python
+        pass_filenames: false
+        files:
+          (?x)
+          ^src/airflowctl/api/operations\.py$


### PR DESCRIPTION
  The check-airflowctl-command-coverage pre-commit hook was not being
  triggered when files in the airflow-ctl-tests/ directory were modified.
  This meant that changes to integration tests could be committed without
  verifying that all airflowctl CLI commands had test coverage.

  Root cause:
  The hook was only defined in airflow-ctl/.pre-commit-config.yaml with
  file patterns attempting to match ../airflow-ctl-tests/ paths. However,
  prek subproject configs cannot reference files in sibling directories
  using relative paths - they can only match files within their own
  directory tree.