### PR TITLE
Add copy button to logs

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/renderStructuredLog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/renderStructuredLog.tsx
@@ -245,7 +245,7 @@ const renderStructuredLogImpl = ({
       const stringifiedValue = val instanceof Object ? JSON.stringify(val) : val;
 
       if (renderingMode === "text") {
-        elements.push(`${key === "logger" ? "source" : key}=${stringifiedValue} `);
+        elements.push(` ${key === "logger" ? "source" : key}=${stringifiedValue} `);
       } else {
         elements.push(
           <React.Fragment key={`space_${key}`}> </React.Fragment>,

--- a/airflow-core/src/airflow/ui/src/components/ui/LazyClipboard.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ui/LazyClipboard.tsx
@@ -1,0 +1,47 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import type { ButtonProps } from "@chakra-ui/react";
+import { IconButton } from "@chakra-ui/react";
+import * as React from "react";
+import { LuCheck, LuClipboard } from "react-icons/lu";
+
+type LazyClipboardProps = {
+  readonly getValue: () => string;
+} & ButtonProps;
+
+/** Clipboard button that lazily computes the value only when clicked */
+export const LazyClipboard = React.forwardRef<HTMLButtonElement, LazyClipboardProps>(
+  ({ getValue, ...props }, ref) => {
+    const [copied, setCopied] = React.useState(false);
+
+    const handleClick = () => {
+      const value = getValue();
+
+      void navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    };
+
+    return (
+      <IconButton onClick={handleClick} ref={ref} size="xs" variant="subtle" {...props}>
+        {copied ? <LuCheck /> : <LuClipboard />}
+      </IconButton>
+    );
+  },
+);

--- a/airflow-core/src/airflow/ui/src/components/ui/index.ts
+++ b/airflow-core/src/airflow/ui/src/components/ui/index.ts
@@ -34,3 +34,4 @@ export * from "./Checkbox";
 export * from "./ResetButton";
 export * from "./InputWithAddon";
 export * from "./ButtonGroupToggle";
+export * from "./LazyClipboard";

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.tsx
@@ -32,8 +32,8 @@ import { useLogs } from "src/queries/useLogs";
 import { parseStreamingLogContent } from "src/utils/logs";
 
 import { ExternalLogLink } from "./ExternalLogLink";
-import { TaskLogContent } from "./TaskLogContent";
-import { TaskLogHeader } from "./TaskLogHeader";
+import { TaskLogContent, type TaskLogContentProps } from "./TaskLogContent";
+import { TaskLogHeader, type TaskLogHeaderProps } from "./TaskLogHeader";
 
 export const Logs = () => {
   const { dagId = "", mapIndex = "-1", runId = "", taskId = "" } = useParams();
@@ -74,13 +74,9 @@ export const Logs = () => {
   const tryNumber = tryNumberParam === null ? taskInstance?.try_number : parseInt(tryNumberParam, 10);
 
   const defaultWrap = Boolean(useConfig("default_wrap"));
-  const defaultShowTimestamp = Boolean(true);
 
   const [wrap, setWrap] = useLocalStorage<boolean>("log_wrap", defaultWrap);
-  const [showTimestamp, setShowTimestamp] = useLocalStorage<boolean>(
-    "log_show_timestamp",
-    defaultShowTimestamp,
-  );
+  const [showTimestamp, setShowTimestamp] = useLocalStorage<boolean>("log_show_timestamp", true);
   const [showSource, setShowSource] = useLocalStorage<boolean>("log_show_source", false);
   const [fullscreen, setFullscreen] = useState(false);
   const [expanded, setExpanded] = useState(false);
@@ -119,9 +115,10 @@ export const Logs = () => {
     );
   };
 
+  const getLogString = () => getParsedLogs().join("\n");
+
   const downloadLogs = () => {
-    const parsedLines = getParsedLogs();
-    const logContent = parsedLines.join("\n");
+    const logContent = getLogString();
     const element = document.createElement("a");
 
     element.href = URL.createObjectURL(new Blob([logContent], { type: "text/plain" }));
@@ -130,8 +127,6 @@ export const Logs = () => {
     element.click();
     element.remove();
   };
-
-  const logString = getParsedLogs().join("\n");
 
   const toggleWrap = () => setWrap(!wrap);
   const toggleTimestamp = () => setShowTimestamp(!showTimestamp);
@@ -153,25 +148,35 @@ export const Logs = () => {
   const externalLogName = useConfig("external_log_name") as string;
   const showExternalLogRedirect = Boolean(useConfig("show_external_log_redirect"));
 
+  const logHeaderProps: TaskLogHeaderProps = {
+    downloadLogs,
+    expanded,
+    getLogString,
+    onSelectTryNumber,
+    showSource,
+    showTimestamp,
+    sourceOptions: parsedData.sources,
+    taskInstance,
+    toggleExpanded,
+    toggleFullscreen,
+    toggleSource,
+    toggleTimestamp,
+    toggleWrap,
+    tryNumber,
+    wrap,
+  };
+
+  const logContentProps: TaskLogContentProps = {
+    error,
+    isLoading: isLoading || isLoadingLogs,
+    logError,
+    parsedLogs: parsedData.parsedLogs ?? [],
+    wrap,
+  };
+
   return (
     <Box display="flex" flexDirection="column" h="100%" p={2}>
-      <TaskLogHeader
-        downloadLogs={downloadLogs}
-        expanded={expanded}
-        logString={logString}
-        onSelectTryNumber={onSelectTryNumber}
-        showSource={showSource}
-        showTimestamp={showTimestamp}
-        sourceOptions={parsedData.sources}
-        taskInstance={taskInstance}
-        toggleExpanded={toggleExpanded}
-        toggleFullscreen={toggleFullscreen}
-        toggleSource={toggleSource}
-        toggleTimestamp={toggleTimestamp}
-        toggleWrap={toggleWrap}
-        tryNumber={tryNumber}
-        wrap={wrap}
-      />
+      <TaskLogHeader {...logHeaderProps} />
       {showExternalLogRedirect && externalLogName && taskInstance ? (
         tryNumber === undefined ? (
           <p>{translate("logs.noTryNumber")}</p>
@@ -183,13 +188,7 @@ export const Logs = () => {
           />
         )
       ) : undefined}
-      <TaskLogContent
-        error={error}
-        isLoading={isLoading || isLoadingLogs}
-        logError={logError}
-        parsedLogs={parsedData.parsedLogs ?? []}
-        wrap={wrap}
-      />
+      <TaskLogContent {...logContentProps} />
       <Dialog.Root onOpenChange={onOpenChange} open={fullscreen} scrollBehavior="inside" size="full">
         {fullscreen ? (
           <Dialog.Content backdrop>
@@ -198,36 +197,14 @@ export const Logs = () => {
                 <Heading mb={2} size="xl">
                   {taskId}
                 </Heading>
-                <TaskLogHeader
-                  downloadLogs={downloadLogs}
-                  expanded={expanded}
-                  logString={logString}
-                  onSelectTryNumber={onSelectTryNumber}
-                  showSource={showSource}
-                  showTimestamp={showTimestamp}
-                  sourceOptions={parsedData.sources}
-                  taskInstance={taskInstance}
-                  toggleExpanded={toggleExpanded}
-                  toggleFullscreen={toggleFullscreen}
-                  toggleSource={toggleSource}
-                  toggleTimestamp={toggleTimestamp}
-                  toggleWrap={toggleWrap}
-                  tryNumber={tryNumber}
-                  wrap={wrap}
-                />
+                <TaskLogHeader {...logHeaderProps} />
               </Box>
             </Dialog.Header>
 
             <Dialog.CloseTrigger />
 
             <Dialog.Body display="flex" flexDirection="column">
-              <TaskLogContent
-                error={error}
-                isLoading={isLoading || isLoadingLogs}
-                logError={logError}
-                parsedLogs={parsedData.parsedLogs ?? []}
-                wrap={wrap}
-              />
+              <TaskLogContent {...logContentProps} />
             </Dialog.Body>
           </Dialog.Content>
         ) : undefined}

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.tsx
@@ -101,9 +101,10 @@ export const Logs = () => {
     tryNumber,
   });
 
-  const downloadLogs = () => {
+  const getParsedLogs = () => {
     const lines = parseStreamingLogContent(fetchedData);
-    const parsedLines = lines.map((line) =>
+
+    return lines.map((line) =>
       renderStructuredLog({
         index: 0,
         logLevelFilters,
@@ -116,7 +117,10 @@ export const Logs = () => {
         translate,
       }),
     );
+  };
 
+  const downloadLogs = () => {
+    const parsedLines = getParsedLogs();
     const logContent = parsedLines.join("\n");
     const element = document.createElement("a");
 
@@ -126,6 +130,8 @@ export const Logs = () => {
     element.click();
     element.remove();
   };
+
+  const logString = getParsedLogs().join("\n");
 
   const toggleWrap = () => setWrap(!wrap);
   const toggleTimestamp = () => setShowTimestamp(!showTimestamp);
@@ -152,6 +158,7 @@ export const Logs = () => {
       <TaskLogHeader
         downloadLogs={downloadLogs}
         expanded={expanded}
+        logString={logString}
         onSelectTryNumber={onSelectTryNumber}
         showSource={showSource}
         showTimestamp={showTimestamp}
@@ -194,6 +201,7 @@ export const Logs = () => {
                 <TaskLogHeader
                   downloadLogs={downloadLogs}
                   expanded={expanded}
+                  logString={logString}
                   onSelectTryNumber={onSelectTryNumber}
                   showSource={showSource}
                   showTimestamp={showTimestamp}

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
@@ -129,7 +129,6 @@ export const TaskLogContent = ({ error, isLoading, logError, parsedLogs, wrap }:
         data-testid="virtual-scroll-container"
         flexGrow={1}
         minHeight={0}
-        overflow="auto"
         position="relative"
         py={3}
         ref={parentRef}
@@ -141,6 +140,7 @@ export const TaskLogContent = ({ error, isLoading, logError, parsedLogs, wrap }:
           }}
           data-testid="virtualized-list"
           display="block"
+          overflow="auto"
           textWrap={wrap ? "pre" : "nowrap"}
           width="100%"
         >

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
@@ -29,7 +29,7 @@ import { getMetaKey } from "src/utils";
 
 import { scrollToBottom, scrollToTop } from "./utils";
 
-type Props = {
+export type TaskLogContentProps = {
   readonly error: unknown;
   readonly isLoading: boolean;
   readonly logError: unknown;
@@ -79,7 +79,7 @@ const ScrollToButton = ({
   );
 };
 
-export const TaskLogContent = ({ error, isLoading, logError, parsedLogs, wrap }: Props) => {
+export const TaskLogContent = ({ error, isLoading, logError, parsedLogs, wrap }: TaskLogContentProps) => {
   const hash = location.hash.replace("#", "");
   const parentRef = useRef<HTMLDivElement | null>(null);
 

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogHeader.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogHeader.tsx
@@ -39,7 +39,8 @@ import { useSearchParams } from "react-router-dom";
 
 import type { TaskInstanceResponse } from "openapi/requests/types.gen";
 import { TaskTrySelect } from "src/components/TaskTrySelect";
-import { Menu, Select } from "src/components/ui";
+import { ClipboardRoot, Menu, Select } from "src/components/ui";
+import { ClipboardIconButton } from "src/components/ui/Clipboard";
 import { SearchParamsKeys } from "src/constants/searchParams";
 import { defaultSystem } from "src/theme";
 import { type LogLevel, logLevelColorMapping, logLevelOptions } from "src/utils/logs";
@@ -48,6 +49,7 @@ type Props = {
   readonly downloadLogs?: () => void;
   readonly expanded?: boolean;
   readonly isFullscreen?: boolean;
+  readonly logString: string;
   readonly onSelectTryNumber: (tryNumber: number) => void;
   readonly showSource: boolean;
   readonly showTimestamp: boolean;
@@ -66,6 +68,7 @@ export const TaskLogHeader = ({
   downloadLogs,
   expanded,
   isFullscreen = false,
+  logString,
   onSelectTryNumber,
   showSource,
   showTimestamp,
@@ -79,7 +82,7 @@ export const TaskLogHeader = ({
   tryNumber,
   wrap,
 }: Props) => {
-  const { t: translate } = useTranslation(["common", "dag"]);
+  const { t: translate } = useTranslation(["common", "dag", "components"]);
   const [searchParams, setSearchParams] = useSearchParams();
   const sources = searchParams.getAll(SearchParamsKeys.SOURCE);
   const logLevels = searchParams.getAll(SearchParamsKeys.LOG_LEVEL);
@@ -248,6 +251,15 @@ export const TaskLogHeader = ({
               <MdOutlineOpenInFull />
             </IconButton>
           )}
+
+          <ClipboardRoot value={logString}>
+            <ClipboardIconButton
+              aria-label={translate("components:clipboard.copy")}
+              size="md"
+              title={translate("components:clipboard.copy")}
+              variant="ghost"
+            />
+          </ClipboardRoot>
 
           <IconButton
             aria-label={translate("download.download")}

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogHeader.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogHeader.tsx
@@ -39,17 +39,17 @@ import { useSearchParams } from "react-router-dom";
 
 import type { TaskInstanceResponse } from "openapi/requests/types.gen";
 import { TaskTrySelect } from "src/components/TaskTrySelect";
-import { ClipboardRoot, Menu, Select } from "src/components/ui";
-import { ClipboardIconButton } from "src/components/ui/Clipboard";
+import { Menu, Select } from "src/components/ui";
+import { LazyClipboard } from "src/components/ui/LazyClipboard";
 import { SearchParamsKeys } from "src/constants/searchParams";
 import { defaultSystem } from "src/theme";
 import { type LogLevel, logLevelColorMapping, logLevelOptions } from "src/utils/logs";
 
-type Props = {
+export type TaskLogHeaderProps = {
   readonly downloadLogs?: () => void;
   readonly expanded?: boolean;
+  readonly getLogString: () => string;
   readonly isFullscreen?: boolean;
-  readonly logString: string;
   readonly onSelectTryNumber: (tryNumber: number) => void;
   readonly showSource: boolean;
   readonly showTimestamp: boolean;
@@ -67,8 +67,8 @@ type Props = {
 export const TaskLogHeader = ({
   downloadLogs,
   expanded,
+  getLogString,
   isFullscreen = false,
-  logString,
   onSelectTryNumber,
   showSource,
   showTimestamp,
@@ -81,7 +81,7 @@ export const TaskLogHeader = ({
   toggleWrap,
   tryNumber,
   wrap,
-}: Props) => {
+}: TaskLogHeaderProps) => {
   const { t: translate } = useTranslation(["common", "dag", "components"]);
   const [searchParams, setSearchParams] = useSearchParams();
   const sources = searchParams.getAll(SearchParamsKeys.SOURCE);
@@ -252,14 +252,13 @@ export const TaskLogHeader = ({
             </IconButton>
           )}
 
-          <ClipboardRoot value={logString}>
-            <ClipboardIconButton
-              aria-label={translate("components:clipboard.copy")}
-              size="md"
-              title={translate("components:clipboard.copy")}
-              variant="ghost"
-            />
-          </ClipboardRoot>
+          <LazyClipboard
+            aria-label={translate("components:clipboard.copy")}
+            getValue={getLogString}
+            size="md"
+            title={translate("components:clipboard.copy")}
+            variant="ghost"
+          />
 
           <IconButton
             aria-label={translate("download.download")}


### PR DESCRIPTION
Add a copy button to logs that copies the currently available log string displayed.

Also fixed an overflow="auto" bug that broke scrolling for unwrapped logs
And cleaned up some of Logs.tsx to be more DRY


Closes https://github.com/apache/airflow/issues/50139

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

<!--
Generated-by: Claude with cursor following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
