### PR TITLE
Always apply proxy configuration with MSAL for KiotaRequestAdapterHook in msgraph module

### DIFF
--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/msgraph.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/msgraph.py
@@ -276,7 +276,7 @@ class KiotaRequestAdapterHook(BaseHook):
                     if authority.endswith(domain_name):
                         return None
             return proxies
-        elif proxies:
+        if proxies:
             return proxies
         return None
 

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/msgraph.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/msgraph.py
@@ -276,6 +276,8 @@ class KiotaRequestAdapterHook(BaseHook):
                     if authority.endswith(domain_name):
                         return None
             return proxies
+        elif proxies:
+            return proxies
         return None
 
     def _build_request_adapter(self, connection) -> tuple[str, RequestAdapter]:

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_msgraph.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_msgraph.py
@@ -431,7 +431,7 @@ class TestKiotaRequestAdapterHook:
                 assert mock_redact.call_count >= 3
                 mock_redact.assert_any_call({"http": "http://user:pass@proxy:3128"}, name="proxies")
                 mock_redact.assert_any_call("my_secret_password", name="client_secret")
-    
+
     def test_msal_returns_none_when_authority_matches_no_proxy(self):
         hook = KiotaRequestAdapterHook(conn_id="msgraph")
 
@@ -461,7 +461,7 @@ class TestKiotaRequestAdapterHook:
         result = hook.to_msal_proxies(authority, proxies)
 
         assert result == proxies
-    
+
     def test_msal_returns_proxies_when_no_authority_with_proxy_key(self):
         hook = KiotaRequestAdapterHook(conn_id="msgraph")
 

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_msgraph.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_msgraph.py
@@ -431,6 +431,46 @@ class TestKiotaRequestAdapterHook:
                 assert mock_redact.call_count >= 3
                 mock_redact.assert_any_call({"http": "http://user:pass@proxy:3128"}, name="proxies")
                 mock_redact.assert_any_call("my_secret_password", name="client_secret")
+    
+    def test_msal_returns_none_when_authority_matches_no_proxy(self):
+        hook = KiotaRequestAdapterHook(conn_id="msgraph")
+
+        proxies = {"http": "http://proxy", "no": "*.example.com"}
+        authority = "api.example.com"
+
+        result = hook.to_msal_proxies(authority, proxies)
+
+        assert result is None
+
+    def test_msal_returns_proxies_when_authority_does_not_match_no_proxy(self):
+        hook = KiotaRequestAdapterHook(conn_id="msgraph")
+
+        proxies = {"http": "http://proxy", "no": "*.example.com"}
+        authority = "api.other.com"
+
+        result = hook.to_msal_proxies(authority, proxies)
+
+        assert result == proxies
+
+    def test_msal_returns_proxies_when_no_authority_no_proxy_key(self):
+        hook = KiotaRequestAdapterHook(conn_id="msgraph")
+
+        proxies = {"no": "*example.com"}
+        authority = None
+
+        result = hook.to_msal_proxies(authority, proxies)
+
+        assert result == proxies
+    
+    def test_msal_returns_proxies_when_no_authority_with_proxy_key(self):
+        hook = KiotaRequestAdapterHook(conn_id="msgraph")
+
+        proxies = {"http": "http://proxy"}
+        authority = None
+
+        result = hook.to_msal_proxies(authority, proxies)
+
+        assert result == proxies
 
 
 class TestResponseHandler:


### PR DESCRIPTION
*closes: #61197 

To be honest, this PR is only a draft. From the Code I can see that **Authority** can be retrieved from connection as an extra parameter. However, there is no information about it in the [documentation](https://airflow.apache.org/docs/apache-airflow-providers-microsoft-azure/stable/connections/powerbi.html#configuring-the-connection). 

So, this is a little bit confusing when using the proxy. So I propose to update the logic of a function _to_msal_proxies_. Return proxies attribute even when the variable authority is not filled.

**Testing**
In our environment I did a functional logic test with and without proxy. It works as expected

This PR makes sure the proxy settings are also applied for the MSAL module used underneath by the Microsoft Kiota library regardless of which authority is used underneath.

