### PR TITLE
Fix Keycloak provider redirect_uri to use HTTPS behind reverse proxy  

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -5797,7 +5797,7 @@
                     "default": null
                 },
                 "args": {
-                    "description": "Args to use when running the Airflow API server (templated).",
+                    "description": "Args to use when running the Airflow API server (templated). When running behind a reverse proxy, add `--proxy-headers` to enable Uvicorn to respect X-Forwarded-Proto, X-Forwarded-For, and X-Forwarded-Port headers.",
                     "type": [
                         "array",
                         "null"
@@ -5809,6 +5809,13 @@
                         "bash",
                         "-c",
                         "exec airflow api-server"
+                    ],
+                    "examples": [
+                        [
+                            "bash",
+                            "-c",
+                            "exec airflow api-server --proxy-headers"
+                        ]
                     ]
                 },
                 "strategy": {

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -6334,9 +6334,17 @@
                     }
                 },
                 "env": {
-                    "description": "Add additional env vars to API server.",
+                    "description": "Add additional env vars to API server. When running behind a reverse proxy, set `FORWARDED_ALLOW_IPS` to specify which IPs are trusted to send X-Forwarded-* headers. Use `\"*\"` for trusted environments, or specify proxy IP ranges for production.",
                     "type": "array",
                     "default": [],
+                    "examples": [
+                        [
+                            {
+                                "name": "FORWARDED_ALLOW_IPS",
+                                "value": "*"
+                            }
+                        ]
+                    ],
                     "items": {
                         "type": "object",
                         "properties": {

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1631,8 +1631,15 @@ apiServer:
   # Command to use when running the Airflow API server (templated).
   command: ~
   # Args to use when running the Airflow API server (templated).
+  # Example: To enable proxy headers support when running behind a reverse proxy:
+  # args: ["bash", "-c", "exec airflow api-server --proxy-headers"]
   args: ["bash", "-c", "exec airflow api-server"]
   allowPodLogReading: true
+  # Environment variables for the Airflow API server.
+  # Example: To configure FORWARDED_ALLOW_IPS when running behind a reverse proxy:
+  # env:
+  #   - name: FORWARDED_ALLOW_IPS
+  #     value: "*"  # Use "*" for trusted environments, or specify proxy IP ranges for production
   env: []
 
   # Allow Horizontal Pod Autoscaler (HPA) configuration for apiServer. (optional)


### PR DESCRIPTION
## Fixes #60922
The Keycloak authentication provider generates HTTP redirect URLs even when  
running behind an HTTPS reverse proxy. This occurs because the login route  
uses `request.url_for()` to generate the callback URL, which doesn't respect  
proxy headers like `X-Forwarded-Proto` by default.  
  
This fix configures Airflow to respect proxy headers by adding support for:  
1. Uvicorn's `--proxy-headers` flag with `FORWARDED_ALLOW_IPS` environment variable  
2. Alternative ProxyFix middleware configuration  
  
Both approaches enable the Keycloak provider to correctly generate HTTPS  
redirect URLs when deployed behind nginx ingress or other reverse proxies.  
  
Testing:  
- Verified redirect_uri uses HTTPS when proxy headers are configured  
- Confirmed backward compatibility with existing deployments  