### PR TITLE
Chart: Fix gitsync version handling

### DIFF
--- a/chart/newsfragments/61027.significant.rst
+++ b/chart/newsfragments/61027.significant.rst
@@ -1,0 +1,4 @@
+Add ``dags.gitSync.version`` configuration
+
+The chart now uses ``dags.gitSync.version`` to determine what version of git sync is used. The ``images.gitSync.tag`` value does not influence this.
+The default ``dags.gitSync.version`` is ``4.4.2``. If you are using git sync v3, you must set ``dags.gitSync.version: 3.x.x`` explicitly.

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -256,8 +256,7 @@ If release name contains chart name it will be used as a full name.
       value: "false"
     {{- end }}
     {{- else if .Values.dags.gitSync.credentialsSecret }}
-    {{- $tag := trimPrefix "v" .Values.images.gitSync.tag }}
-    {{- if or (eq $tag "latest") (semverCompare ">=4.0.0" $tag) }}
+    {{- if semverCompare ">=4.0.0" .Values.dags.gitSync.version }}
     - name: GITSYNC_USERNAME
       valueFrom:
         secretKeyRef:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1074,7 +1074,7 @@
                             "default": "registry.k8s.io/git-sync/git-sync"
                         },
                         "tag": {
-                            "description": "The gitSync image tag.",
+                            "description": "The gitSync image tag. Update both `dags.gitSync.version` and this tag when changing git-sync versions.",
                             "type": "string",
                             "default": "v4.4.2"
                         },
@@ -10144,6 +10144,11 @@
                             "description": "Enable Git sync.",
                             "type": "boolean",
                             "default": false
+                        },
+                        "version": {
+                            "description": "Git sync version. Must be a valid semver string (e.g., '4.4.2', '3.6.9'). If you change the git-sync image version in `images.gitSync.tag`, you must also update this to the appropriate version.",
+                            "type": "string",
+                            "default": "4.4.2"
                         },
                         "repo": {
                             "description": "Git repository.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -123,10 +123,8 @@ images:
     pullPolicy: IfNotPresent
   gitSync:
     repository: registry.k8s.io/git-sync/git-sync
+    # Update both `dags.gitSync.version` and this tag when changing git-sync versions.
     tag: v4.4.2
-    # NOTE:
-    # - If the tag is "v3.x.x" or any version < 4.0.0 - use GIT_SYNC_* env variables
-    # - If the tag is "v4.x.x" or "latest" - use GITSYNC_* env variables
     pullPolicy: IfNotPresent
 
 # Select certain nodes for airflow pods.
@@ -3419,7 +3417,10 @@ dags:
     subPath: ~
   gitSync:
     enabled: false
-
+    # If you change the git-sync image version in `images.gitSync.tag`,
+    # you must also update this to the appropriate version.
+    # Must be a valid semver string (e.g., "4.4.2", "3.6.9").
+    version: 4.4.2
     # git repo clone url
     # ssh example: git@github.com:apache/airflow.git
     # https example: https://github.com/apache/airflow.git

--- a/helm-tests/tests/helm_tests/airflow_aux/test_pod_template_file.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_pod_template_file.py
@@ -255,14 +255,13 @@ class TestPodTemplateFile:
         } in jmespath.search("spec.initContainers[0].volumeMounts", docs[0])
 
     @pytest.mark.parametrize(
-        ("tag", "expected_prefix"),
+        ("version", "expected_prefix"),
         [
-            ("v3.6.7", "GIT_SYNC_"),
-            ("v4.4.2", "GITSYNC_"),
-            ("latest", "GITSYNC_"),
+            ("3.6.9", "GIT_SYNC_"),
+            ("4.4.2", "GITSYNC_"),
         ],
     )
-    def test_should_set_username_and_pass_env_variables(self, tag, expected_prefix):
+    def test_should_set_username_and_pass_env_variables(self, version, expected_prefix):
         docs = render_chart(
             values={
                 "dags": {
@@ -270,11 +269,7 @@ class TestPodTemplateFile:
                         "enabled": True,
                         "credentialsSecret": "user-pass-secret",
                         "sshKeySecret": None,
-                    }
-                },
-                "images": {
-                    "gitSync": {
-                        "tag": tag,
+                        "version": version,
                     }
                 },
             },
@@ -293,6 +288,41 @@ class TestPodTemplateFile:
             "name": f"{expected_prefix}PASSWORD",
             "valueFrom": {"secretKeyRef": {"name": "user-pass-secret", "key": f"{expected_prefix}PASSWORD"}},
         } in envs
+
+    def test_gitsync_version_ignores_image_tag(self):
+        """Test that dags.gitSync.version controls env vars, not images.gitSync.tag."""
+        docs = render_chart(
+            values={
+                "dags": {
+                    "gitSync": {
+                        "enabled": True,
+                        "credentialsSecret": "user-pass-secret",
+                        "sshKeySecret": None,
+                        "version": "3.6.9",  # Explicitly set v3
+                    }
+                },
+                "images": {
+                    "gitSync": {
+                        "tag": "notanumber",
+                    }
+                },
+            },
+            show_only=["templates/pod-template-file.yaml"],
+            chart_dir=self.temp_chart_dir,
+        )
+
+        envs = jmespath.search("spec.initContainers[0].env", docs[0])
+
+        # Should use v3 env vars based on version field, not tag
+        assert {
+            "name": "GIT_SYNC_USERNAME",
+            "valueFrom": {"secretKeyRef": {"name": "user-pass-secret", "key": "GIT_SYNC_USERNAME"}},
+        } in envs
+        # v4 vars should NOT be present
+        assert {
+            "name": "GITSYNC_USERNAME",
+            "valueFrom": {"secretKeyRef": {"name": "user-pass-secret", "key": "GITSYNC_USERNAME"}},
+        } not in envs
 
     def test_should_set_the_dags_volume_claim_correctly_when_using_an_existing_claim(self):
         docs = render_chart(


### PR DESCRIPTION
We can't rely on the tag to determine the version. Instead, add a new `dags.gitSync.version` config.

Related: #56245

---

##### Was generative AI tooling used to co-author this PR?


- [x] Yes (please specify the tool below)

Generated-by: Cursor (Claude Opus 4.5)