### PR TITLE
Remove breaking change for createUser in Chart

### DIFF
--- a/chart/RELEASE_NOTES.rst
+++ b/chart/RELEASE_NOTES.rst
@@ -53,6 +53,17 @@ This change introduces support for advanced Celery Workers topologies to Apache 
 
 **Granular Configuration Overrides**: This change allows for overwrite of any currently available workers configuration per worker set. For example, a user can enable KEDA globally, but explicitly disable it for a specific worker set that requires a static number of replicas.
 
+Options to create a default user have been moved under the ``createUserJob`` section
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+Please update your configuration accordingly:
+
+* ``webserver.defaultUser`` section is now deprecated in favor of ``createUserJob`` (#59767)
+
+The previous configuration options are still working but are deprecated and will be removed in a future version.
+
+Note that the previous documentation described also the option ``apiServer.defaultUser``, which was never implemented in the chart. The only supported option is now ``createUserJob``. Using ``apiServer.defaultUser`` will raise an error.
+
 Celery specific config options have been moved under the ``celery`` section in ``workers``
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 

--- a/chart/reproducible_build.yaml
+++ b/chart/reproducible_build.yaml
@@ -1,2 +1,2 @@
-release-notes-hash: b0ace4cbce4fe3f1c34de9c60ecc7fb7
-source-date-epoch: 1769927217
+release-notes-hash: b769a1a52290c4c11fc21615511aef6d
+source-date-epoch: 1769977763

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -114,7 +114,11 @@ Flower Dashboard:      kubectl port-forward svc/{{ include "airflow.fullname" . 
 {{- end }}
 
 
-{{- if .Values.createUserJob.enabled}}
+{{- if and .Values.webserver.defaultUser .Values.webserver.defaultUser.enabled}}
+Default user (Airflow UI) Login credentials:
+    username: {{ .Values.createUserJob.defaultUser.username }}
+    password: {{ .Values.createUserJob.defaultUser.password }}
+{{- else if .Values.createUserJob.enabled}}
 Default user (Airflow UI) Login credentials:
     username: {{ .Values.createUserJob.defaultUser.username }}
     password: {{ .Values.createUserJob.defaultUser.password }}
@@ -336,6 +340,14 @@ DEPRECATION WARNING:
 
  DEPRECATION WARNING:
     `workers.podManagementPolicy` has been renamed to `workers.celery.podManagementPolicy`.
+    Please change your values as support for the old name will be dropped in a future release.
+
+{{- end }}
+
+{{- if not (empty .Values.webserver.defaultUser) }}
+
+ DEPRECATION WARNING:
+    `webserver.defaultUser` has been renamed to `createUserJob.defaultUser`.
     Please change your values as support for the old name will be dropped in a future release.
 
 {{- end }}

--- a/chart/templates/jobs/create-user-job-serviceaccount.yaml
+++ b/chart/templates/jobs/create-user-job-serviceaccount.yaml
@@ -17,9 +17,9 @@
  under the License.
 */}}
 
-###########################################
+#########################################
 ## Airflow Create User Job ServiceAccount
-###########################################
+#########################################
 {{- if .Values.createUserJob.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount

--- a/chart/templates/jobs/create-user-job.yaml
+++ b/chart/templates/jobs/create-user-job.yaml
@@ -17,10 +17,10 @@
  under the License.
 */}}
 
-################################
+##########################
 ## Airflow Create User Job
-#################################
-{{- if .Values.createUserJob.enabled }}
+##########################
+{{- if or (and .Values.webserver.defaultUser .Values.webserver.defaultUser.enabled) .Values.createUserJob.enabled }}
 {{- $nodeSelector := or .Values.createUserJob.nodeSelector .Values.nodeSelector }}
 {{- $affinity := or .Values.createUserJob.affinity .Values.affinity }}
 {{- $tolerations := or .Values.createUserJob.tolerations .Values.tolerations }}

--- a/chart/templates/rbac/security-context-constraint-rolebinding.yaml
+++ b/chart/templates/rbac/security-context-constraint-rolebinding.yaml
@@ -17,9 +17,9 @@
  under the License.
 */}}
 
-################################
+###########################
 ## Airflow SCC Role Binding
-#################################
+###########################
 {{- if and .Values.rbac.create .Values.rbac.createSCCRoleBinding }}
 {{- $hasWorkers := has .Values.executor (list "CeleryExecutor" "LocalKubernetesExecutor" "KubernetesExecutor" "CeleryKubernetesExecutor") }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -88,7 +88,7 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "migrateDatabaseJob.serviceAccountName" . }}
     namespace: "{{ .Release.Namespace }}"
-  {{- if .Values.createUserJob.enabled }}
+  {{- if or (and .Values.webserver.defaultUser .Values.webserver.defaultUser.enabled) .Values.createUserJob.enabled }}
   - kind: ServiceAccount
     name: {{ include "createUserJob.serviceAccountName" . }}
     namespace: "{{ .Release.Namespace }}"

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -5027,17 +5027,17 @@
                         "exec \\\nairflow {{ semverCompare \">=2.0.0\" .Values.airflowVersion | ternary \"users create\" \"create_user\" }} \"$@\"",
                         "--",
                         "-r",
-                        "{{ .Values.createUserJob.defaultUser.role }}",
+                        "{{ if .Values.webserver.defaultUser }}{{ .Values.webserver.defaultUser.role }}{{ else }}{{ .Values.createUserJob.defaultUser.role }}{{ end }}",
                         "-u",
