### PR TITLE
Exclude unnecessary ui build artifacts from wheel

### DIFF
--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -260,9 +260,9 @@ artifacts = [
     "src/airflow/git_version"
 ]
 exclude = [
-    "src/airflow/ui/node_modules/",
-    "src/airflow/api_fastapi/auth/managers/simple/ui/node_modules",
-    "src/airflow/ui/openapi.merged.json",
+    # Only dist/ (declared as artifacts) is needed
+    "src/airflow/ui/**",
+    "src/airflow/api_fastapi/auth/managers/simple/ui/**",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

## Related Issue

closes #59821

## Why

Production wheels ship 872 unnecessary frontend dev files (package.json, pnpm-lock.yaml, TypeScript source, configs, etc.) that bloat the wheel by ~1.5MB. Only the pre-built dist/ directories are needed at runtime.

## How

Replace the narrow node_modules/-only excludes in the wheel target with ** globs that exclude everything under UI folder.
The dist/ folders are preserved because hatch artifacts override exclude patterns.

```
Before:                                                                                                                 
5.6M  apache_airflow_core-3.2.0-py3-none-any.whl (1806 files)                                                           
                                                                                                                        
After:                                                                                                                  
4.1M  apache_airflow_core-3.2.0-py3-none-any.whl (935 files) 
```

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
