### PR TITLE
Add integration tests for config sensitive masking in airflowctl

### DIFF
--- a/airflow-ctl-tests/tests/airflowctl_tests/conftest.py
+++ b/airflow-ctl-tests/tests/airflowctl_tests/conftest.py
@@ -20,6 +20,7 @@ import os
 import subprocess
 import sys
 
+import pytest
 from python_on_whales import DockerClient, docker
 
 from airflowctl_tests import console
@@ -27,9 +28,81 @@ from airflowctl_tests.constants import (
     AIRFLOW_ROOT_PATH,
     DOCKER_COMPOSE_FILE_PATH,
     DOCKER_IMAGE,
+    LOGIN_COMMAND,
+    LOGIN_OUTPUT,
 )
 
 from tests_common.test_utils.fernet import generate_fernet_key_string
+
+
+@pytest.fixture
+def run_command():
+    """Fixture that provides a helper to run airflowctl commands."""
+
+    def _run_command(command: str, skip_login: bool = False) -> str:
+        import os
+        from subprocess import PIPE, STDOUT, Popen
+
+        host_envs = os.environ.copy()
+        host_envs["AIRFLOW_CLI_DEBUG_MODE"] = "true"
+
+        command_from_config = f"airflowctl {command}"
+
+        # We need to run auth login first for all commands except login itself (unless skipped)
+        if not skip_login and command != LOGIN_COMMAND:
+            run_cmd = f"airflowctl {LOGIN_COMMAND} && {command_from_config}"
+        else:
+            run_cmd = command_from_config
+
+        console.print(f"[yellow]Running command: {command}")
+
+        # Give some time for the command to execute and output to be ready
+        proc = Popen(run_cmd.encode(), stdout=PIPE, stderr=STDOUT, stdin=PIPE, shell=True, env=host_envs)
+        stdout_bytes, stderr_result = proc.communicate(timeout=60)
+
+        # CLI command gave errors
+        assert not stderr_result, f"Errors while executing command '{command_from_config}':\n{stderr_result.decode()}"
+
+        # Decode the output
+        stdout_result = stdout_bytes.decode()
+
+        # We need to trim auth login output if the command is not login itself and clean backspaces
+        if not skip_login and command != LOGIN_COMMAND:
+            assert (
+                LOGIN_OUTPUT in stdout_result
+            ), f"❌ Login output not found before command output for '{command_from_config}'\nFull output:\n{stdout_result}"
+            stdout_result = stdout_result.split(f"{LOGIN_OUTPUT}\n")[1].strip()
+        else:
+            stdout_result = stdout_result.strip()
+
+        # Check for non-zero exit code
+        assert (
+            proc.returncode == 0
+        ), f"❌ Command '{command_from_config}' exited with code {proc.returncode}\nOutput:\n{stdout_result}"
+
+        # Error patterns to detect failures that might otherwise slip through
+        # Please ensure it is aligning with airflowctl.api.client.get_json_error
+        error_patterns = [
+            "Server error",
+            "command error",
+            "unrecognized arguments",
+            "invalid choice",
+            "Traceback (most recent call last):",
+        ]
+        matched_error = next((error for error in error_patterns if error in stdout_result), None)
+        assert not matched_error, (
+            f"❌ Output contained unexpected text for command '{command_from_config}'\n"
+            f"Matched error pattern: {matched_error}\n"
+            f"Output:\n{stdout_result}"
+        )
+
+        console.print(f"[green]✅ Output did not contain unexpected text for command '{command_from_config}'")
+        console.print(f"[cyan]Result:\n{stdout_result}\n")
+        proc.kill()
+
+        return stdout_result
+
+    return _run_command
 
 
 class _CtlTestState:

--- a/airflow-ctl-tests/tests/airflowctl_tests/conftest.py
+++ b/airflow-ctl-tests/tests/airflowctl_tests/conftest.py
@@ -61,24 +61,26 @@ def run_command():
         stdout_bytes, stderr_result = proc.communicate(timeout=60)
 
         # CLI command gave errors
-        assert not stderr_result, f"Errors while executing command '{command_from_config}':\n{stderr_result.decode()}"
+        assert not stderr_result, (
+            f"Errors while executing command '{command_from_config}':\n{stderr_result.decode()}"
+        )
 
         # Decode the output
         stdout_result = stdout_bytes.decode()
 
         # We need to trim auth login output if the command is not login itself and clean backspaces
         if not skip_login and command != LOGIN_COMMAND:
