### PR TITLE
Fix airflowctl crash when incorrect keyring password is entered

### DIFF
--- a/airflow-ctl/src/airflowctl/api/client.py
+++ b/airflow-ctl/src/airflowctl/api/client.py
@@ -169,12 +169,16 @@ class Credentials:
                         self.api_token = debug_credentials.get(f"api_token_{self.api_environment}")
                 else:
                     try:
-                        self.api_token = keyring.get_password("airflowctl", f"api_token_{self.api_environment}")
+                        self.api_token = keyring.get_password(
+                            "airflowctl", f"api_token_{self.api_environment}"
+                        )
                     except ValueError as e:
                         # Incorrect keyring password
                         if self.client_kind == ClientKind.AUTH:
                             # For AUTH kind, log warning and continue (user is logging in)
-                            log.warning(f"Could not access keyring for environment {self.api_environment}: {e}")
+                            log.warning(
+                                "Could not access keyring for environment %s: %s", self.api_environment, e
+                            )
                             self.api_token = None
                         else:
                             # For CLI kind, provide helpful error and raise
@@ -189,15 +193,14 @@ class Credentials:
                             raise AirflowCtlCredentialNotFoundException(error_msg) from e
                     except NoKeyringError as e:
                         # No keyring backend available
-                        log.error(f"No keyring backend available: {e}")
+                        log.error("No keyring backend available: %s", e)
                         if self.client_kind == ClientKind.CLI:
                             error_msg = (
-                                f"No keyring backend available to retrieve credentials.\n"
-                                f"Use AIRFLOW_CLI_DEBUG_MODE=true environment variable to store credentials in files instead."
+                                "No keyring backend available to retrieve credentials.\n"
+                                "Use AIRFLOW_CLI_DEBUG_MODE=true environment variable to store credentials in files instead."
                             )
                             raise AirflowCtlCredentialNotFoundException(error_msg) from e
-                        else:
-                            self.api_token = None
+                        self.api_token = None
         except FileNotFoundError:
             if self.client_kind == ClientKind.AUTH:
                 # Saving the URL set from the Auth Commands if Kind is AUTH

--- a/airflow-ctl/src/airflowctl/api/client.py
+++ b/airflow-ctl/src/airflowctl/api/client.py
@@ -28,7 +28,6 @@ from typing import TYPE_CHECKING, Any, Literal, ParamSpec, TypeVar, cast
 
 import httpx
 import keyring
-import rich
 import structlog
 from httpx import URL
 from keyring.errors import NoKeyringError
@@ -53,6 +52,7 @@ from airflowctl.api.operations import (
 from airflowctl.exceptions import (
     AirflowCtlCredentialNotFoundException,
     AirflowCtlException,
+    AirflowCtlKeyringException,
     AirflowCtlNotFoundException,
 )
 
@@ -179,25 +179,22 @@ class Credentials:
                             "Could not access keyring for environment %s: %s", self.api_environment, e
                         )
                         if self.client_kind == ClientKind.CLI:
-                            rich.print(
-                                f"[red]Incorrect keyring password for environment {self.api_environment}[/red]"
-                            )
-                            sys.exit(1)
+                            raise AirflowCtlKeyringException(
+                                f"Incorrect keyring password for environment {self.api_environment}"
+                            ) from e
                         self.api_token = None
                     except NoKeyringError as e:
                         # No keyring backend available
                         log.error("No keyring backend available: %s", e)
                         if self.client_kind == ClientKind.CLI:
-                            rich.print("[red]Keyring backend is not available[/red]")
-                            sys.exit(1)
+                            raise AirflowCtlKeyringException("Keyring backend is not available") from e
                         self.api_token = None
         except FileNotFoundError:
             if self.client_kind == ClientKind.AUTH:
                 # Saving the URL set from the Auth Commands if Kind is AUTH
                 self.save()
             elif self.client_kind == ClientKind.CLI:
-                rich.print("[red]No credentials file found[/red]")
-                sys.exit(1)
+                raise AirflowCtlCredentialNotFoundException("No credentials file found. Please login first.")
             else:
                 raise AirflowCtlException(f"Unknown client kind: {self.client_kind}")
 

--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -43,6 +43,7 @@ from airflowctl.ctl.console_formatting import AirflowConsole
 from airflowctl.exceptions import (
     AirflowCtlConnectionException,
     AirflowCtlCredentialNotFoundException,
+    AirflowCtlKeyringException,
     AirflowCtlNotFoundException,
 )
 from airflowctl.utils.module_loading import import_string
