### PR TITLE
Return files destination uris in `GoogleDriverToGCSOperator` and `SheetsToGCSOperator`

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/transfers/gdrive_to_gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/gdrive_to_gcs.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
 from airflow.providers.google.suite.hooks.drive import GoogleDriveHook
@@ -88,6 +88,7 @@ class GoogleDriveToGCSOperator(BaseOperator):
         if unwrap_single is None:
             self.unwrap_single = True
             import warnings
+
             warnings.warn(
                 "The default value of unwrap_single will change from True to False in a future release. "
                 "Please set unwrap_single explicitly to avoid this warning.",
@@ -113,10 +114,10 @@ class GoogleDriveToGCSOperator(BaseOperator):
             bucket_name=self.bucket_name, object_name=self.object_name
         ) as file:
             gdrive_hook.download_file(file_id=file_metadata["id"], file_handle=file)
-        
+
         gcs_uri = f"gs://{self.bucket_name}/{self.object_name}"
         result = [gcs_uri]
-        
+
         if self.unwrap_single:
             return result[0]
         return result

--- a/providers/google/src/airflow/providers/google/cloud/transfers/gdrive_to_gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/gdrive_to_gcs.py
@@ -51,8 +51,6 @@ class GoogleDriveToGCSOperator(BaseOperator):
         If set as a sequence, the identities from the list must grant
         Service Account Token Creator IAM role to the directly preceding identity, with first
         account from the list granting this role to the originating account (templated).
