### PR TITLE
Return list of destination URIs from GCSToGCSOperator

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
@@ -278,19 +278,16 @@ class GCSToGCSOperator(BaseOperator):
         for prefix in self.source_objects:
             # Check if prefix contains wildcard
             if WILDCARD in prefix:
-                destination_uris_result.extend(
-                    self._copy_source_with_wildcard(hook=hook, prefix=prefix)
-                )
+                destination_uris_result.extend(self._copy_source_with_wildcard(hook=hook, prefix=prefix))
             # Now search with prefix using provided delimiter if any
             else:
-                destination_uris_result.extend(
-                    self._copy_source_without_wildcard(hook=hook, prefix=prefix)
-                )
+                destination_uris_result.extend(self._copy_source_without_wildcard(hook=hook, prefix=prefix))
 
         # Deduplicate while preserving order. Same destination URI can appear when multiple
         # source paths map to one file, e.g. source_objects=["src/foo.png", "src/data/"] with
         # data/ containing foo.png yields backup/list/foo.png twice.
         destination_uris_result = list(dict.fromkeys(destination_uris_result))
+
         # Exclude directory-like URIs (ending with /) from return; copy behavior is unchanged.
         return [u for u in destination_uris_result if not u.endswith("/")]
 
@@ -430,9 +427,7 @@ class GCSToGCSOperator(BaseOperator):
         if len(objects) == 1 and objects[0][-1] != "/":
             result_uris.extend(self._copy_file(hook=hook, source_object=objects[0]))
         elif len(objects):
-            result_uris.extend(
-                self._copy_multiple_objects(hook=hook, source_objects=objects, prefix=prefix)
-            )
+            result_uris.extend(self._copy_multiple_objects(hook=hook, source_objects=objects, prefix=prefix))
         return result_uris
 
     def _copy_file(self, hook, source_object) -> list[str]:

--- a/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
@@ -237,7 +237,7 @@ class GCSToGCSOperator(BaseOperator):
         self.exact_match = exact_match
         self.match_glob = match_glob
 
