### PR TITLE
Add BREEZE_SELF_UPGRADE_TIMEOUT in reinstall_if_setup_changed

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/path_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/path_utils.py
@@ -132,14 +132,35 @@ def reinstall_if_setup_changed() -> bool:
     :return: True if warning was printed.
     """
 
-    res = subprocess.run(
-        ["uv", "tool", "upgrade", "apache-airflow-breeze"],
-        cwd=MY_BREEZE_ROOT_PATH,
-        check=True,
-        text=True,
-        capture_output=True,
-    )
-    if "Modified" in res.stderr:
+    timeout_seconds = int(os.environ.get("BREEZE_SELF_UPGRADE_TIMEOUT", "3"))
+    try:
+        res = subprocess.run(
+            ["uv", "tool", "upgrade", "apache-airflow-breeze"],
+            cwd=MY_BREEZE_ROOT_PATH,
+            check=True,
+            text=True,
+            capture_output=True,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired:
+        get_console().print(
+            f"[warning]Breeze self-upgrade check timed out after {timeout_seconds}s. Skipping check.[/]"
+        )
+        return False
+    except subprocess.CalledProcessError as err:
+        # Non-zero exit: warn in verbose mode but don't block startup.
+        if get_verbose():
+            get_console().print(
+                "[warning]Breeze self-upgrade check failed (uv returned non-zero). Continuing.[/]\n"
+            )
+            try:
+                if err.stderr:
+                    get_console().print(err.stderr)
+            except Exception:
+                pass
+        return False
+
+    if "Modified" in (res.stderr or ""):
         inform_about_self_upgrade()
         return True
     return False

--- a/dev/breeze/src/airflow_breeze/utils/path_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/path_utils.py
@@ -132,7 +132,7 @@ def reinstall_if_setup_changed() -> bool:
     :return: True if warning was printed.
     """
 
-    timeout_seconds = int(os.environ.get("BREEZE_SELF_UPGRADE_TIMEOUT", "3"))
+    timeout_seconds = int(os.environ.get("BREEZE_SELF_UPGRADE_TIMEOUT", "10"))
     try:
         res = subprocess.run(
             ["uv", "tool", "upgrade", "apache-airflow-breeze"],

--- a/dev/breeze/tests/test_path_utils.py
+++ b/dev/breeze/tests/test_path_utils.py
@@ -1,0 +1,86 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import os
+import subprocess
+from unittest import mock
+
+from airflow_breeze.utils.path_utils import reinstall_if_setup_changed
+
+
+@mock.patch.dict(os.environ, {"BREEZE_SELF_UPGRADE_TIMEOUT": "3"})
+@mock.patch("airflow_breeze.utils.path_utils.inform_about_self_upgrade")
+@mock.patch("airflow_breeze.utils.path_utils.subprocess.run")
+def test_reinstall_if_setup_changed_returns_true_when_modified(mock_subprocess_run, mock_inform):
+    completed = subprocess.CompletedProcess(
+        args=["uv", "tool", "upgrade", "..."],
+        returncode=0,
+        stdout="Updated successfully",
+        stderr="... Modified ...",
+    )
+    mock_subprocess_run.return_value = completed
+
+    result = reinstall_if_setup_changed()
+
+    assert result is True
+    mock_inform.assert_called_once()
+    mock_subprocess_run.assert_called_once_with(
+        ["uv", "tool", "upgrade", "apache-airflow-breeze"],
+        cwd=mock.ANY,
+        check=True,
+        text=True,
+        capture_output=True,
+        timeout=3,
+    )
+
+
+@mock.patch.dict(os.environ, {"BREEZE_SELF_UPGRADE_TIMEOUT": "1"})
+@mock.patch("airflow_breeze.utils.path_utils.get_console")
+@mock.patch("airflow_breeze.utils.path_utils.subprocess.run")
+def test_reinstall_if_setup_changed_timeout(mock_subprocess_run, mock_get_console):
+    """When subprocess.run times out, the function should return False and print a warning."""
+    mock_subprocess_run.side_effect = subprocess.TimeoutExpired(cmd="uv", timeout=1)
+    mock_console = mock.MagicMock()
+    mock_get_console.return_value = mock_console
+
+    res = reinstall_if_setup_changed()
+
+    assert res is False
+    assert mock_console.print.called
+
+
+@mock.patch.dict(os.environ, {"BREEZE_SELF_UPGRADE_TIMEOUT": "2"})
+@mock.patch("airflow_breeze.utils.path_utils.get_console")
+@mock.patch("airflow_breeze.utils.path_utils.get_verbose")
+@mock.patch("airflow_breeze.utils.path_utils.subprocess.run")
+def test_reinstall_if_setup_changed_calledprocesserror_verbose(
+    mock_subprocess_run, mock_get_verbose, mock_get_console
+):
+    """When subprocess.run raises CalledProcessError and verbose is True, we print stderr and return False."""
+    err = subprocess.CalledProcessError(returncode=1, cmd="uv", stderr="some error text")
+    mock_subprocess_run.side_effect = err
+    mock_get_verbose.return_value = True
+    mock_console = mock.MagicMock()
+    mock_get_console.return_value = mock_console
+
+    res = reinstall_if_setup_changed()
+
+    assert res is False
+    # In verbose mode the function should print at least once.
+    assert mock_console.print.called


### PR DESCRIPTION
## What

Implemented a timeout mechanism for the automatic Breeze self-upgrade check.

Introduced the `BREEZE_SELF_UPGRADE_TIMEOUT` environment variable to allow users to configure the timeout duration (default: 10 seconds).

Added error handling to catch subprocess.TimeoutExpired and subprocess.CalledProcessError, ensuring the CLI startup does not crash or hang indefinitely if the upgrade check fails.

## Why
Currently, if we run a Breeze command with a typo (e.g., `breeze ci upgradee`), the terminal doesn't show the error message immediately. Instead, it just blocks/hangs while checking for updates in the background. This makes it hard for users to realize they made a simple typo.

closes: #61125


---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
