### PR TITLE
Revert "Chart gitsync vars (#56245)"

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -255,31 +255,27 @@ If release name contains chart name it will be used as a full name.
     - name: GITSYNC_SSH_KNOWN_HOSTS
       value: "false"
     {{- end }}
-    {{- else if .Values.dags.gitSync.credentialsSecret }}
-    {{- $tag := trimPrefix "v" .Values.images.gitSync.tag }}
-    {{- if or (eq $tag "latest") (semverCompare ">=4.0.0" $tag) }}
-    - name: GITSYNC_USERNAME
-      valueFrom:
-        secretKeyRef:
-          name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
-          key: GITSYNC_USERNAME
-    - name: GITSYNC_PASSWORD
-      valueFrom:
-        secretKeyRef:
-          name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
-          key: GITSYNC_PASSWORD
-    {{- else }}
+    {{ else if .Values.dags.gitSync.credentialsSecret }}
     - name: GIT_SYNC_USERNAME
       valueFrom:
         secretKeyRef:
           name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
           key: GIT_SYNC_USERNAME
+    - name: GITSYNC_USERNAME
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
+          key: GITSYNC_USERNAME
     - name: GIT_SYNC_PASSWORD
       valueFrom:
         secretKeyRef:
           name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
           key: GIT_SYNC_PASSWORD
-    {{- end }}
+    - name: GITSYNC_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
+          key: GITSYNC_PASSWORD
     {{- end }}
     - name: GIT_SYNC_REV
       value: {{ .Values.dags.gitSync.rev | quote }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -124,9 +124,6 @@ images:
   gitSync:
     repository: registry.k8s.io/git-sync/git-sync
     tag: v4.4.2
-    # NOTE:
-    # - If the tag is "v3.x.x" or any version < 4.0.0 - use GIT_SYNC_* env variables
-    # - If the tag is "v4.x.x" or "latest" - use GITSYNC_* env variables
     pullPolicy: IfNotPresent
 
 # Select certain nodes for airflow pods.

--- a/helm-tests/tests/helm_tests/airflow_aux/test_pod_template_file.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_pod_template_file.py
@@ -254,15 +254,7 @@ class TestPodTemplateFile:
             "readOnly": True,
         } in jmespath.search("spec.initContainers[0].volumeMounts", docs[0])
 
-    @pytest.mark.parametrize(
-        ("tag", "expected_prefix"),
-        [
-            ("v3.6.7", "GIT_SYNC_"),
-            ("v4.4.2", "GITSYNC_"),
-            ("latest", "GITSYNC_"),
-        ],
-    )
-    def test_should_set_username_and_pass_env_variables(self, tag, expected_prefix):
+    def test_should_set_username_and_pass_env_variables(self):
         docs = render_chart(
             values={
                 "dags": {
@@ -271,28 +263,30 @@ class TestPodTemplateFile:
                         "credentialsSecret": "user-pass-secret",
                         "sshKeySecret": None,
                     }
-                },
-                "images": {
-                    "gitSync": {
-                        "tag": tag,
-                    }
-                },
+                }
             },
             show_only=["templates/pod-template-file.yaml"],
             chart_dir=self.temp_chart_dir,
         )
 
