### PR TITLE
Re-enable missing metric: dag_processing.last_duration.<dag_file>

### DIFF
--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -1195,10 +1195,11 @@ def process_parse_results(
             run_count=run_count + 1,
         )
 
-    # TODO: AIP-66 emit metrics
-    # file_name = Path(dag_file.path).stem
-    # Stats.timing(f"dag_processing.last_duration.{file_name}", stat.last_duration)
-    # Stats.timing("dag_processing.last_duration", stat.last_duration, tags={"file_name": file_name})
+    # Note: relative_fileloc has a None default. In practice it is always provided but code defensively here in case
+    if relative_fileloc is not None and stat.last_duration is not None:
+        file_name = Path(relative_fileloc).stem
+        Stats.timing(f"dag_processing.last_duration.{file_name}", stat.last_duration)
+        Stats.timing("dag_processing.last_duration", stat.last_duration, tags={"file_name": file_name})
 
     if parsing_result is None:
         # No DAGs were parsed - this happens for callback-only processing

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -45,7 +45,7 @@ from sqlalchemy.orm import load_only
 from tabulate import tabulate
 from uuid6 import uuid7
 
-from airflow._shared.observability.metrics.stats import Stats
+from airflow._shared.observability.metrics.stats import Stats, normalize_name_for_stats
 from airflow._shared.timezones import timezone
 from airflow.api_fastapi.execution_api.app import InProcessExecutionAPI
 from airflow.configuration import conf
