### PR TITLE
Split Deadline Alerts into core and task-sdk components

### DIFF
--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -55,6 +55,8 @@ from airflow.models.dagbundle import DagBundleModel
 from airflow.models.dagrun import DagRun
 from airflow.models.team import Team
 from airflow.serialization.definitions.assets import SerializedAssetUniqueKey
+from airflow.serialization.encoders import DAT, encode_deadline_alert
+from airflow.serialization.enums import Encoding
 from airflow.settings import json
 from airflow.timetables.base import DataInterval, Timetable
 from airflow.timetables.interval import CronDataIntervalTimetable, DeltaDataIntervalTimetable
@@ -484,9 +486,6 @@ class DagModel(Base):
     @deadline.setter
     def deadline(self, value):
         """Set and serialize the deadline alert."""
-        from airflow.serialization.encoders import encode_deadline_alert
-        from airflow.serialization.enums import DagAttributeTypes as DAT, Encoding
-
         if value is None:
             self._deadline = None
         elif isinstance(value, list):

--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -484,16 +484,22 @@ class DagModel(Base):
     @deadline.setter
     def deadline(self, value):
         """Set and serialize the deadline alert."""
+        from airflow.serialization.encoders import encode_deadline_alert
+        from airflow.serialization.enums import DagAttributeTypes as DAT, Encoding
+
         if value is None:
             self._deadline = None
         elif isinstance(value, list):
             self._deadline = [
-                item if isinstance(item, dict) else item.serialize_deadline_alert() for item in value
+                item
+                if isinstance(item, dict)
+                else {Encoding.TYPE: DAT.DEADLINE_ALERT, Encoding.VAR: encode_deadline_alert(item)}
+                for item in value
             ]
         elif isinstance(value, dict):
             self._deadline = value
         else:
-            self._deadline = value.serialize_deadline_alert()
+            self._deadline = {Encoding.TYPE: DAT.DEADLINE_ALERT, Encoding.VAR: encode_deadline_alert(value)}
 
     @property
     def timezone(self):

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -72,7 +72,7 @@ from airflow.models.taskinstancehistory import TaskInstanceHistory as TIH
 from airflow.models.tasklog import LogTemplate
 from airflow.models.taskmap import TaskMap
 from airflow.observability.trace import Trace
-from airflow.sdk.definitions.deadline import DeadlineReference
+from airflow.serialization.definitions.deadline import SerializedReferenceModels
 from airflow.serialization.definitions.notset import NOTSET, ArgNotSet, is_arg_set
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.dependencies_states import SCHEDULEABLE_STATES
@@ -1270,7 +1270,7 @@ class DagRun(Base, LoggingMixin):
                 ]
 
                 if any(
-                    deadline_alert.reference_class in DeadlineReference.TYPES.DAGRUN
+                    deadline_alert.reference_class in SerializedReferenceModels.TYPES.DAGRUN
                     for deadline_alert in deadline_alerts
                 ):
                     Deadline.prune_deadlines(session=session, conditions={DagRun.id: self.id})

--- a/airflow-core/src/airflow/models/deadline_alert.py
+++ b/airflow-core/src/airflow/models/deadline_alert.py
@@ -27,7 +27,7 @@ from sqlalchemy_utils import UUIDType
 
 from airflow._shared.timezones import timezone
 from airflow.models import Base
-from airflow.models.deadline import ReferenceModels
+from airflow.serialization.definitions.deadline import SerializedReferenceModels
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.sqlalchemy import UtcDateTime, mapped_column
 
@@ -86,9 +86,11 @@ class DeadlineAlert(Base):
         return hash((str(self.reference), self.interval, str(self.callback_def)))
 
     @property
-    def reference_class(self) -> type[ReferenceModels.BaseDeadlineReference]:
-        """Return the deserialized reference object."""
-        return ReferenceModels.get_reference_class(self.reference[ReferenceModels.REFERENCE_TYPE_FIELD])
+    def reference_class(self) -> type[SerializedReferenceModels.SerializedBaseDeadlineReference]:
+        """Return the deserialized reference class."""
+        return SerializedReferenceModels.get_reference_class(
+            self.reference[SerializedReferenceModels.REFERENCE_TYPE_FIELD]
+        )
 
     @classmethod
     @provide_session

--- a/airflow-core/src/airflow/serialization/decoders.py
+++ b/airflow-core/src/airflow/serialization/decoders.py
@@ -36,6 +36,7 @@ from airflow.serialization.definitions.assets import (
 )
 from airflow.serialization.definitions.deadline import (
     DeadlineAlertFields,
+    SerializedDeadlineAlert,
     SerializedReferenceModels,
 )
 from airflow.serialization.enums import DagAttributeTypes as DAT, Encoding
@@ -141,10 +142,7 @@ def decode_deadline_alert(encoded_data: dict):
 
     :meta private:
     """
-    from datetime import timedelta
-
     from airflow.sdk.serde import deserialize
-    from airflow.serialization.definitions.deadline import SerializedDeadlineAlert
 
     data = encoded_data.get(Encoding.VAR, encoded_data)
 
@@ -156,7 +154,7 @@ def decode_deadline_alert(encoded_data: dict):
 
     return SerializedDeadlineAlert(
         reference=reference,
-        interval=timedelta(seconds=data[DeadlineAlertFields.INTERVAL]),
+        interval=datetime.timedelta(seconds=data[DeadlineAlertFields.INTERVAL]),
         callback=deserialize(data[DeadlineAlertFields.CALLBACK]),
     )
 

--- a/airflow-core/src/airflow/serialization/decoders.py
+++ b/airflow-core/src/airflow/serialization/decoders.py
@@ -143,6 +143,7 @@ def decode_deadline_alert(encoded_data: dict):
     """
     from datetime import timedelta
 
+    from airflow.serialization.definitions.deadline import SerializedDeadlineAlert
     from airflow.serialization.serialized_objects import BaseSerialization
 
     data = encoded_data.get(Encoding.VAR, encoded_data)
