### PR TITLE
feat(sdk): add CronPartitionTimetable to task-sdk

### DIFF
--- a/airflow-core/src/airflow/serialization/encoders.py
+++ b/airflow-core/src/airflow/serialization/encoders.py
@@ -49,6 +49,7 @@ from airflow.sdk.definitions.timetables.assets import (
     PartitionedAssetTimetable,
 )
 from airflow.sdk.definitions.timetables.simple import ContinuousTimetable, NullTimetable, OnceTimetable
+from airflow.sdk.definitions.timetables.trigger import CronPartitionTimetable
 from airflow.serialization.decoders import decode_deadline_alert
 from airflow.serialization.definitions.assets import (
     SerializedAsset,
@@ -242,6 +243,7 @@ class _Serializer:
         ContinuousTimetable: "airflow.timetables.simple.ContinuousTimetable",
         CronDataIntervalTimetable: "airflow.timetables.interval.CronDataIntervalTimetable",
         CronTriggerTimetable: "airflow.timetables.trigger.CronTriggerTimetable",
+        CronPartitionTimetable: "airflow.timetables.trigger.CronPartitionTimetable",
         DeltaDataIntervalTimetable: "airflow.timetables.interval.DeltaDataIntervalTimetable",
         DeltaTriggerTimetable: "airflow.timetables.trigger.DeltaTriggerTimetable",
         EventsTimetable: "airflow.timetables.events.EventsTimetable",
@@ -303,6 +305,16 @@ class _Serializer:
             "timezone": encode_timezone(timetable.timezone),
             "interval": encode_interval(timetable.interval),
             "run_immediately": encode_run_immediately(timetable.run_immediately),
+        }
+
+    @serialize_timetable.register
+    def _(self, timetable: CronPartitionTimetable) -> dict[str, Any]:
+        return {
+            "expression": timetable.expression,
+            "timezone": encode_timezone(timetable.timezone),
+            "run_immediately": encode_run_immediately(timetable.run_immediately),
+            "run_offset": timetable.run_offset,
+            "key_format": timetable.key_format,
         }
 
     @serialize_timetable.register

