### PR TITLE
Chart: use same bitnami postgres image as 1.18.0

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -10063,6 +10063,23 @@
                             "default": ""
                         }
                     }
+                },
+                "image": {
+                    "description": "PostgreSQL image configuration.",
+                    "type": "object",
+                    "additionalProperties": true,
+                    "properties": {
+                        "repository": {
+                            "description": "The PostgreSQL image repository.",
+                            "type": "string",
+                            "default": "bitnamilegacy/postgresql"
+                        },
+                        "tag": {
+                            "description": "The PostgreSQL image tag.",
+                            "type": "string",
+                            "default": "16.1.0-debian-11-r15"
+                        }
+                    }
                 }
             }
         },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -3264,8 +3264,8 @@ databaseCleanup:
 postgresql:
   enabled: true
   image:
-    repository: postgres
-    tag: "13"
+    repository: bitnamilegacy/postgresql
+    tag: "16.1.0-debian-11-r15"
   auth:
     enablePostgresUser: true
     postgresPassword: postgres


### PR DESCRIPTION
Instead of downgrading from 16 -> 13, lets just keep using the same exact bitnami image we had been previously. It's likely users of the provided postgres moved to this image anyways.

Related: #55820

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: Cursor (Claude Opus 4.5)