### PR TITLE
Executor Synchronous callback workload

### DIFF
--- a/airflow-core/src/airflow/executors/base_executor.py
+++ b/airflow-core/src/airflow/executors/base_executor.py
@@ -143,6 +143,7 @@ class BaseExecutor(LoggingMixin):
     active_spans = ThreadSafeDict()
 
     supports_ad_hoc_ti_run: bool = False
+    supports_callbacks: bool = False
     supports_multi_team: bool = False
     sentry_integration: str = ""
 
@@ -186,8 +187,9 @@ class BaseExecutor(LoggingMixin):
         self.parallelism: int = parallelism
         self.team_name: str | None = team_name
         self.queued_tasks: dict[TaskInstanceKey, workloads.ExecuteTask] = {}
-        self.running: set[TaskInstanceKey] = set()
-        self.event_buffer: dict[TaskInstanceKey, EventBufferValueType] = {}
+        self.queued_callbacks: dict[str, workloads.ExecuteCallback] = {}
+        self.running: set[TaskInstanceKey | str] = set()
+        self.event_buffer: dict[TaskInstanceKey | str, EventBufferValueType] = {}
         self._task_event_logs: deque[Log] = deque()
         self.conf = ExecutorConf(team_name)
 
@@ -224,10 +226,46 @@ class BaseExecutor(LoggingMixin):
         self._task_event_logs.append(Log(event=event, task_instance=ti_key, extra=extra))
 
     def queue_workload(self, workload: workloads.All, session: Session) -> None:
-        if not isinstance(workload, workloads.ExecuteTask):
+        if isinstance(workload, workloads.ExecuteTask):
+            ti = workload.ti
+            self.queued_tasks[ti.key] = workload
+        elif isinstance(workload, workloads.ExecuteCallback):
+            self.queued_callbacks[workload.callback.id] = workload
+        else:
             raise ValueError(f"Un-handled workload kind {type(workload).__name__!r} in {type(self).__name__}")
-        ti = workload.ti
-        self.queued_tasks[ti.key] = workload
+
+    def _get_workloads_to_schedule(
+        self, open_slots: int
+    ) -> list[tuple[TaskInstanceKey | str, workloads.All]]:
+        """
+        Select and return the next batch of workloads to schedule, respecting priority policy.
+
+        Priority Policy: Callbacks are scheduled before tasks (callbacks complete existing work).
+        Callbacks are processed in FIFO order. Tasks are sorted by priority_weight (higher priority first).
+
+        :param open_slots: Number of available execution slots
+        """
+        workloads_to_schedule: list[tuple[TaskInstanceKey | str, workloads.All]] = []
+
+        if self.queued_callbacks:
+            for key, workload in self.queued_callbacks.items():
+                if len(workloads_to_schedule) >= open_slots:
+                    break
+                workloads_to_schedule.append((key, workload))
+
+        remaining_slots = open_slots - len(workloads_to_schedule)
+        if remaining_slots and self.queued_tasks:
+            sorted_tasks = sorted(
+                self.queued_tasks.items(),
+                key=lambda x: x[1].ti.priority_weight,
+                reverse=True,
+            )
+            for key, workload in sorted_tasks:
+                if len(workloads_to_schedule) >= open_slots:
+                    break
+                workloads_to_schedule.append((key, workload))
+
+        return workloads_to_schedule
 
     def _process_workloads(self, workloads: Sequence[workloads.All]) -> None:
         """
@@ -266,10 +304,10 @@ class BaseExecutor(LoggingMixin):
         """Heartbeat sent to trigger new jobs."""
         open_slots = self.parallelism - len(self.running)
 
-        num_running_tasks = len(self.running)
-        num_queued_tasks = len(self.queued_tasks)
+        num_running_workloads = len(self.running)
+        num_queued_workloads = len(self.queued_tasks) + len(self.queued_callbacks)
 
-        self._emit_metrics(open_slots, num_running_tasks, num_queued_tasks)
+        self._emit_metrics(open_slots, num_running_workloads, num_queued_workloads)
         self.trigger_tasks(open_slots)
 
         # Calling child class sync method
@@ -350,16 +388,16 @@ class BaseExecutor(LoggingMixin):
 
     def trigger_tasks(self, open_slots: int) -> None:
         """
-        Initiate async execution of the queued tasks, up to the number of available slots.
+        Initiate async execution of queued workloads (tasks and callbacks), up to the number of available slots.
+
+        Callbacks are prioritized over tasks to complete existing work before starting new work.
 
         :param open_slots: Number of open slots
         """
-        sorted_queue = self.order_queued_tasks_by_priority()
+        workloads_to_schedule = self._get_workloads_to_schedule(open_slots)
         workload_list = []
 
-        for _ in range(min((open_slots, len(self.queued_tasks)))):
-            key, item = sorted_queue.pop()
-
+        for key, workload in workloads_to_schedule:
             # If a task makes it here but is still understood by the executor
             # to be running, it generally means that the task has been killed
             # externally and not yet been marked as failed.
@@ -373,8 +411,8 @@ class BaseExecutor(LoggingMixin):
             if key in self.attempts:
                 del self.attempts[key]
 
-            if isinstance(item, workloads.ExecuteTask) and hasattr(item, "ti"):
-                ti = item.ti
+            if isinstance(workload, workloads.ExecuteTask) and hasattr(workload, "ti"):
+                ti = workload.ti
 
                 # If it's None, then the span for the current id hasn't been started.
                 if self.active_spans is not None and self.active_spans.get("ti:" + str(ti.id)) is None:
@@ -397,9 +435,20 @@ class BaseExecutor(LoggingMixin):
                     carrier = Trace.inject()
                     ti.context_carrier = carrier
 
-                workload_list.append(item)
+            workload_list.append(workload)
+
         if workload_list:
-            self._process_workloads(workload_list)
+            try:
+                self._process_workloads(workload_list)
+            except AttributeError as e:
+                if any(isinstance(workload, workloads.ExecuteCallback) for workload in workload_list):
+                    raise NotImplementedError(
+                        f"{type(self).__name__} does not support ExecuteCallback workloads. "
+                        f"This executor needs to be updated to handle both ExecuteTask and ExecuteCallback types. "
+                        f"See any executor with supports_callbacks=True (LocalExecutor or CeleryExecutor, for example) for reference implementation."
+                    ) from e
+                # Re-raise if it's a different AttributeError
+                raise
 
     # TODO: This should not be using `TaskInstanceState` here, this is just "did the process complete, or did
     # it die". It is possible for the task itself to finish with success, but the state of the task to be set
@@ -529,20 +578,25 @@ class BaseExecutor(LoggingMixin):
 
     @property
     def slots_available(self):
-        """Number of new tasks this executor instance can accept."""
-        return self.parallelism - len(self.running) - len(self.queued_tasks)
+        """Number of new workloads (tasks and callbacks) this executor instance can accept."""
+        return self.parallelism - len(self.running) - len(self.queued_tasks) - len(self.queued_callbacks)
 
     @property
     def slots_occupied(self):
-        """Number of tasks this executor instance is currently managing."""
-        return len(self.running) + len(self.queued_tasks)
+        """Number of workloads (tasks and callbacks) this executor instance is currently managing."""
+        return len(self.running) + len(self.queued_tasks) + len(self.queued_callbacks)
 
     def debug_dump(self):
         """Get called in response to SIGUSR2 by the scheduler."""
         self.log.info(
-            "executor.queued (%d)\n\t%s",
+            "executor.queued_tasks (%d)\n\t%s",
             len(self.queued_tasks),
             "\n\t".join(map(repr, self.queued_tasks.items())),
+        )
+        self.log.info(
+            "executor.queued_callbacks (%d)\n\t%s",
+            len(self.queued_callbacks),
+            "\n\t".join(map(repr, self.queued_callbacks.items())),
         )
         self.log.info("executor.running (%d)\n\t%s", len(self.running), "\n\t".join(map(repr, self.running)))
         self.log.info(

--- a/airflow-core/src/airflow/executors/base_executor.py
+++ b/airflow-core/src/airflow/executors/base_executor.py
@@ -241,7 +241,10 @@ class BaseExecutor(LoggingMixin):
                 )
             self.queued_callbacks[workload.callback.id] = workload
         else:
-            raise ValueError(f"Un-handled workload kind {type(workload).__name__!r} in {type(self).__name__}")
+            raise ValueError(
+                f"Un-handled workload type {type(workload).__name__!r} in {type(self).__name__}. "
+                f"Workload must be one of: ExecuteTask, ExecuteCallback."
+            )
 
     def _get_workloads_to_schedule(self, open_slots: int) -> list[tuple[WorkloadKey, workloads.All]]:
         """

--- a/airflow-core/src/airflow/executors/base_executor.py
+++ b/airflow-core/src/airflow/executors/base_executor.py
@@ -52,6 +52,7 @@ if TYPE_CHECKING:
     from airflow.callbacks.callback_requests import CallbackRequest
     from airflow.cli.cli_config import GroupCommand
     from airflow.executors.executor_utils import ExecutorName
+    from airflow.executors.workloads import WorkloadKey
     from airflow.models.taskinstance import TaskInstance
     from airflow.models.taskinstancekey import TaskInstanceKey
 
@@ -188,8 +189,8 @@ class BaseExecutor(LoggingMixin):
         self.team_name: str | None = team_name
         self.queued_tasks: dict[TaskInstanceKey, workloads.ExecuteTask] = {}
         self.queued_callbacks: dict[str, workloads.ExecuteCallback] = {}
-        self.running: set[TaskInstanceKey | str] = set()
-        self.event_buffer: dict[TaskInstanceKey | str, EventBufferValueType] = {}
+        self.running: set[WorkloadKey] = set()
+        self.event_buffer: dict[WorkloadKey, EventBufferValueType] = {}
         self._task_event_logs: deque[Log] = deque()
         self.conf = ExecutorConf(team_name)
 
@@ -205,7 +206,7 @@ class BaseExecutor(LoggingMixin):
         :meta private:
         """
 
-        self.attempts: dict[TaskInstanceKey, RunningRetryAttemptType] = defaultdict(RunningRetryAttemptType)
+        self.attempts: dict[WorkloadKey, RunningRetryAttemptType] = defaultdict(RunningRetryAttemptType)
 
     def __repr__(self):
         _repr = f"{self.__class__.__name__}(parallelism={self.parallelism}"
@@ -230,13 +231,13 @@ class BaseExecutor(LoggingMixin):
             ti = workload.ti
             self.queued_tasks[ti.key] = workload
         elif isinstance(workload, workloads.ExecuteCallback):
-            self.queued_callbacks[workload.callback.id] = workload
+            self.queued_callbacks[str(workload.callback.id)] = workload
         else:
             raise ValueError(f"Un-handled workload kind {type(workload).__name__!r} in {type(self).__name__}")
 
     def _get_workloads_to_schedule(
         self, open_slots: int
-    ) -> list[tuple[TaskInstanceKey | str, workloads.All]]:
+    ) -> list[tuple[WorkloadKey, workloads.All]]:
         """
         Select and return the next batch of workloads to schedule, respecting priority policy.
 
@@ -245,7 +246,7 @@ class BaseExecutor(LoggingMixin):
 
         :param open_slots: Number of available execution slots
         """
-        workloads_to_schedule: list[tuple[TaskInstanceKey | str, workloads.All]] = []
+        workloads_to_schedule: list[tuple[WorkloadKey, workloads.All]] = []
 
         if self.queued_callbacks:
             for key, workload in self.queued_callbacks.items():
@@ -508,24 +509,26 @@ class BaseExecutor(LoggingMixin):
         """
         self.change_state(key, TaskInstanceState.RUNNING, info, remove_running=False)
 
-    def get_event_buffer(self, dag_ids=None) -> dict[TaskInstanceKey, EventBufferValueType]:
+    def get_event_buffer(self, dag_ids=None) -> dict[WorkloadKey, EventBufferValueType]:
         """
         Return and flush the event buffer.
 
         In case dag_ids is specified it will only return and flush events
         for the given dag_ids. Otherwise, it returns and flushes all events.
+        Note: Callback events (with string keys) are always included regardless of dag_ids filter.
 
         :param dag_ids: the dag_ids to return events for; returns all if given ``None``.
         :return: a dict of events
         """
-        cleared_events: dict[TaskInstanceKey, EventBufferValueType] = {}
+        cleared_events: dict[WorkloadKey, EventBufferValueType] = {}
         if dag_ids is None:
             cleared_events = self.event_buffer
             self.event_buffer = {}
         else:
-            for ti_key in list(self.event_buffer.keys()):
-                if ti_key.dag_id in dag_ids:
-                    cleared_events[ti_key] = self.event_buffer.pop(ti_key)
+            for key in list(self.event_buffer.keys()):
+                # Include if it's a callback (string key) or if it's a task in the specified dags
+                if isinstance(key, str) or key.dag_id in dag_ids:
+                    cleared_events[key] = self.event_buffer.pop(key)
 
         return cleared_events
 

--- a/airflow-core/src/airflow/executors/base_executor.py
+++ b/airflow-core/src/airflow/executors/base_executor.py
@@ -34,6 +34,7 @@ from airflow.executors import workloads
 from airflow.executors.executor_loader import ExecutorLoader
 from airflow.executors.workloads.task import TaskInstanceDTO
 from airflow.models import Log
+from airflow.models.callback import CallbackKey
 from airflow.observability.metrics import stats_utils
 from airflow.observability.trace import Trace
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -515,8 +516,8 @@ class BaseExecutor(LoggingMixin):
             self.event_buffer = {}
         else:
             for key in list(self.event_buffer.keys()):
-                # Include if it's a callback (string key) or if it's a task in the specified dags
-                if isinstance(key, str) or key.dag_id in dag_ids:
+                # Include if it's a callback or if it's a task in the specified dags
+                if isinstance(key, CallbackKey) or key.dag_id in dag_ids:
                     cleared_events[key] = self.event_buffer.pop(key)
 
         return cleared_events

--- a/airflow-core/src/airflow/executors/base_executor.py
+++ b/airflow-core/src/airflow/executors/base_executor.py
@@ -237,7 +237,7 @@ class BaseExecutor(LoggingMixin):
                     f"Set supports_callbacks = True and implement callback handling in _process_workloads(). "
                     f"See LocalExecutor or CeleryExecutor for reference implementation."
                 )
-            self.queued_callbacks[str(workload.callback.id)] = workload
+            self.queued_callbacks[workload.callback.id] = workload
         else:
             raise ValueError(f"Un-handled workload kind {type(workload).__name__!r} in {type(self).__name__}")
 
@@ -259,10 +259,10 @@ class BaseExecutor(LoggingMixin):
                 workloads_to_schedule.append((key, workload))
 
         if open_slots > len(workloads_to_schedule) and self.queued_tasks:
-            for key, workload in self.order_queued_tasks_by_priority():
+            for task_key, task_workload in self.order_queued_tasks_by_priority():
                 if len(workloads_to_schedule) >= open_slots:
                     break
-                workloads_to_schedule.append((key, workload))
+                workloads_to_schedule.append((task_key, task_workload))
 
         return workloads_to_schedule
 

--- a/airflow-core/src/airflow/executors/base_executor.py
+++ b/airflow-core/src/airflow/executors/base_executor.py
@@ -231,13 +231,17 @@ class BaseExecutor(LoggingMixin):
             ti = workload.ti
             self.queued_tasks[ti.key] = workload
         elif isinstance(workload, workloads.ExecuteCallback):
+            if not self.supports_callbacks:
+                raise NotImplementedError(
+                    f"{type(self).__name__} does not support ExecuteCallback workloads. "
+                    f"Set supports_callbacks = True and implement callback handling in _process_workloads(). "
+                    f"See LocalExecutor or CeleryExecutor for reference implementation."
+                )
             self.queued_callbacks[str(workload.callback.id)] = workload
         else:
             raise ValueError(f"Un-handled workload kind {type(workload).__name__!r} in {type(self).__name__}")
 
-    def _get_workloads_to_schedule(
-        self, open_slots: int
-    ) -> list[tuple[WorkloadKey, workloads.All]]:
+    def _get_workloads_to_schedule(self, open_slots: int) -> list[tuple[WorkloadKey, workloads.All]]:
         """
         Select and return the next batch of workloads to schedule, respecting priority policy.
 
@@ -254,14 +258,8 @@ class BaseExecutor(LoggingMixin):
                     break
                 workloads_to_schedule.append((key, workload))
 
-        remaining_slots = open_slots - len(workloads_to_schedule)
-        if remaining_slots and self.queued_tasks:
-            sorted_tasks = sorted(
-                self.queued_tasks.items(),
-                key=lambda x: x[1].ti.priority_weight,
-                reverse=True,
-            )
-            for key, workload in sorted_tasks:
+        if open_slots > len(workloads_to_schedule) and self.queued_tasks:
+            for key, workload in self.order_queued_tasks_by_priority():
                 if len(workloads_to_schedule) >= open_slots:
                     break
                 workloads_to_schedule.append((key, workload))
@@ -439,17 +437,7 @@ class BaseExecutor(LoggingMixin):
             workload_list.append(workload)
 
         if workload_list:
-            try:
-                self._process_workloads(workload_list)
-            except AttributeError as e:
-                if any(isinstance(workload, workloads.ExecuteCallback) for workload in workload_list):
-                    raise NotImplementedError(
-                        f"{type(self).__name__} does not support ExecuteCallback workloads. "
-                        f"This executor needs to be updated to handle both ExecuteTask and ExecuteCallback types. "
-                        f"See any executor with supports_callbacks=True (LocalExecutor or CeleryExecutor, for example) for reference implementation."
-                    ) from e
-                # Re-raise if it's a different AttributeError
-                raise
+            self._process_workloads(workload_list)
 
     # TODO: This should not be using `TaskInstanceState` here, this is just "did the process complete, or did
     # it die". It is possible for the task itself to finish with success, but the state of the task to be set

--- a/airflow-core/src/airflow/executors/base_executor.py
+++ b/airflow-core/src/airflow/executors/base_executor.py
@@ -32,6 +32,7 @@ from airflow.cli.cli_config import DefaultHelpParser
 from airflow.configuration import conf
 from airflow.executors import workloads
 from airflow.executors.executor_loader import ExecutorLoader
+from airflow.executors.workloads.task import TaskInstanceDTO
 from airflow.models import Log
 from airflow.observability.metrics import stats_utils
 from airflow.observability.trace import Trace
@@ -52,7 +53,7 @@ if TYPE_CHECKING:
     from airflow.callbacks.callback_requests import CallbackRequest
     from airflow.cli.cli_config import GroupCommand
     from airflow.executors.executor_utils import ExecutorName
-    from airflow.executors.workloads import WorkloadKey
+    from airflow.executors.workloads.types import WorkloadKey
     from airflow.models.taskinstance import TaskInstance
     from airflow.models.taskinstancekey import TaskInstanceKey
 
@@ -415,7 +416,7 @@ class BaseExecutor(LoggingMixin):
 
                 # If it's None, then the span for the current id hasn't been started.
                 if self.active_spans is not None and self.active_spans.get("ti:" + str(ti.id)) is None:
-                    if isinstance(ti, workloads.TaskInstance):
+                    if isinstance(ti, TaskInstanceDTO):
                         parent_context = Trace.extract(ti.parent_context_carrier)
                     else:
                         parent_context = Trace.extract(ti.dag_run.context_carrier)

--- a/airflow-core/src/airflow/executors/base_executor.py
+++ b/airflow-core/src/airflow/executors/base_executor.py
@@ -516,7 +516,6 @@ class BaseExecutor(LoggingMixin):
             self.event_buffer = {}
         else:
             for key in list(self.event_buffer.keys()):
-                # Include if it's a callback or if it's a task in the specified dags
                 if isinstance(key, CallbackKey) or key.dag_id in dag_ids:
                     cleared_events[key] = self.event_buffer.pop(key)
 

--- a/airflow-core/src/airflow/executors/local_executor.py
+++ b/airflow-core/src/airflow/executors/local_executor.py
@@ -102,22 +102,20 @@ def _run_worker(
 
         # Handle different workload types
         if isinstance(workload, workloads.ExecuteTask):
-            key: WorkloadKey = workload.ti.key
             try:
                 _execute_work(log, workload, team_conf)
-                output.put((key, TaskInstanceState.SUCCESS, None))
+                output.put((workload.ti.key, TaskInstanceState.SUCCESS, None))
             except Exception as e:
                 log.exception("Task execution failed.")
-                output.put((key, TaskInstanceState.FAILED, e))
+                output.put((workload.ti.key, TaskInstanceState.FAILED, e))
 
         elif isinstance(workload, workloads.ExecuteCallback):
-            key: WorkloadKey = workload.callback.id
             try:
                 _execute_callback(log, workload, team_conf)
-                output.put((key, CallbackState.SUCCESS, None))
+                output.put((workload.callback.id, CallbackState.SUCCESS, None))
             except Exception as e:
                 log.exception("Callback execution failed")
-                output.put((key, CallbackState.FAILED, e))
+                output.put((workload.callback.id, CallbackState.FAILED, e))
 
         else:
             raise ValueError(f"LocalExecutor does not know how to handle {type(workload)}")

--- a/airflow-core/src/airflow/executors/local_executor.py
+++ b/airflow-core/src/airflow/executors/local_executor.py
@@ -50,9 +50,7 @@ else:
 if TYPE_CHECKING:
     from structlog.typing import FilteringBoundLogger as Logger
 
-    from airflow.executors.workloads import WorkloadKey, WorkloadState
-
-    WorkloadResultType = tuple[WorkloadKey, WorkloadState, Exception | None]
+    from airflow.executors.workloads.types import WorkloadResultType
 
 
 def _get_executor_process_title_prefix(team_name: str | None) -> str:

--- a/airflow-core/src/airflow/executors/local_executor.py
+++ b/airflow-core/src/airflow/executors/local_executor.py
@@ -109,6 +109,7 @@ def _run_worker(
                 output.put((workload.ti.key, TaskInstanceState.FAILED, e))
 
         elif isinstance(workload, workloads.ExecuteCallback):
+            output.put((workload.callback.id, CallbackState.RUNNING, None))
             try:
                 _execute_callback(log, workload, team_conf)
                 output.put((workload.callback.id, CallbackState.SUCCESS, None))

--- a/airflow-core/src/airflow/executors/local_executor.py
+++ b/airflow-core/src/airflow/executors/local_executor.py
@@ -37,6 +37,7 @@ import structlog
 
 from airflow.executors import workloads
 from airflow.executors.base_executor import BaseExecutor
+from airflow.executors.workloads.callback import execute_callback_workload
 from airflow.utils.state import CallbackState, TaskInstanceState
 
 # add logger to parameter of setproctitle to support logging
@@ -160,7 +161,7 @@ def _execute_callback(log: Logger, workload: workloads.ExecuteCallback, team_con
     """
     setproctitle(f"{_get_executor_process_title_prefix(team_conf.team_name)} {workload.callback.id}", log)
 
