### PR TITLE
Fix assets UI E2E flaky test and and fix test pattern arg order 

### DIFF
--- a/airflow-core/src/airflow/ui/tests/e2e/pages/AssetDetailPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/AssetDetailPage.ts
@@ -71,12 +71,12 @@ export class AssetDetailPage extends BasePage {
 
     if (count > 0) {
       await button.click();
-      // Wait for popover and verify links using role-based selector
-      const popoverLinks = this.page.getByRole("dialog").getByRole("link");
+      await expect(button).toHaveAttribute("aria-expanded", "true", { timeout: 5000 });
+      const popoverLinks = this.page.getByRole("dialog").last().getByRole("link");
 
       await expect(popoverLinks).toHaveCount(count);
-      // Close popover
-      await this.page.keyboard.press("Escape");
+      await button.click();
+      await expect(button).toHaveAttribute("aria-expanded", "false", { timeout: 5000 });
     }
   }
 }

--- a/dev/breeze/src/airflow_breeze/commands/testing_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/testing_commands.py
@@ -1560,6 +1560,9 @@ def ui_e2e_tests(
 
         playwright_cmd = ["pnpm", "exec", "playwright", "test"]
 
+        # Test pattern must come before --project flag
+        if test_pattern:
+            playwright_cmd.append(test_pattern)
         if browser != "all":
             playwright_cmd.extend(["--project", browser])
         if headed:
@@ -1574,8 +1577,6 @@ def ui_e2e_tests(
             playwright_cmd.extend(["--timeout", str(timeout)])
         if reporter != "html":
             playwright_cmd.extend(["--reporter", reporter])
-        if test_pattern:
-            playwright_cmd.append(test_pattern)
         if extra_playwright_args:
             playwright_cmd.extend(extra_playwright_args)
 


### PR DESCRIPTION
This PR fixes two issues with the UI E2E tests:

1. Test pattern argument order - Moved test pattern before --project flag in the Breeze ui-e2e-tests command to prevent Playwright from interpreting it as a project name.
2. [Flaky](https://github.com/apache/airflow/actions/runs/21456457760) popover close on WebKit - Changed popover closing from Escape key to button toggle, which is more reliable across browsers. Added aria-expanded attribute checks to verify popover state.

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
