### PR TITLE
Add configurable bundle version defaults

### DIFF
--- a/airflow-core/src/airflow/api/common/trigger_dag.py
+++ b/airflow-core/src/airflow/api/common/trigger_dag.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from airflow._shared.timezones import timezone
 from airflow.exceptions import DagNotFound, DagRunAlreadyExists
@@ -50,6 +50,7 @@ def _trigger_dag(
     conf: dict | str | None = None,
     logical_date: datetime | None = None,
     replace_microseconds: bool = True,
+    bundle_version: Literal["__LATEST__"] | None = None,
     session: Session = NEW_SESSION,
 ) -> DagRun | None:
     """
@@ -118,6 +119,7 @@ def _trigger_dag(
         triggered_by=triggered_by,
         triggering_user_name=triggering_user_name,
         state=DagRunState.QUEUED,
+        use_latest_sentinel=bundle_version,
         session=session,
     )
 
@@ -135,6 +137,7 @@ def trigger_dag(
     conf: dict | str | None = None,
     logical_date: datetime | None = None,
     replace_microseconds: bool = True,
+    bundle_version: Literal["__LATEST__"] | None = None,
     session: Session = NEW_SESSION,
 ) -> DagRun | None:
     """
@@ -166,7 +169,8 @@ def trigger_dag(
         replace_microseconds=replace_microseconds,
         triggered_by=triggered_by,
         triggering_user_name=triggering_user_name,
+        bundle_version=bundle_version,
         session=session,
     )
 
-    return dr if dr else None
+    return dr

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dags.py
@@ -168,6 +168,7 @@ class DAGDetailsResponse(DAGResponse):
     owner_links: dict[str, str] | None = None
     is_favorite: bool = False
     active_runs_count: int = 0
+    run_on_latest_version: bool | None = None
 
     @field_validator("timezone", mode="before")
     @classmethod

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/task_instance_history.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/task_instance_history.py
@@ -48,6 +48,7 @@ class TaskInstanceHistoryResponse(BaseModel):
     max_tries: int
     task_display_name: str
     dag_display_name: str = Field(validation_alias=AliasPath("dag_run", "dag_model", "dag_display_name"))
+    dag_run_bundle_version: str | None = Field(validation_alias=AliasPath("dag_run", "bundle_version"))
     hostname: str | None
     unixname: str | None
     pool: str

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/task_instances.py
@@ -57,6 +57,7 @@ class TaskInstanceResponse(BaseModel):
     max_tries: int
     task_display_name: str
     dag_display_name: str = Field(validation_alias=AliasPath("dag_run", "dag_model", "dag_display_name"))
+    dag_run_bundle_version: str | None = Field(validation_alias=AliasPath("dag_run", "bundle_version"))
     hostname: str | None
     unixname: str | None
     pool: str

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/ui/config.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/ui/config.py
@@ -36,3 +36,4 @@ class ConfigResponse(BaseModel):
     external_log_name: str | None = None
     theme: Theme | None
     multi_team: bool
+    run_on_latest_version: bool

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -1382,6 +1382,9 @@ components:
         multi_team:
           type: boolean
           title: Multi Team
+        run_on_latest_version:
+          type: boolean
+          title: Run On Latest Version
       type: object
       required:
       - fallback_page_limit
@@ -1396,6 +1399,7 @@ components:
       - show_external_log_redirect
       - theme
       - multi_team
+      - run_on_latest_version
       title: ConfigResponse
       description: configuration serializer.
     ConnectionHookFieldBehavior:
@@ -2479,6 +2483,11 @@ components:
         dag_display_name:
           type: string
           title: Dag Display Name
+        dag_run_bundle_version:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Dag Run Bundle Version
         hostname:
           anyOf:
           - type: string
@@ -2583,6 +2592,7 @@ components:
       - max_tries
       - task_display_name
       - dag_display_name
+      - dag_run_bundle_version
       - hostname
       - unixname
       - pool

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -10316,6 +10316,11 @@ components:
           type: integer
           title: Active Runs Count
           default: 0
+        run_on_latest_version:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Run On Latest Version
         file_token:
           type: string
           title: File Token
@@ -12483,6 +12488,11 @@ components:
         dag_display_name:
           type: string
           title: Dag Display Name
+        dag_run_bundle_version:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Dag Run Bundle Version
         hostname:
           anyOf:
           - type: string
@@ -12562,6 +12572,7 @@ components:
       - max_tries
       - task_display_name
       - dag_display_name
+      - dag_run_bundle_version
       - hostname
       - unixname
       - pool
@@ -12638,6 +12649,11 @@ components:
         dag_display_name:
           type: string
           title: Dag Display Name
+        dag_run_bundle_version:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Dag Run Bundle Version
         hostname:
           anyOf:
           - type: string
@@ -12742,6 +12758,7 @@ components:
       - max_tries
       - task_display_name
       - dag_display_name
+      - dag_run_bundle_version
       - hostname
       - unixname
       - pool

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/config.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/config.py
@@ -62,6 +62,7 @@ def get_configs() -> ConfigResponse:
         "external_log_name": getattr(task_log_reader.log_handler, "log_name", None),
         "theme": loads(conf.get("api", "theme", fallback="{}")) or None,
         "multi_team": conf.getboolean("core", "multi_team"),
+        "run_on_latest_version": conf.getboolean("core", "run_on_latest_version", fallback=False),
     }
 
     config.update({key: value for key, value in additional_config.items()})

--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/dagrun.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/dagrun.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import Field
 
 from airflow.api_fastapi.common.types import UtcDateTime
@@ -30,6 +32,8 @@ class TriggerDAGRunPayload(StrictBaseModel):
     logical_date: UtcDateTime | None = None
     conf: dict = Field(default_factory=dict)
     reset_dag_run: bool = False
+    # Note: Literal requires string literal, see BUNDLE_VERSION_LATEST_SENTINEL in dagbundle.py
+    bundle_version: Literal["__LATEST__"] | None = None
 
 
 class DagRunStateResponse(BaseModel):

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/dag_runs.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/dag_runs.py
@@ -122,6 +122,7 @@ def trigger_dag_run(
             logical_date=payload.logical_date,
             triggered_by=DagRunTriggeredByType.OPERATOR,
             replace_microseconds=False,
+            bundle_version=payload.bundle_version,
             session=session,
         )
     except DagRunAlreadyExists:

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -515,6 +515,21 @@ core:
       type: boolean
       example: ~
       default: "False"
