### PR TITLE
Restrict EC2CreateInstanceOperator cleanup to waiter failures and add guard flag

### DIFF
--- a/providers/amazon/tests/unit/amazon/aws/operators/test_ec2.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_ec2.py
@@ -107,6 +107,7 @@ class TestEC2CreateInstanceOperator(BaseEc2TestClass):
             task_id="test_cleanup_on_error",
             image_id=self._get_image_id(ec2_hook),
             wait_for_completion=True,
+            terminate_instance_on_failure=True,
         )
 
         waiter_error = WaiterError(
@@ -140,6 +141,7 @@ class TestEC2CreateInstanceOperator(BaseEc2TestClass):
             task_id="test_cleanup_failure_does_not_mask_error",
             image_id=self._get_image_id(ec2_hook),
             wait_for_completion=True,
+            terminate_instance_on_failure=True,
         )
 
         waiter_error = WaiterError(


### PR DESCRIPTION
**Description**

This PR follows up on PR #60904 by refining cleanup behavior in `EC2CreateInstanceOperator`. Cleanup behavior is **guarded by a flag** and is **opted in by default**. Cleanup is only triggered for post-start EC2 instance failures (including `WaiterError`), ensuring termination is attempted only when an instance was successfully created and **avoiding interception of non-AWS exceptions**.

**Rationale**

Restricting cleanup to post-creation EC2 instance failures prevents unintended termination in unrelated failure paths while still addressing orphaned instances created during execution, and aligns EC2 cleanup semantics with recent changes to other AWS resource creation operators proposed in PRs #61145, #61051, and #61010 .

**Tests**

Existing tests continue to validate cleanup behavior. The new `terminate_instance_on_failure` flag is now explicitly set to `True` in applicable tests for explicitness.

**Documentation**

The docstring for `EC2CreateInstanceOperator` has been updated with a brief description of the new flag term.

**Backwards Compatibility**

A new flag, `terminate_instance_on_failure`, has been added to `EC2CreateInstanceOperator` with a default value of `True`. Best-effort cleanup will now be attempted if a post-creation failure (including `WaiterError`) occurs after the EC2 instance has been successfully created.