### PR TITLE
docs: remove duplicate task failure permission entry

### DIFF
--- a/providers/fab/docs/auth-manager/access-control.rst
+++ b/providers/fab/docs/auth-manager/access-control.rst
@@ -263,7 +263,6 @@ Show Configurations menu               Configurations.menu_access               
 Show Configs                           Configurations.can_read                                                 Viewer
 Delete multiple records                Dags.can_edit                                                           User
 Set Task Instance as running           Dags.can_edit                                                           User
-Set Task Instance as failed            Dags.can_edit                                                           User
 Set Task Instance as success           Dags.can_edit                                                           User
 Set Task Instance as up_for_retry      Dags.can_edit                                                           User
 Autocomplete                           Dags.can_read                                                           Viewer


### PR DESCRIPTION
This PR fixes a documentation issue where a duplicate and inconsistent permission
description was listed for failing task instances in the FAB access control documentation.
Removes a duplicate/inconsistent permission description for failing task instances in the access control documentation.


Closes #58449

