### PR TITLE
Simplify bug report template by making OS and Deployment optional

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-airflow_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1-airflow_bug_report.yml
@@ -88,8 +88,6 @@ body:
       label: Operating System
       description: What Operating System are you using?
       placeholder: "You can get it via `cat /etc/os-release` for example"
-    validations:
-      required: true
   - type: textarea
     attributes:
       label: Versions of Apache Airflow Providers
@@ -113,8 +111,6 @@ body:
         - "Amazon (AWS) MWAA"
         - "Microsoft ADF Managed Airflow"
         - "Other"
-    validations:
-      required: true
   - type: textarea
     attributes:
       label: Deployment details


### PR DESCRIPTION
## Summary

Simplifies the bug report template by making Operating System and Deployment fields optional instead of required, addressing #55840.

## Changes

- Operating System: changed from required to optional
- Deployment: changed from required to optional

## Rationale

The current template requires 6 fields (Version, Description, Reproduction Steps, OS, Deployment, Code of Conduct), which can discourage users from filing bugs. This change reduces required fields to 4 while still collecting critical information:

**Still Required:**
- Airflow version
- Bug description  
- Reproduction steps
- Code of Conduct acceptance

**Now Optional:**
- Operating System (not relevant for many bugs)
- Deployment type (not relevant for many bugs)

Optional fields can still be filled in when relevant, but users won't be blocked from submitting a bug report if they don't have all deployment details. This makes it easier for users to report bugs while maintaining the quality of submissions.

Fixes #55840