### PR TITLE
Keycloak auth manager: enforce team‑scoped authorization (AIP‑67)

### DIFF
--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
@@ -76,6 +76,20 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 RESOURCE_ID_ATTRIBUTE_NAME = "resource_id"
+TEAM_SCOPED_RESOURCES = frozenset(
+    {
+        KeycloakResource.DAG,
+        KeycloakResource.ASSET,
+    }
+)
+TEAM_OPTIONAL_RESOURCES = frozenset(
+    {
+        KeycloakResource.CONNECTION,
+        KeycloakResource.VARIABLE,
+        KeycloakResource.POOL,
+        KeycloakResource.BACKFILL,
+    }
+)
 
 
 class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
@@ -184,10 +198,7 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
     ) -> bool:
         config_section = details.section if details else None
         return self._is_authorized(
-            method=method,
-            resource_type=KeycloakResource.CONFIGURATION,
-            user=user,
-            resource_id=config_section,
+            method=method, resource_type=KeycloakResource.CONFIGURATION, user=user, resource_id=config_section
         )
 
     def is_authorized_connection(
@@ -198,8 +209,13 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
         details: ConnectionDetails | None = None,
     ) -> bool:
         connection_id = details.conn_id if details else None
+        team_name = details.team_name if details else None
         return self._is_authorized(
-            method=method, resource_type=KeycloakResource.CONNECTION, user=user, resource_id=connection_id
+            method=method,
+            resource_type=KeycloakResource.CONNECTION,
+            user=user,
+            resource_id=connection_id,
+            team_name=team_name,
         )
 
     def is_authorized_dag(
@@ -211,12 +227,14 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
         details: DagDetails | None = None,
     ) -> bool:
         dag_id = details.id if details else None
+        team_name = details.team_name if details else None
         access_entity_str = access_entity.value if access_entity else None
         return self._is_authorized(
             method=method,
             resource_type=KeycloakResource.DAG,
             user=user,
             resource_id=dag_id,
+            team_name=team_name,
             attributes={"dag_entity": access_entity_str},
         )
 
@@ -231,16 +249,26 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
         )
 
         backfill_id = str(details.id) if details else None
+        team_name = getattr(details, "team_name", None) if details else None
         return self._is_authorized(
-            method=method, resource_type=KeycloakResource.BACKFILL, user=user, resource_id=backfill_id
+            method=method,
+            resource_type=KeycloakResource.BACKFILL,
+            user=user,
+            resource_id=backfill_id,
+            team_name=team_name,
         )
 
     def is_authorized_asset(
         self, *, method: ResourceMethod, user: KeycloakAuthManagerUser, details: AssetDetails | None = None
     ) -> bool:
         asset_id = details.id if details else None
+        team_name = getattr(details, "team_name", None) if details else None
         return self._is_authorized(
-            method=method, resource_type=KeycloakResource.ASSET, user=user, resource_id=asset_id
+            method=method,
+            resource_type=KeycloakResource.ASSET,
+            user=user,
+            resource_id=asset_id,
+            team_name=team_name,
         )
 
     def is_authorized_asset_alias(
@@ -262,16 +290,26 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
         self, *, method: ResourceMethod, user: KeycloakAuthManagerUser, details: VariableDetails | None = None
     ) -> bool:
         variable_key = details.key if details else None
+        team_name = details.team_name if details else None
         return self._is_authorized(
-            method=method, resource_type=KeycloakResource.VARIABLE, user=user, resource_id=variable_key
+            method=method,
+            resource_type=KeycloakResource.VARIABLE,
+            user=user,
+            resource_id=variable_key,
+            team_name=team_name,
         )
 
     def is_authorized_pool(
         self, *, method: ResourceMethod, user: KeycloakAuthManagerUser, details: PoolDetails | None = None
     ) -> bool:
         pool_name = details.name if details else None
+        team_name = details.team_name if details else None
         return self._is_authorized(
-            method=method, resource_type=KeycloakResource.POOL, user=user, resource_id=pool_name
+            method=method,
+            resource_type=KeycloakResource.POOL,
+            user=user,
+            resource_id=pool_name,
+            team_name=team_name,
         )
 
     def is_authorized_view(self, *, access_view: AccessView, user: KeycloakAuthManagerUser) -> bool:
@@ -356,6 +394,7 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
         resource_type: KeycloakResource,
         user: KeycloakAuthManagerUser,
         resource_id: str | None = None,
+        team_name: str | None = None,
         attributes: dict[str, str | None] | None = None,
     ) -> bool:
         client_id = conf.get(CONF_SECTION_NAME, CONF_CLIENT_ID_KEY)
@@ -368,26 +407,51 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
         elif method == "GET":
             method = "LIST"
 
-        resp = self.http_session.post(
-            self._get_token_url(server_url, realm),
-            data=self._get_payload(client_id, f"{resource_type.value}#{method}", context_attributes),
-            headers=self._get_headers(user.access_token),
-            timeout=5,
-        )
+        if (
+            method == "LIST"
+            and conf.getboolean("core", "multi_team")
+            and team_name is None
+            and resource_type in TEAM_SCOPED_RESOURCES.union(TEAM_OPTIONAL_RESOURCES)
+        ):
+            # Allow list access based on team membership when team_name is missing on list requests.
+            team_names = sorted(self._get_user_team_names(user))
+            if not team_names:
+                return False
+            for team in team_names:
+                attributes_with_team = dict(context_attributes)
+                resource_name = self._get_resource_name(resource_type, team)
+                if resource_name is None:
+                    continue
+                if self._check_permission(
+                    server_url=server_url,
+                    realm=realm,
+                    client_id=client_id,
+                    permission=f"{resource_name}#{method}",
+                    attributes=attributes_with_team,
+                    user=user,
+                ):
+                    return True
+            return False
 
-        if resp.status_code == 200:
-            return True
-        if resp.status_code == 401:
-            log.debug("Received 401 from Keycloak: %s", resp.text)
+        if (
+            method != "LIST"
+            and conf.getboolean("core", "multi_team")
+            and team_name is None
+            and resource_type in TEAM_OPTIONAL_RESOURCES
+        ):
             return False
-        if resp.status_code == 403:
+
+        resource_name = self._get_resource_name(resource_type, team_name)
+        if resource_name is None:
             return False
