### PR TITLE
Remove unused method `is_default_pool` in Pool model

### DIFF
--- a/airflow-core/src/airflow/models/pool.py
+++ b/airflow-core/src/airflow/models/pool.py
@@ -28,7 +28,6 @@ from sqlalchemy.orm import Mapped
 from airflow.exceptions import AirflowException, PoolNotFound
 from airflow.models.base import Base
 from airflow.ti_deps.dependencies_states import EXECUTION_STATES
-from airflow.utils.db import exists_query
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.sqlalchemy import mapped_column, with_row_locks
 from airflow.utils.state import TaskInstanceState
@@ -128,22 +127,6 @@ class Pool(Base):
         :return: the pool object
         """
         return Pool.get_pool(Pool.DEFAULT_POOL_NAME, session=session)
-
-    @staticmethod
-    @provide_session
-    def is_default_pool(id: int, session: Session = NEW_SESSION) -> bool:
-        """
-        Check id if is the default_pool.
-
-        :param id: pool id
-        :param session: SQLAlchemy ORM Session
-        :return: True if id is default_pool, otherwise False
-        """
-        return exists_query(
-            Pool.id == id,
-            Pool.pool == Pool.DEFAULT_POOL_NAME,
-            session=session,
-        )
 
     @staticmethod
     @provide_session

--- a/airflow-core/tests/unit/models/test_pool.py
+++ b/airflow-core/tests/unit/models/test_pool.py
@@ -320,14 +320,6 @@ class TestPool:
         with pytest.raises(AirflowException, match="^default_pool cannot be deleted$"):
             Pool.delete_pool(Pool.DEFAULT_POOL_NAME)
 
-    def test_is_default_pool(self):
-        pool = Pool.create_or_update_pool(
-            name="not_default_pool", slots=1, description="test", include_deferred=False
-        )
-        default_pool = Pool.get_default_pool()
-        assert not Pool.is_default_pool(id=pool.id)
-        assert Pool.is_default_pool(str(default_pool.id))
-
     def test_get_team_name(self, testing_team: Team, session: Session):
         pool = Pool(pool="test", include_deferred=False, team_name=testing_team.name)
         session.add(pool)


### PR DESCRIPTION
While working on pools, I found out this method is unused in the codebase.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
