### PR TITLE
Migrate deadline references over to task sdk

### DIFF
--- a/airflow-core/docs/howto/deadline-alerts.rst
+++ b/airflow-core/docs/howto/deadline-alerts.rst
@@ -341,15 +341,12 @@ implement an ``_evaluate_with()`` method.
 
 .. code-block:: python
 
-    from airflow.models.deadline import ReferenceModels
-    from sqlalchemy.orm import Session
-
     from airflow.sdk import DeadlineReference
-    from airflow.sdk.definitions.deadline import deadline_reference
+    from airflow.sdk.definitions.deadline import ReferenceModels, deadline_reference
     from airflow.sdk.timezone import datetime
 
 
-    # By default, the evaluate_with method will be executed when the dagrun is created.
+    # By default, the _evaluate_with method will be executed when the dagrun is created.
     @deadline_reference()
     class MyCustomDecoratedReference(ReferenceModels.BaseDeadlineReference):
         """A custom reference evaluated when Dag runs are created."""
@@ -359,7 +356,7 @@ implement an ``_evaluate_with()`` method.
             return your_datetime
 
 
-    # You can specify when evaluate_with will be called by providing a DeadlineReference.TYPES value.
+    # You can specify when _evaluate_with will be called by providing a DeadlineReference.TYPES value.
     @deadline_reference(DeadlineReference.TYPES.DAGRUN_QUEUED)
     class MyQueuedReference(ReferenceModels.BaseDeadlineReference):
         """A custom reference evaluated when Dag runs are queued."""

--- a/airflow-core/src/airflow/models/deadline.py
+++ b/airflow-core/src/airflow/models/deadline.py
@@ -17,13 +17,11 @@
 from __future__ import annotations
 
 import logging
-from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any, cast
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
 
 import uuid6
-from sqlalchemy import Boolean, ForeignKey, Index, Integer, and_, func, inspect, select, text
+from sqlalchemy import Boolean, ForeignKey, Index, Integer, and_, inspect, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Mapped, relationship
 from sqlalchemy_utils import UUIDType
@@ -32,13 +30,11 @@ from airflow._shared.observability.metrics.stats import Stats
 from airflow._shared.timezones import timezone
 from airflow.models.base import Base
 from airflow.models.callback import Callback, CallbackDefinitionProtocol
-from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import provide_session
-from airflow.utils.sqlalchemy import UtcDateTime, get_dialect_name, mapped_column
+from airflow.utils.sqlalchemy import UtcDateTime, mapped_column
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
-    from sqlalchemy.sql import ColumnElement
 
     from airflow.models.callback import CallbackDefinitionProtocol
     from airflow.models.deadline_alert import DeadlineAlert
@@ -233,220 +229,30 @@ class Deadline(Base):
         )
 
 
-class ReferenceModels:
-    """
-    Store the implementations for the different Deadline References.
+def __getattr__(name: str):
+    import warnings
 
-    After adding the implementations here, all DeadlineReferences should be added
-    to the user interface in airflow.sdk.definitions.deadline.DeadlineReference
-    """
+    if name == "ReferenceModels":
+        from airflow.sdk.definitions.deadline import ReferenceModels
 
