### PR TITLE
Enable Operators to Set Task Notes During Execution

### DIFF
--- a/airflow-core/tests/unit/dag_processing/test_processor.py
+++ b/airflow-core/tests/unit/dag_processing/test_processor.py
@@ -1901,6 +1901,7 @@ class TestDagProcessingMessageTypes:
             "UpdateHITLDetail",
             "GetHITLDetailResponse",
             "SetRenderedMapIndex",
+            "SetTaskInstanceNote",
         }
 
         in_task_runner_but_not_in_dag_processing_process = {

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -1237,6 +1237,7 @@ class TestTriggererMessageTypes:
             "RescheduleTask",
             "RetryTask",
             "SetRenderedFields",
+            "SetTaskInstanceNote",
             "SkipDownstreamTasks",
             "SucceedTask",
             "ValidateInletsAndOutlets",

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -279,6 +279,11 @@ class TaskInstanceOperations:
         self.client.patch(f"task-instances/{id}/rendered-map-index", json=rendered_map_index)
         return OKResponse(ok=True)
 
+    def set_task_instance_note(self, id: uuid.UUID, note: str) -> OKResponse:
+        """Set note for a task instance via the API server."""
+        self.client.patch(f"task-instances/{id}/note", json=note)
+        return OKResponse(ok=True)
+
     def get_previous_successful_dagrun(self, id: uuid.UUID) -> PrevSuccessfulDagRunResponse:
         """
         Get the previous successful dag run for a given task instance.

--- a/task-sdk/src/airflow/sdk/execution_time/comms.py
+++ b/task-sdk/src/airflow/sdk/execution_time/comms.py
@@ -877,6 +877,13 @@ class SetRenderedMapIndex(BaseModel):
     type: Literal["SetRenderedMapIndex"] = "SetRenderedMapIndex"
 
 
+class SetTaskInstanceNote(BaseModel):
+    """Payload for setting note for a task instance."""
+
+    note: str
+    type: Literal["SetTaskInstanceNote"] = "SetTaskInstanceNote"
+
+
 class TriggerDagRun(TriggerDAGRunPayload):
     dag_id: str
     run_id: Annotated[str, Field(title="Dag Run Id")]
@@ -1046,6 +1053,7 @@ ToSupervisor = Annotated[
     | RetryTask
     | SetRenderedFields
     | SetRenderedMapIndex
+    | SetTaskInstanceNote
     | SetXCom
     | SkipDownstreamTasks
     | SucceedTask

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -103,6 +103,7 @@ from airflow.sdk.execution_time.comms import (
     SentFDs,
     SetRenderedFields,
     SetRenderedMapIndex,
+    SetTaskInstanceNote,
     SetXCom,
     SkipDownstreamTasks,
     StartupDetails,
@@ -1325,6 +1326,8 @@ class ActivitySubprocess(WatchedSubprocess):
             self.client.task_instances.set_rtif(self.id, msg.rendered_fields)
         elif isinstance(msg, SetRenderedMapIndex):
             self.client.task_instances.set_rendered_map_index(self.id, msg.rendered_map_index)
+        elif isinstance(msg, SetTaskInstanceNote):
+            self.client.task_instances.set_task_instance_note(self.id, msg.note)
         elif isinstance(msg, GetAssetByName):
             asset_resp = self.client.assets.get(name=msg.name)
             if isinstance(asset_resp, AssetResponse):

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -92,6 +92,7 @@ from airflow.sdk.execution_time.comms import (
     SentFDs,
     SetRenderedFields,
     SetRenderedMapIndex,
+    SetTaskInstanceNote,
     SkipDownstreamTasks,
     StartupDetails,
     SucceedTask,
@@ -489,6 +490,14 @@ class RuntimeTaskInstance(TaskInstance):
             assert isinstance(response, TaskRescheduleStartDate)
 
         return response.start_date
+
+    def set_task_instance_note(self, note: str) -> None:
+        """Set a note for the TaskInstance during execution."""
+        log = structlog.get_logger(logger_name="task")
+
+        log.debug("Setting task instance note", note=note)
+
+        SUPERVISOR_COMMS.send(msg=SetTaskInstanceNote(note=note))
 
     def get_previous_dagrun(self, state: str | None = None) -> DagRun | None:
         """Return the previous Dag run before the given logical date, optionally filtered by state."""

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -113,6 +113,7 @@ from airflow.sdk.execution_time.comms import (
     SentFDs,
     SetRenderedFields,
     SetRenderedMapIndex,
+    SetTaskInstanceNote,
     SetXCom,
     SkipDownstreamTasks,
     SucceedTask,
@@ -1676,6 +1677,15 @@ REQUEST_TEST_CASES = [
             response=OKResponse(ok=True),
         ),
         test_id="set_rendered_map_index",
+    ),
+    RequestTestCase(
+        message=SetTaskInstanceNote(note="Test note content"),
+        client_mock=ClientMock(
+            method_path="task_instances.set_task_instance_note",
+            args=(TI_ID, "Test note content"),
+            response=OKResponse(ok=True),
+        ),
+        test_id="set_task_instance_note",
     ),
     RequestTestCase(
         message=SucceedTask(

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -100,6 +100,7 @@ from airflow.sdk.execution_time.comms import (
     PrevSuccessfulDagRunResult,
     RescheduleTask,
     SetRenderedFields,
+    SetTaskInstanceNote,
     SetXCom,
     SkipDownstreamTasks,
     StartupDetails,
@@ -2205,6 +2206,20 @@ class TestRuntimeTaskInstance:
 
         context = runtime_ti.get_template_context()
         assert runtime_ti.get_first_reschedule_date(context=context) == expected_date
+
+    def test_set_task_instance_note(self, create_runtime_ti, mock_supervisor_comms):
+        """Test that the first reschedule date is fetched from the Supervisor."""
+        task = BaseOperator(task_id="test_task")
+        dag_id = "test_dag"
+        runtime_ti = create_runtime_ti(task=task, dag_id=dag_id, logical_date=timezone.datetime(2025, 1, 2))
+
+        runtime_ti.set_task_instance_note(note="This is a test note.")
+
+        mock_supervisor_comms.send.assert_called_once_with(
+            msg=SetTaskInstanceNote(
+                note="This is a test note.",
+            ),
+        )
 
     def test_get_ti_count(self, mock_supervisor_comms):
         """Test that get_ti_count sends the correct request and returns the count."""


### PR DESCRIPTION
# Overview

This PR enables operators to set task instance notes during execution using:
`context["ti"].set_task_instance_note(note="test note")`

As an operator developer, I want to inform users about task results via task instance notes to provide a quick overview of issues without requiring detailed log inspection.

While we may contribute a dedicated feature to the web UI for displaying user-facing text in the future, that capability isn't currently available. This PR enables the functionality immediately using the existing task instance note mechanism. If a dedicated text display feature becomes available later, migrating would only require minimal function naming changes.

We view this as a pragmatic enablement that can be enhanced over time.

What are your opinions about this feature? 


# Details of change:

* Enables supervisor to set task instance note.
* Enables task runner to set note via the supervisor.
* Enables easy context access to set task instance note.