### PR TITLE
fix: typo in ci/04_selective_checks.md

### DIFF
--- a/dev/breeze/doc/ci/04_selective_checks.md
+++ b/dev/breeze/doc/ci/04_selective_checks.md
@@ -75,7 +75,7 @@ We have the following Groups of files for CI that determine which tests are run:
 
 We have a number of `TEST_TYPES` that can be selectively disabled/enabled based on the
 content of the incoming PR. Usually they are limited to a sub-folder of the "tests" folder but there
-are some exceptions. You can read more about those in `testing.rst <contribiting-docs/09_testing.rst>`. Those types
+are some exceptions. You can read more about those in `testing.rst <contributing-docs/09_testing.rst>`. Those types
 are determined by selective checks and are used to run `DB` and `Non-DB` tests.
 
 The `DB` tests inside each `TEST_TYPE` are run sequentially (because they use DB as state) while `TEST_TYPES`


### PR DESCRIPTION
Fix typo in dev/breeze/doc/ci/04_selective_checks.md on line 78
from contribiting-docs/09_testing.rst to contributing-docs/09_testing.rst

---

##### Was generative AI tooling used to co-author this PR?
- [ ] Yes (please specify the tool below)