@@ -153,11 +154,11 @@ def decode_deadline_alert(encoded_data: dict):
     reference_class = SerializedReferenceModels.get_reference_class(reference_type)
     reference = reference_class.deserialize_reference(reference_data)
 
-    return {
-        "reference": reference,
-        "interval": timedelta(seconds=data[DeadlineAlertFields.INTERVAL]),
-        "callback": BaseSerialization.deserialize(data[DeadlineAlertFields.CALLBACK]),
-    }
+    return SerializedDeadlineAlert(
+        reference=reference,
+        interval=timedelta(seconds=data[DeadlineAlertFields.INTERVAL]),
+        callback=BaseSerialization.deserialize(data[DeadlineAlertFields.CALLBACK]),
+    )
 
 
 def decode_timetable(var: dict[str, Any]) -> CoreTimetable:

--- a/airflow-core/src/airflow/serialization/decoders.py
+++ b/airflow-core/src/airflow/serialization/decoders.py
@@ -143,8 +143,8 @@ def decode_deadline_alert(encoded_data: dict):
     """
     from datetime import timedelta
 
+    from airflow.sdk.serde import deserialize
     from airflow.serialization.definitions.deadline import SerializedDeadlineAlert
-    from airflow.serialization.serialized_objects import BaseSerialization
 
     data = encoded_data.get(Encoding.VAR, encoded_data)
 
@@ -157,7 +157,7 @@ def decode_deadline_alert(encoded_data: dict):
     return SerializedDeadlineAlert(
         reference=reference,
         interval=timedelta(seconds=data[DeadlineAlertFields.INTERVAL]),
-        callback=BaseSerialization.deserialize(data[DeadlineAlertFields.CALLBACK]),
+        callback=deserialize(data[DeadlineAlertFields.CALLBACK]),
     )
 
 

--- a/airflow-core/src/airflow/serialization/definitions/dag.py
+++ b/airflow-core/src/airflow/serialization/definitions/dag.py
@@ -41,6 +41,7 @@ from airflow.models.deadline_alert import DeadlineAlert as DeadlineAlertModel
 from airflow.models.taskinstancekey import TaskInstanceKey
 from airflow.models.tasklog import LogTemplate
 from airflow.sdk._shared.observability.metrics.stats import Stats
+from airflow.serialization.decoders import decode_deadline_alert
 from airflow.serialization.definitions.deadline import DeadlineAlertFields, SerializedReferenceModels
 from airflow.serialization.definitions.param import SerializedParamsDict
 from airflow.serialization.enums import DagAttributeTypes as DAT, Encoding
@@ -644,7 +645,6 @@ class SerializedDAG:
         for deadline_alert in deadline_alert_records:
             if not deadline_alert:
                 continue
-            from airflow.serialization.decoders import decode_deadline_alert
 
             deserialized_deadline_alert = decode_deadline_alert(
                 {

--- a/airflow-core/src/airflow/serialization/definitions/dag.py
+++ b/airflow-core/src/airflow/serialization/definitions/dag.py
@@ -41,7 +41,6 @@ from airflow.models.deadline_alert import DeadlineAlert as DeadlineAlertModel
 from airflow.models.taskinstancekey import TaskInstanceKey
 from airflow.models.tasklog import LogTemplate
 from airflow.sdk._shared.observability.metrics.stats import Stats
-from airflow.sdk.definitions.deadline import DeadlineAlert
 from airflow.serialization.definitions.deadline import DeadlineAlertFields, SerializedReferenceModels
 from airflow.serialization.definitions.param import SerializedParamsDict
 from airflow.serialization.enums import DagAttributeTypes as DAT, Encoding
@@ -645,7 +644,9 @@ class SerializedDAG:
         for deadline_alert in deadline_alert_records:
             if not deadline_alert:
                 continue
-            deserialized_deadline_alert = DeadlineAlert.deserialize_deadline_alert(
+            from airflow.serialization.decoders import decode_deadline_alert
+
+            deserialized_deadline_alert = decode_deadline_alert(
                 {
                     Encoding.TYPE: DAT.DEADLINE_ALERT,
                     Encoding.VAR: {

--- a/airflow-core/src/airflow/serialization/definitions/dag.py
+++ b/airflow-core/src/airflow/serialization/definitions/dag.py
@@ -41,8 +41,8 @@ from airflow.models.deadline_alert import DeadlineAlert as DeadlineAlertModel
 from airflow.models.taskinstancekey import TaskInstanceKey
 from airflow.models.tasklog import LogTemplate
 from airflow.sdk._shared.observability.metrics.stats import Stats
-from airflow.sdk.definitions.deadline import DeadlineAlert, DeadlineReference
-from airflow.serialization.definitions.deadline import DeadlineAlertFields
+from airflow.sdk.definitions.deadline import DeadlineAlert
+from airflow.serialization.definitions.deadline import DeadlineAlertFields, SerializedReferenceModels
 from airflow.serialization.definitions.param import SerializedParamsDict
 from airflow.serialization.enums import DagAttributeTypes as DAT, Encoding
 from airflow.timetables.base import DagRunInfo, DataInterval, TimeRestriction
@@ -656,7 +656,7 @@ class SerializedDAG:
                 }
             )
 
-            if isinstance(deserialized_deadline_alert.reference, DeadlineReference.TYPES.DAGRUN):
+            if isinstance(deserialized_deadline_alert.reference, SerializedReferenceModels.TYPES.DAGRUN):
                 deadline_time = deserialized_deadline_alert.reference.evaluate_with(
                     session=session,
                     interval=deserialized_deadline_alert.interval,

--- a/airflow-core/src/airflow/serialization/definitions/deadline.py
+++ b/airflow-core/src/airflow/serialization/definitions/deadline.py
@@ -240,3 +240,17 @@ def _fetch_from_db(column, *, session: Session, dag_id: str, run_id: str) -> dat
     if result is None:
         logger.warning("Could not find DagRun for dag_id=%s, run_id=%s", dag_id, run_id)
     return result
+
+
+class SerializedDeadlineAlert:
+    """Serialized representation of a deadline alert."""
+
+    def __init__(
+        self,
+        reference: SerializedReferenceModels.SerializedBaseDeadlineReference,
+        interval: timedelta,
+        callback,
+    ):
+        self.reference = reference
+        self.interval = interval
+        self.callback = callback

--- a/airflow-core/src/airflow/serialization/definitions/deadline.py
+++ b/airflow-core/src/airflow/serialization/definitions/deadline.py
@@ -225,6 +225,30 @@ class SerializedReferenceModels:
         def deserialize_reference(cls, reference_data: dict):
             return cls(max_runs=reference_data["max_runs"], min_runs=reference_data.get("min_runs"))
 
+    class TYPES:
+        """Collection of SerializedDeadlineReference types for type checking."""
+
+        # Deadlines that should be created when the DagRun is created.
+        DAGRUN_CREATED: tuple = ()
+
+        # Deadlines that should be created when the DagRun is queued.
+        DAGRUN_QUEUED: tuple = ()
+
+        # All DagRun-related deadline types.
+        DAGRUN: tuple = ()
+
+
+# Initialize TYPES after all reference classes are defined
+SerializedReferenceModels.TYPES.DAGRUN_CREATED = (
+    SerializedReferenceModels.SerializedDagRunLogicalDateDeadline,
+    SerializedReferenceModels.SerializedFixedDatetimeDeadline,
+    SerializedReferenceModels.SerializedAverageRuntimeDeadline,
+)
+SerializedReferenceModels.TYPES.DAGRUN_QUEUED = (SerializedReferenceModels.SerializedDagRunQueuedAtDeadline,)
+SerializedReferenceModels.TYPES.DAGRUN = (
+    SerializedReferenceModels.TYPES.DAGRUN_CREATED + SerializedReferenceModels.TYPES.DAGRUN_QUEUED
+)
+
 
 def _fetch_from_db(column, *, session: Session, dag_id: str, run_id: str) -> datetime | None:
     """

