### PR TITLE
Fix aria-label for TriggerDAGButton to use correct translation key

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGButton.tsx
@@ -93,7 +93,7 @@ export const TriggerDAGButton = ({
         <Menu.Root>
           <Menu.Trigger asChild>
             <Button
-              aria-label={translate("triggerDag.button")}
+              aria-label={translate("triggerDag.title")}
               colorPalette="brand"
               size="md"
               variant={variant}
@@ -130,7 +130,7 @@ export const TriggerDAGButton = ({
       <Tooltip content={translate("triggerDag.button")} disabled={withText}>
         {withText ? (
           <Button
-            aria-label={translate("triggerDag.button")}
+            aria-label={translate("triggerDag.title")}
             colorPalette="brand"
             onClick={handleNormalTrigger}
             size="md"
@@ -141,7 +141,7 @@ export const TriggerDAGButton = ({
           </Button>
         ) : (
           <IconButton
-            aria-label={translate("triggerDag.button")}
+            aria-label={translate("triggerDag.title")}
             colorPalette="brand"
             onClick={onOpen}
             size="md"

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/BackfillPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/BackfillPage.ts
@@ -75,7 +75,7 @@ export class BackfillPage extends BasePage {
 
   public constructor(page: Page) {
     super(page);
-    this.triggerButton = page.locator('button[aria-label="Trigger"]:has-text("Trigger")');
+    this.triggerButton = page.locator('button[aria-label="Trigger Dag"]:has-text("Trigger")');
     this.backfillModeRadio = page.locator('label:has-text("Backfill")');
     this.backfillFromDateInput = page.locator('input[type="datetime-local"]').first();
     this.backfillToDateInput = page.locator('input[type="datetime-local"]').nth(1);

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/DagsPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/DagsPage.ts
@@ -46,7 +46,7 @@ export class DagsPage extends BasePage {
 
   public constructor(page: Page) {
     super(page);
-    this.triggerButton = page.locator('button[aria-label="Trigger"]:has-text("Trigger")');
+    this.triggerButton = page.locator('button[aria-label="Trigger Dag"]:has-text("Trigger")');
     this.confirmButton = page.locator('button:has-text("Trigger")').nth(1);
     this.stateElement = page.locator('*:has-text("State") + *').first();
     this.paginationNextButton = page.locator('[data-testid="next"]');


### PR DESCRIPTION
follow-up: #60555

This PR changes the aria-label from `triggerDag.title` to `triggerDag.button` to use correct translation key

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