@@ -77,6 +78,7 @@ def safe_call_command(function: Callable, args: Iterable[Arg]) -> None:
     except (
         AirflowCtlCredentialNotFoundException,
         AirflowCtlConnectionException,
+        AirflowCtlKeyringException,
         AirflowCtlNotFoundException,
     ) as e:
         rich.print(f"command failed due to {e}")

--- a/airflow-ctl/src/airflowctl/exceptions.py
+++ b/airflow-ctl/src/airflowctl/exceptions.py
@@ -40,3 +40,7 @@ class AirflowCtlCredentialNotFoundException(AirflowCtlNotFoundException):
 
 class AirflowCtlConnectionException(AirflowCtlException):
     """Raise when a connection error occurs while performing an operation."""
+
+
+class AirflowCtlKeyringException(AirflowCtlException):
+    """Raise when a keyring error occurs while performing an operation."""

--- a/airflow-ctl/tests/airflow_ctl/api/test_client.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_client.py
@@ -29,7 +29,6 @@ from httpx import URL
 
 from airflowctl.api.client import Client, ClientKind, Credentials
 from airflowctl.api.operations import ServerResponseError
-from airflowctl.exceptions import AirflowCtlNotFoundException
 
 
 @pytest.fixture(autouse=True)
@@ -159,7 +158,8 @@ class TestCredentials:
         config_dir = os.environ.get("AIRFLOW_HOME", os.path.expanduser("~/airflow"))
         if os.path.exists(config_dir):
             shutil.rmtree(config_dir)
-        with pytest.raises(AirflowCtlNotFoundException):
+        with pytest.raises(SystemExit) as exc_info:
             Credentials(client_kind=cli_client).load()
 
+        assert exc_info.value.code == 1
         assert not os.path.exists(config_dir)

--- a/airflow-ctl/tests/airflow_ctl/api/test_client.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_client.py
@@ -29,6 +29,7 @@ from httpx import URL
 
 from airflowctl.api.client import Client, ClientKind, Credentials
 from airflowctl.api.operations import ServerResponseError
+from airflowctl.exceptions import AirflowCtlCredentialNotFoundException, AirflowCtlKeyringException
 
 
 @pytest.fixture(autouse=True)
@@ -158,8 +159,35 @@ class TestCredentials:
         config_dir = os.environ.get("AIRFLOW_HOME", os.path.expanduser("~/airflow"))
         if os.path.exists(config_dir):
             shutil.rmtree(config_dir)
-        with pytest.raises(SystemExit) as exc_info:
+        with pytest.raises(AirflowCtlCredentialNotFoundException, match="No credentials file found"):
             Credentials(client_kind=cli_client).load()
 
-        assert exc_info.value.code == 1
         assert not os.path.exists(config_dir)
+
+    @patch.dict(os.environ, {"AIRFLOW_CLI_ENVIRONMENT": "TEST_KEYRING_VALUE_ERROR"})
+    @patch("airflowctl.api.client.keyring")
+    def test_load_incorrect_keyring_password(self, mock_keyring):
+        cli_client = ClientKind.CLI
+        config_dir = os.environ.get("AIRFLOW_HOME", os.path.expanduser("~/airflow"))
+        os.makedirs(config_dir, exist_ok=True)
+        with open(os.path.join(config_dir, "TEST_KEYRING_VALUE_ERROR.json"), "w") as f:
+            json.dump({"api_url": "http://localhost:8080"}, f)
+        mock_keyring.get_password.side_effect = ValueError("incorrect password")
+
+        with pytest.raises(AirflowCtlKeyringException, match="Incorrect keyring password"):
+            Credentials(client_kind=cli_client).load()
+
+    @patch.dict(os.environ, {"AIRFLOW_CLI_ENVIRONMENT": "TEST_NO_KEYRING_BACKEND"})
+    @patch("airflowctl.api.client.keyring")
+    def test_load_no_keyring_backend(self, mock_keyring):
+        from keyring.errors import NoKeyringError
+
+        cli_client = ClientKind.CLI
+        config_dir = os.environ.get("AIRFLOW_HOME", os.path.expanduser("~/airflow"))
+        os.makedirs(config_dir, exist_ok=True)
+        with open(os.path.join(config_dir, "TEST_NO_KEYRING_BACKEND.json"), "w") as f:
+            json.dump({"api_url": "http://localhost:8080"}, f)
+        mock_keyring.get_password.side_effect = NoKeyringError("no backend")
+
+        with pytest.raises(AirflowCtlKeyringException, match="Keyring backend is not available"):
+            Credentials(client_kind=cli_client).load()


