### PR TITLE
Fix Keycloak double-slash URL bug (#61121)

### DIFF
--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
@@ -412,7 +412,8 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
 
     @staticmethod
     def _get_token_url(server_url, realm):
-        return f"{server_url}/realms/{realm}/protocol/openid-connect/token"
+        # Normalize server_url to avoid double slashes (required for Keycloak 26.4+ strict path validation).
+        return f"{server_url.rstrip('/')}/realms/{realm}/protocol/openid-connect/token"
 
     @staticmethod
     def _get_payload(client_id: str, permission: str, attributes: dict[str, str] | None = None):

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
@@ -559,3 +559,25 @@ class TestKeycloakAuthManager:
             client_secret_key="client_secret",
         )
         assert client == mock_keycloak_openid.return_value
+
+    def test_get_token_url_without_trailing_slash(self, auth_manager):
+        """Test that _get_token_url constructs correct URL when server_url has no trailing slash."""
+        token_url = auth_manager._get_token_url("https://keycloak.example.com/auth", "myrealm")
+        assert token_url == "https://keycloak.example.com/auth/realms/myrealm/protocol/openid-connect/token"
+
+    def test_get_token_url_with_trailing_slash(self, auth_manager):
+        """Test that _get_token_url constructs correct URL when server_url has trailing slash."""
+        token_url = auth_manager._get_token_url("https://keycloak.example.com/auth/", "myrealm")
+        # Should produce the same URL as without trailing slash (no double-slash)
+        assert token_url == "https://keycloak.example.com/auth/realms/myrealm/protocol/openid-connect/token"
+
+    def test_get_token_url_with_multiple_trailing_slashes(self, auth_manager):
+        """Test that _get_token_url handles multiple trailing slashes correctly."""
+        token_url = auth_manager._get_token_url("https://keycloak.example.com/auth///", "myrealm")
+        # Should strip all trailing slashes
+        assert token_url == "https://keycloak.example.com/auth/realms/myrealm/protocol/openid-connect/token"
+
+    def test_get_token_url_with_root_path(self, auth_manager):
+        """Test that _get_token_url works correctly when server_url is at root."""
+        token_url = auth_manager._get_token_url("https://keycloak.example.com/", "myrealm")
+        assert token_url == "https://keycloak.example.com/realms/myrealm/protocol/openid-connect/token"


### PR DESCRIPTION
Fixes #61121 - Fix KeycloakAuthManager double-slash URL construction when server_url has trailing slash

## Description

- Normalize server_url in _get_token_url to prevent double-slashes
- Add .rstrip('/') to handle trailing slashes in server_url configuration
- Add comprehensive tests for URL normalization scenarios
- Resolves compatibility issue with Keycloak 26.4+ strict path validation

When server_url has a trailing slash (e.g., 'https://host/auth/'), the previous implementation would create invalid URLs with double-slashes (e.g., 'https://host/auth//realms/...'), which Keycloak 26.4+ rejects with HTTP 400 'missingNormalization' error.

This fix allows users to configure server_url with or without trailing slashes while ensuring properly normalized URLs are always generated.

## Changes

- **keycloak_auth_manager.py**: Added URL normalization with `.rstrip('/')` in `_get_token_url()` method
- **test_keycloak_auth_manager.py**: Added 4 new test methods covering URL normalization scenarios:
  - `test_get_token_url_without_trailing_slash` - Baseline behavior
  - `test_get_token_url_with_trailing_slash` - Main bug scenario
  - `test_get_token_url_with_multiple_trailing_slashes` - Edge case handling
  - `test_get_token_url_with_root_path` - Root URL scenario

## Testing

- ✅ All ruff linting checks passed
- ✅ Code properly formatted per project standards
- ✅ All new tests pass
- ✅ Backward compatible with existing configurations

## Impact

- **Backward Compatible**: Yes - works with or without trailing slash in configuration
- **Breaking Changes**: None
- **Affected Components**: Keycloak auth manager token URL generation

Fixes #61121

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: GitHub Copilot
---
