### PR TITLE
Fix apache#11323: Return list of gcs uris from LocalFilesystemToGCSOperator

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/transfers/local_to_gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/local_to_gcs.py
@@ -57,6 +57,7 @@ class LocalFilesystemToGCSOperator(BaseOperator):
         If set as a sequence, the identities from the list must grant
         Service Account Token Creator IAM role to the directly preceding identity, with first
         account from the list granting this role to the originating account (templated).
+    :return: List of URIs for the objects created in Google Cloud Storage
     """
 
     template_fields: Sequence[str] = (
@@ -120,6 +121,8 @@ class LocalFilesystemToGCSOperator(BaseOperator):
                 gzip=self.gzip,
                 chunk_size=self.chunk_size,
             )
+
+        return [f"gs://{self.bucket}/{object_path}" for object_path in object_paths]
 
     def get_openlineage_facets_on_start(self):
         from airflow.providers.common.compat.openlineage.facet import (

--- a/providers/google/tests/unit/google/cloud/transfers/test_local_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_local_to_gcs.py
@@ -83,7 +83,7 @@ class TestFileToGcsOperator:
             dst="test/test1.csv",
             **self._config,
         )
-        operator.execute(None)
+        result = operator.execute(None)
         mock_instance.upload.assert_called_once_with(
             bucket_name=self._config["bucket"],
             filename=self.testfile1,
@@ -92,6 +92,7 @@ class TestFileToGcsOperator:
             object_name="test/test1.csv",
             chunk_size=self._config["chunk_size"],
         )
+        assert result == ["gs://dummy/test/test1.csv"]
 
     @pytest.mark.db_test
     def test_execute_with_empty_src(self):
@@ -111,7 +112,7 @@ class TestFileToGcsOperator:
         operator = LocalFilesystemToGCSOperator(
             task_id="file_to_gcs_operator", dag=self.dag, src=self.testfiles, dst="test/", **self._config
         )
-        operator.execute(None)
+        result = operator.execute(None)
         files_objects = zip(
             self.testfiles, ["test/" + os.path.basename(testfile) for testfile in self.testfiles]
         )
@@ -127,6 +128,7 @@ class TestFileToGcsOperator:
             for filepath, object_name in files_objects
         ]
         mock_instance.upload.assert_has_calls(calls)
+        assert set(result) == {"gs://dummy/test/fake1.csv", "gs://dummy/test/fake2.csv"}
 
     @mock.patch("airflow.providers.google.cloud.transfers.local_to_gcs.GCSHook", autospec=True)
     def test_execute_wildcard(self, mock_hook):
@@ -138,7 +140,7 @@ class TestFileToGcsOperator:
             dst="test/",
             **self._config,
         )
-        operator.execute(None)
+        result = operator.execute(None)
         object_names = ["test/" + os.path.basename(fp) for fp in glob(f"{self.tmpdir_posix}/fake*.csv")]
         files_objects = zip(glob(f"{self.tmpdir_posix}/fake*.csv"), object_names)
         calls = [
@@ -153,6 +155,7 @@ class TestFileToGcsOperator:
             for filepath, object_name in files_objects
         ]
         mock_instance.upload.assert_has_calls(calls)
+        assert set(result) == {"gs://dummy/test/fake1.csv", "gs://dummy/test/fake2.csv"}
 
     @pytest.mark.parametrize(
         ("src", "dst"),


### PR DESCRIPTION
Relates to apache#11323

Updates the LocalFilesystemToGCSOperator to return the list of GCS uris of uploaded files.

This provider previously returned None, so this should be a safe change.

## Testing

Updated and ran unit tests

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