-            assert (
-                LOGIN_OUTPUT in stdout_result
-            ), f"❌ Login output not found before command output for '{command_from_config}'\nFull output:\n{stdout_result}"
+            assert LOGIN_OUTPUT in stdout_result, (
+                f"❌ Login output not found before command output for '{command_from_config}'\nFull output:\n{stdout_result}"
+            )
             stdout_result = stdout_result.split(f"{LOGIN_OUTPUT}\n")[1].strip()
         else:
             stdout_result = stdout_result.strip()
 
         # Check for non-zero exit code
-        assert (
-            proc.returncode == 0
-        ), f"❌ Command '{command_from_config}' exited with code {proc.returncode}\nOutput:\n{stdout_result}"
+        assert proc.returncode == 0, (
+            f"❌ Command '{command_from_config}' exited with code {proc.returncode}\nOutput:\n{stdout_result}"
+        )
 
         # Error patterns to detect failures that might otherwise slip through
         # Please ensure it is aligning with airflowctl.api.client.get_json_error

--- a/airflow-ctl-tests/tests/airflowctl_tests/constants.py
+++ b/airflow-ctl-tests/tests/airflowctl_tests/constants.py
@@ -30,3 +30,6 @@ DOCKER_COMPOSE_HOST_PORT = os.environ.get("HOST_PORT", "localhost:8080")
 DOCKER_COMPOSE_FILE_PATH = (
     AIRFLOW_ROOT_PATH / "airflow-core" / "docs" / "howto" / "docker-compose" / "docker-compose.yaml"
 )
+
+LOGIN_COMMAND = "auth login --username airflow --password airflow"
+LOGIN_OUTPUT = "Login successful! Welcome to airflowctl!"

--- a/airflow-ctl-tests/tests/airflowctl_tests/test_config_sensitive_masking.py
+++ b/airflow-ctl-tests/tests/airflowctl_tests/test_config_sensitive_masking.py
@@ -1,0 +1,111 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import os
+from subprocess import PIPE, STDOUT, Popen
+
+import pytest
+
+from airflowctl_tests import console
+
+
+LOGIN_COMMAND = "auth login --username airflow --password airflow"
+LOGIN_OUTPUT = "Login successful! Welcome to airflowctl!"
+
+# Test commands for config sensitive masking verification
+SENSITIVE_CONFIG_COMMANDS = [
+    # Test that config list shows masked sensitive values
+    "config list",
+    # Test that getting specific sensitive config values are masked
+    "config get --section core --option fernet_key",
+    "config get --section database --option sql_alchemy_conn",
+]
+
+
+@pytest.mark.flaky(reruns=3, reruns_delay=1)
+@pytest.mark.parametrize(
+    "command",
+    SENSITIVE_CONFIG_COMMANDS,
+    ids=[" ".join(command.split(" ", 2)[:2]) for command in SENSITIVE_CONFIG_COMMANDS],
+)
+def test_config_sensitive_masking(command: str):
+    """
+    Test that sensitive config values are properly masked by airflowctl.
+
+    This integration test verifies that when airflowctl retrieves config data from the
+    Airflow API, sensitive values (like fernet_key, sql_alchemy_conn) appear masked
+    as '< hidden >' and do not leak actual secret values.
+    """
+    host_envs = os.environ.copy()
+    host_envs["AIRFLOW_CLI_DEBUG_MODE"] = "true"
+
+    command_from_config = f"airflowctl {command}"
+    # Run auth login first, then the config command
+    run_command = f"airflowctl {LOGIN_COMMAND} && {command_from_config}"
+    console.print(f"[yellow]Running command: {command}")
+
+    # Execute the command
+    proc = Popen(run_command.encode(), stdout=PIPE, stderr=STDOUT, stdin=PIPE, shell=True, env=host_envs)
+    stdout_bytes, stderr_result = proc.communicate(timeout=60)
+
+    # CLI command gave errors
+    assert not stderr_result, (
+        f"Errors while executing command '{command_from_config}':\n{stderr_result.decode()}"
+    )
+
+    # Decode the output
+    stdout_result = stdout_bytes.decode()
+
+    # Trim auth login output and get the actual command output
+    assert LOGIN_OUTPUT in stdout_result, (
+        f"❌ Login output not found before command output for '{command_from_config}'",
+        f"\nFull output:\n{stdout_result}",
+    )
+    stdout_result = stdout_result.split(f"{LOGIN_OUTPUT}\n")[1].strip()
+
+    # Check for non-zero exit code
+    assert proc.returncode == 0, (
+        f"❌ Command '{command_from_config}' exited with code {proc.returncode}",
+        f"\nOutput:\n{stdout_result}",
+    )
+
+    # Error patterns to detect failures
+    error_patterns = [
+        "Server error",
+        "command error",
+        "unrecognized arguments",
+        "invalid choice",
+        "Traceback (most recent call last):",
+    ]
+    matched_error = next((error for error in error_patterns if error in stdout_result), None)
+    assert not matched_error, (
+        f"❌ Output contained unexpected text for command '{command_from_config}'",
+        f"\nMatched error pattern: {matched_error}",
+        f"\nOutput:\n{stdout_result}",
+    )
+
+    # CRITICAL: Verify that sensitive values are masked
+    # The Airflow API returns masked values as "< hidden >" for sensitive configs
+    assert "< hidden >" in stdout_result, (
+        f"❌ Expected masked value '< hidden >' not found in output for '{command_from_config}'",
+        f"\nOutput:\n{stdout_result}",
+    )
+
+    console.print(f"[green]✅ Sensitive config values are properly masked in command '{command_from_config}'")
+    console.print(f"[cyan]Result:\n{stdout_result}\n")
+    proc.kill()