-    success, error_msg = workloads.execute_callback_workload(workload.callback, log)
+    success, error_msg = execute_callback_workload(workload.callback, log)
 
     if not success:
         raise RuntimeError(error_msg or "Callback execution failed")

--- a/airflow-core/src/airflow/executors/local_executor.py
+++ b/airflow-core/src/airflow/executors/local_executor.py
@@ -102,7 +102,7 @@ def _run_worker(
 
         # Handle different workload types
         if isinstance(workload, workloads.ExecuteTask):
-            key = workload.ti.key
+            key: WorkloadKey = workload.ti.key
             try:
                 _execute_work(log, workload, team_conf)
                 output.put((key, TaskInstanceState.SUCCESS, None))
@@ -111,7 +111,7 @@ def _run_worker(
                 output.put((key, TaskInstanceState.FAILED, e))
 
         elif isinstance(workload, workloads.ExecuteCallback):
-            key = workload.callback.id
+            key: WorkloadKey = workload.callback.id
             try:
                 _execute_callback(log, workload, team_conf)
                 output.put((key, CallbackState.SUCCESS, None))

--- a/airflow-core/src/airflow/executors/local_executor.py
+++ b/airflow-core/src/airflow/executors/local_executor.py
@@ -145,7 +145,7 @@ def _execute_work(log: Logger, workload: workloads.ExecuteTask, team_conf) -> No
         ti=workload.ti,  # type: ignore[arg-type]
         dag_rel_path=workload.dag_rel_path,
         bundle_info=workload.bundle_info,
-        token=workload.token,
+        token=workload.identity_token,
         server=team_conf.get("core", "execution_api_server_url", fallback=default_execution_api_server),
         log_path=workload.log_path,
     )

--- a/airflow-core/src/airflow/executors/local_executor.py
+++ b/airflow-core/src/airflow/executors/local_executor.py
@@ -146,7 +146,7 @@ def _execute_work(log: Logger, workload: workloads.ExecuteTask, team_conf) -> No
         ti=workload.ti,  # type: ignore[arg-type]
         dag_rel_path=workload.dag_rel_path,
         bundle_info=workload.bundle_info,
-        token=workload.identity_token,
+        token=workload.token,
         server=team_conf.get("core", "execution_api_server_url", fallback=default_execution_api_server),
         log_path=workload.log_path,
     )

--- a/airflow-core/src/airflow/executors/workloads.py
+++ b/airflow-core/src/airflow/executors/workloads.py
@@ -20,16 +20,19 @@ import os
 import uuid
 from abc import ABC
 from datetime import datetime
+from importlib import import_module
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Literal
 
 import structlog
 from pydantic import BaseModel, Field
 
+from airflow.models.callback import CallbackFetchMethod
+
 if TYPE_CHECKING:
     from airflow.api_fastapi.auth.tokens import JWTGenerator
     from airflow.models import DagRun
-    from airflow.models.callback import Callback as CallbackModel, CallbackFetchMethod
+    from airflow.models.callback import Callback as CallbackModel
     from airflow.models.taskinstance import TaskInstance as TIModel
     from airflow.models.taskinstancekey import TaskInstanceKey
 
@@ -92,7 +95,7 @@ class Callback(BaseModel):
     """Schema for Callback with minimal required fields needed for Executors and Task SDK."""
 
     id: uuid.UUID
-    fetch_type: CallbackFetchMethod
+    fetch_method: CallbackFetchMethod
     data: dict
 
 
@@ -208,3 +211,61 @@ All = Annotated[
     ExecuteTask | ExecuteCallback | RunTrigger,
     Field(discriminator="type"),
 ]
+
+
+def execute_callback_workload(
+    callback: Callback,
+    log,
+) -> tuple[bool, str | None]:
+    """
+    Execute a callback function by importing and calling it, returning the success state.
+
+    Supports two patterns:
+    1. Functions - called directly with kwargs
+    2. Classes that return callable instances (like BaseNotifier) - instantiated then called with context
+
+    Example:
+        # Function callback
+        callback.data = {"path": "my_module.alert_func", "kwargs": {"msg": "Alert!", "context": {...}}}
+        execute_callback_workload(callback, log)  # Calls alert_func(msg="Alert!", context={...})
+
+        # Notifier callback
+        callback.data = {"path": "airflow.providers.slack...SlackWebhookNotifier", "kwargs": {"text": "Alert!", "context": {...}}}
+        execute_callback_workload(callback, log)  # SlackWebhookNotifier(text=..., context=...) then calls instance(context)
+
+    :param callback: The Callback schema containing path and kwargs
+    :param log: Logger instance for recording execution
+    :return: Tuple of (success: bool, error_message: str | None)
+    """
+    # Extract callback details from data
+    callback_path = callback.data.get("path")
+    callback_kwargs = callback.data.get("kwargs", {})
+
+    if not callback_path:
+        return False, "Callback path not found in data."
+
+    try:
+        # Import the callback callable
+        # Expected format: "module.path.to.function_or_class"
+        module_path, function_name = callback_path.rsplit(".", 1)
+        module = import_module(module_path)
+        callback_callable = getattr(module, function_name)
+
+        log.debug("Executing callback %s(%s)...", callback_path, callback_kwargs)
+
+        # If the callback is a callabale, call it.  If it is a class, instantiate it.
+        result = callback_callable(**callback_kwargs)
+
+        # If the callback is a class then it is now instantiated and callable, call it.
+        if callable(result):
+            context = callback_kwargs.get("context", {})
+            log.debug("Calling result with context for %s", callback_path)
+            result = result(context)
+
+        log.info("Callback %s executed successfully.", callback_path)
+        return True, None
+
+    except Exception as e:
+        error_msg = f"Callback execution failed: {type(e).__name__}: {str(e)}"
+        log.exception("Callback %s(%s) execution failed: %s", callback_path, callback_kwargs, error_msg)
+        return False, error_msg

--- a/airflow-core/src/airflow/executors/workloads.py
+++ b/airflow-core/src/airflow/executors/workloads.py
@@ -205,6 +205,6 @@ class RunTrigger(BaseModel):
 
 
 All = Annotated[
-    ExecuteTask | RunTrigger,
+    ExecuteTask | ExecuteCallback | RunTrigger,
     Field(discriminator="type"),
 ]

--- a/airflow-core/src/airflow/executors/workloads.py
+++ b/airflow-core/src/airflow/executors/workloads.py
@@ -27,14 +27,20 @@ from typing import TYPE_CHECKING, Annotated, Literal
 import structlog
 from pydantic import BaseModel, Field
 
-from airflow.models.callback import CallbackFetchMethod
+# NOTE: noqa because ruff wants this in TYPE_CHECKING, but if we do that then pydantic fails at runtime.
+from airflow.models.callback import CallbackFetchMethod  # noqa: TCH001
 
 if TYPE_CHECKING:
     from airflow.api_fastapi.auth.tokens import JWTGenerator
     from airflow.models import DagRun
-    from airflow.models.callback import Callback as CallbackModel
+    from airflow.models.callback import Callback as CallbackModel, CallbackKey
     from airflow.models.taskinstance import TaskInstance as TIModel
     from airflow.models.taskinstancekey import TaskInstanceKey
+    from airflow.utils.state import CallbackState, TaskInstanceState
+
+    # TODO:  I wonder if we can programatically assemble these unions somehow
+    WorkloadKey = TaskInstanceKey | CallbackKey
+    WorkloadState = TaskInstanceState | CallbackState
 
 
 __all__ = ["All", "ExecuteTask", "ExecuteCallback"]

--- a/airflow-core/src/airflow/executors/workloads.py
+++ b/airflow-core/src/airflow/executors/workloads.py
@@ -38,7 +38,6 @@ if TYPE_CHECKING:
     from airflow.models.taskinstancekey import TaskInstanceKey
     from airflow.utils.state import CallbackState, TaskInstanceState
 
-    # TODO:  I wonder if we can programatically assemble these unions somehow
     WorkloadKey = TaskInstanceKey | CallbackKey
     WorkloadState = TaskInstanceState | CallbackState
 

--- a/airflow-core/src/airflow/executors/workloads.py
+++ b/airflow-core/src/airflow/executors/workloads.py
@@ -99,7 +99,7 @@ class TaskInstance(BaseModel):
 class Callback(BaseModel):
     """Schema for Callback with minimal required fields needed for Executors and Task SDK."""
 
-    id: uuid.UUID
+    id: str  # A uuid.UUID stored as a string
     fetch_method: CallbackFetchMethod
     data: dict
 
@@ -180,7 +180,7 @@ class ExecuteCallback(BaseDagBundleWorkload):
         return cls(
             callback=Callback.model_validate(callback, from_attributes=True),
             dag_rel_path=dag_rel_path or Path(dag_run.dag_model.relative_fileloc or ""),
-            token=cls.generate_token(str(callback.id), generator),
+            token=cls.generate_token(callback.id, generator),
             log_path=fname,
             bundle_info=bundle_info,
         )

--- a/airflow-core/src/airflow/executors/workloads/__init__.py
+++ b/airflow-core/src/airflow/executors/workloads/__init__.py
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Workload schemas for executor communication."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from pydantic import Field
+
+from airflow.executors.workloads.base import BaseWorkload, BundleInfo
+from airflow.executors.workloads.callback import CallbackFetchMethod, ExecuteCallback
+from airflow.executors.workloads.task import ExecuteTask
+from airflow.executors.workloads.trigger import RunTrigger
+
+All = Annotated[
+    ExecuteTask | ExecuteCallback | RunTrigger,
+    Field(discriminator="type"),
+]
+
+__all__ = ["All", "BaseWorkload", "BundleInfo", "CallbackFetchMethod", "ExecuteCallback", "ExecuteTask"]

--- a/airflow-core/src/airflow/executors/workloads/base.py
+++ b/airflow-core/src/airflow/executors/workloads/base.py
@@ -22,7 +22,7 @@ import os
 from abc import ABC
 from typing import TYPE_CHECKING
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 if TYPE_CHECKING:
     from airflow.api_fastapi.auth.tokens import JWTGenerator
@@ -67,7 +67,12 @@ class BundleInfo(BaseModel):
 class BaseWorkloadSchema(BaseModel):
     """Base Pydantic schema for executor workload DTOs."""
 
-    identity_token: str
+    identity_token: str = Field(validation_alias="token")
+
+    @property
+    def token(self) -> str:
+        """Backward compat alias for identity_token."""
+        return self.identity_token
 
     @staticmethod
     def generate_token(sub_id: str, generator: JWTGenerator | None = None) -> str:

--- a/airflow-core/src/airflow/executors/workloads/base.py
+++ b/airflow-core/src/airflow/executors/workloads/base.py
@@ -1,0 +1,82 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""ORM models and Pydantic schemas for BaseWorkload."""
+
+from __future__ import annotations
+
+import os
+from abc import ABC
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from airflow.api_fastapi.auth.tokens import JWTGenerator
+
+
+class BaseWorkload:
+    """
+    Mixin for ORM models that can be scheduled as workloads.
+
+    This mixin defines the interface that scheduler workloads (TaskInstance,
+    ExecutorCallback, etc.) must implement to provide routing information to the scheduler.
+
+    Subclasses must override:
+    - get_dag_id() -> str | None
+    - get_executor_name() -> str | None
+    """
+
+    def get_dag_id(self) -> str | None:
+        """
+        Return the DAG ID for scheduler routing.
+
+        Must be implemented by subclasses.
+        """
+        raise NotImplementedError(f"{self.__class__.__name__} must implement get_dag_id()")
+
+    def get_executor_name(self) -> str | None:
+        """
+        Return the executor name for scheduler routing.
+
+        Must be implemented by subclasses.
+        """
+        raise NotImplementedError(f"{self.__class__.__name__} must implement get_executor_name()")
+
+
+class BundleInfo(BaseModel):
+    """Schema for telling task which bundle to run with."""
+
+    name: str
+    version: str | None = None
+
+
+class BaseWorkloadSchema(BaseModel):
+    """Base Pydantic schema for executor workload DTOs."""
+
+    token: str  # The identity token for this workload.
+
+    @staticmethod
+    def generate_token(sub_id: str, generator: JWTGenerator | None = None) -> str:
+        return generator.generate({"sub": sub_id}) if generator else ""
+
+
+class BaseDagBundleWorkload(BaseWorkloadSchema, ABC):
+    """Base class for Workloads that are associated with a DAG bundle."""
+
+    dag_rel_path: os.PathLike[str]  # Filepath where the DAG can be found (likely prefixed with `DAG_FOLDER/`)
+    bundle_info: BundleInfo
+    log_path: str | None  # Rendered relative log filename template the task logs should be written to.

--- a/airflow-core/src/airflow/executors/workloads/base.py
+++ b/airflow-core/src/airflow/executors/workloads/base.py
@@ -22,7 +22,7 @@ import os
 from abc import ABC
 from typing import TYPE_CHECKING
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 if TYPE_CHECKING:
     from airflow.api_fastapi.auth.tokens import JWTGenerator
@@ -66,6 +66,8 @@ class BundleInfo(BaseModel):
 
 class BaseWorkloadSchema(BaseModel):
     """Base Pydantic schema for executor workload DTOs."""
+
+    model_config = ConfigDict(populate_by_name=True)
 
     identity_token: str = Field(validation_alias="token")
 

--- a/airflow-core/src/airflow/executors/workloads/base.py
+++ b/airflow-core/src/airflow/executors/workloads/base.py
@@ -67,7 +67,7 @@ class BundleInfo(BaseModel):
 class BaseWorkloadSchema(BaseModel):
     """Base Pydantic schema for executor workload DTOs."""
 
-    token: str  # The identity token for this workload.
+    identity_token: str
 
     @staticmethod
     def generate_token(sub_id: str, generator: JWTGenerator | None = None) -> str:

--- a/airflow-core/src/airflow/executors/workloads/base.py
+++ b/airflow-core/src/airflow/executors/workloads/base.py
@@ -22,7 +22,7 @@ import os
 from abc import ABC
 from typing import TYPE_CHECKING
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict
 
 if TYPE_CHECKING:
     from airflow.api_fastapi.auth.tokens import JWTGenerator
@@ -69,12 +69,8 @@ class BaseWorkloadSchema(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    identity_token: str = Field(validation_alias="token")
-
-    @property
-    def token(self) -> str:
-        """Backward compat alias for identity_token."""
-        return self.identity_token
+    token: str
+    """The identity token for this workload"""
 
     @staticmethod
     def generate_token(sub_id: str, generator: JWTGenerator | None = None) -> str:

--- a/airflow-core/src/airflow/executors/workloads/callback.py
+++ b/airflow-core/src/airflow/executors/workloads/callback.py
@@ -31,7 +31,7 @@ from airflow.executors.workloads.base import BaseDagBundleWorkload, BundleInfo
 if TYPE_CHECKING:
     from airflow.api_fastapi.auth.tokens import JWTGenerator
     from airflow.models import DagRun
-    from airflow.models.callback import Callback as CallbackModel
+    from airflow.models.callback import Callback as CallbackModel, CallbackKey
 
 log = structlog.get_logger(__name__)
 
@@ -52,6 +52,11 @@ class CallbackDTO(BaseModel):
     id: str  # A uuid.UUID stored as a string
     fetch_method: CallbackFetchMethod
     data: dict
+
+    @property
+    def key(self) -> CallbackKey:
+        """Return callback ID as key (CallbackKey = str)."""
+        return self.id
 
 
 class ExecuteCallback(BaseDagBundleWorkload):

--- a/airflow-core/src/airflow/executors/workloads/callback.py
+++ b/airflow-core/src/airflow/executors/workloads/callback.py
@@ -95,7 +95,7 @@ class ExecuteCallback(BaseDagBundleWorkload):
         return cls(
             callback=CallbackDTO.model_validate(callback, from_attributes=True),
             dag_rel_path=dag_rel_path or Path(dag_run.dag_model.relative_fileloc or ""),
-            token=cls.generate_token(str(callback.id), generator),
+            identity_token=cls.generate_token(str(callback.id), generator),
             log_path=fname,
             bundle_info=bundle_info,
         )

--- a/airflow-core/src/airflow/executors/workloads/callback.py
+++ b/airflow-core/src/airflow/executors/workloads/callback.py
@@ -14,89 +14,39 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""Callback workload schemas for executor communication."""
+
 from __future__ import annotations
 
-import os
-import uuid
-from abc import ABC
-from datetime import datetime
+from enum import Enum
 from importlib import import_module
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Literal
+from typing import TYPE_CHECKING, Literal
 
 import structlog
 from pydantic import BaseModel, Field
 