--- a/airflow-core/src/airflow/serialization/definitions/deadline.py
+++ b/airflow-core/src/airflow/serialization/definitions/deadline.py
@@ -239,7 +239,6 @@ class SerializedReferenceModels:
         DAGRUN: tuple = ()
 
 
-# Initialize TYPES after all reference classes are defined
 SerializedReferenceModels.TYPES.DAGRUN_CREATED = (
     SerializedReferenceModels.DagRunLogicalDateDeadline,
     SerializedReferenceModels.FixedDatetimeDeadline,

--- a/airflow-core/src/airflow/serialization/definitions/deadline.py
+++ b/airflow-core/src/airflow/serialization/definitions/deadline.py
@@ -201,13 +201,14 @@ class SerializedReferenceModels:
 
             durations = list(session.execute(query).scalars())
 
-            if len(durations) < self.min_runs:
+            min_runs = self.min_runs
+            if len(durations) < min_runs:
                 logger.info(
                     "Not enough completed runs to calculate average runtime for dag_id=%s "
                     "(found %d, need %d)",
                     dag_id,
                     len(durations),
-                    self.min_runs,
+                    min_runs,
                 )
                 return None
 

--- a/airflow-core/src/airflow/serialization/definitions/deadline.py
+++ b/airflow-core/src/airflow/serialization/definitions/deadline.py
@@ -201,7 +201,7 @@ class SerializedReferenceModels:
 
             durations = list(session.execute(query).scalars())
 
-            min_runs = self.min_runs
+            min_runs = self.min_runs or 0
             if len(durations) < min_runs:
                 logger.info(
                     "Not enough completed runs to calculate average runtime for dag_id=%s "

--- a/airflow-core/src/airflow/serialization/definitions/deadline.py
+++ b/airflow-core/src/airflow/serialization/definitions/deadline.py
@@ -16,6 +16,24 @@
 # under the License.
 from __future__ import annotations
 
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+from airflow._shared.timezones import timezone
+from airflow.models.deadline import classproperty
+from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.session import provide_session
+from airflow.utils.sqlalchemy import get_dialect_name
+
+if TYPE_CHECKING:
+    from sqlalchemy import ColumnElement
+    from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
 
 class DeadlineAlertFields:
     """
@@ -28,3 +46,197 @@ class DeadlineAlertFields:
     REFERENCE = "reference"
     INTERVAL = "interval"
     CALLBACK = "callback"
+
+
+class SerializedReferenceModels:
+    """
+    Store the implementations for the different Deadline References.
+
+    :meta private:
+    """
+
+    REFERENCE_TYPE_FIELD = "reference_type"
+
+    @classmethod
+    def get_reference_class(cls, reference_name: str) -> type[SerializedBaseDeadlineReference]:
+        """
+        Get a reference class by its name.
+
+        :param reference_name: The name of the reference class to find
+        """
+        try:
+            return next(
+                ref_class
+                for name, ref_class in vars(cls).items()
+                if isinstance(ref_class, type)
+                and issubclass(ref_class, cls.SerializedBaseDeadlineReference)
+                and ref_class.__name__ == reference_name
+            )
+        except StopIteration:
+            raise ValueError(f"No reference class found with name: {reference_name}")
+
+    class SerializedBaseDeadlineReference(LoggingMixin, ABC):
+        """Base class for all serialized Deadline implementations."""
+
+        required_kwargs: set[str] = set()
+
+        @classproperty
+        def reference_name(cls: Any) -> str:
+            return cls.__name__
+
+        def evaluate_with(self, *, session: Session, interval: timedelta, **kwargs: Any) -> datetime | None:
+            """Validate the provided kwargs and evaluate this deadline with the given conditions."""
+            filtered_kwargs = {k: v for k, v in kwargs.items() if k in self.required_kwargs}
+
+            if missing_kwargs := self.required_kwargs - filtered_kwargs.keys():
+                raise ValueError(
+                    f"{self.__class__.__name__} is missing required parameters: {', '.join(missing_kwargs)}"
+                )
+
+            if extra_kwargs := kwargs.keys() - filtered_kwargs.keys():
+                self.log.debug("Ignoring unexpected parameters: %s", ", ".join(extra_kwargs))
+
+            base_time = self._evaluate_with(session=session, **filtered_kwargs)
+            return base_time + interval if base_time is not None else None
+
+        @abstractmethod
+        def _evaluate_with(self, *, session: Session, **kwargs: Any) -> datetime | None:
+            """Must be implemented by subclasses to perform the actual evaluation."""
+            raise NotImplementedError
+
+        @classmethod
+        def deserialize_reference(cls, reference_data: dict):
+            """
+            Deserialize a reference type from its dictionary representation.
+
+            :param reference_data: Dictionary containing serialized reference data.
+            """
+            return cls()
+
+        def serialize_reference(self) -> dict:
+            """Serialize this reference type into a dictionary representation."""
+            return {SerializedReferenceModels.REFERENCE_TYPE_FIELD: self.reference_name}
+
+    @dataclass
+    class SerializedFixedDatetimeDeadline(SerializedBaseDeadlineReference):
+        """A deadline that always returns a fixed datetime."""
+
+        _datetime: datetime
+
+        def _evaluate_with(self, *, session: Session, **kwargs: Any) -> datetime | None:
+            return self._datetime
+
+        def serialize_reference(self) -> dict:
+            return {
+                SerializedReferenceModels.REFERENCE_TYPE_FIELD: self.reference_name,
+                "datetime": self._datetime.timestamp(),
+            }
+
+        @classmethod
+        def deserialize_reference(cls, reference_data: dict):
+            return cls(_datetime=timezone.from_timestamp(reference_data["datetime"]))
+
+    class SerializedDagRunLogicalDateDeadline(SerializedBaseDeadlineReference):
+        """A deadline that returns a DagRun's logical date."""
+
+        required_kwargs = {"dag_id", "run_id"}
+
+        def _evaluate_with(self, *, session: Session, **kwargs: Any) -> datetime | None:
+            from airflow.models import DagRun
+
+            return _fetch_from_db(DagRun.logical_date, session=session, **kwargs)
+
+    class SerializedDagRunQueuedAtDeadline(SerializedBaseDeadlineReference):
+        """A deadline that returns when a DagRun was queued."""
+
+        required_kwargs = {"dag_id", "run_id"}
+
+        @provide_session
+        def _evaluate_with(self, *, session: Session, **kwargs: Any) -> datetime | None:
+            from airflow.models import DagRun
+
+            return _fetch_from_db(DagRun.queued_at, session=session, **kwargs)
+
+    @dataclass
+    class SerializedAverageRuntimeDeadline(SerializedBaseDeadlineReference):
+        """A deadline that calculates the average runtime from past DAG runs."""
+
+        DEFAULT_LIMIT = 10
+        max_runs: int
+        min_runs: int | None = None
+        required_kwargs = {"dag_id"}
+
+        def __post_init__(self):
+            if self.min_runs is None:
+                self.min_runs = self.max_runs
+            if self.min_runs < 1:
+                raise ValueError("min_runs must be at least 1")
+
+        @provide_session
+        def _evaluate_with(self, *, session: Session, **kwargs: Any) -> datetime | None:
+            from sqlalchemy import func, select, text
+
+            from airflow.models import DagRun
+
+            dag_id = kwargs["dag_id"]
+
+            dialect = get_dialect_name(session)
+
+            duration_expr: ColumnElement[Any]
+            if dialect == "postgresql":
+                duration_expr = func.extract("epoch", DagRun.end_date - DagRun.start_date)
+            elif dialect == "mysql":
+                duration_expr = func.timestampdiff(text("SECOND"), DagRun.start_date, DagRun.end_date)
+            elif dialect == "sqlite":
+                duration_expr = (func.julianday(DagRun.end_date) - func.julianday(DagRun.start_date)) * 86400
+            else:
+                raise ValueError(f"Unsupported database dialect: {dialect}")
+
+            query = (
+                select(duration_expr)
+                .filter(DagRun.dag_id == dag_id, DagRun.start_date.isnot(None), DagRun.end_date.isnot(None))
+                .order_by(DagRun.logical_date.desc())
+                .limit(self.max_runs)
+            )
+
+            durations = list(session.execute(query).scalars())
+
+            if len(durations) < self.min_runs:
+                logger.info(
+                    "Not enough completed runs to calculate average runtime for dag_id=%s "
+                    "(found %d, need %d)",
+                    dag_id,
+                    len(durations),
+                    self.min_runs,
+                )
+                return None
+
+            avg_duration_seconds = sum(durations) / len(durations)
+            return timezone.utcnow() + timedelta(seconds=avg_duration_seconds)
+
+        def serialize_reference(self) -> dict:
+            return {
+                SerializedReferenceModels.REFERENCE_TYPE_FIELD: self.reference_name,
+                "max_runs": self.max_runs,
+                "min_runs": self.min_runs,
+            }
+
+        @classmethod
+        def deserialize_reference(cls, reference_data: dict):
+            return cls(max_runs=reference_data["max_runs"], min_runs=reference_data.get("min_runs"))
+
+
+def _fetch_from_db(column, *, session: Session, dag_id: str, run_id: str) -> datetime | None:
+    """
+    Fetch a datetime column from the DagRun table.
+
+    :meta private:
+    """
+    from sqlalchemy import select
+
+    from airflow.models import DagRun
+
+    result = session.execute(select(column).where(DagRun.dag_id == dag_id, DagRun.run_id == run_id)).scalar()
+    if result is None:
+        logger.warning("Could not find DagRun for dag_id=%s, run_id=%s", dag_id, run_id)
+    return result

--- a/airflow-core/src/airflow/serialization/definitions/deadline.py
+++ b/airflow-core/src/airflow/serialization/definitions/deadline.py
@@ -22,6 +22,8 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
+from sqlalchemy import select
+
 from airflow._shared.timezones import timezone
 from airflow.models.deadline import classproperty
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -256,8 +258,6 @@ def _fetch_from_db(column, *, session: Session, dag_id: str, run_id: str) -> dat
 
     :meta private:
     """
-    from sqlalchemy import select
-
     from airflow.models import DagRun
 
     result = session.execute(select(column).where(DagRun.dag_id == dag_id, DagRun.run_id == run_id)).scalar()

--- a/airflow-core/src/airflow/serialization/definitions/deadline.py
+++ b/airflow-core/src/airflow/serialization/definitions/deadline.py
@@ -118,7 +118,7 @@ class SerializedReferenceModels:
             return {SerializedReferenceModels.REFERENCE_TYPE_FIELD: self.reference_name}
 
     @dataclass
-    class SerializedFixedDatetimeDeadline(SerializedBaseDeadlineReference):
+    class FixedDatetimeDeadline(SerializedBaseDeadlineReference):
         """A deadline that always returns a fixed datetime."""
 
         _datetime: datetime
@@ -136,7 +136,7 @@ class SerializedReferenceModels:
         def deserialize_reference(cls, reference_data: dict):
             return cls(_datetime=timezone.from_timestamp(reference_data["datetime"]))
 
-    class SerializedDagRunLogicalDateDeadline(SerializedBaseDeadlineReference):
+    class DagRunLogicalDateDeadline(SerializedBaseDeadlineReference):
         """A deadline that returns a DagRun's logical date."""
 
         required_kwargs = {"dag_id", "run_id"}
@@ -146,7 +146,7 @@ class SerializedReferenceModels:
 
             return _fetch_from_db(DagRun.logical_date, session=session, **kwargs)
 
-    class SerializedDagRunQueuedAtDeadline(SerializedBaseDeadlineReference):
+    class DagRunQueuedAtDeadline(SerializedBaseDeadlineReference):
         """A deadline that returns when a DagRun was queued."""
 
         required_kwargs = {"dag_id", "run_id"}
@@ -158,7 +158,7 @@ class SerializedReferenceModels:
             return _fetch_from_db(DagRun.queued_at, session=session, **kwargs)
 
     @dataclass
-    class SerializedAverageRuntimeDeadline(SerializedBaseDeadlineReference):
+    class AverageRuntimeDeadline(SerializedBaseDeadlineReference):
         """A deadline that calculates the average runtime from past DAG runs."""
 
         DEFAULT_LIMIT = 10
@@ -240,11 +240,11 @@ class SerializedReferenceModels:
 
 # Initialize TYPES after all reference classes are defined
 SerializedReferenceModels.TYPES.DAGRUN_CREATED = (
-    SerializedReferenceModels.SerializedDagRunLogicalDateDeadline,
-    SerializedReferenceModels.SerializedFixedDatetimeDeadline,
-    SerializedReferenceModels.SerializedAverageRuntimeDeadline,
+    SerializedReferenceModels.DagRunLogicalDateDeadline,
+    SerializedReferenceModels.FixedDatetimeDeadline,
+    SerializedReferenceModels.AverageRuntimeDeadline,
 )
-SerializedReferenceModels.TYPES.DAGRUN_QUEUED = (SerializedReferenceModels.SerializedDagRunQueuedAtDeadline,)
+SerializedReferenceModels.TYPES.DAGRUN_QUEUED = (SerializedReferenceModels.DagRunQueuedAtDeadline,)
 SerializedReferenceModels.TYPES.DAGRUN = (
     SerializedReferenceModels.TYPES.DAGRUN_CREATED + SerializedReferenceModels.TYPES.DAGRUN_QUEUED
 )

--- a/airflow-core/src/airflow/serialization/definitions/deadline.py
+++ b/airflow-core/src/airflow/serialization/definitions/deadline.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
+import attrs
 from sqlalchemy import select
 
 from airflow._shared.timezones import timezone
@@ -118,6 +119,14 @@ class SerializedReferenceModels:
         def serialize_reference(self) -> dict:
             """Serialize this reference type into a dictionary representation."""
             return {SerializedReferenceModels.REFERENCE_TYPE_FIELD: self.reference_name}
+
+        def __eq__(self, other) -> bool:
+            if not isinstance(other, SerializedReferenceModels.SerializedBaseDeadlineReference):
+                return NotImplemented("Comparison not implemented for other types.")
+            return self.serialize_reference() == other.serialize_reference()
+
+        def __hash__(self) -> int:
+            return hash(frozenset(self.serialize_reference().items()))
 
     @dataclass
     class FixedDatetimeDeadline(SerializedBaseDeadlineReference):
@@ -266,15 +275,10 @@ def _fetch_from_db(column, *, session: Session, dag_id: str, run_id: str) -> dat
     return result
 
 
+@attrs.define
 class SerializedDeadlineAlert:
     """Serialized representation of a deadline alert."""
 
-    def __init__(
-        self,
-        reference: SerializedReferenceModels.SerializedBaseDeadlineReference,
-        interval: timedelta,
-        callback,
-    ):
-        self.reference = reference
-        self.interval = interval
-        self.callback = callback
+    reference: SerializedReferenceModels.SerializedBaseDeadlineReference
+    interval: timedelta
+    callback: Any

--- a/airflow-core/src/airflow/serialization/encoders.py
+++ b/airflow-core/src/airflow/serialization/encoders.py
@@ -191,7 +191,6 @@ def encode_deadline_alert(d: DeadlineAlert | SerializedDeadlineAlert) -> dict[st
     from airflow.serialization.serialized_objects import BaseSerialization
 
     return {
-        "__type": DAT.DEADLINE_ALERT,
         "reference": d.reference.serialize_reference(),
         "interval": d.interval.total_seconds(),
         "callback": BaseSerialization.serialize(d.callback),

--- a/airflow-core/src/airflow/serialization/encoders.py
+++ b/airflow-core/src/airflow/serialization/encoders.py
@@ -180,6 +180,31 @@ def encode_asset_like(a: BaseAsset | SerializedAssetBase) -> dict[str, Any]:
     raise ValueError(f"serialization not implemented for {type(a).__name__!r}")
 
 
+def encode_deadline_alert(d) -> dict[str, Any]:
+    """
+    Encode a deadline alert.
+
+    :meta private:
+    """
+    from airflow.serialization.serialized_objects import BaseSerialization
+
+    return {
+        "__type": DAT.DEADLINE_ALERT,
+        "reference": d.reference.serialize_reference(),
+        "interval": d.interval.total_seconds(),
+        "callback": BaseSerialization.serialize(d.callback),
+    }
+
+
+def encode_deadline_reference(ref) -> dict[str, Any]:
+    """
+    Encode a deadline reference.
+
+    :meta private:
+    """
+    return ref.serialize_reference()
+
+
 def _get_serialized_timetable_import_path(var: BaseTimetable | CoreTimetable) -> str:
     # Find SDK classes.
     with contextlib.suppress(KeyError):
@@ -381,6 +406,17 @@ def ensure_serialized_asset(obj: BaseAsset | SerializedAssetBase) -> SerializedA
     from airflow.serialization.decoders import decode_asset_like
 
     return decode_asset_like(encode_asset_like(obj))
+
+
+def ensure_serialized_deadline_alert(obj):
+    """
+    Convert *obj* from an SDK deadline alert to a serialized deadline alert if needed.
+
+    :meta private:
+    """
+    from airflow.serialization.decoders import decode_deadline_alert
+
+    return decode_deadline_alert(encode_deadline_alert(obj))
 
 
 def encode_partition_mapper(var: PartitionMapper) -> dict[str, Any]:

--- a/airflow-core/src/airflow/serialization/encoders.py
+++ b/airflow-core/src/airflow/serialization/encoders.py
@@ -188,12 +188,12 @@ def encode_deadline_alert(d: DeadlineAlert | SerializedDeadlineAlert) -> dict[st
 
     :meta private:
     """
-    from airflow.serialization.serialized_objects import BaseSerialization
+    from airflow.sdk.serde import serialize
 
     return {
         "reference": d.reference.serialize_reference(),
         "interval": d.interval.total_seconds(),
-        "callback": BaseSerialization.serialize(d.callback),
+        "callback": serialize(d.callback),
     }
 
 

--- a/airflow-core/src/airflow/serialization/encoders.py
+++ b/airflow-core/src/airflow/serialization/encoders.py
@@ -71,6 +71,8 @@ if TYPE_CHECKING:
 
     from airflow.sdk.definitions._internal.expandinput import ExpandInput
     from airflow.sdk.definitions.asset import BaseAsset
+    from airflow.sdk.definitions.deadline import DeadlineAlert
+    from airflow.serialization.definitions.deadline import SerializedDeadlineAlert
     from airflow.triggers.base import BaseEventTrigger
 
     T = TypeVar("T")
@@ -180,7 +182,7 @@ def encode_asset_like(a: BaseAsset | SerializedAssetBase) -> dict[str, Any]:
     raise ValueError(f"serialization not implemented for {type(a).__name__!r}")
 
 
-def encode_deadline_alert(d) -> dict[str, Any]:
+def encode_deadline_alert(d: DeadlineAlert | SerializedDeadlineAlert) -> dict[str, Any]:
     """
     Encode a deadline alert.
 

--- a/airflow-core/src/airflow/serialization/encoders.py
+++ b/airflow-core/src/airflow/serialization/encoders.py
@@ -49,6 +49,7 @@ from airflow.sdk.definitions.timetables.assets import (
     PartitionedAssetTimetable,
 )
 from airflow.sdk.definitions.timetables.simple import ContinuousTimetable, NullTimetable, OnceTimetable
+from airflow.serialization.decoders import decode_deadline_alert
 from airflow.serialization.definitions.assets import (
     SerializedAsset,
     SerializedAssetAlias,
@@ -415,8 +416,6 @@ def ensure_serialized_deadline_alert(obj):
 
     :meta private:
     """
-    from airflow.serialization.decoders import decode_deadline_alert
-
     return decode_deadline_alert(encode_deadline_alert(obj))
 
 

--- a/airflow-core/src/airflow/serialization/encoders.py
+++ b/airflow-core/src/airflow/serialization/encoders.py
@@ -58,6 +58,7 @@ from airflow.serialization.definitions.assets import (
     SerializedAssetBase,
     SerializedAssetRef,
 )
+from airflow.serialization.definitions.deadline import SerializedDeadlineAlert
 from airflow.serialization.enums import DagAttributeTypes as DAT, Encoding
 from airflow.serialization.helpers import (
     find_registered_custom_partition_mapper,
@@ -73,7 +74,6 @@ if TYPE_CHECKING:
     from airflow.sdk.definitions._internal.expandinput import ExpandInput
     from airflow.sdk.definitions.asset import BaseAsset
     from airflow.sdk.definitions.deadline import DeadlineAlert
-    from airflow.serialization.definitions.deadline import SerializedDeadlineAlert
     from airflow.triggers.base import BaseEventTrigger
 
     T = TypeVar("T")
@@ -410,12 +410,14 @@ def ensure_serialized_asset(obj: BaseAsset | SerializedAssetBase) -> SerializedA
     return decode_asset_like(encode_asset_like(obj))
 
 
-def ensure_serialized_deadline_alert(obj):
+def ensure_serialized_deadline_alert(obj: DeadlineAlert | SerializedDeadlineAlert) -> SerializedDeadlineAlert:
     """
     Convert *obj* from an SDK deadline alert to a serialized deadline alert if needed.
 
     :meta private:
     """
+    if isinstance(obj, SerializedDeadlineAlert):
+        return obj
     return decode_deadline_alert(encode_deadline_alert(obj))
 
 

--- a/airflow-core/tests/unit/models/test_dagrun.py
+++ b/airflow-core/tests/unit/models/test_dagrun.py
@@ -37,7 +37,7 @@ from airflow.callbacks.callback_requests import DagCallbackRequest, DagRunContex
 from airflow.models.dag import DagModel, infer_automated_data_interval
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagrun import DagRun, DagRunNote
-from airflow.models.deadline import Deadline, ReferenceModels
+from airflow.models.deadline import Deadline
 from airflow.models.deadline_alert import DeadlineAlert as DeadlineAlertModel
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskinstance import TaskInstance, TaskInstanceNote, clear_task_instances
@@ -49,6 +49,7 @@ from airflow.providers.standard.operators.python import PythonOperator, ShortCir
 from airflow.sdk import DAG, BaseOperator, get_current_context, setup, task, task_group, teardown
 from airflow.sdk.definitions.callback import AsyncCallback
 from airflow.sdk.definitions.deadline import DeadlineAlert, DeadlineReference
+from airflow.serialization.definitions.deadline import SerializedReferenceModels
 from airflow.serialization.serialized_objects import LazyDeserializedDAG
 from airflow.task.trigger_rule import TriggerRule
 from airflow.triggers.base import StartTriggerArgs
@@ -1321,7 +1322,7 @@ class TestDagRun:
         self, mock_get_by_id, mock_prune, session, deadline_test_dag
     ):
         mock_deadline_alert = mock.MagicMock()
-        mock_deadline_alert.reference_class = ReferenceModels.FixedDatetimeDeadline
+        mock_deadline_alert.reference_class = SerializedReferenceModels.FixedDatetimeDeadline
         mock_get_by_id.return_value = mock_deadline_alert
 
         scheduler_dag = deadline_test_dag()

--- a/airflow-core/tests/unit/models/test_deadline_alert.py
+++ b/airflow-core/tests/unit/models/test_deadline_alert.py
@@ -20,10 +20,10 @@ import pytest
 import time_machine
 from sqlalchemy import select
 
-from airflow.models.deadline import ReferenceModels
 from airflow.models.deadline_alert import DeadlineAlert
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.sdk.definitions.deadline import DeadlineReference
+from airflow.serialization.definitions.deadline import SerializedReferenceModels
 
 from tests_common.test_utils import db
 from unit.models import DEFAULT_DATE
@@ -175,7 +175,7 @@ class TestDeadlineAlert:
         assert hash(alert1) == hash(alert2)
 
     def test_deadline_alert_reference_class_property(self, deadline_alert_orm):
-        assert deadline_alert_orm.reference_class == ReferenceModels.DagRunQueuedAtDeadline
+        assert deadline_alert_orm.reference_class == SerializedReferenceModels.DagRunQueuedAtDeadline
 
     def test_deadline_alert_get_by_id(self, deadline_alert_orm, session):
         retrieved_alert = DeadlineAlert.get_by_id(deadline_alert_orm.id, session=session)

--- a/airflow-core/tests/unit/serialization/test_serialized_objects.py
+++ b/airflow-core/tests/unit/serialization/test_serialized_objects.py
@@ -493,8 +493,7 @@ def test_serialize_deserialize_deadline_alert(reference):
     deserialized = BaseSerialization.deserialize(serialized)
     assert deserialized.reference.serialize_reference() == reference.serialize_reference()
     assert deserialized.interval == original.interval
-    # Callback is deserialized as SerializedDeadlineAlert, which may have different callback representation
-    assert deserialized.callback is not None
+    assert deserialized.callback == original.callback
 
 
 @pytest.mark.parametrize(

--- a/airflow-core/tests/unit/serialization/test_serialized_objects.py
+++ b/airflow-core/tests/unit/serialization/test_serialized_objects.py
@@ -485,14 +485,16 @@ def test_serialize_deserialize_deadline_alert(reference):
         callback=AsyncCallback(empty_callback_for_deadline, kwargs=TEST_CALLBACK_KWARGS),
     )
 
-    serialized = original.serialize_deadline_alert()
+    # Use BaseSerialization like assets do
+    serialized = BaseSerialization.serialize(original)
     assert serialized[Encoding.TYPE] == DAT.DEADLINE_ALERT
     assert set(serialized[Encoding.VAR].keys()) == public_deadline_alert_fields
 
-    deserialized = DeadlineAlert.deserialize_deadline_alert(serialized)
+    deserialized = BaseSerialization.deserialize(serialized)
     assert deserialized.reference.serialize_reference() == reference.serialize_reference()
     assert deserialized.interval == original.interval
-    assert deserialized.callback == original.callback
+    # Callback is deserialized as SerializedDeadlineAlert, which may have different callback representation
+    assert deserialized.callback is not None
 
 
 @pytest.mark.parametrize(

--- a/airflow-core/tests/unit/serialization/test_serialized_objects.py
+++ b/airflow-core/tests/unit/serialization/test_serialized_objects.py
@@ -76,8 +76,8 @@ from airflow.serialization.definitions.assets import (
     SerializedAssetBase,
     SerializedAssetRef,
 )
-from airflow.serialization.definitions.deadline import DeadlineAlertFields
-from airflow.serialization.encoders import ensure_serialized_asset
+from airflow.serialization.definitions.deadline import DeadlineAlertFields, SerializedDeadlineAlert
+from airflow.serialization.encoders import ensure_serialized_asset, ensure_serialized_deadline_alert
 from airflow.serialization.enums import DagAttributeTypes as DAT, Encoding
 from airflow.serialization.helpers import PartitionMapperNotFound
 from airflow.serialization.serialized_objects import (
@@ -274,6 +274,17 @@ def equal_serialized_asset(a: SerializedAssetBase | BaseAsset, b: SerializedAsse
     return ensure_serialized_asset(a) == ensure_serialized_asset(b)
 
 
+def equal_serialized_deadline_alert(
+    a: DeadlineAlert | SerializedDeadlineAlert,
+    b: DeadlineAlert | SerializedDeadlineAlert,
+) -> bool:
+    """Compare deadline alerts for equality, normalizing to serialized form."""
+    a_ser = ensure_serialized_deadline_alert(a)
+    b_ser = ensure_serialized_deadline_alert(b)
+
+    return a_ser == b_ser
+
+
 class MockLazySelectSequence(LazySelectSequence):
     _data = ["a", "b", "c"]
 
@@ -451,7 +462,7 @@ class MockLazySelectSequence(LazySelectSequence):
                 callback=AsyncCallback("valid.callback.path", kwargs={"arg1": "value1"}),
             ),
             DAT.DEADLINE_ALERT,
-            equals,
+            equal_serialized_deadline_alert,
         ),
     ],
 )

--- a/task-sdk/src/airflow/sdk/definitions/deadline.py
+++ b/task-sdk/src/airflow/sdk/definitions/deadline.py
@@ -18,13 +18,10 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from airflow.models.deadline import DeadlineReferenceType, ReferenceModels
 from airflow.sdk.definitions.callback import AsyncCallback, Callback
-from airflow.sdk.serde import deserialize, serialize
-from airflow.serialization.definitions.deadline import DeadlineAlertFields
-from airflow.serialization.enums import DagAttributeTypes as DAT, Encoding
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -67,34 +64,6 @@ class DeadlineAlert:
                 self.interval,
                 self.callback,
             )
-        )
-
-    def serialize_deadline_alert(self):
-        """Return the data in a format that BaseSerialization can handle."""
-        return {
-            Encoding.TYPE: DAT.DEADLINE_ALERT,
-            Encoding.VAR: {
-                DeadlineAlertFields.REFERENCE: self.reference.serialize_reference(),
-                DeadlineAlertFields.INTERVAL: self.interval.total_seconds(),
-                DeadlineAlertFields.CALLBACK: serialize(self.callback),
-            },
-        }
-
-    @classmethod
-    def deserialize_deadline_alert(cls, encoded_data: dict) -> DeadlineAlert:
-        """Deserialize a DeadlineAlert from serialized data."""
-        data = encoded_data.get(Encoding.VAR, encoded_data)
-
-        reference_data = data[DeadlineAlertFields.REFERENCE]
-        reference_type = reference_data[ReferenceModels.REFERENCE_TYPE_FIELD]
-
-        reference_class = ReferenceModels.get_reference_class(reference_type)
-        reference = reference_class.deserialize_reference(reference_data)
-
-        return cls(
-            reference=reference,
-            interval=timedelta(seconds=data[DeadlineAlertFields.INTERVAL]),
-            callback=cast("Callback", deserialize(data[DeadlineAlertFields.CALLBACK])),
         )
 
 


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
Used cursor IDE

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

### Why This Change?

Trying to assist the client-server separation by moving worker side deadline functionality to `task-sdk` while keeping the DB dependent evaluation logic in `airflow-core`. This follows the established pattern from the assets migration: #58993


### What stays where?

In simpler terms, this PR tries to address this.

#### SDK
- `DeadlineAlert`: Its the user facing class for defining deadline alerts (no serialization methods from now)
- `DeadlineReference`: The same factory class for creating deadline references
- `ReferenceModels.*`: Original reference implementations for backward compatibility

The principle here it to keep the lightweight DAG authoring interface with no database dependencies in sdk

#### Core / Serialization module
- `SerializedDeadlineAlert`: Internal representation for core usages used post deserialization of a DeadlineAlert
- `SerializedReferenceModels.*`: Reference implementations with database access
- `encode_deadline_alert()` / `decode_deadline_alert()`: Centralized serialization functions used to ser/deser the deadline alerts


The principle here is to keep the serialization, deserialization, and deadline evaluation with database access in core.

### Serialization Changes

#### Structure
Serialization format remains **unchanged** - no breaking changes to stored DAGs:

```json
{
  "__type": "deadline_alert",
  "__var": {
    "reference": {"reference_type": "DagRunLogicalDateDeadline"},
    "interval": 3600.0,
    "callback": {
      "__classname__": "airflow.sdk.definitions.callback.AsyncCallback",
      "__version__": 0,
      "__data__": {"path": "...", "kwargs": {...}}
    }
  }
}
```

Same with the flow of control
1. Encode (DAG Processor): `DeadlineAlert` → dict via `encode_deadline_alert()` using `airflow.sdk.serde`
2. Stored as JSON in database
3. Decode (Scheduler): dict → `SerializedDeadlineAlert` via `decode_deadline_alert()`
4. Evaluate: `SerializedReferenceModels` uses database session to calculate deadlines

One thing of note is the callback serialisation, I chose to continue using serde for this purpose because BaseSerialisation cannot handle callbacks. Using serde made sense since this part of serialisation runs in dag processor, which untilmately is not a _core component_ and can use task sdk. So, flow:

- Uses `airflow.sdk.serde.serialize()` / `deserialize()` for proper callback handling
- Runs in DAG Processor context where SDK is available
- Callbacks fully serialize with path and kwargs (no string representations)

### Backward Compatibility

- Serialization format identical to main branch
- Reference class names unchanged (e.g., `DagRunLogicalDateDeadline` not `SerializedDagRunLogicalDateDeadline`)
- Existing serialized DAGs deserialize correctly
- Internal API only - no user-facing changes, so nothing to worry about hopefully


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