--- a/airflow-core/src/airflow/timetables/trigger.py
+++ b/airflow-core/src/airflow/timetables/trigger.py
@@ -242,10 +242,10 @@ class CronTriggerTimetable(CronMixin, _TriggerTimetable):
 
 class MultipleCronTriggerTimetable(Timetable):
     """
-    Timetable that triggers DAG runs according to multiple cron expressions.
+    Timetable that triggers Dag runs according to multiple cron expressions.
 
     This combines multiple ``CronTriggerTimetable`` instances underneath, and
-    triggers a DAG run whenever one of the timetables want to trigger a run.
+    triggers a Dag run whenever one of the timetables want to trigger a run.
 
     Only at most one run is triggered for any given time, even if more than one
     timetable fires at the same time.

--- a/airflow-core/tests/unit/models/test_dag.py
+++ b/airflow-core/tests/unit/models/test_dag.py
@@ -65,7 +65,15 @@ from airflow.models.taskinstance import TaskInstance as TI
 from airflow.providers.standard.operators.bash import BashOperator
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.standard.operators.python import PythonOperator
-from airflow.sdk import DAG, BaseOperator, TaskGroup, setup, task as task_decorator, teardown
+from airflow.sdk import (
+    DAG,
+    BaseOperator,
+    CronPartitionTimetable,
+    TaskGroup,
+    setup,
+    task as task_decorator,
+    teardown,
+)
 from airflow.sdk.definitions._internal.contextmanager import TaskGroupContext
 from airflow.sdk.definitions._internal.templater import NativeEnvironment, SandboxedEnvironment
 from airflow.sdk.definitions.asset import Asset, AssetAlias, AssetAll, AssetAny
@@ -82,7 +90,6 @@ from airflow.timetables.simple import (
     NullTimetable,
     OnceTimetable,
 )
-from airflow.timetables.trigger import CronPartitionTimetable
 from airflow.utils.file import list_py_file_paths
 from airflow.utils.session import create_session
 from airflow.utils.state import DagRunState, State, TaskInstanceState

--- a/airflow-core/tests/unit/timetables/test_trigger_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_trigger_timetable.py
@@ -28,9 +28,9 @@ from sqlalchemy import select
 from airflow._shared.timezones.timezone import utc
 from airflow.exceptions import AirflowTimetableInvalid
 from airflow.models import DagModel
+from airflow.sdk import CronPartitionTimetable
 from airflow.timetables.base import DagRunInfo, DataInterval, TimeRestriction, Timetable
 from airflow.timetables.trigger import (
-    CronPartitionTimetable,
     CronTriggerTimetable,
     DeltaTriggerTimetable,
     MultipleCronTriggerTimetable,

--- a/task-sdk/docs/api.rst
+++ b/task-sdk/docs/api.rst
@@ -175,17 +175,19 @@ Timetables
 
 .. autoapiclass:: airflow.sdk.CronTriggerTimetable
 
+.. autoapiclass:: airflow.sdk.CronPartitionTimetable
+
 .. autoapiclass:: airflow.sdk.DeltaDataIntervalTimetable
 
 .. autoapiclass:: airflow.sdk.DeltaTriggerTimetable
 
 .. autoapiclass:: airflow.sdk.EventsTimetable
 
+.. autoapiclass:: airflow.sdk.IdentityMapper
+
 .. autoapiclass:: airflow.sdk.MultipleCronTriggerTimetable
 
 .. autoapiclass:: airflow.sdk.PartitionMapper
-
-.. autoapiclass:: airflow.sdk.IdentityMapper
 
 .. autoapiclass:: airflow.sdk.PartitionedAssetTimetable
 

--- a/task-sdk/src/airflow/sdk/__init__.py
+++ b/task-sdk/src/airflow/sdk/__init__.py
@@ -37,6 +37,7 @@ __all__ = [
     "Context",
     "CronDataIntervalTimetable",
     "CronTriggerTimetable",
+    "CronPartitionTimetable",
     "DAG",
     "DagRunState",
     "DeadlineAlert",
@@ -121,6 +122,7 @@ if TYPE_CHECKING:
         DeltaDataIntervalTimetable,
     )
     from airflow.sdk.definitions.timetables.trigger import (
+        CronPartitionTimetable,
         CronTriggerTimetable,
         DeltaTriggerTimetable,
         MultipleCronTriggerTimetable,
@@ -151,6 +153,7 @@ __lazy_imports: dict[str, str] = {
     "Context": ".definitions.context",
     "CronDataIntervalTimetable": ".definitions.timetables.interval",
     "CronTriggerTimetable": ".definitions.timetables.trigger",
+    "CronPartitionTimetable": ".definitions.timetables.trigger",
     "DAG": ".definitions.dag",
     "DagRunState": ".api.datamodels._generated",
     "DeadlineAlert": ".definitions.deadline",

--- a/task-sdk/src/airflow/sdk/__init__.pyi
+++ b/task-sdk/src/airflow/sdk/__init__.pyi
@@ -70,6 +70,7 @@ from airflow.sdk.definitions.timetables.interval import (
     DeltaDataIntervalTimetable,
 )
 from airflow.sdk.definitions.timetables.trigger import (
+    CronPartitionTimetable,
     CronTriggerTimetable,
     DeltaTriggerTimetable,
     MultipleCronTriggerTimetable,
@@ -100,6 +101,7 @@ __all__ = [
     "Context",
     "CronDataIntervalTimetable",
     "CronTriggerTimetable",
+    "CronPartitionTimetable",
     "DAG",
     "DagRunState",
     "DeltaDataIntervalTimetable",

--- a/task-sdk/src/airflow/sdk/definitions/timetables/trigger.py
+++ b/task-sdk/src/airflow/sdk/definitions/timetables/trigger.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import datetime
+from types import NoneType
 from typing import TYPE_CHECKING
 
 import attrs
@@ -88,10 +89,10 @@ class CronTriggerTimetable(CronMixin, BaseTimetable):
 @attrs.define(init=False)
 class MultipleCronTriggerTimetable(BaseTimetable):
     """
