### PR TITLE
Move IDE setup scripts to `dev/ide_setup`

### DIFF
--- a/contributing-docs/03a_contributors_quick_start_beginners.rst
+++ b/contributing-docs/03a_contributors_quick_start_beginners.rst
@@ -74,10 +74,10 @@ Option A – Breeze on Your Laptop
 .. code-block:: text
 
     # For IntelliJ IDEA and PyCharm
-    uv run setup_idea.py
+    uv run dev/ide_setup/setup_idea.py
 
     # For VS Code
-    uv run setup_vscode.py
+    uv run dev/ide_setup/setup_vscode.py
 
 3.  **Start the development container** (first run builds the image)
 
@@ -157,7 +157,7 @@ Option B – One-Click GitHub Codespaces
       prek install -f
       prek install -f --hook-type pre-push # for running mypy checks when pushing to repo
       uv tool install -e ./dev/breeze
-      uv run setup_vscode.py
+      uv run dev/ide_setup/setup_vscode.py
       breeze start-airflow
 
 5. Edit a file in the editor, save, and commit via the Source Control sidebar.

--- a/contributing-docs/20_debugging_airflow_components.rst
+++ b/contributing-docs/20_debugging_airflow_components.rst
@@ -106,7 +106,7 @@ Setting up VSCode for Remote Debugging
 
    .. code-block:: bash
 
-       python setup_vscode.py
+       uv run dev/ide_setup/setup_vscode.py
 
    This will create debug configurations for all Airflow components. Here's an example configuration for the scheduler:
 

--- a/contributing-docs/quick-start-ide/contributors_quick_start_pycharm.rst
+++ b/contributing-docs/quick-start-ide/contributors_quick_start_pycharm.rst
@@ -60,7 +60,7 @@ Or for specific provider and its cross-provider dependencies:
 Next: Configure your IDEA project.
 
 3. The fastest way to add source roots is to configure the ``airflow.iml`` file under ``.idea`` directory and update the
-   ``module.xml`` file using the ``setup_idea.py`` script:
+   ``module.xml`` file using the ``dev/ide_setup/setup_idea.py`` script:
 
    To setup the source roots for all the modules that exist in the project, you can run the following command:
    This needs to done on the Airflow repository root directory. It overwrites the existing ``.idea/airflow.iml`` and
@@ -68,7 +68,7 @@ Next: Configure your IDEA project.
 
     .. code-block:: bash
 
-      $ uv run setup_idea.py
+      $ uv run dev/ide_setup/setup_idea.py
 
    Then Restart the PyCharm/IntelliJ IDEA.
 

--- a/dev/ide_setup/setup_idea.py
+++ b/dev/ide_setup/setup_idea.py
@@ -90,7 +90,7 @@ source_root_modules: list[str] = [
 
 all_module_paths: list[str] = []
 
-ROOT_AIRFLOW_FOLDER_PATH = Path(__file__).parent
+ROOT_AIRFLOW_FOLDER_PATH = Path(__file__).parents[2]
 IDEA_FOLDER_PATH = ROOT_AIRFLOW_FOLDER_PATH / ".idea"
 AIRFLOW_IML_FILE = IDEA_FOLDER_PATH / "airflow.iml"
 MODULES_XML_FILE = IDEA_FOLDER_PATH / "modules.xml"

--- a/dev/ide_setup/setup_vscode.py
+++ b/dev/ide_setup/setup_vscode.py
@@ -49,7 +49,7 @@ COMPONENT_NAMES = {
     "edge-worker": "Edge Worker",
 }
 
-ROOT_AIRFLOW_FOLDER_PATH = Path(__file__).parent
+ROOT_AIRFLOW_FOLDER_PATH = Path(__file__).parents[2]
 VSCODE_FOLDER_PATH = ROOT_AIRFLOW_FOLDER_PATH / ".vscode"
 LAUNCH_JSON_FILE = VSCODE_FOLDER_PATH / "launch.json"
 


### PR DESCRIPTION
Moves `setup_idea.py` and `setup_vscode.py` from the repo root to `dev/ide_setup` to declutter the root directory. Updates the scripts to correctly resolve the repository root from their new location, and updates documentation references to point to the new paths.

##### Was generative AI tooling used to co-author this PR?


- [x] Yes (please specify the tool below)


Generated-by: Cursor CLI (Gemini 3 Pro)
