### PR TITLE
Update msgraph.py get_host 

### DIFF
--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/msgraph.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/msgraph.py
@@ -232,7 +232,7 @@ class KiotaRequestAdapterHook(BaseHook):
             if connection.schema and connection.host:
                 return f"{connection.schema}://{connection.host}"
             return NationalClouds.Global.value
-        if not self.host.startswith("http://") or not self.host.startswith("https://"):
+        if not self.host.startswith(("http://", "https://")):
             return f"{connection.schema}://{self.host}"
         return self.host
 


### PR DESCRIPTION
* related: #60573 

**Description of issue**
Calling the Power BI operator consistently resulted in the following error:

> Request URL is missing an http:// or https:// protocol.

From the DAG logs I discovered that the host URL was parsed incorrectly. The resolved host value looked like this:

> None:/ https://api.powerbi.com

Because of this malformed host string, all outgoing requests failed with the protocol‑missing error.

**Solution**
I updated the OR condition in the get_host method inside msgraph.py (within the hooks folder).
The updated logic correctly handles the provided host URL (https://api.powerbi.com), ensuring that it is parsed and returned properly.

**Testing**
After modifying the OR condition I did a testing directly in our Airflow Test instance.

- The connection to Power BI via its Airflow operators works as expected.
- In our Airflow instance, the provider now operates correctly without triggering the protocol error.




