### PR TITLE
Deprecate api page size

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/common/parameters.py
+++ b/airflow-core/src/airflow/api_fastapi/common/parameters.py
@@ -103,7 +103,7 @@ class LimitFilter(BaseParam[NonNegativeInt]):
         return select.limit(self.value)
 
     @classmethod
-    def depends(cls, limit: NonNegativeInt = conf.getint("api", "page_size")) -> LimitFilter:
+    def depends(cls, limit: NonNegativeInt = conf.getint("api", "fallback_page_limit")) -> LimitFilter:
         return cls().set_value(min(limit, conf.getint("api", "maximum_page_limit")))
 
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/ui/config.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/ui/config.py
@@ -23,7 +23,7 @@ from airflow.api_fastapi.core_api.base import BaseModel
 class ConfigResponse(BaseModel):
     """configuration serializer."""
 
-    page_size: int
+    fallback_page_limit: int
     auto_refresh_interval: int
     hide_paused_dags_by_default: bool
     instance_name: str

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -1338,9 +1338,9 @@ components:
       description: Represents a summary of DAG runs for a specific calendar time range.
     ConfigResponse:
       properties:
-        page_size:
+        fallback_page_limit:
           type: integer
-          title: Page Size
+          title: Fallback Page Limit
         auto_refresh_interval:
           type: integer
           title: Auto Refresh Interval
@@ -1384,7 +1384,7 @@ components:
           title: Multi Team
       type: object
       required:
-      - page_size
+      - fallback_page_limit
       - auto_refresh_interval
       - hide_paused_dags_by_default
       - instance_name

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/config.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/config.py
@@ -36,7 +36,7 @@ config_router = AirflowRouter(tags=["Config"])
 API_CONFIG_KEYS = [
     "enable_swagger_ui",
     "hide_paused_dags_by_default",
-    "page_size",
+    "fallback_page_limit",
     "default_wrap",
     "auto_refresh_interval",
     "require_confirmation_dag_change",

--- a/airflow-core/src/airflow/cli/commands/config_command.py
+++ b/airflow-core/src/airflow/cli/commands/config_command.py
@@ -641,6 +641,11 @@ CONFIGS_CHANGES = [
         config=ConfigParameter("webserver", "navbar_logo_text_color"),
         was_deprecated=False,
     ),
+    # api
+    ConfigChange(
+        config=ConfigParameter("api", "page_size"),
+        renamed_to=ConfigParameter("api", "fallback_page_limit"),
+    ),
     # scheduler
     ConfigChange(
         config=ConfigParameter("scheduler", "dependency_detector"),

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1577,13 +1577,6 @@ api:
       type: boolean
       example: ~
       default: "False"
-    page_size:
-      description: |
-        Consistent page size across all listing views in the UI
-      version_added: ~
-      type: integer
-      example: ~
-      default: "50"
     default_wrap:
       description: |
         Default setting for wrap toggle on DAG code and TI log views.

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -7127,9 +7127,9 @@ export const $CalendarTimeRangeResponse = {
 
 export const $ConfigResponse = {
     properties: {
-        page_size: {
+        fallback_page_limit: {
             type: 'integer',
-            title: 'Page Size'
+            title: 'Fallback Page Limit'
         },
         auto_refresh_interval: {
             type: 'integer',
@@ -7197,7 +7197,7 @@ export const $ConfigResponse = {
         }
     },
     type: 'object',
-    required: ['page_size', 'auto_refresh_interval', 'hide_paused_dags_by_default', 'instance_name', 'enable_swagger_ui', 'require_confirmation_dag_change', 'default_wrap', 'test_connection', 'dashboard_alert', 'show_external_log_redirect', 'theme', 'multi_team'],
+    required: ['fallback_page_limit', 'auto_refresh_interval', 'hide_paused_dags_by_default', 'instance_name', 'enable_swagger_ui', 'require_confirmation_dag_change', 'default_wrap', 'test_connection', 'dashboard_alert', 'show_external_log_redirect', 'theme', 'multi_team'],
     title: 'ConfigResponse',
     description: 'configuration serializer.'
 } as const;

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -1764,7 +1764,7 @@ export type state = 'queued' | 'running' | 'success' | 'failed' | 'planned';
  * configuration serializer.
  */
 export type ConfigResponse = {
-    page_size: number;
+    fallback_page_limit: number;
     auto_refresh_interval: number;
     hide_paused_dags_by_default: boolean;
     instance_name: string;

--- a/airflow-core/src/airflow/ui/src/components/DataTable/useTableUrlState.ts
+++ b/airflow-core/src/airflow/ui/src/components/DataTable/useTableUrlState.ts
@@ -35,7 +35,7 @@ export const useTableURLState = (defaultState?: Partial<TableState>) => {
     [],
   );
 
-  const pageSize = useConfig("page_size") as number;
+  const pageSize = useConfig("fallback_page_limit") as number;
 
   const defaultTableState = {
     pagination: {

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_config.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_config.py
@@ -46,7 +46,7 @@ THEME = {
 }
 
 expected_config_response = {
-    "page_size": 100,
+    "fallback_page_limit": 100,
     "auto_refresh_interval": 3,
     "hide_paused_dags_by_default": True,
     "instance_name": "Airflow",
@@ -72,7 +72,7 @@ def mock_config_data():
             ("api", "instance_name"): "Airflow",
             ("api", "enable_swagger_ui"): "true",
             ("api", "hide_paused_dags_by_default"): "true",
-            ("api", "page_size"): "100",
+            ("api", "fallback_page_limit"): "100",
             ("api", "default_wrap"): "false",
             ("api", "auto_refresh_interval"): "3",
             ("api", "require_confirmation_dag_change"): "false",

--- a/shared/configuration/src/airflow_shared/configuration/parser.py
+++ b/shared/configuration/src/airflow_shared/configuration/parser.py
@@ -159,6 +159,7 @@ class AirflowConfigParser(ConfigParser):
         ("api", "instance_name"): ("webserver", "instance_name", "3.1.0"),
         ("api", "log_config"): ("api", "access_logfile", "3.1.0"),
         ("scheduler", "ti_metrics_interval"): ("scheduler", "running_metrics_interval", "3.2.0"),
+        ("api", "fallback_page_limit"): ("api", "page_size", "3.2.0"),
     }
 
     # A mapping of new section -> (old section, since_version).


### PR DESCRIPTION
Follow up of https://github.com/apache/airflow/pull/60989

Only the last commit is relevant. 'page_size' is a duplicate of `fallback_page_limit`