### PR TITLE
Remove some global variables in airflow.settings

### DIFF
--- a/devel-common/src/tests_common/test_utils/config.py
+++ b/devel-common/src/tests_common/test_utils/config.py
@@ -52,7 +52,7 @@ def conf_vars(overrides):
             elif conf.has_section(section) and conf.has_option(section, key):
                 conf.remove_option(section, key)
 
-    if "airflow.configuration" in sys.modules:
+    if "airflow.configuration" in sys.modules and "airflow.settings" in sys.modules:
         del sys.modules["airflow.settings"]
 
     try:
@@ -70,7 +70,7 @@ def conf_vars(overrides):
         for env, value in original_env_vars.items():
             os.environ[env] = value
 
-        if "airflow.configuration" in sys.modules:
+        if "airflow.configuration" in sys.modules and "airflow.settings" in sys.modules:
             del sys.modules["airflow.settings"]
 
 

--- a/devel-common/src/tests_common/test_utils/config.py
+++ b/devel-common/src/tests_common/test_utils/config.py
@@ -26,8 +26,6 @@ def conf_vars(overrides):
     """Automatically detects which config modules are loaded (Core, SDK, or both) and updates them accordingly temporarily."""
     import sys
 
-    from airflow import settings
-
     configs = []
     if "airflow.configuration" in sys.modules:
         from airflow.configuration import conf
@@ -55,7 +53,7 @@ def conf_vars(overrides):
                 conf.remove_option(section, key)
 
     if "airflow.configuration" in sys.modules:
-        settings.configure_vars()
+        del sys.modules["airflow.settings"]
 
     try:
         yield
@@ -73,7 +71,7 @@ def conf_vars(overrides):
             os.environ[env] = value
 
         if "airflow.configuration" in sys.modules:
-            settings.configure_vars()
+            del sys.modules["airflow.settings"]
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Another small increment to remove `global` statements for PR https://github.com/apache/airflow/pull/58116

This removes (some - not all) global statements from settings.py where the a lot of state was hold in variables used with global and then a lot of code way relying to access these globals. Is a like a public interface and refactoring would be needed. Attempting to re-sort initialization order to get rid of global.

`global` is evil.

Note that usage of `glocal` in ORM engine will be a separate PR

---

##### Was generative AI tooling used to co-author this PR?

- [ ] No (please specify the tool below)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
