### PR TITLE
AIP-67 Fix incomplete workload payloads in Celery executor integration test

### DIFF
--- a/providers/celery/tests/integration/celery/test_celery_executor.py
+++ b/providers/celery/tests/integration/celery/test_celery_executor.py
@@ -186,11 +186,13 @@ class TestCeleryExecutor:
             with start_worker(app=app, logfile=sys.stdout, loglevel="info"):
                 ti = workloads.TaskInstance.model_construct(
                     id=uuid7(),
+                    dag_version_id=uuid7(),
                     task_id="success",
                     dag_id="id",
                     run_id="abc",
                     try_number=0,
                     priority_weight=1,
+                    pool_slots=1,
                     queue=celery_executor_utils.get_celery_configuration()["task_default_queue"],
                     executor_config=executor_config,
                 )
@@ -199,8 +201,22 @@ class TestCeleryExecutor:
                     TaskInstanceKey("id", "fail", "abc", 0, -1),
                 ]
                 for w in (
-                    workloads.ExecuteTask.model_construct(ti=ti),
-                    workloads.ExecuteTask.model_construct(ti=ti.model_copy(update={"task_id": "fail"})),
+                    workloads.ExecuteTask.model_construct(
+                        ti=ti,
+                        token="",
+                        dag_rel_path="",
+                        bundle_info=workloads.BundleInfo(name="test"),
+                        log_path=None,
+                        type="ExecuteTask",
+                    ),
+                    workloads.ExecuteTask.model_construct(
+                        ti=ti.model_copy(update={"task_id": "fail"}),
+                        token="",
+                        dag_rel_path="",
+                        bundle_info=workloads.BundleInfo(name="test"),
+                        log_path=None,
+                        type="ExecuteTask",
+                    ),
                 ):
                     executor.queue_workload(w, session=None)
 


### PR DESCRIPTION
The test constructed ExecuteTask and TaskInstance via model_construct(),
which bypasses Pydantic validation. Fields added or made required by
#50825 (dag_version_id, pool_slots) and inherited from BaseDagBundleWorkload
(token, dag_rel_path, bundle_info, log_path) were missing. This went
unnoticed until #60675 changed task dispatch to run in ProcessPoolExecutor
subprocesses where mock patches don't apply, causing the real
execute_workload (with full schema validation) to run on the worker.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
ClaudeCode