-        envs = jmespath.search("spec.initContainers[0].env", docs[0])
-
         assert {
-            "name": f"{expected_prefix}USERNAME",
-            "valueFrom": {"secretKeyRef": {"name": "user-pass-secret", "key": f"{expected_prefix}USERNAME"}},
-        } in envs
-
+            "name": "GIT_SYNC_USERNAME",
+            "valueFrom": {"secretKeyRef": {"name": "user-pass-secret", "key": "GIT_SYNC_USERNAME"}},
+        } in jmespath.search("spec.initContainers[0].env", docs[0])
         assert {
-            "name": f"{expected_prefix}PASSWORD",
-            "valueFrom": {"secretKeyRef": {"name": "user-pass-secret", "key": f"{expected_prefix}PASSWORD"}},
-        } in envs
+            "name": "GIT_SYNC_PASSWORD",
+            "valueFrom": {"secretKeyRef": {"name": "user-pass-secret", "key": "GIT_SYNC_PASSWORD"}},
+        } in jmespath.search("spec.initContainers[0].env", docs[0])
+
+        # Testing git-sync v4
+        assert {
+            "name": "GITSYNC_USERNAME",
+            "valueFrom": {"secretKeyRef": {"name": "user-pass-secret", "key": "GITSYNC_USERNAME"}},
+        } in jmespath.search("spec.initContainers[0].env", docs[0])
+        assert {
+            "name": "GITSYNC_PASSWORD",
+            "valueFrom": {"secretKeyRef": {"name": "user-pass-secret", "key": "GITSYNC_PASSWORD"}},
+        } in jmespath.search("spec.initContainers[0].env", docs[0])
 
     def test_should_set_the_dags_volume_claim_correctly_when_using_an_existing_claim(self):
         docs = render_chart(

--- a/helm-tests/tests/helm_tests/other/test_git_sync_scheduler.py
+++ b/helm-tests/tests/helm_tests/other/test_git_sync_scheduler.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import jmespath
-import pytest
 from chart_utils.helm_template_generator import render_chart
 
 
@@ -267,15 +266,7 @@ class TestGitSyncSchedulerTest:
         )
         assert "git-sync-ssh-key" not in jmespath.search("spec.template.spec.volumes[].name", docs[0])
 
-    @pytest.mark.parametrize(
-        ("tag", "expected_prefix"),
-        [
-            ("v3.6.7", "GIT_SYNC_"),
-            ("v4.4.2", "GITSYNC_"),
-            ("latest", "GITSYNC_"),
-        ],
-    )
-    def test_should_set_username_and_pass_env_variables_in_scheduler(self, tag, expected_prefix):
+    def test_should_set_username_and_pass_env_variables(self):
         docs = render_chart(
             values={
                 "airflowVersion": "2.10.5",
@@ -286,26 +277,28 @@ class TestGitSyncSchedulerTest:
                         "sshKeySecret": None,
                     }
                 },
-                "images": {
-                    "gitSync": {
-                        "tag": tag,
-                    }
-                },
             },
             show_only=["templates/scheduler/scheduler-deployment.yaml"],
         )
 
-        envs = jmespath.search("spec.template.spec.containers[1].env", docs[0])
-
         assert {
-            "name": f"{expected_prefix}USERNAME",
-            "valueFrom": {"secretKeyRef": {"name": "user-pass-secret", "key": f"{expected_prefix}USERNAME"}},
-        } in envs
-
+            "name": "GIT_SYNC_USERNAME",
+            "valueFrom": {"secretKeyRef": {"name": "user-pass-secret", "key": "GIT_SYNC_USERNAME"}},
+        } in jmespath.search("spec.template.spec.containers[1].env", docs[0])
         assert {
-            "name": f"{expected_prefix}PASSWORD",
-            "valueFrom": {"secretKeyRef": {"name": "user-pass-secret", "key": f"{expected_prefix}PASSWORD"}},
-        } in envs
+            "name": "GIT_SYNC_PASSWORD",
+            "valueFrom": {"secretKeyRef": {"name": "user-pass-secret", "key": "GIT_SYNC_PASSWORD"}},
+        } in jmespath.search("spec.template.spec.containers[1].env", docs[0])
+
+        # Testing git-sync v4
+        assert {
+            "name": "GITSYNC_USERNAME",
+            "valueFrom": {"secretKeyRef": {"name": "user-pass-secret", "key": "GITSYNC_USERNAME"}},
+        } in jmespath.search("spec.template.spec.containers[1].env", docs[0])
+        assert {
+            "name": "GITSYNC_PASSWORD",
+            "valueFrom": {"secretKeyRef": {"name": "user-pass-secret", "key": "GITSYNC_PASSWORD"}},
+        } in jmespath.search("spec.template.spec.containers[1].env", docs[0])
 
     def test_should_set_the_volume_claim_correctly_when_using_an_existing_claim(self):
         docs = render_chart(


### PR DESCRIPTION
This reverts commit d0da0c02046260a652ca4506a29fa454f197f261.

Reverts #56245, as we can't safely use the tag to determine the version. Since we will be dropping support for 3 in the next release anyways, we will just keep it as-is for 1 more release.


Alternative of #61027

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: Cursor (Gemini 3 Pro)
