### PR TITLE
Refactor datamodel defaulting logic into dedicated method

### DIFF
--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -583,6 +583,31 @@ class CommandFactory:
 
             self.args_map[(operation.get("name"), operation.get("parent").name)] = args
 
+    def _apply_datamodel_defaults(self, datamodel: type, params: dict) -> dict:
+        """
+        Apply datamodel-specific default values.
+
+        Centralizes special handling for different datamodels to keep
+        CLI parameter processing logic clean and maintainable.
+
+        Args:
+            datamodel: The Pydantic datamodel class
+            params: Dictionary of parameters for the datamodel
+
+        Returns:
+            Updated params dictionary with defaults applied
+        """
+        # Handle TriggerDAGRunPostBody: default logical_date to now
+        # This matches the Airflow UI behavior where the form pre-fills with current time
+        if (
+            datamodel.__name__ == "TriggerDAGRunPostBody"
+            and "logical_date" in params
+            and params["logical_date"] is None
+        ):
+            params["logical_date"] = datetime.datetime.now(datetime.timezone.utc)
+
+        return params
+
     def _create_func_map_from_operation(self):
         """Create function map from Operation Method checking for parameters and return types."""
 
@@ -621,16 +646,10 @@ class CommandFactory:
 
             if datamodel:
                 if datamodel_param_name:
-                    # Special handling for TriggerDAGRunPostBody: default logical_date to now
-                    # This matches the Airflow UI behavior where the form pre-fills with current time
-                    if (
-                        datamodel.__name__ == "TriggerDAGRunPostBody"
-                        and "logical_date" in method_params[datamodel_param_name]
-                        and method_params[datamodel_param_name]["logical_date"] is None
-                    ):
-                        method_params[datamodel_param_name]["logical_date"] = datetime.datetime.now(
-                            datetime.timezone.utc
-                        )
+                    # Apply datamodel-specific defaults (e.g., logical_date for TriggerDAGRunPostBody)
+                    method_params[datamodel_param_name] = self._apply_datamodel_defaults(
+                        datamodel, method_params[datamodel_param_name]
+                    )
                     method_params[datamodel_param_name] = datamodel.model_validate(
                         method_params[datamodel_param_name]
                     )


### PR DESCRIPTION
Extract TriggerDAGRunPostBody logical_date defaulting from _get_func into
a new _apply_datamodel_defaults method. This addresses review feedback to
reduce cyclomatic complexity in the already-complex _get_func method and
provides a centralized location for managing datamodel-specific defaults.

Follow up from: #61047

