### PR TITLE
docs: add DAG documentation for example_bash_operator

### DIFF
--- a/providers/standard/src/airflow/providers/standard/example_dags/example_bash_operator.py
+++ b/providers/standard/src/airflow/providers/standard/example_dags/example_bash_operator.py
@@ -36,6 +36,21 @@ with DAG(
     tags=["example", "example2"],
     params={"example_key": "example_value"},
 ) as dag:
+    dag.doc_md = """
+    ### Example BashOperator DAG
+
+    This DAG demonstrates how to use the **BashOperator** to execute shell commands
+    as part of an Apache Airflow workflow.
+
+    **What this DAG shows:**
+    - Defining tasks using `BashOperator`
+    - Executing simple bash commands
+    - Creating task dependencies, including loops and templated commands
+
+    This example is intended for beginners who want to understand how Airflow
+    interacts with system-level commands using bash.
+    """
+
     run_this_last = EmptyOperator(
         task_id="run_this_last",
     )


### PR DESCRIPTION
What does this PR do?
-> Adds DAG-level documentation (doc_md) to the example_bash_operator DAG
-> Improves clarity for users via the Airflow UI Docs tab

Which issue does this PR close?
Closes issue: #60128

Additional Notes:
-> This is my first contribution to Apache Airflow. Feedback is welcome!!