### PR DESCRIPTION
When using an encrypted keyring with airflowctl, entering an incorrect
keyring password caused an unhandled ValueError exception. This adds
proper exception handling in Credentials.load() to provide user-friendly
error messages with actionable steps for recovery. AUTH commands now
continue gracefully while CLI commands display helpful guidance.

```
Please enter password for encrypted keyring:
Please enter password for encrypted keyring:
Traceback (most recent call last):
  File "/usr/python/lib/python3.10/site-packages/keyrings/alt/file.py", line 186, in _unlock
    ref_pw = self.get_password('keyring-setting', 'password reference')
  File "/usr/python/lib/python3.10/site-packages/keyrings/alt/file_base.py", line 106, in get_password
    password = self.decrypt(password_encrypted, assoc).decode('utf-8')
  File "/usr/python/lib/python3.10/site-packages/keyrings/alt/file.py", line 218, in decrypt
    assert plaintext.startswith(self.pw_prefix)
AssertionError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/python/lib/python3.10/site-packages/keyrings/alt/file_base.py", line 106, in get_password
    password = self.decrypt(password_encrypted, assoc).decode('utf-8')
  File "/usr/python/lib/python3.10/site-packages/keyrings/alt/file.py", line 216, in decrypt
    cipher = self._create_cipher(self.keyring_key, data['salt'], data['IV'])
  File "/usr/python/lib/python3.10/site-packages/jaraco/classes/properties.py", line 76, in __get__
    return self.fget(obj)
  File "/usr/python/lib/python3.10/site-packages/keyrings/alt/file.py", line 99, in keyring_key
    self._unlock()
  File "/usr/python/lib/python3.10/site-packages/keyrings/alt/file.py", line 190, in _unlock
    raise ValueError("Incorrect Password")
ValueError: Incorrect Password

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/python/lib/python3.10/site-packages/keyrings/alt/file.py", line 186, in _unlock
    ref_pw = self.get_password('keyring-setting', 'password reference')
  File "/usr/python/lib/python3.10/site-packages/keyrings/alt/file_base.py", line 106, in get_password
    password = self.decrypt(password_encrypted, assoc).decode('utf-8')
  File "/usr/python/lib/python3.10/site-packages/keyrings/alt/file.py", line 218, in decrypt
    assert plaintext.startswith(self.pw_prefix)
AssertionError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/python/bin/airflowctl", line 10, in <module>
    sys.exit(main())
  File "/opt/airflow/airflow-ctl/src/airflowctl/__main__.py", line 34, in main
    safe_call_command(args.func, args=args)
  File "/opt/airflow/airflow-ctl/src/airflowctl/ctl/cli_config.py", line 76, in safe_call_command
    function(args)
  File "/opt/airflow/airflow-ctl/src/airflowctl/ctl/cli_config.py", line 59, in command
    return func(*args, **kwargs)
  File "/opt/airflow/airflow-ctl/src/airflowctl/api/client.py", line 355, in wrapper
    with get_client(kind=kind) as api_client:
  File "/usr/python/lib/python3.10/contextlib.py", line 135, in __enter__
    return next(self.gen)
  File "/opt/airflow/airflow-ctl/src/airflowctl/api/client.py", line 323, in get_client
    credentials = Credentials(client_kind=kind).load()
  File "/opt/airflow/airflow-ctl/src/airflowctl/api/client.py", line 172, in load
    self.api_token = keyring.get_password("airflowctl", f"api_token_{self.api_environment}")
  File "/usr/python/lib/python3.10/site-packages/keyring/core.py", line 63, in get_password
    return get_keyring().get_password(service_name, username)
  File "/usr/python/lib/python3.10/site-packages/keyring/backends/chainer.py", line 49, in get_password
    password = keyring.get_password(service, username)
  File "/usr/python/lib/python3.10/site-packages/keyrings/alt/file_base.py", line 109, in get_password
    password = self.decrypt(password_encrypted).decode('utf-8')
  File "/usr/python/lib/python3.10/site-packages/keyrings/alt/file.py", line 216, in decrypt
    cipher = self._create_cipher(self.keyring_key, data['salt'], data['IV'])
  File "/usr/python/lib/python3.10/site-packages/jaraco/classes/properties.py", line 76, in __get__
    return self.fget(obj)
  File "/usr/python/lib/python3.10/site-packages/keyrings/alt/file.py", line 99, in keyring_key
    self._unlock()
  File "/usr/python/lib/python3.10/site-packages/keyrings/alt/file.py", line 190, in _unlock
    raise ValueError("Incorrect Password")
ValueError: Incorrect Password
```