### PR TITLE
Fix airflowctl auth login reporting success when keyring backend is unavailable

### DIFF
--- a/airflow-ctl/src/airflowctl/api/client.py
+++ b/airflow-ctl/src/airflowctl/api/client.py
@@ -149,6 +149,9 @@ class Credentials:
                 keyring.set_password("airflowctl", f"api_token_{self.api_environment}", self.api_token)
         except NoKeyringError as e:
             log.error(e)
+            raise AirflowCtlKeyringException(
+                "Keyring backend is not available. Cannot save credentials."
+            ) from e
         except TypeError as e:
             # This happens when the token is None, which is not allowed by keyring
             if self.api_token is None and self.client_kind == ClientKind.CLI:


### PR DESCRIPTION
Credentials.save() caught `NoKeyringError` and logged it without re-raising, so the login command never saw the failure and printed "Login successful!" despite the token never being persisted.

```
2026-01-31 17:14:06 [error    ] No keyring backend available: No recommended backend was available. Install a recommended 3rd party backend package; or, install the keyrings.alt package if you want to use the non-recommended backends. See https://pypi.org/project/keyring for details. [airflowctl.api.client]
2026-01-31 17:14:06 [error    ] No recommended backend was available. Install a recommended 3rd party backend package; or, install the keyrings.alt package if you want to use the non-recommended backends. See https://pypi.org/project/keyring for details. [airflowctl.api.client]
2026-01-31 17:14:06 [error    ] No recommended backend was available. Install a recommended 3rd party backend package; or, install the keyrings.alt package if you want to use the non-recommended backends. See https://pypi.org/project/keyring for details. [airflowctl.api.client]
Login successful! Welcome to airflowctl
```