### PR TITLE
Clarify warning for partition-driven DAGs in dags next-execution

### DIFF
--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -336,6 +336,7 @@ def dag_next_execution(args) -> None:
             print(
                 "[WARN] No following schedule can be found. "
                 "This DAG may have schedule interval '@once' or `None`.",
+                "or have a schedule of '@once' or None.",
                 file=sys.stderr,
             )
             print(None)


### PR DESCRIPTION
What does this PR do?

Clarifies the warning message shown by `airflow dags next-execution` when no next
data interval can be determined, noting that this can also occur for
dataset- or partition-driven DAGs.

Why is this needed?

With AIP-76, partition-driven and dataset-driven DAGs may not have a
determinable next execution date. The previous message only mentioned
`@once` or `None` schedules, which could be misleading.

This change improves CLI clarity without altering behavior.

How was this tested?

- Manual verification of CLI output

Related issue

- https://github.com/apache/airflow/issues/61076