-    def execute(self, context: Context):
+    def execute(self, context: Context) -> list[str]:
         hook = GCSHook(
             gcp_conn_id=self.gcp_conn_id,
             impersonation_chain=self.impersonation_chain,
@@ -274,13 +274,25 @@ class GCSToGCSOperator(BaseOperator):
             raise AirflowException("You can't have two empty strings inside source_object")
 
         # Iterate over the source_objects and do the copy
+        destination_uris_result: list[str] = []
         for prefix in self.source_objects:
             # Check if prefix contains wildcard
             if WILDCARD in prefix:
-                self._copy_source_with_wildcard(hook=hook, prefix=prefix)
+                destination_uris_result.extend(
+                    self._copy_source_with_wildcard(hook=hook, prefix=prefix)
+                )
             # Now search with prefix using provided delimiter if any
             else:
-                self._copy_source_without_wildcard(hook=hook, prefix=prefix)
+                destination_uris_result.extend(
+                    self._copy_source_without_wildcard(hook=hook, prefix=prefix)
+                )
+
+        # Deduplicate while preserving order. Same destination URI can appear when multiple
+        # source paths map to one file, e.g. source_objects=["src/foo.png", "src/data/"] with
+        # data/ containing foo.png yields backup/list/foo.png twice.
+        destination_uris_result = list(dict.fromkeys(destination_uris_result))
+        # Exclude directory-like URIs (ending with /) from return; copy behavior is unchanged.
+        return [u for u in destination_uris_result if not u.endswith("/")]
 
     def _ignore_existing_files(self, hook, prefix, **kwargs):
         # list all files in the Destination GCS bucket
@@ -312,9 +324,11 @@ class GCSToGCSOperator(BaseOperator):
             self.log.info("There are no new files to sync. Have a nice day!")
         return objects
 
-    def _copy_source_without_wildcard(self, hook, prefix):
+    def _copy_source_without_wildcard(self, hook, prefix) -> list[str]:
         """
         List all files in source_objects, copy files to destination_object, and rename each source file.
+
+        :return: List of destination URIs (gs://bucket/object) for files that were copied.
 
         For source_objects with no wildcard, this operator would first list
         all files in source_objects, using provided delimiter if any. Then copy
@@ -399,32 +413,39 @@ class GCSToGCSOperator(BaseOperator):
                 hook, prefix, objects=objects, delimiter=self.delimiter, match_glob=self.match_glob
             )
 
+        result_uris: list[str] = []
         # If objects is empty, and we have prefix, let's check if prefix is a blob
         # and copy directly
         if len(objects) == 0 and prefix:
             if hook.exists(self.source_bucket, prefix):
-                self._copy_single_object(
+                uri = self._copy_single_object(
                     hook=hook, source_object=prefix, destination_object=self.destination_object
                 )
+                if uri:
+                    result_uris.append(uri)
             elif self.source_object_required:
                 msg = f"{prefix} does not exist in bucket {self.source_bucket}"
                 self.log.warning(msg)
                 raise AirflowException(msg)
         if len(objects) == 1 and objects[0][-1] != "/":
-            self._copy_file(hook=hook, source_object=objects[0])
+            result_uris.extend(self._copy_file(hook=hook, source_object=objects[0]))
         elif len(objects):
-            self._copy_multiple_objects(hook=hook, source_objects=objects, prefix=prefix)
+            result_uris.extend(
+                self._copy_multiple_objects(hook=hook, source_objects=objects, prefix=prefix)
+            )
+        return result_uris
 
-    def _copy_file(self, hook, source_object):
+    def _copy_file(self, hook, source_object) -> list[str]:
         destination_object = self.destination_object or source_object
         if self.destination_object and self.destination_object[-1] == "/":
             file_name = source_object.split("/")[-1]
             destination_object += file_name
-        self._copy_single_object(
+        uri = self._copy_single_object(
             hook=hook, source_object=source_object, destination_object=destination_object
         )
+        return [uri] if uri else []
 
-    def _copy_multiple_objects(self, hook, source_objects, prefix):
+    def _copy_multiple_objects(self, hook, source_objects, prefix) -> list[str]:
         # Check whether the prefix is a root directory for all the rest of objects.
         _pref = prefix.rstrip("/")
         is_directory = prefix.endswith("/") or all(
@@ -436,6 +457,7 @@ class GCSToGCSOperator(BaseOperator):
         else:
             base_path = prefix[0 : prefix.rfind("/") + 1] if "/" in prefix else ""
 
+        result_uris: list[str] = []
         for source_obj in source_objects:
             if not self._check_exact_match(source_obj, prefix):
                 continue
@@ -445,9 +467,12 @@ class GCSToGCSOperator(BaseOperator):
                 file_name_postfix = source_obj.replace(base_path, "", 1)
                 destination_object = self.destination_object.rstrip("/") + "/" + file_name_postfix
 
-            self._copy_single_object(
+            uri = self._copy_single_object(
                 hook=hook, source_object=source_obj, destination_object=destination_object
             )
+            if uri:
+                result_uris.append(uri)
+        return result_uris
 
     def _check_exact_match(self, source_object: str, prefix: str) -> bool:
         """Check whether source_object's name matches the prefix according to the exact_match flag."""
@@ -455,7 +480,7 @@ class GCSToGCSOperator(BaseOperator):
             return False
         return True
 
-    def _copy_source_with_wildcard(self, hook, prefix):
+    def _copy_source_with_wildcard(self, hook, prefix) -> list[str]:
         total_wildcards = prefix.count(WILDCARD)
         if total_wildcards > 1:
             error_msg = (
@@ -480,17 +505,22 @@ class GCSToGCSOperator(BaseOperator):
             #       remove previous line and uncomment the following:
             # objects = self._ignore_existing_files(hook, prefix_, match_glob=match_glob, objects=objects)
 
+        result_uris: list[str] = []
         for source_object in objects:
             if self.destination_object is None:
                 destination_object = source_object
             else:
                 destination_object = source_object.replace(prefix_, self.destination_object, 1)
 
-            self._copy_single_object(
+            uri = self._copy_single_object(
                 hook=hook, source_object=source_object, destination_object=destination_object
             )
+            if uri:
+                result_uris.append(uri)
+        return result_uris
 
-    def _copy_single_object(self, hook, source_object, destination_object):
+    def _copy_single_object(self, hook, source_object, destination_object) -> str | None:
+        dest_bucket = self.destination_bucket
         if self.is_older_than:
             # Here we check if the given object is older than the given time
             # If given, last_modified_time and maximum_modified_time is ignored
@@ -498,7 +528,7 @@ class GCSToGCSOperator(BaseOperator):
                 self.log.info("Object is older than %s seconds ago", self.is_older_than)
             else:
                 self.log.debug("Object is not older than %s seconds ago", self.is_older_than)
-                return
+                return None
         elif self.last_modified_time and self.maximum_modified_time:
             # check to see if object was modified between last_modified_time and
             # maximum_modified_time
@@ -516,7 +546,7 @@ class GCSToGCSOperator(BaseOperator):
                     self.last_modified_time,
                     self.maximum_modified_time,
                 )
-                return
+                return None
 
         elif self.last_modified_time is not None:
             # Check to see if object was modified after last_modified_time
@@ -524,26 +554,28 @@ class GCSToGCSOperator(BaseOperator):
                 self.log.info("Object has been modified after %s ", self.last_modified_time)
             else:
                 self.log.debug("Object was not modified after %s ", self.last_modified_time)
-                return
+                return None
         elif self.maximum_modified_time is not None:
             # Check to see if object was modified before maximum_modified_time
             if hook.is_updated_before(self.source_bucket, source_object, self.maximum_modified_time):
                 self.log.info("Object has been modified before %s ", self.maximum_modified_time)
             else:
                 self.log.debug("Object was not modified before %s ", self.maximum_modified_time)
-                return
+                return None
 
         self.log.info(
             "Executing copy of gs://%s/%s to gs://%s/%s",
             self.source_bucket,
             source_object,
-            self.destination_bucket,
+            dest_bucket,
             destination_object,
         )
-        hook.rewrite(self.source_bucket, source_object, self.destination_bucket, destination_object)
+        hook.rewrite(self.source_bucket, source_object, dest_bucket, destination_object)
 
         if self.move_object:
             hook.delete(self.source_bucket, source_object)
+
+        return f"gs://{dest_bucket}/{destination_object}"
 
     def get_openlineage_facets_on_complete(self, task_instance):
         """

--- a/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_gcs.py
@@ -1000,3 +1000,65 @@ class TestGoogleCloudStorageToCloudStorageOperator:
         assert all(element in inputs for element in lineage.inputs)
         assert all(element in lineage.outputs for element in outputs)
         assert all(element in outputs for element in lineage.outputs)
+
+    # Return value tests
+    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSHook")
+    def test_execute_returns_list_of_destination_uris_single_file(self, mock_hook):
+        mock_hook.return_value.list.return_value = [SOURCE_OBJECT_NO_WILDCARD]
+        operator = GCSToGCSOperator(
+            task_id=TASK_ID,
+            source_bucket=TEST_BUCKET,
+            source_object=SOURCE_OBJECT_NO_WILDCARD,
+            destination_bucket=DESTINATION_BUCKET,
+            destination_object=DESTINATION_OBJECT_PREFIX + "/",
+            exact_match=True,
+        )
+        result = operator.execute(None)
+        expected_uri = f"gs://{DESTINATION_BUCKET}/{DESTINATION_OBJECT_PREFIX}/{SOURCE_OBJECT_NO_WILDCARD}"
+        assert result == [expected_uri]
+
+    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSHook")
+    def test_execute_returns_list_of_destination_uris_multiple_files(self, mock_hook):
+        mock_hook.return_value.list.return_value = SOURCE_OBJECTS_LIST
+        with pytest.warns(AirflowProviderDeprecationWarning, match="Usage of wildcard"):
+            operator = GCSToGCSOperator(
+                task_id=TASK_ID,
+                source_bucket=TEST_BUCKET,
+                source_object=SOURCE_OBJECT_WILDCARD_FILENAME,
+                destination_bucket=DESTINATION_BUCKET,
+                destination_object=DESTINATION_OBJECT_PREFIX,
+            )
+        result = operator.execute(None)
+        expected = [
+            f"gs://{DESTINATION_BUCKET}/foo/bar/file1.txt",
+            f"gs://{DESTINATION_BUCKET}/foo/bar/file2.txt",
+            f"gs://{DESTINATION_BUCKET}/foo/bar/file3.json"
+        ]
+        assert sorted(result) == sorted(expected)
+
+    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSHook")
+    def test_execute_returns_empty_list_when_no_files_copied(self, mock_hook):
+        mock_hook.return_value.is_updated_after.return_value = False
+        operator = GCSToGCSOperator(
+            task_id=TASK_ID,
+            source_bucket=TEST_BUCKET,
+            source_object=SOURCE_OBJECT_NO_WILDCARD,
+            destination_bucket=DESTINATION_BUCKET,
+            destination_object=SOURCE_OBJECT_NO_WILDCARD,
+            last_modified_time=MOD_TIME_1,
+        )
+        result = operator.execute(None)
+        assert result == []
+
+    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSHook")
+    def test_execute_excludes_directory_uri_from_return(self, mock_hook):
+        mock_hook.return_value.list.return_value = ["prefix/file.txt", "prefix/"]
+        operator = GCSToGCSOperator(
+            task_id=TASK_ID,
+            source_bucket=TEST_BUCKET,
+            source_objects=["prefix/"],
+            destination_bucket=DESTINATION_BUCKET,
+            destination_object="backup/",
+        )
+        result = operator.execute(None)
+        assert result == [f"gs://{DESTINATION_BUCKET}/backup/file.txt"]

--- a/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_gcs.py
@@ -1032,7 +1032,7 @@ class TestGoogleCloudStorageToCloudStorageOperator:
         expected = [
             f"gs://{DESTINATION_BUCKET}/foo/bar/file1.txt",
             f"gs://{DESTINATION_BUCKET}/foo/bar/file2.txt",
-            f"gs://{DESTINATION_BUCKET}/foo/bar/file3.json"
+            f"gs://{DESTINATION_BUCKET}/foo/bar/file3.json",
         ]
         assert sorted(result) == sorted(expected)
 


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

Related: #11323

- **Return value:** `execute()` now returns a `list[str]` of destination URIs for copied objects (single and multiple files). This operator did not return a value before, so `unwrap_single` was not added.

- **Deduplication for multi-file copy:** When multiple source paths map to the same destination (e.g. `source_objects=["src/foo.png", "src/data/"]` with `foo.png` under `data/`), the same URI can appear more than once. The result list is deduplicated while preserving order via `dict.fromkeys`.

- **Directory-like URIs excluded from return:** If GCS `list` returns keys ending with `/` (e.g. `prefix/`), they are still copied, but such URIs are filtered out of the returned list so only file URIs are included.

---

## Test screenshot

<img width="1092" height="388" alt="image" src="https://github.com/user-attachments/assets/29f6517a-b9b5-4a61-9f58-019d7f81ece7" />


---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)
  - Cursor

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