+    run_on_latest_version:
+      description: |
+        When True, DAG runs will use the latest available bundle version by default
+        when triggered, rerun, or cleared. This can be overridden at the DAG level
+        (via the DAG's ``run_on_latest_version`` parameter) or operator level
+        (via TriggerDagRunOperator's ``run_on_latest_version`` parameter).
+
+        .. note::
+
+          This only applies to bundles that support versioning (e.g., GitDagBundle).
+          LocalDagBundle and other non-versioned bundles are unaffected.
+      version_added: 3.2.0
+      type: boolean
+      example: ~
+      default: "False"
 database:
   description: ~
   options:

--- a/airflow-core/src/airflow/config_templates/unit_tests.cfg
+++ b/airflow-core/src/airflow/config_templates/unit_tests.cfg
@@ -57,6 +57,8 @@ unit_test_mode = True
 killed_task_cleanup_time = 5
 # We only allow our own classes to be deserialized in tests
 allowed_deserialization_classes = airflow.* tests.*
+# Default behavior for bundle versioning
+run_on_latest_version = False
 
 [database]
 

--- a/airflow-core/src/airflow/models/dagbundle.py
+++ b/airflow-core/src/airflow/models/dagbundle.py
@@ -27,6 +27,9 @@ from airflow.models.team import dag_bundle_team_association_table
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.sqlalchemy import UtcDateTime, mapped_column
 
+# Sentinel value to indicate that the latest bundle version should be used
+BUNDLE_VERSION_LATEST_SENTINEL = "__LATEST__"
+
 
 class DagBundleModel(Base, LoggingMixin):
     """

--- a/airflow-core/src/airflow/serialization/definitions/dag.py
+++ b/airflow-core/src/airflow/serialization/definitions/dag.py
@@ -24,7 +24,7 @@ import itertools
 import operator
 import re
 import weakref
-from typing import TYPE_CHECKING, TypedDict, cast, overload
+from typing import TYPE_CHECKING, Literal, TypedDict, cast, overload
 
 import attrs
 import structlog
@@ -35,6 +35,7 @@ from airflow.configuration import conf as airflow_conf
 from airflow.exceptions import AirflowException, TaskNotFound
 from airflow.models.dag import DagModel
 from airflow.models.dag_version import DagVersion
+from airflow.models.dagbundle import BUNDLE_VERSION_LATEST_SENTINEL
 from airflow.models.dagrun import DagRun
 from airflow.models.deadline import Deadline
 from airflow.models.deadline_alert import DeadlineAlert as DeadlineAlertModel
@@ -103,6 +104,7 @@ class SerializedDAG:
     default_args: dict[str, Any] = attrs.field(factory=dict)
     description: str | None = None
     disable_bundle_versioning: bool = False
+    run_on_latest_version: bool | None = None
     doc_md: str | None = None
     edge_info: dict[str, dict[str, EdgeInfoType]] = attrs.field(factory=dict)
     end_date: datetime.datetime | None = None
@@ -542,6 +544,7 @@ class SerializedDAG:
         creating_job_id: int | None = None,
         backfill_id: NonNegativeInt | None = None,
         partition_key: str | None = None,
+        use_latest_sentinel: Literal["__LATEST__"] | None = None,
         session: Session = NEW_SESSION,
     ) -> DagRun:
         """
@@ -625,6 +628,7 @@ class SerializedDAG:
             triggered_by=triggered_by,
             triggering_user_name=triggering_user_name,
             partition_key=partition_key,
+            use_latest_sentinel=use_latest_sentinel,
             session=session,
         )
 
@@ -1136,6 +1140,136 @@ class SerializedDAG:
         return empty
 
 
+def _resolve_bundle_version(
+    dag: SerializedDAG,
+    use_latest_sentinel: Literal["__LATEST__"] | None,
+    session: Session,
+) -> str | None:
+    """
+    Resolve the bundle version for a DAG run based on the precedence hierarchy.
+
+    Precedence (highest to lowest):
+    1. Operator-level override (use_latest_bundle_version=True, passed as BUNDLE_VERSION_LATEST_SENTINEL)
+    2. DAG-level configuration (dag.run_on_latest_version)
+    3. Global configuration (core.run_on_latest_version)
+    4. System default (use original version from DagModel)
+
+    :param dag: The serialized DAG
+    :param use_latest_sentinel: BUNDLE_VERSION_LATEST_SENTINEL or None
+    :param session: Database session
+    :return: The resolved bundle version, or None if versioning is disabled
+    """
+    if dag.disable_bundle_versioning:
+        return None
+
+    # Level 1: Operator-level override (use latest)
+    if use_latest_sentinel == BUNDLE_VERSION_LATEST_SENTINEL:
+        log.info(
+            "Using latest bundle version due to operator-level override",
+            dag_id=dag.dag_id,
+        )
+        return _get_latest_bundle_version(dag.dag_id, session, explicit_request=True)
+
+    # Level 2: DAG-level configuration
+    if dag.run_on_latest_version is True:
+        log.info(
+            "Using latest bundle version due to DAG configuration",
+            dag_id=dag.dag_id,
+        )
+        return _get_latest_bundle_version(dag.dag_id, session)
+    if dag.run_on_latest_version is False:
+        log.debug(
+            "Using original bundle version due to DAG configuration",
+            dag_id=dag.dag_id,
+        )
+        return _get_original_bundle_version(dag.dag_id, session)
+
+    # Level 3: Global configuration
+    if airflow_conf.getboolean("core", "run_on_latest_version", fallback=False):
+        log.debug(
+            "Using latest bundle version due to global configuration",
+            dag_id=dag.dag_id,
+        )
+        return _get_latest_bundle_version(dag.dag_id, session)
+
+    # Level 4: System default - use original version
+    log.debug(
+        "Using original bundle version (system default)",
+        dag_id=dag.dag_id,
+    )
+    return _get_original_bundle_version(dag.dag_id, session)
+
+
+def _get_latest_bundle_version(dag_id: str, session: Session, explicit_request: bool = False) -> str | None:
+    """
+    Get the latest bundle version from DagBundleModel, falling back to DagModel.
+
+    :param dag_id: The DAG ID
+    :param session: Database session
+    :param explicit_request: True if this is an operator-level override (use_latest_bundle_version=True)
+    """
+    from airflow.models.dagbundle import DagBundleModel
+
+    dag_model = session.scalar(select(DagModel).where(DagModel.dag_id == dag_id))
+    if not dag_model:
+        if explicit_request:
+            log.error(
+                "Cannot resolve latest bundle version: DagModel not found",
+                dag_id=dag_id,
+            )
+        else:
+            log.warning(
+                "DagModel not found when resolving default bundle version, using None",
+                dag_id=dag_id,
+            )
+        return None
+
+    if not dag_model.bundle_name:
+        # Non-versioned bundle (e.g., LocalDagBundle) - use original version
+        log.debug(
+            "Using original bundle version (no bundle_name)",
+            dag_id=dag_id,
+            bundle_version=dag_model.bundle_version,
+        )
+        return dag_model.bundle_version
+
+    dag_bundle = session.scalar(select(DagBundleModel).where(DagBundleModel.name == dag_model.bundle_name))
+    if not dag_bundle:
+        # Bundle not yet refreshed, fall back to original version
+        if explicit_request:
+            log.error(
+                "Cannot use latest bundle version: DagBundleModel not found. "
+                "Falling back to original version. This may indicate the bundle refresh job "
+                "has not run yet or failed. Check bundle refresh job status.",
+                dag_id=dag_id,
+                bundle_name=dag_model.bundle_name,
+                fallback_version=dag_model.bundle_version,
+            )
+        else:
+            log.warning(
+                "DagBundleModel not found, using original version",
+                dag_id=dag_id,
+                bundle_name=dag_model.bundle_name,
+                bundle_version=dag_model.bundle_version,
+            )
+        return dag_model.bundle_version
+
+    log.debug(
+        "Resolved to latest bundle version",
+        dag_id=dag_id,
+        bundle_name=dag_model.bundle_name,
+        bundle_version=dag_bundle.version,
+    )
+    return dag_bundle.version
+
+
+def _get_original_bundle_version(dag_id: str, session: Session) -> str | None:
+    """Get the original bundle version from DagModel."""
+    version = session.scalar(select(DagModel.bundle_version).where(DagModel.dag_id == dag_id))
+    log.debug("Using original bundle version", dag_id=dag_id, bundle_version=version)
+    return version
+
+
 @provide_session
 def _create_orm_dagrun(
     *,
@@ -1153,13 +1287,14 @@ def _create_orm_dagrun(
     triggered_by: DagRunTriggeredByType,
     triggering_user_name: str | None = None,
     partition_key: str | None = None,
+    use_latest_sentinel: Literal["__LATEST__"] | None = None,
     session: Session = NEW_SESSION,
 ) -> DagRun:
-    bundle_version = None
-    if not dag.disable_bundle_versioning:
-        bundle_version = session.scalar(
-            select(DagModel.bundle_version).where(DagModel.dag_id == dag.dag_id),
-        )
+    bundle_version = _resolve_bundle_version(
+        dag=dag,
+        use_latest_sentinel=use_latest_sentinel,
+        session=session,
+    )
     dag_version = DagVersion.get_latest_version(dag.dag_id, session=session)
     if not dag_version:
         raise AirflowException(f"Cannot create DagRun for DAG {dag.dag_id} because the dag is not serialized")

--- a/airflow-core/src/airflow/serialization/schema.json
+++ b/airflow-core/src/airflow/serialization/schema.json
@@ -218,7 +218,8 @@
         ]},
         "edge_info": { "$ref": "#/definitions/edge_info" },
         "dag_dependencies": { "$ref": "#/definitions/dag_dependencies" },
-        "disable_bundle_versioning": {"type":  "boolean", "default": false }
+        "disable_bundle_versioning": {"type":  "boolean", "default": false },
+        "run_on_latest_version": {"type": ["boolean", "null"]}
       },
       "required": [
         "dag_id",

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -2225,6 +2225,7 @@ class LazyDeserializedDAG(pydantic.BaseModel):
         "jinja_environment_kwargs",
         "relative_fileloc",
         "disable_bundle_versioning",
+        "run_on_latest_version",
         "fail_fast",
         "last_loaded",
     }

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -2133,6 +2133,17 @@ export const $DAGDetailsResponse = {
             title: 'Active Runs Count',
             default: 0
         },
