### PR TITLE
Update the heading for BigtableCreateTableOperator in docs

### DIFF
--- a/providers/google/docs/operators/cloud/bigtable.rst
+++ b/providers/google/docs/operators/cloud/bigtable.rst
@@ -114,7 +114,7 @@ it will be retrieved from the Google Cloud connection used. Both variants are sh
 .. _howto/operator:BigtableCreateTableOperator:
 
 BigtableCreateTableOperator
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-----------------------------
 
 Creates a table in a Cloud Bigtable instance.
 


### PR DESCRIPTION
Fixed the heading for `BigtableCreateTableOperator`. currently the `BigtableCreateTableOperator` isusing a lower-level heading
than other operators in the docs. Modified it so that it aligns with rest of the other operators.