### PR TITLE
Default logical_date to now in airflowctl dagrun trigger to match UI behavior

### DIFF
--- a/airflow-ctl-tests/tests/airflowctl_tests/test_airflowctl_commands.py
+++ b/airflow-ctl-tests/tests/airflowctl_tests/test_airflowctl_commands.py
@@ -86,6 +86,8 @@ TEST_COMMANDS = [
     "dags list-warning",
     # Order of trigger and pause/unpause is important for test stability because state checked
     f"dags trigger --dag-id=example_bash_operator --logical-date={ONE_DATE_PARAM} --run-after={ONE_DATE_PARAM}",
+    # Test trigger without logical-date (should default to now)
+    "dags trigger --dag-id=example_bash_operator",
     "dags pause example_bash_operator",
     "dags unpause example_bash_operator",
     # DAG Run commands

--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -621,6 +621,16 @@ class CommandFactory:
 
             if datamodel:
                 if datamodel_param_name:
+                    # Special handling for TriggerDAGRunPostBody: default logical_date to now
+                    # This matches the Airflow UI behavior where the form pre-fills with current time
+                    if (
+                        datamodel.__name__ == "TriggerDAGRunPostBody"
+                        and "logical_date" in method_params[datamodel_param_name]
+                        and method_params[datamodel_param_name]["logical_date"] is None
+                    ):
+                        method_params[datamodel_param_name]["logical_date"] = datetime.datetime.now(
+                            datetime.timezone.utc
+                        )
                     method_params[datamodel_param_name] = datamodel.model_validate(
                         method_params[datamodel_param_name]
                     )


### PR DESCRIPTION
When triggering DAG runs via airflowctl without specifying --logical-date, the
parameter now defaults to the current timestamp instead of None. This aligns
with the Airflow UI behavior where the trigger form pre-populates logical_date
with the current time, providing a more intuitive user experience.