### PR TITLE
Add unit test for PostgresHook with invalid connection id

### DIFF
--- a/providers/postgres/tests/unit/postgres/hooks/test_postgres.py
+++ b/providers/postgres/tests/unit/postgres/hooks/test_postgres.py
@@ -31,6 +31,8 @@ from airflow.models import Connection
 from airflow.providers.common.compat.sdk import AirflowException, AirflowOptionalProviderFeatureException
 from airflow.providers.postgres.dialects.postgres import PostgresDialect
 from airflow.providers.postgres.hooks.postgres import CompatConnection, PostgresHook
+from airflow.exceptions import AirflowConfigException
+
 
 from tests_common.test_utils.common_sql import mock_db_hook
 from tests_common.test_utils.version_compat import NOTSET, SQLALCHEMY_V_1_4
@@ -1274,5 +1276,6 @@ class TestPostgresHookPPG3:
         assert isinstance(self.db_hook.dialect, PostgresDialect)
 
     def test_postgres_hook_invalid_conn_id():
-       with pytest.raises(Exception):
-         PostgresHook(postgres_conn_id=None)
+        with pytest.raises(AirflowConfigException):
+            hook = PostgresHook(postgres_conn_id=None)
+            hook.get_con()

--- a/providers/postgres/tests/unit/postgres/hooks/test_postgres.py
+++ b/providers/postgres/tests/unit/postgres/hooks/test_postgres.py
@@ -1272,3 +1272,7 @@ class TestPostgresHookPPG3:
 
     def test_dialect(self):
         assert isinstance(self.db_hook.dialect, PostgresDialect)
+
+    def test_postgres_hook_invalid_conn_id():
+       with pytest.raises(Exception):
+         PostgresHook(postgres_conn_id=None)


### PR DESCRIPTION
This pull request adds a unit test to ensure that `PostgresHook` fails fast
when initialized with an invalid `postgres_conn_id`.

The test improves defensive coverage for the Postgres provider by validating
error handling for incorrect hook configuration.

Note: Tests could not be executed locally due to missing Airflow pytest plugins.
Relying on CI for validation.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (ChatGPT)

Generated-by: ChatGPT following the Apache Airflow guidelines
