### PR TITLE
Respect deprecated options in default config parser

### DIFF
--- a/airflow-core/src/airflow/configuration.py
+++ b/airflow-core/src/airflow/configuration.py
@@ -43,6 +43,7 @@ from airflow._shared.configuration.parser import (
     VALUE_NOT_FOUND_SENTINEL,
     AirflowConfigParser as _SharedAirflowConfigParser,
     ValueNotFound,
+    configure_parser_from_configuration_description,
 )
 from airflow._shared.module_loading import import_string
 from airflow.exceptions import AirflowConfigException, RemovedInAirflow4Warning
@@ -684,17 +685,7 @@ def create_default_config_parser(configuration_description: dict[str, dict[str, 
     """
     parser = ConfigParser()
     all_vars = get_all_expansion_variables()
-    for section, section_desc in configuration_description.items():
-        parser.add_section(section)
-        options = section_desc["options"]
-        for key in options:
-            default_value = options[key]["default"]
-            is_template = options[key].get("is_template", False)
-            if default_value is not None:
-                if is_template or not isinstance(default_value, str):
-                    parser.set(section, key, default_value)
-                else:
-                    parser.set(section, key, default_value.format(**all_vars))
+    configure_parser_from_configuration_description(parser, configuration_description, all_vars)
     return parser
 
 

--- a/shared/configuration/tests/configuration/test_parser.py
+++ b/shared/configuration/tests/configuration/test_parser.py
@@ -31,7 +31,10 @@ from unittest.mock import patch
 import pytest
 
 from airflow_shared.configuration.exceptions import AirflowConfigException
-from airflow_shared.configuration.parser import AirflowConfigParser as _SharedAirflowConfigParser
+from airflow_shared.configuration.parser import (
+    AirflowConfigParser as _SharedAirflowConfigParser,
+    configure_parser_from_configuration_description,
+)
 
 
 class AirflowConfigParser(_SharedAirflowConfigParser):
@@ -790,3 +793,39 @@ existing_list = one,two,three
         test_conf.set("Test", "NewKey", "new_value")
         assert test_conf.get("test", "newkey") == "new_value"
         assert test_conf.get("TEST", "NEWKEY") == "new_value"
+
+    def test_configure_parser_from_configuration_description_with_deprecated_options(self):
+        """
+        Test that configure_parser_from_configuration_description respects deprecated options.
+        """
+        configuration_description = {
+            "test_section": {
+                "options": {
+                    "non_deprecated_key": {"default": "non_deprecated_value"},
+                    "deprecated_key_version": {
+                        "default": "deprecated_value_version",
+                        "version_deprecated": "3.0.0",
+                    },
+                    "deprecated_key_reason": {
+                        "default": "deprecated_value_reason",
+                        "deprecation_reason": "Some reason",
+                    },
+                    "none_default_deprecated": {"default": None, "deprecation_reason": "No default"},
+                }
+            }
+        }
+        parser = ConfigParser()
+        all_vars = {}
+
+        configure_parser_from_configuration_description(parser, configuration_description, all_vars)
+
+        # Assert that the non-deprecated key is present
+        assert parser.has_option("test_section", "non_deprecated_key")
+        assert parser.get("test_section", "non_deprecated_key") == "non_deprecated_value"
+
+        # Assert that the deprecated keys are NOT present
+        assert not parser.has_option("test_section", "deprecated_key_version")
+        assert not parser.has_option("test_section", "deprecated_key_reason")
+
+        # Assert that options with default None are still not set
+        assert not parser.has_option("test_section", "none_default_deprecated")

--- a/shared/configuration/tests/configuration/test_parser.py
+++ b/shared/configuration/tests/configuration/test_parser.py
@@ -831,7 +831,7 @@ existing_list = one,two,three
         assert not parser.has_option("test_section", "none_default_deprecated")
 
     def test_get_default_value_deprecated(self):
-        """Test get_default_value for deprecated options where default is ignored."""
+        """Test 'conf.get' for deprecated options and should not return default value."""
 
         class TestConfigParser(AirflowConfigParser):
             def __init__(self):
@@ -844,6 +844,10 @@ existing_list = one,two,three
                             },
                             "deprecated_key2": {
                                 "default": "some_value",
+                                "version_deprecated": "2.0.0",
+                            },
+                            "deprecated_key3": {
+                                "default": None,
                                 "version_deprecated": "2.0.0",
                             },
                             "active_key": {
@@ -860,14 +864,27 @@ existing_list = one,two,three
                 _SharedAirflowConfigParser.__init__(self, configuration_description, _default_values)
 
         test_conf = TestConfigParser()
+        deprecated_conf_list = [
+            ("test_section", "deprecated_key"),
+            ("test_section", "deprecated_key2"),
+            ("test_section", "deprecated_key3"),
+        ]
 
-        # get_default_value should return fallback if not found
+        # case 1: using `get` with fallback
+        # should return fallback if not found
         expected_sentinel = object()
-        assert (
-            test_conf.get("test_section", "deprecated_key", fallback=expected_sentinel) is expected_sentinel
-        )
-        assert (
-            test_conf.get("test_section", "deprecated_key2", fallback=expected_sentinel) is expected_sentinel
-        )
+        for section, key in deprecated_conf_list:
+            assert test_conf.get(section, key, fallback=expected_sentinel) is expected_sentinel
+
+        # case 2: using `get` without fallback
+        # should raise AirflowConfigException
+        for section, key in deprecated_conf_list:
+            with pytest.raises(
+                AirflowConfigException,
+                match=re.escape(f"section/key [{section}/{key}] not found in config"),
+            ):
+                test_conf.get(section, key)
+
+        # case 3: active (non-deprecated) key
         # Active key should be present
         assert test_conf.get("test_section", "active_key") == "active_value"

--- a/shared/configuration/tests/configuration/test_parser.py
+++ b/shared/configuration/tests/configuration/test_parser.py
@@ -829,3 +829,45 @@ existing_list = one,two,three
 
         # Assert that options with default None are still not set
         assert not parser.has_option("test_section", "none_default_deprecated")
+
+    def test_get_default_value_deprecated(self):
+        """Test get_default_value for deprecated options where default is ignored."""
+
+        class TestConfigParser(AirflowConfigParser):
+            def __init__(self):
+                configuration_description = {
+                    "test_section": {
+                        "options": {
+                            "deprecated_key": {
+                                "default": "some_value",
+                                "deprecation_reason": "deprecated",
+                            },
+                            "deprecated_key2": {
+                                "default": "some_value",
+                                "version_deprecated": "2.0.0",
+                            },
+                            "active_key": {
+                                "default": "active_value",
+                            },
+                        }
+                    }
+                }
+                _default_values = ConfigParser()
+                # verify configure_parser_from_configuration_description logic of skipping
+                configure_parser_from_configuration_description(
+                    _default_values, configuration_description, {}
+                )
+                _SharedAirflowConfigParser.__init__(self, configuration_description, _default_values)
+
+        test_conf = TestConfigParser()
+
+        # get_default_value should return fallback if not found
+        expected_sentinel = object()
+        assert (
+            test_conf.get("test_section", "deprecated_key", fallback=expected_sentinel) is expected_sentinel
+        )
+        assert (
+            test_conf.get("test_section", "deprecated_key2", fallback=expected_sentinel) is expected_sentinel
+        )
+        # Active key should be present
+        assert test_conf.get("test_section", "active_key") == "active_value"

--- a/task-sdk/src/airflow/sdk/configuration.py
+++ b/task-sdk/src/airflow/sdk/configuration.py
@@ -27,7 +27,10 @@ from io import StringIO
 from typing import Any
 
 from airflow.sdk import yaml
-from airflow.sdk._shared.configuration.parser import AirflowConfigParser as _SharedAirflowConfigParser
+from airflow.sdk._shared.configuration.parser import (
+    AirflowConfigParser as _SharedAirflowConfigParser,
+    configure_parser_from_configuration_description,
+)
 from airflow.sdk.execution_time.secrets import _SERVER_DEFAULT_SECRETS_SEARCH_PATH
 
 log = logging.getLogger(__name__)
@@ -85,20 +88,7 @@ def create_default_config_parser(configuration_description: dict[str, dict[str, 
     """
     parser = ConfigParser()
     all_vars = get_sdk_expansion_variables()
-    for section, section_desc in configuration_description.items():
-        parser.add_section(section)
-        options = section_desc["options"]
-        for key in options:
-            default_value = options[key]["default"]
-            is_template = options[key].get("is_template", False)
-            if default_value is not None:
-                if is_template or not isinstance(default_value, str):
-                    parser.set(section, key, str(default_value))
-                else:
-                    try:
-                        parser.set(section, key, default_value.format(**all_vars))
-                    except (KeyError, ValueError):
-                        parser.set(section, key, default_value)
+    configure_parser_from_configuration_description(parser, configuration_description, all_vars)
     return parser
 
 


### PR DESCRIPTION

* related: #56150

## Why

Previously, the default value parser logic in `AirflowConfigParser` did not check for `version_deprecated ` or `deprecation_reason ` for default `config.yaml`

This means that if we really deprecated a `[config/key]`, like the case of https://github.com/apache/airflow/pull/56150#discussion_r2734687449 (not renaming or moving to other section like AF2 -to AF3), the `conf.get` will still get default value from the `config.yaml`.

From my perspective, the default value parser should respect deprecated options (the option that provide either `version_deprecated` or `deprecation_reason`) and ignore it.

## What

- Update the config parser to **respect deprecated options for default value parser**
- Extract the `configure_parser_from_configuration_description` logic to shared lib

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: Copilot (ChatGPT 4.1), Gemini-CLI (auto model) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