-    :param unwrap_single: If True (default), returns a single URI string when there's only one file.
-        If False, always returns a list of URIs. Default will change to False in a future release.
     """
 
     template_fields: Sequence[str] = (
@@ -74,7 +72,6 @@ class GoogleDriveToGCSOperator(BaseOperator):
         drive_id: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
-        unwrap_single: bool | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -85,20 +82,8 @@ class GoogleDriveToGCSOperator(BaseOperator):
         self.file_name = file_name
         self.gcp_conn_id = gcp_conn_id
         self.impersonation_chain = impersonation_chain
-        if unwrap_single is None:
-            self.unwrap_single = True
-            import warnings
 
-            warnings.warn(
-                "The default value of unwrap_single will change from True to False in a future release. "
-                "Please set unwrap_single explicitly to avoid this warning.",
-                FutureWarning,
-                stacklevel=2,
-            )
-        else:
-            self.unwrap_single = unwrap_single
-
-    def execute(self, context: Context) -> str | list[str]:
+    def execute(self, context: Context) -> list[str]:
         gdrive_hook = GoogleDriveHook(
             gcp_conn_id=self.gcp_conn_id,
             impersonation_chain=self.impersonation_chain,
@@ -118,8 +103,6 @@ class GoogleDriveToGCSOperator(BaseOperator):
         gcs_uri = f"gs://{self.bucket_name}/{self.object_name}"
         result = [gcs_uri]
 
-        if self.unwrap_single:
-            return result[0]
         return result
 
     def dry_run(self):

--- a/providers/google/src/airflow/providers/google/cloud/transfers/sheets_to_gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/sheets_to_gcs.py
@@ -53,8 +53,9 @@ class GoogleSheetsToGCSOperator(BaseOperator):
         If set as a sequence, the identities from the list must grant
         Service Account Token Creator IAM role to the directly preceding identity, with first
         account from the list granting this role to the originating account (templated).
-    :param unwrap_single: If True (default), returns a single URI string when there's only one file.
-        If False, always returns a list of URIs. Default will change to False in a future release.
+    :param return_gcs_uris: If True, returns full GCS URIs (e.g., ``gs://bucket/path/file.csv``).
+        If False (default), returns object names only (e.g., ``path/to/file.csv``).
+        Default will change to True in a future release.
     """
 
     template_fields: Sequence[str] = (
@@ -74,7 +75,7 @@ class GoogleSheetsToGCSOperator(BaseOperator):
         destination_path: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
         impersonation_chain: str | Sequence[str] | None = None,
-        unwrap_single: bool | None = None,
+        return_gcs_uris: bool = False,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -84,18 +85,16 @@ class GoogleSheetsToGCSOperator(BaseOperator):
         self.destination_bucket = destination_bucket
         self.destination_path = destination_path
         self.impersonation_chain = impersonation_chain
-        if unwrap_single is None:
-            self.unwrap_single = True
+        self.return_gcs_uris = return_gcs_uris
+        if not self.return_gcs_uris:
             import warnings
 
             warnings.warn(
-                "The default value of unwrap_single will change from True to False in a future release. "
-                "Please set unwrap_single explicitly to avoid this warning.",
+                "The default value of return_gcs_uris will change from False to True in a future release. "
+                "Please set return_gcs_uris explicitly to avoid this warning.",
                 FutureWarning,
                 stacklevel=2,
             )
-        else:
-            self.unwrap_single = unwrap_single
 
     def _upload_data(
         self,
@@ -125,7 +124,7 @@ class GoogleSheetsToGCSOperator(BaseOperator):
             )
         return dest_file_name
 
-    def execute(self, context: Context) -> str | list[str]:
+    def execute(self, context: Context) -> list[str]:
         sheet_hook = GSheetsHook(
             gcp_conn_id=self.gcp_conn_id,
             impersonation_chain=self.impersonation_chain,
@@ -143,11 +142,11 @@ class GoogleSheetsToGCSOperator(BaseOperator):
         for sheet_range in sheet_titles:
             data = sheet_hook.get_values(spreadsheet_id=self.spreadsheet_id, range_=sheet_range)
             gcs_path_to_file = self._upload_data(gcs_hook, sheet_hook, sheet_range, data)
-            gcs_uri = f"gs://{self.destination_bucket}/{gcs_path_to_file}"
-            destination_array.append(gcs_uri)
+            if self.return_gcs_uris:
+                gcs_uri = f"gs://{self.destination_bucket}/{gcs_path_to_file}"
+                destination_array.append(gcs_uri)
+            else:
+                destination_array.append(gcs_path_to_file)
 
         context["ti"].xcom_push(key="destination_objects", value=destination_array)
-
-        if self.unwrap_single:
-            return destination_array[0] if len(destination_array) == 1 else destination_array
         return destination_array

--- a/providers/google/src/airflow/providers/google/cloud/transfers/sheets_to_gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/sheets_to_gcs.py
@@ -87,6 +87,7 @@ class GoogleSheetsToGCSOperator(BaseOperator):
         if unwrap_single is None:
             self.unwrap_single = True
             import warnings
+
             warnings.warn(
                 "The default value of unwrap_single will change from True to False in a future release. "
                 "Please set unwrap_single explicitly to avoid this warning.",
@@ -146,7 +147,7 @@ class GoogleSheetsToGCSOperator(BaseOperator):
             destination_array.append(gcs_uri)
 
         context["ti"].xcom_push(key="destination_objects", value=destination_array)
-        
+
         if self.unwrap_single:
             return destination_array[0] if len(destination_array) == 1 else destination_array
         return destination_array

--- a/providers/google/tests/unit/google/cloud/transfers/test_gdrive_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_gdrive_to_gcs.py
@@ -65,7 +65,7 @@ class TestGoogleDriveToGCSOperator:
         # Assert single string is returned when unwrap_single=True (default)
         assert result == f"gs://{BUCKET}/{OBJECT}"
         assert op.dry_run() is None
-    
+
     @mock.patch("airflow.providers.google.cloud.transfers.gdrive_to_gcs.GCSHook")
     @mock.patch("airflow.providers.google.cloud.transfers.gdrive_to_gcs.GoogleDriveHook")
     def test_execute_with_unwrap_single_false(self, mock_gdrive_hook, mock_gcs_hook):
@@ -99,7 +99,7 @@ class TestGoogleDriveToGCSOperator:
 
         # Assert list is returned when unwrap_single=False
         assert result == [f"gs://{BUCKET}/{OBJECT}"]
-        
+
     @mock.patch("airflow.providers.google.cloud.transfers.gdrive_to_gcs.GCSHook")
     @mock.patch("airflow.providers.google.cloud.transfers.gdrive_to_gcs.GoogleDriveHook")
     def test_execute_with_unwrap_single_default(self, mock_gdrive_hook, mock_gcs_hook):

--- a/providers/google/tests/unit/google/cloud/transfers/test_gdrive_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_gdrive_to_gcs.py
@@ -33,7 +33,7 @@ IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 class TestGoogleDriveToGCSOperator:
     @mock.patch("airflow.providers.google.cloud.transfers.gdrive_to_gcs.GCSHook")
     @mock.patch("airflow.providers.google.cloud.transfers.gdrive_to_gcs.GoogleDriveHook")
-    def test_execute_with_unwrap_single_true(self, mock_gdrive_hook, mock_gcs_hook):
+    def test_execute(self, mock_gdrive_hook, mock_gcs_hook):
         context = {}
         op = GoogleDriveToGCSOperator(
             task_id="test_task",
@@ -44,7 +44,6 @@ class TestGoogleDriveToGCSOperator:
             object_name=OBJECT,
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
-            unwrap_single=True,
         )
         meta = {"id": "123xyz"}
         mock_gdrive_hook.return_value.get_file_id.return_value = meta
@@ -62,74 +61,6 @@ class TestGoogleDriveToGCSOperator:
             bucket_name=BUCKET, object_name=OBJECT
         )
 
-        # Assert single string is returned when unwrap_single=True (default)
-        assert result == f"gs://{BUCKET}/{OBJECT}"
-        assert op.dry_run() is None
-
-    @mock.patch("airflow.providers.google.cloud.transfers.gdrive_to_gcs.GCSHook")
-    @mock.patch("airflow.providers.google.cloud.transfers.gdrive_to_gcs.GoogleDriveHook")
-    def test_execute_with_unwrap_single_false(self, mock_gdrive_hook, mock_gcs_hook):
-        context = {}
-        op = GoogleDriveToGCSOperator(
-            task_id="test_task",
-            folder_id=FOLDER_ID,
-            file_name=FILE_NAME,
-            drive_id=DRIVE_ID,
-            bucket_name=BUCKET,
-            object_name=OBJECT,
-            gcp_conn_id=GCP_CONN_ID,
-            impersonation_chain=IMPERSONATION_CHAIN,
-            unwrap_single=False,
-        )
-        meta = {"id": "123xyz"}
-        mock_gdrive_hook.return_value.get_file_id.return_value = meta
-
-        result = op.execute(context)
-        mock_gdrive_hook.return_value.get_file_id.assert_called_once_with(
-            folder_id=FOLDER_ID, file_name=FILE_NAME, drive_id=DRIVE_ID
-        )
-
-        mock_gdrive_hook.return_value.download_file.assert_called_once_with(
-            file_id=meta["id"], file_handle=mock.ANY
-        )
-
-        mock_gcs_hook.return_value.provide_file_and_upload.assert_called_once_with(
-            bucket_name=BUCKET, object_name=OBJECT
-        )
-
-        # Assert list is returned when unwrap_single=False
+        # Assert list with GCS URI is returned
         assert result == [f"gs://{BUCKET}/{OBJECT}"]
-
-    @mock.patch("airflow.providers.google.cloud.transfers.gdrive_to_gcs.GCSHook")
-    @mock.patch("airflow.providers.google.cloud.transfers.gdrive_to_gcs.GoogleDriveHook")
-    def test_execute_with_unwrap_single_default(self, mock_gdrive_hook, mock_gcs_hook):
-        context = {}
-        op = GoogleDriveToGCSOperator(
-            task_id="test_task",
-            folder_id=FOLDER_ID,
-            file_name=FILE_NAME,
-            drive_id=DRIVE_ID,
-            bucket_name=BUCKET,
-            object_name=OBJECT,
-            gcp_conn_id=GCP_CONN_ID,
-            impersonation_chain=IMPERSONATION_CHAIN,
-            # unwrap_single not specified, should default to True with warning
-        )
-        meta = {"id": "123xyz"}
-        mock_gdrive_hook.return_value.get_file_id.return_value = meta
-
-        result = op.execute(context)
-        mock_gdrive_hook.return_value.get_file_id.assert_called_once_with(
-            folder_id=FOLDER_ID, file_name=FILE_NAME, drive_id=DRIVE_ID
-        )
-
-        mock_gdrive_hook.return_value.download_file.assert_called_once_with(
-            file_id=meta["id"], file_handle=mock.ANY
-        )
-
-        mock_gcs_hook.return_value.provide_file_and_upload.assert_called_once_with(
-            bucket_name=BUCKET, object_name=OBJECT
-        )
-
-        # Assert single string is returned when unwrap_single defaults to True
-        assert result == f"gs://{BUCKET}/{OBJECT}"
+        assert op.dry_run() is None

--- a/providers/google/tests/unit/google/cloud/transfers/test_sheets_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_sheets_to_gcs.py
@@ -138,19 +138,19 @@ class TestGoogleSheetsToGCSOperator:
         "airflow.providers.google.cloud.transfers.sheets_to_gcs.GoogleSheetsToGCSOperator._upload_data"
     )
     def test_execute_with_unwrap_single_true_single_file(
-        self, mock_upload_data, mock_sheet_hook, mock_gcs_hook  # <--- Added missing arguments
+        self,
+        mock_upload_data,
+        mock_sheet_hook,
+        mock_gcs_hook  # <--- Added missing arguments
     ):
         # mock_sheet_hook = mock.MagicMock()  <--- REMOVE THIS (it shadows the patched mock)
-        
         mock_ti = mock.MagicMock()
         mock_context = {"ti": mock_ti}
         data = ["data1"]
-        
         # Configure the injected mock directly
         mock_sheet_hook.return_value.get_sheet_titles.return_value = ["single_range"]
         mock_sheet_hook.return_value.get_values.side_effect = data
         mock_upload_data.side_effect = [PATH]
-        
         op = GoogleSheetsToGCSOperator(
             task_id="test_task",
             spreadsheet_id=SPREADSHEET_ID,
@@ -173,19 +173,19 @@ class TestGoogleSheetsToGCSOperator:
         "airflow.providers.google.cloud.transfers.sheets_to_gcs.GoogleSheetsToGCSOperator._upload_data"
     )
     def test_execute_with_unwrap_single_false(
-        self, mock_upload_data, mock_sheet_hook, mock_gcs_hook  # <--- Added missing arguments
+        self,
+        mock_upload_data,
+        mock_sheet_hook,
+        mock_gcs_hook  # <--- Added missing arguments
     ):
         # mock_sheet_hook = mock.MagicMock() <--- REMOVE THIS
-        
         mock_ti = mock.MagicMock()
         mock_context = {"ti": mock_ti}
         data = ["data1", "data2"]
-        
         # Configure the injected mock directly
         mock_sheet_hook.return_value.get_sheet_titles.return_value = RANGES
         mock_sheet_hook.return_value.get_values.side_effect = data
         mock_upload_data.side_effect = [PATH, PATH]
-        
         op = GoogleSheetsToGCSOperator(
             task_id="test_task",
             spreadsheet_id=SPREADSHEET_ID,

--- a/providers/google/tests/unit/google/cloud/transfers/test_sheets_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_sheets_to_gcs.py
@@ -137,15 +137,20 @@ class TestGoogleSheetsToGCSOperator:
     @mock.patch(
         "airflow.providers.google.cloud.transfers.sheets_to_gcs.GoogleSheetsToGCSOperator._upload_data"
     )
-    def test_execute_with_unwrap_single_true_single_file(self, mock_upload_data):
-        mock_sheet_hook = mock.MagicMock()
+    def test_execute_with_unwrap_single_true_single_file(
+        self, mock_upload_data, mock_sheet_hook, mock_gcs_hook  # <--- Added missing arguments
+    ):
+        # mock_sheet_hook = mock.MagicMock()  <--- REMOVE THIS (it shadows the patched mock)
+        
         mock_ti = mock.MagicMock()
         mock_context = {"ti": mock_ti}
         data = ["data1"]
+        
+        # Configure the injected mock directly
         mock_sheet_hook.return_value.get_sheet_titles.return_value = ["single_range"]
         mock_sheet_hook.return_value.get_values.side_effect = data
         mock_upload_data.side_effect = [PATH]
-
+        
         op = GoogleSheetsToGCSOperator(
             task_id="test_task",
             spreadsheet_id=SPREADSHEET_ID,
@@ -157,7 +162,6 @@ class TestGoogleSheetsToGCSOperator:
             unwrap_single=True,
         )
         result = op.execute(mock_context)
-
         expected_uri = f"gs://{BUCKET}/{PATH}"
         mock_ti.xcom_push.assert_called_once_with(key="destination_objects", value=[expected_uri])
         # When single file and unwrap_single=True, should return the single URI string
@@ -168,15 +172,20 @@ class TestGoogleSheetsToGCSOperator:
     @mock.patch(
         "airflow.providers.google.cloud.transfers.sheets_to_gcs.GoogleSheetsToGCSOperator._upload_data"
     )
-    def test_execute_with_unwrap_single_false(self, mock_upload_data):
-        mock_sheet_hook = mock.MagicMock()
+    def test_execute_with_unwrap_single_false(
+        self, mock_upload_data, mock_sheet_hook, mock_gcs_hook  # <--- Added missing arguments
+    ):
+        # mock_sheet_hook = mock.MagicMock() <--- REMOVE THIS
+        
         mock_ti = mock.MagicMock()
         mock_context = {"ti": mock_ti}
         data = ["data1", "data2"]
+        
+        # Configure the injected mock directly
         mock_sheet_hook.return_value.get_sheet_titles.return_value = RANGES
         mock_sheet_hook.return_value.get_values.side_effect = data
         mock_upload_data.side_effect = [PATH, PATH]
-
+        
         op = GoogleSheetsToGCSOperator(
             task_id="test_task",
             spreadsheet_id=SPREADSHEET_ID,
@@ -188,7 +197,6 @@ class TestGoogleSheetsToGCSOperator:
             unwrap_single=False,
         )
         result = op.execute(mock_context)
-
         expected_uris = [f"gs://{BUCKET}/{PATH}", f"gs://{BUCKET}/{PATH}"]
         mock_ti.xcom_push.assert_called_once_with(key="destination_objects", value=expected_uris)
         # When unwrap_single=False, should return the full list regardless of file count

--- a/providers/google/tests/unit/google/cloud/transfers/test_sheets_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_sheets_to_gcs.py
@@ -81,7 +81,9 @@ class TestGoogleSheetsToGCSOperator:
     @mock.patch(
         "airflow.providers.google.cloud.transfers.sheets_to_gcs.GoogleSheetsToGCSOperator._upload_data"
     )
-    def test_execute_with_unwrap_single_true_multiple_files(self, mock_upload_data, mock_sheet_hook, mock_gcs_hook):
+    def test_execute_with_unwrap_single_true_multiple_files(
+        self, mock_upload_data, mock_sheet_hook, mock_gcs_hook
+    ):
         mock_ti = mock.MagicMock()
         mock_context = {"ti": mock_ti}
         data = ["data1", "data2"]
@@ -129,11 +131,14 @@ class TestGoogleSheetsToGCSOperator:
         mock_ti.xcom_push.assert_called_once_with(key="destination_objects", value=expected_uris)
         # When multiple files and unwrap_single=True, should return the full list
         assert result == expected_uris
-    
+
+    @mock.patch("airflow.providers.google.cloud.transfers.sheets_to_gcs.GCSHook")
+    @mock.patch("airflow.providers.google.cloud.transfers.sheets_to_gcs.GSheetsHook")
     @mock.patch(
         "airflow.providers.google.cloud.transfers.sheets_to_gcs.GoogleSheetsToGCSOperator._upload_data"
     )
-    def test_execute_with_unwrap_single_true_single_file(self, mock_upload_data, mock_sheet_hook, mock_gcs_hook):
+    def test_execute_with_unwrap_single_true_single_file(self, mock_upload_data):
+        mock_sheet_hook = mock.MagicMock()
         mock_ti = mock.MagicMock()
         mock_context = {"ti": mock_ti}
         data = ["data1"]
@@ -157,11 +162,14 @@ class TestGoogleSheetsToGCSOperator:
         mock_ti.xcom_push.assert_called_once_with(key="destination_objects", value=[expected_uri])
         # When single file and unwrap_single=True, should return the single URI string
         assert result == expected_uri
-    
+
+    @mock.patch("airflow.providers.google.cloud.transfers.sheets_to_gcs.GCSHook")
+    @mock.patch("airflow.providers.google.cloud.transfers.sheets_to_gcs.GSheetsHook")
     @mock.patch(
         "airflow.providers.google.cloud.transfers.sheets_to_gcs.GoogleSheetsToGCSOperator._upload_data"
     )
-    def test_execute_with_unwrap_single_false(self, mock_upload_data, mock_sheet_hook, mock_gcs_hook):
+    def test_execute_with_unwrap_single_false(self, mock_upload_data):
+        mock_sheet_hook = mock.MagicMock()
         mock_ti = mock.MagicMock()
         mock_context = {"ti": mock_ti}
         data = ["data1", "data2"]

--- a/providers/google/tests/unit/google/cloud/transfers/test_sheets_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_sheets_to_gcs.py
@@ -141,7 +141,7 @@ class TestGoogleSheetsToGCSOperator:
         self,
         mock_upload_data,
         mock_sheet_hook,
-        mock_gcs_hook  # <--- Added missing arguments
+        mock_gcs_hook,  # <--- Added missing arguments
     ):
         # mock_sheet_hook = mock.MagicMock()  <--- REMOVE THIS (it shadows the patched mock)
         mock_ti = mock.MagicMock()
@@ -176,7 +176,7 @@ class TestGoogleSheetsToGCSOperator:
         self,
         mock_upload_data,
         mock_sheet_hook,
-        mock_gcs_hook  # <--- Added missing arguments
+        mock_gcs_hook,  # <--- Added missing arguments
     ):
         # mock_sheet_hook = mock.MagicMock() <--- REMOVE THIS
         mock_ti = mock.MagicMock()

