### PR TITLE
Fix language selector state not updating on change

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Nav/LanguageSelector.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/LanguageSelector.tsx
@@ -18,27 +18,33 @@
  */
 import { Field, VStack, Box, Text } from "@chakra-ui/react";
 import { Select, type SingleValue } from "chakra-react-select";
-import React from "react";
+import React, { useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 
 import { supportedLanguages } from "src/i18n/config";
 
 const LanguageSelector: React.FC = () => {
   const { i18n, t: translate } = useTranslation();
+  const [selectedLang, setSelectedLang] = useState(i18n.resolvedLanguage ?? i18n.language);
 
   const options = supportedLanguages.map((lang) => ({
     label: lang.name,
     value: lang.code,
   }));
 
-  const handleLanguageChange = (selectedOption: SingleValue<{ label: string; value: string }>) => {
-    if (selectedOption) {
-      void i18n.changeLanguage(selectedOption.value);
-    }
-  };
+  const handleLanguageChange = useCallback(
+    (selectedOption: SingleValue<{ label: string; value: string }>) => {
+      if (selectedOption) {
+        void i18n.changeLanguage(selectedOption.value).then(() => {
+          setSelectedLang(selectedOption.value);
+        });
+      }
+    },
+    [i18n],
+  );
 
-  const currentLang = options.find((option) => option.value === i18n.language);
-  const langDir = i18n.dir(i18n.language);
+  const currentLang = options.find((option) => option.value === selectedLang);
+  const langDir = i18n.dir(selectedLang);
 
   return (
     <VStack align="stretch" gap={6}>
@@ -62,7 +68,7 @@ const LanguageSelector: React.FC = () => {
       </Field.Root>
       <Box borderRadius="md" boxShadow="sm" display="flex" flexDirection="column" gap={2} p={6}>
         <Text fontSize="lg" fontWeight="bold">
-          {currentLang?.label} ({i18n.language})
+          {currentLang?.label} ({selectedLang})
         </Text>
         <Text>{`${translate("direction")}: ${langDir.toUpperCase()}`}</Text>
       </Box>


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

## Why 

Changing language didn't update the dropdown display because i18n.language isn't React state.

## How

Added useState to track the selected language locally. 
Calling setSelectedLang() after changeLanguage() completes triggers the re-render needed to update the UI.

**before**


https://github.com/user-attachments/assets/7daa003a-7161-4f12-85ed-dd82f42667ad

**after**


https://github.com/user-attachments/assets/3e06e942-825e-4c8f-823a-e6cd9c43d84f

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
