### PR TITLE
Flatten grid structure endpoint memory consumption

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/grid.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/grid.py
@@ -144,7 +144,7 @@ def get_dag_structure(
     latest_serdag = _get_latest_serdag(dag_id, session)
     latest_dag = latest_serdag.dag
     latest_serdag_id = latest_serdag.id
-    session.expunge(latest_serdag)  # to allow garbage collection of serdag - we have the dag now
+    session.expunge(latest_serdag)  # allow GC of serdag; only latest_dag is needed from here
 
     # Apply filtering if root task is specified
     if root:
@@ -203,25 +203,24 @@ def get_dag_structure(
                 .distinct()
             ),
         )
-        .execution_options(yield_per=5)
+        .execution_options(yield_per=5)  # balance between peak memory usage and round trips
     )
 
     for serdag in session.scalars(serdags_query):
-        if serdag:
-            filtered_dag = serdag.dag
-            # Apply the same filtering to historical DAG versions
-            if root:
-                filtered_dag = filtered_dag.partial_subset(
-                    task_ids=root,
-                    include_upstream=include_upstream,
-                    include_downstream=include_downstream,
-                    depth=depth,
-                )
-            # Merge immediately instead of collecting all DAGs in memory
-            nodes = [task_group_to_dict_grid(x) for x in task_group_sort(filtered_dag.task_group)]
-            _merge_node_dicts(merged_nodes, nodes)
+        filtered_dag = serdag.dag
+        # Apply the same filtering to historical DAG versions
+        if root:
+            filtered_dag = filtered_dag.partial_subset(
+                task_ids=root,
+                include_upstream=include_upstream,
+                include_downstream=include_downstream,
+                depth=depth,
+            )
+        # Merge immediately instead of collecting all DAGs in memory
+        nodes = [task_group_to_dict_grid(x) for x in task_group_sort(filtered_dag.task_group)]
+        _merge_node_dicts(merged_nodes, nodes)
 
-            session.expunge(serdag)  # to allow garbage collection
+        session.expunge(serdag)  # to allow garbage collection
 
     return [GridNodeResponse(**n) for n in merged_nodes]
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/grid.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/grid.py
@@ -143,6 +143,8 @@ def get_dag_structure(
     """Return dag structure for grid view."""
     latest_serdag = _get_latest_serdag(dag_id, session)
     latest_dag = latest_serdag.dag
+    latest_serdag_id = latest_serdag.id
+    session.expunge(latest_serdag)  # to allow garbage collection of serdag - we have the dag now
 
     # Apply filtering if root task is specified
     if root:
@@ -176,12 +178,22 @@ def get_dag_structure(
         nodes = [task_group_to_dict_grid(x) for x in task_group_sort(latest_dag.task_group)]
         return [GridNodeResponse(**n) for n in nodes]
 
-    serdags = session.scalars(
-        select(SerializedDagModel).where(
+    # Process and merge the latest serdag first
+    merged_nodes: list[dict[str, Any]] = []
+    nodes = [task_group_to_dict_grid(x) for x in task_group_sort(latest_dag.task_group)]
+    _merge_node_dicts(merged_nodes, nodes)
+    del latest_dag
+
+    # Process serdags one by one and merge immediately to reduce memory usage.
+    # Use yield_per() for streaming results and expunge each serdag after processing
+    # to allow garbage collection and prevent memory buildup in the session identity map.
+    serdags_query = (
+        select(SerializedDagModel)
+        .where(
             # Even though dag_id is filtered in base_query,
             # adding this line here can improve the performance of this endpoint
             SerializedDagModel.dag_id == dag_id,
-            SerializedDagModel.id != latest_serdag.id,
+            SerializedDagModel.id != latest_serdag_id,
             SerializedDagModel.dag_version_id.in_(
                 select(TaskInstance.dag_version_id)
                 .join(TaskInstance.dag_run)
@@ -191,10 +203,10 @@ def get_dag_structure(
                 .distinct()
             ),
         )
+        .execution_options(yield_per=5)
     )
-    merged_nodes: list[dict[str, Any]] = []
-    dags = [latest_dag]
-    for serdag in serdags:
+
+    for serdag in session.scalars(serdags_query):
         if serdag:
             filtered_dag = serdag.dag
             # Apply the same filtering to historical DAG versions
@@ -205,10 +217,11 @@ def get_dag_structure(
                     include_downstream=include_downstream,
                     depth=depth,
                 )
-            dags.append(filtered_dag)
-    for dag in dags:
-        nodes = [task_group_to_dict_grid(x) for x in task_group_sort(dag.task_group)]
-        _merge_node_dicts(merged_nodes, nodes)
+            # Merge immediately instead of collecting all DAGs in memory
+            nodes = [task_group_to_dict_grid(x) for x in task_group_sort(filtered_dag.task_group)]
+            _merge_node_dicts(merged_nodes, nodes)
+
+            session.expunge(serdag)  # to allow garbage collection
 
     return [GridNodeResponse(**n) for n in merged_nodes]
 


### PR DESCRIPTION
The grid structure endpoint was loading all serdags for the shown dagruns into memory at once, before merging them together.

Now, we load 5 at a time and also expunge so they can be gc'd more quickly.

For normal simple dags this makes nearly no difference:

Before:
  Average:      0.0163 secs
  Requests/sec: 184.5453
  95%% in 0.0225 secs

After:
Average:      0.0177 secs
Requests/sec: 169.2285
95%% in 0.0214 secs


But for "edge case" dags - those with many serdag versions shown on a single grid, and large serdag versions, it makes a significant difference and can be the difference between an healthy api server and one that OOMs.

Before:
<img width="1616" height="297" alt="before_bad" src="https://github.com/user-attachments/assets/461c307c-2ebc-486e-9cb5-cf8466b5655c" />

Average:      12.5568 secs
Requests/sec: 0.0796
90%% in 12.9824 secs

After:
<img width="1621" height="261" alt="after_bad" src="https://github.com/user-attachments/assets/3bf2ada0-55e2-4b03-97a1-8e609bf80b3c" />

Average:      12.2856 secs
Requests/sec: 0.0814
90%% in 12.4549 secs


(This profiling was done with an intentionally bad dag to really highlight the difference) 

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: Cursor (Claude 4.5 Opus)
Generated-by: Gemini CLI (Gemini 3 Pro)
