### PR TITLE
Fix airflowctl auth login failing with trailing slash in api-url

### DIFF
--- a/airflow-ctl/src/airflowctl/api/client.py
+++ b/airflow-ctl/src/airflowctl/api/client.py
@@ -226,6 +226,7 @@ class Client(httpx.Client):
         cls, base_url: str, kind: Literal[ClientKind.AUTH, ClientKind.CLI] = ClientKind.CLI
     ) -> str:
         """Get the base URL of the client."""
+        base_url = base_url.rstrip("/")
         if kind == ClientKind.AUTH:
             return f"{base_url}/auth"
         return f"{base_url}/api/v2"

--- a/airflow-ctl/tests/airflow_ctl/api/test_client.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_client.py
@@ -93,6 +93,10 @@ class TestClient:
             ("http://localhost:8080", ClientKind.AUTH, "http://localhost:8080/auth/"),
             ("https://example.com", ClientKind.CLI, "https://example.com/api/v2/"),
             ("https://example.com", ClientKind.AUTH, "https://example.com/auth/"),
+            ("http://localhost:8080/", ClientKind.CLI, "http://localhost:8080/api/v2/"),
+            ("http://localhost:8080/", ClientKind.AUTH, "http://localhost:8080/auth/"),
+            ("https://example.com/", ClientKind.CLI, "https://example.com/api/v2/"),
+            ("https://example.com/", ClientKind.AUTH, "https://example.com/auth/"),
         ],
     )
     def test_refresh_base_url(self, base_url, client_kind, expected_base_url):


### PR DESCRIPTION
  ### Description
closes: #61244
Fixes an authentication failure triggered when `airflowctl auth login --api-url` is given a base URL with a trailing slash.


  #### Problem
  When users copy the Airflow base URL from their browser's address bar (which typically includes a trailing slash), the `_get_base_url()`
   method concatenates it directly with path segments, creating malformed URLs with double slashes (e.g., `http://localhost:8080//auth`),
  resulting in "Method Not Allowed" errors.

  #### Solution
  Normalize the base URL by stripping trailing slashes before constructing endpoint paths using `rstrip("/")` in the `_get_base_url()`
  method.

  #### Testing
  Added test cases to verify URLs with trailing slashes are handled correctly for both CLI and AUTH client kinds.


---

  ### Related Issues

-   #61244 

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