+        run_on_latest_version: {
+            anyOf: [
+                {
+                    type: 'boolean'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Run On Latest Version'
+        },
         file_token: {
             type: 'string',
             title: 'File Token',
@@ -5215,6 +5226,17 @@ export const $TaskInstanceHistoryResponse = {
             type: 'string',
             title: 'Dag Display Name'
         },
+        dag_run_bundle_version: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Dag Run Bundle Version'
+        },
         hostname: {
             anyOf: [
                 {
@@ -5351,7 +5373,7 @@ export const $TaskInstanceHistoryResponse = {
         }
     },
     type: 'object',
-    required: ['task_id', 'dag_id', 'dag_run_id', 'map_index', 'start_date', 'end_date', 'duration', 'state', 'try_number', 'max_tries', 'task_display_name', 'dag_display_name', 'hostname', 'unixname', 'pool', 'pool_slots', 'queue', 'priority_weight', 'operator', 'operator_name', 'queued_when', 'scheduled_when', 'pid', 'executor', 'executor_config', 'dag_version'],
+    required: ['task_id', 'dag_id', 'dag_run_id', 'map_index', 'start_date', 'end_date', 'duration', 'state', 'try_number', 'max_tries', 'task_display_name', 'dag_display_name', 'dag_run_bundle_version', 'hostname', 'unixname', 'pool', 'pool_slots', 'queue', 'priority_weight', 'operator', 'operator_name', 'queued_when', 'scheduled_when', 'pid', 'executor', 'executor_config', 'dag_version'],
     title: 'TaskInstanceHistoryResponse',
     description: 'TaskInstanceHistory serializer for responses.'
 } as const;
@@ -5455,6 +5477,17 @@ export const $TaskInstanceResponse = {
         dag_display_name: {
             type: 'string',
             title: 'Dag Display Name'
+        },
+        dag_run_bundle_version: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Dag Run Bundle Version'
         },
         hostname: {
             anyOf: [
@@ -5639,7 +5672,7 @@ export const $TaskInstanceResponse = {
         }
     },
     type: 'object',
-    required: ['id', 'task_id', 'dag_id', 'dag_run_id', 'map_index', 'logical_date', 'run_after', 'start_date', 'end_date', 'duration', 'state', 'try_number', 'max_tries', 'task_display_name', 'dag_display_name', 'hostname', 'unixname', 'pool', 'pool_slots', 'queue', 'priority_weight', 'operator', 'operator_name', 'queued_when', 'scheduled_when', 'pid', 'executor', 'executor_config', 'note', 'rendered_map_index', 'trigger', 'triggerer_job', 'dag_version'],
+    required: ['id', 'task_id', 'dag_id', 'dag_run_id', 'map_index', 'logical_date', 'run_after', 'start_date', 'end_date', 'duration', 'state', 'try_number', 'max_tries', 'task_display_name', 'dag_display_name', 'dag_run_bundle_version', 'hostname', 'unixname', 'pool', 'pool_slots', 'queue', 'priority_weight', 'operator', 'operator_name', 'queued_when', 'scheduled_when', 'pid', 'executor', 'executor_config', 'note', 'rendered_map_index', 'trigger', 'triggerer_job', 'dag_version'],
     title: 'TaskInstanceResponse',
     description: 'TaskInstance serializer for responses.'
 } as const;
@@ -7197,10 +7230,14 @@ export const $ConfigResponse = {
         multi_team: {
             type: 'boolean',
             title: 'Multi Team'
+        },
+        run_on_latest_version: {
+            type: 'boolean',
+            title: 'Run On Latest Version'
         }
     },
     type: 'object',
-    required: ['fallback_page_limit', 'auto_refresh_interval', 'hide_paused_dags_by_default', 'instance_name', 'enable_swagger_ui', 'require_confirmation_dag_change', 'default_wrap', 'test_connection', 'dashboard_alert', 'show_external_log_redirect', 'theme', 'multi_team'],
+    required: ['fallback_page_limit', 'auto_refresh_interval', 'hide_paused_dags_by_default', 'instance_name', 'enable_swagger_ui', 'require_confirmation_dag_change', 'default_wrap', 'test_connection', 'dashboard_alert', 'show_external_log_redirect', 'theme', 'multi_team', 'run_on_latest_version'],
     title: 'ConfigResponse',
     description: 'configuration serializer.'
 } as const;

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -575,6 +575,7 @@ export type DAGDetailsResponse = {
 } | null;
     is_favorite?: boolean;
     active_runs_count?: number;
+    run_on_latest_version?: boolean | null;
     /**
      * Return file token.
      */
@@ -1376,6 +1377,7 @@ export type TaskInstanceHistoryResponse = {
     max_tries: number;
     task_display_name: string;
     dag_display_name: string;
+    dag_run_bundle_version: string | null;
     hostname: string | null;
     unixname: string | null;
     pool: string;
@@ -1411,6 +1413,7 @@ export type TaskInstanceResponse = {
     max_tries: number;
     task_display_name: string;
     dag_display_name: string;
+    dag_run_bundle_version: string | null;
     hostname: string | null;
     unixname: string | null;
     pool: string;
@@ -1777,6 +1780,7 @@ export type ConfigResponse = {
     external_log_name?: string | null;
     theme: Theme | null;
     multi_team: boolean;
+    run_on_latest_version: boolean;
 };
 
 /**

--- a/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunDialog.tsx
@@ -17,18 +17,18 @@
  * under the License.
  */
 import { Button, Flex, Heading, VStack } from "@chakra-ui/react";
-import { useEffect, useMemo, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { CgRedo } from "react-icons/cg";
 
 import { useDagServiceGetDagDetails } from "openapi/queries";
 import type { DAGRunResponse, TaskInstanceResponse } from "openapi/requests/types.gen";
 import { ActionAccordion } from "src/components/ActionAccordion";
+import { useRunOnLatestVersion } from "src/components/Clear/useRunOnLatestVersion";
 import { Checkbox, Dialog } from "src/components/ui";
 import SegmentedControl from "src/components/ui/SegmentedControl";
 import { useClearDagRunDryRun } from "src/queries/useClearDagRunDryRun";
 import { useClearDagRun } from "src/queries/useClearRun";
-import { useConfig } from "src/queries/useConfig";
 import { usePatchDagRun } from "src/queries/usePatchDagRun";
 import { isStatePending, useAutoRefresh } from "src/utils";
 
@@ -52,26 +52,16 @@ const ClearRunDialog = ({ dagRun, onClose, open }: Props) => {
     dagId,
   });
 
-  // Get global config for run_on_latest_version
-  const globalDefaultRunOnLatestVersion = Boolean(useConfig("run_on_latest_version"));
-
-  // Determine checkbox default based on precedence: DAG-level > Global config > System default (false)
-  const defaultRunOnLatestVersion = useMemo(() => {
-    // Level 1: DAG-level configuration
-    if (dagDetails?.run_on_latest_version !== undefined && dagDetails.run_on_latest_version !== null) {
-      return dagDetails.run_on_latest_version;
-    }
-
-    // Level 2: Global configuration (Boolean() always returns true or false)
-    return globalDefaultRunOnLatestVersion;
-  }, [dagDetails?.run_on_latest_version, globalDefaultRunOnLatestVersion]);
-
-  const [runOnLatestVersion, setRunOnLatestVersion] = useState(defaultRunOnLatestVersion);
-
-  // Update checkbox when default changes (e.g., config loads after mount)
-  useEffect(() => {
-    setRunOnLatestVersion(defaultRunOnLatestVersion);
-  }, [defaultRunOnLatestVersion]);
+  // Use custom hook for run_on_latest_version checkbox state and visibility
+  const {
+    setValue: setRunOnLatestVersion,
+    shouldShowCheckbox: shouldShowBundleVersionOption,
+    value: runOnLatestVersion,
+  } = useRunOnLatestVersion({
+    currentBundleVersion: dagDetails?.bundle_version,
+    dagLevelConfig: dagDetails?.run_on_latest_version,
+    runBundleVersion: dagRun.bundle_version,
+  });
 
   const refetchInterval = useAutoRefresh({ dagId });
 
@@ -98,13 +88,6 @@ const ClearRunDialog = ({ dagRun, onClose, open }: Props) => {
     dagRunId,
     onSuccess: onClose,
   });
-
-  // Check if bundle versions are different
-  const currentDagBundleVersion = dagDetails?.bundle_version;
-  const dagRunBundleVersion = dagRun.bundle_version;
-  const bundleVersionsDiffer = currentDagBundleVersion !== dagRunBundleVersion;
-  const shouldShowBundleVersionOption =
-    bundleVersionsDiffer && dagRunBundleVersion !== null && dagRunBundleVersion !== "";
 
   return (
     <Dialog.Root lazyMount onOpenChange={onClose} open={open} size="xl">
@@ -154,7 +137,7 @@ const ClearRunDialog = ({ dagRun, onClose, open }: Props) => {
             {shouldShowBundleVersionOption ? (
               <Checkbox
                 checked={runOnLatestVersion}
-                onCheckedChange={(event) => setRunOnLatestVersion(Boolean(event.checked))}
+                onCheckedChange={(event) => setRunOnLatestVersion(Boolean(event.checked) || false)}
               >
                 {translate("dags:runAndTaskActions.options.runOnLatestVersion")}
               </Checkbox>

--- a/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearGroupTaskInstanceDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearGroupTaskInstanceDialog.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { Button, Flex, Heading, VStack } from "@chakra-ui/react";
-import { useEffect, useMemo, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { CgRedo } from "react-icons/cg";
 import { useParams } from "react-router-dom";
@@ -29,11 +29,11 @@ import {
 } from "openapi/queries";
 import type { LightGridTaskInstanceSummary, TaskInstanceResponse } from "openapi/requests/types.gen";
 import { ActionAccordion } from "src/components/ActionAccordion";
+import { useRunOnLatestVersion } from "src/components/Clear/useRunOnLatestVersion";
 import { Checkbox, Dialog } from "src/components/ui";
 import SegmentedControl from "src/components/ui/SegmentedControl";
 import { useClearTaskInstances } from "src/queries/useClearTaskInstances";
 import { useClearTaskInstancesDryRun } from "src/queries/useClearTaskInstancesDryRun";
-import { useConfig } from "src/queries/useConfig";
 import { isStatePending, useAutoRefresh } from "src/utils";
 
 type Props = {
@@ -73,26 +73,16 @@ export const ClearGroupTaskInstanceDialog = ({ onClose, open, taskInstance }: Pr
     dagRunId: runId,
   });
 
-  // Get global config for run_on_latest_version
-  const globalDefaultRunOnLatestVersion = Boolean(useConfig("run_on_latest_version"));
-
-  // Determine checkbox default based on precedence: DAG-level > Global config > System default (false)
-  const defaultRunOnLatestVersion = useMemo(() => {
-    // Level 1: DAG-level configuration
-    if (dagDetails?.run_on_latest_version !== undefined && dagDetails.run_on_latest_version !== null) {
-      return dagDetails.run_on_latest_version;
-    }
-
-    // Level 2: Global configuration (Boolean() always returns true or false)
-    return globalDefaultRunOnLatestVersion;
-  }, [dagDetails?.run_on_latest_version, globalDefaultRunOnLatestVersion]);
-
-  const [runOnLatestVersion, setRunOnLatestVersion] = useState(defaultRunOnLatestVersion);
-
-  // Update checkbox when default changes (e.g., config loads after mount)
-  useEffect(() => {
-    setRunOnLatestVersion(defaultRunOnLatestVersion);
-  }, [defaultRunOnLatestVersion]);
+  // Use custom hook for run_on_latest_version checkbox state and visibility
+  const {
+    setValue: setRunOnLatestVersion,
+    shouldShowCheckbox: shouldShowBundleVersionOption,
+    value: runOnLatestVersion,
+  } = useRunOnLatestVersion({
+    currentBundleVersion: dagDetails?.bundle_version,
+    dagLevelConfig: dagDetails?.run_on_latest_version,
+    runBundleVersion: dagRun?.bundle_version,
+  });
 
   const { data: groupTaskInstances } = useTaskInstanceServiceGetTaskInstances(
     {
@@ -136,13 +126,6 @@ export const ClearGroupTaskInstanceDialog = ({ onClose, open, taskInstance }: Pr
     task_instances: [],
     total_entries: 0,
   };
-
-  // Check if bundle versions are different
-  const currentDagBundleVersion = dagDetails?.bundle_version;
-  const dagRunBundleVersion = dagRun?.bundle_version;
-  const bundleVersionsDiffer = currentDagBundleVersion !== dagRunBundleVersion;
-  const shouldShowBundleVersionOption =
-    bundleVersionsDiffer && dagRunBundleVersion !== null && dagRunBundleVersion !== "";
 
   return (
     <Dialog.Root lazyMount onOpenChange={onClose} open={open} size="xl">
@@ -203,7 +186,7 @@ export const ClearGroupTaskInstanceDialog = ({ onClose, open, taskInstance }: Pr
             {shouldShowBundleVersionOption ? (
               <Checkbox
                 checked={runOnLatestVersion}
-                onCheckedChange={(event) => setRunOnLatestVersion(Boolean(event.checked))}
+                onCheckedChange={(event) => setRunOnLatestVersion(Boolean(event.checked) || false)}
               >
                 {translate("dags:runAndTaskActions.options.runOnLatestVersion")}
               </Checkbox>

--- a/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceDialog.tsx
@@ -17,19 +17,19 @@
  * under the License.
  */
 import { Button, Flex, Heading, useDisclosure, VStack } from "@chakra-ui/react";
-import { useEffect, useMemo, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { CgRedo } from "react-icons/cg";
 
 import { useDagServiceGetDagDetails } from "openapi/queries";
 import type { TaskInstanceResponse } from "openapi/requests/types.gen";
 import { ActionAccordion } from "src/components/ActionAccordion";
+import { useRunOnLatestVersion } from "src/components/Clear/useRunOnLatestVersion";
 import Time from "src/components/Time";
 import { Checkbox, Dialog } from "src/components/ui";
 import SegmentedControl from "src/components/ui/SegmentedControl";
 import { useClearTaskInstances } from "src/queries/useClearTaskInstances";
 import { useClearTaskInstancesDryRun } from "src/queries/useClearTaskInstancesDryRun";
-import { useConfig } from "src/queries/useConfig";
 import { usePatchTaskInstance } from "src/queries/usePatchTaskInstance";
 import { isStatePending, useAutoRefresh } from "src/utils";
 
@@ -73,31 +73,21 @@ const ClearTaskInstanceDialog = ({ onClose: onCloseDialog, open: openDialog, tas
     taskId,
   });
 
-  // Get current DAG's bundle version to compare with task instance's DAG version bundle version
+  // Get current DAG's bundle version to compare with task instance's DAG run bundle version
   const { data: dagDetails } = useDagServiceGetDagDetails({
     dagId,
   });
 
-  // Get global config for run_on_latest_version
-  const globalDefaultRunOnLatestVersion = Boolean(useConfig("run_on_latest_version"));
-
-  // Determine checkbox default based on precedence: DAG-level > Global config > System default (false)
-  const defaultRunOnLatestVersion = useMemo(() => {
-    // Level 1: DAG-level configuration
-    if (dagDetails?.run_on_latest_version !== undefined && dagDetails.run_on_latest_version !== null) {
-      return dagDetails.run_on_latest_version;
-    }
-
-    // Level 2: Global configuration (Boolean() always returns true or false)
-    return globalDefaultRunOnLatestVersion;
-  }, [dagDetails?.run_on_latest_version, globalDefaultRunOnLatestVersion]);
-
-  const [runOnLatestVersion, setRunOnLatestVersion] = useState(defaultRunOnLatestVersion);
-
-  // Update checkbox when default changes (e.g., config loads after mount)
-  useEffect(() => {
-    setRunOnLatestVersion(defaultRunOnLatestVersion);
-  }, [defaultRunOnLatestVersion]);
+  // Use custom hook for run_on_latest_version checkbox state and visibility
+  const {
+    setValue: setRunOnLatestVersion,
+    shouldShowCheckbox: shouldShowBundleVersionOption,
+    value: runOnLatestVersion,
+  } = useRunOnLatestVersion({
+    currentBundleVersion: dagDetails?.bundle_version,
+    dagLevelConfig: dagDetails?.run_on_latest_version,
+    runBundleVersion: taskInstance.dag_run_bundle_version,
+  });
 
   const refetchInterval = useAutoRefresh({ dagId });
 
@@ -127,13 +117,6 @@ const ClearTaskInstanceDialog = ({ onClose: onCloseDialog, open: openDialog, tas
     task_instances: [],
     total_entries: 0,
   };
-
-  // Check if bundle versions are different
-  const currentDagBundleVersion = dagDetails?.bundle_version;
-  const dagRunBundleVersion = taskInstance.dag_run_bundle_version;
-  const bundleVersionsDiffer = currentDagBundleVersion !== dagRunBundleVersion;
-  const shouldShowBundleVersionOption =
-    bundleVersionsDiffer && dagRunBundleVersion !== null && dagRunBundleVersion !== "";
 
   return (
     <>
@@ -197,7 +180,7 @@ const ClearTaskInstanceDialog = ({ onClose: onCloseDialog, open: openDialog, tas
               {shouldShowBundleVersionOption ? (
                 <Checkbox
                   checked={runOnLatestVersion}
-                  onCheckedChange={(event) => setRunOnLatestVersion(Boolean(event.checked))}
+                  onCheckedChange={(event) => setRunOnLatestVersion(Boolean(event.checked) || false)}
                 >
                   {translate("dags:runAndTaskActions.options.runOnLatestVersion")}
                 </Checkbox>

--- a/airflow-core/src/airflow/ui/src/components/Clear/useRunOnLatestVersion.ts
+++ b/airflow-core/src/airflow/ui/src/components/Clear/useRunOnLatestVersion.ts
@@ -1,0 +1,97 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useState } from "react";
+
+import { useConfig } from "src/queries/useConfig";
+
+type UseRunOnLatestVersionProps = {
+  /**
+   * Current DAG bundle version
+   */
+  currentBundleVersion?: string | null;
+
+  /**
+   * DAG-level configuration from the DAG details.
+   * If defined (true or false), takes precedence over global config.
+   */
+  dagLevelConfig?: boolean | null;
+
+  /**
+   * DAG run bundle version
+   */
+  runBundleVersion?: string | null;
+};
+
+type UseRunOnLatestVersionResult = {
+  /**
+   * Setter for the checkbox value
+   */
+  setValue: (value: boolean) => void;
+
+  /**
+   * Whether the checkbox should be shown
+   */
+  shouldShowCheckbox: boolean;
+
+  /**
+   * Current value of the checkbox (controlled)
+   */
+  value: boolean;
+};
+
+/**
+ * Custom hook for managing "Run on Latest Version" checkbox state.
+ *
+ * Implements the three-level precedence hierarchy:
+ * 1. DAG-level configuration (highest)
+ * 2. Global configuration
+ * 3. System default (false)
+ *
+ * Uses nullable override pattern to avoid unnecessary re-renders.
+ */
+export const useRunOnLatestVersion = ({
+  currentBundleVersion,
+  dagLevelConfig,
+  runBundleVersion,
+}: UseRunOnLatestVersionProps): UseRunOnLatestVersionResult => {
+  // Get global config value as string and convert correctly
+  const globalConfigValue = useConfig("run_on_latest_version");
+  const globalDefault = globalConfigValue === "true";
+
+  // Calculate default based on precedence: DAG-level > Global > System default (false)
+  // Use nullish coalescing for clean, efficient code
+  const defaultValue = dagLevelConfig ?? globalDefault;
+
+  // Use nullable override pattern: null until user interacts, then stores user's choice
+  // This avoids state synchronization anti-pattern (useState + useEffect)
+  const [userOverride, setUserOverride] = useState<boolean | null>(null);
+
+  // Actual value: user's override if they've interacted, otherwise the default
+  const value = userOverride ?? defaultValue;
+
+  // Check if versions differ to determine if checkbox should be shown
+  const bundleVersionsDiffer = currentBundleVersion !== runBundleVersion;
+  const shouldShowCheckbox = bundleVersionsDiffer && runBundleVersion !== null && runBundleVersion !== "";
+
+  return {
+    setValue: setUserOverride,
+    shouldShowCheckbox,
+    value,
+  };
+};

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_hitl.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_hitl.py
@@ -228,6 +228,7 @@ def expected_sample_hitl_detail_dict(sample_ti: TaskInstance) -> dict[str, Any]:
         "task_instance": {
             "dag_display_name": DAG_ID,
             "dag_id": DAG_ID,
+            "dag_run_bundle_version": None,
             "dag_run_id": "test",
             "dag_version": {
                 "bundle_name": "dag_maker",

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -200,6 +200,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
                 "version_number": 1,
             },
             "dag_display_name": "example_python_operator",
+            "dag_run_bundle_version": None,
             "duration": 10000.0,
             "end_date": "2020-01-03T00:00:00Z",
             "logical_date": "2020-01-01T00:00:00Z",
@@ -279,6 +280,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "dag_id": "dag_with_multiple_versions",
             "dag_run_id": run_id,
             "dag_display_name": "dag_with_multiple_versions",
+            "dag_run_bundle_version": f"some_commit_hash{expected_version_number}",
             "map_index": -1,
             "logical_date": mock.ANY,
             "start_date": None,
@@ -358,6 +360,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
                 "version_number": 1,
             },
             "dag_display_name": "example_python_operator",
+            "dag_run_bundle_version": None,
             "duration": 10000.0,
             "end_date": "2020-01-03T00:00:00Z",
             "logical_date": "2020-01-01T00:00:00Z",
@@ -422,6 +425,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
                 "version_number": 1,
             },
             "dag_display_name": "example_python_operator",
+            "dag_run_bundle_version": None,
             "duration": 10000.0,
             "end_date": "2020-01-03T00:00:00Z",
             "logical_date": "2020-01-01T00:00:00Z",
@@ -478,6 +482,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
                 "version_number": 1,
             },
             "dag_display_name": "example_python_operator",
+            "dag_run_bundle_version": None,
             "duration": 10000.0,
             "end_date": "2020-01-03T00:00:00Z",
             "logical_date": "2020-01-01T00:00:00Z",
@@ -598,6 +603,7 @@ class TestGetMappedTaskInstance(TestTaskInstanceEndpoint):
                     "version_number": 1,
                 },
                 "dag_display_name": "example_python_operator",
+                "dag_run_bundle_version": None,
                 "duration": 10000.0,
                 "end_date": "2020-01-03T00:00:00Z",
                 "logical_date": "2020-01-01T00:00:00Z",
@@ -2068,6 +2074,7 @@ class TestGetTaskInstanceTry(TestTaskInstanceEndpoint):
         assert response_data == {
             "dag_id": "example_python_operator",
             "dag_display_name": "example_python_operator",
+            "dag_run_bundle_version": None,
             "duration": 10000.0,
             "end_date": "2020-01-03T00:00:00Z",
             "executor": None,
@@ -2114,6 +2121,7 @@ class TestGetTaskInstanceTry(TestTaskInstanceEndpoint):
         assert response_data == {
             "dag_id": "example_python_operator",
             "dag_display_name": "example_python_operator",
+            "dag_run_bundle_version": None,
             "duration": 10000.0,
             "end_date": "2020-01-03T00:00:00Z",
             "executor": None,
@@ -2191,6 +2199,7 @@ class TestGetTaskInstanceTry(TestTaskInstanceEndpoint):
             assert response_data == {
                 "dag_id": "example_python_operator",
                 "dag_display_name": "example_python_operator",
+                "dag_run_bundle_version": None,
                 "duration": 10000.0,
                 "end_date": "2020-01-03T00:00:00Z",
                 "executor": None,
@@ -2263,6 +2272,7 @@ class TestGetTaskInstanceTry(TestTaskInstanceEndpoint):
         assert response_data == {
             "dag_id": "example_python_operator",
             "dag_display_name": "example_python_operator",
+            "dag_run_bundle_version": None,
             "duration": 10000.0,
             "end_date": "2020-01-03T00:00:00Z",
             "executor": None,
@@ -2310,6 +2320,7 @@ class TestGetTaskInstanceTry(TestTaskInstanceEndpoint):
         assert response_data == {
             "dag_id": "example_python_operator",
             "dag_display_name": "example_python_operator",
+            "dag_run_bundle_version": None,
             "duration": 10000.0,
             "end_date": "2020-01-03T00:00:00Z",
             "executor": None,
@@ -2390,6 +2401,7 @@ class TestGetTaskInstanceTry(TestTaskInstanceEndpoint):
             "task_id": "task1",
             "dag_id": "dag_with_multiple_versions",
             "dag_display_name": "dag_with_multiple_versions",
+            "dag_run_bundle_version": f"some_commit_hash{expected_version_number}",
             "dag_run_id": run_id,
             "map_index": -1,
             "start_date": None,
@@ -2444,6 +2456,7 @@ class TestGetTaskInstanceTry(TestTaskInstanceEndpoint):
             "task_id": "task1",
             "dag_id": "dag_with_multiple_versions",
             "dag_display_name": "dag_with_multiple_versions",
+            "dag_run_bundle_version": f"some_commit_hash{expected_version_number}",
             "dag_run_id": run_id,
             "map_index": -1,
             "start_date": None,
@@ -3139,6 +3152,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
             {
                 "dag_id": "example_python_operator",
                 "dag_display_name": "example_python_operator",
+                "dag_run_bundle_version": None,
                 "dag_version": {
                     "bundle_name": "dags-folder",
                     "bundle_url": None,
@@ -3526,6 +3540,7 @@ class TestGetTaskInstanceTries(TestTaskInstanceEndpoint):
                 {
                     "dag_id": "example_python_operator",
                     "dag_display_name": "example_python_operator",
+                    "dag_run_bundle_version": None,
                     "duration": 10000.0,
                     "end_date": "2020-01-03T00:00:00Z",
                     "executor": None,
@@ -3563,6 +3578,7 @@ class TestGetTaskInstanceTries(TestTaskInstanceEndpoint):
                 {
                     "dag_id": "example_python_operator",
                     "dag_display_name": "example_python_operator",
+                    "dag_run_bundle_version": None,
                     "duration": 10000.0,
                     "end_date": "2020-01-03T00:00:00Z",
                     "executor": None,
@@ -3634,6 +3650,7 @@ class TestGetTaskInstanceTries(TestTaskInstanceEndpoint):
                 {
                     "dag_id": "example_python_operator",
                     "dag_display_name": "example_python_operator",
+                    "dag_run_bundle_version": None,
                     "duration": 10000.0,
                     "end_date": "2020-01-03T00:00:00Z",
                     "executor": None,
@@ -3717,6 +3734,7 @@ class TestGetTaskInstanceTries(TestTaskInstanceEndpoint):
                     {
                         "dag_id": "example_python_operator",
                         "dag_display_name": "example_python_operator",
+                        "dag_run_bundle_version": None,
                         "duration": 10000.0,
                         "end_date": "2020-01-03T00:00:00Z",
                         "executor": None,
@@ -3754,6 +3772,7 @@ class TestGetTaskInstanceTries(TestTaskInstanceEndpoint):
                     {
                         "dag_id": "example_python_operator",
                         "dag_display_name": "example_python_operator",
+                        "dag_run_bundle_version": None,
                         "duration": 10000.0,
                         "end_date": "2020-01-03T00:00:00Z",
                         "executor": None,
@@ -3826,6 +3845,7 @@ class TestGetTaskInstanceTries(TestTaskInstanceEndpoint):
             "task_id": "task1",
             "dag_id": "dag_with_multiple_versions",
             "dag_display_name": "dag_with_multiple_versions",
+            "dag_run_bundle_version": f"some_commit_hash{expected_version_number}",
             "dag_run_id": run_id,
             "map_index": -1,
             "start_date": None,
@@ -3880,6 +3900,7 @@ class TestGetTaskInstanceTries(TestTaskInstanceEndpoint):
             "task_id": "task1",
             "dag_id": "dag_with_multiple_versions",
             "dag_display_name": "dag_with_multiple_versions",
+            "dag_run_bundle_version": f"some_commit_hash{expected_version_number}",
             "dag_run_id": run_id,
             "map_index": -1,
             "start_date": None,
@@ -3979,6 +4000,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
                 {
                     "dag_id": self.DAG_ID,
                     "dag_display_name": self.DAG_DISPLAY_NAME,
+                    "dag_run_bundle_version": None,
                     "dag_version": {
                         "bundle_name": "dags-folder",
                         "bundle_url": None,
@@ -4253,6 +4275,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
                         {
                             "dag_id": "example_python_operator",
                             "dag_display_name": "example_python_operator",
+                            "dag_run_bundle_version": None,
                             "dag_version": {
                                 "bundle_name": "dags-folder",
                                 "bundle_url": None,
@@ -4389,6 +4412,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
                 {
                     "dag_id": self.DAG_ID,
                     "dag_display_name": self.DAG_DISPLAY_NAME,
+                    "dag_run_bundle_version": None,
                     "dag_version": {
                         "bundle_name": "dags-folder",
                         "bundle_url": None,
@@ -4450,6 +4474,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
                 {
                     "dag_id": self.DAG_ID,
                     "dag_display_name": self.DAG_DISPLAY_NAME,
+                    "dag_run_bundle_version": None,
                     "dag_version": {
                         "bundle_name": "dags-folder",
                         "bundle_url": None,
@@ -4529,6 +4554,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
                     {
                         "dag_id": self.DAG_ID,
                         "dag_display_name": self.DAG_DISPLAY_NAME,
+                        "dag_run_bundle_version": None,
                         "dag_version": {
                             "bundle_name": "dags-folder",
                             "bundle_url": None,
@@ -4610,6 +4636,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
             assert response_ti == {
                 "dag_id": self.DAG_ID,
                 "dag_display_name": self.DAG_DISPLAY_NAME,
+                "dag_run_bundle_version": None,
                 "dag_version": {
                     "bundle_name": "dags-folder",
                     "bundle_url": None,
@@ -4726,6 +4753,7 @@ class TestPatchTaskInstanceDryRun(TestTaskInstanceEndpoint):
                 {
                     "dag_id": self.DAG_ID,
                     "dag_display_name": self.DAG_DISPLAY_NAME,
+                    "dag_run_bundle_version": None,
                     "dag_version": {
                         "bundle_name": "dags-folder",
                         "bundle_url": None,
@@ -5012,6 +5040,7 @@ class TestPatchTaskInstanceDryRun(TestTaskInstanceEndpoint):
                         {
                             "dag_id": "example_python_operator",
                             "dag_display_name": "example_python_operator",
+                            "dag_run_bundle_version": None,
                             "dag_version": {
                                 "bundle_name": "dags-folder",
                                 "bundle_url": None,

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_config.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_config.py
@@ -67,6 +67,7 @@ expected_config_response = {
     "external_log_name": None,
     "theme": THEME,
     "multi_team": False,
+    "run_on_latest_version": False,
 }
 
 
@@ -110,3 +111,44 @@ class TestGetConfig:
         response = unauthorized_test_client.get("/config")
         assert response.status_code == 200
         assert response.json() == expected_config_response
+
+    def test_get_config_with_run_on_latest_version_true(self, test_client):
+        """Test that run_on_latest_version config is properly exposed when True."""
+        with conf_vars(
+            {
+                ("core", "run_on_latest_version"): "true",
+                ("api", "instance_name"): "Airflow",
+                ("api", "enable_swagger_ui"): "true",
+                ("api", "hide_paused_dags_by_default"): "true",
+                ("api", "page_size"): "100",
+                ("api", "default_wrap"): "false",
+                ("api", "auto_refresh_interval"): "3",
+                ("api", "require_confirmation_dag_change"): "false",
+                ("api", "theme"): json.dumps(THEME),
+            }
+        ):
+            response = test_client.get("/config")
+
+        assert response.status_code == 200
+        response_data = response.json()
+        assert response_data["run_on_latest_version"] is True
+
+    def test_get_config_with_run_on_latest_version_false(self, test_client):
+        """Test that run_on_latest_version config defaults to False when not set."""
+        with conf_vars(
+            {
+                ("api", "instance_name"): "Airflow",
+                ("api", "enable_swagger_ui"): "true",
+                ("api", "hide_paused_dags_by_default"): "true",
+                ("api", "page_size"): "100",
+                ("api", "default_wrap"): "false",
+                ("api", "auto_refresh_interval"): "3",
+                ("api", "require_confirmation_dag_change"): "false",
+                ("api", "theme"): json.dumps(THEME),
+            }
+        ):
+            response = test_client.get("/config")
+
+        assert response.status_code == 200
+        response_data = response.json()
+        assert response_data["run_on_latest_version"] is False

--- a/airflow-core/tests/unit/dag_processing/test_processor.py
+++ b/airflow-core/tests/unit/dag_processing/test_processor.py
@@ -1909,6 +1909,7 @@ class TestDagProcessingMessageTypes:
             "GetAssetByUri",
             "GetAssetEventByAsset",
             "GetAssetEventByAssetAlias",
+            "GetDag",
             "GetDagRun",
             "GetDagRunState",
             "GetDRCount",
@@ -1935,6 +1936,7 @@ class TestDagProcessingMessageTypes:
         in_task_runner_but_not_in_dag_processing_process = {
             "AssetResult",
             "AssetEventsResult",
+            "DagResult",
             "DagRunResult",
             "DagRunStateResult",
             "DRCount",

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -1226,6 +1226,7 @@ class TestTriggererMessageTypes:
             "GetAssetByUri",
             "GetAssetEventByAsset",
             "GetAssetEventByAssetAlias",
+            "GetDag",
             "GetDagRun",
             "GetPrevSuccessfulDagRun",
             "GetPreviousDagRun",
@@ -1250,6 +1251,7 @@ class TestTriggererMessageTypes:
         in_task_but_not_in_trigger_runner = {
             "AssetResult",
             "AssetEventsResult",
+            "DagResult",
             "DagRunResult",
             "SentFDs",
             "StartupDetails",

--- a/airflow-core/tests/unit/models/test_dag.py
+++ b/airflow-core/tests/unit/models/test_dag.py
@@ -58,7 +58,7 @@ from airflow.models.dag import (
     get_run_data_interval,
 )
 from airflow.models.dagbag import DBDagBag
-from airflow.models.dagbundle import DagBundleModel
+from airflow.models.dagbundle import BUNDLE_VERSION_LATEST_SENTINEL, DagBundleModel
 from airflow.models.dagrun import DagRun
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskinstance import TaskInstance as TI
@@ -1207,6 +1207,84 @@ class TestDag:
             )
             assert dr.partition_key == partition_key
 
+    def _setup_bundle(self, session, dag_id, bundle_name, original_version="v1.0.0", latest_version="v2.0.0"):
+        """Helper to set up bundle configuration for tests."""
+        from airflow.models.dagbundle import DagBundleModel
+
+        dag_bundle = DagBundleModel(name=bundle_name, version=latest_version)
+        session.add(dag_bundle)
+        session.flush()
+
+        dag_model = session.scalar(select(DagModel).where(DagModel.dag_id == dag_id))
+        if dag_model:
+            dag_model.bundle_name = bundle_name
+            dag_model.bundle_version = original_version
+            session.flush()
+
+    def _create_test_dagrun(self, dag_maker, run_id="test_run", days_offset=0, **kwargs):
+        """Helper to create a dagrun with common defaults."""
+        logical_date = DEFAULT_DATE + timedelta(days=days_offset)
+        return dag_maker.create_dagrun(
+            run_id=run_id,
+            logical_date=logical_date,
+            run_after=logical_date,
+            run_type=DagRunType.MANUAL,
+            state=State.NONE,
+            triggered_by=DagRunTriggeredByType.TEST,
+            **kwargs,
+        )
+
+    @mock.patch("airflow.configuration.conf.getboolean")
+    def test_create_dagrun_with_global_run_on_latest_version(self, mock_getboolean, dag_maker, session):
+        """Test that global config run_on_latest_version uses latest bundle version."""
+        mock_getboolean.side_effect = lambda section, key, fallback=None: (
+            True if section == "core" and key == "run_on_latest_version" else fallback
+        )
+
+        with dag_maker("test_global_default_run_on_latest"):
+            ...
+
+        self._setup_bundle(session, "test_global_default_run_on_latest", "test_bundle_global")
+
+        dr = self._create_test_dagrun(dag_maker)
+        assert dr.bundle_version == "v2.0.0"
+
+    def test_create_dagrun_with_dag_level_run_on_latest_version(self, dag_maker, session):
+        """Test that DAG-level run_on_latest_version uses latest bundle version."""
+        with dag_maker("test_dag_default_run_on_latest", run_on_latest_version=True):
+            ...
+
+        self._setup_bundle(session, "test_dag_default_run_on_latest", "test_bundle_dag_level")
+
+        dr = self._create_test_dagrun(dag_maker)
+        assert dr.bundle_version == "v2.0.0"
+
+    @mock.patch("airflow.configuration.conf.getboolean")
+    def test_create_dagrun_precedence_hierarchy(self, mock_getboolean, dag_maker, session):
+        """Test that precedence hierarchy works: operator > DAG > global > system default."""
+        mock_getboolean.side_effect = lambda section, key, fallback=None: (
+            True if section == "core" and key == "run_on_latest_version" else fallback
+        )
+
+        # DAG level explicitly says False (should override global True)
+        with dag_maker("test_precedence", run_on_latest_version=False):
+            ...
+
+        self._setup_bundle(session, "test_precedence", "test_bundle_precedence")
+
+        # DAG level False should override global True - uses original version
+        dr1 = self._create_test_dagrun(dag_maker, run_id="test_dag_level_overrides_global")
+        assert dr1.bundle_version == "v1.0.0"
+
+        # Operator level override (use latest) should override DAG level (use original)
+        dr2 = self._create_test_dagrun(
+            dag_maker,
+            run_id="test_operator_overrides_dag",
+            days_offset=1,
+            use_latest_sentinel=BUNDLE_VERSION_LATEST_SENTINEL,
+        )
+        assert dr2.bundle_version == "v2.0.0"  # Latest version
+
     def test_dag_add_task_sets_default_task_group(self):
         dag = DAG(dag_id="test_dag_add_task_sets_default_task_group", schedule=None, start_date=DEFAULT_DATE)
         task_without_task_group = EmptyOperator(task_id="task_without_group_id")
@@ -1219,6 +1297,37 @@ class TestDag:
         dag.add_task(task_with_task_group)
         assert task_group.get_child_by_label("task_with_task_group") == task_with_task_group
         assert dag.get_task("task_group.task_with_task_group") == task_with_task_group
+
+    def test_create_dagrun_system_default_uses_original_version(self, dag_maker, session):
+        """Test system default: when DAG=None and global=False, uses original bundle version."""
+        with conf_vars({("core", "run_on_latest_version"): "False"}):
+            with dag_maker("test_system_default", run_on_latest_version=None):
+                ...
+
+            self._setup_bundle(session, "test_system_default", "test_bundle_system_default")
+
+            dr = self._create_test_dagrun(dag_maker, run_id="test_system_default")
+            assert dr.bundle_version == "v1.0.0"
+
+    def test_create_dagrun_disable_bundle_versioning_bypasses_logic(self, dag_maker, session):
+        """Test that disable_bundle_versioning=True bypasses all bundle version logic."""
+        with conf_vars({("core", "run_on_latest_version"): "True"}):
+            with dag_maker("test_bypass", disable_bundle_versioning=True):
+                ...
+
+            self._setup_bundle(session, "test_bypass", "test_bundle_bypass")
+
+            dr = self._create_test_dagrun(dag_maker, run_id="test_bypass")
+            assert dr.bundle_version is None
+
+            # Also test with latest sentinel - should still be bypassed
+            dr2 = self._create_test_dagrun(
+                dag_maker,
+                run_id="test_bypass_with_override",
+                days_offset=1,
+                use_latest_sentinel=BUNDLE_VERSION_LATEST_SENTINEL,
+            )
+            assert dr2.bundle_version is None
 
     @pytest.mark.parametrize("dag_run_state", [DagRunState.QUEUED, DagRunState.RUNNING])
     @pytest.mark.need_serialized_dag

--- a/airflow-core/tests/unit/serialization/test_dag_serialization.py
+++ b/airflow-core/tests/unit/serialization/test_dag_serialization.py
@@ -4577,3 +4577,20 @@ class TestWeightRule:
         op = BaseOperator(task_id="empty_task", weight_rule=NotRegisteredPriorityWeightStrategy())
         with pytest.raises(ValueError, match="Unknown priority strategy"):
             OperatorSerialization.serialize(op)
+
+
+@pytest.mark.parametrize("run_on_latest_version", [None, True, False])
+def test_dag_run_on_latest_version_serialization(run_on_latest_version):
+    """Test that run_on_latest_version is serialized and deserialized correctly."""
+    dag = DAG(
+        dag_id=f"test_dag_{run_on_latest_version}",
+        start_date=datetime(2023, 1, 1),
+        schedule=None,
+        run_on_latest_version=run_on_latest_version,
+    )
+    BaseOperator(task_id="task", dag=dag)
+
+    assert dag.run_on_latest_version is run_on_latest_version
+    serialized = DagSerialization.to_dict(dag)
+    deserialized = DagSerialization.from_dict(serialized)
+    assert deserialized.run_on_latest_version is run_on_latest_version

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -1377,6 +1377,7 @@ class DAGDetailsResponse(BaseModel):
     owner_links: Annotated[dict[str, str] | None, Field(title="Owner Links")] = None
     is_favorite: Annotated[bool | None, Field(title="Is Favorite")] = False
     active_runs_count: Annotated[int | None, Field(title="Active Runs Count")] = 0
+    run_on_latest_version: Annotated[bool | None, Field(title="Run On Latest Version")] = None
     file_token: Annotated[str, Field(description="Return file token.", title="File Token")]
     concurrency: Annotated[
         int,
@@ -1702,6 +1703,7 @@ class TaskInstanceHistoryResponse(BaseModel):
     max_tries: Annotated[int, Field(title="Max Tries")]
     task_display_name: Annotated[str, Field(title="Task Display Name")]
     dag_display_name: Annotated[str, Field(title="Dag Display Name")]
+    dag_run_bundle_version: Annotated[str | None, Field(title="Dag Run Bundle Version")] = None
     hostname: Annotated[str | None, Field(title="Hostname")] = None
     unixname: Annotated[str | None, Field(title="Unixname")] = None
     pool: Annotated[str, Field(title="Pool")]
@@ -1738,6 +1740,7 @@ class TaskInstanceResponse(BaseModel):
     max_tries: Annotated[int, Field(title="Max Tries")]
     task_display_name: Annotated[str, Field(title="Task Display Name")]
     dag_display_name: Annotated[str, Field(title="Dag Display Name")]
+    dag_run_bundle_version: Annotated[str | None, Field(title="Dag Run Bundle Version")] = None
     hostname: Annotated[str | None, Field(title="Hostname")] = None
     unixname: Annotated[str | None, Field(title="Unixname")] = None
     pool: Annotated[str, Field(title="Pool")]

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -355,6 +355,7 @@ class TriggerDAGRunPayload(BaseModel):
     logical_date: Annotated[AwareDatetime | None, Field(title="Logical Date")] = None
     conf: Annotated[dict[str, Any] | None, Field(title="Conf")] = None
     reset_dag_run: Annotated[bool | None, Field(title="Reset Dag Run")] = False
+    bundle_version: Annotated[str | None, Field(title="Bundle Version")] = None
 
 
 class UpdateHITLDetailPayload(BaseModel):

--- a/task-sdk/src/airflow/sdk/definitions/dag.py
+++ b/task-sdk/src/airflow/sdk/definitions/dag.py
@@ -397,6 +397,11 @@ class DAG:
         **Warning**: A fail stop dag can only have tasks with the default trigger rule ("all_success").
         An exception will be thrown if any task in a fail stop dag has a non default trigger rule.
     :param dag_display_name: The display name of the Dag which appears on the UI.
+    :param run_on_latest_version: If True, runs of this DAG will use the latest
+        available bundle version when triggered, rerun, or cleared. If False, runs will
+        use the original bundle version. If None (default), inherits from the global config
+        ``[core] run_on_latest_version``. Can be overridden by operator-level
+        parameters in TriggerDagRunOperator.
     """
 
     __serialized_fields: ClassVar[frozenset[str]]
@@ -525,6 +530,7 @@ class DAG:
     disable_bundle_versioning: bool = attrs.field(
         factory=_config_bool_factory("dag_processor", "disable_bundle_versioning")
     )
+    run_on_latest_version: bool | None = attrs.field(default=None, converter=attrs.converters.optional(bool))
 
     # TODO (GH-52141): This is never used in the sdk dag (it only makes sense
     # after this goes through the dag processor), but various parts of the code
@@ -1528,6 +1534,7 @@ if TYPE_CHECKING:
         fail_fast: bool = False,
         dag_display_name: str | None = None,
         disable_bundle_versioning: bool = False,
+        run_on_latest_version: bool | None = None,
     ) -> Callable[[Callable], Callable[..., DAG]]:
         """
         Python dag decorator which wraps a function into an Airflow Dag.

--- a/task-sdk/src/airflow/sdk/exceptions.py
+++ b/task-sdk/src/airflow/sdk/exceptions.py
@@ -248,6 +248,7 @@ class DagRunTriggerException(AirflowException):
         failed_states: list[str],
         poke_interval: int,
         deferrable: bool,
+        bundle_version: str | None = None,
     ):
         super().__init__()
         self.trigger_dag_id = trigger_dag_id
@@ -261,6 +262,7 @@ class DagRunTriggerException(AirflowException):
         self.failed_states = failed_states
         self.poke_interval = poke_interval
         self.deferrable = deferrable
+        self.bundle_version = bundle_version
 
 
 class DownstreamTasksSkipped(AirflowException):

--- a/task-sdk/src/airflow/sdk/execution_time/comms.py
+++ b/task-sdk/src/airflow/sdk/execution_time/comms.py
@@ -576,6 +576,15 @@ class DagRunStateResult(DagRunStateResponse):
         return cls(**dr_state_response.model_dump(exclude_defaults=True), type="DagRunStateResult")
 
 
+class DagResult(BaseModel):
+    """Response containing DAG information."""
+
+    dag_id: str
+    is_paused: bool
+    bundle_version: str | None = None
+    type: Literal["DagResult"] = "DagResult"
+
+
 class PreviousDagRunResult(BaseModel):
     """Response containing previous Dag run information."""
 
@@ -698,6 +707,7 @@ ToTask = Annotated[
     AssetResult
     | AssetEventsResult
     | ConnectionResult
+    | DagResult
     | DagRunResult
     | DagRunStateResult
     | DRCount
@@ -889,6 +899,11 @@ class GetDagRun(BaseModel):
     type: Literal["GetDagRun"] = "GetDagRun"
 
 
+class GetDag(BaseModel):
+    dag_id: str
+    type: Literal["GetDag"] = "GetDag"
+
+
 class GetDagRunState(BaseModel):
     dag_id: str
     run_id: str
@@ -1026,6 +1041,7 @@ ToSupervisor = Annotated[
     | GetAssetEventByAsset
     | GetAssetEventByAssetAlias
     | GetConnection
+    | GetDag
     | GetDagRun
     | GetDagRunState
     | GetDRCount

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1346,6 +1346,7 @@ def _handle_trigger_dag_run(
             logical_date=drte.logical_date,
             conf=drte.conf,
             reset_dag_run=drte.reset_dag_run,
+            bundle_version=drte.bundle_version,
         ),
     )
 


### PR DESCRIPTION
## Summary

This PR adds the ability to configure default bundle version behavior at three levels with a clear precedence hierarchy. Users can now set organization-wide, per-DAG, or per-operator defaults for whether DAG runs should use the latest bundle version or the original version, eliminating the need to specify this on every clear/rerun operation.

Additionally, this PR adds the `run_on_latest_version` parameter to `TriggerDagRunOperator`, allowing explicit control when triggering child DAGs programmatically.

## What Changed

### 1. Global Configuration
Added `[core] run_on_latest_version` configuration option that applies organization-wide default behavior.

```ini
[core]
run_on_latest_version = True
```

### 2. DAG-Level Configuration
Added `run_on_latest_version` parameter to the DAG class that overrides global configuration for specific DAGs.

```python
with DAG(dag_id="my_dag", run_on_latest_version=True, ...) as dag:
    ...
```

### 3. Operator-Level Control
Added `run_on_latest_version` parameter to `TriggerDagRunOperator` with highest precedence, overriding both DAG and global configuration.

```python
trigger = TriggerDagRunOperator(
    task_id="trigger_latest",
    trigger_dag_id="target_dag",
    run_on_latest_version=True,
)
```

### 4. UI Integration
Configured existing "Run on Latest Version" checkboxes in all three Clear dialogs (Run, Task Instance, Task Group) to respect the configuration hierarchy. Checkboxes now default based on precedence: DAG-level > Global > System.

### 5. Precedence Hierarchy

```
Operator Level > DAG Level > Global Level > System Default (original version)
```

## Implementation Details

### Backend Changes (9 files)
- **Configuration**: Added new config option with documentation
- **DAG Definition**: Added parameter to DAG class and serialization
- **Resolution Logic**: Implemented precedence hierarchy in `_resolve_bundle_version()`
- **API Layer**: Exposed configuration and bundle version fields in responses
- **Error Handling**: Improved logging with INFO/ERROR/WARNING levels based on context

### Operator Changes (1 file)
- **TriggerDagRunOperator**: Added `run_on_latest_version` parameter
- **Supervisor Integration**: Forwards bundle_version to API client
- **API Client**: Accepts and passes bundle_version parameter

### UI (3 files)                                                                                                                                                                                           
- Clear dialog checkboxes respect precedence hierarchy                                                                                                                                                      
- Custom hook (`useRunOnLatestVersion`) consolidates precedence resolution, visibility logic, and state management across all three dialog components                                                       
- Dynamic defaults based on DAG and global configuration

### Test Coverage (3 files)
- Added tests for global config API
- Added tests for DAG-level configuration
- Added tests for precedence hierarchy resolution
- Added integration tests for supervisor → API → database flow
- Fixed SQLAlchemy deprecation warnings

### Documentation (1 file)
- Updated dag-bundles.rst with comprehensive examples
- Documented precedence hierarchy
- Added configuration reference

## Use Cases

### Use Case 1: Organization-Wide Default
Set global config to True so all DAG runs use the latest bundle version by default.

### Use Case 2: Critical DAG Exception
Override global config at DAG level for critical DAGs that must use original version for compliance.

### Use Case 3: Specific Task Override
Override at operator level to test original version while other tasks use latest.

## Testing

### Unit Tests
- ✅ Config API tests (2 new tests)
- ✅ DAG resolution tests (5 new tests)
- ✅ Supervisor forwarding tests (3 tests including new bundle_version test)
- ✅ API client tests (3 tests)
- ✅ Serialization tests

### Manual Testing
- ✅ Checkbox defaults respect precedence hierarchy
- ✅ TriggerDagRunOperator passes bundle version correctly
- ✅ AF2 compatibility maintained (bundle versioning ignored)
- ✅ AF3 functionality working

## Backward Compatibility

**✅ Fully backward compatible**:                                                                                                                                                                            
  - All new configuration defaults to `False` (preserves current behavior)                                                                                                                                    
  - No database schema changes required                                                                                                                                                                       
  - No breaking changes to existing APIs                                                                                                                                                                      
  - UI enhancements are progressive                                                                                                                                                                           
  - Non-versioned bundles (LocalDagBundle) unaffected                                                                                                                                                         
                                                                                                                                                                                                              
**Version Requirements**:                                                                                                                                                                                   
  - This feature targets Airflow 3.2.0                                                                                                                                    
  - The code uses `AIRFLOW_V_3_2_PLUS` for version checks                                                                                                                                                     
  - **Note for maintainers**: If this PR ships in a different version (e.g., 3.1.x or 3.3.x),                                                                                                                 
  update the `AIRFLOW_V_3_2_PLUS` checks in:                                                                                                                                                                
    - `providers/standard/src/airflow/providers/standard/operators/trigger_dagrun.py`                                                                                                                         
    - `providers/standard/tests/unit/standard/operators/test_trigger_dagrun.py` 

## Migration

**No migration required!** The feature is completely opt-in:
1. Default behavior preserved (use original bundle version)
2. Enable at global, DAG, or operator level as needed
3. No database changes or data migration

## Related Issues

- Closes #60880: TriggerDagRunOperator bundle version parameters
- Closes #60887: Global and DAG-level bundle version defaults

## Breaking Changes

**None**

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Sonnet 4.5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
