### PR TITLE
Replace all occurrence of lineage hook over sdk for compat provider

### DIFF
--- a/devel-common/src/sphinx_exts/providers_extensions.py
+++ b/devel-common/src/sphinx_exts/providers_extensions.py
@@ -278,7 +278,7 @@ def _render_openlineage_supported_classes_content():
         "get_openlineage_database_info",
         "get_openlineage_database_specific_lineage",
     )
-    hook_lineage_collector_path = "airflow.providers.common.compat.lineage.hook.get_hook_lineage_collector"
+    hook_lineage_collector_path = "airflow.providers.common.compat.sdk.get_hook_lineage_collector"
     hook_level_lineage_collector_calls = {
         f"{hook_lineage_collector_path}.add_input_asset",  # Airflow 3
         f"{hook_lineage_collector_path}.add_output_asset",  # Airflow 3

--- a/devel-common/src/tests_common/pytest_plugin.py
+++ b/devel-common/src/tests_common/pytest_plugin.py
@@ -1988,7 +1988,7 @@ def hook_lineage_collector():
         return_value=hlc,
     ):
         # Redirect calls to compat provider to support back-compat tests of 2.x as well
-        from airflow.providers.common.compat.lineage.hook import get_hook_lineage_collector
+        from airflow.providers.common.compat.sdk import get_hook_lineage_collector
 
         yield get_hook_lineage_collector()
 

--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/s3.py
@@ -61,8 +61,11 @@ from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.amazon.aws.exceptions import S3HookUriParseFailure
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from airflow.providers.amazon.aws.utils.tags import format_tags
-from airflow.providers.common.compat.lineage.hook import get_hook_lineage_collector
-from airflow.providers.common.compat.sdk import AirflowException, AirflowNotFoundException
+from airflow.providers.common.compat.sdk import (
+    AirflowException,
+    AirflowNotFoundException,
+    get_hook_lineage_collector,
+)
 from airflow.utils.helpers import chunks
 
 logger = logging.getLogger(__name__)

--- a/providers/common/compat/tests/unit/common/compat/lineage/test_hook.py
+++ b/providers/common/compat/tests/unit/common/compat/lineage/test_hook.py
@@ -20,7 +20,7 @@ from unittest import mock
 
 import pytest
 
-from airflow.providers.common.compat.lineage.hook import _lacks_add_extra_method, _lacks_asset_methods
+from airflow.providers.common.compat.sdk import _lacks_add_extra_method, _lacks_asset_methods
 
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
@@ -34,7 +34,7 @@ def collector():
         "airflow.lineage.hook.get_hook_lineage_collector",
         return_value=HookLineageCollector(),
     ):
-        from airflow.providers.common.compat.lineage.hook import get_hook_lineage_collector
+        from airflow.providers.common.compat.sdk import get_hook_lineage_collector
 
         yield get_hook_lineage_collector()
 
@@ -48,7 +48,7 @@ def noop_collector():
         "airflow.lineage.hook.get_hook_lineage_collector",
         return_value=NoOpCollector(),
     ):
-        from airflow.providers.common.compat.lineage.hook import get_hook_lineage_collector
+        from airflow.providers.common.compat.sdk import get_hook_lineage_collector
 
         yield get_hook_lineage_collector()
 
@@ -118,7 +118,7 @@ def test_lacks_add_extra_method_missing():
 
 
 def test_retrieval_does_not_raise():  # do not use fixture here
-    from airflow.providers.common.compat.lineage.hook import get_hook_lineage_collector
+    from airflow.providers.common.compat.sdk import get_hook_lineage_collector
 
     # On compat tests this goes into ImportError code path
     assert get_hook_lineage_collector() is not None
@@ -126,7 +126,7 @@ def test_retrieval_does_not_raise():  # do not use fixture here
 
 
 def test_global_collector_is_reused():  # do not use fixture here
-    from airflow.providers.common.compat.lineage.hook import get_hook_lineage_collector
+    from airflow.providers.common.compat.sdk import get_hook_lineage_collector
 
     c1 = get_hook_lineage_collector()
     c2 = get_hook_lineage_collector()

--- a/providers/google/src/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/bigquery.py
@@ -60,8 +60,11 @@ from pandas_gbq.gbq import GbqConnector  # noqa: F401 used in ``airflow.contrib.
 from sqlalchemy import create_engine
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
-from airflow.providers.common.compat.lineage.hook import get_hook_lineage_collector
-from airflow.providers.common.compat.sdk import AirflowException, AirflowOptionalProviderFeatureException
+from airflow.providers.common.compat.sdk import (
+    AirflowException,
+    AirflowOptionalProviderFeatureException,
+    get_hook_lineage_collector,
+)
 from airflow.providers.common.sql.hooks.sql import DbApiHook
 from airflow.providers.google.cloud.utils.bigquery import bq_cast
 from airflow.providers.google.cloud.utils.credentials_provider import _get_scopes

--- a/providers/google/src/airflow/providers/google/cloud/hooks/gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/gcs.py
@@ -44,8 +44,7 @@ from google.cloud.exceptions import GoogleCloudError
 from google.cloud.storage.retry import DEFAULT_RETRY
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
-from airflow.providers.common.compat.lineage.hook import get_hook_lineage_collector
-from airflow.providers.common.compat.sdk import AirflowException, timezone
+from airflow.providers.common.compat.sdk import AirflowException, get_hook_lineage_collector, timezone
 from airflow.providers.google.cloud.utils.helpers import normalize_directory_path
 from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import (

--- a/providers/openlineage/src/airflow/providers/openlineage/extractors/manager.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/extractors/manager.py
@@ -195,7 +195,7 @@ class ExtractorManager(LoggingMixin):
 
     def get_hook_lineage(self) -> tuple[list[Dataset], list[Dataset]] | None:
         try:
-            from airflow.providers.common.compat.lineage.hook import get_hook_lineage_collector
+            from airflow.providers.common.compat.sdk import get_hook_lineage_collector
         except ImportError:
             return None
 

--- a/providers/openlineage/tests/unit/openlineage/extractors/test_manager.py
+++ b/providers/openlineage/tests/unit/openlineage/extractors/test_manager.py
@@ -62,12 +62,12 @@ def hook_lineage_collector():
         from unittest import mock
 
         with mock.patch(patch_target, return_value=hlc):
-            from airflow.providers.common.compat.lineage.hook import get_hook_lineage_collector
+            from airflow.providers.common.compat.sdk import get_hook_lineage_collector
 
             yield get_hook_lineage_collector()
     else:
         from airflow.lineage import hook
-        from airflow.providers.common.compat.lineage.hook import get_hook_lineage_collector
+        from airflow.providers.common.compat.sdk import get_hook_lineage_collector
 
         hook._hook_lineage_collector = hlc
 


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
