### PR TITLE
Fail DbtCloudHook.wait_for_job_run_status on ERROR or CANCELLED dbt Cloud job runs

### DIFF
--- a/providers/dbt/cloud/src/airflow/providers/dbt/cloud/hooks/dbt.py
+++ b/providers/dbt/cloud/src/airflow/providers/dbt/cloud/hooks/dbt.py
@@ -797,20 +797,32 @@ class DbtCloudHook(HttpHook):
         :param check_interval: Time in seconds to check on a pipeline run's status.
         :param timeout: Time in seconds to wait for a pipeline to reach a terminal status or the expected
             status.
-        :return: Boolean indicating if the job run has reached the ``expected_status``.
+        :return: ``True`` if the job run has reached the ``expected_status``.
+        :raises: ``DbtCloudJobRunException`` If the job run reaches an unexpected terminal status
+            or does not reach an expected status within the timeout.
         """
         expected_statuses = (expected_statuses,) if isinstance(expected_statuses, int) else expected_statuses
 
         DbtCloudJobRunStatus.check_is_valid(expected_statuses)
 
         job_run_info = JobRunInfo(account_id=account_id, run_id=run_id)
-        job_run_status = self.get_job_run_status(**job_run_info)
 
         start_time = time.monotonic()
 
-        while (
-            not DbtCloudJobRunStatus.is_terminal(job_run_status) and job_run_status not in expected_statuses
-        ):
+        while True:
+            job_run_status = self.get_job_run_status(**job_run_info)
+
+            if job_run_status in expected_statuses:
+                return True
+
+            # Reached terminal failure before expected state.
+            if DbtCloudJobRunStatus.is_terminal(job_run_status):
+                raise DbtCloudJobRunException(
+                    f"Job run {run_id} reached terminal status "
+                    f"{DbtCloudJobRunStatus(job_run_status).name} "
+                    f"before reaching expected statuses {expected_statuses}"
+                )
+
             # Check if the job-run duration has exceeded the ``timeout`` configured.
             if start_time + timeout < time.monotonic():
                 raise DbtCloudJobRunException(
@@ -819,10 +831,6 @@ class DbtCloudHook(HttpHook):
 
             # Wait to check the status of the job run based on the ``check_interval`` configured.
             time.sleep(check_interval)
-
-            job_run_status = self.get_job_run_status(**job_run_info)
-
-        return job_run_status in expected_statuses
 
     @fallback_to_default_account
     def cancel_job_run(self, run_id: int, account_id: int | None = None) -> None:

--- a/providers/dbt/cloud/tests/unit/dbt/cloud/hooks/test_dbt.py
+++ b/providers/dbt/cloud/tests/unit/dbt/cloud/hooks/test_dbt.py
@@ -904,8 +904,8 @@ class TestDbtCloudHook:
 
     wait_for_job_run_status_test_args = [
         (DbtCloudJobRunStatus.SUCCESS.value, DbtCloudJobRunStatus.SUCCESS.value, True),
-        (DbtCloudJobRunStatus.ERROR.value, DbtCloudJobRunStatus.SUCCESS.value, False),
-        (DbtCloudJobRunStatus.CANCELLED.value, DbtCloudJobRunStatus.SUCCESS.value, False),
+        (DbtCloudJobRunStatus.ERROR.value, DbtCloudJobRunStatus.SUCCESS.value, "exception"),
+        (DbtCloudJobRunStatus.CANCELLED.value, DbtCloudJobRunStatus.SUCCESS.value, "exception"),
         (DbtCloudJobRunStatus.RUNNING.value, DbtCloudJobRunStatus.SUCCESS.value, "timeout"),
         (DbtCloudJobRunStatus.QUEUED.value, DbtCloudJobRunStatus.SUCCESS.value, "timeout"),
         (DbtCloudJobRunStatus.STARTING.value, DbtCloudJobRunStatus.SUCCESS.value, "timeout"),
@@ -943,7 +943,7 @@ class TestDbtCloudHook:
         ):
             mock_job_run_status.return_value = job_run_status
 
-            if expected_output != "timeout":
+            if expected_output not in ("timeout", "exception"):
                 assert hook.wait_for_job_run_status(**config) == expected_output
             else:
                 with pytest.raises(DbtCloudJobRunException):

--- a/providers/dbt/cloud/tests/unit/dbt/cloud/operators/test_dbt.py
+++ b/providers/dbt/cloud/tests/unit/dbt/cloud/operators/test_dbt.py
@@ -376,7 +376,7 @@ class TestDbtCloudRunJobOperator:
                 assert mock_run_job.return_value.data["id"] == RUN_ID
             elif expected_output == "exception":
                 # The operator should fail if the job run fails or is cancelled.
-                error_message = r"has failed or has been cancelled\.$"
+                error_message = r"reached terminal status (ERROR|CANCELLED)"
                 with pytest.raises(DbtCloudJobRunException, match=error_message):
                     operator.execute(context=self.mock_context)
             else:


### PR DESCRIPTION
**Description**

This change updates `DbtCloudHook.wait_for_job_run_status` to raise an exception when a dbt Cloud job run reaches an unexpected terminal state (`ERROR` or `CANCELLED`), instead of returning `False`.

The method now behaves as a safe synchronization primitive:

* Returns `True` when the job run reaches an expected status.
* Raises `DbtCloudJobRunException` on terminal failure before the expected state.
* Raises on timeout if the expected status is not reached in time.

**Rationale**

`wait_for_job_run_status` blocks until a job run completes and defaults to waiting for `SUCCESS`. Returning a boolean for terminal failure states is error-prone in an Airflow context, where task success and failure are exception-driven.

The previous behavior allowed Airflow tasks to complete successfully even when the underlying dbt Cloud job failed, which is surprising given the method name, blocking behavior, and default expectations. Raising on unexpected terminal states aligns the method with Airflow execution semantics and prevents silent task success.

**Notes**

`DbtCloudRunJobOperator.on_kill` now treats cancellation confirmation as best-effort and guards against propagated exceptions to avoid masking task termination. Previously, this method relied on a boolean return value from `wait_for_job_run_status` to confirm cancellation. Since `wait_for_job_run_status` can now raise `DbtCloudJobRunException` under normal operation (for example, if the job reaches an unexpected terminal state or the confirmation times out), allowing those exceptions to propagate from `on_kill` could incorrectly surface as task failures during shutdown.

**Tests**

Updated unit tests for `wait_for_job_run_status` to assert exception-driven behavior on terminal job run failures.

**Documentation**

The docstring for `wait_for_job_run_status` has been updated to explicitly document its exception-driven behavior, including the conditions under which `DbtCloudJobRunException` is raised.

**Backwards Compatibility**

This change does not alter the public API or method signature, but it does change runtime behavior:

* Terminal job run failures now raise instead of returning `False`.
* Callers relying on boolean inspection must handle exceptions instead.

This behavior is consistent with Airflow’s exception-driven model and matches user expectations for a blocking “wait until complete” helper.

Closes: #61297