-# NOTE: noqa because ruff wants this in TYPE_CHECKING, but if we do that then pydantic fails at runtime.
-from airflow.models.callback import CallbackFetchMethod  # noqa: TCH001
+from airflow.executors.workloads.base import BaseDagBundleWorkload, BundleInfo
 
 if TYPE_CHECKING:
     from airflow.api_fastapi.auth.tokens import JWTGenerator
     from airflow.models import DagRun
-    from airflow.models.callback import Callback as CallbackModel, CallbackKey
-    from airflow.models.taskinstance import TaskInstance as TIModel
-    from airflow.models.taskinstancekey import TaskInstanceKey
-    from airflow.utils.state import CallbackState, TaskInstanceState
-
-    WorkloadKey = TaskInstanceKey | CallbackKey
-    WorkloadState = TaskInstanceState | CallbackState
-
-
-__all__ = ["All", "ExecuteTask", "ExecuteCallback"]
+    from airflow.models.callback import Callback as CallbackModel
 
 log = structlog.get_logger(__name__)
 
 
-class BaseWorkload(BaseModel):
-    token: str
-    """The identity token for this workload"""
+class CallbackFetchMethod(str, Enum):
+    """Methods used to fetch callback at runtime."""
 
-    @staticmethod
-    def generate_token(sub_id: str, generator: JWTGenerator | None = None) -> str:
-        return generator.generate({"sub": sub_id}) if generator else ""
+    # For future use once Dag Processor callbacks (on_success_callback/on_failure_callback) get moved to executors
+    DAG_ATTRIBUTE = "dag_attribute"
 
-
-class BundleInfo(BaseModel):
-    """Schema for telling task which bundle to run with."""
-
-    name: str
-    version: str | None = None
+    # For deadline callbacks since they import callbacks through the import path
+    IMPORT_PATH = "import_path"
 
 
-class TaskInstance(BaseModel):
-    """Schema for TaskInstance with minimal required fields needed for Executors and Task SDK."""
-
-    id: uuid.UUID
-    dag_version_id: uuid.UUID
-    task_id: str
-    dag_id: str
-    run_id: str
-    try_number: int
-    map_index: int = -1
-
-    pool_slots: int
-    queue: str
-    priority_weight: int
-    executor_config: dict | None = Field(default=None, exclude=True)
-
-    parent_context_carrier: dict | None = None
-    context_carrier: dict | None = None
-
-    # TODO: Task-SDK: Can we replace TastInstanceKey with just the uuid across the codebase?
-    @property
-    def key(self) -> TaskInstanceKey:
-        from airflow.models.taskinstancekey import TaskInstanceKey
-
-        return TaskInstanceKey(
-            dag_id=self.dag_id,
-            task_id=self.task_id,
-            run_id=self.run_id,
-            try_number=self.try_number,
-            map_index=self.map_index,
-        )
-
-
-class Callback(BaseModel):
+class CallbackDTO(BaseModel):
     """Schema for Callback with minimal required fields needed for Executors and Task SDK."""
 
     id: str  # A uuid.UUID stored as a string
@@ -104,60 +54,10 @@ class Callback(BaseModel):
     data: dict
 
 
-class BaseDagBundleWorkload(BaseWorkload, ABC):
-    """Base class for Workloads that are associated with a DAG bundle."""
-
-    dag_rel_path: os.PathLike[str]
-    """The filepath where the DAG can be found (likely prefixed with `DAG_FOLDER/`)"""
-
-    bundle_info: BundleInfo
-
-    log_path: str | None
-    """The rendered relative log filename template the task logs should be written to"""
-
-
-class ExecuteTask(BaseDagBundleWorkload):
-    """Execute the given Task."""
-
-    ti: TaskInstance
-    sentry_integration: str = ""
-
-    type: Literal["ExecuteTask"] = Field(init=False, default="ExecuteTask")
-
-    @classmethod
-    def make(
-        cls,
-        ti: TIModel,
-        dag_rel_path: Path | None = None,
-        generator: JWTGenerator | None = None,
-        bundle_info: BundleInfo | None = None,
-        sentry_integration: str = "",
-    ) -> ExecuteTask:
-        from airflow.utils.helpers import log_filename_template_renderer
-
-        ser_ti = TaskInstance.model_validate(ti, from_attributes=True)
-        ser_ti.parent_context_carrier = ti.dag_run.context_carrier
-        if not bundle_info:
-            bundle_info = BundleInfo(
-                name=ti.dag_model.bundle_name,
-                version=ti.dag_run.bundle_version,
-            )
-        fname = log_filename_template_renderer()(ti=ti)
-
-        return cls(
-            ti=ser_ti,
-            dag_rel_path=dag_rel_path or Path(ti.dag_model.relative_fileloc or ""),
-            token=cls.generate_token(str(ti.id), generator),
-            log_path=fname,
-            bundle_info=bundle_info,
-            sentry_integration=sentry_integration,
-        )
-
-
 class ExecuteCallback(BaseDagBundleWorkload):
     """Execute the given Callback."""
 
-    callback: Callback
+    callback: CallbackDTO
 
     type: Literal["ExecuteCallback"] = Field(init=False, default="ExecuteCallback")
 
@@ -170,6 +70,7 @@ class ExecuteCallback(BaseDagBundleWorkload):
         generator: JWTGenerator | None = None,
         bundle_info: BundleInfo | None = None,
     ) -> ExecuteCallback:
+        """Create an ExecuteCallback workload from a Callback ORM model."""
         if not bundle_info:
             bundle_info = BundleInfo(
                 name=dag_run.dag_model.bundle_name,
@@ -178,7 +79,7 @@ class ExecuteCallback(BaseDagBundleWorkload):
         fname = f"executor_callbacks/{callback.id}"  # TODO: better log file template
 
         return cls(
-            callback=Callback.model_validate(callback, from_attributes=True),
+            callback=CallbackDTO.model_validate(callback, from_attributes=True),
             dag_rel_path=dag_rel_path or Path(dag_run.dag_model.relative_fileloc or ""),
             token=cls.generate_token(callback.id, generator),
             log_path=fname,
@@ -186,40 +87,8 @@ class ExecuteCallback(BaseDagBundleWorkload):
         )
 
 
-class RunTrigger(BaseModel):
-    """Execute an async "trigger" process that yields events."""
-
-    id: int
-
-    ti: TaskInstance | None
-    """
-    The task instance associated with this trigger.
-
-    Could be none for asset-based triggers.
-    """
-
-    classpath: str
-    """
-    Dot-separated name of the module+fn to import and run this workload.
-
-    Consumers of this Workload must perform their own validation of this input.
-    """
-
-    encrypted_kwargs: str
-
-    timeout_after: datetime | None = None
-
-    type: Literal["RunTrigger"] = Field(init=False, default="RunTrigger")
-
-
-All = Annotated[
-    ExecuteTask | ExecuteCallback | RunTrigger,
-    Field(discriminator="type"),
-]
-
-
 def execute_callback_workload(
-    callback: Callback,
+    callback: CallbackDTO,
     log,
 ) -> tuple[bool, str | None]:
     """
@@ -242,7 +111,6 @@ def execute_callback_workload(
     :param log: Logger instance for recording execution
     :return: Tuple of (success: bool, error_message: str | None)
     """
-    # Extract callback details from data
     callback_path = callback.data.get("path")
     callback_kwargs = callback.data.get("kwargs", {})
 

--- a/airflow-core/src/airflow/executors/workloads/callback.py
+++ b/airflow-core/src/airflow/executors/workloads/callback.py
@@ -140,7 +140,7 @@ def execute_callback_workload(
 
         log.debug("Executing callback %s(%s)...", callback_path, callback_kwargs)
 
-        # If the callback is a callabale, call it.  If it is a class, instantiate it.
+        # If the callback is a callable, call it.  If it is a class, instantiate it.
         result = callback_callable(**callback_kwargs)
 
         # If the callback is a class then it is now instantiated and callable, call it.

--- a/airflow-core/src/airflow/executors/workloads/callback.py
+++ b/airflow-core/src/airflow/executors/workloads/callback.py
@@ -95,7 +95,7 @@ class ExecuteCallback(BaseDagBundleWorkload):
         return cls(
             callback=CallbackDTO.model_validate(callback, from_attributes=True),
             dag_rel_path=dag_rel_path or Path(dag_run.dag_model.relative_fileloc or ""),
-            identity_token=cls.generate_token(str(callback.id), generator),
+            token=cls.generate_token(str(callback.id), generator),
             log_path=fname,
             bundle_info=bundle_info,
         )

--- a/airflow-core/src/airflow/executors/workloads/task.py
+++ b/airflow-core/src/airflow/executors/workloads/task.py
@@ -1,0 +1,104 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Task workload schemas for executor communication."""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import BaseModel, Field
+
+from airflow.executors.workloads.base import BaseDagBundleWorkload, BundleInfo
+
+if TYPE_CHECKING:
+    from airflow.api_fastapi.auth.tokens import JWTGenerator
+    from airflow.models.taskinstance import TaskInstance as TIModel
+    from airflow.models.taskinstancekey import TaskInstanceKey
+
+
+class TaskInstanceDTO(BaseModel):
+    """Schema for TaskInstance with minimal required fields needed for Executors and Task SDK."""
+
+    id: uuid.UUID
+    dag_version_id: uuid.UUID
+    task_id: str
+    dag_id: str
+    run_id: str
+    try_number: int
+    map_index: int = -1
+
+    pool_slots: int
+    queue: str
+    priority_weight: int
+    executor_config: dict | None = Field(default=None, exclude=True)
+
+    parent_context_carrier: dict | None = None
+    context_carrier: dict | None = None
+
+    @property
+    def key(self) -> TaskInstanceKey:
+        """Return the TaskInstanceKey for this task instance."""
+        from airflow.models.taskinstancekey import TaskInstanceKey
+
+        return TaskInstanceKey(
+            dag_id=self.dag_id,
+            task_id=self.task_id,
+            run_id=self.run_id,
+            try_number=self.try_number,
+            map_index=self.map_index,
+        )
+
+
+class ExecuteTask(BaseDagBundleWorkload):
+    """Execute the given Task."""
+
+    ti: TaskInstanceDTO
+    sentry_integration: str = ""
+
+    type: Literal["ExecuteTask"] = Field(init=False, default="ExecuteTask")
+
+    @classmethod
+    def make(
+        cls,
+        ti: TIModel,
+        dag_rel_path: Path | None = None,
+        generator: JWTGenerator | None = None,
+        bundle_info: BundleInfo | None = None,
+        sentry_integration: str = "",
+    ) -> ExecuteTask:
+        """Create an ExecuteTask workload from a TaskInstance ORM model."""
+        from airflow.utils.helpers import log_filename_template_renderer
+
+        ser_ti = TaskInstanceDTO.model_validate(ti, from_attributes=True)
+        ser_ti.parent_context_carrier = ti.dag_run.context_carrier
+        if not bundle_info:
+            bundle_info = BundleInfo(
+                name=ti.dag_model.bundle_name,
+                version=ti.dag_run.bundle_version,
+            )
+        fname = log_filename_template_renderer()(ti=ti)
+
+        return cls(
+            ti=ser_ti,
+            dag_rel_path=dag_rel_path or Path(ti.dag_model.relative_fileloc or ""),
+            token=cls.generate_token(str(ti.id), generator),
+            log_path=fname,
+            bundle_info=bundle_info,
+            sentry_integration=sentry_integration,
+        )

--- a/airflow-core/src/airflow/executors/workloads/task.py
+++ b/airflow-core/src/airflow/executors/workloads/task.py
@@ -97,7 +97,7 @@ class ExecuteTask(BaseDagBundleWorkload):
         return cls(
             ti=ser_ti,
             dag_rel_path=dag_rel_path or Path(ti.dag_model.relative_fileloc or ""),
-            token=cls.generate_token(str(ti.id), generator),
+            identity_token=cls.generate_token(str(ti.id), generator),
             log_path=fname,
             bundle_info=bundle_info,
             sentry_integration=sentry_integration,

--- a/airflow-core/src/airflow/executors/workloads/task.py
+++ b/airflow-core/src/airflow/executors/workloads/task.py
@@ -51,9 +51,9 @@ class TaskInstanceDTO(BaseModel):
     parent_context_carrier: dict | None = None
     context_carrier: dict | None = None
 
+    # TODO: Task-SDK: Can we replace TaskInstanceKey with just the uuid across the codebase?
     @property
     def key(self) -> TaskInstanceKey:
-        """Return the TaskInstanceKey for this task instance."""
         from airflow.models.taskinstancekey import TaskInstanceKey
 
         return TaskInstanceKey(

--- a/airflow-core/src/airflow/executors/workloads/task.py
+++ b/airflow-core/src/airflow/executors/workloads/task.py
@@ -97,7 +97,7 @@ class ExecuteTask(BaseDagBundleWorkload):
         return cls(
             ti=ser_ti,
             dag_rel_path=dag_rel_path or Path(ti.dag_model.relative_fileloc or ""),
-            identity_token=cls.generate_token(str(ti.id), generator),
+            token=cls.generate_token(str(ti.id), generator),
             log_path=fname,
             bundle_info=bundle_info,
             sentry_integration=sentry_integration,

--- a/airflow-core/src/airflow/executors/workloads/trigger.py
+++ b/airflow-core/src/airflow/executors/workloads/trigger.py
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Trigger workload schemas for executor communication."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+# Using noqa because Ruff wants this in a TYPE_CHECKING block but Pydantic fails if it is.
+from airflow.executors.workloads.task import TaskInstanceDTO  # noqa: TCH001
+
+
+class RunTrigger(BaseModel):
+    """
+    Execute an async "trigger" process that yields events.
+
+    Consumers of this Workload must perform their own validation of the classpath input.
+    """
+
+    id: int
+    ti: TaskInstanceDTO | None  # Could be none for asset-based triggers.
+    classpath: str  # Dot-separated name of the module+fn to import and run this workload.
+    encrypted_kwargs: str
+    timeout_after: datetime | None = None
+    type: Literal["RunTrigger"] = Field(init=False, default="RunTrigger")

--- a/airflow-core/src/airflow/executors/workloads/types.py
+++ b/airflow-core/src/airflow/executors/workloads/types.py
@@ -18,20 +18,23 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeAlias
+
+from airflow.models.callback import ExecutorCallback
+from airflow.models.taskinstance import TaskInstance
 
 if TYPE_CHECKING:
-    from airflow.models.callback import CallbackKey, ExecutorCallback
-    from airflow.models.taskinstance import TaskInstance
+    from airflow.models.callback import CallbackKey
     from airflow.models.taskinstancekey import TaskInstanceKey
     from airflow.utils.state import CallbackState, TaskInstanceState
 
     # Type aliases for workload keys and states (used by executor layer)
-    WorkloadKey = TaskInstanceKey | CallbackKey
-    WorkloadState = TaskInstanceState | CallbackState
-
-    # Type alias for scheduler workloads (ORM models that can be routed to executors)
-    SchedulerWorkload = TaskInstance | ExecutorCallback
+    WorkloadKey: TypeAlias = TaskInstanceKey | CallbackKey
+    WorkloadState: TypeAlias = TaskInstanceState | CallbackState
 
     # Type alias for executor workload results (used by executor implementations)
-    WorkloadResultType = tuple[WorkloadKey, WorkloadState, Exception | None]
+    WorkloadResultType: TypeAlias = tuple[WorkloadKey, WorkloadState, Exception | None]
+
+# Type alias for scheduler workloads (ORM models that can be routed to executors)
+# Must be outside TYPE_CHECKING for use in function signatures
+SchedulerWorkload: TypeAlias = TaskInstance | ExecutorCallback

--- a/airflow-core/src/airflow/executors/workloads/types.py
+++ b/airflow-core/src/airflow/executors/workloads/types.py
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Type aliases for Workloads."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from airflow.models.callback import CallbackKey, ExecutorCallback
+    from airflow.models.taskinstance import TaskInstance
+    from airflow.models.taskinstancekey import TaskInstanceKey
+    from airflow.utils.state import CallbackState, TaskInstanceState
+
+    # Type aliases for workload keys and states (used by executor layer)
+    WorkloadKey = TaskInstanceKey | CallbackKey
+    WorkloadState = TaskInstanceState | CallbackState
+
+    # Type alias for scheduler workloads (ORM models that can be routed to executors)
+    SchedulerWorkload = TaskInstance | ExecutorCallback
+
+    # Type alias for executor workload results (used by executor implementations)
+    WorkloadResultType = tuple[WorkloadKey, WorkloadState, Exception | None]

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -1138,7 +1138,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             else:
                 # Callback event (key is string UUID)
                 cls.logger().info("Received executor event with state %s for callback %s", state, key)
-                if state in (TaskInstanceState.FAILED, TaskInstanceState.SUCCESS):
+                if state in (CallbackState.FAILED, CallbackState.SUCCESS):
                     callback_keys_with_events.append(key)
 
         # Handle callback completion events
@@ -1146,12 +1146,10 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             state, info = event_buffer.pop(callback_id)
             callback = session.get(Callback, callback_id)
             if callback:
-                # Note: We receive TaskInstanceState from executor (SUCCESS/FAILED) but convert to CallbackState here.
-                # This is intentional - executor layer uses generic completion states, scheduler converts to proper types.
-                if state == TaskInstanceState.SUCCESS:
+                if state == CallbackState.SUCCESS:
                     callback.state = CallbackState.SUCCESS
                     cls.logger().info("Callback %s completed successfully", callback_id)
-                elif state == TaskInstanceState.FAILED:
+                elif state == CallbackState.FAILED:
                     callback.state = CallbackState.FAILED
                     callback.output = str(info) if info else "Execution failed"
                     cls.logger().error("Callback %s failed: %s", callback_id, callback.output)

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -86,7 +86,6 @@ from airflow.models.asset import (
 )
 from airflow.models.backfill import Backfill
 from airflow.models.callback import Callback, ExecutorCallback
-from airflow.utils.state import CallbackState
 from airflow.models.dag import DagModel, get_next_data_interval
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagbag import DBDagBag
@@ -117,7 +116,7 @@ from airflow.utils.sqlalchemy import (
     prohibit_commit,
     with_row_locks,
 )
-from airflow.utils.state import DagRunState, State, TaskInstanceState
+from airflow.utils.state import CallbackState, DagRunState, State, TaskInstanceState
 from airflow.utils.thread_safe_dict import ThreadSafeDict
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
 

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -1030,7 +1030,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 if not isinstance(callback, ExecutorCallback):
                     # Can't happen since we queried ExecutorCallback, but satisfies mypy.
                     continue
-                
+
                 # TODO: Add dagrun_id as a proper ORM foreign key on the callback table instead of storing in data dict.
                 #       This would eliminate this reconstruction step. For now, all ExecutorCallbacks
                 #       are expected to have dag_run_id set in their data dict (e.g., by Deadline.handle_miss).
@@ -1038,19 +1038,18 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     self.log.error(
                         "ExecutorCallback %s is missing required 'dag_run_id' in data dict. "
                         "This indicates a bug in callback creation. Skipping callback.",
-                        callback.id
+                        callback.id,
                     )
                     continue
-                
+
                 dag_run_id = callback.data["dag_run_id"]
                 dag_run = session.get(DagRun, dag_run_id)
-                
+
                 if dag_run is None:
                     self.log.warning(
-                        "Could not find DagRun with id=%s for callback %s. "
-                        "DagRun may have been deleted.", 
-                        dag_run_id, 
-                        callback.id
+                        "Could not find DagRun with id=%s for callback %s. DagRun may have been deleted.",
+                        dag_run_id,
+                        callback.id,
                     )
                     continue
 
@@ -1154,9 +1153,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             if not callback:
                 # This should not normally happen - we just received an event for this callback.
                 # Only possible if callback was deleted mid-execution (e.g., cascade delete from DagRun deletion).
-                cls.logger().warning("Callback %s not found in database (may have been cascade deleted)", callback_id)
+                cls.logger().warning(
+                    "Callback %s not found in database (may have been cascade deleted)", callback_id
+                )
                 continue
-            
+
             if state == CallbackState.RUNNING:
                 callback.state = CallbackState.RUNNING
                 cls.logger().info("Callback %s is currently running", callback_id)

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -86,7 +86,7 @@ from airflow.models.asset import (
 )
 from airflow.models.backfill import Backfill
 from airflow.models.callback import Callback, CallbackType, ExecutorCallback
-from airflow.models.dag import DagModel, get_next_data_interval
+from airflow.models.dag import DagModel
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagbag import DBDagBag
 from airflow.models.dagbundle import DagBundleModel

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -95,6 +95,7 @@ from airflow.models.dagwarning import DagWarning, DagWarningType
 from airflow.models.pool import normalize_pool_name_for_stats
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskinstance import TaskInstance
+from airflow.models.taskinstancekey import TaskInstanceKey
 from airflow.models.team import Team
 from airflow.models.trigger import TRIGGER_FAIL_REPR, Trigger, TriggerFailureReason
 from airflow.observability.metrics import stats_utils
@@ -130,7 +131,6 @@ if TYPE_CHECKING:
     from airflow._shared.logging.types import Logger
     from airflow.executors.base_executor import BaseExecutor
     from airflow.executors.executor_utils import ExecutorName
-    from airflow.models.taskinstance import TaskInstanceKey
     from airflow.serialization.definitions.dag import SerializedDAG
     from airflow.utils.sqlalchemy import CommitProhibitorGuard
 
@@ -1152,21 +1152,44 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         ti_primary_key_to_try_number_map: dict[tuple[str, str, str, int], int] = {}
         event_buffer = executor.get_event_buffer()
         tis_with_right_state: list[TaskInstanceKey] = []
+        callback_keys_with_events: list[str] = []
 
-        # Report execution
-        for ti_key, (state, _) in event_buffer.items():
-            # We create map (dag_id, task_id, logical_date) -> in-memory try_number
-            ti_primary_key_to_try_number_map[ti_key.primary] = ti_key.try_number
+        # Report execution - handle both task and callback events
+        for key, (state, _) in event_buffer.items():
+            if isinstance(key, TaskInstanceKey):
+                ti_primary_key_to_try_number_map[key.primary] = key.try_number
+                cls.logger().info("Received executor event with state %s for task instance %s", state, key)
+                if state in (
+                    TaskInstanceState.FAILED,
+                    TaskInstanceState.SUCCESS,
+                    TaskInstanceState.QUEUED,
+                    TaskInstanceState.RUNNING,
+                    TaskInstanceState.RESTARTING,
+                ):
+                    tis_with_right_state.append(key)
+            else:
+                # Callback event (key is string UUID)
+                cls.logger().info("Received executor event with state %s for callback %s", state, key)
+                if state in (TaskInstanceState.FAILED, TaskInstanceState.SUCCESS):
+                    callback_keys_with_events.append(key)
 
-            cls.logger().info("Received executor event with state %s for task instance %s", state, ti_key)
-            if state in (
-                TaskInstanceState.FAILED,
-                TaskInstanceState.SUCCESS,
-                TaskInstanceState.QUEUED,
-                TaskInstanceState.RUNNING,
-                TaskInstanceState.RESTARTING,
-            ):
-                tis_with_right_state.append(ti_key)
+        # Handle callback completion events
+        for callback_id in callback_keys_with_events:
+            state, info = event_buffer.pop(callback_id)
+            callback = session.get(Callback, callback_id)
+            if callback:
+                # Note: We receive TaskInstanceState from executor (SUCCESS/FAILED) but convert to CallbackState here.
+                # This is intentional - executor layer uses generic completion states, scheduler converts to proper types.
+                if state == TaskInstanceState.SUCCESS:
+                    callback.state = CallbackState.SUCCESS
+                    cls.logger().info("Callback %s completed successfully", callback_id)
+                elif state == TaskInstanceState.FAILED:
+                    callback.state = CallbackState.FAILED
+                    callback.output = str(info) if info else "Execution failed"
+                    cls.logger().error("Callback %s failed: %s", callback_id, callback.output)
+                session.add(callback)
+            else:
+                cls.logger().warning("Callback %s not found in database", callback_id)
 
         # Return if no finished tasks
         if not tis_with_right_state:

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -85,7 +85,8 @@ from airflow.models.asset import (
     TaskOutletAssetReference,
 )
 from airflow.models.backfill import Backfill
-from airflow.models.callback import Callback, CallbackState, ExecutorCallback
+from airflow.models.callback import Callback, ExecutorCallback
+from airflow.utils.state import CallbackState
 from airflow.models.dag import DagModel, get_next_data_interval
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagbag import DBDagBag

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -379,14 +379,14 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
         if team_name:
             self.log.debug(
-                "Resolved team name '%s' for workload %s (dag_id=%s)",
+                "Resolved team name '%s' for task or callback %s (dag_id=%s)",
                 team_name,
                 workload,
                 dag_id,
             )
         else:
             self.log.debug(
-                "No team found for workload %s (dag_id=%s) - DAG may not have bundle or team association",
+                "No team found for task or callback %s (dag_id=%s) - DAG may not have bundle or team association",
                 workload,
                 dag_id,
             )
@@ -3268,7 +3268,9 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                         executor = _executor
 
         if executor is not None:
-            self.log.debug("Found executor %s for workload %s (team: %s)", executor.name, workload, team_name)
+            self.log.debug(
+                "Found executor %s for task or callback %s (team: %s)", executor.name, workload, team_name
+            )
         else:
             # This case should not happen unless some (as of now unknown) edge case occurs or direct DB
             # modification, since the DAG parser will validate the tasks in the DAG and ensure the executor
@@ -3276,7 +3278,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             # Keeping this exception handling because this is a critical issue if we do somehow find
             # ourselves here and the user should get some feedback about that.
             self.log.warning(
-                "Executor, %s, was not found but a workload was configured to use it",
+                "Executor, %s, was not found but a Task or Callback was configured to use it",
                 workload.get_executor_name(),
             )
 

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -3241,14 +3241,13 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 team_name = self._get_workload_team_name(workload, session)
         else:
             team_name = None
-        # Firstly, check if there is no executor set on the workload, if not, we need to fetch the default
-        # (either globally or for the team)
+        # If there is no executor set on the workload fetch the default (either globally or for the team)
         if workload.get_executor_name() is None:
             if not team_name:
-                # No team is specified, so just use the global default executor
+                # No team is specified, use the global default executor
                 executor = self.executor
             else:
-                # We do have a team, so we need to find the default executor for that team
+                # We do have a team, use the default executor for that team
                 for _executor in self.executors:
                     # First executor that resolves should be the default for that team
                     if _executor.team_name == team_name:

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -131,6 +131,7 @@ if TYPE_CHECKING:
     from airflow._shared.logging.types import Logger
     from airflow.executors.base_executor import BaseExecutor
     from airflow.executors.executor_utils import ExecutorName
+    from airflow.executors.workloads.types import SchedulerWorkload
     from airflow.serialization.definitions.dag import SerializedDAG
     from airflow.utils.sqlalchemy import CommitProhibitorGuard
 
@@ -981,7 +982,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         queued_tis = self._executable_task_instances_to_queued(max_tis, session=session)
 
         # Sort queued TIs to their respective executor
-        executor_to_queued_tis = self._executor_to_tis(queued_tis, session)
+        executor_to_queued_tis = self._executor_to_workloads(queued_tis, session)
         for executor, queued_tis_per_executor in executor_to_queued_tis.items():
             self.log.info(
                 "Trying to enqueue tasks: %s for executor: %s",
@@ -1020,38 +1021,15 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         if not queued_callbacks:
             return
 
-        executor_to_callbacks: dict[BaseExecutor, list[ExecutorCallback]] = defaultdict(list)
-
-        for callback in queued_callbacks:
-            executor_name = None
-            if isinstance(callback.data, dict):
-                executor_name = callback.data.get("executor")
-
-            executor = None
-            if executor_name:
-                for e in self.job.executors:
-                    if e.__class__.__name__ == executor_name:
-                        executor = e
-                        break
-                    if hasattr(e, "name") and e.name and str(e.name) == executor_name:
-                        executor = e
-                        break
-                    if hasattr(e, "executor_name") and e.executor_name == executor_name:
-                        executor = e
-                        break
-            # Default to first executor if no specific executor found
-            if executor is None:
-                executor = self.job.executors[0] if self.job.executors else None
-
-            if executor is None:
-                self.log.warning("No executor available for callback %s", callback.id)
-                continue
-
-            executor_to_callbacks[executor].append(callback)
+        # Route callbacks to executors using the generalized routing method
+        executor_to_callbacks = self._executor_to_workloads(queued_callbacks, session)
 
         # Enqueue callbacks for each executor
         for executor, callbacks in executor_to_callbacks.items():
             for callback in callbacks:
+                if not isinstance(callback, ExecutorCallback):
+                    # Can't happen since we queried ExecutorCallback, but satisfies mypy.
+                    continue
                 dag_run = None
                 if isinstance(callback.data, dict) and "dag_run_id" in callback.data:
                     dag_run_id = callback.data["dag_run_id"]
@@ -1150,11 +1128,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 ti_primary_key_to_try_number_map[key.primary] = key.try_number
                 cls.logger().info("Received executor event with state %s for task instance %s", state, key)
                 if state in (
-                    TaskInstanceState.FAILED,
-                    TaskInstanceState.SUCCESS,
-                    TaskInstanceState.QUEUED,
-                    TaskInstanceState.RUNNING,
-                    TaskInstanceState.RESTARTING,
+                        TaskInstanceState.FAILED,
+                        TaskInstanceState.SUCCESS,
+                        TaskInstanceState.QUEUED,
+                        TaskInstanceState.RUNNING,
+                        TaskInstanceState.RESTARTING,
                 ):
                     tis_with_right_state.append(key)
             else:
@@ -2547,7 +2525,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         scheduled) up to 2 times before failing the task.
         """
         tasks_stuck_in_queued = self._get_tis_stuck_in_queued(session)
-        for executor, stuck_tis in self._executor_to_tis(tasks_stuck_in_queued, session).items():
+        for executor, stuck_tis in self._executor_to_workloads(tasks_stuck_in_queued, session).items():
             try:
                 for ti in stuck_tis:
                     executor.revoke_task(ti=ti)
@@ -2838,7 +2816,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     )
 
                     to_reset: list[TaskInstance] = []
-                    exec_to_tis = self._executor_to_tis(tis_to_adopt_or_reset, session)
+                    exec_to_tis = self._executor_to_workloads(tis_to_adopt_or_reset, session)
                     for executor, tis in exec_to_tis.items():
                         to_reset.extend(executor.try_adopt_task_instances(tis))
 
@@ -3187,50 +3165,54 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             session.add(warning)
             existing_warned_dag_ids.add(warning.dag_id)
 
-    def _executor_to_tis(
+    def _executor_to_workloads(
         self,
-        tis: Iterable[TaskInstance],
+        workloads: Iterable[SchedulerWorkload],
         session,
         dag_id_to_team_name: dict[str, str | None] | None = None,
-    ) -> dict[BaseExecutor, list[TaskInstance]]:
-        """Organize TIs into lists per their respective executor."""
-        tis_iter: Iterable[TaskInstance]
+    ) -> dict[BaseExecutor, list[SchedulerWorkload]]:
+        """Organize workloads into lists per their respective executor."""
+        workloads_iter: Iterable[SchedulerWorkload]
         if conf.getboolean("core", "multi_team"):
             if dag_id_to_team_name is None:
-                if isinstance(tis, list):
-                    tis_list = tis
+                if isinstance(workloads, list):
+                    workloads_list = workloads
                 else:
-                    tis_list = list(tis)
-                if tis_list:
+                    workloads_list = list(workloads)
+                if workloads_list:
                     dag_id_to_team_name = self._get_team_names_for_dag_ids(
-                        {ti.dag_id for ti in tis_list}, session
+                        {dag_id for workload in workloads_list if
+                         (dag_id := workload.get_dag_id()) is not None},
+                        session,
                     )
                 else:
                     dag_id_to_team_name = {}
-                tis_iter = tis_list
+                workloads_iter = workloads_list
             else:
-                tis_iter = tis
+                workloads_iter = workloads
         else:
             dag_id_to_team_name = {}
-            tis_iter = tis
+            workloads_iter = workloads
 
-        _executor_to_tis: defaultdict[BaseExecutor, list[TaskInstance]] = defaultdict(list)
-        for ti in tis_iter:
+        _executor_to_workloads: defaultdict[BaseExecutor, list[SchedulerWorkload]] = defaultdict(list)
+        for workload in workloads_iter:
             if executor_obj := self._try_to_load_executor(
-                ti, session, team_name=dag_id_to_team_name.get(ti.dag_id, NOTSET)
+                workload, session, team_name=dag_id_to_team_name.get(workload.get_dag_id(), NOTSET)
             ):
-                _executor_to_tis[executor_obj].append(ti)
+                _executor_to_workloads[executor_obj].append(workload)
 
-        return _executor_to_tis
+        return _executor_to_workloads
 
-    def _try_to_load_executor(self, ti: TaskInstance, session, team_name=NOTSET) -> BaseExecutor | None:
+    def _try_to_load_executor(
+        self, workload: SchedulerWorkload, session, team_name=NOTSET
+    ) -> BaseExecutor | None:
         """
         Try to load the given executor.
 
         In this context, we don't want to fail if the executor does not exist. Catch the exception and
         log to the user.
 
-        :param ti: TaskInstance to load executor for
+        :param workload: SchedulerWorkload (TaskInstance or ExecutorCallback) to load executor for
         :param session: Database session for queries
         :param team_name: Optional pre-resolved team name. If NOTSET and multi-team is enabled,
                          will query the database to resolve team name. None indicates global team.
@@ -3239,12 +3221,12 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         if conf.getboolean("core", "multi_team"):
             # Use provided team_name if available, otherwise query the database
             if team_name is NOTSET:
-                team_name = self._get_task_team_name(ti, session)
+                team_name = self._get_task_team_name(workload, session)
         else:
             team_name = None
-        # Firstly, check if there is no executor set on the TaskInstance, if not, we need to fetch the default
+        # Firstly, check if there is no executor set on the workload, if not, we need to fetch the default
         # (either globally or for the team)
-        if ti.executor is None:
+        if workload.executor is None:
             if not team_name:
                 # No team is specified, so just use the global default executor
                 executor = self.executor
@@ -3259,22 +3241,24 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     # No executor found for that team, fall back to global default
                     executor = self.executor
         else:
-            # An executor is specified on the TaskInstance (as a str), so we need to find it in the list of executors
-            for _executor in self.executors:
-                if _executor.name and ti.executor in (_executor.name.alias, _executor.name.module_path):
+            # An executor is specified on the workload (as a str), so we need to find it in the list of executors
+            for _executor in self.job.executors:
+                if _executor.name and workload.executor in (_executor.name.alias, _executor.name.module_path):
                     # The executor must either match the team or be global (i.e. team_name is None)
                     if team_name and _executor.team_name == team_name or _executor.team_name is None:
                         executor = _executor
 
         if executor is not None:
-            self.log.debug("Found executor %s for task %s (team: %s)", executor.name, ti, team_name)
+            self.log.debug("Found executor %s for workload %s (team: %s)", executor.name, workload, team_name)
         else:
             # This case should not happen unless some (as of now unknown) edge case occurs or direct DB
             # modification, since the DAG parser will validate the tasks in the DAG and ensure the executor
             # they request is available and if not, disallow the DAG to be scheduled.
             # Keeping this exception handling because this is a critical issue if we do somehow find
             # ourselves here and the user should get some feedback about that.
-            self.log.warning("Executor, %s, was not found but a Task was configured to use it", ti.executor)
+            self.log.warning(
+                "Executor, %s, was not found but a workload was configured to use it", workload.executor
+            )
 
         return executor
 

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -360,32 +360,35 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             # Return dict with all None values to ensure graceful degradation
             return {}
 
-    def _get_task_team_name(self, task_instance: TaskInstance, session: Session) -> str | None:
+    def _get_workload_team_name(self, workload: SchedulerWorkload, session: Session) -> str | None:
         """
-        Resolve team name for a task instance using the DAG > Bundle > Team relationship chain.
+        Resolve team name for a workload using the DAG > Bundle > Team relationship chain.
 
-        TaskInstance > DagModel (via dag_id) > DagBundleModel (via bundle_name) > Team
+        Workload > DagModel (via dag_id) > DagBundleModel (via bundle_name) > Team
 
-        :param task_instance: The TaskInstance to resolve team name for
+        :param workload: The Workload to resolve team name for
         :param session: Database session for queries
         :return: Team name if found or None
         """
         # Use the batch query function with a single DAG ID
-        dag_id_to_team_name = self._get_team_names_for_dag_ids([task_instance.dag_id], session)
-        team_name = dag_id_to_team_name.get(task_instance.dag_id)
+        if dag_id := workload.get_dag_id():
+            dag_id_to_team_name = self._get_team_names_for_dag_ids([dag_id], session)
+            team_name = dag_id_to_team_name.get(dag_id)
+        else:
+            team_name = None  # mypy didn't like the implicit defaulting to None
 
         if team_name:
             self.log.debug(
-                "Resolved team name '%s' for task %s (dag_id=%s)",
+                "Resolved team name '%s' for workload %s (dag_id=%s)",
                 team_name,
-                task_instance.task_id,
-                task_instance.dag_id,
+                workload,
+                dag_id,
             )
         else:
             self.log.debug(
-                "No team found for task %s (dag_id=%s) - DAG may not have bundle or team association",
-                task_instance.task_id,
-                task_instance.dag_id,
+                "No team found for workload %s (dag_id=%s) - DAG may not have bundle or team association",
+                workload,
+                dag_id,
             )
 
         return team_name
@@ -1003,7 +1006,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
         :param session: The database session
         """
-        num_occupied_slots = sum(executor.slots_occupied for executor in self.job.executors)
+        num_occupied_slots = sum(executor.slots_occupied for executor in self.executors)
         max_callbacks = conf.getint("core", "parallelism") - num_occupied_slots
 
         if max_callbacks <= 0:
@@ -1133,11 +1136,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 ti_primary_key_to_try_number_map[key.primary] = key.try_number
                 cls.logger().info("Received executor event with state %s for task instance %s", state, key)
                 if state in (
-                        TaskInstanceState.FAILED,
-                        TaskInstanceState.SUCCESS,
-                        TaskInstanceState.QUEUED,
-                        TaskInstanceState.RUNNING,
-                        TaskInstanceState.RESTARTING,
+                    TaskInstanceState.FAILED,
+                    TaskInstanceState.SUCCESS,
+                    TaskInstanceState.QUEUED,
+                    TaskInstanceState.RUNNING,
+                    TaskInstanceState.RESTARTING,
                 ):
                     tis_with_right_state.append(key)
             else:
@@ -3192,8 +3195,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     workloads_list = list(workloads)
                 if workloads_list:
                     dag_id_to_team_name = self._get_team_names_for_dag_ids(
-                        {dag_id for workload in workloads_list if
-                         (dag_id := workload.get_dag_id()) is not None},
+                        {
+                            dag_id
+                            for workload in workloads_list
+                            if (dag_id := workload.get_dag_id()) is not None
+                        },
                         session,
                     )
                 else:
@@ -3207,9 +3213,9 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
         _executor_to_workloads: defaultdict[BaseExecutor, list[SchedulerWorkload]] = defaultdict(list)
         for workload in workloads_iter:
-            if executor_obj := self._try_to_load_executor(
-                workload, session, team_name=dag_id_to_team_name.get(workload.get_dag_id(), NOTSET)
-            ):
+            _dag_id = workload.get_dag_id()
+            _team = dag_id_to_team_name.get(_dag_id, NOTSET) if _dag_id else NOTSET
+            if executor_obj := self._try_to_load_executor(workload, session, team_name=_team):
                 _executor_to_workloads[executor_obj].append(workload)
 
         return _executor_to_workloads
@@ -3232,7 +3238,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         if conf.getboolean("core", "multi_team"):
             # Use provided team_name if available, otherwise query the database
             if team_name is NOTSET:
-                team_name = self._get_task_team_name(workload, session)
+                team_name = self._get_workload_team_name(workload, session)
         else:
             team_name = None
         # Firstly, check if there is no executor set on the workload, if not, we need to fetch the default
@@ -3253,8 +3259,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     executor = self.executor
         else:
             # An executor is specified on the workload (as a str), so we need to find it in the list of executors
-            for _executor in self.job.executors:
-                if workload.get_executor_name() in (_executor.name.alias, _executor.name.module_path):
+            for _executor in self.executors:
+                if _executor.name and workload.get_executor_name() in (
+                    _executor.name.alias,
+                    _executor.name.module_path,
+                ):
                     # The executor must either match the team or be global (i.e. team_name is None)
                     if team_name and _executor.team_name == team_name or _executor.team_name is None:
                         executor = _executor

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -3226,7 +3226,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             team_name = None
         # Firstly, check if there is no executor set on the workload, if not, we need to fetch the default
         # (either globally or for the team)
-        if workload.executor is None:
+        if workload.get_executor_name() is None:
             if not team_name:
                 # No team is specified, so just use the global default executor
                 executor = self.executor
@@ -3243,7 +3243,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         else:
             # An executor is specified on the workload (as a str), so we need to find it in the list of executors
             for _executor in self.job.executors:
-                if _executor.name and workload.executor in (_executor.name.alias, _executor.name.module_path):
+                if workload.get_executor_name() in (_executor.name.alias, _executor.name.module_path):
                     # The executor must either match the team or be global (i.e. team_name is None)
                     if team_name and _executor.team_name == team_name or _executor.team_name is None:
                         executor = _executor
@@ -3257,7 +3257,8 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             # Keeping this exception handling because this is a critical issue if we do somehow find
             # ourselves here and the user should get some feedback about that.
             self.log.warning(
-                "Executor, %s, was not found but a workload was configured to use it", workload.executor
+                "Executor, %s, was not found but a workload was configured to use it",
+                workload.get_executor_name(),
             )
 
         return executor

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -85,8 +85,8 @@ from airflow.models.asset import (
     TaskOutletAssetReference,
 )
 from airflow.models.backfill import Backfill
-from airflow.models.callback import Callback
-from airflow.models.dag import DagModel
+from airflow.models.callback import Callback, CallbackState, ExecutorCallback
+from airflow.models.dag import DagModel, get_next_data_interval
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagbag import DBDagBag
 from airflow.models.dagbundle import DagBundleModel
@@ -993,6 +993,103 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
         return len(queued_tis)
 
+    def _enqueue_executor_callbacks(self, session: Session) -> None:
+        """
+        Enqueue ExecutorCallback workloads to executors.
+
+        Similar to _enqueue_task_instances, but for callbacks that need to run on executors.
+        Queries for QUEUED ExecutorCallback instances and routes them to the appropriate executor.
+
+        :param session: The database session
+        """
+        # Query for QUEUED ExecutorCallback instances
+        from airflow.models.callback import CallbackType
+
+        queued_callbacks = session.scalars(
+            select(ExecutorCallback)
+            .where(ExecutorCallback.type == CallbackType.EXECUTOR)
+            .where(ExecutorCallback.state == CallbackState.QUEUED)
+            .order_by(ExecutorCallback.priority_weight.desc())
+            .limit(conf.getint("scheduler", "max_callback_workloads_per_loop", fallback=100))
+        ).all()
+
+        if not queued_callbacks:
+            return
+
+        # Group callbacks by executor (based on callback executor attribute or default executor)
+        executor_to_callbacks: dict[BaseExecutor, list[ExecutorCallback]] = defaultdict(list)
+
+        for callback in queued_callbacks:
+            # Get the executor name from callback data if specified
+            executor_name = None
+            if isinstance(callback.data, dict):
+                executor_name = callback.data.get("executor")
+
+            # Find the appropriate executor
+            executor = None
+            if executor_name:
+                # Find executor by name - try multiple matching strategies
+                for exec in self.job.executors:
+                    # Match by class name (e.g., "CeleryExecutor")
+                    if exec.__class__.__name__ == executor_name:
+                        executor = exec
+                        break
+                    # Match by executor name attribute if available
+                    if hasattr(exec, "name") and exec.name and str(exec.name) == executor_name:
+                        executor = exec
+                        break
+                    # Match by executor name attribute if available
+                    if hasattr(exec, "executor_name") and exec.executor_name == executor_name:
+                        executor = exec
+                        break
+
+            # Default to first executor if no specific executor found
+            if executor is None:
+                executor = self.job.executors[0] if self.job.executors else None
+
+            if executor is None:
+                self.log.warning("No executor available for callback %s", callback.id)
+                continue
+
+            executor_to_callbacks[executor].append(callback)
+
+        # Enqueue callbacks for each executor
+        for executor, callbacks in executor_to_callbacks.items():
+            for callback in callbacks:
+                # Get the associated DagRun for the callback
+                # For deadline callbacks, we stored dag_run_id in the callback data
+                dag_run = None
+                if isinstance(callback.data, dict) and "dag_run_id" in callback.data:
+                    dag_run_id = callback.data["dag_run_id"]
+                    dag_run = session.get(DagRun, dag_run_id)
+                elif isinstance(callback.data, dict) and "dag_id" in callback.data:
+                    # Fallback: try to find the latest dag_run for the dag_id
+                    dag_id = callback.data["dag_id"]
+                    dag_run = session.scalars(
+                        select(DagRun)
+                        .where(DagRun.dag_id == dag_id)
+                        .order_by(DagRun.execution_date.desc())
+                        .limit(1)
+                    ).first()
+
+                if dag_run is None:
+                    self.log.warning("Could not find DagRun for callback %s", callback.id)
+                    continue
+
+                # Create ExecuteCallback workload
+                workload = workloads.ExecuteCallback.make(
+                    callback=callback,
+                    dag_run=dag_run,
+                    generator=executor.jwt_generator,
+                )
+
+                # Queue the workload
+                executor.queue_workload(workload, session=session)
+
+                # Update callback state to RUNNING
+                callback.state = CallbackState.RUNNING
+                session.add(callback)
+
     @staticmethod
     def _process_task_event_logs(log_records: deque[Log], session: Session):
         objects = (log_records.popleft() for _ in range(len(log_records)))
@@ -1656,6 +1753,9 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                         .options(selectinload(Deadline.callback), selectinload(Deadline.dagrun))
                     ):
                         deadline.handle_miss(session)
