### PR TITLE
Fix links in helm chart package

### DIFF
--- a/dev/README_RELEASE_HELM_CHART.md
+++ b/dev/README_RELEASE_HELM_CHART.md
@@ -225,14 +225,13 @@ rm -rf dist/*
 breeze release-management prepare-helm-chart-tarball --version ${VERSION} --version-suffix ${VERSION_SUFFIX}
 ```
 
+Note: The version suffix is only used for the RC tag and tag message. The version in the tarball is without the suffix, so the tarball can be released as-is when the vote passes.
+
 - Generate the binary Helm Chart release:
 
 ```shell
-breeze release-management prepare-helm-chart-package --sign-email jedcunningham@apache.org --version-suffix ${VERSION_SUFFIX}
+breeze release-management prepare-helm-chart-package --sign-email jedcunningham@apache.org
 ```
-
-Note: The `--version-suffix` parameter is optional but recommended for RC releases to ensure proper documentation
-links generation. When specified, it will generate staging documentation links instead of production ones.
 
 Warning: you need the `helm gpg` plugin to sign the chart (instructions to install it above)
 
@@ -499,8 +498,8 @@ rm -rf dist/*
    check and skip tagging. There is no need to specify version as it is stored in Chart.yaml of the rc tag.
 
 ```shell
-breeze release-management prepare-helm-chart-tarball --version-suffix ${VERSION_SUFFIX} --ignore-version-check --skip-tagging
-breeze release-management prepare-helm-chart-package --version-suffix ${VERSION_SUFFIX}
+breeze release-management prepare-helm-chart-tarball --ignore-version-check --skip-tagging
+breeze release-management prepare-helm-chart-package
 ```
 
 5. Compare the produced tarball binary with ones in SVN:


### PR DESCRIPTION
We do _not_ want the staging links in our RC assets, since we copy those assets over as-is when the vote has passed.

PR #55677 incorrectly assumed there were separate production and RC builds.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)


Generated-by: Cursor CLI (Claude Opus 4.5)