--- a/providers/google/tests/unit/google/cloud/transfers/test_sheets_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_sheets_to_gcs.py
@@ -81,8 +81,11 @@ class TestGoogleSheetsToGCSOperator:
     @mock.patch(
         "airflow.providers.google.cloud.transfers.sheets_to_gcs.GoogleSheetsToGCSOperator._upload_data"
     )
-    def test_execute_with_unwrap_single_true_multiple_files(
-        self, mock_upload_data, mock_sheet_hook, mock_gcs_hook
+    def test_execute_with_return_gcs_uris_true(
+        self,
+        mock_upload_data,
+        mock_sheet_hook,
+        mock_gcs_hook,
     ):
         mock_ti = mock.MagicMock()
         mock_context = {"ti": mock_ti}
@@ -99,7 +102,7 @@ class TestGoogleSheetsToGCSOperator:
             destination_path=PATH,
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
-            unwrap_single=True,
+            return_gcs_uris=True,
         )
         result = op.execute(mock_context)
 
@@ -129,7 +132,6 @@ class TestGoogleSheetsToGCSOperator:
 
         expected_uris = [f"gs://{BUCKET}/{PATH}", f"gs://{BUCKET}/{PATH}"]
         mock_ti.xcom_push.assert_called_once_with(key="destination_objects", value=expected_uris)