-                        "{{ .Values.createUserJob.defaultUser.username }}",
+                        "{{ if .Values.webserver.defaultUser }}{{ .Values.webserver.defaultUser.username }}{{ else }}{{ .Values.createUserJob.defaultUser.username }}{{ end }}",
                         "-e",
-                        "{{ .Values.createUserJob.defaultUser.email }}",
+                        "{{ if .Values.webserver.defaultUser }}{{ .Values.webserver.defaultUser.email }}{{ else }}{{ .Values.createUserJob.defaultUser.email }}{{ end }}",
                         "-f",
-                        "{{ .Values.createUserJob.defaultUser.firstName }}",
+                        "{{ if .Values.webserver.defaultUser }}{{ .Values.webserver.defaultUser.firstName }}{{ else }}{{ .Values.createUserJob.defaultUser.firstName }}{{ end }}",
                         "-l",
-                        "{{ .Values.createUserJob.defaultUser.lastName }}",
+                        "{{ if .Values.webserver.defaultUser }}{{ .Values.webserver.defaultUser.lastName }}{{ else }}{{ .Values.createUserJob.defaultUser.lastName }}{{ end }}",
                         "-p",
-                        "{{ .Values.createUserJob.defaultUser.password }}"
+                        "{{ if .Values.webserver.defaultUser }}{{ .Values.webserver.defaultUser.password }}{{ else }}{{ .Values.createUserJob.defaultUser.password }}{{ end }}"
                     ]
                 },
                 "annotations": {
@@ -6878,6 +6878,42 @@
                         }
                     ],
                     "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements"
+                },
+                "defaultUser": {
+                    "description": "Optional default Airflow user information (deprecated, use createUserJob section instead)",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "enabled": {
+                            "description": "Enable default user creation.",
+                            "type": "boolean",
+                            "x-docsSection": "Common"
+                        },
+                        "role": {
+                            "description": "Default user role.",
+                            "type": "string"
+                        },
+                        "username": {
+                            "description": "Default user username.",
+                            "type": "string"
+                        },
+                        "email": {
+                            "description": "Default user email address.",
+                            "type": "string"
+                        },
+                        "firstName": {
+                            "description": "Default user firstname.",
+                            "type": "string"
+                        },
+                        "lastName": {
+                            "description": "Default user lastname.",
+                            "type": "string"
+                        },
+                        "password": {
+                            "description": "Default user password.",
+                            "type": "string"
+                        }
+                    }
                 },
                 "extraContainers": {
                     "description": "Launch additional containers into webserver (templated).",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1414,19 +1414,19 @@ createUserJob:
       exec \
       airflow {{ semverCompare ">=2.0.0" .Values.airflowVersion | ternary "users create" "create_user" }} "$@"
     - --
+    # yamllint disable rule:line-length
     - "-r"
-    - "{{ .Values.createUserJob.defaultUser.role }}"
+    - "{{ if .Values.webserver.defaultUser }}{{ .Values.webserver.defaultUser.role }}{{ else }}{{ .Values.createUserJob.defaultUser.role }}{{ end }}"
     - "-u"
-    - "{{ .Values.createUserJob.defaultUser.username }}"
+    - "{{ if .Values.webserver.defaultUser }}{{ .Values.webserver.defaultUser.username }}{{ else }}{{ .Values.createUserJob.defaultUser.username }}{{ end }}"
     - "-e"
-    - "{{ .Values.createUserJob.defaultUser.email }}"
+    - "{{ if .Values.webserver.defaultUser }}{{ .Values.webserver.defaultUser.email }}{{ else }}{{ .Values.createUserJob.defaultUser.email }}{{ end }}"
     - "-f"
-    - "{{ .Values.createUserJob.defaultUser.firstName }}"
+    - "{{ if .Values.webserver.defaultUser }}{{ .Values.webserver.defaultUser.firstName }}{{ else }}{{ .Values.createUserJob.defaultUser.firstName }}{{ end }}"
     - "-l"
-    - "{{ .Values.createUserJob.defaultUser.lastName }}"
+    - "{{ if .Values.webserver.defaultUser }}{{ .Values.webserver.defaultUser.lastName }}{{ else }}{{ .Values.createUserJob.defaultUser.lastName }}{{ end }}"
     - "-p"
-    - "{{ .Values.createUserJob.defaultUser.password }}"
-
+    - "{{ if .Values.webserver.defaultUser }}{{ .Values.webserver.defaultUser.password }}{{ else }}{{ .Values.createUserJob.defaultUser.password }}{{ end }}"
   # Annotations on the create user job pod
   annotations: {}
   # jobAnnotations are annotations on the create user job
@@ -1929,6 +1929,16 @@ webserver:
   #   requests:
   #     cpu: 100m
   #     memory: 128Mi
+
+  # Create initial user. (Note: Deprecated, use createUserJob section instead)
+  # defaultUser:
+  #   enabled: true
+  #   role: Admin
+  #   username: admin
+  #   email: admin@example.com
+  #   firstName: admin
+  #   lastName: user
+  #   password: admin
 
   # Launch additional containers into webserver (templated).
   extraContainers: []


### PR DESCRIPTION
Pull requests #59767 #59762 broke the backwards compatibility and therefore violated against SemVer promise of Helm Chart.

Therefore as a fix, this PR restores the possibility to still (deprecated) define the user via `webserver.defaultUser`.

Note: The PR doe NOT restore the property `apiServer.defaultUser` as besides schema definition the property was not used and was broken anyway. Specifying this in a previous config had no effect. If in 1.19.0 somebody will specify it it will raise an error instead.

---

##### Was generative AI tooling used to co-author this PR?

- [ ] No (please specify the tool below)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
