### PR TITLE
fix dag version inflation caused by unmatched serialized result of task using reserialized command

### DIFF
--- a/airflow-core/src/airflow/models/serialized_dag.py
+++ b/airflow-core/src/airflow/models/serialized_dag.py
@@ -383,7 +383,7 @@ class SerializedDagModel(Base):
         """Recursively sort json_dict and its nested dictionaries and lists."""
         if isinstance(serialized_dag, dict):
             return {k: cls._sort_serialized_dag_dict(v) for k, v in sorted(serialized_dag.items())}
-        if isinstance(serialized_dag, list):
+        if isinstance(serialized_dag, list) or isinstance(serialized_dag, tuple):
             if all(isinstance(i, dict) for i in serialized_dag):
                 if all(
                     isinstance(i.get("__var", {}), Iterable) and "task_id" in i.get("__var", {})

--- a/airflow-core/src/airflow/models/serialized_dag.py
+++ b/airflow-core/src/airflow/models/serialized_dag.py
@@ -383,7 +383,7 @@ class SerializedDagModel(Base):
         """Recursively sort json_dict and its nested dictionaries and lists."""
         if isinstance(serialized_dag, dict):
             return {k: cls._sort_serialized_dag_dict(v) for k, v in sorted(serialized_dag.items())}
-        if isinstance(serialized_dag, list) or isinstance(serialized_dag, tuple):
+        if isinstance(serialized_dag, (list, tuple)):
             if all(isinstance(i, dict) for i in serialized_dag):
                 if all(
                     isinstance(i.get("__var", {}), Iterable) and "task_id" in i.get("__var", {})

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -1027,7 +1027,6 @@ class TestCliDagsReserialize:
         "bundle1": TEST_DAGS_FOLDER / "test_example_bash_operator.py",
         "bundle2": TEST_DAGS_FOLDER / "test_sensor.py",
         "bundle3": TEST_DAGS_FOLDER / "test_dag_with_no_tags.py",
-        "bundle4": TEST_DAGS_FOLDER / "test_dag_reserialize.py",
     }
 
     @classmethod
@@ -1043,12 +1042,7 @@ class TestCliDagsReserialize:
             dag_command.dag_reserialize(self.parser.parse_args(["dags", "reserialize"]))
 
         serialized_dag_ids = set(session.execute(select(SerializedDagModel.dag_id)).scalars())
-        assert serialized_dag_ids == {
-            "test_example_bash_operator",
-            "test_dag_with_no_tags",
-            "test_sensor",
-            "test_dag_reserialize",
-        }
+        assert serialized_dag_ids == {"test_example_bash_operator", "test_dag_with_no_tags", "test_sensor"}
 
         example_bash_op = session.execute(
             select(DagModel).where(DagModel.dag_id == "test_example_bash_operator")
@@ -1084,14 +1078,15 @@ class TestCliDagsReserialize:
         from airflow.sdk.execution_time.comms import _RequestFrame, _ResponseFrame
         from airflow.serialization.serialized_objects import DagSerialization, LazyDeserializedDAG
 
-        with configure_dag_bundles(self.test_bundles_config):
+        bundles = {"bundle_reserialize": TEST_DAGS_FOLDER / "test_dag_reserialize.py"}
+        with configure_dag_bundles(bundles):
             dag_command.dag_reserialize(
-                self.parser.parse_args(["dags", "reserialize", "--bundle-name", "bundle4"])
+                self.parser.parse_args(["dags", "reserialize", "--bundle-name", "bundle_reserialize"])
             )
 
-        dagbag = DagBag(self.test_bundles_config["bundle4"], bundle_path=self.test_bundles_config["bundle4"])
+        dagbag = DagBag(bundles["bundle_reserialize"], bundle_path=bundles["bundle_reserialize"])
         dag_parsing_result = DagFileParsingResult(
-            fileloc=self.test_bundles_config["bundle4"].name,
+            fileloc=bundles["bundle_reserialize"].name,
             serialized_dags=[
                 LazyDeserializedDAG(data=DagSerialization.to_dict(dag)) for dag in dagbag.dags.values()
             ],

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -25,6 +25,7 @@ from datetime import datetime, timedelta
 from unittest import mock
 from unittest.mock import MagicMock
 
+import msgspec
 import pendulum
 import pytest
 import time_machine
@@ -42,6 +43,7 @@ from airflow.models.serialized_dag import SerializedDagModel
 from airflow.providers.standard.triggers.temporal import DateTimeTrigger, TimeDeltaTrigger
 from airflow.sdk import DAG, BaseOperator, task
 from airflow.sdk.definitions.dag import _run_inline_trigger
+from airflow.sdk.execution_time.comms import _RequestFrame, _ResponseFrame
 from airflow.serialization.serialized_objects import DagSerialization
 from airflow.triggers.base import TriggerEvent
 from airflow.utils.session import create_session
@@ -1079,7 +1081,8 @@ class TestCliDagsReserialize:
         assert serialized_dag_ids == {"test_example_bash_operator", "test_sensor"}
 
     @conf_vars({("core", "load_examples"): "false"})
-    def test_reserialize_should_make_equal_hash(self, configure_dag_bundles, session):
+    def test_reserialize_should_make_equal_hash_with_dag_processor(self, configure_dag_bundles, session):
+        from airflow.dag_processing.processor import DagFileParsingResult, DagFileProcessorProcess
         from airflow.serialization.serialized_objects import LazyDeserializedDAG
 
         with configure_dag_bundles(self.test_bundles_config):
@@ -1088,13 +1091,22 @@ class TestCliDagsReserialize:
             )
 
         dagbag = DagBag(self.test_bundles_config["bundle4"], bundle_path=self.test_bundles_config["bundle4"])
-        dag_hashes = set(
-            [LazyDeserializedDAG(data=DagSerialization.to_dict(dag)).hash for dag in dagbag.dags.values()]
+        dag_parsing_result = DagFileParsingResult(
+            fileloc=self.test_bundles_config["bundle4"].name,
+            serialized_dags=[
+                LazyDeserializedDAG(data=DagSerialization.to_dict(dag)) for dag in dagbag.dags.values()
+            ],
         )
 
-        serialized_dag_hash = set(session.execute(select(SerializedDagModel.dag_hash)).scalars())
+        frame = _ResponseFrame(id=0, body=dag_parsing_result.model_dump()).as_bytes()
+        request_frame = msgspec.msgpack.Decoder[_RequestFrame](_RequestFrame).decode(frame[4:])
+        dag_processor_parsing_result = DagFileProcessorProcess.decoder.validate_python(request_frame.body)
 
-        assert dag_hashes == serialized_dag_hash
+        serialized_dag_hash = list(session.execute(select(SerializedDagModel.dag_hash)).scalars())
+
+        assert len(dag_processor_parsing_result.serialized_dags) == 1
+        assert len(serialized_dag_hash) == 1
+        assert dag_processor_parsing_result.serialized_dags[0].hash == serialized_dag_hash[0]
 
 
 class TestDagDetailsIsBackfillable:

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -36,6 +36,7 @@ from airflow._shared.timezones import timezone
 from airflow.cli import cli_parser
 from airflow.cli.commands import dag_command
 from airflow.dag_processing.dagbag import DagBag, sync_bag_to_db
+from airflow.dag_processing.processor import DagFileParsingResult, DagFileProcessorProcess
 from airflow.exceptions import AirflowException
 from airflow.models import DagModel, DagRun
 from airflow.models.dagbag import DBDagBag
@@ -43,6 +44,8 @@ from airflow.models.serialized_dag import SerializedDagModel
 from airflow.providers.standard.triggers.temporal import DateTimeTrigger, TimeDeltaTrigger
 from airflow.sdk import DAG, BaseOperator, task
 from airflow.sdk.definitions.dag import _run_inline_trigger
+from airflow.sdk.execution_time.comms import _RequestFrame, _ResponseFrame
+from airflow.serialization.serialized_objects import DagSerialization, LazyDeserializedDAG
 from airflow.triggers.base import TriggerEvent
 from airflow.utils.session import create_session
 from airflow.utils.state import DagRunState
@@ -1074,10 +1077,6 @@ class TestCliDagsReserialize:
 
     @conf_vars({("core", "load_examples"): "false"})
     def test_reserialize_should_make_equal_hash_with_dag_processor(self, configure_dag_bundles, session):
-        from airflow.dag_processing.processor import DagFileParsingResult, DagFileProcessorProcess
-        from airflow.sdk.execution_time.comms import _RequestFrame, _ResponseFrame
-        from airflow.serialization.serialized_objects import DagSerialization, LazyDeserializedDAG
-
         bundles = {"bundle_reserialize": TEST_DAGS_FOLDER / "test_dag_reserialize.py"}
         with configure_dag_bundles(bundles):
             dag_command.dag_reserialize(

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -42,6 +42,7 @@ from airflow.models.serialized_dag import SerializedDagModel
 from airflow.providers.standard.triggers.temporal import DateTimeTrigger, TimeDeltaTrigger
 from airflow.sdk import DAG, BaseOperator, task
 from airflow.sdk.definitions.dag import _run_inline_trigger
+from airflow.serialization.serialized_objects import DagSerialization
 from airflow.triggers.base import TriggerEvent
 from airflow.utils.session import create_session
 from airflow.utils.state import DagRunState
@@ -1026,6 +1027,7 @@ class TestCliDagsReserialize:
         "bundle1": TEST_DAGS_FOLDER / "test_example_bash_operator.py",
         "bundle2": TEST_DAGS_FOLDER / "test_sensor.py",
         "bundle3": TEST_DAGS_FOLDER / "test_dag_with_no_tags.py",
+        "bundle4": TEST_DAGS_FOLDER / "test_dag_reserialize.py",
     }
 
     @classmethod
@@ -1041,7 +1043,12 @@ class TestCliDagsReserialize:
             dag_command.dag_reserialize(self.parser.parse_args(["dags", "reserialize"]))
 
         serialized_dag_ids = set(session.execute(select(SerializedDagModel.dag_id)).scalars())
-        assert serialized_dag_ids == {"test_example_bash_operator", "test_dag_with_no_tags", "test_sensor"}
+        assert serialized_dag_ids == {
+            "test_example_bash_operator",
+            "test_dag_with_no_tags",
+            "test_sensor",
+            "test_dag_reserialize",
+        }
 
         example_bash_op = session.execute(
             select(DagModel).where(DagModel.dag_id == "test_example_bash_operator")
@@ -1070,6 +1077,24 @@ class TestCliDagsReserialize:
 
         serialized_dag_ids = set(session.execute(select(SerializedDagModel.dag_id)).scalars())
         assert serialized_dag_ids == {"test_example_bash_operator", "test_sensor"}
+
+    @conf_vars({("core", "load_examples"): "false"})
+    def test_reserialize_should_make_equal_hash(self, configure_dag_bundles, session):
+        from airflow.serialization.serialized_objects import LazyDeserializedDAG
+
+        with configure_dag_bundles(self.test_bundles_config):
+            dag_command.dag_reserialize(
+                self.parser.parse_args(["dags", "reserialize", "--bundle-name", "bundle4"])
+            )
+
+        dagbag = DagBag(self.test_bundles_config["bundle4"], bundle_path=self.test_bundles_config["bundle4"])
+        dag_hashes = set(
+            [LazyDeserializedDAG(data=DagSerialization.to_dict(dag)).hash for dag in dagbag.dags.values()]
+        )
+
+        serialized_dag_hash = set(session.execute(select(SerializedDagModel.dag_hash)).scalars())
+
+        assert dag_hashes == serialized_dag_hash
 
 
 class TestDagDetailsIsBackfillable:

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -43,8 +43,6 @@ from airflow.models.serialized_dag import SerializedDagModel
 from airflow.providers.standard.triggers.temporal import DateTimeTrigger, TimeDeltaTrigger
 from airflow.sdk import DAG, BaseOperator, task
 from airflow.sdk.definitions.dag import _run_inline_trigger
-from airflow.sdk.execution_time.comms import _RequestFrame, _ResponseFrame
-from airflow.serialization.serialized_objects import DagSerialization
 from airflow.triggers.base import TriggerEvent
 from airflow.utils.session import create_session
 from airflow.utils.state import DagRunState
@@ -1083,7 +1081,8 @@ class TestCliDagsReserialize:
     @conf_vars({("core", "load_examples"): "false"})
     def test_reserialize_should_make_equal_hash_with_dag_processor(self, configure_dag_bundles, session):
         from airflow.dag_processing.processor import DagFileParsingResult, DagFileProcessorProcess
-        from airflow.serialization.serialized_objects import LazyDeserializedDAG
+        from airflow.sdk.execution_time.comms import _RequestFrame, _ResponseFrame
+        from airflow.serialization.serialized_objects import DagSerialization, LazyDeserializedDAG
 
         with configure_dag_bundles(self.test_bundles_config):
             dag_command.dag_reserialize(

--- a/airflow-core/tests/unit/dags/test_dag_reserialize.py
+++ b/airflow-core/tests/unit/dags/test_dag_reserialize.py
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from datetime import datetime
+from time import sleep
+
+from airflow.providers.standard.operators.python import PythonOperator
+from airflow.sdk import DAG
+
+
+def sleep_task():
+    sleep(1)
+
+
+with DAG(
+    "test_dag_reserialize",
+    start_date=datetime(2026, 1, 20),
+    schedule="* * * * *",
+    catchup=False,
+    max_active_runs=1,
+) as dag:
+    task_b = PythonOperator(task_id="bear", python_callable=sleep_task)

--- a/airflow-core/tests/unit/dags/test_dag_reserialize.py
+++ b/airflow-core/tests/unit/dags/test_dag_reserialize.py
@@ -17,14 +17,13 @@
 from __future__ import annotations
 
 from datetime import datetime
-from time import sleep
 
 from airflow.providers.standard.operators.python import PythonOperator
 from airflow.sdk import DAG
 
 
-def sleep_task():
-    sleep(1)
+def empty_task():
+    pass
 
 
 with DAG(
@@ -34,4 +33,4 @@ with DAG(
     catchup=False,
     max_active_runs=1,
 ) as dag:
-    task_b = PythonOperator(task_id="bear", python_callable=sleep_task)
+    task_b = PythonOperator(task_id="bear", python_callable=empty_task)


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/60868

## Reason the Issue occurs?
To summarize the issue: when dag_parsing occurs, there is no increase in the Dag version, but when the command `airflow dags reserialize` is executed, an increase in the Dag version is observed.

For the following Dag, I confirmed that the hash result from parsing in the dag_processor differs from the hash result through the airflow command. Upon checking the serialized values, I found that the order of the following two fields was different:
```
// dag_processor
'task_group': {
    "children": {
  	"bear": ["bear", "operator"]
    }
}

// airflow command
'task_group': {
    "children": {
  	"bear": ["operator", "bear"]
    }
}
```

I understood that sorting should be applied to the values, so I needed to investigate the cause of this discrepancy.

## Deep Dive

Initially, I checked whether there were differences in the logic between the dag_processor and the airflow command parsing logic, but they were identical. Therefore, I logged and compared the serialize_dag before sorting was applied.
the location of each logging is here ( [dag_data](https://github.com/apache/airflow/blob/3.1.6/airflow-core/src/airflow/models/serialized_dag.py#L342,) [data_](https://github.com/apache/airflow/blob/3.1.6/airflow-core/src/airflow/models/serialized_dag.py#L344,) [data_json](https://github.com/apache/airflow/blob/3.1.6/airflow-core/src/airflow/models/serialized_dag.py#L350))

```
// serialized dag from airflow dags command 
'children': {'bear': (<DagAttributeTypes.OP: 'operator'>, 'bear')} 
// state after sorting dict
'children': {'bear': (<DagAttributeTypes.OP: 'operator'>, 'bear')} 
// state after json.loads in here
'children': {'bear': ['operator', 'bear']}

// serialized dag from dag_processor
'children': {'bear': ['operator', 'bear']}
// state after sorting dict
'children': {'bear': ['bear', 'operator']}
// state after json.loads in here
'children': {'bear': ['bear', 'operator']}
```

The parsing results were different from the start. In fact, the Dag parsing result should match what's generated from the airflow dags command. However, I inferred that in the dag_processor, the format was changed during the dumps process of the model for inter-subprocess communication.

I confirmed that the result from the airflow dags command was also changed to match the dag_processor format after json.loads was applied (enum -> str, tuple -> list).

Ironically, the dag_processor, where the format was changed, had sorting applied correctly, while the airflow dags command did not, resulting in the discrepancy between the two.

## Solution

~~The standard solution would be to control the values that change in the dag_processor, but this appears to be impossible with the current approach. Therefore, I modified the existing task_group serialization method to align with the dag_processor's format.~~

I did not modify the serialize logic to maintain logic consistency. Instead, I modified the sorting logic for generating hash values so that sorting is also applied to tuple values.

I confirmed that applying sorted to a tuple of enum and str, such as `(<DagAttributeTypes.OP: 'operator'>, 'bear')`, applies sorting the same way as with strings. `('bear', (<DagAttributeTypes.OP: 'operator'>, 'bear'))` Therefore, the hash result values are generated identically.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