@@ -1197,9 +1197,16 @@ def process_parse_results(
 
     # Note: relative_fileloc has a None default. In practice it is always provided but code defensively here in case
     if relative_fileloc is not None and stat.last_duration is not None:
-        file_name = Path(relative_fileloc).stem
-        Stats.timing(f"dag_processing.last_duration.{file_name}", stat.last_duration)
-        Stats.timing("dag_processing.last_duration", stat.last_duration, tags={"file_name": file_name})
+        # Normalize names to ensure they only contain valid characters for stats (alphanumeric, underscore, dot, dash)
+        file_name = normalize_name_for_stats(Path(relative_fileloc).stem)
+        # bundle_name is included to distinguish files with the same name across different bundles
+        normalized_bundle = normalize_name_for_stats(bundle_name)
+        Stats.timing(f"dag_processing.last_duration.{normalized_bundle}.{file_name}", stat.last_duration)
+        Stats.timing(
+            "dag_processing.last_duration",
+            stat.last_duration,
+            tags={"file_name": file_name, "bundle_name": normalized_bundle},
+        )
 
     if parsing_result is None:
         # No DAGs were parsed - this happens for callback-only processing

--- a/airflow-core/src/airflow/models/pool.py
+++ b/airflow-core/src/airflow/models/pool.py
@@ -18,13 +18,13 @@
 from __future__ import annotations
 
 import logging
-import re
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, TypedDict
 
 from sqlalchemy import Boolean, ForeignKey, Integer, String, Text, func, select
 from sqlalchemy.orm import Mapped
 
+from airflow._shared.observability.metrics.stats import normalize_name_for_stats
 from airflow.exceptions import AirflowException, PoolNotFound
 from airflow.models.base import Base
 from airflow.ti_deps.dependencies_states import EXECUTION_STATES
@@ -39,33 +39,26 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_VALID_POOL_NAME_CHARS_RE = re.compile(r"^[a-zA-Z0-9_.-]+$")
-_INVALID_POOL_NAME_CHARS_RE = re.compile(r"[^a-zA-Z0-9_.-]")
-
 
 def normalize_pool_name_for_stats(name: str) -> str:
     """
     Normalize pool name for stats reporting by replacing invalid characters.
 
-    Stats names must only contain ASCII alphabets, numbers, underscores, dots, and dashes.
-    Invalid characters are replaced with underscores.
+    This is a convenience wrapper around normalize_name_for_stats that provides
+    a pool-specific warning message.
 
     :param name: The pool name to normalize
     :return: Normalized pool name safe for stats reporting
     """
-    if _VALID_POOL_NAME_CHARS_RE.match(name):
-        return name
-
-    normalized = _INVALID_POOL_NAME_CHARS_RE.sub("_", name)
-
-    logger.warning(
-        "Pool name '%s' contains invalid characters for stats reporting. "
-        "Reporting stats with normalized name '%s'. "
-        "Consider renaming the pool to avoid this warning.",
-        name,
-        normalized,
-    )
-
+    normalized = normalize_name_for_stats(name, log_warning=False)
+    if normalized != name:
+        logger.warning(
+            "Pool name '%s' contains invalid characters for stats reporting. "
+            "Reporting stats with normalized name '%s'. "
+            "Consider renaming the pool to avoid this warning.",
+            name,
+            normalized,
+        )
     return normalized
 
 

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -717,7 +717,6 @@ class TestDagFileProcessorManager:
 
     @conf_vars({("core", "load_examples"): "False"})
     @mock.patch("airflow.dag_processing.manager.Stats.timing")
-    @pytest.mark.skip("AIP-66: stats are not implemented yet")
     def test_send_file_processing_statsd_timing(
         self, statsd_timing_mock, tmp_path, configure_testing_dag_bundle
     ):
@@ -734,7 +733,12 @@ class TestDagFileProcessorManager:
             manager = DagFileProcessorManager(max_runs=1)
             manager.run()
 
-        last_runtime = manager._file_stats[os.fspath(path_to_parse)].last_duration
+        file_info = DagFileInfo(
+            bundle_name="testing",
+            rel_path=Path("temp_dag.py"),
+            bundle_path=tmp_path,
+        )
+        last_runtime = manager._file_stats[file_info].last_duration
         statsd_timing_mock.assert_has_calls(
             [
                 mock.call("dag_processing.last_duration.temp_dag", last_runtime),

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -720,7 +720,8 @@ class TestDagFileProcessorManager:
     def test_send_file_processing_statsd_timing(
         self, statsd_timing_mock, tmp_path, configure_testing_dag_bundle
     ):
-        path_to_parse = tmp_path / "temp_dag.py"
+        dag_filename = "temp_dag.py"
+        path_to_parse = tmp_path / dag_filename
         dag_code = textwrap.dedent(
             """
             from airflow import DAG
@@ -733,9 +734,10 @@ class TestDagFileProcessorManager:
             manager = DagFileProcessorManager(max_runs=1)
             manager.run()
 
+        bundle_name = "testing"
         file_info = DagFileInfo(
-            bundle_name="testing",
-            rel_path=Path("temp_dag.py"),
+            bundle_name=bundle_name,
+            rel_path=Path(dag_filename),
             bundle_path=tmp_path,
         )
         last_runtime = manager._file_stats[file_info].last_duration
@@ -745,7 +747,7 @@ class TestDagFileProcessorManager:
                 mock.call(
                     "dag_processing.last_duration",
                     last_runtime,
-                    tags={"file_name": "temp_dag", "bundle_name": "testing"},
+                    tags={"file_name": dag_filename[:-3], "bundle_name": bundle_name},
                 ),
             ],
             any_order=True,

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -741,8 +741,12 @@ class TestDagFileProcessorManager:
         last_runtime = manager._file_stats[file_info].last_duration
         statsd_timing_mock.assert_has_calls(
             [
-                mock.call("dag_processing.last_duration.temp_dag", last_runtime),
-                mock.call("dag_processing.last_duration", last_runtime, tags={"file_name": "temp_dag"}),
+                mock.call("dag_processing.last_duration.testing.temp_dag", last_runtime),
+                mock.call(
+                    "dag_processing.last_duration",
+                    last_runtime,
+                    tags={"file_name": "temp_dag", "bundle_name": "testing"},
+                ),
             ],
             any_order=True,
         )

--- a/shared/observability/src/airflow_shared/observability/metrics/stats.py
+++ b/shared/observability/src/airflow_shared/observability/metrics/stats.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import socket
 from collections.abc import Callable
 from typing import TYPE_CHECKING
@@ -28,6 +29,36 @@ if TYPE_CHECKING:
     from .base_stats_logger import StatsLogger
 
 log = logging.getLogger(__name__)
+
+_VALID_STAT_NAME_CHARS_RE = re.compile(r"^[a-zA-Z0-9_.-]+$")
+_INVALID_STAT_NAME_CHARS_RE = re.compile(r"[^a-zA-Z0-9_.-]")
+
+
+def normalize_name_for_stats(name: str, log_warning: bool = True) -> str:
+    """
+    Normalize a name for stats reporting by replacing invalid characters.
+
+    Stats names must only contain ASCII alphabets, numbers, underscores, dots, and dashes.
+    Invalid characters are replaced with underscores.
+
+    :param name: The name to normalize
+    :param log_warning: Whether to log a warning when normalization occurs
+    :return: Normalized name safe for stats reporting
+    """
+    if _VALID_STAT_NAME_CHARS_RE.match(name):
+        return name
+
+    normalized = _INVALID_STAT_NAME_CHARS_RE.sub("_", name)
+
+    if log_warning:
+        log.warning(
+            "Name '%s' contains invalid characters for stats reporting. "
+            "Reporting stats with normalized name '%s'.",
+            name,
+            normalized,
+        )
+
+    return normalized
 
 
 class _Stats(type):


### PR DESCRIPTION
This metric was intentionally disabled during AIP-66 development. These changes bring the metric back using relative_fileloc instead of dag_path.file

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
Cline - Claude Opus 4.5

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
