### PR TITLE
[v3-1-test] Get rid of the bleeding edge of our prek-hooks (#60452)

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -272,11 +272,7 @@ jobs:
           platform: ${{ inputs.platform }}
           save-cache: false
       - name: "Autoupdate all prek hooks"
-        run: prek auto-update --cooldown-days 4 --freeze
-      - name: "Autoupdate Lucas-C hooks to bleeding edge"
-        run: prek auto-update --bleeding-edge --freeze --repo https://github.com/Lucas-C/pre-commit-hooks
-      - name: "Autoupdate Octopin to bleeding edge"
-        run: prek auto-update --bleeding-edge --freeze --repo https://github.com/eclipse-csi/octopin
+        run: prek autoupdate --cooldown-days 4 --freeze
       - name: "Check if there are any changes in prek hooks"
         run: |
           if ! git diff --exit-code; then

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,8 +31,7 @@ repos:
       - id: check-hooks-apply
         name: Check if all hooks apply to the repository
   - repo: https://github.com/eclipse-csi/octopin
-    # We need this commit because if supports two spaces before comments (yamllint compatibility)
-    rev: 74fd075c7b326c771cd95ca86c59cbe65f0dda37
+    rev: 67eac129b3e1d8ddb47e657bb2fda28c33d948ca  # frozen: v0.1.4
     hooks:
       - id: pin-versions
         name: Pin versions of dependencies in CI workflows (manual)

--- a/dev/breeze/src/airflow_breeze/commands/ci_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_commands.py
@@ -629,9 +629,7 @@ def upgrade(target_branch: str, create_pr: bool | None, switch_to_base: bool | N
 
     # Define all upgrade commands to run (all run with check=False to continue on errors)
     upgrade_commands = [
-        "prek auto-update --cooldown-days 4 --freeze",
-        "prek auto-update --bleeding-edge --freeze --repo https://github.com/Lucas-C/pre-commit-hooks",
-        "prek auto-update --bleeding-edge --freeze --repo https://github.com/eclipse-csi/octopin",
+        "prek autoupdate --cooldown-days 4 --freeze",
         "prek --all-files --verbose --hook-stage manual pin-versions",
         "prek --all-files --show-diff-on-failure --color always --verbose --hook-stage manual update-chart-dependencies",
         "prek --all-files --show-diff-on-failure --color always --verbose --hook-stage manual upgrade-important-versions",


### PR DESCRIPTION
Finally the Lucas-C pre-commit hook and octopin repo got released with changes we need so we can get rid of bleeding-edge.
(cherry picked from commit f94039b365deb1db95e37a65d716db9e943b6fe5)

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
