### PR TITLE
Prevent lazy loading for cached plugins

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/ExternalView.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/ExternalView.tsx
@@ -18,7 +18,7 @@
  */
 import { Box } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
-import { useParams } from "react-router-dom";
+import { useLocation, useParams } from "react-router-dom";
 
 import { usePluginServiceGetPlugins } from "openapi/queries";
 import { ProgressBar } from "src/components/ui";
@@ -31,6 +31,8 @@ export const ExternalView = () => {
   const { t: translate } = useTranslation();
   const { page } = useParams();
   const { data: pluginData, isLoading } = usePluginServiceGetPlugins();
+
+  const { pathname } = useLocation();
 
   const externalView =
     page === "legacy-fab-views"
@@ -82,7 +84,7 @@ export const ExternalView = () => {
         m={-2} // Compensate for parent padding
         minHeight={0}
       >
-        <ReactPlugin reactApp={reactApp} />
+        <ReactPlugin key={pathname} reactApp={reactApp} />
       </Box>
     );
   }


### PR DESCRIPTION
This will prevent flashing 'loading' spinner when going back and forth between a plugin page and a core UI page.

Also this will make sure that plugins are re-rendered when the host plugin url is changed. Something, sometimes updates are missed, it was the case on `v3-1-test` branch and there doesn't seem to be any easy explanation. (dependencies, router code, plugin loading etc...), something changed in the way that subtree are handled.