+
+                    # Route ExecutorCallback workloads to executors (similar to task routing)
+                    self._enqueue_executor_callbacks(session)
 
                 # Heartbeat the scheduler periodically
                 perform_heartbeat(

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -45,6 +45,7 @@ from airflow._shared.observability.metrics.stats import Stats
 from airflow._shared.timezones import timezone
 from airflow.configuration import conf
 from airflow.executors import workloads
+from airflow.executors.workloads.task import TaskInstanceDTO
 from airflow.jobs.base_job_runner import BaseJobRunner
 from airflow.jobs.job import perform_heartbeat
 from airflow.models.trigger import Trigger
@@ -687,9 +688,7 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
                         ti_id=new_trigger_orm.task_instance.id,
                     )
                     continue
-                ser_ti = workloads.TaskInstance.model_validate(
-                    new_trigger_orm.task_instance, from_attributes=True
-                )
+                ser_ti = TaskInstanceDTO.model_validate(new_trigger_orm.task_instance, from_attributes=True)
                 # When producing logs from TIs, include the job id producing the logs to disambiguate it.
                 self.logger_cache[new_id] = TriggerLoggingFactory(
                     log_path=f"{log_path}.trigger.{self.job.id}.log",

--- a/airflow-core/src/airflow/models/callback.py
+++ b/airflow-core/src/airflow/models/callback.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
 log = structlog.get_logger(__name__)
 
 
-ACTIVE_STATES = frozenset((CallbackState.QUEUED, CallbackState.RUNNING))
+ACTIVE_STATES = frozenset((CallbackState.PENDING, CallbackState.QUEUED, CallbackState.RUNNING))
 TERMINAL_STATES = frozenset((CallbackState.SUCCESS, CallbackState.FAILED))
 
 
@@ -130,7 +130,7 @@ class Callback(Base, BaseWorkload):
         :param prefix: Optional prefix for metric names
         :param kwargs: Additional data emitted in metric tags
         """
-        self.state = CallbackState.PENDING
+        self.state = CallbackState.SCHEDULED
         self.priority_weight = priority_weight
         self.data = kwargs  # kwargs can be used to include additional info in metric tags
         if prefix:

--- a/airflow-core/src/airflow/models/callback.py
+++ b/airflow-core/src/airflow/models/callback.py
@@ -36,13 +36,13 @@ from airflow.models import Base
 from airflow.utils.sqlalchemy import ExtendedJSON, UtcDateTime
 from airflow.utils.state import CallbackState
 
+CallbackKey = str  # Callback keys are str(UUID)
+
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
     from airflow.callbacks.callback_requests import CallbackRequest
     from airflow.triggers.base import TriggerEvent
-
-    CallbackKey = str  # Callback keys are str(UUID)
 
 log = structlog.get_logger(__name__)
 

--- a/airflow-core/src/airflow/models/callback.py
+++ b/airflow-core/src/airflow/models/callback.py
@@ -31,6 +31,7 @@ from airflow._shared.observability.metrics.stats import Stats
 from airflow._shared.timezones import timezone
 from airflow.models import Base
 from airflow.utils.sqlalchemy import ExtendedJSON, UtcDateTime
+from airflow.utils.state import CallbackState
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -38,20 +39,9 @@ if TYPE_CHECKING:
     from airflow.callbacks.callback_requests import CallbackRequest
     from airflow.triggers.base import TriggerEvent
 
+    CallbackKey = str  # Callback keys are str(UUID)
+
 log = structlog.get_logger(__name__)
-
-
-class CallbackState(str, Enum):
-    """All possible states of callbacks."""
-
-    PENDING = "pending"
-    QUEUED = "queued"
-    RUNNING = "running"
-    SUCCESS = "success"
-    FAILED = "failed"
-
-    def __str__(self) -> str:
-        return self.value
 
 
 ACTIVE_STATES = frozenset((CallbackState.QUEUED, CallbackState.RUNNING))

--- a/airflow-core/src/airflow/models/callback.py
+++ b/airflow-core/src/airflow/models/callback.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
 from __future__ import annotations
 
 from datetime import datetime

--- a/airflow-core/src/airflow/models/deadline.py
+++ b/airflow-core/src/airflow/models/deadline.py
@@ -21,7 +21,6 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from enum import Enum
 from typing import TYPE_CHECKING, Any, cast
 from uuid import UUID
 
@@ -81,19 +80,6 @@ class classproperty:
 
     def __get__(self, instance, cls=None):
         return self.method(cls)
-
-
-class DeadlineCallbackState(str, Enum):
-    """
-    All possible states of deadline callbacks once the deadline is missed.
-
-    `None` state implies that the deadline is pending (`deadline_time` hasn't passed yet).
-    """
-
-    QUEUED = "queued"
-    RUNNING = "running"
-    SUCCESS = "success"
-    FAILED = "failed"
 
 
 class Deadline(Base):

--- a/airflow-core/src/airflow/models/deadline.py
+++ b/airflow-core/src/airflow/models/deadline.py
@@ -32,12 +32,12 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from airflow._shared.observability.metrics.stats import Stats
 from airflow._shared.timezones import timezone
-from airflow.models import Trigger
 from airflow.models.base import Base
-from airflow.models.callback import Callback, CallbackDefinitionProtocol
-from airflow.observability.stats import Stats
-from airflow.sdk.definitions.callback import AsyncCallback, SyncCallback
-from airflow.triggers.callback import CallbackTrigger
+from airflow.models.callback import (
+    Callback,
+    ExecutorCallback,
+    TriggererCallback,
+)
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import provide_session
 from airflow.utils.sqlalchemy import UtcDateTime, get_dialect_name
@@ -242,48 +242,36 @@ class Deadline(Base):
                 "deadline": {"id": self.id, "deadline_time": self.deadline_time},
             }
 
-        if isinstance(self.callback, AsyncCallback):
-            callback_trigger = CallbackTrigger(
-                callback_path=self.callback.path,
-                callback_kwargs=(self.callback.kwargs or {}) | {"context": get_simple_context()},
-            )
-            trigger_orm = Trigger.from_object(callback_trigger)
-            session.add(trigger_orm)
+        if isinstance(self.callback, TriggererCallback):
+            # Update the callback with context before queuing
+            if "kwargs" not in self.callback.data:
+                self.callback.data["kwargs"] = {}
+            self.callback.data["kwargs"] = (self.callback.data.get("kwargs") or {}) | {
+                "context": get_simple_context()
+            }
+
+            self.callback.queue()
+            session.add(self.callback)
             session.flush()
-            self.trigger = trigger_orm
 
-        elif isinstance(self.callback, SyncCallback):
-            from airflow.models.callback import CallbackFetchMethod, ExecutorCallback
+        elif isinstance(self.callback, ExecutorCallback):
+            if "kwargs" not in self.callback.data:
+                self.callback.data["kwargs"] = {}
+            self.callback.data["kwargs"] = (self.callback.data.get("kwargs") or {}) | {
+                "context": get_simple_context()
+            }
+            self.callback.data["deadline_id"] = str(self.id)
+            self.callback.data["dag_run_id"] = str(self.dagrun.id)
+            self.callback.data["dag_id"] = self.dagrun.dag_id
 
-            # Create an ExecutorCallback for processing through the executor pipeline
-            # Store deadline and dag_run info in the callback data for later retrieval
-            callback_data = self.callback.serialize()
-            callback_data["deadline_id"] = str(self.id)
-            callback_data["dag_run_id"] = str(self.dagrun.id)
-            callback_data["dag_id"] = self.dagrun.dag_id
-
-            # Add context to callback kwargs (similar to AsyncCallback)
-            if "kwargs" not in callback_data:
-                callback_data["kwargs"] = {}
-            callback_data["kwargs"] = (callback_data.get("kwargs") or {}) | {"context": get_simple_context()}
-
-            # Create a modified callback_def with the additional data
-            class ModifiedCallback:
-                def serialize(self):
-                    return callback_data
-
-            executor_callback = ExecutorCallback(
-                callback_def=ModifiedCallback(),
-                fetch_method=CallbackFetchMethod.IMPORT_PATH,
-                priority_weight=1,
-            )
-            executor_callback.queue()
-            session.add(executor_callback)
+            self.callback.queue()
+            session.add(self.callback)
             session.flush()
 
         else:
-            raise TypeError("Unknown Callback type")
+            raise TypeError(f"Unknown Callback type: {type(self.callback).__name__}")
 
+        self.missed = True
         session.add(self)
         Stats.incr(
             "deadline_alerts.deadline_missed",

--- a/airflow-core/src/airflow/models/deadline.py
+++ b/airflow-core/src/airflow/models/deadline.py
@@ -21,6 +21,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from enum import Enum
 from typing import TYPE_CHECKING, Any, cast
 from uuid import UUID
 
@@ -31,8 +32,12 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from airflow._shared.observability.metrics.stats import Stats
 from airflow._shared.timezones import timezone
+from airflow.models import Trigger
 from airflow.models.base import Base
 from airflow.models.callback import Callback, CallbackDefinitionProtocol
+from airflow.observability.stats import Stats
+from airflow.sdk.definitions.callback import AsyncCallback, SyncCallback
+from airflow.triggers.callback import CallbackTrigger
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import provide_session
 from airflow.utils.sqlalchemy import UtcDateTime, get_dialect_name
@@ -75,6 +80,19 @@ class classproperty:
 
     def __get__(self, instance, cls=None):
         return self.method(cls)
+
+
+class DeadlineCallbackState(str, Enum):
+    """
+    All possible states of deadline callbacks once the deadline is missed.
+
+    `None` state implies that the deadline is pending (`deadline_time` hasn't passed yet).
+    """
+
+    QUEUED = "queued"
+    RUNNING = "running"
+    SUCCESS = "success"
+    FAILED = "failed"
 
 
 class Deadline(Base):
@@ -224,9 +242,48 @@ class Deadline(Base):
                 "deadline": {"id": self.id, "deadline_time": self.deadline_time},
             }
 
-        self.callback.data["kwargs"] = self.callback.data["kwargs"] | {"context": get_simple_context()}
-        self.missed = True
-        self.callback.queue()
+        if isinstance(self.callback, AsyncCallback):
+            callback_trigger = CallbackTrigger(
+                callback_path=self.callback.path,
+                callback_kwargs=(self.callback.kwargs or {}) | {"context": get_simple_context()},
+            )
+            trigger_orm = Trigger.from_object(callback_trigger)
+            session.add(trigger_orm)
+            session.flush()
+            self.trigger = trigger_orm
+
+        elif isinstance(self.callback, SyncCallback):
+            from airflow.models.callback import CallbackFetchMethod, ExecutorCallback
+
+            # Create an ExecutorCallback for processing through the executor pipeline
+            # Store deadline and dag_run info in the callback data for later retrieval
+            callback_data = self.callback.serialize()
+            callback_data["deadline_id"] = str(self.id)
+            callback_data["dag_run_id"] = str(self.dagrun.id)
+            callback_data["dag_id"] = self.dagrun.dag_id
+
+            # Add context to callback kwargs (similar to AsyncCallback)
+            if "kwargs" not in callback_data:
+                callback_data["kwargs"] = {}
+            callback_data["kwargs"] = (callback_data.get("kwargs") or {}) | {"context": get_simple_context()}
+
+            # Create a modified callback_def with the additional data
+            class ModifiedCallback:
+                def serialize(self):
+                    return callback_data
+
+            executor_callback = ExecutorCallback(
+                callback_def=ModifiedCallback(),
+                fetch_method=CallbackFetchMethod.IMPORT_PATH,
+                priority_weight=1,
+            )
+            executor_callback.queue()
+            session.add(executor_callback)
+            session.flush()
+
+        else:
+            raise TypeError("Unknown Callback type")
+
         session.add(self)
         Stats.incr(
             "deadline_alerts.deadline_missed",

--- a/airflow-core/src/airflow/models/deadline.py
+++ b/airflow-core/src/airflow/models/deadline.py
@@ -41,6 +41,7 @@ from airflow.models.callback import (
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import provide_session
 from airflow.utils.sqlalchemy import UtcDateTime, get_dialect_name
+from airflow.utils.state import CallbackState
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -264,7 +265,7 @@ class Deadline(Base):
             self.callback.data["dag_run_id"] = str(self.dagrun.id)
             self.callback.data["dag_id"] = self.dagrun.dag_id
 
-            self.callback.queue()
+            self.callback.state = CallbackState.PENDING
             session.add(self.callback)
             session.flush()
 

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -70,6 +70,7 @@ from airflow._shared.observability.metrics.stats import Stats
 from airflow._shared.timezones import timezone
 from airflow.assets.manager import asset_manager
 from airflow.configuration import conf
+from airflow.executors.workloads import BaseWorkload
 from airflow.listeners.listener import get_listener_manager
 from airflow.models.asset import AssetModel
 from airflow.models.base import Base, StringID, TaskInstanceDependencies
@@ -406,7 +407,7 @@ def uuid7() -> UUID:
     return uuid6.uuid7()
 
 
-class TaskInstance(Base, LoggingMixin):
+class TaskInstance(Base, LoggingMixin, BaseWorkload):
     """
     Task instances store the state of a task instance.
 
@@ -801,6 +802,14 @@ class TaskInstance(Base, LoggingMixin):
     def key(self) -> TaskInstanceKey:
         """Returns a tuple that identifies the task instance uniquely."""
         return TaskInstanceKey(self.dag_id, self.task_id, self.run_id, self.try_number, self.map_index)
+
+    def get_dag_id(self) -> str:
+        """Return the DAG ID for scheduler routing."""
+        return self.dag_id
+
+    def get_executor_name(self) -> str | None:
+        """Return the executor name for scheduler routing."""
+        return self.executor
 
     @provide_session
     def set_state(self, state: str | None, session: Session = NEW_SESSION) -> bool:

--- a/airflow-core/src/airflow/utils/state.py
+++ b/airflow-core/src/airflow/utils/state.py
@@ -23,6 +23,7 @@ from enum import Enum
 class CallbackState(str, Enum):
     """All possible states of callbacks."""
 
+    SCHEDULED = "scheduled"
     PENDING = "pending"
     QUEUED = "queued"
     RUNNING = "running"

--- a/airflow-core/src/airflow/utils/state.py
+++ b/airflow-core/src/airflow/utils/state.py
@@ -20,6 +20,19 @@ from __future__ import annotations
 from enum import Enum
 
 
+class CallbackState(str, Enum):
+    """All possible states of callbacks."""
+
+    PENDING = "pending"
+    QUEUED = "queued"
+    RUNNING = "running"
+    SUCCESS = "success"
+    FAILED = "failed"
+
+    def __str__(self) -> str:
+        return self.value
+
+
 class TerminalTIState(str, Enum):
     """States that a Task Instance can be in that indicate it has reached a terminal state."""
 

--- a/airflow-core/tests/unit/executors/test_base_executor.py
+++ b/airflow-core/tests/unit/executors/test_base_executor.py
@@ -35,7 +35,8 @@ from airflow.cli.cli_parser import AirflowHelpFormatter
 from airflow.executors import workloads
 from airflow.executors.base_executor import BaseExecutor, RunningRetryAttemptType
 from airflow.executors.local_executor import LocalExecutor
-from airflow.executors.workloads import Callback, execute_callback_workload
+from airflow.executors.workloads.base import BundleInfo
+from airflow.executors.workloads.callback import CallbackDTO, execute_callback_workload
 from airflow.models.callback import CallbackFetchMethod
 from airflow.models.taskinstance import TaskInstance, TaskInstanceKey
 from airflow.sdk import BaseOperator
@@ -591,7 +592,7 @@ class TestCallbackSupport:
     @pytest.mark.db_test
     def test_queue_callback_without_support_raises_error(self, dag_maker, session):
         executor = BaseExecutor()  # supports_callbacks = False by default
-        callback_data = Callback(
+        callback_data = CallbackDTO(
             id="12345678-1234-5678-1234-567812345678",
             fetch_method=CallbackFetchMethod.IMPORT_PATH,
             data={"path": "test.func", "kwargs": {}},
@@ -599,7 +600,7 @@ class TestCallbackSupport:
         callback_workload = workloads.ExecuteCallback(
             callback=callback_data,
             dag_rel_path="test.py",
-            bundle_info=workloads.BundleInfo(name="test_bundle", version="1.0"),
+            bundle_info=BundleInfo(name="test_bundle", version="1.0"),
             token="test_token",
             log_path="test.log",
         )
@@ -611,7 +612,7 @@ class TestCallbackSupport:
     def test_queue_workload_with_execute_callback(self, dag_maker, session):
         executor = BaseExecutor()
         executor.supports_callbacks = True  # Enable for this test
-        callback_data = Callback(
+        callback_data = CallbackDTO(
             id="12345678-1234-5678-1234-567812345678",
             fetch_method=CallbackFetchMethod.IMPORT_PATH,
             data={"path": "test.func", "kwargs": {}},
@@ -619,7 +620,7 @@ class TestCallbackSupport:
         callback_workload = workloads.ExecuteCallback(
             callback=callback_data,
             dag_rel_path="test.py",
-            bundle_info=workloads.BundleInfo(name="test_bundle", version="1.0"),
+            bundle_info=BundleInfo(name="test_bundle", version="1.0"),
             token="test_token",
             log_path="test.log",
         )
@@ -634,7 +635,7 @@ class TestCallbackSupport:
         executor = BaseExecutor()
         executor.supports_callbacks = True  # Enable for this test
         dagrun = setup_dagrun(dag_maker)
-        callback_data = Callback(
+        callback_data = CallbackDTO(
             id="12345678-1234-5678-1234-567812345678",
             fetch_method=CallbackFetchMethod.IMPORT_PATH,
             data={"path": "test.func", "kwargs": {}},
@@ -642,7 +643,7 @@ class TestCallbackSupport:
         callback_workload = workloads.ExecuteCallback(
             callback=callback_data,
             dag_rel_path="test.py",
-            bundle_info=workloads.BundleInfo(name="test_bundle", version="1.0"),
+            bundle_info=BundleInfo(name="test_bundle", version="1.0"),
             token="test_token",
             log_path="test.log",
         )
@@ -661,7 +662,7 @@ class TestCallbackSupport:
 
 class TestExecuteCallbackWorkload:
     def test_execute_function_callback_success(self):
-        callback_data = Callback(
+        callback_data = CallbackDTO(
             id="12345678-1234-5678-1234-567812345678",
             fetch_method=CallbackFetchMethod.IMPORT_PATH,
             data={
@@ -677,7 +678,7 @@ class TestExecuteCallbackWorkload:
         assert error is None
 
     def test_execute_callback_missing_path(self):
-        callback_data = Callback(
+        callback_data = CallbackDTO(
             id="12345678-1234-5678-1234-567812345678",
             fetch_method=CallbackFetchMethod.IMPORT_PATH,
             data={"kwargs": {}},  # Missing 'path'
@@ -690,7 +691,7 @@ class TestExecuteCallbackWorkload:
         assert "Callback path not found" in error
 
     def test_execute_callback_import_error(self):
-        callback_data = Callback(
+        callback_data = CallbackDTO(
             id="12345678-1234-5678-1234-567812345678",
             fetch_method=CallbackFetchMethod.IMPORT_PATH,
             data={
@@ -707,7 +708,7 @@ class TestExecuteCallbackWorkload:
 
     def test_execute_callback_execution_error(self):
         # Use a function that will raise an error; len() requires an argument
-        callback_data = Callback(
+        callback_data = CallbackDTO(
             id="12345678-1234-5678-1234-567812345678",
             fetch_method=CallbackFetchMethod.IMPORT_PATH,
             data={

--- a/airflow-core/tests/unit/executors/test_base_executor.py
+++ b/airflow-core/tests/unit/executors/test_base_executor.py
@@ -601,7 +601,7 @@ class TestCallbackSupport:
             callback=callback_data,
             dag_rel_path="test.py",
             bundle_info=BundleInfo(name="test_bundle", version="1.0"),
-            token="test_token",
+            identity_token="test_token",
             log_path="test.log",
         )
 
@@ -621,7 +621,7 @@ class TestCallbackSupport:
             callback=callback_data,
             dag_rel_path="test.py",
             bundle_info=BundleInfo(name="test_bundle", version="1.0"),
-            token="test_token",
+            identity_token="test_token",
             log_path="test.log",
         )
 
@@ -644,7 +644,7 @@ class TestCallbackSupport:
             callback=callback_data,
             dag_rel_path="test.py",
             bundle_info=BundleInfo(name="test_bundle", version="1.0"),
-            token="test_token",
+            identity_token="test_token",
             log_path="test.log",
         )
         executor.queue_workload(callback_workload, session)

--- a/airflow-core/tests/unit/executors/test_base_executor.py
+++ b/airflow-core/tests/unit/executors/test_base_executor.py
@@ -601,7 +601,7 @@ class TestCallbackSupport:
             callback=callback_data,
             dag_rel_path="test.py",
             bundle_info=BundleInfo(name="test_bundle", version="1.0"),
-            identity_token="test_token",
+            token="test_token",
             log_path="test.log",
         )
 
@@ -621,7 +621,7 @@ class TestCallbackSupport:
             callback=callback_data,
             dag_rel_path="test.py",
             bundle_info=BundleInfo(name="test_bundle", version="1.0"),
-            identity_token="test_token",
+            token="test_token",
             log_path="test.log",
         )
 
@@ -644,7 +644,7 @@ class TestCallbackSupport:
             callback=callback_data,
             dag_rel_path="test.py",
             bundle_info=BundleInfo(name="test_bundle", version="1.0"),
-            identity_token="test_token",
+            token="test_token",
             log_path="test.log",
         )
         executor.queue_workload(callback_workload, session)

--- a/airflow-core/tests/unit/executors/test_local_executor.py
+++ b/airflow-core/tests/unit/executors/test_local_executor.py
@@ -125,7 +125,7 @@ class TestLocalExecutor:
             for ti in success_tis:
                 executor.queue_workload(
                     workloads.ExecuteTask(
-                        token="",
+                        identity_token="",
                         ti=ti,
                         dag_rel_path="some/path",
                         log_path=None,
@@ -136,7 +136,7 @@ class TestLocalExecutor:
 
             executor.queue_workload(
                 workloads.ExecuteTask(
-                    token="",
+                    identity_token="",
                     ti=fail_ti,
                     dag_rel_path="some/path",
                     log_path=None,
@@ -353,7 +353,7 @@ class TestLocalExecutorCallbackSupport:
             callback=callback_data,
             dag_rel_path="test.py",
             bundle_info=BundleInfo(name="test_bundle", version="1.0"),
-            token="test_token",
+            identity_token="test_token",
             log_path="test.log",
         )
 

--- a/airflow-core/tests/unit/executors/test_local_executor.py
+++ b/airflow-core/tests/unit/executors/test_local_executor.py
@@ -21,7 +21,6 @@ import gc
 import multiprocessing
 import os
 from unittest import mock
-from uuid import UUID
 
 import pytest
 from kgb import spy_on
@@ -344,7 +343,7 @@ class TestLocalExecutorCallbackSupport:
 
         executor = LocalExecutor(parallelism=1)
         callback_data = Callback(
-            id=UUID("12345678-1234-5678-1234-567812345678"),
+            id="12345678-1234-5678-1234-567812345678",
             fetch_method=CallbackFetchMethod.IMPORT_PATH,
             data={"path": "test.func", "kwargs": {}},
         )

--- a/airflow-core/tests/unit/executors/test_local_executor.py
+++ b/airflow-core/tests/unit/executors/test_local_executor.py
@@ -125,7 +125,7 @@ class TestLocalExecutor:
             for ti in success_tis:
                 executor.queue_workload(
                     workloads.ExecuteTask(
-                        identity_token="",
+                        token="",
                         ti=ti,
                         dag_rel_path="some/path",
                         log_path=None,
@@ -136,7 +136,7 @@ class TestLocalExecutor:
 
             executor.queue_workload(
                 workloads.ExecuteTask(
-                    identity_token="",
+                    token="",
                     ti=fail_ti,
                     dag_rel_path="some/path",
                     log_path=None,
@@ -353,7 +353,7 @@ class TestLocalExecutorCallbackSupport:
             callback=callback_data,
             dag_rel_path="test.py",
             bundle_info=BundleInfo(name="test_bundle", version="1.0"),
-            identity_token="test_token",
+            token="test_token",
             log_path="test.log",
         )
 

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -8363,13 +8363,13 @@ class TestSchedulerJob:
 
         with (
             assert_queries_count(1, session=session),
-            mock.patch.object(self.job_runner, "_get_task_team_name") as mock_single,
+            mock.patch.object(self.job_runner, "_get_workload_team_name") as mock_single,
         ):
-            executor_to_tis = self.job_runner._executor_to_tis([ti1, ti2], session)
+            executor_to_workloads = self.job_runner._executor_to_workloads([ti1, ti2], session)
 
             mock_single.assert_not_called()
-            assert executor_to_tis[mock_executors[0]] == [ti1]
-            assert executor_to_tis[mock_executors[1]] == [ti2]
+            assert executor_to_workloads[mock_executors[0]] == [ti1]
+            assert executor_to_workloads[mock_executors[1]] == [ti2]
 
     @conf_vars({("core", "multi_team"): "false"})
     def test_multi_team_config_disabled_uses_legacy_behavior(self, dag_maker, mock_executors, session):

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -8220,7 +8220,8 @@ class TestSchedulerJob:
 
             # Should log a warning when no executor is found
             mock_log.warning.assert_called_once_with(
-                "Executor, %s, was not found but a workload was configured to use it", "secondary_exec"
+                "Executor, %s, was not found but a Task or Callback was configured to use it",
+                "secondary_exec",
             )
 
         # Should return None since we failed to resolve an executor due to the mismatch. In practice, this

--- a/airflow-core/tests/unit/models/test_callback.py
+++ b/airflow-core/tests/unit/models/test_callback.py
@@ -123,7 +123,7 @@ class TestTriggererCallback:
         assert isinstance(retrieved, TriggererCallback)
         assert retrieved.fetch_method == CallbackFetchMethod.IMPORT_PATH
         assert retrieved.data == TEST_ASYNC_CALLBACK.serialize()
-        assert retrieved.state == CallbackState.PENDING.value
+        assert retrieved.state == CallbackState.SCHEDULED.value
         assert retrieved.output is None
         assert retrieved.priority_weight == 1
         assert retrieved.created_at is not None
@@ -131,7 +131,7 @@ class TestTriggererCallback:
 
     def test_queue(self, session):
         callback = TriggererCallback(TEST_ASYNC_CALLBACK)
-        assert callback.state == CallbackState.PENDING
+        assert callback.state == CallbackState.SCHEDULED
         assert callback.trigger is None
 
         callback.queue()
@@ -193,7 +193,7 @@ class TestExecutorCallback:
         assert isinstance(retrieved, ExecutorCallback)
         assert retrieved.fetch_method == CallbackFetchMethod.IMPORT_PATH
         assert retrieved.data == TEST_SYNC_CALLBACK.serialize()
-        assert retrieved.state == CallbackState.PENDING.value
+        assert retrieved.state == CallbackState.SCHEDULED.value
         assert retrieved.output is None
         assert retrieved.priority_weight == 1
         assert retrieved.created_at is not None
@@ -201,7 +201,7 @@ class TestExecutorCallback:
 
     def test_queue(self):
         callback = ExecutorCallback(TEST_SYNC_CALLBACK, fetch_method=CallbackFetchMethod.DAG_ATTRIBUTE)
-        assert callback.state == CallbackState.PENDING
+        assert callback.state == CallbackState.SCHEDULED
 
         callback.queue()
         assert callback.state == CallbackState.QUEUED

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -2092,6 +2092,7 @@ winrm
 WIT
 workgroup
 workgroups
+WorkloadKey
 workspaces
 writeable
 wsman

--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
@@ -91,6 +91,7 @@ class CeleryExecutor(BaseExecutor):
     """
 
     supports_ad_hoc_ti_run: bool = True
+    supports_callbacks: bool = True
     sentry_integration: str = "sentry_sdk.integrations.celery.CeleryIntegration"
 
     # TODO: Remove this flag once providers depend on Airflow 3.2.

--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
@@ -52,11 +52,8 @@ CELERY_SEND_ERR_MSG_HEADER = "Error sending Celery task"
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from sqlalchemy.orm import Session
-
     from airflow.cli.cli_config import GroupCommand
     from airflow.executors import workloads
-    from airflow.executors.workloads.types import WorkloadKey
     from airflow.models.taskinstance import TaskInstance
     from airflow.models.taskinstancekey import TaskInstanceKey
     from airflow.providers.celery.executors.celery_executor_utils import TaskTuple, WorkloadInCelery
@@ -100,13 +97,9 @@ class CeleryExecutor(BaseExecutor):
     supports_multi_team: bool = True
 
     if TYPE_CHECKING:
-        if AIRFLOW_V_3_2_PLUS:
-            # In v3.2+, callbacks are supported, so keys can be TaskInstanceKey OR str (CallbackKey)
-            queued_tasks: dict[WorkloadKey, workloads.All]  # type: ignore[assignment]
-        elif AIRFLOW_V_3_0_PLUS:
-            # In v3.0-3.1, only tasks are supported (no callbacks yet)
+        if AIRFLOW_V_3_0_PLUS:
             # TODO: TaskSDK: move this type change into BaseExecutor
-            queued_tasks: dict[TaskInstanceKey, workloads.All]  # type: ignore[assignment,no-redef]
+            queued_tasks: dict[TaskInstanceKey, workloads.All]  # type: ignore[assignment]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -208,7 +201,10 @@ class CeleryExecutor(BaseExecutor):
                     )
                     self.task_publish_retries[key] = retries + 1
                     continue
-            self.queued_tasks.pop(key)
+            if key in self.queued_tasks:
+                self.queued_tasks.pop(key)
+            else:
+                self.queued_callbacks.pop(key, None)
             self.task_publish_retries.pop(key, None)
             if isinstance(result, ExceptionWithTraceback):
                 self.log.error("%s: %s\n%s\n", CELERY_SEND_ERR_MSG_HEADER, result.exception, result.traceback)
@@ -388,15 +384,3 @@ class CeleryExecutor(BaseExecutor):
         from airflow.providers.celery.cli.definition import get_celery_cli_commands
 
         return get_celery_cli_commands()
-
-    def queue_workload(self, workload: workloads.All, session: Session | None) -> None:
-        from airflow.executors import workloads
-
-        if isinstance(workload, workloads.ExecuteTask):
-            ti = workload.ti
-            self.queued_tasks[ti.key] = workload
-        elif isinstance(workload, workloads.ExecuteCallback):
-            # Use workload.callback.key (CallbackKey = str)
-            self.queued_tasks[workload.callback.key] = workload
-        else:
-            raise RuntimeError(f"{type(self)} cannot handle workloads of type {type(workload)}")

--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
@@ -39,7 +39,7 @@ from deprecated import deprecated
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.executors.base_executor import BaseExecutor
-from airflow.providers.celery.version_compat import AIRFLOW_V_3_0_PLUS
+from airflow.providers.celery.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_2_PLUS
 from airflow.providers.common.compat.sdk import AirflowTaskTimeout, Stats
 from airflow.utils.state import TaskInstanceState
 
@@ -160,14 +160,21 @@ class CeleryExecutor(BaseExecutor):
         # Airflow V3 version -- have to delay imports until we know we are on v3
         from airflow.executors.workloads import ExecuteTask
 
-        tasks = [
-            (workload.ti.key, workload, workload.ti.queue, self.team_name)
-            for workload in workloads
-            if isinstance(workload, ExecuteTask)
-        ]
-        if len(tasks) != len(workloads):
-            invalid = list(workload for workload in workloads if not isinstance(workload, ExecuteTask))
-            raise ValueError(f"{type(self)}._process_workloads cannot handle {invalid}")
+        if AIRFLOW_V_3_2_PLUS:
+            from airflow.executors.workloads import ExecuteCallback
+
+        tasks = []
+        for workload in workloads:
+            if isinstance(workload, ExecuteTask):
+                tasks.append((workload.ti.key, workload, workload.ti.queue, self.team_name))
+            elif AIRFLOW_V_3_2_PLUS and isinstance(workload, ExecuteCallback):
+                # Use default queue for callbacks, or extract from callback data if available
+                queue = "default"
+                if isinstance(workload.callback.data, dict) and "queue" in workload.callback.data:
+                    queue = workload.callback.data["queue"]
+                tasks.append((workload.callback.key, workload, queue, self.team_name))
+            else:
+                raise ValueError(f"{type(self)}._process_workloads cannot handle {type(workload)}")
 
         self._send_tasks(tasks)
 
@@ -378,8 +385,20 @@ class CeleryExecutor(BaseExecutor):
 
     def queue_workload(self, workload: workloads.All, session: Session | None) -> None:
         from airflow.executors import workloads
+        from airflow.models.taskinstancekey import TaskInstanceKey
 
-        if not isinstance(workload, workloads.ExecuteTask):
+        if isinstance(workload, workloads.ExecuteTask):
+            ti = workload.ti
+            self.queued_tasks[ti.key] = workload
+        elif isinstance(workload, workloads.ExecuteCallback):
+            # For callbacks, use a synthetic key based on callback ID
+            callback_key = TaskInstanceKey(
+                dag_id="callback",
+                task_id=str(workload.callback.id),
+                run_id="callback",
+                try_number=1,
+                map_index=-1,
+            )
+            self.queued_tasks[callback_key] = workload
+        else:
             raise RuntimeError(f"{type(self)} cannot handle workloads of type {type(workload)}")
-        ti = workload.ti
-        self.queued_tasks[ti.key] = workload

--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
@@ -164,7 +164,7 @@ class CeleryExecutor(BaseExecutor):
         if AIRFLOW_V_3_2_PLUS:
             from airflow.executors.workloads import ExecuteCallback
 
-        tasks = []
+        tasks: list[TaskInstanceInCelery] = []
         for workload in workloads:
             if isinstance(workload, ExecuteTask):
                 tasks.append((workload.ti.key, workload, workload.ti.queue, self.team_name))

--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
@@ -157,6 +157,37 @@ class CeleryExecutor(BaseExecutor):
 
         self._send_tasks(task_tuples_to_send)
 
+        from airflow.executors.workloads import ExecuteCallback, ExecuteTask
+        from airflow.models.taskinstancekey import TaskInstanceKey
+        from airflow.providers.celery.executors.celery_executor_utils import execute_workload
+>>>>>>> 5f63b2e16c (CI fixes and minor type-related cleanup)
+
+        tasks: list[TaskInstanceInCelery] = []
+        for workload in workloads:
+            if isinstance(workload, ExecuteTask):
+<<<<<<< HEAD
+                tasks.append((workload.ti.key, workload, workload.ti.queue, self.team_name))
+            elif AIRFLOW_V_3_2_PLUS and isinstance(workload, ExecuteCallback):
+                tasks.append((workload.ti.key, workload, workload.ti.queue, execute_workload))
+            elif isinstance(workload, ExecuteCallback):
+                # For callbacks, use a synthetic key based on callback ID
+                callback_key = TaskInstanceKey(
+                    dag_id="callback",
+                    task_id=workload.callback.id,
+                    run_id="callback",
+                    try_number=1,
+                    map_index=-1,
+                )
+>>>>>>> 5f63b2e16c (CI fixes and minor type-related cleanup)
+                # Use default queue for callbacks, or extract from callback data if available
+                queue = "default"
+                if isinstance(workload.callback.data, dict) and "queue" in workload.callback.data:
+                    queue = workload.callback.data["queue"]
+                tasks.append((workload.callback.key, workload, queue, self.team_name))
+            else:
+                raise ValueError(f"{type(self)}._process_workloads cannot handle {type(workload)}")
+
+        self._send_tasks(tasks)
     def _process_workloads(self, workloads: Sequence[workloads.All]) -> None:
         # Airflow V3 version -- have to delay imports until we know we are on v3
         from airflow.executors.workloads import ExecuteTask
@@ -169,6 +200,39 @@ class CeleryExecutor(BaseExecutor):
             if isinstance(workload, ExecuteTask):
                 tasks.append((workload.ti.key, workload, workload.ti.queue, self.team_name))
             elif AIRFLOW_V_3_2_PLUS and isinstance(workload, ExecuteCallback):
+                # Use default queue for callbacks, or extract from callback data if available
+                queue = "default"
+                if isinstance(workload.callback.data, dict) and "queue" in workload.callback.data:
+                    queue = workload.callback.data["queue"]
+                tasks.append((workload.callback.key, workload, queue, self.team_name))
+            else:
+                raise ValueError(f"{type(self)}._process_workloads cannot handle {type(workload)}")
+
+        self._send_tasks(tasks)
+=======
+        from airflow.executors.workloads import ExecuteCallback, ExecuteTask
+        from airflow.models.taskinstancekey import TaskInstanceKey
+        from airflow.providers.celery.executors.celery_executor_utils import execute_workload
+>>>>>>> 5f63b2e16c (CI fixes and minor type-related cleanup)
+
+        tasks: list[TaskInstanceInCelery] = []
+        for workload in workloads:
+            if isinstance(workload, ExecuteTask):
+<<<<<<< HEAD
+                tasks.append((workload.ti.key, workload, workload.ti.queue, self.team_name))
+            elif AIRFLOW_V_3_2_PLUS and isinstance(workload, ExecuteCallback):
+=======
+                tasks.append((workload.ti.key, workload, workload.ti.queue, execute_workload))
+            elif isinstance(workload, ExecuteCallback):
+                # For callbacks, use a synthetic key based on callback ID
+                callback_key = TaskInstanceKey(
+                    dag_id="callback",
+                    task_id=workload.callback.id,
+                    run_id="callback",
+                    try_number=1,
+                    map_index=-1,
+                )
+>>>>>>> 5f63b2e16c (CI fixes and minor type-related cleanup)
                 # Use default queue for callbacks, or extract from callback data if available
                 queue = "default"
                 if isinstance(workload.callback.data, dict) and "queue" in workload.callback.data:
@@ -395,7 +459,7 @@ class CeleryExecutor(BaseExecutor):
             # For callbacks, use a synthetic key based on callback ID
             callback_key = TaskInstanceKey(
                 dag_id="callback",
-                task_id=str(workload.callback.id),
+                task_id=workload.callback.id,
                 run_id="callback",
                 try_number=1,
                 map_index=-1,

--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
@@ -157,37 +157,6 @@ class CeleryExecutor(BaseExecutor):
 
         self._send_tasks(task_tuples_to_send)
 
-        from airflow.executors.workloads import ExecuteCallback, ExecuteTask
-        from airflow.models.taskinstancekey import TaskInstanceKey
-        from airflow.providers.celery.executors.celery_executor_utils import execute_workload
->>>>>>> 5f63b2e16c (CI fixes and minor type-related cleanup)
-
-        tasks: list[TaskInstanceInCelery] = []
-        for workload in workloads:
-            if isinstance(workload, ExecuteTask):
-<<<<<<< HEAD
-                tasks.append((workload.ti.key, workload, workload.ti.queue, self.team_name))
-            elif AIRFLOW_V_3_2_PLUS and isinstance(workload, ExecuteCallback):
-                tasks.append((workload.ti.key, workload, workload.ti.queue, execute_workload))
-            elif isinstance(workload, ExecuteCallback):
-                # For callbacks, use a synthetic key based on callback ID
-                callback_key = TaskInstanceKey(
-                    dag_id="callback",
-                    task_id=workload.callback.id,
-                    run_id="callback",
-                    try_number=1,
-                    map_index=-1,
-                )
->>>>>>> 5f63b2e16c (CI fixes and minor type-related cleanup)
-                # Use default queue for callbacks, or extract from callback data if available
-                queue = "default"
-                if isinstance(workload.callback.data, dict) and "queue" in workload.callback.data:
-                    queue = workload.callback.data["queue"]
-                tasks.append((workload.callback.key, workload, queue, self.team_name))
-            else:
-                raise ValueError(f"{type(self)}._process_workloads cannot handle {type(workload)}")
-
-        self._send_tasks(tasks)
     def _process_workloads(self, workloads: Sequence[workloads.All]) -> None:
         # Airflow V3 version -- have to delay imports until we know we are on v3
         from airflow.executors.workloads import ExecuteTask
@@ -200,39 +169,6 @@ class CeleryExecutor(BaseExecutor):
             if isinstance(workload, ExecuteTask):
                 tasks.append((workload.ti.key, workload, workload.ti.queue, self.team_name))
             elif AIRFLOW_V_3_2_PLUS and isinstance(workload, ExecuteCallback):
-                # Use default queue for callbacks, or extract from callback data if available
-                queue = "default"
-                if isinstance(workload.callback.data, dict) and "queue" in workload.callback.data:
-                    queue = workload.callback.data["queue"]
-                tasks.append((workload.callback.key, workload, queue, self.team_name))
-            else:
-                raise ValueError(f"{type(self)}._process_workloads cannot handle {type(workload)}")
-
-        self._send_tasks(tasks)
-=======
-        from airflow.executors.workloads import ExecuteCallback, ExecuteTask
-        from airflow.models.taskinstancekey import TaskInstanceKey
-        from airflow.providers.celery.executors.celery_executor_utils import execute_workload
->>>>>>> 5f63b2e16c (CI fixes and minor type-related cleanup)
-
-        tasks: list[TaskInstanceInCelery] = []
-        for workload in workloads:
-            if isinstance(workload, ExecuteTask):
-<<<<<<< HEAD
-                tasks.append((workload.ti.key, workload, workload.ti.queue, self.team_name))
-            elif AIRFLOW_V_3_2_PLUS and isinstance(workload, ExecuteCallback):
-=======
-                tasks.append((workload.ti.key, workload, workload.ti.queue, execute_workload))
-            elif isinstance(workload, ExecuteCallback):
-                # For callbacks, use a synthetic key based on callback ID
-                callback_key = TaskInstanceKey(
-                    dag_id="callback",
-                    task_id=workload.callback.id,
-                    run_id="callback",
-                    try_number=1,
-                    map_index=-1,
-                )
->>>>>>> 5f63b2e16c (CI fixes and minor type-related cleanup)
                 # Use default queue for callbacks, or extract from callback data if available
                 queue = "default"
                 if isinstance(workload.callback.data, dict) and "queue" in workload.callback.data:

--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
@@ -56,9 +56,10 @@ if TYPE_CHECKING:
 
     from airflow.cli.cli_config import GroupCommand
     from airflow.executors import workloads
+    from airflow.executors.workloads.types import WorkloadKey
     from airflow.models.taskinstance import TaskInstance
     from airflow.models.taskinstancekey import TaskInstanceKey
-    from airflow.providers.celery.executors.celery_executor_utils import TaskInstanceInCelery, TaskTuple
+    from airflow.providers.celery.executors.celery_executor_utils import TaskTuple, WorkloadInCelery
 
 
 # PEP562
@@ -98,10 +99,14 @@ class CeleryExecutor(BaseExecutor):
     supports_sentry: bool = True
     supports_multi_team: bool = True
 
-    if TYPE_CHECKING and AIRFLOW_V_3_0_PLUS:
-        # In the v3 path, we store workloads, not commands as strings.
-        # TODO: TaskSDK: move this type change into BaseExecutor
-        queued_tasks: dict[TaskInstanceKey, workloads.All]  # type: ignore[assignment]
+    if TYPE_CHECKING:
+        if AIRFLOW_V_3_2_PLUS:
+            # In v3.2+, callbacks are supported, so keys can be TaskInstanceKey OR str (CallbackKey)
+            queued_tasks: dict[WorkloadKey, workloads.All]  # type: ignore[assignment]
+        elif AIRFLOW_V_3_0_PLUS:
+            # In v3.0-3.1, only tasks are supported (no callbacks yet)
+            # TODO: TaskSDK: move this type change into BaseExecutor
+            queued_tasks: dict[TaskInstanceKey, workloads.All]  # type: ignore[assignment,no-redef]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -164,7 +169,7 @@ class CeleryExecutor(BaseExecutor):
         if AIRFLOW_V_3_2_PLUS:
             from airflow.executors.workloads import ExecuteCallback
 
-        tasks: list[TaskInstanceInCelery] = []
+        tasks: list[WorkloadInCelery] = []
         for workload in workloads:
             if isinstance(workload, ExecuteTask):
                 tasks.append((workload.ti.key, workload, workload.ti.queue, self.team_name))
@@ -179,7 +184,7 @@ class CeleryExecutor(BaseExecutor):
 
         self._send_tasks(tasks)
 
-    def _send_tasks(self, task_tuples_to_send: Sequence[TaskInstanceInCelery]):
+    def _send_tasks(self, task_tuples_to_send: Sequence[WorkloadInCelery]):
         # Celery state queries will be stuck if we do not use one same backend
         # for all tasks.
         cached_celery_backend = self.celery_app.backend
@@ -218,7 +223,7 @@ class CeleryExecutor(BaseExecutor):
                 # which point we don't need the ID anymore anyway
                 self.event_buffer[key] = (TaskInstanceState.QUEUED, result.task_id)
 
-    def _send_tasks_to_celery(self, task_tuples_to_send: Sequence[TaskInstanceInCelery]):
+    def _send_tasks_to_celery(self, task_tuples_to_send: Sequence[WorkloadInCelery]):
         from airflow.providers.celery.executors.celery_executor_utils import send_task_to_executor
 
         if len(task_tuples_to_send) == 1 or self._sync_parallelism == 1:
@@ -386,20 +391,12 @@ class CeleryExecutor(BaseExecutor):
 
     def queue_workload(self, workload: workloads.All, session: Session | None) -> None:
         from airflow.executors import workloads
-        from airflow.models.taskinstancekey import TaskInstanceKey
 
         if isinstance(workload, workloads.ExecuteTask):
             ti = workload.ti
             self.queued_tasks[ti.key] = workload
         elif isinstance(workload, workloads.ExecuteCallback):
-            # For callbacks, use a synthetic key based on callback ID
-            callback_key = TaskInstanceKey(
-                dag_id="callback",
-                task_id=workload.callback.id,
-                run_id="callback",
-                try_number=1,
-                map_index=-1,
-            )
-            self.queued_tasks[callback_key] = workload
+            # Use workload.callback.key (CallbackKey = str)
+            self.queued_tasks[workload.callback.key] = workload
         else:
             raise RuntimeError(f"{type(self)} cannot handle workloads of type {type(workload)}")

--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
@@ -182,9 +182,6 @@ def execute_workload(input: str) -> None:
 
     celery_task_id = app.current_task.request.id
 
-    if not isinstance(workload, workloads.ExecuteTask):
-        raise ValueError(f"CeleryExecutor does not know how to handle {type(workload)}")
-
     log.info("[%s] Executing workload in Celery: %s", celery_task_id, workload)
 
     base_url = conf.get("api", "base_url", fallback="/")
@@ -193,15 +190,53 @@ def execute_workload(input: str) -> None:
         base_url = f"http://localhost:8080{base_url}"
     default_execution_api_server = f"{base_url.rstrip('/')}/execution/"
 
-    supervise(
-        # This is the "wrong" ti type, but it duck types the same. TODO: Create a protocol for this.
-        ti=workload.ti,  # type: ignore[arg-type]
-        dag_rel_path=workload.dag_rel_path,
-        bundle_info=workload.bundle_info,
-        token=workload.token,
-        server=conf.get("core", "execution_api_server_url", fallback=default_execution_api_server),
-        log_path=workload.log_path,
-    )
+    if isinstance(workload, workloads.ExecuteTask):
+        supervise(
+            # This is the "wrong" ti type, but it duck types the same. TODO: Create a protocol for this.
+            ti=workload.ti,  # type: ignore[arg-type]
+            dag_rel_path=workload.dag_rel_path,
+            bundle_info=workload.bundle_info,
+            token=workload.token,
+            server=conf.get("core", "execution_api_server_url", fallback=default_execution_api_server),
+            log_path=workload.log_path,
+        )
+    elif isinstance(workload, workloads.ExecuteCallback):
+        # Execute callback workload - import and execute the callback function
+        from airflow.models.callback import CallbackFetchMethod
+
+        callback = workload.callback
+        if callback.fetch_type != CallbackFetchMethod.IMPORT_PATH:
+            raise ValueError(
+                f"CeleryExecutor only supports callbacks with fetch_type={CallbackFetchMethod.IMPORT_PATH}, "
+                f"got {callback.fetch_type}"
+            )
+
+        # Extract callback path and kwargs from data
+        if not isinstance(callback.data, dict):
+            raise ValueError(f"Callback data must be a dict, got {type(callback.data)}")
+
+        callback_path = callback.data.get("path")
+        callback_kwargs = callback.data.get("kwargs") or {}
+
+        if not callback_path:
+            raise ValueError("Callback path not found in callback data")
+
+        # Import the callback function using Airflow's import_string utility
+        from airflow.utils.module_loading import import_string
+
+        callback_func = import_string(callback_path)
+
+        # Execute the callback
+        log.info("[%s] Executing callback: %s", celery_task_id, callback_path)
+        try:
+            result = callback_func(**callback_kwargs)
+            log.info("[%s] Callback executed successfully", celery_task_id)
+            return result
+        except Exception:
+            log.exception("[%s] Callback execution failed", celery_task_id)
+            raise
+    else:
+        raise ValueError(f"CeleryExecutor does not know how to handle {type(workload)}")
 
 
 if not AIRFLOW_V_3_0_PLUS:

--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
@@ -201,40 +201,9 @@ def execute_workload(input: str) -> None:
             log_path=workload.log_path,
         )
     elif isinstance(workload, workloads.ExecuteCallback):
-        # Execute callback workload - import and execute the callback function
-        from airflow.models.callback import CallbackFetchMethod
-
-        callback = workload.callback
-        if callback.fetch_type != CallbackFetchMethod.IMPORT_PATH:
-            raise ValueError(
-                f"CeleryExecutor only supports callbacks with fetch_type={CallbackFetchMethod.IMPORT_PATH}, "
-                f"got {callback.fetch_type}"
-            )
-
-        # Extract callback path and kwargs from data
-        if not isinstance(callback.data, dict):
-            raise ValueError(f"Callback data must be a dict, got {type(callback.data)}")
-
-        callback_path = callback.data.get("path")
-        callback_kwargs = callback.data.get("kwargs") or {}
-
-        if not callback_path:
-            raise ValueError("Callback path not found in callback data")
-
-        # Import the callback function using Airflow's import_string utility
-        from airflow.utils.module_loading import import_string
-
-        callback_func = import_string(callback_path)
-
-        # Execute the callback
-        log.info("[%s] Executing callback: %s", celery_task_id, callback_path)
-        try:
-            result = callback_func(**callback_kwargs)
-            log.info("[%s] Callback executed successfully", celery_task_id)
-            return result
-        except Exception:
-            log.exception("[%s] Callback execution failed", celery_task_id)
-            raise
+        success, error_msg = workloads.execute_callback_workload(workload.callback, log)
+        if not success:
+            raise RuntimeError(error_msg or "Callback execution failed")
     else:
         raise ValueError(f"CeleryExecutor does not know how to handle {type(workload)}")
 

--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
@@ -331,7 +331,6 @@ def send_workload_to_executor(
     if TYPE_CHECKING:
         _conf: ExecutorConf | AirflowConfigParser
     # Check if Airflow version is greater than or equal to 3.2 to import ExecutorConf
-    # Check if Airflow version is greater than or equal to 3.2 to import ExecutorConf
     if AIRFLOW_V_3_2_PLUS:
         from airflow.executors.base_executor import ExecutorConf
 

--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
@@ -204,7 +204,7 @@ def execute_workload(input: str) -> None:
             ti=workload.ti,  # type: ignore[arg-type]
             dag_rel_path=workload.dag_rel_path,
             bundle_info=workload.bundle_info,
-            token=workload.token,
+            token=workload.identity_token,
             server=conf.get("core", "execution_api_server_url", fallback=default_execution_api_server),
             log_path=workload.log_path,
         )

--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
@@ -204,7 +204,7 @@ def execute_workload(input: str) -> None:
             ti=workload.ti,  # type: ignore[arg-type]
             dag_rel_path=workload.dag_rel_path,
             bundle_info=workload.bundle_info,
-            token=workload.identity_token,
+            token=workload.token,
             server=conf.get("core", "execution_api_server_url", fallback=default_execution_api_server),
             log_path=workload.log_path,
         )

--- a/providers/celery/src/airflow/providers/celery/executors/celery_kubernetes_executor.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_kubernetes_executor.py
@@ -104,18 +104,18 @@ class CeleryKubernetesExecutor(BaseExecutor):
     def queued_tasks(self) -> dict[TaskInstanceKey, Any]:
         """Return queued tasks from celery and kubernetes executor."""
         queued_tasks = self.celery_executor.queued_tasks.copy()
-        queued_tasks.update(self.kubernetes_executor.queued_tasks)
+        queued_tasks.update(self.kubernetes_executor.queued_tasks)  # type: ignore[arg-type]
 
-        return queued_tasks
+        return queued_tasks  # type: ignore[return-value]
 
     @queued_tasks.setter
     def queued_tasks(self, value) -> None:
         """Not implemented for hybrid executors."""
 
-    @property
+    @property  # type: ignore[override]
     def running(self) -> set[TaskInstanceKey]:
         """Return running tasks from celery and kubernetes executor."""
-        return self.celery_executor.running.union(self.kubernetes_executor.running)
+        return self.celery_executor.running.union(self.kubernetes_executor.running)  # type: ignore[return-value, arg-type]
 
     @running.setter
     def running(self, value) -> None:
@@ -225,7 +225,7 @@ class CeleryKubernetesExecutor(BaseExecutor):
         self.celery_executor.heartbeat()
         self.kubernetes_executor.heartbeat()
 
-    def get_event_buffer(
+    def get_event_buffer(  # type: ignore[override]
         self, dag_ids: list[str] | None = None
     ) -> dict[TaskInstanceKey, EventBufferValueType]:
         """
@@ -237,7 +237,7 @@ class CeleryKubernetesExecutor(BaseExecutor):
         cleared_events_from_celery = self.celery_executor.get_event_buffer(dag_ids)
         cleared_events_from_kubernetes = self.kubernetes_executor.get_event_buffer(dag_ids)
 
-        return {**cleared_events_from_celery, **cleared_events_from_kubernetes}
+        return {**cleared_events_from_celery, **cleared_events_from_kubernetes}  # type: ignore[dict-item]
 
     def try_adopt_task_instances(self, tis: Sequence[TaskInstance]) -> Sequence[TaskInstance]:
         """

--- a/providers/celery/src/airflow/providers/celery/executors/celery_kubernetes_executor.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_kubernetes_executor.py
@@ -228,7 +228,7 @@ class CeleryKubernetesExecutor(BaseExecutor):
 
     def get_event_buffer(
         self, dag_ids: list[str] | None = None
-    ) -> dict[TaskInstanceKey, EventBufferValueType]:
+    ) -> dict[WorkloadKey, EventBufferValueType]:
         """
         Return and flush the event buffer from celery and kubernetes executor.
 

--- a/providers/celery/src/airflow/providers/celery/executors/celery_kubernetes_executor.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_kubernetes_executor.py
@@ -226,9 +226,7 @@ class CeleryKubernetesExecutor(BaseExecutor):
         self.celery_executor.heartbeat()
         self.kubernetes_executor.heartbeat()
 
-    def get_event_buffer(
-        self, dag_ids: list[str] | None = None
-    ) -> dict[WorkloadKey, EventBufferValueType]:
+    def get_event_buffer(self, dag_ids: list[str] | None = None) -> dict[WorkloadKey, EventBufferValueType]:
         """
         Return and flush the event buffer from celery and kubernetes executor.
 

--- a/providers/celery/src/airflow/providers/celery/executors/celery_kubernetes_executor.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_kubernetes_executor.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     from airflow.callbacks.callback_requests import CallbackRequest
     from airflow.cli.cli_config import GroupCommand
     from airflow.executors.base_executor import EventBufferValueType
-    from airflow.executors.workloads import WorkloadKey
+    from airflow.executors.workloads.types import WorkloadKey
     from airflow.models.taskinstance import (  # type: ignore[attr-defined]
         SimpleTaskInstance,
         TaskInstance,
@@ -101,11 +101,15 @@ class CeleryKubernetesExecutor(BaseExecutor):
     def _task_event_logs(self, value):
         """Not implemented for hybrid executors."""
 
-    @property
-    def queued_tasks(self) -> dict[TaskInstanceKey, Any]:
-        """Return queued tasks from celery and kubernetes executor."""
+    @property  # type: ignore[override]
+    def queued_tasks(self) -> dict[TaskInstanceKey | str, Any]:
+        """
+        Return queued tasks from celery and kubernetes executor.
+
+        TODO: Union type used for compatibility. When AIRFLOW_V_3_0_PLUS is removed, change return type to WorkloadKey.
+        """
         queued_tasks = self.celery_executor.queued_tasks.copy()
-        queued_tasks.update(self.kubernetes_executor.queued_tasks)
+        queued_tasks.update(self.kubernetes_executor.queued_tasks)  # type: ignore[arg-type]
 
         return queued_tasks
 

--- a/providers/celery/src/airflow/providers/celery/executors/celery_kubernetes_executor.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_kubernetes_executor.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
     from airflow.callbacks.callback_requests import CallbackRequest
     from airflow.cli.cli_config import GroupCommand
     from airflow.executors.base_executor import EventBufferValueType
+    from airflow.executors.workloads import WorkloadKey
     from airflow.models.taskinstance import (  # type: ignore[attr-defined]
         SimpleTaskInstance,
         TaskInstance,
@@ -113,8 +114,8 @@ class CeleryKubernetesExecutor(BaseExecutor):
         """Not implemented for hybrid executors."""
 
     @property
-    def running(self) -> set[TaskInstanceKey]:
-        """Return running tasks from celery and kubernetes executor."""
+    def running(self) -> set[WorkloadKey]:
+        """Combine running from both executors."""
         return self.celery_executor.running.union(self.kubernetes_executor.running)
 
     @running.setter

--- a/providers/celery/tests/integration/celery/test_celery_executor.py
+++ b/providers/celery/tests/integration/celery/test_celery_executor.py
@@ -42,6 +42,7 @@ from uuid6 import uuid7
 from airflow._shared.timezones import timezone
 from airflow.configuration import conf
 from airflow.executors import workloads
+from airflow.executors.workloads.task import TaskInstanceDTO
 from airflow.models.dag import DAG
 from airflow.models.taskinstance import TaskInstance
 from airflow.providers.common.compat.sdk import AirflowException, AirflowTaskTimeout, TaskInstanceKey
@@ -197,7 +198,7 @@ def setup_dagrun_with_success_and_fail_tasks(dag_maker):
             executor.start()
 
             with start_worker(app=app, logfile=sys.stdout, loglevel="info"):
-                ti_success = workloads.TaskInstance.model_construct(
+                ti_success = TaskInstanceDTO.model_construct(
                     id=uuid7(),
                     task_id="success",
                     dag_id="id",
@@ -257,7 +258,7 @@ def setup_dagrun_with_success_and_fail_tasks(dag_maker):
             else:
                 ti = TaskInstance(task=task, run_id="abc")
             workload = workloads.ExecuteTask.model_construct(
-                ti=workloads.TaskInstance.model_validate(ti, from_attributes=True),
+                ti=TaskInstanceDTO.model_validate(ti, from_attributes=True),
             )
 
             key = (task.dag.dag_id, task.task_id, ti.run_id, 0, -1)
@@ -309,7 +310,7 @@ def setup_dagrun_with_success_and_fail_tasks(dag_maker):
             else:
                 ti = TaskInstance(task=task, run_id="abc")
             workload = workloads.ExecuteTask.model_construct(
-                ti=workloads.TaskInstance.model_validate(ti, from_attributes=True),
+                ti=TaskInstanceDTO.model_validate(ti, from_attributes=True),
             )
 
             key = (task.dag.dag_id, task.task_id, ti.run_id, 0, -1)

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/local_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/local_kubernetes_executor.py
@@ -108,10 +108,10 @@ class LocalKubernetesExecutor(BaseExecutor):
     def queued_tasks(self, value) -> None:
         """Not implemented for hybrid executors."""
 
-    @property
+    @property  # type: ignore[override]
     def running(self) -> set[TaskInstanceKey]:
         """Return running tasks from local and kubernetes executor."""
-        return self.local_executor.running.union(self.kubernetes_executor.running)
+        return self.local_executor.running.union(self.kubernetes_executor.running)  # type: ignore[return-value, arg-type]
 
     @running.setter
     def running(self, value) -> None:
@@ -219,7 +219,7 @@ class LocalKubernetesExecutor(BaseExecutor):
         self.local_executor.heartbeat()
         self.kubernetes_executor.heartbeat()
 
-    def get_event_buffer(
+    def get_event_buffer(  # type: ignore[override]
         self, dag_ids: list[str] | None = None
     ) -> dict[TaskInstanceKey, EventBufferValueType]:
         """
@@ -231,7 +231,7 @@ class LocalKubernetesExecutor(BaseExecutor):
         cleared_events_from_local = self.local_executor.get_event_buffer(dag_ids)
         cleared_events_from_kubernetes = self.kubernetes_executor.get_event_buffer(dag_ids)
 
-        return {**cleared_events_from_local, **cleared_events_from_kubernetes}
+        return {**cleared_events_from_local, **cleared_events_from_kubernetes}  # type: ignore[dict-item]
 
     def try_adopt_task_instances(self, tis: Sequence[TaskInstance]) -> Sequence[TaskInstance]:
         """

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/local_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/local_kubernetes_executor.py
@@ -25,7 +25,6 @@ from deprecated import deprecated
 from airflow.configuration import conf
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.executors.base_executor import BaseExecutor
-from airflow.executors.workloads import WorkloadKey
 from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_0_PLUS
 
 if TYPE_CHECKING:
@@ -34,6 +33,7 @@ if TYPE_CHECKING:
     from airflow.cli.cli_config import GroupCommand
     from airflow.executors.base_executor import EventBufferValueType
     from airflow.executors.local_executor import LocalExecutor
+    from airflow.executors.workloads import WorkloadKey
     from airflow.models.taskinstance import (  # type: ignore[attr-defined]
         SimpleTaskInstance,
         TaskInstance,

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/local_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/local_kubernetes_executor.py
@@ -222,7 +222,7 @@ class LocalKubernetesExecutor(BaseExecutor):
 
     def get_event_buffer(
         self, dag_ids: list[str] | None = None
-    ) -> dict[TaskInstanceKey, EventBufferValueType]:
+    ) -> dict[WorkloadKey, EventBufferValueType]:
         """
         Return and flush the event buffer from local and kubernetes executor.
 

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/local_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/local_kubernetes_executor.py
@@ -220,9 +220,7 @@ class LocalKubernetesExecutor(BaseExecutor):
         self.local_executor.heartbeat()
         self.kubernetes_executor.heartbeat()
 
-    def get_event_buffer(
-        self, dag_ids: list[str] | None = None
-    ) -> dict[WorkloadKey, EventBufferValueType]:
+    def get_event_buffer(self, dag_ids: list[str] | None = None) -> dict[WorkloadKey, EventBufferValueType]:
         """
         Return and flush the event buffer from local and kubernetes executor.
 

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/local_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/local_kubernetes_executor.py
@@ -33,7 +33,6 @@ if TYPE_CHECKING:
     from airflow.cli.cli_config import GroupCommand
     from airflow.executors.base_executor import EventBufferValueType
     from airflow.executors.local_executor import LocalExecutor
-    from airflow.executors.workloads.types import WorkloadKey
     from airflow.models.taskinstance import (  # type: ignore[attr-defined]
         SimpleTaskInstance,
         TaskInstance,
@@ -110,8 +109,8 @@ class LocalKubernetesExecutor(BaseExecutor):
         """Not implemented for hybrid executors."""
 
     @property
-    def running(self) -> set[WorkloadKey]:
-        """Combine running from both executors."""
+    def running(self) -> set[TaskInstanceKey]:
+        """Return running tasks from local and kubernetes executor."""
         return self.local_executor.running.union(self.kubernetes_executor.running)
 
     @running.setter
@@ -220,7 +219,9 @@ class LocalKubernetesExecutor(BaseExecutor):
         self.local_executor.heartbeat()
         self.kubernetes_executor.heartbeat()
 
-    def get_event_buffer(self, dag_ids: list[str] | None = None) -> dict[WorkloadKey, EventBufferValueType]:
+    def get_event_buffer(
+        self, dag_ids: list[str] | None = None
+    ) -> dict[TaskInstanceKey, EventBufferValueType]:
         """
         Return and flush the event buffer from local and kubernetes executor.
 

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/local_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/local_kubernetes_executor.py
@@ -25,6 +25,7 @@ from deprecated import deprecated
 from airflow.configuration import conf
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.executors.base_executor import BaseExecutor
+from airflow.executors.workloads import WorkloadKey
 from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_0_PLUS
 
 if TYPE_CHECKING:
@@ -109,8 +110,8 @@ class LocalKubernetesExecutor(BaseExecutor):
         """Not implemented for hybrid executors."""
 
     @property
-    def running(self) -> set[TaskInstanceKey]:
-        """Return running tasks from local and kubernetes executor."""
+    def running(self) -> set[WorkloadKey]:
+        """Combine running from both executors."""
         return self.local_executor.running.union(self.kubernetes_executor.running)
 
     @running.setter

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/local_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/local_kubernetes_executor.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from airflow.cli.cli_config import GroupCommand
     from airflow.executors.base_executor import EventBufferValueType
     from airflow.executors.local_executor import LocalExecutor
-    from airflow.executors.workloads import WorkloadKey
+    from airflow.executors.workloads.types import WorkloadKey
     from airflow.models.taskinstance import (  # type: ignore[attr-defined]
         SimpleTaskInstance,
         TaskInstance,

--- a/providers/edge3/src/airflow/providers/edge3/worker_api/v2-edge-generated.yaml
+++ b/providers/edge3/src/airflow/providers/edge3/worker_api/v2-edge-generated.yaml
@@ -1005,7 +1005,7 @@ components:
           - type: 'null'
           title: Log Path
         ti:
-          $ref: '#/components/schemas/TaskInstance'
+          $ref: '#/components/schemas/TaskInstanceDTO'
         sentry_integration:
           type: string
           title: Sentry Integration
@@ -1151,7 +1151,7 @@ components:
       - log_chunk_data
       title: PushLogsBody
       description: Incremental new log content from worker.
-    TaskInstance:
+    TaskInstanceDTO:
       properties:
         id:
           type: string
@@ -1209,7 +1209,7 @@ components:
       - pool_slots
       - queue
       - priority_weight
-      title: TaskInstance
+      title: TaskInstanceDTO
       description: Schema for TaskInstance with minimal required fields needed for
         Executors and Task SDK.
     TaskInstanceState:

--- a/providers/edge3/src/airflow/providers/edge3/worker_api/v2-edge-generated.yaml
+++ b/providers/edge3/src/airflow/providers/edge3/worker_api/v2-edge-generated.yaml
@@ -990,9 +990,9 @@ components:
       description: Status of a Edge Worker instance.
     ExecuteTask:
       properties:
-        token:
+        identity_token:
           type: string
-          title: Token
+          title: Identity Token
         dag_rel_path:
           type: string
           format: path
@@ -1017,7 +1017,7 @@ components:
           default: ExecuteTask
       type: object
       required:
-      - token
+      - identity_token
       - dag_rel_path
       - bundle_info
       - log_path

--- a/providers/edge3/src/airflow/providers/edge3/worker_api/v2-edge-generated.yaml
+++ b/providers/edge3/src/airflow/providers/edge3/worker_api/v2-edge-generated.yaml
@@ -990,9 +990,9 @@ components:
       description: Status of a Edge Worker instance.
     ExecuteTask:
       properties:
-        identity_token:
+        token:
           type: string
-          title: Identity Token
+          title: Token
         dag_rel_path:
           type: string
           format: path
@@ -1017,7 +1017,7 @@ components:
           default: ExecuteTask
       type: object
       required:
-      - identity_token
+      - token
       - dag_rel_path
       - bundle_info
       - log_path

--- a/task-sdk/src/airflow/sdk/definitions/deadline.py
+++ b/task-sdk/src/airflow/sdk/definitions/deadline.py
@@ -21,7 +21,10 @@ from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
 from airflow.models.deadline import DeadlineReferenceType, ReferenceModels
-from airflow.sdk.definitions.callback import AsyncCallback, Callback
+from airflow.sdk.definitions.callback import AsyncCallback, Callback, SyncCallback
+from airflow.sdk.serde import deserialize, serialize
+from airflow.serialization.definitions.deadline import DeadlineAlertFields
+from airflow.serialization.enums import DagAttributeTypes as DAT, Encoding
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -44,7 +47,7 @@ class DeadlineAlert:
         self.reference = reference
         self.interval = interval
 
-        if not isinstance(callback, AsyncCallback):
+        if not isinstance(callback, (AsyncCallback, SyncCallback)):
             raise ValueError(f"Callbacks of type {type(callback).__name__} are not currently supported")
         self.callback = callback
 

--- a/task-sdk/src/airflow/sdk/definitions/deadline.py
+++ b/task-sdk/src/airflow/sdk/definitions/deadline.py
@@ -22,9 +22,6 @@ from typing import TYPE_CHECKING
 
 from airflow.models.deadline import DeadlineReferenceType, ReferenceModels
 from airflow.sdk.definitions.callback import AsyncCallback, Callback, SyncCallback
-from airflow.sdk.serde import deserialize, serialize
-from airflow.serialization.definitions.deadline import DeadlineAlertFields
-from airflow.serialization.enums import DagAttributeTypes as DAT, Encoding
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/task-sdk/src/airflow/sdk/execution_time/execute_workload.py
+++ b/task-sdk/src/airflow/sdk/execution_time/execute_workload.py
@@ -68,7 +68,7 @@ def execute_workload(workload: ExecuteTask) -> None:
         ti=workload.ti,  # type: ignore[arg-type]
         dag_rel_path=workload.dag_rel_path,
         bundle_info=workload.bundle_info,
-        token=workload.token,
+        token=workload.identity_token,
         server=server,
         log_path=workload.log_path,
         sentry_integration=workload.sentry_integration,

--- a/task-sdk/src/airflow/sdk/execution_time/execute_workload.py
+++ b/task-sdk/src/airflow/sdk/execution_time/execute_workload.py
@@ -68,7 +68,7 @@ def execute_workload(workload: ExecuteTask) -> None:
         ti=workload.ti,  # type: ignore[arg-type]
         dag_rel_path=workload.dag_rel_path,
         bundle_info=workload.bundle_info,
-        token=workload.identity_token,
+        token=workload.token,
         server=server,
         log_path=workload.log_path,
         sentry_integration=workload.sentry_integration,


### PR DESCRIPTION
Add support for the Callback workload to be run in the executors.  Other executors will need to be updated before they can support the workload, but I tried to make it as non-invasive as I could.

This is the bulk of the work required to allow synchronous callbacks to be used in DeadlineAlerts.   For example, this now works in LocalExecutor:

```python
with DAG(
    dag_id="sync_deadline",
    deadline=DeadlineAlert(
        reference=DeadlineReference.FIXED_DATETIME(datetime(1980, 8, 10, 2)),
        interval=timedelta(0),
        callback=SyncCallback(
            SlackWebhookNotifier,
            {"text": "Sync Callback; Alert should trigger immediately!"},
        )
    )
):
    EmptyOperator(task_id='empty_task')
```

Co-author:  Builds on work handed off by @seanghaeli and research from @ramitkataria; if I did this right then they should be getting co-author credits, I think?

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ x ] Yes (please specify the tool below)
Cline (Claude Sonnet 4.5) was used for debugging and suggesting some unit test edge cases.

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
