### PR TITLE
Fix serde recursion limit test by using correct MAX_RECURSION_DEPTH

### DIFF
--- a/task-sdk/tests/task_sdk/serde/test_serializers.py
+++ b/task-sdk/tests/task_sdk/serde/test_serializers.py
@@ -40,7 +40,7 @@ from pydantic.dataclasses import dataclass as pydantic_dataclass
 
 from airflow.sdk._shared.module_loading import qualname
 from airflow.sdk.definitions.param import Param, ParamsDict
-from airflow.sdk.serde import CLASSNAME, DATA, VERSION, decode, deserialize, serialize, MAX_RECURSION_DEPTH
+from airflow.sdk.serde import CLASSNAME, DATA, MAX_RECURSION_DEPTH, VERSION, decode, deserialize, serialize
 from airflow.sdk.serde.serializers import builtin
 
 from tests_common.test_utils.config import conf_vars
@@ -680,6 +680,7 @@ class TestSerializers:
         deserialized = deserialize(serialized)
         assert isinstance(deserialized, uuid.UUID)
         assert uuid_value == deserialized
+
     def test_serde_serialize_recursion_limit(self):
         depth = MAX_RECURSION_DEPTH
         with pytest.raises(RecursionError, match="maximum recursion depth reached for serialization"):

--- a/task-sdk/tests/task_sdk/serde/test_serializers.py
+++ b/task-sdk/tests/task_sdk/serde/test_serializers.py
@@ -40,7 +40,7 @@ from pydantic.dataclasses import dataclass as pydantic_dataclass
 
 from airflow.sdk._shared.module_loading import qualname
 from airflow.sdk.definitions.param import Param, ParamsDict
-from airflow.sdk.serde import CLASSNAME, DATA, VERSION, decode, deserialize, serialize
+from airflow.sdk.serde import CLASSNAME, DATA, VERSION, decode, deserialize, serialize, MAX_RECURSION_DEPTH
 from airflow.sdk.serde.serializers import builtin
 
 from tests_common.test_utils.config import conf_vars
@@ -680,3 +680,7 @@ class TestSerializers:
         deserialized = deserialize(serialized)
         assert isinstance(deserialized, uuid.UUID)
         assert uuid_value == deserialized
+    def test_serde_serialize_recursion_limit(self):
+        depth = MAX_RECURSION_DEPTH
+        with pytest.raises(RecursionError, match="maximum recursion depth reached for serialization"):
+            serialize(object(), depth=depth)


### PR DESCRIPTION
This PR fixes a flaky unit test `test_serde_serialize_recursion_limit` in `task-sdk`.

The test was previously using `sys.getrecursionlimit() - 1` to simulate the recursion depth. However, this system limit (often 1000) does not match the internal `MAX_RECURSION_DEPTH` constant (which is 10) used in the `serialize` function.

Because of this mismatch, the `depth` check in `serialize` passed (since 999 != 10), causing the function to attempt to serialize the empty `object()`, resulting in a `TypeError` instead of the expected `RecursionError`.

### Verification
Ran the test locally with `pytest` and it passed:

<img width="1037" height="211" alt="截圖 2026-01-29 凌晨3 17 53" src="https://github.com/user-attachments/assets/21a6c7f1-b0ad-4dcf-b079-d5bd0d3a77a0" />


Changes:
- Imported `MAX_RECURSION_DEPTH` from `airflow.sdk.serde.serde`.
- Updated the test to use this constant for the `depth` parameter to correctly trigger the `RecursionError`.

closes: #51915