### PR TITLE
Add guardrail to handle DAG deserialization errors in scheduler

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -151,14 +151,6 @@ def _eager_load_dag_run_for_validation() -> tuple[LoaderOption, LoaderOption]:
     )
 
 
-def _get_current_dag(dag_id: str, session: Session) -> SerializedDAG | None:
-    serdag = SerializedDagModel.get(dag_id=dag_id, session=session)  # grabs the latest version
-    if not serdag:
-        return None
-    serdag.load_op_links = False
-    return serdag.dag
-
-
 class ConcurrencyMap:
     """
     Dataclass to represent concurrency maps.
@@ -262,6 +254,17 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
     @provide_session
     def heartbeat_callback(self, session: Session = NEW_SESSION) -> None:
         Stats.incr("scheduler_heartbeat", 1, 1)
+
+    def _get_current_dag(self, dag_id: str, session: Session) -> SerializedDAG | None:
+        try:
+            serdag = SerializedDagModel.get(dag_id=dag_id, session=session)
+            if not serdag:
+                return None
+            serdag.load_op_links = False
+            return serdag.dag
+        except Exception:
+            self.log.exception("Failed to deserialize DAG '%s'", dag_id)
+            return None
 
     def register_signals(self) -> ExitStack:
         """Register signals that stop child processes."""
@@ -1697,7 +1700,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             if TYPE_CHECKING:
                 assert apdr.target_dag_id
 
-            if not (dag := _get_current_dag(dag_id=apdr.target_dag_id, session=session)):
+            if not (dag := self._get_current_dag(dag_id=apdr.target_dag_id, session=session)):
                 self.log.error("Dag '%s' not found in serialized_dag table", apdr.target_dag_id)
                 continue
 
@@ -1845,7 +1848,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 )
                 continue
 
-            serdag = _get_current_dag(dag_id=dag_model.dag_id, session=session)
+            serdag = self._get_current_dag(dag_id=dag_model.dag_id, session=session)
             if not serdag:
                 self.log.error("DAG '%s' not found in serialized_dag table", dag_model.dag_id)
                 continue
@@ -1913,7 +1916,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         }
 
         for dag_model in dag_models:
-            dag = _get_current_dag(dag_id=dag_model.dag_id, session=session)
+            dag = self._get_current_dag(dag_id=dag_model.dag_id, session=session)
             if not dag:
                 self.log.error("DAG '%s' not found in serialized_dag table", dag_model.dag_id)
                 continue

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -4787,6 +4787,39 @@ class TestSchedulerJob:
             session.delete(sdm)
         session.commit()
 
+    def test_scheduler_create_dag_runs_does_not_crash_on_deserialization_error(self, caplog, dag_maker):
+        """
+        Test that scheduler._create_dag_runs does not crash when DAG deserialization fails.
+        This is a guardrail to ensure the scheduler continues processing other DAGs even if
+        one DAG has a deserialization error.
+        """
+        with dag_maker(dag_id="test_scheduler_create_dag_runs_deserialization_error"):
+            EmptyOperator(task_id="dummy")
+
+        scheduler_job = Job(executor=self.null_exec)
+        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+
+        caplog.set_level("FATAL")
+        caplog.clear()
+        with (
+            create_session() as session,
+            caplog.at_level(
+                "ERROR",
+                logger="airflow.jobs.scheduler_job_runner",
+            ),
+            patch(
+                "airflow.models.serialized_dag.SerializedDagModel.get",
+                side_effect=Exception("Simulated deserialization error"),
+            ),
+        ):
+            self.job_runner._create_dag_runs([dag_maker.dag_model], session)
+            scheduler_messages = [
+                record.message for record in caplog.records if record.levelno >= logging.ERROR
+            ]
+            assert any("Failed to deserialize DAG" in msg for msg in scheduler_messages), (
+                f"Expected deserialization error log, got: {scheduler_messages}"
+            )
+
     def test_bulk_write_to_db_external_trigger_dont_skip_scheduled_run(self, dag_maker, testing_dag_bundle):
         """
         Test that externally triggered Dag Runs should not affect (by skipping) next


### PR DESCRIPTION
Add try/except in _get_current_dag(). If deserialization fails, the scheduler logs the error and continues to the next DAG instead of crashing.

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
