### PR TITLE
Fix JWT token generation with unset issuer/audience config

### DIFF
--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -125,7 +125,7 @@ dependencies = [
     # Pygments 2.19.0 improperly renders .ini files with dictionaries as values
     # See https://github.com/pygments/pygments/issues/2834
     "pygments>=2.0.1,!=2.19.0",
-    "pyjwt>=2.10.0",
+    "pyjwt>=2.11.0",
     "python-daemon>=3.0.0",
     "python-dateutil>=2.7.0",
     "python-slugify>=5.0",

--- a/airflow-core/src/airflow/api_fastapi/auth/tokens.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/tokens.py
@@ -242,13 +242,13 @@ def _conf_list_factory(
 
 
 def _conf_list_factory(section, key, first_only: bool = False, **kwargs):
-    def factory() -> list[str] | str:
+    def factory() -> list[str] | str | None:
         from airflow.configuration import conf
 
         val = conf.getlist(section, key, **kwargs, suppress_warnings=True)
 
-        if first_only and val:
-            return val[0]
+        if first_only:
+            return val[0] if val else None
         return val or []
 
     return factory
@@ -446,9 +446,12 @@ class JWTGenerator:
             "iat": now,
         }
 
-        if claims["iss"] is None:
+        # Remove iss and aud claims if they are falsy (None, [], "", etc.)
+        # Per RFC 7519, these are optional claims and should be omitted entirely
+        # rather than set to empty/invalid values: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.1
+        if not claims["iss"]:
             del claims["iss"]
-        if claims["aud"] is None:
+        if not claims["aud"]:
             del claims["aud"]
 
         if extras is not None:

--- a/airflow-core/src/airflow/api_fastapi/auth/tokens.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/tokens.py
@@ -330,7 +330,7 @@ class JWTValidator:
             key,
             audience=self.audience,
             issuer=self.issuer,
-            options={"require": self.required_claims},
+            options={"require": list(self.required_claims)},
             algorithms=self.algorithm,
             leeway=self.leeway,
         )


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

PyJWT released 2.11.0 https://pyjwt.readthedocs.io/en/stable/changelog.html#v2-11-0 which adds stricter validation for JWT claims. 

The change: https://github.com/jpadilla/pyjwt/issues/1039 and https://github.com/jpadilla/pyjwt/pull/1040 ensures that the `iss` and `aud` claims must me StringOrURI as per RFC 7519: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.1

An example of earlier behaviour with 2.10.1 pyjwt 

```python
jwt.encode({"iss": []}, key, algorithm="HS256")
Out[9]: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOltdfQ.-iVQNepE7AkWkxP2IyS2A8YlkvsSpgHKFoGElirCGSQ'
jwt.encode({"iss": 123}, "XdHWZSEDZw1KS+qP1ggxDQ==", algorithm="HS256") 
Out[10]: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOjEyM30.segFYHCUVHVGM6RbSGnqSJXnUNObaTwQGex_YMFn5IY'

```

With 2.11.0 pyjwt:

```python
jwt.encode({"iss": 123}, "XdHWZSEDZw1KS+qP1ggxDQ==", algorithm="HS256") 
Traceback (most recent call last):
  File "/Users/amoghdesai/Documents/OSS/repos/airflow/.venv/lib/python3.13/site-packages/IPython/core/interactiveshell.py", line 3701, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
    ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<ipython-input-7-3b5e0f6758f3>", line 1, in <module>
    jwt.encode({"iss": 123}, "XdHWZSEDZw1KS+qP1ggxDQ==", algorithm="HS256")
    ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/amoghdesai/Documents/OSS/repos/airflow/.venv/lib/python3.13/site-packages/jwt/api_jwt.py", line 145, in encode
    raise TypeError("Issuer (iss) must be a string.")
TypeError: Issuer (iss) must be a string.
jwt.encode({"iss": []}, key, algorithm="HS256")
Traceback (most recent call last):
  File "/Users/amoghdesai/Documents/OSS/repos/airflow/.venv/lib/python3.13/site-packages/IPython/core/interactiveshell.py", line 3701, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
    ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<ipython-input-8-320ea77fa0bd>", line 1, in <module>
    jwt.encode({"iss": []}, key, algorithm="HS256")
    ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/amoghdesai/Documents/OSS/repos/airflow/.venv/lib/python3.13/site-packages/jwt/api_jwt.py", line 145, in encode
    raise TypeError("Issuer (iss) must be a string.")
TypeError: Issuer (iss) must be a string.
```

Now, airflow's config parser returned `[]` for unset configs when `first_only` was set. This is now rejected by PyJWT as invalid claims.

The fix is to return `None` for unset configs when single string is expected and for list values empty list is still valid -- this needs to be handled in the `_conf_list_factory` as well as the `JWTGenerator` to handle falsy values.



---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