-        if resp.status_code == 400:
-            error = json.loads(resp.text)
-            raise AirflowException(
-                f"Request not recognized by Keycloak. {error.get('error')}. {error.get('error_description')}"
-            )
-        raise AirflowException(f"Unexpected error: {resp.status_code} - {resp.text}")
+        return self._check_permission(
+            server_url=server_url,
+            realm=realm,
+            client_id=client_id,
+            permission=f"{resource_name}#{method}",
+            attributes=context_attributes,
+            user=user,
+        )
 
     def _is_batch_authorized(
         self,
@@ -426,6 +490,19 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
         return f"{server_url.rstrip('/')}/realms/{realm}/protocol/openid-connect/token"
 
     @staticmethod
+    def _get_resource_name(resource_type: KeycloakResource, team_name: str | None) -> str | None:
+        if not conf.getboolean("core", "multi_team"):
+            return resource_type.value
+
+        if resource_type in TEAM_SCOPED_RESOURCES:
+            return f"{resource_type.value}:{team_name}" if team_name else None
+
+        if resource_type in TEAM_OPTIONAL_RESOURCES and team_name:
+            return f"{resource_type.value}:{team_name}"
+
+        return resource_type.value
+
+    @staticmethod
     def _get_payload(client_id: str, permission: str, attributes: dict[str, str] | None = None):
         payload: dict[str, Any] = {
             "grant_type": "urn:ietf:params:oauth:grant-type:uma-ticket",
@@ -455,6 +532,37 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
 
         return payload
 
+    def _check_permission(
+        self,
+        *,
+        server_url: str,
+        realm: str,
+        client_id: str,
+        permission: str,
+        attributes: dict[str, str | None] | None,
+        user: KeycloakAuthManagerUser,
+    ) -> bool:
+        resp = self.http_session.post(
+            self._get_token_url(server_url, realm),
+            data=self._get_payload(client_id, permission, prune_dict(attributes or {})),
+            headers=self._get_headers(user.access_token),
+            timeout=5,
+        )
+
+        if resp.status_code == 200:
+            return True
+        if resp.status_code == 401:
+            log.debug("Received 401 from Keycloak: %s", resp.text)
+            return False
+        if resp.status_code == 403:
+            return False
+        if resp.status_code == 400:
+            error = json.loads(resp.text)
+            raise AirflowException(
+                f"Request not recognized by Keycloak. {error.get('error')}. {error.get('error_description')}"
+            )
+        raise AirflowException(f"Unexpected error: {resp.status_code} - {resp.text}")
+
     @staticmethod
     def _get_headers(access_token):
         return {
@@ -475,3 +583,28 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
         payload_bytes = urlsafe_b64decode(payload_b64)
         payload = json.loads(payload_bytes)
         return payload["exp"] < int(time.time())
+
+    @staticmethod
+    def _get_token_payload(token: str) -> dict[str, Any]:
+        try:
+            payload_b64 = token.split(".")[1] + "=="
+            payload_bytes = urlsafe_b64decode(payload_b64)
+            return json.loads(payload_bytes)
+        except (IndexError, ValueError, json.JSONDecodeError):
+            return {}
+
+    def _get_user_team_names(self, user: KeycloakAuthManagerUser) -> set[str]:
+        payload = self._get_token_payload(user.access_token)
+        groups = payload.get("groups") or payload.get("group") or []
+        if isinstance(groups, str):
+            groups = [groups]
+        team_names: set[str] = set()
+        for group in groups:
+            if not isinstance(group, str):
+                continue
+            group_name = group.strip("/")
+            if not group_name:
+                continue
+            group_name = group_name.split("/")[-1]
+            team_names.add(group_name)
+        return team_names

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
@@ -396,7 +396,10 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
         elif method == "GET":
             method = "LIST"
 
-        resource_name = self._get_resource_name(resource_type, team_name)
+        if conf.getboolean("core", "multi_team", fallback=False) and resource_type in TEAM_SCOPED_RESOURCES:
+            resource_name = f"{resource_type.value}:{team_name}" if team_name else resource_type.value
+        else:
+            resource_name = resource_type.value
         permission = f"{resource_name}#{method}"
 
         resp = self.http_session.post(
@@ -455,15 +458,6 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
     def _get_token_url(server_url, realm):
         # Normalize server_url to avoid double slashes (required for Keycloak 26.4+ strict path validation).
         return f"{server_url.rstrip('/')}/realms/{realm}/protocol/openid-connect/token"
-
-    @staticmethod
-    def _get_resource_name(resource_type: KeycloakResource, team_name: str | None) -> str | None:
-        if (
-            not conf.getboolean("core", "multi_team", fallback=False)
-            or resource_type not in TEAM_SCOPED_RESOURCES
-        ):
-            return resource_type.value
-        return f"{resource_type.value}:{team_name}" if team_name else resource_type.value
 
     @staticmethod
     def _get_team_name(details: Any | None) -> str | None:

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
@@ -397,7 +397,7 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
 
         # Team-scoped resources require a team, except for LIST which uses global permission.
         if is_multi_team and is_team_scoped and is_teamless and method != "LIST":
-            return False
+            raise ValueError("Missing team_name for team-scoped resource in multi-team mode.")
         if is_multi_team and is_team_scoped and is_teamless and method == "LIST":
             permission = f"{resource_type.value}#{method}"
         else:
@@ -465,10 +465,12 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
 
     @staticmethod
     def _get_resource_name(resource_type: KeycloakResource, team_name: str | None) -> str | None:
-        if not conf.getboolean("core", "multi_team", fallback=False) or resource_type not in TEAM_SCOPED_RESOURCES:
+        if (
+            not conf.getboolean("core", "multi_team", fallback=False)
+            or resource_type not in TEAM_SCOPED_RESOURCES
+        ):
             return resource_type.value
-        else:
-            return f"{resource_type.value}:{team_name}" if team_name else None
+        return f"{resource_type.value}:{team_name}" if team_name else None
 
     @staticmethod
     def _get_team_name(details: Any | None) -> str | None:

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
@@ -465,13 +465,10 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
 
     @staticmethod
     def _get_resource_name(resource_type: KeycloakResource, team_name: str | None) -> str | None:
-        if not conf.getboolean("core", "multi_team", fallback=False):
+        if not conf.getboolean("core", "multi_team", fallback=False) or resource_type not in TEAM_SCOPED_RESOURCES:
             return resource_type.value
-
-        if resource_type in TEAM_SCOPED_RESOURCES:
+        else:
             return f"{resource_type.value}:{team_name}" if team_name else None
-
-        return resource_type.value
 
     @staticmethod
     def _get_team_name(details: Any | None) -> str | None:

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
@@ -396,8 +396,8 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
         elif method == "GET":
             method = "LIST"
 
-        if conf.getboolean("core", "multi_team", fallback=False) and resource_type in TEAM_SCOPED_RESOURCES:
-            resource_name = f"{resource_type.value}:{team_name}" if team_name else resource_type.value
+        if team_name and conf.getboolean("core", "multi_team", fallback=False) and resource_type in TEAM_SCOPED_RESOURCES:
+            resource_name = f"{resource_type.value}:{team_name}"
         else:
             resource_name = resource_type.value
         permission = f"{resource_name}#{method}"

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
@@ -74,7 +74,6 @@ if TYPE_CHECKING:
     from airflow.cli.cli_config import CLICommand
 
 log = logging.getLogger(__name__)
-IS_MULTI_TEAM = conf.getboolean("core", "multi_team")
 
 RESOURCE_ID_ATTRIBUTE_NAME = "resource_id"
 TEAM_SCOPED_RESOURCES = frozenset(
@@ -392,7 +391,7 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
         elif method == "GET":
             method = "LIST"
 
-        is_multi_team = IS_MULTI_TEAM
+        is_multi_team = conf.getboolean("core", "multi_team", fallback=False)
         is_team_scoped = resource_type in TEAM_SCOPED_RESOURCES
         is_teamless = team_name is None
 
@@ -466,7 +465,7 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
 
     @staticmethod
     def _get_resource_name(resource_type: KeycloakResource, team_name: str | None) -> str | None:
-        if not IS_MULTI_TEAM:
+        if not conf.getboolean("core", "multi_team", fallback=False):
             return resource_type.value
 
         if resource_type in TEAM_SCOPED_RESOURCES:

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
@@ -396,20 +396,8 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
         elif method == "GET":
             method = "LIST"
 
-        is_multi_team = conf.getboolean("core", "multi_team", fallback=False)
-        is_team_scoped = resource_type in TEAM_SCOPED_RESOURCES
-        is_teamless = team_name is None
-
-        # Team-scoped resources require a team, except for LIST which uses global permission.
-        if is_multi_team and is_team_scoped and is_teamless and method != "LIST":
-            raise ValueError("Missing team_name for team-scoped resource in multi-team mode.")
-        if is_multi_team and is_team_scoped and is_teamless and method == "LIST":
-            permission = f"{resource_type.value}#{method}"
-        else:
-            resource_name = self._get_resource_name(resource_type, team_name)
-            if resource_name is None:
-                return False
-            permission = f"{resource_name}#{method}"
+        resource_name = self._get_resource_name(resource_type, team_name)
+        permission = f"{resource_name}#{method}"
 
         resp = self.http_session.post(
             self._get_token_url(server_url, realm),
@@ -475,7 +463,7 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
             or resource_type not in TEAM_SCOPED_RESOURCES
         ):
             return resource_type.value
-        return f"{resource_type.value}:{team_name}" if team_name else None
+        return f"{resource_type.value}:{team_name}" if team_name else resource_type.value
 
     @staticmethod
     def _get_team_name(details: Any | None) -> str | None:

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
@@ -79,15 +79,9 @@ RESOURCE_ID_ATTRIBUTE_NAME = "resource_id"
 TEAM_SCOPED_RESOURCES = frozenset(
     {
         KeycloakResource.DAG,
-        KeycloakResource.ASSET,
-    }
-)
-TEAM_OPTIONAL_RESOURCES = frozenset(
-    {
         KeycloakResource.CONNECTION,
-        KeycloakResource.VARIABLE,
         KeycloakResource.POOL,
-        KeycloakResource.BACKFILL,
+        KeycloakResource.VARIABLE,
     }
 )
 
@@ -249,26 +243,16 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
         )
 
         backfill_id = str(details.id) if details else None
-        team_name = getattr(details, "team_name", None) if details else None
         return self._is_authorized(
-            method=method,
-            resource_type=KeycloakResource.BACKFILL,
-            user=user,
-            resource_id=backfill_id,
-            team_name=team_name,
+            method=method, resource_type=KeycloakResource.BACKFILL, user=user, resource_id=backfill_id
         )
 
     def is_authorized_asset(
         self, *, method: ResourceMethod, user: KeycloakAuthManagerUser, details: AssetDetails | None = None
     ) -> bool:
         asset_id = details.id if details else None
-        team_name = getattr(details, "team_name", None) if details else None
         return self._is_authorized(
-            method=method,
-            resource_type=KeycloakResource.ASSET,
-            user=user,
-            resource_id=asset_id,
-            team_name=team_name,
+            method=method, resource_type=KeycloakResource.ASSET, user=user, resource_id=asset_id
         )
 
     def is_authorized_asset_alias(
@@ -407,51 +391,41 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
         elif method == "GET":
             method = "LIST"
 
-        if (
-            method == "LIST"
-            and conf.getboolean("core", "multi_team")
-            and team_name is None
-            and resource_type in TEAM_SCOPED_RESOURCES.union(TEAM_OPTIONAL_RESOURCES)
-        ):
-            # Allow list access based on team membership when team_name is missing on list requests.
-            team_names = sorted(self._get_user_team_names(user))
-            if not team_names:
+        is_multi_team = conf.getboolean("core", "multi_team")
+        is_team_scoped = resource_type in TEAM_SCOPED_RESOURCES
+        is_teamless = team_name is None
+
+        # Team-scoped resources require a team, except for LIST which uses global permission.
+        if is_multi_team and is_team_scoped and is_teamless and method != "LIST":
+            return False
+        if is_multi_team and is_team_scoped and is_teamless and method == "LIST":
+            permission = f"{resource_type.value}#{method}"
+        else:
+            resource_name = self._get_resource_name(resource_type, team_name)
+            if resource_name is None:
                 return False
-            for team in team_names:
-                attributes_with_team = dict(context_attributes)
-                resource_name = self._get_resource_name(resource_type, team)
-                if resource_name is None:
-                    continue
-                if self._check_permission(
-                    server_url=server_url,
-                    realm=realm,
-                    client_id=client_id,
-                    permission=f"{resource_name}#{method}",
-                    attributes=attributes_with_team,
-                    user=user,
-                ):
-                    return True
-            return False
+            permission = f"{resource_name}#{method}"
 
-        if (
-            method != "LIST"
-            and conf.getboolean("core", "multi_team")
-            and team_name is None
-            and resource_type in TEAM_OPTIONAL_RESOURCES
-        ):
-            return False
-
-        resource_name = self._get_resource_name(resource_type, team_name)
-        if resource_name is None:
-            return False
-        return self._check_permission(
-            server_url=server_url,
-            realm=realm,
-            client_id=client_id,
-            permission=f"{resource_name}#{method}",
-            attributes=context_attributes,
-            user=user,
+        resp = self.http_session.post(
+            self._get_token_url(server_url, realm),
+            data=self._get_payload(client_id, permission, context_attributes),
+            headers=self._get_headers(user.access_token),
+            timeout=5,
         )
+
+        if resp.status_code == 200:
+            return True
+        if resp.status_code == 401:
+            log.debug("Received 401 from Keycloak: %s", resp.text)
+            return False
+        if resp.status_code == 403:
+            return False
+        if resp.status_code == 400:
+            error = json.loads(resp.text)
+            raise AirflowException(
+                f"Request not recognized by Keycloak. {error.get('error')}. {error.get('error_description')}"
+            )
+        raise AirflowException(f"Unexpected error: {resp.status_code} - {resp.text}")
 
     def _is_batch_authorized(
         self,
@@ -497,9 +471,6 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
         if resource_type in TEAM_SCOPED_RESOURCES:
             return f"{resource_type.value}:{team_name}" if team_name else None
 
-        if resource_type in TEAM_OPTIONAL_RESOURCES and team_name:
-            return f"{resource_type.value}:{team_name}"
-
         return resource_type.value
 
     @staticmethod
@@ -532,37 +503,6 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
 
         return payload
 
-    def _check_permission(
-        self,
-        *,
-        server_url: str,
-        realm: str,
-        client_id: str,
-        permission: str,
-        attributes: dict[str, str | None] | None,
-        user: KeycloakAuthManagerUser,
-    ) -> bool:
-        resp = self.http_session.post(
-            self._get_token_url(server_url, realm),
-            data=self._get_payload(client_id, permission, prune_dict(attributes or {})),
-            headers=self._get_headers(user.access_token),
-            timeout=5,
-        )
-
-        if resp.status_code == 200:
-            return True
-        if resp.status_code == 401:
-            log.debug("Received 401 from Keycloak: %s", resp.text)
-            return False
-        if resp.status_code == 403:
-            return False
-        if resp.status_code == 400:
-            error = json.loads(resp.text)
-            raise AirflowException(
-                f"Request not recognized by Keycloak. {error.get('error')}. {error.get('error_description')}"
-            )
-        raise AirflowException(f"Unexpected error: {resp.status_code} - {resp.text}")
-
     @staticmethod
     def _get_headers(access_token):
         return {
@@ -583,28 +523,3 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
         payload_bytes = urlsafe_b64decode(payload_b64)
         payload = json.loads(payload_bytes)
         return payload["exp"] < int(time.time())
-
-    @staticmethod
-    def _get_token_payload(token: str) -> dict[str, Any]:
-        try:
-            payload_b64 = token.split(".")[1] + "=="
-            payload_bytes = urlsafe_b64decode(payload_b64)
-            return json.loads(payload_bytes)
-        except (IndexError, ValueError, json.JSONDecodeError):
-            return {}
-
-    def _get_user_team_names(self, user: KeycloakAuthManagerUser) -> set[str]:
-        payload = self._get_token_payload(user.access_token)
-        groups = payload.get("groups") or payload.get("group") or []
-        if isinstance(groups, str):
-            groups = [groups]
-        team_names: set[str] = set()
-        for group in groups:
-            if not isinstance(group, str):
-                continue
-            group_name = group.strip("/")
-            if not group_name:
-                continue
-            group_name = group_name.split("/")[-1]
-            team_names.add(group_name)
-        return team_names

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
@@ -43,7 +43,12 @@ except ImportError:
 
 from airflow.api_fastapi.common.types import MenuItem
 from airflow.cli.cli_config import CLICommand
-from airflow.providers.common.compat.sdk import AirflowException, conf
+
+try:
+    from airflow.providers.common.compat.sdk import AirflowException, conf
+except ModuleNotFoundError:
+    from airflow.configuration import conf
+    from airflow.exceptions import AirflowException
 from airflow.providers.keycloak.auth_manager.constants import (
     CONF_CLIENT_ID_KEY,
     CONF_CLIENT_SECRET_KEY,
@@ -474,7 +479,7 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
 
     @staticmethod
     def _get_team_name(details: Any | None) -> str | None:
-        return details.team_name if details else None
+        return getattr(details, "team_name", None) if details else None
 
     @staticmethod
     def _get_payload(client_id: str, permission: str, attributes: dict[str, str] | None = None):

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
@@ -396,7 +396,11 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
         elif method == "GET":
             method = "LIST"
 
-        if team_name and conf.getboolean("core", "multi_team", fallback=False) and resource_type in TEAM_SCOPED_RESOURCES:
+        if (
+            team_name
+            and conf.getboolean("core", "multi_team", fallback=False)
+            and resource_type in TEAM_SCOPED_RESOURCES
+        ):
             resource_name = f"{resource_type.value}:{team_name}"
         else:
             resource_name = resource_type.value
@@ -460,7 +464,9 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
         return f"{server_url.rstrip('/')}/realms/{realm}/protocol/openid-connect/token"
 
     @staticmethod
-    def _get_team_name(details: Any | None) -> str | None:
+    def _get_team_name(
+        details: ConnectionDetails | DagDetails | PoolDetails | VariableDetails | None,
+    ) -> str | None:
         return getattr(details, "team_name", None) if details else None
 
     @staticmethod

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
@@ -74,6 +74,7 @@ if TYPE_CHECKING:
     from airflow.cli.cli_config import CLICommand
 
 log = logging.getLogger(__name__)
+IS_MULTI_TEAM = conf.getboolean("core", "multi_team")
 
 RESOURCE_ID_ATTRIBUTE_NAME = "resource_id"
 TEAM_SCOPED_RESOURCES = frozenset(
@@ -203,7 +204,7 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
         details: ConnectionDetails | None = None,
     ) -> bool:
         connection_id = details.conn_id if details else None
-        team_name = details.team_name if details else None
+        team_name = self._get_team_name(details)
         return self._is_authorized(
             method=method,
             resource_type=KeycloakResource.CONNECTION,
@@ -221,7 +222,7 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
         details: DagDetails | None = None,
     ) -> bool:
         dag_id = details.id if details else None
-        team_name = details.team_name if details else None
+        team_name = self._get_team_name(details)
         access_entity_str = access_entity.value if access_entity else None
         return self._is_authorized(
             method=method,
@@ -274,7 +275,7 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
         self, *, method: ResourceMethod, user: KeycloakAuthManagerUser, details: VariableDetails | None = None
     ) -> bool:
         variable_key = details.key if details else None
-        team_name = details.team_name if details else None
+        team_name = self._get_team_name(details)
         return self._is_authorized(
             method=method,
             resource_type=KeycloakResource.VARIABLE,
@@ -287,7 +288,7 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
         self, *, method: ResourceMethod, user: KeycloakAuthManagerUser, details: PoolDetails | None = None
     ) -> bool:
         pool_name = details.name if details else None
-        team_name = details.team_name if details else None
+        team_name = self._get_team_name(details)
         return self._is_authorized(
             method=method,
             resource_type=KeycloakResource.POOL,
@@ -391,7 +392,7 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
         elif method == "GET":
             method = "LIST"
 
-        is_multi_team = conf.getboolean("core", "multi_team")
+        is_multi_team = IS_MULTI_TEAM
         is_team_scoped = resource_type in TEAM_SCOPED_RESOURCES
         is_teamless = team_name is None
 
@@ -465,13 +466,17 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
 
     @staticmethod
     def _get_resource_name(resource_type: KeycloakResource, team_name: str | None) -> str | None:
-        if not conf.getboolean("core", "multi_team"):
+        if not IS_MULTI_TEAM:
             return resource_type.value
 
         if resource_type in TEAM_SCOPED_RESOURCES:
             return f"{resource_type.value}:{team_name}" if team_name else None
 
         return resource_type.value
+
+    @staticmethod
+    def _get_team_name(details: Any | None) -> str | None:
+        return details.team_name if details else None
 
     @staticmethod
     def _get_payload(client_id: str, permission: str, attributes: dict[str, str] | None = None):

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
@@ -508,13 +508,20 @@ class TestKeycloakAuthManager:
         auth_manager_multi_team.http_session.post.assert_not_called()
         assert result is False
 
-    def test_is_authorized_dag_list_multi_team_without_team_denied(self, auth_manager_multi_team, user):
-        auth_manager_multi_team.http_session.post = Mock()
+    def test_is_authorized_dag_list_multi_team_without_team_global_list(self, auth_manager_multi_team, user):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        auth_manager_multi_team.http_session.post = Mock(return_value=mock_response)
 
         result = auth_manager_multi_team.is_authorized_dag(method="GET", user=user)
 
-        auth_manager_multi_team.http_session.post.assert_not_called()
-        assert result is False
+        token_url = auth_manager_multi_team._get_token_url("server_url", "realm")
+        payload = auth_manager_multi_team._get_payload("client_id", "Dag#LIST", {})
+        headers = auth_manager_multi_team._get_headers(user.access_token)
+        auth_manager_multi_team.http_session.post.assert_called_once_with(
+            token_url, data=payload, headers=headers, timeout=5
+        )
+        assert result is True
 
     def test_is_authorized_dag_list_team_scoped_permission(self, auth_manager_multi_team, user):
         user.access_token = _build_access_token({"groups": ["team-a"]})

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import base64
-import inspect
 import json
 from contextlib import ExitStack
 from unittest.mock import Mock, patch
@@ -266,33 +265,6 @@ class TestKeycloakAuthManager:
         ["is_authorized_pool", "GET", None, "Pool#LIST", {}],
     ]
 
-    if AIRFLOW_V_3_2_PLUS:
-        _AUTHORIZED_PARAMS.extend(
-            [
-                [
-                    "is_authorized_connection",
-                    "DELETE",
-                    ConnectionDetails(conn_id="test", team_name="team-a"),
-                    "Connection#DELETE",
-                    {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
-                ],
-                [
-                    "is_authorized_variable",
-                    "PUT",
-                    VariableDetails(key="test", team_name="team-a"),
-                    "Variable#PUT",
-                    {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
-                ],
-                [
-                    "is_authorized_pool",
-                    "POST",
-                    PoolDetails(name="test", team_name="team-a"),
-                    "Pool#POST",
-                    {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
-                ],
-            ]
-        )
-
     @pytest.mark.parametrize(
         ("function", "method", "details", "permission", "attributes"),
         _AUTHORIZED_PARAMS,
@@ -436,29 +408,6 @@ class TestKeycloakAuthManager:
         ],
     ]
 
-    if AIRFLOW_V_3_2_PLUS:
-        _DAG_AUTHORIZED_PARAMS.extend(
-            [
-                [
-                    "GET",
-                    DagAccessEntity.TASK_INSTANCE,
-                    DagDetails(id="test", team_name="team-a"),
-                    "Dag#GET",
-                    {
-                        RESOURCE_ID_ATTRIBUTE_NAME: "test",
-                        "dag_entity": "TASK_INSTANCE",
-                    },
-                ],
-                [
-                    "GET",
-                    None,
-                    DagDetails(id="test", team_name="team-a"),
-                    "Dag#GET",
-                    {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
-                ],
-            ]
-        )
-
     @pytest.mark.parametrize(
         ("method", "access_entity", "details", "permission", "attributes"),
         _DAG_AUTHORIZED_PARAMS,
@@ -498,7 +447,41 @@ class TestKeycloakAuthManager:
         )
         assert result == expected
 
-    _TEAM_SCOPED_PERMISSION_PARAMS = (
+    @pytest.mark.parametrize(
+        ("function", "method", "details", "permission"),
+        [
+            ("is_authorized_dag", "GET", DagDetails(id="test", team_name="team-a"), "Dag#GET"),
+            (
+                "is_authorized_connection",
+                "DELETE",
+                ConnectionDetails(conn_id="test", team_name="team-a"),
+                "Connection#DELETE",
+            ),
+            (
+                "is_authorized_variable",
+                "PUT",
+                VariableDetails(key="test", team_name="team-a"),
+                "Variable#PUT",
+            ),
+            ("is_authorized_pool", "POST", PoolDetails(name="test", team_name="team-a"), "Pool#POST"),
+        ]
+        if AIRFLOW_V_3_2_PLUS
+        else [],
+    )
+    def test_team_name_ignored_when_multi_team_disabled(
+        self, auth_manager, user, function, method, details, permission
+    ):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        auth_manager.http_session.post = Mock(return_value=mock_response)
+
+        getattr(auth_manager, function)(method=method, user=user, details=details)
+
+        actual_permission = auth_manager.http_session.post.call_args.kwargs["data"]["permission"]
+        assert actual_permission == permission
+
+    @pytest.mark.parametrize(
+        ("function", "details", "permission"),
         [
             ("is_authorized_dag", DagDetails(id="test", team_name="team-a"), "Dag:team-a#GET"),
             (
@@ -514,91 +497,40 @@ class TestKeycloakAuthManager:
             ("is_authorized_pool", PoolDetails(name="test", team_name="team-a"), "Pool:team-a#GET"),
         ]
         if AIRFLOW_V_3_2_PLUS
-        else [
-            pytest.param(
-                None,
-                None,
-                None,
-                marks=pytest.mark.skip(reason="multi_team not supported before 3.2.0"),
-            )
-        ]
+        else [],
     )
+    def test_with_team_name_uses_team_scoped_permission(
+        self, auth_manager_multi_team, user, function, details, permission
+    ):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        auth_manager_multi_team.http_session.post = Mock(return_value=mock_response)
+
+        getattr(auth_manager_multi_team, function)(method="GET", user=user, details=details)
+
+        actual_permission = auth_manager_multi_team.http_session.post.call_args.kwargs["data"]["permission"]
+        assert actual_permission == permission
 
     @pytest.mark.parametrize(
         ("function", "details", "permission"),
-        _TEAM_SCOPED_PERMISSION_PARAMS,
-    )
-    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="multi_team not supported before 3.2.0")
-    def test_is_authorized_team_scoped_permission(
-        self, auth_manager_multi_team, user, function, details, permission
-    ):
-        if function is None:
-            pytest.skip("multi_team not supported before 3.2.0")
-        mock_response = Mock()
-        mock_response.status_code = 200
-        auth_manager_multi_team.http_session.post = Mock(return_value=mock_response)
-
-        result = getattr(auth_manager_multi_team, function)(method="GET", user=user, details=details)
-
-        token_url = auth_manager_multi_team._get_token_url("server_url", "realm")
-        payload = auth_manager_multi_team._get_payload(
-            "client_id",
-            permission,
-            {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
-        )
-        headers = auth_manager_multi_team._get_headers(user.access_token)
-        auth_manager_multi_team.http_session.post.assert_called_once_with(
-            token_url, data=payload, headers=headers, timeout=5
-        )
-        assert result is True
-
-    @pytest.mark.parametrize(
-        ("function", "details", "permission", "resource_id"),
         [
-            ("is_authorized_dag", DagDetails(id="test"), "Dag#GET", "test"),
-            ("is_authorized_connection", ConnectionDetails(conn_id="test"), "Connection#GET", "test"),
-            ("is_authorized_variable", VariableDetails(key="test"), "Variable#GET", "test"),
-            ("is_authorized_pool", PoolDetails(name="test"), "Pool#GET", "test"),
+            ("is_authorized_dag", DagDetails(id="test"), "Dag#GET"),
+            ("is_authorized_connection", ConnectionDetails(conn_id="test"), "Connection#GET"),
+            ("is_authorized_variable", VariableDetails(key="test"), "Variable#GET"),
+            ("is_authorized_pool", PoolDetails(name="test"), "Pool#GET"),
         ],
     )
-    def test_is_authorized_team_scoped_no_team_uses_global_permission(
-        self, auth_manager_multi_team, user, function, details, permission, resource_id
+    def test_without_team_name_uses_global_permission(
+        self, auth_manager_multi_team, user, function, details, permission
     ):
         mock_response = Mock()
         mock_response.status_code = 200
         auth_manager_multi_team.http_session.post = Mock(return_value=mock_response)
 
-        result = getattr(auth_manager_multi_team, function)(method="GET", user=user, details=details)
+        getattr(auth_manager_multi_team, function)(method="GET", user=user, details=details)
 
-        token_url = auth_manager_multi_team._get_token_url("server_url", "realm")
-        payload = auth_manager_multi_team._get_payload(
-            "client_id",
-            permission,
-            {RESOURCE_ID_ATTRIBUTE_NAME: resource_id},
-        )
-        headers = auth_manager_multi_team._get_headers(user.access_token)
-        auth_manager_multi_team.http_session.post.assert_called_once_with(
-            token_url, data=payload, headers=headers, timeout=5
-        )
-        assert result is True
-
-    _TEAM_SCOPED_LIST_PARAMS = (
-        [
-            ("is_authorized_dag", DagDetails(team_name="team-a"), "Dag:team-a#LIST"),
-            ("is_authorized_connection", ConnectionDetails(team_name="team-a"), "Connection:team-a#LIST"),
-            ("is_authorized_variable", VariableDetails(team_name="team-a"), "Variable:team-a#LIST"),
-            ("is_authorized_pool", PoolDetails(team_name="team-a"), "Pool:team-a#LIST"),
-        ]
-        if AIRFLOW_V_3_2_PLUS
-        else [
-            pytest.param(
-                None,
-                None,
-                None,
-                marks=pytest.mark.skip(reason="multi_team not supported before 3.2.0"),
-            )
-        ]
-    )
+        actual_permission = auth_manager_multi_team.http_session.post.call_args.kwargs["data"]["permission"]
+        assert actual_permission == permission
 
     @pytest.mark.parametrize(
         ("function", "permission"),
@@ -609,51 +541,45 @@ class TestKeycloakAuthManager:
             ("is_authorized_pool", "Pool#LIST"),
         ],
     )
-    def test_is_authorized_team_scoped_list_multi_team_without_team_global_list(
+    def test_list_without_team_name_uses_global_permission(
         self, auth_manager_multi_team, user, function, permission
     ):
         mock_response = Mock()
         mock_response.status_code = 200
         auth_manager_multi_team.http_session.post = Mock(return_value=mock_response)
 
-        result = getattr(auth_manager_multi_team, function)(method="GET", user=user)
+        getattr(auth_manager_multi_team, function)(method="GET", user=user)
 
-        token_url = auth_manager_multi_team._get_token_url("server_url", "realm")
-        payload = auth_manager_multi_team._get_payload("client_id", permission, {})
-        headers = auth_manager_multi_team._get_headers(user.access_token)
-        auth_manager_multi_team.http_session.post.assert_called_once_with(
-            token_url, data=payload, headers=headers, timeout=5
-        )
-        assert result is True
+        actual_permission = auth_manager_multi_team.http_session.post.call_args.kwargs["data"]["permission"]
+        assert actual_permission == permission
 
     @pytest.mark.parametrize(
         ("function", "details", "permission"),
-        _TEAM_SCOPED_LIST_PARAMS,
+        [
+            ("is_authorized_dag", DagDetails(team_name="team-a"), "Dag:team-a#LIST"),
+            ("is_authorized_connection", ConnectionDetails(team_name="team-a"), "Connection:team-a#LIST"),
+            ("is_authorized_variable", VariableDetails(team_name="team-a"), "Variable:team-a#LIST"),
+            ("is_authorized_pool", PoolDetails(team_name="team-a"), "Pool:team-a#LIST"),
+        ]
+        if AIRFLOW_V_3_2_PLUS
+        else [],
     )
-    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="multi_team not supported before 3.2.0")
-    def test_is_authorized_team_scoped_list_team_scoped_permission(
+    def test_list_with_team_name_uses_team_scoped_permission(
         self, auth_manager_multi_team, user, function, details, permission
     ):
-        if function is None:
-            pytest.skip("multi_team not supported before 3.2.0")
         user.access_token = _build_access_token({"groups": ["team-a"]})
         mock_response = Mock()
         mock_response.status_code = 200
         auth_manager_multi_team.http_session.post = Mock(return_value=mock_response)
 
-        result = getattr(auth_manager_multi_team, function)(method="GET", user=user, details=details)
+        getattr(auth_manager_multi_team, function)(method="GET", user=user, details=details)
 
-        token_url = auth_manager_multi_team._get_token_url("server_url", "realm")
-        payload = auth_manager_multi_team._get_payload("client_id", permission, {})
-        headers = auth_manager_multi_team._get_headers(user.access_token)
-        auth_manager_multi_team.http_session.post.assert_called_once_with(
-            token_url, data=payload, headers=headers, timeout=5
-        )
-        assert result is True
+        actual_permission = auth_manager_multi_team.http_session.post.call_args.kwargs["data"]["permission"]
+        assert actual_permission == permission
 
     def test_filter_authorized_dag_ids_team_mismatch(self, auth_manager_multi_team, user):
-        if "team_name" not in inspect.signature(auth_manager_multi_team.filter_authorized_dag_ids).parameters:
-            pytest.skip("team_name not supported by filter_authorized_dag_ids in this Airflow version.")
+        if not AIRFLOW_V_3_2_PLUS:
+            pytest.skip("team_name not supported before Airflow 3.2.0")
 
         with patch.object(KeycloakAuthManager, "is_authorized_dag", return_value=False) as mock_is_authorized:
             result = auth_manager_multi_team.filter_authorized_dag_ids(
@@ -664,8 +590,8 @@ class TestKeycloakAuthManager:
             assert result == set()
 
     def test_filter_authorized_dag_ids_team_match(self, auth_manager_multi_team, user):
-        if "team_name" not in inspect.signature(auth_manager_multi_team.filter_authorized_dag_ids).parameters:
-            pytest.skip("team_name not supported by filter_authorized_dag_ids in this Airflow version.")
+        if not AIRFLOW_V_3_2_PLUS:
+            pytest.skip("team_name not supported before Airflow 3.2.0")
 
         with patch.object(KeycloakAuthManager, "is_authorized_dag", return_value=True) as mock_is_authorized:
             result = auth_manager_multi_team.filter_authorized_dag_ids(
@@ -676,8 +602,8 @@ class TestKeycloakAuthManager:
             assert result == {"dag-a"}
 
     def test_filter_authorized_pools_no_team_returns_empty(self, auth_manager_multi_team, user):
-        if not hasattr(auth_manager_multi_team, "filter_authorized_pools"):
-            pytest.skip("filter_authorized_pools not available in this Airflow version.")
+        if not AIRFLOW_V_3_2_PLUS:
+            pytest.skip("filter_authorized_pools not supported before Airflow 3.2.0")
 
         with patch.object(
             KeycloakAuthManager, "is_authorized_pool", return_value=False
@@ -689,7 +615,8 @@ class TestKeycloakAuthManager:
             mock_is_authorized.assert_called_once()
             assert result == set()
 
-    _TEAM_SCOPED_LIST_MISMATCH_PARAMS = (
+    @pytest.mark.parametrize(
+        ("function", "details"),
         [
             ("is_authorized_dag", DagDetails(team_name="team-b")),
             ("is_authorized_connection", ConnectionDetails(team_name="team-b")),
@@ -697,25 +624,11 @@ class TestKeycloakAuthManager:
             ("is_authorized_pool", PoolDetails(team_name="team-b")),
         ]
         if AIRFLOW_V_3_2_PLUS
-        else [
-            pytest.param(
-                None,
-                None,
-                marks=pytest.mark.skip(reason="multi_team not supported before 3.2.0"),
-            )
-        ]
+        else [],
     )
-
-    @pytest.mark.parametrize(
-        ("function", "details"),
-        _TEAM_SCOPED_LIST_MISMATCH_PARAMS,
-    )
-    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="multi_team not supported before 3.2.0")
-    def test_is_authorized_team_scoped_list_team_mismatch_calls_keycloak(
+    def test_list_with_mismatched_team_delegates_to_keycloak(
         self, auth_manager_multi_team, user, function, details
     ):
-        if function is None:
-            pytest.skip("multi_team not supported before 3.2.0")
         mock_response = Mock()
         mock_response.status_code = 403
         auth_manager_multi_team.http_session.post = Mock(return_value=mock_response)

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import base64
+import inspect
 import json
 from contextlib import ExitStack
 from unittest.mock import Mock, patch
@@ -39,7 +40,11 @@ from airflow.api_fastapi.auth.managers.models.resource_details import (
 )
 from airflow.api_fastapi.common.types import MenuItem
 from airflow.exceptions import AirflowProviderDeprecationWarning
-from airflow.providers.common.compat.sdk import AirflowException
+
+try:
+    from airflow.providers.common.compat.sdk import AirflowException
+except ModuleNotFoundError:
+    from airflow.exceptions import AirflowException
 from airflow.providers.keycloak.auth_manager.constants import (
     CONF_CLIENT_ID_KEY,
     CONF_CLIENT_SECRET_KEY,
@@ -195,94 +200,102 @@ class TestKeycloakAuthManager:
 
         keycloak_client.refresh_token.assert_called_with("refresh_token")
 
+    _AUTHORIZED_PARAMS = [
+        [
+            "is_authorized_configuration",
+            "GET",
+            ConfigurationDetails(section="test"),
+            "Configuration#GET",
+            {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
+        ],
+        ["is_authorized_configuration", "GET", None, "Configuration#LIST", None],
+        [
+            "is_authorized_configuration",
+            "PUT",
+            ConfigurationDetails(section="test"),
+            "Configuration#PUT",
+            {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
+        ],
+        [
+            "is_authorized_connection",
+            "DELETE",
+            ConnectionDetails(conn_id="test"),
+            "Connection#DELETE",
+            {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
+        ],
+        ["is_authorized_connection", "GET", None, "Connection#LIST", {}],
+        [
+            "is_authorized_backfill",
+            "POST",
+            BackfillDetails(id=1),
+            "Backfill#POST",
+            {RESOURCE_ID_ATTRIBUTE_NAME: "1"},
+        ],
+        ["is_authorized_backfill", "GET", None, "Backfill#LIST", {}],
+        [
+            "is_authorized_asset",
+            "GET",
+            AssetDetails(id="test"),
+            "Asset#GET",
+            {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
+        ],
+        ["is_authorized_asset", "GET", None, "Asset#LIST", {}],
+        [
+            "is_authorized_asset_alias",
+            "GET",
+            AssetAliasDetails(id="test"),
+            "AssetAlias#GET",
+            {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
+        ],
+        ["is_authorized_asset_alias", "GET", None, "AssetAlias#LIST", {}],
+        [
+            "is_authorized_variable",
+            "PUT",
+            VariableDetails(key="test"),
+            "Variable#PUT",
+            {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
+        ],
+        ["is_authorized_variable", "GET", None, "Variable#LIST", {}],
+        [
+            "is_authorized_pool",
+            "POST",
+            PoolDetails(name="test"),
+            "Pool#POST",
+            {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
+        ],
+        ["is_authorized_pool", "GET", None, "Pool#LIST", {}],
+    ]
+
+    if AIRFLOW_V_3_1_7_PLUS:
+        _AUTHORIZED_PARAMS.extend(
+            [
+                [
+                    "is_authorized_connection",
+                    "DELETE",
+                    ConnectionDetails(conn_id="test", team_name="team-a"),
+                    "Connection#DELETE",
+                    {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
+                ],
+                [
+                    "is_authorized_variable",
+                    "PUT",
+                    VariableDetails(key="test", team_name="team-a"),
+                    "Variable#PUT",
+                    {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
+                ],
+                [
+                    "is_authorized_pool",
+                    "POST",
+                    PoolDetails(name="test", team_name="team-a"),
+                    "Pool#POST",
+                    {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
+                ],
+            ]
+        )
+
     @pytest.mark.parametrize(
         ("function", "method", "details", "permission", "attributes"),
-        [
-            [
-                "is_authorized_configuration",
-                "GET",
-                ConfigurationDetails(section="test"),
-                "Configuration#GET",
-                {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
-            ],
-            ["is_authorized_configuration", "GET", None, "Configuration#LIST", None],
-            [
-                "is_authorized_configuration",
-                "PUT",
-                ConfigurationDetails(section="test"),
-                "Configuration#PUT",
-                {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
-            ],
-            [
-                "is_authorized_connection",
-                "DELETE",
-                ConnectionDetails(conn_id="test"),
-                "Connection#DELETE",
-                {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
-            ],
-            [
-                "is_authorized_connection",
-                "DELETE",
-                ConnectionDetails(conn_id="test", team_name="team-a"),
-                "Connection#DELETE",
-                {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
-            ],
-            ["is_authorized_connection", "GET", None, "Connection#LIST", {}],
-            [
-                "is_authorized_backfill",
-                "POST",
-                BackfillDetails(id=1),
-                "Backfill#POST",
-                {RESOURCE_ID_ATTRIBUTE_NAME: "1"},
-            ],
-            ["is_authorized_backfill", "GET", None, "Backfill#LIST", {}],
-            [
-                "is_authorized_asset",
-                "GET",
-                AssetDetails(id="test"),
-                "Asset#GET",
-                {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
-            ],
-            ["is_authorized_asset", "GET", None, "Asset#LIST", {}],
-            [
-                "is_authorized_asset_alias",
-                "GET",
-                AssetAliasDetails(id="test"),
-                "AssetAlias#GET",
-                {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
-            ],
-            ["is_authorized_asset_alias", "GET", None, "AssetAlias#LIST", {}],
-            [
-                "is_authorized_variable",
-                "PUT",
-                VariableDetails(key="test"),
-                "Variable#PUT",
-                {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
-            ],
-            [
-                "is_authorized_variable",
-                "PUT",
-                VariableDetails(key="test", team_name="team-a"),
-                "Variable#PUT",
-                {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
-            ],
-            ["is_authorized_variable", "GET", None, "Variable#LIST", {}],
-            [
-                "is_authorized_pool",
-                "POST",
-                PoolDetails(name="test"),
-                "Pool#POST",
-                {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
-            ],
-            [
-                "is_authorized_pool",
-                "POST",
-                PoolDetails(name="test", team_name="team-a"),
-                "Pool#POST",
-                {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
-            ],
-            ["is_authorized_pool", "GET", None, "Pool#LIST", {}],
-        ],
+        _AUTHORIZED_PARAMS,
     )
     @pytest.mark.parametrize(
         ("status_code", "expected"),
@@ -392,55 +405,63 @@ class TestKeycloakAuthManager:
 
             assert "Request not recognized by Keycloak. invalid_scope. Invalid scopes: GET" in str(e.value)
 
+    _DAG_AUTHORIZED_PARAMS = [
+        [
+            "GET",
+            None,
+            None,
+            "Dag#LIST",
+            {},
+        ],
+        [
+            "GET",
+            DagAccessEntity.TASK_INSTANCE,
+            DagDetails(id="test"),
+            "Dag#GET",
+            {RESOURCE_ID_ATTRIBUTE_NAME: "test", "dag_entity": "TASK_INSTANCE"},
+        ],
+        [
+            "GET",
+            None,
+            DagDetails(id="test"),
+            "Dag#GET",
+            {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
+        ],
+        [
+            "GET",
+            DagAccessEntity.TASK_INSTANCE,
+            None,
+            "Dag#LIST",
+            {"dag_entity": "TASK_INSTANCE"},
+        ],
+    ]
+
+    if AIRFLOW_V_3_1_7_PLUS:
+        _DAG_AUTHORIZED_PARAMS.extend(
+            [
+                [
+                    "GET",
+                    DagAccessEntity.TASK_INSTANCE,
+                    DagDetails(id="test", team_name="team-a"),
+                    "Dag#GET",
+                    {
+                        RESOURCE_ID_ATTRIBUTE_NAME: "test",
+                        "dag_entity": "TASK_INSTANCE",
+                    },
+                ],
+                [
+                    "GET",
+                    None,
+                    DagDetails(id="test", team_name="team-a"),
+                    "Dag#GET",
+                    {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
+                ],
+            ]
+        )
+
     @pytest.mark.parametrize(
         ("method", "access_entity", "details", "permission", "attributes"),
-        [
-            [
-                "GET",
-                None,
-                None,
-                "Dag#LIST",
-                {},
-            ],
-            [
-                "GET",
-                DagAccessEntity.TASK_INSTANCE,
-                DagDetails(id="test"),
-                "Dag#GET",
-                {RESOURCE_ID_ATTRIBUTE_NAME: "test", "dag_entity": "TASK_INSTANCE"},
-            ],
-            [
-                "GET",
-                DagAccessEntity.TASK_INSTANCE,
-                DagDetails(id="test", team_name="team-a"),
-                "Dag#GET",
-                {
-                    RESOURCE_ID_ATTRIBUTE_NAME: "test",
-                    "dag_entity": "TASK_INSTANCE",
-                },
-            ],
-            [
-                "GET",
-                None,
-                DagDetails(id="test"),
-                "Dag#GET",
-                {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
-            ],
-            [
-                "GET",
-                None,
-                DagDetails(id="test", team_name="team-a"),
-                "Dag#GET",
-                {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
-            ],
-            [
-                "GET",
-                DagAccessEntity.TASK_INSTANCE,
-                None,
-                "Dag#LIST",
-                {"dag_entity": "TASK_INSTANCE"},
-            ],
-        ],
+        _DAG_AUTHORIZED_PARAMS,
     )
     @pytest.mark.parametrize(
         ("status_code", "expected"),
@@ -477,19 +498,52 @@ class TestKeycloakAuthManager:
         )
         assert result == expected
 
-    def test_is_authorized_dag_team_scoped_permission(self, auth_manager_multi_team, user):
+    _TEAM_SCOPED_PERMISSION_PARAMS = (
+        [
+            ("is_authorized_dag", DagDetails(id="test", team_name="team-a"), "Dag:team-a#GET"),
+            (
+                "is_authorized_connection",
+                ConnectionDetails(conn_id="test", team_name="team-a"),
+                "Connection:team-a#GET",
+            ),
+            (
+                "is_authorized_variable",
+                VariableDetails(key="test", team_name="team-a"),
+                "Variable:team-a#GET",
+            ),
+            ("is_authorized_pool", PoolDetails(name="test", team_name="team-a"), "Pool:team-a#GET"),
+        ]
+        if AIRFLOW_V_3_1_7_PLUS
+        else [
+            pytest.param(
+                None,
+                None,
+                None,
+                marks=pytest.mark.skip(reason="multi_team not supported before 3.1.7"),
+            )
+        ]
+    )
+
+    @pytest.mark.parametrize(
+        ("function", "details", "permission"),
+        _TEAM_SCOPED_PERMISSION_PARAMS,
+    )
+    @pytest.mark.skipif(not AIRFLOW_V_3_1_7_PLUS, reason="multi_team not supported before 3.1.7")
+    def test_is_authorized_team_scoped_permission(
+        self, auth_manager_multi_team, user, function, details, permission
+    ):
+        if function is None:
+            pytest.skip("multi_team not supported before 3.1.7")
         mock_response = Mock()
         mock_response.status_code = 200
         auth_manager_multi_team.http_session.post = Mock(return_value=mock_response)
 
-        result = auth_manager_multi_team.is_authorized_dag(
-            method="GET", user=user, details=DagDetails(id="test", team_name="team-a")
-        )
+        result = getattr(auth_manager_multi_team, function)(method="GET", user=user, details=details)
 
         token_url = auth_manager_multi_team._get_token_url("server_url", "realm")
         payload = auth_manager_multi_team._get_payload(
             "client_id",
-            "Dag:team-a#GET",
+            permission,
             {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
         )
         headers = auth_manager_multi_team._get_headers(user.access_token)
@@ -498,47 +552,88 @@ class TestKeycloakAuthManager:
         )
         assert result is True
 
-    def test_is_authorized_dag_no_team_denied(self, auth_manager_multi_team, user):
+    @pytest.mark.parametrize(
+        ("function", "details"),
+        [
+            ("is_authorized_dag", DagDetails(id="test")),
+            ("is_authorized_connection", ConnectionDetails(conn_id="test")),
+            ("is_authorized_variable", VariableDetails(key="test")),
+            ("is_authorized_pool", PoolDetails(name="test")),
+        ],
+    )
+    def test_is_authorized_team_scoped_no_team_denied(self, auth_manager_multi_team, user, function, details):
         auth_manager_multi_team.http_session.post = Mock()
 
         with pytest.raises(
             ValueError, match="Missing team_name for team-scoped resource in multi-team mode."
         ):
-            auth_manager_multi_team.is_authorized_dag(method="GET", user=user, details=DagDetails(id="test"))
+            getattr(auth_manager_multi_team, function)(method="GET", user=user, details=details)
 
         auth_manager_multi_team.http_session.post.assert_not_called()
 
-    def test_is_authorized_dag_list_multi_team_without_team_global_list(self, auth_manager_multi_team, user):
+    _TEAM_SCOPED_LIST_PARAMS = (
+        [
+            ("is_authorized_dag", DagDetails(team_name="team-a"), "Dag:team-a#LIST"),
+            ("is_authorized_connection", ConnectionDetails(team_name="team-a"), "Connection:team-a#LIST"),
+            ("is_authorized_variable", VariableDetails(team_name="team-a"), "Variable:team-a#LIST"),
+            ("is_authorized_pool", PoolDetails(team_name="team-a"), "Pool:team-a#LIST"),
+        ]
+        if AIRFLOW_V_3_1_7_PLUS
+        else [
+            pytest.param(
+                None,
+                None,
+                None,
+                marks=pytest.mark.skip(reason="multi_team not supported before 3.1.7"),
+            )
+        ]
+    )
+
+    @pytest.mark.parametrize(
+        ("function", "permission"),
+        [
+            ("is_authorized_dag", "Dag#LIST"),
+            ("is_authorized_connection", "Connection#LIST"),
+            ("is_authorized_variable", "Variable#LIST"),
+            ("is_authorized_pool", "Pool#LIST"),
+        ],
+    )
+    def test_is_authorized_team_scoped_list_multi_team_without_team_global_list(
+        self, auth_manager_multi_team, user, function, permission
+    ):
         mock_response = Mock()
         mock_response.status_code = 200
         auth_manager_multi_team.http_session.post = Mock(return_value=mock_response)
 
-        result = auth_manager_multi_team.is_authorized_dag(method="GET", user=user)
+        result = getattr(auth_manager_multi_team, function)(method="GET", user=user)
 
         token_url = auth_manager_multi_team._get_token_url("server_url", "realm")
-        payload = auth_manager_multi_team._get_payload("client_id", "Dag#LIST", {})
+        payload = auth_manager_multi_team._get_payload("client_id", permission, {})
         headers = auth_manager_multi_team._get_headers(user.access_token)
         auth_manager_multi_team.http_session.post.assert_called_once_with(
             token_url, data=payload, headers=headers, timeout=5
         )
         assert result is True
 
-    def test_is_authorized_dag_list_team_scoped_permission(self, auth_manager_multi_team, user):
+    @pytest.mark.parametrize(
+        ("function", "details", "permission"),
+        _TEAM_SCOPED_LIST_PARAMS,
+    )
+    @pytest.mark.skipif(not AIRFLOW_V_3_1_7_PLUS, reason="multi_team not supported before 3.1.7")
+    def test_is_authorized_team_scoped_list_team_scoped_permission(
+        self, auth_manager_multi_team, user, function, details, permission
+    ):
+        if function is None:
+            pytest.skip("multi_team not supported before 3.1.7")
         user.access_token = _build_access_token({"groups": ["team-a"]})
         mock_response = Mock()
         mock_response.status_code = 200
         auth_manager_multi_team.http_session.post = Mock(return_value=mock_response)
 
-        result = auth_manager_multi_team.is_authorized_dag(
-            method="GET", user=user, details=DagDetails(id=None, team_name="team-a")
-        )
+        result = getattr(auth_manager_multi_team, function)(method="GET", user=user, details=details)
 
         token_url = auth_manager_multi_team._get_token_url("server_url", "realm")
-        payload = auth_manager_multi_team._get_payload(
-            "client_id",
-            "Dag:team-a#LIST",
-            {},
-        )
+        payload = auth_manager_multi_team._get_payload("client_id", permission, {})
         headers = auth_manager_multi_team._get_headers(user.access_token)
         auth_manager_multi_team.http_session.post.assert_called_once_with(
             token_url, data=payload, headers=headers, timeout=5
@@ -546,6 +641,9 @@ class TestKeycloakAuthManager:
         assert result is True
 
     def test_filter_authorized_dag_ids_team_mismatch(self, auth_manager_multi_team, user):
+        if "team_name" not in inspect.signature(auth_manager_multi_team.filter_authorized_dag_ids).parameters:
+            pytest.skip("team_name not supported by filter_authorized_dag_ids in this Airflow version.")
+
         with patch.object(KeycloakAuthManager, "is_authorized_dag", return_value=False) as mock_is_authorized:
             result = auth_manager_multi_team.filter_authorized_dag_ids(
                 dag_ids={"dag-a"}, user=user, team_name="team-b"
@@ -555,6 +653,9 @@ class TestKeycloakAuthManager:
             assert result == set()
 
     def test_filter_authorized_dag_ids_team_match(self, auth_manager_multi_team, user):
+        if "team_name" not in inspect.signature(auth_manager_multi_team.filter_authorized_dag_ids).parameters:
+            pytest.skip("team_name not supported by filter_authorized_dag_ids in this Airflow version.")
+
         with patch.object(KeycloakAuthManager, "is_authorized_dag", return_value=True) as mock_is_authorized:
             result = auth_manager_multi_team.filter_authorized_dag_ids(
                 dag_ids={"dag-a"}, user=user, team_name="team-a"
@@ -564,6 +665,9 @@ class TestKeycloakAuthManager:
             assert result == {"dag-a"}
 
     def test_filter_authorized_pools_no_team_returns_empty(self, auth_manager_multi_team, user):
+        if not hasattr(auth_manager_multi_team, "filter_authorized_pools"):
+            pytest.skip("filter_authorized_pools not available in this Airflow version.")
+
         with patch.object(
             KeycloakAuthManager, "is_authorized_pool", return_value=False
         ) as mock_is_authorized:
@@ -574,14 +678,38 @@ class TestKeycloakAuthManager:
             mock_is_authorized.assert_called_once()
             assert result == set()
 
-    def test_is_authorized_dag_list_team_mismatch_calls_keycloak(self, auth_manager_multi_team, user):
+    _TEAM_SCOPED_LIST_MISMATCH_PARAMS = (
+        [
+            ("is_authorized_dag", DagDetails(team_name="team-b")),
+            ("is_authorized_connection", ConnectionDetails(team_name="team-b")),
+            ("is_authorized_variable", VariableDetails(team_name="team-b")),
+            ("is_authorized_pool", PoolDetails(team_name="team-b")),
+        ]
+        if AIRFLOW_V_3_1_7_PLUS
+        else [
+            pytest.param(
+                None,
+                None,
+                marks=pytest.mark.skip(reason="multi_team not supported before 3.1.7"),
+            )
+        ]
+    )
+
+    @pytest.mark.parametrize(
+        ("function", "details"),
+        _TEAM_SCOPED_LIST_MISMATCH_PARAMS,
+    )
+    @pytest.mark.skipif(not AIRFLOW_V_3_1_7_PLUS, reason="multi_team not supported before 3.1.7")
+    def test_is_authorized_team_scoped_list_team_mismatch_calls_keycloak(
+        self, auth_manager_multi_team, user, function, details
+    ):
+        if function is None:
+            pytest.skip("multi_team not supported before 3.1.7")
         mock_response = Mock()
         mock_response.status_code = 403
         auth_manager_multi_team.http_session.post = Mock(return_value=mock_response)
 
-        result = auth_manager_multi_team.is_authorized_dag(
-            method="GET", user=user, details=DagDetails(id=None, team_name="team-b")
-        )
+        result = getattr(auth_manager_multi_team, function)(method="GET", user=user, details=details)
 
         auth_manager_multi_team.http_session.post.assert_called_once()
         assert result is False

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
@@ -58,7 +58,7 @@ from airflow.providers.keycloak.auth_manager.keycloak_auth_manager import (
 from airflow.providers.keycloak.auth_manager.user import KeycloakAuthManagerUser
 
 from tests_common.test_utils.config import conf_vars
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_2_PLUS
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_1_7_PLUS, AIRFLOW_V_3_2_PLUS
 
 
 def _build_access_token(payload: dict[str, object]) -> str:
@@ -189,7 +189,7 @@ class TestKeycloakAuthManager:
 
         mock_get_keycloak_client.return_value = keycloak_client
 
-        if AIRFLOW_V_3_2_PLUS:
+        if AIRFLOW_V_3_1_7_PLUS:
             from airflow.api_fastapi.auth.managers.exceptions import AuthManagerRefreshTokenExpiredException
 
             with pytest.raises(AuthManagerRefreshTokenExpiredException):
@@ -199,75 +199,73 @@ class TestKeycloakAuthManager:
 
         keycloak_client.refresh_token.assert_called_with("refresh_token")
 
-    _AUTHORIZED_PARAMS = [
-        [
-            "is_authorized_configuration",
-            "GET",
-            ConfigurationDetails(section="test"),
-            "Configuration#GET",
-            {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
-        ],
-        ["is_authorized_configuration", "GET", None, "Configuration#LIST", None],
-        [
-            "is_authorized_configuration",
-            "PUT",
-            ConfigurationDetails(section="test"),
-            "Configuration#PUT",
-            {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
-        ],
-        [
-            "is_authorized_connection",
-            "DELETE",
-            ConnectionDetails(conn_id="test"),
-            "Connection#DELETE",
-            {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
-        ],
-        ["is_authorized_connection", "GET", None, "Connection#LIST", {}],
-        [
-            "is_authorized_backfill",
-            "POST",
-            BackfillDetails(id=1),
-            "Backfill#POST",
-            {RESOURCE_ID_ATTRIBUTE_NAME: "1"},
-        ],
-        ["is_authorized_backfill", "GET", None, "Backfill#LIST", {}],
-        [
-            "is_authorized_asset",
-            "GET",
-            AssetDetails(id="test"),
-            "Asset#GET",
-            {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
-        ],
-        ["is_authorized_asset", "GET", None, "Asset#LIST", {}],
-        [
-            "is_authorized_asset_alias",
-            "GET",
-            AssetAliasDetails(id="test"),
-            "AssetAlias#GET",
-            {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
-        ],
-        ["is_authorized_asset_alias", "GET", None, "AssetAlias#LIST", {}],
-        [
-            "is_authorized_variable",
-            "PUT",
-            VariableDetails(key="test"),
-            "Variable#PUT",
-            {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
-        ],
-        ["is_authorized_variable", "GET", None, "Variable#LIST", {}],
-        [
-            "is_authorized_pool",
-            "POST",
-            PoolDetails(name="test"),
-            "Pool#POST",
-            {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
-        ],
-        ["is_authorized_pool", "GET", None, "Pool#LIST", {}],
-    ]
-
     @pytest.mark.parametrize(
         ("function", "method", "details", "permission", "attributes"),
-        _AUTHORIZED_PARAMS,
+        [
+            [
+                "is_authorized_configuration",
+                "GET",
+                ConfigurationDetails(section="test"),
+                "Configuration#GET",
+                {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
+            ],
+            ["is_authorized_configuration", "GET", None, "Configuration#LIST", None],
+            [
+                "is_authorized_configuration",
+                "PUT",
+                ConfigurationDetails(section="test"),
+                "Configuration#PUT",
+                {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
+            ],
+            [
+                "is_authorized_connection",
+                "DELETE",
+                ConnectionDetails(conn_id="test"),
+                "Connection#DELETE",
+                {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
+            ],
+            ["is_authorized_connection", "GET", None, "Connection#LIST", {}],
+            [
+                "is_authorized_backfill",
+                "POST",
+                BackfillDetails(id=1),
+                "Backfill#POST",
+                {RESOURCE_ID_ATTRIBUTE_NAME: "1"},
+            ],
+            ["is_authorized_backfill", "GET", None, "Backfill#LIST", {}],
+            [
+                "is_authorized_asset",
+                "GET",
+                AssetDetails(id="test"),
+                "Asset#GET",
+                {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
+            ],
+            ["is_authorized_asset", "GET", None, "Asset#LIST", {}],
+            [
+                "is_authorized_asset_alias",
+                "GET",
+                AssetAliasDetails(id="test"),
+                "AssetAlias#GET",
+                {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
+            ],
+            ["is_authorized_asset_alias", "GET", None, "AssetAlias#LIST", {}],
+            [
+                "is_authorized_variable",
+                "PUT",
+                VariableDetails(key="test"),
+                "Variable#PUT",
+                {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
+            ],
+            ["is_authorized_variable", "GET", None, "Variable#LIST", {}],
+            [
+                "is_authorized_pool",
+                "POST",
+                PoolDetails(name="test"),
+                "Pool#POST",
+                {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
+            ],
+            ["is_authorized_pool", "GET", None, "Pool#LIST", {}],
+        ],
     )
     @pytest.mark.parametrize(
         ("status_code", "expected"),
@@ -377,40 +375,38 @@ class TestKeycloakAuthManager:
 
             assert "Request not recognized by Keycloak. invalid_scope. Invalid scopes: GET" in str(e.value)
 
-    _DAG_AUTHORIZED_PARAMS = [
-        [
-            "GET",
-            None,
-            None,
-            "Dag#LIST",
-            {},
-        ],
-        [
-            "GET",
-            DagAccessEntity.TASK_INSTANCE,
-            DagDetails(id="test"),
-            "Dag#GET",
-            {RESOURCE_ID_ATTRIBUTE_NAME: "test", "dag_entity": "TASK_INSTANCE"},
-        ],
-        [
-            "GET",
-            None,
-            DagDetails(id="test"),
-            "Dag#GET",
-            {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
-        ],
-        [
-            "GET",
-            DagAccessEntity.TASK_INSTANCE,
-            None,
-            "Dag#LIST",
-            {"dag_entity": "TASK_INSTANCE"},
-        ],
-    ]
-
     @pytest.mark.parametrize(
         ("method", "access_entity", "details", "permission", "attributes"),
-        _DAG_AUTHORIZED_PARAMS,
+        [
+            [
+                "GET",
+                None,
+                None,
+                "Dag#LIST",
+                {},
+            ],
+            [
+                "GET",
+                DagAccessEntity.TASK_INSTANCE,
+                DagDetails(id="test"),
+                "Dag#GET",
+                {RESOURCE_ID_ATTRIBUTE_NAME: "test", "dag_entity": "TASK_INSTANCE"},
+            ],
+            [
+                "GET",
+                None,
+                DagDetails(id="test"),
+                "Dag#GET",
+                {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
+            ],
+            [
+                "GET",
+                DagAccessEntity.TASK_INSTANCE,
+                None,
+                "Dag#LIST",
+                {"dag_entity": "TASK_INSTANCE"},
+            ],
+        ],
     )
     @pytest.mark.parametrize(
         ("status_code", "expected"),
@@ -447,30 +443,32 @@ class TestKeycloakAuthManager:
         )
         assert result == expected
 
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="team_name not supported before Airflow 3.2.0")
     @pytest.mark.parametrize(
-        ("function", "method", "details", "permission"),
+        ("function", "method", "details_cls", "details_kwargs", "permission"),
         [
-            ("is_authorized_dag", "GET", DagDetails(id="test", team_name="team-a"), "Dag#GET"),
+            ("is_authorized_dag", "GET", DagDetails, {"id": "test", "team_name": "team-a"}, "Dag#GET"),
             (
                 "is_authorized_connection",
                 "DELETE",
-                ConnectionDetails(conn_id="test", team_name="team-a"),
+                ConnectionDetails,
+                {"conn_id": "test", "team_name": "team-a"},
                 "Connection#DELETE",
             ),
             (
                 "is_authorized_variable",
                 "PUT",
-                VariableDetails(key="test", team_name="team-a"),
+                VariableDetails,
+                {"key": "test", "team_name": "team-a"},
                 "Variable#PUT",
             ),
-            ("is_authorized_pool", "POST", PoolDetails(name="test", team_name="team-a"), "Pool#POST"),
-        ]
-        if AIRFLOW_V_3_2_PLUS
-        else [],
+            ("is_authorized_pool", "POST", PoolDetails, {"name": "test", "team_name": "team-a"}, "Pool#POST"),
+        ],
     )
     def test_team_name_ignored_when_multi_team_disabled(
-        self, auth_manager, user, function, method, details, permission
+        self, auth_manager, user, function, method, details_cls, details_kwargs, permission
     ):
+        details = details_cls(**details_kwargs)
         mock_response = Mock()
         mock_response.status_code = 200
         auth_manager.http_session.post = Mock(return_value=mock_response)
@@ -480,28 +478,30 @@ class TestKeycloakAuthManager:
         actual_permission = auth_manager.http_session.post.call_args.kwargs["data"]["permission"]
         assert actual_permission == permission
 
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="team_name not supported before Airflow 3.2.0")
     @pytest.mark.parametrize(
-        ("function", "details", "permission"),
+        ("function", "details_cls", "details_kwargs", "permission"),
         [
-            ("is_authorized_dag", DagDetails(id="test", team_name="team-a"), "Dag:team-a#GET"),
+            ("is_authorized_dag", DagDetails, {"id": "test", "team_name": "team-a"}, "Dag:team-a#GET"),
             (
                 "is_authorized_connection",
-                ConnectionDetails(conn_id="test", team_name="team-a"),
+                ConnectionDetails,
+                {"conn_id": "test", "team_name": "team-a"},
                 "Connection:team-a#GET",
             ),
             (
                 "is_authorized_variable",
-                VariableDetails(key="test", team_name="team-a"),
+                VariableDetails,
+                {"key": "test", "team_name": "team-a"},
                 "Variable:team-a#GET",
             ),
-            ("is_authorized_pool", PoolDetails(name="test", team_name="team-a"), "Pool:team-a#GET"),
-        ]
-        if AIRFLOW_V_3_2_PLUS
-        else [],
+            ("is_authorized_pool", PoolDetails, {"name": "test", "team_name": "team-a"}, "Pool:team-a#GET"),
+        ],
     )
     def test_with_team_name_uses_team_scoped_permission(
-        self, auth_manager_multi_team, user, function, details, permission
+        self, auth_manager_multi_team, user, function, details_cls, details_kwargs, permission
     ):
+        details = details_cls(**details_kwargs)
         mock_response = Mock()
         mock_response.status_code = 200
         auth_manager_multi_team.http_session.post = Mock(return_value=mock_response)
@@ -553,20 +553,25 @@ class TestKeycloakAuthManager:
         actual_permission = auth_manager_multi_team.http_session.post.call_args.kwargs["data"]["permission"]
         assert actual_permission == permission
 
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="team_name not supported before Airflow 3.2.0")
     @pytest.mark.parametrize(
-        ("function", "details", "permission"),
+        ("function", "details_cls", "details_kwargs", "permission"),
         [
-            ("is_authorized_dag", DagDetails(team_name="team-a"), "Dag:team-a#LIST"),
-            ("is_authorized_connection", ConnectionDetails(team_name="team-a"), "Connection:team-a#LIST"),
-            ("is_authorized_variable", VariableDetails(team_name="team-a"), "Variable:team-a#LIST"),
-            ("is_authorized_pool", PoolDetails(team_name="team-a"), "Pool:team-a#LIST"),
-        ]
-        if AIRFLOW_V_3_2_PLUS
-        else [],
+            ("is_authorized_dag", DagDetails, {"team_name": "team-a"}, "Dag:team-a#LIST"),
+            (
+                "is_authorized_connection",
+                ConnectionDetails,
+                {"team_name": "team-a"},
+                "Connection:team-a#LIST",
+            ),
+            ("is_authorized_variable", VariableDetails, {"team_name": "team-a"}, "Variable:team-a#LIST"),
+            ("is_authorized_pool", PoolDetails, {"team_name": "team-a"}, "Pool:team-a#LIST"),
+        ],
     )
     def test_list_with_team_name_uses_team_scoped_permission(
-        self, auth_manager_multi_team, user, function, details, permission
+        self, auth_manager_multi_team, user, function, details_cls, details_kwargs, permission
     ):
+        details = details_cls(**details_kwargs)
         user.access_token = _build_access_token({"groups": ["team-a"]})
         mock_response = Mock()
         mock_response.status_code = 200
@@ -577,10 +582,8 @@ class TestKeycloakAuthManager:
         actual_permission = auth_manager_multi_team.http_session.post.call_args.kwargs["data"]["permission"]
         assert actual_permission == permission
 
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="team_name not supported before Airflow 3.2.0")
     def test_filter_authorized_dag_ids_team_mismatch(self, auth_manager_multi_team, user):
-        if not AIRFLOW_V_3_2_PLUS:
-            pytest.skip("team_name not supported before Airflow 3.2.0")
-
         with patch.object(KeycloakAuthManager, "is_authorized_dag", return_value=False) as mock_is_authorized:
             result = auth_manager_multi_team.filter_authorized_dag_ids(
                 dag_ids={"dag-a"}, user=user, team_name="team-b"
@@ -589,10 +592,8 @@ class TestKeycloakAuthManager:
             mock_is_authorized.assert_called_once()
             assert result == set()
 
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="team_name not supported before Airflow 3.2.0")
     def test_filter_authorized_dag_ids_team_match(self, auth_manager_multi_team, user):
-        if not AIRFLOW_V_3_2_PLUS:
-            pytest.skip("team_name not supported before Airflow 3.2.0")
-
         with patch.object(KeycloakAuthManager, "is_authorized_dag", return_value=True) as mock_is_authorized:
             result = auth_manager_multi_team.filter_authorized_dag_ids(
                 dag_ids={"dag-a"}, user=user, team_name="team-a"
@@ -601,10 +602,8 @@ class TestKeycloakAuthManager:
             mock_is_authorized.assert_called_once()
             assert result == {"dag-a"}
 
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="team_name not supported before Airflow 3.2.0")
     def test_filter_authorized_pools_no_team_returns_empty(self, auth_manager_multi_team, user):
-        if not AIRFLOW_V_3_2_PLUS:
-            pytest.skip("filter_authorized_pools not supported before Airflow 3.2.0")
-
         with patch.object(
             KeycloakAuthManager, "is_authorized_pool", return_value=False
         ) as mock_is_authorized:
@@ -615,20 +614,20 @@ class TestKeycloakAuthManager:
             mock_is_authorized.assert_called_once()
             assert result == set()
 
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="team_name not supported before Airflow 3.2.0")
     @pytest.mark.parametrize(
-        ("function", "details"),
+        ("function", "details_cls", "details_kwargs"),
         [
-            ("is_authorized_dag", DagDetails(team_name="team-b")),
-            ("is_authorized_connection", ConnectionDetails(team_name="team-b")),
-            ("is_authorized_variable", VariableDetails(team_name="team-b")),
-            ("is_authorized_pool", PoolDetails(team_name="team-b")),
-        ]
-        if AIRFLOW_V_3_2_PLUS
-        else [],
+            ("is_authorized_dag", DagDetails, {"team_name": "team-b"}),
+            ("is_authorized_connection", ConnectionDetails, {"team_name": "team-b"}),
+            ("is_authorized_variable", VariableDetails, {"team_name": "team-b"}),
+            ("is_authorized_pool", PoolDetails, {"team_name": "team-b"}),
+        ],
     )
     def test_list_with_mismatched_team_delegates_to_keycloak(
-        self, auth_manager_multi_team, user, function, details
+        self, auth_manager_multi_team, user, function, details_cls, details_kwargs
     ):
+        details = details_cls(**details_kwargs)
         mock_response = Mock()
         mock_response.status_code = 403
         auth_manager_multi_team.http_session.post = Mock(return_value=mock_response)

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
@@ -59,7 +59,7 @@ from airflow.providers.keycloak.auth_manager.keycloak_auth_manager import (
 from airflow.providers.keycloak.auth_manager.user import KeycloakAuthManagerUser
 
 from tests_common.test_utils.config import conf_vars
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_1_7_PLUS
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_2_PLUS
 
 
 def _build_access_token(payload: dict[str, object]) -> str:
@@ -190,7 +190,7 @@ class TestKeycloakAuthManager:
 
         mock_get_keycloak_client.return_value = keycloak_client
 
-        if AIRFLOW_V_3_1_7_PLUS:
+        if AIRFLOW_V_3_2_PLUS:
             from airflow.api_fastapi.auth.managers.exceptions import AuthManagerRefreshTokenExpiredException
 
             with pytest.raises(AuthManagerRefreshTokenExpiredException):
@@ -266,7 +266,7 @@ class TestKeycloakAuthManager:
         ["is_authorized_pool", "GET", None, "Pool#LIST", {}],
     ]
 
-    if AIRFLOW_V_3_1_7_PLUS:
+    if AIRFLOW_V_3_2_PLUS:
         _AUTHORIZED_PARAMS.extend(
             [
                 [
@@ -436,7 +436,7 @@ class TestKeycloakAuthManager:
         ],
     ]
 
-    if AIRFLOW_V_3_1_7_PLUS:
+    if AIRFLOW_V_3_2_PLUS:
         _DAG_AUTHORIZED_PARAMS.extend(
             [
                 [
@@ -513,7 +513,7 @@ class TestKeycloakAuthManager:
             ),
             ("is_authorized_pool", PoolDetails(name="test", team_name="team-a"), "Pool:team-a#GET"),
         ]
-        if AIRFLOW_V_3_1_7_PLUS
+        if AIRFLOW_V_3_2_PLUS
         else [
             pytest.param(
                 None,
@@ -528,7 +528,7 @@ class TestKeycloakAuthManager:
         ("function", "details", "permission"),
         _TEAM_SCOPED_PERMISSION_PARAMS,
     )
-    @pytest.mark.skipif(not AIRFLOW_V_3_1_7_PLUS, reason="multi_team not supported before 3.1.7")
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="multi_team not supported before 3.1.7")
     def test_is_authorized_team_scoped_permission(
         self, auth_manager_multi_team, user, function, details, permission
     ):
@@ -578,7 +578,7 @@ class TestKeycloakAuthManager:
             ("is_authorized_variable", VariableDetails(team_name="team-a"), "Variable:team-a#LIST"),
             ("is_authorized_pool", PoolDetails(team_name="team-a"), "Pool:team-a#LIST"),
         ]
-        if AIRFLOW_V_3_1_7_PLUS
+        if AIRFLOW_V_3_2_PLUS
         else [
             pytest.param(
                 None,
@@ -619,7 +619,7 @@ class TestKeycloakAuthManager:
         ("function", "details", "permission"),
         _TEAM_SCOPED_LIST_PARAMS,
     )
-    @pytest.mark.skipif(not AIRFLOW_V_3_1_7_PLUS, reason="multi_team not supported before 3.1.7")
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="multi_team not supported before 3.1.7")
     def test_is_authorized_team_scoped_list_team_scoped_permission(
         self, auth_manager_multi_team, user, function, details, permission
     ):
@@ -685,7 +685,7 @@ class TestKeycloakAuthManager:
             ("is_authorized_variable", VariableDetails(team_name="team-b")),
             ("is_authorized_pool", PoolDetails(team_name="team-b")),
         ]
-        if AIRFLOW_V_3_1_7_PLUS
+        if AIRFLOW_V_3_2_PLUS
         else [
             pytest.param(
                 None,
@@ -699,7 +699,7 @@ class TestKeycloakAuthManager:
         ("function", "details"),
         _TEAM_SCOPED_LIST_MISMATCH_PARAMS,
     )
-    @pytest.mark.skipif(not AIRFLOW_V_3_1_7_PLUS, reason="multi_team not supported before 3.1.7")
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="multi_team not supported before 3.1.7")
     def test_is_authorized_team_scoped_list_team_mismatch_calls_keycloak(
         self, auth_manager_multi_team, user, function, details
     ):

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
@@ -583,36 +583,36 @@ class TestKeycloakAuthManager:
         assert actual_permission == permission
 
     @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="team_name not supported before Airflow 3.2.0")
-    def test_filter_authorized_dag_ids_team_mismatch(self, auth_manager_multi_team, user):
-        with patch.object(KeycloakAuthManager, "is_authorized_dag", return_value=False) as mock_is_authorized:
-            result = auth_manager_multi_team.filter_authorized_dag_ids(
-                dag_ids={"dag-a"}, user=user, team_name="team-b"
-            )
+    @patch.object(KeycloakAuthManager, "is_authorized_dag", return_value=False)
+    def test_filter_authorized_dag_ids_team_mismatch(self, mock_is_authorized, auth_manager_multi_team, user):
+        result = auth_manager_multi_team.filter_authorized_dag_ids(
+            dag_ids={"dag-a"}, user=user, team_name="team-b"
+        )
 
-            mock_is_authorized.assert_called_once()
-            assert result == set()
-
-    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="team_name not supported before Airflow 3.2.0")
-    def test_filter_authorized_dag_ids_team_match(self, auth_manager_multi_team, user):
-        with patch.object(KeycloakAuthManager, "is_authorized_dag", return_value=True) as mock_is_authorized:
-            result = auth_manager_multi_team.filter_authorized_dag_ids(
-                dag_ids={"dag-a"}, user=user, team_name="team-a"
-            )
-
-            mock_is_authorized.assert_called_once()
-            assert result == {"dag-a"}
+        mock_is_authorized.assert_called_once()
+        assert result == set()
 
     @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="team_name not supported before Airflow 3.2.0")
-    def test_filter_authorized_pools_no_team_returns_empty(self, auth_manager_multi_team, user):
-        with patch.object(
-            KeycloakAuthManager, "is_authorized_pool", return_value=False
-        ) as mock_is_authorized:
-            result = auth_manager_multi_team.filter_authorized_pools(
-                pool_names={"pool-a"}, user=user, team_name=None
-            )
+    @patch.object(KeycloakAuthManager, "is_authorized_dag", return_value=True)
+    def test_filter_authorized_dag_ids_team_match(self, mock_is_authorized, auth_manager_multi_team, user):
+        result = auth_manager_multi_team.filter_authorized_dag_ids(
+            dag_ids={"dag-a"}, user=user, team_name="team-a"
+        )
 
-            mock_is_authorized.assert_called_once()
-            assert result == set()
+        mock_is_authorized.assert_called_once()
+        assert result == {"dag-a"}
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="team_name not supported before Airflow 3.2.0")
+    @patch.object(KeycloakAuthManager, "is_authorized_pool", return_value=False)
+    def test_filter_authorized_pools_no_team_returns_empty(
+        self, mock_is_authorized, auth_manager_multi_team, user
+    ):
+        result = auth_manager_multi_team.filter_authorized_pools(
+            pool_names={"pool-a"}, user=user, team_name=None
+        )
+
+        mock_is_authorized.assert_called_once()
+        assert result == set()
 
     @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="team_name not supported before Airflow 3.2.0")
     @pytest.mark.parametrize(

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import base64
 import json
 from contextlib import ExitStack
 from unittest.mock import Mock, patch
@@ -56,10 +57,31 @@ from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_1_7_PLUS
 
 
+def _build_access_token(payload: dict[str, object]) -> str:
+    header = {"alg": "none", "typ": "JWT"}
+    header_b64 = base64.urlsafe_b64encode(json.dumps(header).encode()).decode().rstrip("=")
+    payload_b64 = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+    return f"{header_b64}.{payload_b64}."
+
+
 @pytest.fixture
 def auth_manager():
     with conf_vars(
         {
+            (CONF_SECTION_NAME, CONF_CLIENT_ID_KEY): "client_id",
+            (CONF_SECTION_NAME, CONF_CLIENT_SECRET_KEY): "client_secret",
+            (CONF_SECTION_NAME, CONF_REALM_KEY): "realm",
+            (CONF_SECTION_NAME, CONF_SERVER_URL_KEY): "server_url",
+        }
+    ):
+        yield KeycloakAuthManager()
+
+
+@pytest.fixture
+def auth_manager_multi_team():
+    with conf_vars(
+        {
+            ("core", "multi_team"): "True",
             (CONF_SECTION_NAME, CONF_CLIENT_ID_KEY): "client_id",
             (CONF_SECTION_NAME, CONF_CLIENT_SECRET_KEY): "client_secret",
             (CONF_SECTION_NAME, CONF_REALM_KEY): "realm",
@@ -198,6 +220,13 @@ class TestKeycloakAuthManager:
                 "Connection#DELETE",
                 {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
             ],
+            [
+                "is_authorized_connection",
+                "DELETE",
+                ConnectionDetails(conn_id="test", team_name="team-a"),
+                "Connection#DELETE",
+                {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
+            ],
             ["is_authorized_connection", "GET", None, "Connection#LIST", {}],
             [
                 "is_authorized_backfill",
@@ -230,11 +259,25 @@ class TestKeycloakAuthManager:
                 "Variable#PUT",
                 {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
             ],
+            [
+                "is_authorized_variable",
+                "PUT",
+                VariableDetails(key="test", team_name="team-a"),
+                "Variable#PUT",
+                {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
+            ],
             ["is_authorized_variable", "GET", None, "Variable#LIST", {}],
             [
                 "is_authorized_pool",
                 "POST",
                 PoolDetails(name="test"),
+                "Pool#POST",
+                {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
+            ],
+            [
+                "is_authorized_pool",
+                "POST",
+                PoolDetails(name="test", team_name="team-a"),
                 "Pool#POST",
                 {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
             ],
@@ -278,7 +321,7 @@ class TestKeycloakAuthManager:
 
         token_url = auth_manager._get_token_url("server_url", "realm")
         payload = auth_manager._get_payload("client_id", permission, attributes)
-        headers = auth_manager._get_headers("access_token")
+        headers = auth_manager._get_headers(user.access_token)
         auth_manager.http_session.post.assert_called_once_with(
             token_url, data=payload, headers=headers, timeout=5
         )
@@ -368,8 +411,25 @@ class TestKeycloakAuthManager:
             ],
             [
                 "GET",
+                DagAccessEntity.TASK_INSTANCE,
+                DagDetails(id="test", team_name="team-a"),
+                "Dag#GET",
+                {
+                    RESOURCE_ID_ATTRIBUTE_NAME: "test",
+                    "dag_entity": "TASK_INSTANCE",
+                },
+            ],
+            [
+                "GET",
                 None,
                 DagDetails(id="test"),
+                "Dag#GET",
+                {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
+            ],
+            [
+                "GET",
+                None,
+                DagDetails(id="test", team_name="team-a"),
                 "Dag#GET",
                 {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
             ],
@@ -411,11 +471,123 @@ class TestKeycloakAuthManager:
 
         token_url = auth_manager._get_token_url("server_url", "realm")
         payload = auth_manager._get_payload("client_id", permission, attributes)
-        headers = auth_manager._get_headers("access_token")
+        headers = auth_manager._get_headers(user.access_token)
         auth_manager.http_session.post.assert_called_once_with(
             token_url, data=payload, headers=headers, timeout=5
         )
         assert result == expected
+
+    def test_is_authorized_dag_team_scoped_permission(self, auth_manager_multi_team, user):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        auth_manager_multi_team.http_session.post = Mock(return_value=mock_response)
+
+        result = auth_manager_multi_team.is_authorized_dag(
+            method="GET", user=user, details=DagDetails(id="test", team_name="team-a")
+        )
+
+        token_url = auth_manager_multi_team._get_token_url("server_url", "realm")
+        payload = auth_manager_multi_team._get_payload(
+            "client_id",
+            "Dag:team-a#GET",
+            {RESOURCE_ID_ATTRIBUTE_NAME: "test"},
+        )
+        headers = auth_manager_multi_team._get_headers(user.access_token)
+        auth_manager_multi_team.http_session.post.assert_called_once_with(
+            token_url, data=payload, headers=headers, timeout=5
+        )
+        assert result is True
+
+    def test_is_authorized_dag_no_team_denied(self, auth_manager_multi_team, user):
+        auth_manager_multi_team.http_session.post = Mock()
+
+        result = auth_manager_multi_team.is_authorized_dag(
+            method="GET", user=user, details=DagDetails(id="test")
+        )
+
+        auth_manager_multi_team.http_session.post.assert_not_called()
+        assert result is False
+
+    def test_is_authorized_dag_list_multi_team_without_team_denied(self, auth_manager_multi_team, user):
+        auth_manager_multi_team.http_session.post = Mock()
+
+        result = auth_manager_multi_team.is_authorized_dag(method="GET", user=user)
+
+        auth_manager_multi_team.http_session.post.assert_not_called()
+        assert result is False
+
+    def test_is_authorized_dag_list_team_scoped_permission(self, auth_manager_multi_team, user):
+        user.access_token = _build_access_token({"groups": ["team-a"]})
+        mock_response = Mock()
+        mock_response.status_code = 200
+        auth_manager_multi_team.http_session.post = Mock(return_value=mock_response)
+
+        result = auth_manager_multi_team.is_authorized_dag(
+            method="GET", user=user, details=DagDetails(id=None, team_name="team-a")
+        )
+
+        token_url = auth_manager_multi_team._get_token_url("server_url", "realm")
+        payload = auth_manager_multi_team._get_payload(
+            "client_id",
+            "Dag:team-a#LIST",
+            {},
+        )
+        headers = auth_manager_multi_team._get_headers(user.access_token)
+        auth_manager_multi_team.http_session.post.assert_called_once_with(
+            token_url, data=payload, headers=headers, timeout=5
+        )
+        assert result is True
+
+    def test_filter_authorized_dag_ids_team_mismatch(self, auth_manager_multi_team, user):
+        with patch.object(KeycloakAuthManager, "is_authorized_dag", return_value=False) as mock_is_authorized:
+            result = auth_manager_multi_team.filter_authorized_dag_ids(
+                dag_ids={"dag-a"}, user=user, team_name="team-b"
+            )
+
+            mock_is_authorized.assert_called_once()
+            assert result == set()
+
+    def test_filter_authorized_dag_ids_team_match(self, auth_manager_multi_team, user):
+        with patch.object(KeycloakAuthManager, "is_authorized_dag", return_value=True) as mock_is_authorized:
+            result = auth_manager_multi_team.filter_authorized_dag_ids(
+                dag_ids={"dag-a"}, user=user, team_name="team-a"
+            )
+
+            mock_is_authorized.assert_called_once()
+            assert result == {"dag-a"}
+
+    def test_filter_authorized_pools_no_team_returns_empty(self, auth_manager_multi_team, user):
+        with patch.object(
+            KeycloakAuthManager, "is_authorized_pool", return_value=False
+        ) as mock_is_authorized:
+            result = auth_manager_multi_team.filter_authorized_pools(
+                pool_names={"pool-a"}, user=user, team_name=None
+            )
+
+            mock_is_authorized.assert_called_once()
+            assert result == set()
+
+    def test_is_authorized_dag_list_team_mismatch_calls_keycloak(self, auth_manager_multi_team, user):
+        mock_response = Mock()
+        mock_response.status_code = 403
+        auth_manager_multi_team.http_session.post = Mock(return_value=mock_response)
+
+        result = auth_manager_multi_team.is_authorized_dag(
+            method="GET", user=user, details=DagDetails(id=None, team_name="team-b")
+        )
+
+        auth_manager_multi_team.http_session.post.assert_called_once()
+        assert result is False
+
+    def test_filter_authorized_menu_items_with_batch_authorized(self, auth_manager, user):
+        with patch.object(
+            KeycloakAuthManager,
+            "_is_batch_authorized",
+            return_value={("MENU", menu.value) for menu in MenuItem},
+        ):
+            result = auth_manager.filter_authorized_menu_items(list(MenuItem), user=user)
+
+        assert set(result) == set(MenuItem)
 
     @pytest.mark.parametrize(
         ("status_code", "expected"),
@@ -441,7 +613,7 @@ class TestKeycloakAuthManager:
         payload = auth_manager._get_payload(
             "client_id", "View#GET", {RESOURCE_ID_ATTRIBUTE_NAME: "CLUSTER_ACTIVITY"}
         )
-        headers = auth_manager._get_headers("access_token")
+        headers = auth_manager._get_headers(user.access_token)
         auth_manager.http_session.post.assert_called_once_with(
             token_url, data=payload, headers=headers, timeout=5
         )
@@ -469,7 +641,7 @@ class TestKeycloakAuthManager:
 
         token_url = auth_manager._get_token_url("server_url", "realm")
         payload = auth_manager._get_payload("client_id", "Custom#GET", {RESOURCE_ID_ATTRIBUTE_NAME: "test"})
-        headers = auth_manager._get_headers("access_token")
+        headers = auth_manager._get_headers(user.access_token)
         auth_manager.http_session.post.assert_called_once_with(
             token_url, data=payload, headers=headers, timeout=5
         )
@@ -502,7 +674,7 @@ class TestKeycloakAuthManager:
         payload = auth_manager._get_batch_payload(
             "client_id", [("MENU", MenuItem.ASSETS.value), ("MENU", MenuItem.CONNECTIONS.value)]
         )
-        headers = auth_manager._get_headers("access_token")
+        headers = auth_manager._get_headers(user.access_token)
         auth_manager.http_session.post.assert_called_once_with(
             token_url, data=payload, headers=headers, timeout=5
         )
@@ -527,7 +699,7 @@ class TestKeycloakAuthManager:
         payload = auth_manager._get_batch_payload(
             "client_id", [("MENU", MenuItem.ASSETS.value), ("MENU", MenuItem.CONNECTIONS.value)]
         )
-        headers = auth_manager._get_headers("access_token")
+        headers = auth_manager._get_headers(user.access_token)
         auth_manager.http_session.post.assert_called_once_with(
             token_url, data=payload, headers=headers, timeout=5
         )

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
@@ -553,23 +553,34 @@ class TestKeycloakAuthManager:
         assert result is True
 
     @pytest.mark.parametrize(
-        ("function", "details"),
+        ("function", "details", "permission", "resource_id"),
         [
-            ("is_authorized_dag", DagDetails(id="test")),
-            ("is_authorized_connection", ConnectionDetails(conn_id="test")),
-            ("is_authorized_variable", VariableDetails(key="test")),
-            ("is_authorized_pool", PoolDetails(name="test")),
+            ("is_authorized_dag", DagDetails(id="test"), "Dag#GET", "test"),
+            ("is_authorized_connection", ConnectionDetails(conn_id="test"), "Connection#GET", "test"),
+            ("is_authorized_variable", VariableDetails(key="test"), "Variable#GET", "test"),
+            ("is_authorized_pool", PoolDetails(name="test"), "Pool#GET", "test"),
         ],
     )
-    def test_is_authorized_team_scoped_no_team_denied(self, auth_manager_multi_team, user, function, details):
-        auth_manager_multi_team.http_session.post = Mock()
+    def test_is_authorized_team_scoped_no_team_uses_global_permission(
+        self, auth_manager_multi_team, user, function, details, permission, resource_id
+    ):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        auth_manager_multi_team.http_session.post = Mock(return_value=mock_response)
 
-        with pytest.raises(
-            ValueError, match="Missing team_name for team-scoped resource in multi-team mode."
-        ):
-            getattr(auth_manager_multi_team, function)(method="GET", user=user, details=details)
+        result = getattr(auth_manager_multi_team, function)(method="GET", user=user, details=details)
 
-        auth_manager_multi_team.http_session.post.assert_not_called()
+        token_url = auth_manager_multi_team._get_token_url("server_url", "realm")
+        payload = auth_manager_multi_team._get_payload(
+            "client_id",
+            permission,
+            {RESOURCE_ID_ATTRIBUTE_NAME: resource_id},
+        )
+        headers = auth_manager_multi_team._get_headers(user.access_token)
+        auth_manager_multi_team.http_session.post.assert_called_once_with(
+            token_url, data=payload, headers=headers, timeout=5
+        )
+        assert result is True
 
     _TEAM_SCOPED_LIST_PARAMS = (
         [

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
@@ -501,12 +501,12 @@ class TestKeycloakAuthManager:
     def test_is_authorized_dag_no_team_denied(self, auth_manager_multi_team, user):
         auth_manager_multi_team.http_session.post = Mock()
 
-        result = auth_manager_multi_team.is_authorized_dag(
-            method="GET", user=user, details=DagDetails(id="test")
-        )
+        with pytest.raises(
+            ValueError, match="Missing team_name for team-scoped resource in multi-team mode."
+        ):
+            auth_manager_multi_team.is_authorized_dag(method="GET", user=user, details=DagDetails(id="test"))
 
         auth_manager_multi_team.http_session.post.assert_not_called()
-        assert result is False
 
     def test_is_authorized_dag_list_multi_team_without_team_global_list(self, auth_manager_multi_team, user):
         mock_response = Mock()

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
@@ -519,7 +519,7 @@ class TestKeycloakAuthManager:
                 None,
                 None,
                 None,
-                marks=pytest.mark.skip(reason="multi_team not supported before 3.1.7"),
+                marks=pytest.mark.skip(reason="multi_team not supported before 3.2.0"),
             )
         ]
     )
@@ -528,12 +528,12 @@ class TestKeycloakAuthManager:
         ("function", "details", "permission"),
         _TEAM_SCOPED_PERMISSION_PARAMS,
     )
-    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="multi_team not supported before 3.1.7")
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="multi_team not supported before 3.2.0")
     def test_is_authorized_team_scoped_permission(
         self, auth_manager_multi_team, user, function, details, permission
     ):
         if function is None:
-            pytest.skip("multi_team not supported before 3.1.7")
+            pytest.skip("multi_team not supported before 3.2.0")
         mock_response = Mock()
         mock_response.status_code = 200
         auth_manager_multi_team.http_session.post = Mock(return_value=mock_response)
@@ -595,7 +595,7 @@ class TestKeycloakAuthManager:
                 None,
                 None,
                 None,
-                marks=pytest.mark.skip(reason="multi_team not supported before 3.1.7"),
+                marks=pytest.mark.skip(reason="multi_team not supported before 3.2.0"),
             )
         ]
     )
@@ -630,12 +630,12 @@ class TestKeycloakAuthManager:
         ("function", "details", "permission"),
         _TEAM_SCOPED_LIST_PARAMS,
     )
-    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="multi_team not supported before 3.1.7")
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="multi_team not supported before 3.2.0")
     def test_is_authorized_team_scoped_list_team_scoped_permission(
         self, auth_manager_multi_team, user, function, details, permission
     ):
         if function is None:
-            pytest.skip("multi_team not supported before 3.1.7")
+            pytest.skip("multi_team not supported before 3.2.0")
         user.access_token = _build_access_token({"groups": ["team-a"]})
         mock_response = Mock()
         mock_response.status_code = 200
@@ -701,7 +701,7 @@ class TestKeycloakAuthManager:
             pytest.param(
                 None,
                 None,
-                marks=pytest.mark.skip(reason="multi_team not supported before 3.1.7"),
+                marks=pytest.mark.skip(reason="multi_team not supported before 3.2.0"),
             )
         ]
     )
@@ -710,12 +710,12 @@ class TestKeycloakAuthManager:
         ("function", "details"),
         _TEAM_SCOPED_LIST_MISMATCH_PARAMS,
     )
-    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="multi_team not supported before 3.1.7")
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="multi_team not supported before 3.2.0")
     def test_is_authorized_team_scoped_list_team_mismatch_calls_keycloak(
         self, auth_manager_multi_team, user, function, details
     ):
         if function is None:
-            pytest.skip("multi_team not supported before 3.1.7")
+            pytest.skip("multi_team not supported before 3.2.0")
         mock_response = Mock()
         mock_response.status_code = 403
         auth_manager_multi_team.http_session.post = Mock(return_value=mock_response)


### PR DESCRIPTION
**Description**

This PR updates the Keycloak auth manager to enforce multi‑team authorization as outlined in AIP‑67. When core.multi_team is enabled, team context (e.g., team_name from DAGs, connections, assets) is now used to build team‑scoped permission checks so users can only list and access resources for their teams. The authorization flow also supports users in multiple teams by evaluating team‑scoped permissions consistently for list and non‑list requests, while preserving backward compatibility for non‑multi‑team deployments.

This is the auth‑manager part of the split. The CLI provisioning changes are in the companion PR: [61256](https://github.com/apache/airflow/pull/61256)

related issue: #60885

Open Questions: 

- Scope alignment: the first review raised questions about which resources should be team‑scoped and whether that should align strictly with [resource_details.py](https://github.com/apache/airflow/blob/main/airflow-core/src/airflow/api_fastapi/auth/managers/models/resource_details.py). I’m still validating the intended model and would welcome guidance on the correct scope.

Was generative AI tooling used to co-author this PR?
- [X] Yes (Codex)