-    Timetable that triggers DAG runs according to multiple cron expressions.
+    Timetable that triggers Dag runs according to multiple cron expressions.
 
     This combines multiple ``CronTriggerTimetable`` instances underneath, and
-    triggers a DAG run whenever one of the timetables want to trigger a run.
+    triggers a Dag run whenever one of the timetables want to trigger a run.
 
     Only at most one run is triggered for any given time, even if more than one
     timetable fires at the same time.
@@ -113,4 +114,68 @@ class MultipleCronTriggerTimetable(BaseTimetable):
                 CronTriggerTimetable(cron, timezone, interval=interval, run_immediately=run_immediately)
                 for cron in crons
             ],
+        )
+
+
+@attrs.define
+class CronPartitionTimetable(CronTriggerTimetable):
+    """
+    Timetable that triggers Dag runs according to a cron expression.
+
+    Creates runs for partition keys.
+
+    The cron expression determines the sequence of run dates. And
+    the partition dates are derived from those according to the ``run_offset``.
+    The partition key is then formatted using the partition date.
+
+    A ``run_offset`` of 1 means the partition_date will be one cron interval
+    after the run date; negative means the partition date will be one cron
+    interval prior to the run date.
+
+    :param cron: cron string that defines when to run
+    :param timezone: Which timezone to use to interpret the cron string
+    :param run_offset: Integer offset that determines which partition date to run for.
+        The partition key will be derived from the partition date.
+    :param key_format: How to translate the partition date into a string partition key.
+
+    *run_immediately* controls, if no *start_time* is given to the Dag, when
+    the first run of the Dag should be scheduled. It has no effect if there already exist runs for this Dag.
+
+    * If *True*, always run immediately the most recent possible Dag run.
+    * If *False*, wait to run until the next scheduled time in the future.
+    * If passed a ``timedelta``, will run the most recent possible Dag run
+      if that run's ``data_interval_end`` is within timedelta of now.
+    * If *None*, the timedelta is calculated as 10% of the time between the
+      most recent past scheduled time and the next scheduled time. E.g. if
+      running every hour, this would run the previous time if less than 6
+      minutes had past since the previous run time, otherwise it would wait
+      until the next hour.
+
+    # todo: AIP-76 talk about how we can have auto-reprocessing of partitions
+    # todo: AIP-76 we could allow a tuple of integer + time-based
+
+    """
+
+    run_offset: int | datetime.timedelta | relativedelta | None = None
+    key_format: str = "%Y-%m-%dT%H:%M:%S"  # todo: AIP-76 we can't infer partition date from this, so we need to store it separately
+
+    def __init__(
+        self,
+        cron: str,
+        *,
+        timezone: str | Timezone | FixedTimezone,
+        run_offset: int | datetime.timedelta | relativedelta | None = None,
+        run_immediately: bool | datetime.timedelta = False,
+        key_format: str = "%Y-%m-%dT%H:%M:%S",  # todo: AIP-76 we can't infer partition date from this, so we need to store it separately
+    ) -> None:
+        # super().__init__(cron, timezone=timezone, run_immediately=run_immediately)
+        if not isinstance(run_offset, (int, NoneType)):
+            # todo: AIP-76 implement timedelta / relative delta?
+            raise ValueError("Run offset other than integer not supported yet.")
+        self.__attrs_init__(  # type: ignore[attr-defined]
+            cron,
+            timezone=timezone,
+            run_offset=run_offset,
+            run_immediately=run_immediately,
+            key_format=key_format,
         )


### PR DESCRIPTION
## Why
closes: https://github.com/apache/airflow/issues/61241

https://github.com/apache/airflow/pull/59115 did not implement `CronPartitionTimetable` in the task SDK

## What
Implement `CronPartitionTimetable` in task sdk

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