-        # When multiple files and unwrap_single=True, should return the full list
         assert result == expected_uris
 
     @mock.patch("airflow.providers.google.cloud.transfers.sheets_to_gcs.GCSHook")
@@ -137,52 +139,15 @@ class TestGoogleSheetsToGCSOperator:
     @mock.patch(
         "airflow.providers.google.cloud.transfers.sheets_to_gcs.GoogleSheetsToGCSOperator._upload_data"
     )
-    def test_execute_with_unwrap_single_true_single_file(
+    def test_execute_with_return_gcs_uris_false(
         self,
         mock_upload_data,
         mock_sheet_hook,
-        mock_gcs_hook,  # <--- Added missing arguments
+        mock_gcs_hook,
     ):
-        # mock_sheet_hook = mock.MagicMock()  <--- REMOVE THIS (it shadows the patched mock)
-        mock_ti = mock.MagicMock()
-        mock_context = {"ti": mock_ti}
-        data = ["data1"]
-        # Configure the injected mock directly
-        mock_sheet_hook.return_value.get_sheet_titles.return_value = ["single_range"]
-        mock_sheet_hook.return_value.get_values.side_effect = data
-        mock_upload_data.side_effect = [PATH]
-        op = GoogleSheetsToGCSOperator(
-            task_id="test_task",
-            spreadsheet_id=SPREADSHEET_ID,
-            destination_bucket=BUCKET,
-            sheet_filter=FILTER,
-            destination_path=PATH,
-            gcp_conn_id=GCP_CONN_ID,
-            impersonation_chain=IMPERSONATION_CHAIN,
-            unwrap_single=True,
-        )
-        result = op.execute(mock_context)
-        expected_uri = f"gs://{BUCKET}/{PATH}"
-        mock_ti.xcom_push.assert_called_once_with(key="destination_objects", value=[expected_uri])
-        # When single file and unwrap_single=True, should return the single URI string
-        assert result == expected_uri
-
-    @mock.patch("airflow.providers.google.cloud.transfers.sheets_to_gcs.GCSHook")
-    @mock.patch("airflow.providers.google.cloud.transfers.sheets_to_gcs.GSheetsHook")
-    @mock.patch(
-        "airflow.providers.google.cloud.transfers.sheets_to_gcs.GoogleSheetsToGCSOperator._upload_data"
-    )
-    def test_execute_with_unwrap_single_false(
-        self,
-        mock_upload_data,
-        mock_sheet_hook,
-        mock_gcs_hook,  # <--- Added missing arguments
-    ):
-        # mock_sheet_hook = mock.MagicMock() <--- REMOVE THIS
         mock_ti = mock.MagicMock()
         mock_context = {"ti": mock_ti}
         data = ["data1", "data2"]
-        # Configure the injected mock directly
         mock_sheet_hook.return_value.get_sheet_titles.return_value = RANGES
         mock_sheet_hook.return_value.get_values.side_effect = data
         mock_upload_data.side_effect = [PATH, PATH]
@@ -194,10 +159,38 @@ class TestGoogleSheetsToGCSOperator:
             destination_path=PATH,
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
-            unwrap_single=False,
+            return_gcs_uris=False,
         )
         result = op.execute(mock_context)
