### PR TITLE
Adding details of way to retrieve provider version for release testing

### DIFF
--- a/dev/README_RELEASE_PROVIDERS.md
+++ b/dev/README_RELEASE_PROVIDERS.md
@@ -1007,6 +1007,8 @@ described in
 But you can use any of the installation methods you prefer (you can even install it via the binary wheels
 downloaded from the SVN).
 
+For values for <provider>==<VERSION>rc<X>, refer to the PR/email from Release Manager. For example, in order to test keycloak provider, [PR-60496](https://github.com/apache/airflow/issues/60496) lists ""Provider keycloak: 0.5.0rc1". Hence use "apache-airflow-providers-keycloak==0.5.0rc1" in below steps.
+
 ### Installing in your local virtualenv
 
 You have to make sure you have Airflow 3* installed in your PIP virtualenv


### PR DESCRIPTION
This PR is a fix to update the README_RELEASE_PROVIDERS.md documentation link below, with clear guidelines as to where to find the values to be entered for "apache-airflow-providers-<provider>==<VERSION>rc<X>". 
This is used in multiple places hence clear steps are provided to help new contributors identify how and where to find the relevant values for these fields.
https://github.com/apache/airflow/blob/main/dev/README_RELEASE_PROVIDERS.md#installing-with-breeze

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- No