### PR TITLE
Multi-team. Verify a task uses a pool it has access to when scheduling

### DIFF
--- a/airflow-core/src/airflow/models/pool.py
+++ b/airflow-core/src/airflow/models/pool.py
@@ -254,6 +254,7 @@ class Pool(Base):
             "slots": self.slots,
             "description": self.description,
             "include_deferred": self.include_deferred,
+            "team": self.team_name,
         }
 
     @provide_session


### PR DESCRIPTION
When scheduling a Dag, verify the pool requested belongs to the same team (if any) as the associated team of the pool (if any).