-        expected_uris = [f"gs://{BUCKET}/{PATH}", f"gs://{BUCKET}/{PATH}"]
-        mock_ti.xcom_push.assert_called_once_with(key="destination_objects", value=expected_uris)
-        # When unwrap_single=False, should return the full list regardless of file count
-        assert result == expected_uris
+        mock_ti.xcom_push.assert_called_once_with(key="destination_objects", value=[PATH, PATH])
+        assert result == [PATH, PATH]
+
+    @mock.patch("airflow.providers.google.cloud.transfers.sheets_to_gcs.GCSHook")
+    @mock.patch("airflow.providers.google.cloud.transfers.sheets_to_gcs.GSheetsHook")
+    @mock.patch(
+        "airflow.providers.google.cloud.transfers.sheets_to_gcs.GoogleSheetsToGCSOperator._upload_data"
+    )
+    def test_execute_with_return_gcs_uris_default(
+        self,
+        mock_upload_data,
+        mock_sheet_hook,
+        mock_gcs_hook,
+    ):
+        mock_ti = mock.MagicMock()
+        mock_context = {"ti": mock_ti}
+        data = ["data1"]
+        mock_sheet_hook.return_value.get_sheet_titles.return_value = ["single_range"]
+        mock_sheet_hook.return_value.get_values.side_effect = data
+        mock_upload_data.side_effect = [PATH]
+        op = GoogleSheetsToGCSOperator(
+            task_id="test_task",
+            spreadsheet_id=SPREADSHEET_ID,
+            destination_bucket=BUCKET,
+            sheet_filter=FILTER,
+            destination_path=PATH,
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
+        result = op.execute(mock_context)
+        mock_ti.xcom_push.assert_called_once_with(key="destination_objects", value=[PATH])
+        assert result == [PATH]


### PR DESCRIPTION
## Description

This PR implements consistent GCS destination URI return behavior for GoogleDriveToGCSOperator and GoogleSheetsToGCSOperator

## Changes

### `GoogleDriveToGCSOperator` (transfers/gdrive_to_gcs.py)

Added unwrap_single parameter to control return format (default: True)
Returns full GCS URIs in gs://bucket/object format instead of None
Added deprecation warning for future default behavior change
Maintains backward compatibility with existing XCom functionality

### `GoogleSheetsToGCSOperator` (transfers/sheets_to_gcs.py)

Added unwrap_single parameter to control return format (default: True)
Returns full GCS URIs in gs://bucket/object format instead of object names only
Added deprecation warning for future default behavior change
Preserves existing XCom push behavior for destination objects

## Implementation Details

Both operators now follow the consistent return convention:
When unwrap_single=True (default): Returns single string for one file, list for multiple files
When unwrap_single=False: Always returns list regardless of file count
Full GCS URI format: All return values include gs:// prefix
Backward compatibility: Existing code continues to work unchanged

## Tests

Added comprehensive test coverage for both operators:
test_execute_with_unwrap_single_true - Single file return behavior
test_execute_with_unwrap_single_false - List return behavior
test_execute_with_unwrap_single_default - Default behavior verification
GoogleSheetsToGCSOperator: Additional tests for single vs multiple file scenarios

## Related Issues

Part of issue #11323 - Return files destination URIs in all ToGCS operators

## Migration Notes

Current behavior (backward compatible):
python
/// Returns single URI string when one file, list when multiple
op = GoogleDriveToGCSOperator(...)
result = op.execute(context)  # e.g., "gs://bucket/file.txt" or ["gs://bucket/file1.txt", "gs://bucket/file2.txt"]
Future behavior (prepare now):
python
/// Explicitly set unwrap_single to avoid future breaking changes
op = GoogleDriveToGCSOperator(unwrap_single=False, ...)
result = op.execute(context)  # Always returns list: ["gs://bucket/file.txt"]

## Checklist

 Added unwrap_single parameter with proper type hints
 Implemented deprecation warning for future default change
 Updated return values to full GCS URI format (gs://bucket/object)
 Maintained backward compatibility with existing XCom behavior
 Added comprehensive unit tests for all scenarios
 Updated docstrings with new parameter documentation
 Verified system test examples remain compatible
 
 Related: #11323
 
 Used AI for resolving conflicts