### PR TITLE
Fix string quotes in deadline alerts documentation

### DIFF
--- a/airflow-core/docs/howto/deadline-alerts.rst
+++ b/airflow-core/docs/howto/deadline-alerts.rst
@@ -247,9 +247,9 @@ A **custom asynchronous callback** might look like this:
     async def custom_async_callback(**kwargs):
         """Handle deadline violation with custom logic."""
         context = kwargs.get("context", {})
-        print(f"Deadline exceeded for Dag {context.get("dag_run", {}).get("dag_id")}!")
+        print(f"Deadline exceeded for Dag {context.get('dag_run', {}).get('dag_id')}!")
         print(f"Context: {context}")
-        print(f"Alert type: {kwargs.get("alert_type")}")
+        print(f"Alert type: {kwargs.get('alert_type')}")
         # Additional custom handling here
 
 2. Restart your Triggerer.


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

Fixing a classic python gotcha to avoid this issue which I faced today while trying to use the documentation by copy pasting:

```python
2026-01-30T06:09:34.038991Z [error    ] Failed to import plugin /files/plugins/deadline_callback.py [airflow._shared.plugins_manager.plugins_manager] loc=plugins_manager.py:252
Traceback (most recent call last):
  File "/opt/airflow/airflow-core/src/airflow/_shared/plugins_manager/plugins_manager.py", line 245, in _load_plugins_from_plugin_directory
    loader.exec_module(mod)
  File "<frozen importlib._bootstrap_external>", line 879, in exec_module
  File "<frozen importlib._bootstrap_external>", line 1017, in get_code
  File "<frozen importlib._bootstrap_external>", line 947, in source_to_code
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/files/plugins/deadline_callback.py", line 3
    print(f"Deadline exceeded for Dag {context.get("dag_run", {}).get("dag_id")}!")
                                                    ^^^^^^^
SyntaxError: f-string: unmatched '('
```

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