-    REFERENCE_TYPE_FIELD = "reference_type"
+        warnings.warn(
+            "Importing ReferenceModels from airflow.models.deadline is deprecated. "
+            "Use airflow.sdk.definitions.deadline.ReferenceModels instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return ReferenceModels
+    if name == "DeadlineReferenceType":
+        from airflow.sdk.definitions.deadline import ReferenceModels
 
-    @classmethod
-    def get_reference_class(cls, reference_name: str) -> type[BaseDeadlineReference]:
-        """
-        Get a reference class by its name.
-
-        :param reference_name: The name of the reference class to find
-        """
-        try:
-            return next(
-                ref_class
-                for name, ref_class in vars(cls).items()
-                if isinstance(ref_class, type)
-                and issubclass(ref_class, cls.BaseDeadlineReference)
-                and ref_class.__name__ == reference_name
-            )
-        except StopIteration:
-            raise ValueError(f"No reference class found with name: {reference_name}")
-
-    class BaseDeadlineReference(LoggingMixin, ABC):
-        """Base class for all Deadline implementations."""
-
-        # Set of required kwargs - subclasses should override this.
-        required_kwargs: set[str] = set()
-
-        @classproperty
-        def reference_name(cls: Any) -> str:
-            return cls.__name__
-
-        def evaluate_with(self, *, session: Session, interval: timedelta, **kwargs: Any) -> datetime | None:
-            """Validate the provided kwargs and evaluate this deadline with the given conditions."""
-            filtered_kwargs = {k: v for k, v in kwargs.items() if k in self.required_kwargs}
-
-            if missing_kwargs := self.required_kwargs - filtered_kwargs.keys():
-                raise ValueError(
-                    f"{self.__class__.__name__} is missing required parameters: {', '.join(missing_kwargs)}"
-                )
-
-            if extra_kwargs := kwargs.keys() - filtered_kwargs.keys():
-                self.log.debug("Ignoring unexpected parameters: %s", ", ".join(extra_kwargs))
-
-            base_time = self._evaluate_with(session=session, **filtered_kwargs)
-            return base_time + interval if base_time is not None else None
-
-        @abstractmethod
-        def _evaluate_with(self, *, session: Session, **kwargs: Any) -> datetime | None:
-            """Must be implemented by subclasses to perform the actual evaluation."""
-            raise NotImplementedError
-
-        @classmethod
-        def deserialize_reference(cls, reference_data: dict):
-            """
-            Deserialize a reference type from its dictionary representation.
-
-            While the base implementation doesn't use reference_data, this parameter is required
-            for subclasses that need additional data for initialization (like FixedDatetimeDeadline
-            which needs a datetime value).
-
-            :param reference_data: Dictionary containing serialized reference data.
-                Always includes a 'reference_type' field, and may include additional
-                fields needed by specific reference implementations.
-            """
-            return cls()
-
-        def serialize_reference(self) -> dict:
-            """
-            Serialize this reference type into a dictionary representation.
-
-            This method assumes that the reference doesn't require any additional data.
-            Override this method in subclasses if additional data is needed for serialization.
-            """
-            return {ReferenceModels.REFERENCE_TYPE_FIELD: self.reference_name}
-
-    @dataclass
-    class FixedDatetimeDeadline(BaseDeadlineReference):
-        """A deadline that always returns a fixed datetime."""
-
-        _datetime: datetime
-
-        def _evaluate_with(self, *, session: Session, **kwargs: Any) -> datetime | None:
-            return self._datetime
-
-        def serialize_reference(self) -> dict:
-            return {
-                ReferenceModels.REFERENCE_TYPE_FIELD: self.reference_name,
-                "datetime": self._datetime.timestamp(),
-            }
-
-        @classmethod
-        def deserialize_reference(cls, reference_data: dict):
-            return cls(_datetime=timezone.from_timestamp(reference_data["datetime"]))
-
-    class DagRunLogicalDateDeadline(BaseDeadlineReference):
-        """A deadline that returns a DagRun's logical date."""
-
-        required_kwargs = {"dag_id", "run_id"}
-
-        def _evaluate_with(self, *, session: Session, **kwargs: Any) -> datetime | None:
-            from airflow.models import DagRun
-
-            return _fetch_from_db(DagRun.logical_date, session=session, **kwargs)
-
-    class DagRunQueuedAtDeadline(BaseDeadlineReference):
-        """A deadline that returns when a DagRun was queued."""
-
-        required_kwargs = {"dag_id", "run_id"}
-
-        @provide_session
-        def _evaluate_with(self, *, session: Session, **kwargs: Any) -> datetime | None:
-            from airflow.models import DagRun
-
-            return _fetch_from_db(DagRun.queued_at, session=session, **kwargs)
-
-    @dataclass
-    class AverageRuntimeDeadline(BaseDeadlineReference):
-        """A deadline that calculates the average runtime from past DAG runs."""
-
-        DEFAULT_LIMIT = 10
-        max_runs: int
-        min_runs: int | None = None
-        required_kwargs = {"dag_id"}
-
-        def __post_init__(self):
-            if self.min_runs is None:
-                self.min_runs = self.max_runs
-            if self.min_runs < 1:
-                raise ValueError("min_runs must be at least 1")
-
-        @provide_session
-        def _evaluate_with(self, *, session: Session, **kwargs: Any) -> datetime | None:
-            from airflow.models import DagRun
-
-            dag_id = kwargs["dag_id"]
-
-            # Get database dialect to use appropriate time difference calculation
-            dialect = get_dialect_name(session)
-
-            # Create database-specific expression for calculating duration in seconds
-            duration_expr: ColumnElement[Any]
-            if dialect == "postgresql":
-                duration_expr = func.extract("epoch", DagRun.end_date - DagRun.start_date)
-            elif dialect == "mysql":
-                # Use TIMESTAMPDIFF to get exact seconds like PostgreSQL EXTRACT(epoch FROM ...)
-                duration_expr = func.timestampdiff(text("SECOND"), DagRun.start_date, DagRun.end_date)
-            elif dialect == "sqlite":
-                duration_expr = (func.julianday(DagRun.end_date) - func.julianday(DagRun.start_date)) * 86400
-            else:
-                raise ValueError(f"Unsupported database dialect: {dialect}")
-
-            # Query for completed DAG runs with both start and end dates
-            # Order by logical_date descending to get most recent runs first
-            query = (
-                select(duration_expr)
-                .filter(DagRun.dag_id == dag_id, DagRun.start_date.isnot(None), DagRun.end_date.isnot(None))
-                .order_by(DagRun.logical_date.desc())
-            )
-
-            # Apply max_runs
-            query = query.limit(self.max_runs)
-
-            # Get all durations and calculate average
-            durations = session.execute(query).scalars().all()
-
-            if len(durations) < cast("int", self.min_runs):
-                logger.info(
-                    "Only %d completed DAG runs found for dag_id: %s (need %d), skipping deadline creation",
-                    len(durations),
-                    dag_id,
-                    self.min_runs,
-                )
-                return None
-            # Convert to float to handle Decimal types from MySQL while preserving precision
-            # Use Decimal arithmetic for higher precision, then convert to float
-            from decimal import Decimal
-
-            decimal_durations = [Decimal(str(d)) for d in durations]
-            avg_seconds = float(sum(decimal_durations) / len(decimal_durations))
-            logger.info(
-                "Average runtime for dag_id %s (from %d runs): %.2f seconds",
-                dag_id,
-                len(durations),
-                avg_seconds,
-            )
-            return timezone.utcnow() + timedelta(seconds=avg_seconds)
-
-        def serialize_reference(self) -> dict:
-            return {
-                ReferenceModels.REFERENCE_TYPE_FIELD: self.reference_name,
-                "max_runs": self.max_runs,
-                "min_runs": self.min_runs,
-            }
-
-        @classmethod
-        def deserialize_reference(cls, reference_data: dict):
-            max_runs = reference_data.get("max_runs", cls.DEFAULT_LIMIT)
-            min_runs = reference_data.get("min_runs", max_runs)
-            if min_runs < 1:
-                raise ValueError("min_runs must be at least 1")
-            return cls(
-                max_runs=max_runs,
-                min_runs=min_runs,
-            )
-
-
-DeadlineReferenceType = ReferenceModels.BaseDeadlineReference
+        warnings.warn(
+            "Importing DeadlineReferenceType from airflow.models.deadline is deprecated. "
+            "Use airflow.sdk.definitions.deadline.ReferenceModels.BaseDeadlineReference instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return ReferenceModels.BaseDeadlineReference
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 @provide_session


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Cursor IDE with claude sonnet 4.5

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->


This is a follow up to: #61118, where deadline references needed to be better handled.

In this PR, I intend to complete the migration of deadline alert references from `airflow-core` to `task-sdk`. task SDK now contains lightweight reference definitions for DAG authoring, while core retains database aware evaluation logic. 

### Changes of Note

1. SDK: Added Lightweight `ReferenceModels`

Added reference classes with serialization only logic:
- `BaseDeadlineReference` - Base class with `serialize_reference()` / `deserialize_reference()`
- `FixedDatetimeDeadline`, `DagRunLogicalDateDeadline`, `DagRunQueuedAtDeadline`, `AverageRuntimeDeadline`
- Added `_evaluate_with()` stub (raises `NotImplementedError`) to support custom references

2. In airlfow-core, removed the `ReferenceModels` class but with `__getattr__` redirect

3. SerializedReferenceModels stays in core with full database logic - no changes made there.


### Sanity Run



---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