--- a/airflow-ctl-tests/tests/airflowctl_tests/test_config_sensitive_masking.py
+++ b/airflow-ctl-tests/tests/airflowctl_tests/test_config_sensitive_masking.py
@@ -23,7 +23,6 @@ import pytest
 
 from airflowctl_tests import console
 
-
 LOGIN_COMMAND = "auth login --username airflow --password airflow"
 LOGIN_OUTPUT = "Login successful! Welcome to airflowctl!"
 

--- a/airflow-ctl-tests/tests/airflowctl_tests/test_config_sensitive_masking.py
+++ b/airflow-ctl-tests/tests/airflowctl_tests/test_config_sensitive_masking.py
@@ -16,15 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-import os
-from subprocess import PIPE, STDOUT, Popen
-
 import pytest
-
-from airflowctl_tests import console
-
-LOGIN_COMMAND = "auth login --username airflow --password airflow"
-LOGIN_OUTPUT = "Login successful! Welcome to airflowctl!"
 
 # Test commands for config sensitive masking verification
 SENSITIVE_CONFIG_COMMANDS = [
@@ -42,7 +34,7 @@ SENSITIVE_CONFIG_COMMANDS = [
     SENSITIVE_CONFIG_COMMANDS,
     ids=[" ".join(command.split(" ", 2)[:2]) for command in SENSITIVE_CONFIG_COMMANDS],
 )
-def test_config_sensitive_masking(command: str):
+def test_config_sensitive_masking(command: str, run_command):
     """
     Test that sensitive config values are properly masked by airflowctl.
 
@@ -50,61 +42,11 @@ def test_config_sensitive_masking(command: str):
     Airflow API, sensitive values (like fernet_key, sql_alchemy_conn) appear masked
     as '< hidden >' and do not leak actual secret values.
     """
-    host_envs = os.environ.copy()
-    host_envs["AIRFLOW_CLI_DEBUG_MODE"] = "true"
-
-    command_from_config = f"airflowctl {command}"
-    # Run auth login first, then the config command
-    run_command = f"airflowctl {LOGIN_COMMAND} && {command_from_config}"
-    console.print(f"[yellow]Running command: {command}")
-
-    # Execute the command
-    proc = Popen(run_command.encode(), stdout=PIPE, stderr=STDOUT, stdin=PIPE, shell=True, env=host_envs)
-    stdout_bytes, stderr_result = proc.communicate(timeout=60)
-
-    # CLI command gave errors
-    assert not stderr_result, (
-        f"Errors while executing command '{command_from_config}':\n{stderr_result.decode()}"
-    )
-
-    # Decode the output
-    stdout_result = stdout_bytes.decode()
-
-    # Trim auth login output and get the actual command output
-    assert LOGIN_OUTPUT in stdout_result, (
-        f"❌ Login output not found before command output for '{command_from_config}'",
-        f"\nFull output:\n{stdout_result}",
-    )
-    stdout_result = stdout_result.split(f"{LOGIN_OUTPUT}\n")[1].strip()
-
-    # Check for non-zero exit code
-    assert proc.returncode == 0, (
-        f"❌ Command '{command_from_config}' exited with code {proc.returncode}",
-        f"\nOutput:\n{stdout_result}",
-    )
-
-    # Error patterns to detect failures
-    error_patterns = [
-        "Server error",
-        "command error",
-        "unrecognized arguments",
-        "invalid choice",
-        "Traceback (most recent call last):",
-    ]
-    matched_error = next((error for error in error_patterns if error in stdout_result), None)
-    assert not matched_error, (
-        f"❌ Output contained unexpected text for command '{command_from_config}'",
-        f"\nMatched error pattern: {matched_error}",
-        f"\nOutput:\n{stdout_result}",
-    )
+    stdout_result = run_command(command)
 
     # CRITICAL: Verify that sensitive values are masked
     # The Airflow API returns masked values as "< hidden >" for sensitive configs
     assert "< hidden >" in stdout_result, (
-        f"❌ Expected masked value '< hidden >' not found in output for '{command_from_config}'",
-        f"\nOutput:\n{stdout_result}",
+        f"❌ Expected masked value '< hidden >' not found in output for 'airflowctl {command}'\n"
+        f"Output:\n{stdout_result}"
     )
-
-    console.print(f"[green]✅ Sensitive config values are properly masked in command '{command_from_config}'")
-    console.print(f"[cyan]Result:\n{stdout_result}\n")
-    proc.kill()

--- a/airflow-ctl-tests/tests/airflowctl_tests/test_config_sensitive_masking.py
+++ b/airflow-ctl-tests/tests/airflowctl_tests/test_config_sensitive_masking.py
@@ -28,7 +28,6 @@ SENSITIVE_CONFIG_COMMANDS = [
 ]
 
 
-@pytest.mark.flaky(reruns=3, reruns_delay=1)
 @pytest.mark.parametrize(
     "command",
     SENSITIVE_CONFIG_COMMANDS,

--- a/dev/breeze/src/airflow_breeze/utils/run_tests.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_tests.py
@@ -152,7 +152,7 @@ def run_docker_compose_tests(
         test_path = Path("tests") / "airflow_e2e_tests" / f"{test_mode}_tests"
         cwd = AIRFLOW_E2E_TESTS_ROOT_PATH.as_posix()
     elif test_type == "airflow-ctl-integration":
-        test_path = Path("tests") / "airflowctl_tests" / "test_airflowctl_commands.py"
+        test_path = Path("tests") / "airflowctl_tests"
         cwd = AIRFLOW_CTL_TESTS_ROOT_PATH.as_posix()
     else:
         test_path = Path("tests") / "docker_tests" / "test_docker_compose_quick_start.py"


### PR DESCRIPTION
## Description
Added integration tests to verify sensitive config values are properly masked end-to-end when using airflowctl with actual Airflow API.

The Airflow API masks sensitive values (like `fernet_key`, `sql_alchemy_conn`) as `< hidden >`. These integration tests confirm that airflowctl correctly preserves and displays those masked values in real scenarios.

## Changes
- Added [test_config_sensitive_masking.py](cci:7://file:///Users/subhamsangwan/airflow/airflow-ctl-tests/tests/airflowctl_tests/test_config_sensitive_masking.py:0:0-0:0) to [airflow-ctl-tests](cci:7://file:///Users/subhamsangwan/airflow/airflow-ctl-tests:0:0-0:0)
- 3 integration test cases covering:
  - `config list` command
  - `config get` for `fernet_key`
  - `config get` for `sql_alchemy_conn`
- Tests run against actual docker-compose Airflow environment
- Verifies `< hidden >` appears in output for sensitive configs

## Related PRs
- Relates to #60361 (unit tests for config masking)

## Related Issue
Closes #59843

## Testing
```bash
# Run from airflow-ctl-tests directory
pytest tests/airflowctl_tests/test_config_sensitive_masking.py -v