### PR TITLE
Fix GCP helpers to use correct chmod value

### DIFF
--- a/devel-common/src/tests_common/test_utils/gcp_system_helpers.py
+++ b/devel-common/src/tests_common/test_utils/gcp_system_helpers.py
@@ -172,7 +172,7 @@ class GoogleSystemTest(SystemTest):
             with open(tmp_path, "w") as file:
                 file.writelines(lines)
                 file.flush()
-            os.chmod(tmp_path, 777)
+            os.chmod(tmp_path, 0o777)
             cls.upload_to_gcs(tmp_path, bucket_name)
 
     @classmethod


### PR DESCRIPTION
`os.chmod()` expects octal values. `777` is almost certainly not producing the intended result.

Discovered in https://github.com/astral-sh/ruff/pull/22915

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

No