### PR TITLE
When a dagrun is cleared, recalculate related deadlines if applicable.

### DIFF
--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -74,6 +74,8 @@ from airflow.listeners.listener import get_listener_manager
 from airflow.models.asset import AssetModel
 from airflow.models.base import Base, StringID, TaskInstanceDependencies
 from airflow.models.dag_version import DagVersion
+from airflow.models.deadline import Deadline, ReferenceModels
+from airflow.models.deadline_alert import DeadlineAlert as DeadlineAlertModel
 
 # Import HITLDetail at runtime so SQLAlchemy can resolve the relationship
 from airflow.models.hitl import HITLDetail  # noqa: F401
@@ -181,6 +183,48 @@ def _stop_remaining_tasks(*, task_instance: TaskInstance, task_teardown_map=None
             log.info("Not skipping teardown task '%s'", ti.task_id)
 
 
+def _recalculate_dagrun_queued_at_deadlines(
+    dagrun: DagRun, new_queued_at: datetime, session: Session
+) -> None:
+    """
+    Recalculate deadline times for deadlines that reference dagrun.queued_at.
+
+    :param dagrun: The DagRun whose deadlines should be recalculated
+    :param new_queued_at: The new queued_at timestamp to use for calculation
+    :param session: Database session
+
+    :meta private:
+    """
+    deadlines = session.scalars(
+        select(Deadline).where(
+            Deadline.dagrun_id == dagrun.id,
+            Deadline.missed == false(),
+        )
+    ).all()
+
+    if not deadlines:
+        return
+
+    for deadline in deadlines:
+        if deadline.deadline_alert_id:
+            if deadline_alert := session.get(DeadlineAlertModel, deadline.deadline_alert_id):
+                reference_type = deadline_alert.reference.get(ReferenceModels.REFERENCE_TYPE_FIELD)
+                if reference_type == ReferenceModels.DagRunQueuedAtDeadline.__name__:
+                    # We can't use evaluate_with() since the new queued_at is not written to the DB yet.
+                    deadline_interval = timedelta(seconds=deadline_alert.interval)
+                    new_deadline_time = new_queued_at + deadline_interval
+
+                    log.info(
+                        "Recalculating deadline %s for DagRun %s.%s: old=%s, new=%s",
+                        deadline.id,
+                        dagrun.dag_id,
+                        dagrun.run_id,
+                        deadline.deadline_time,
+                        new_deadline_time,
+                    )
+                    deadline.deadline_time = new_deadline_time
+
+
 def clear_task_instances(
     tis: list[TaskInstance],
     session: Session,
@@ -273,6 +317,8 @@ def clear_task_instances(
             # Always update clear_number and queued_at when clearing tasks, regardless of state
             dr.clear_number += 1
             dr.queued_at = timezone.utcnow()
+
+            _recalculate_dagrun_queued_at_deadlines(dr, dr.queued_at, session)
 
             if dr.state in State.finished_dr_states:
                 dr.state = dag_run_state

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -214,7 +214,7 @@ def _recalculate_dagrun_queued_at_deadlines(
         deadline_interval = timedelta(seconds=deadline_alert.interval)
         new_deadline_time = new_queued_at + deadline_interval
 
-        log.info(
+        log.debug(
             "Recalculating deadline %s for DagRun %s.%s: old=%s, new=%s",
             deadline.id,
             dagrun.dag_id,
@@ -223,6 +223,8 @@ def _recalculate_dagrun_queued_at_deadlines(
             new_deadline_time,
         )
         deadline.deadline_time = new_deadline_time
+    # Do not flush/commit here in order to keep the scheduler loop atomic.
+    # These changes are committed by the calling function.
 
 
 def clear_task_instances(

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -195,34 +195,34 @@ def _recalculate_dagrun_queued_at_deadlines(
 
     :meta private:
     """
-    deadlines = session.scalars(
-        select(Deadline).where(
+    results = session.execute(
+        select(Deadline, DeadlineAlertModel)
+        .join(DeadlineAlertModel, Deadline.deadline_alert_id == DeadlineAlertModel.id)
+        .where(
             Deadline.dagrun_id == dagrun.id,
             Deadline.missed == false(),
+            DeadlineAlertModel.reference[ReferenceModels.REFERENCE_TYPE_FIELD].as_string()
+            == ReferenceModels.DagRunQueuedAtDeadline.__name__,
         )
     ).all()
 
-    if not deadlines:
+    if not results:
         return
 
-    for deadline in deadlines:
-        if deadline.deadline_alert_id:
-            if deadline_alert := session.get(DeadlineAlertModel, deadline.deadline_alert_id):
-                reference_type = deadline_alert.reference.get(ReferenceModels.REFERENCE_TYPE_FIELD)
-                if reference_type == ReferenceModels.DagRunQueuedAtDeadline.__name__:
-                    # We can't use evaluate_with() since the new queued_at is not written to the DB yet.
-                    deadline_interval = timedelta(seconds=deadline_alert.interval)
-                    new_deadline_time = new_queued_at + deadline_interval
+    for deadline, deadline_alert in results:
+        # We can't use evaluate_with() since the new queued_at is not written to the DB yet.
+        deadline_interval = timedelta(seconds=deadline_alert.interval)
+        new_deadline_time = new_queued_at + deadline_interval
 
-                    log.info(
-                        "Recalculating deadline %s for DagRun %s.%s: old=%s, new=%s",
-                        deadline.id,
-                        dagrun.dag_id,
-                        dagrun.run_id,
-                        deadline.deadline_time,
-                        new_deadline_time,
-                    )
-                    deadline.deadline_time = new_deadline_time
+        log.info(
+            "Recalculating deadline %s for DagRun %s.%s: old=%s, new=%s",
+            deadline.id,
+            dagrun.dag_id,
+            dagrun.run_id,
+            deadline.deadline_time,
+            new_deadline_time,
+        )
+        deadline.deadline_time = new_deadline_time
 
 
 def clear_task_instances(

--- a/airflow-core/tests/unit/models/test_dagrun.py
+++ b/airflow-core/tests/unit/models/test_dagrun.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import datetime
 from collections import defaultdict
 from collections.abc import Mapping
+from datetime import timedelta
 from functools import reduce
 from typing import TYPE_CHECKING
 from unittest import mock
@@ -1396,6 +1397,88 @@ class TestDagRun:
 
         mock_prune.assert_not_called()
         assert dag_run.state == DagRunState.SUCCESS
+
+    def test_clear_task_instances_recalculates_dagrun_queued_deadlines(self, session, dag_maker):
+        """Test that clearing tasks recalculates all (and only) DAGRUN_QUEUED_AT deadlines."""
+        with dag_maker(
+            dag_id="test_recalculate_deadlines",
+            schedule=datetime.timedelta(days=1),
+        ) as dag:
+            EmptyOperator(task_id="task_1")
+
+        dag_run = self.create_dag_run(
+            dag=dag,
+            task_states={"task_1": TaskInstanceState.SUCCESS},
+            session=session,
+        )
+
+        original_queued_at = timezone.utcnow() - datetime.timedelta(hours=2)
+        dag_run.queued_at = original_queued_at
+        session.flush()
+
+        serialized_dag_id = session.scalar(
+            select(SerializedDagModel.id).where(SerializedDagModel.dag_id == dag.dag_id)
+        )
+
+        deadline_configs = [
+            (DeadlineReference.DAGRUN_QUEUED_AT, datetime.timedelta(hours=1)),
+            (DeadlineReference.DAGRUN_QUEUED_AT, datetime.timedelta(hours=2)),
+            (DeadlineReference.FIXED_DATETIME, datetime.timedelta(hours=1)),
+        ]
+
+        for deadline_type, interval in deadline_configs:
+            if deadline_type == DeadlineReference.DAGRUN_QUEUED_AT:
+                reference = DeadlineReference.DAGRUN_QUEUED_AT.serialize_reference()
+                deadline_time = dag_run.queued_at + interval
+            else:  # FIXED_DATETIME
+                future_date = timezone.utcnow() + datetime.timedelta(days=7)
+                reference = DeadlineReference.FIXED_DATETIME(future_date).serialize_reference()
+                deadline_time = future_date + interval
+
+            deadline_alert = DeadlineAlertModel(
+                serialized_dag_id=serialized_dag_id,
+                reference=reference,
+                interval=interval.total_seconds(),
+                callback_def={"path": f"{__name__}.empty_callback_for_deadline", "kwargs": {}},
+            )
+            session.add(deadline_alert)
+            session.flush()
+
+            deadline = Deadline(
+                dagrun_id=dag_run.id,
+                deadline_alert_id=deadline_alert.id,
+                deadline_time=deadline_time,
+                callback=AsyncCallback(empty_callback_for_deadline),
+                dag_id=dag_run.dag_id,
+            )
+            session.add(deadline)
+
+        session.flush()
+
+        deadlines_before = session.scalars(select(Deadline).where(Deadline.dagrun_id == dag_run.id)).all()
+        deadline_times_by_alert = {
+            deadline.deadline_alert_id: deadline.deadline_time for deadline in deadlines_before
+        }
+
+        tis = session.scalars(select(TI).where(TI.dag_id == dag.dag_id, TI.run_id == dag_run.run_id)).all()
+        clear_task_instances(tis, session)
+
+        dag_run = session.scalar(select(DagRun).where(DagRun.id == dag_run.id))
+        assert dag_run.queued_at > original_queued_at
+
+        deadlines_after = session.scalars(select(Deadline).where(Deadline.dagrun_id == dag_run.id)).all()
+        assert len(deadlines_after) == 3
+
+        # Verify exactly 2 DAGRUN_QUEUED_AT deadlines were recalculated, FIXED_DATETIME was not
+        recalculated_count = 0
+        for deadline in deadlines_after:
+            if deadline.deadline_time != deadline_times_by_alert[deadline.deadline_alert_id]:
+                recalculated_count += 1
+                deadline_alert = session.get(DeadlineAlertModel, deadline.deadline_alert_id)
+                expected_time = dag_run.queued_at + timedelta(seconds=deadline_alert.interval)
+                assert deadline.deadline_time == expected_time
+
+        assert recalculated_count == 2
 
 
 @pytest.mark.parametrize(

--- a/airflow-core/tests/unit/models/test_dagrun.py
+++ b/airflow-core/tests/unit/models/test_dagrun.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import datetime
 from collections import defaultdict
 from collections.abc import Mapping
-from datetime import timedelta
 from functools import reduce
 from typing import TYPE_CHECKING
 from unittest import mock
@@ -1397,88 +1396,6 @@ class TestDagRun:
 
         mock_prune.assert_not_called()
         assert dag_run.state == DagRunState.SUCCESS
-
-    def test_clear_task_instances_recalculates_dagrun_queued_deadlines(self, session, dag_maker):
-        """Test that clearing tasks recalculates all (and only) DAGRUN_QUEUED_AT deadlines."""
-        with dag_maker(
-            dag_id="test_recalculate_deadlines",
-            schedule=datetime.timedelta(days=1),
-        ) as dag:
-            EmptyOperator(task_id="task_1")
-
-        dag_run = self.create_dag_run(
-            dag=dag,
-            task_states={"task_1": TaskInstanceState.SUCCESS},
-            session=session,
-        )
-
-        original_queued_at = timezone.utcnow() - datetime.timedelta(hours=2)
-        dag_run.queued_at = original_queued_at
-        session.flush()
-
-        serialized_dag_id = session.scalar(
-            select(SerializedDagModel.id).where(SerializedDagModel.dag_id == dag.dag_id)
-        )
-
-        deadline_configs = [
-            (DeadlineReference.DAGRUN_QUEUED_AT, datetime.timedelta(hours=1)),
-            (DeadlineReference.DAGRUN_QUEUED_AT, datetime.timedelta(hours=2)),
-            (DeadlineReference.FIXED_DATETIME, datetime.timedelta(hours=1)),
-        ]
-
-        for deadline_type, interval in deadline_configs:
-            if deadline_type == DeadlineReference.DAGRUN_QUEUED_AT:
-                reference = DeadlineReference.DAGRUN_QUEUED_AT.serialize_reference()
-                deadline_time = dag_run.queued_at + interval
-            else:  # FIXED_DATETIME
-                future_date = timezone.utcnow() + datetime.timedelta(days=7)
-                reference = DeadlineReference.FIXED_DATETIME(future_date).serialize_reference()
-                deadline_time = future_date + interval
-
-            deadline_alert = DeadlineAlertModel(
-                serialized_dag_id=serialized_dag_id,
-                reference=reference,
-                interval=interval.total_seconds(),
-                callback_def={"path": f"{__name__}.empty_callback_for_deadline", "kwargs": {}},
-            )
-            session.add(deadline_alert)
-            session.flush()
-
-            deadline = Deadline(
-                dagrun_id=dag_run.id,
-                deadline_alert_id=deadline_alert.id,
-                deadline_time=deadline_time,
-                callback=AsyncCallback(empty_callback_for_deadline),
-                dag_id=dag_run.dag_id,
-            )
-            session.add(deadline)
-
-        session.flush()
-
-        deadlines_before = session.scalars(select(Deadline).where(Deadline.dagrun_id == dag_run.id)).all()
-        deadline_times_by_alert = {
-            deadline.deadline_alert_id: deadline.deadline_time for deadline in deadlines_before
-        }
-
-        tis = session.scalars(select(TI).where(TI.dag_id == dag.dag_id, TI.run_id == dag_run.run_id)).all()
-        clear_task_instances(tis, session)
-
-        dag_run = session.scalar(select(DagRun).where(DagRun.id == dag_run.id))
-        assert dag_run.queued_at > original_queued_at
-
-        deadlines_after = session.scalars(select(Deadline).where(Deadline.dagrun_id == dag_run.id)).all()
-        assert len(deadlines_after) == 3
-
-        # Verify exactly 2 DAGRUN_QUEUED_AT deadlines were recalculated, FIXED_DATETIME was not
-        recalculated_count = 0
-        for deadline in deadlines_after:
-            if deadline.deadline_time != deadline_times_by_alert[deadline.deadline_alert_id]:
-                recalculated_count += 1
-                deadline_alert = session.get(DeadlineAlertModel, deadline.deadline_alert_id)
-                expected_time = dag_run.queued_at + timedelta(seconds=deadline_alert.interval)
-                assert deadline.deadline_time == expected_time
-
-        assert recalculated_count == 2
 
 
 @pytest.mark.parametrize(

--- a/airflow-core/tests/unit/models/test_taskinstance.py
+++ b/airflow-core/tests/unit/models/test_taskinstance.py
@@ -50,6 +50,8 @@ from airflow.models.asset import (
 )
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagrun import DagRun
+from airflow.models.deadline import Deadline
+from airflow.models.deadline_alert import DeadlineAlert as DeadlineAlertModel
 from airflow.models.pool import Pool
 from airflow.models.renderedtifields import RenderedTaskInstanceFields
 from airflow.models.serialized_dag import SerializedDagModel
@@ -57,6 +59,7 @@ from airflow.models.taskinstance import (
     TaskInstance,
     TaskInstance as TI,
     TaskInstanceNote,
+    clear_task_instances,
     find_relevant_relatives,
 )
 from airflow.models.taskinstancehistory import TaskInstanceHistory
@@ -80,6 +83,8 @@ from airflow.sdk import (
     task_group,
 )
 from airflow.sdk.api.datamodels._generated import AssetEventResponse, AssetResponse
+from airflow.sdk.definitions.callback import AsyncCallback
+from airflow.sdk.definitions.deadline import DeadlineReference
 from airflow.sdk.definitions.param import process_params
 from airflow.sdk.definitions.taskgroup import TaskGroup
 from airflow.sdk.execution_time.comms import AssetEventsResult
@@ -3088,3 +3093,90 @@ def test_when_dag_run_has_partition_and_downstreams_listening_then_tables_popula
     assert pakl.asset_partition_dag_run_id == apdr.id
     assert pakl.source_partition_key == "abc123"
     assert pakl.target_dag_id == "asset_event_listener"
+
+
+async def empty_callback_for_deadline():
+    """Used in deadline tests to confirm that Deadlines and DeadlineAlerts function correctly."""
+    pass
+
+
+def test_clear_task_instances_recalculates_dagrun_queued_deadlines(dag_maker, session):
+    """Test that clearing tasks recalculates all (and only) DAGRUN_QUEUED_AT deadlines."""
+    with dag_maker(
+        dag_id="test_recalculate_deadlines",
+        schedule=datetime.timedelta(days=1),
+    ) as dag:
+        EmptyOperator(task_id="task_1")
+
+    dag_run = dag_maker.create_dagrun()
+    # Set the task to SUCCESS state
+    ti = dag_run.get_task_instance("task_1", session=session)
+    ti.set_state(TaskInstanceState.SUCCESS, session=session)
+
+    original_queued_at = timezone.utcnow() - datetime.timedelta(hours=2)
+    dag_run.queued_at = original_queued_at
+    session.flush()
+
+    serialized_dag_id = session.scalar(
+        select(SerializedDagModel.id).where(SerializedDagModel.dag_id == dag.dag_id)
+    )
+
+    deadline_configs = [
+        (DeadlineReference.DAGRUN_QUEUED_AT, datetime.timedelta(hours=1)),
+        (DeadlineReference.DAGRUN_QUEUED_AT, datetime.timedelta(hours=2)),
+        (DeadlineReference.FIXED_DATETIME, datetime.timedelta(hours=1)),
+    ]
+
+    for deadline_type, interval in deadline_configs:
+        if deadline_type == DeadlineReference.DAGRUN_QUEUED_AT:
+            reference = DeadlineReference.DAGRUN_QUEUED_AT.serialize_reference()
+            deadline_time = dag_run.queued_at + interval
+        else:  # FIXED_DATETIME
+            future_date = timezone.utcnow() + datetime.timedelta(days=7)
+            reference = DeadlineReference.FIXED_DATETIME(future_date).serialize_reference()
+            deadline_time = future_date + interval
+
+        deadline_alert = DeadlineAlertModel(
+            serialized_dag_id=serialized_dag_id,
+            reference=reference,
+            interval=interval.total_seconds(),
+            callback_def={"path": f"{__name__}.empty_callback_for_deadline", "kwargs": {}},
+        )
+        session.add(deadline_alert)
+        session.flush()
+
+        deadline = Deadline(
+            dagrun_id=dag_run.id,
+            deadline_alert_id=deadline_alert.id,
+            deadline_time=deadline_time,
+            callback=AsyncCallback(empty_callback_for_deadline),
+            dag_id=dag_run.dag_id,
+        )
+        session.add(deadline)
+
+    session.flush()
+
+    deadlines_before = session.scalars(select(Deadline).where(Deadline.dagrun_id == dag_run.id)).all()
+    deadline_times_by_alert = {
+        deadline.deadline_alert_id: deadline.deadline_time for deadline in deadlines_before
+    }
+
+    tis = session.scalars(select(TI).where(TI.dag_id == dag.dag_id, TI.run_id == dag_run.run_id)).all()
+    clear_task_instances(tis, session)
+
+    dag_run = session.scalar(select(DagRun).where(DagRun.id == dag_run.id))
+    assert dag_run.queued_at > original_queued_at
+
+    deadlines_after = session.scalars(select(Deadline).where(Deadline.dagrun_id == dag_run.id)).all()
+    assert len(deadlines_after) == 3
+
+    # Verify exactly 2 DAGRUN_QUEUED_AT deadlines were recalculated, FIXED_DATETIME was not
+    recalculated_count = 0
+    for deadline in deadlines_after:
+        if deadline.deadline_time != deadline_times_by_alert[deadline.deadline_alert_id]:
+            recalculated_count += 1
+            deadline_alert = session.get(DeadlineAlertModel, deadline.deadline_alert_id)
+            expected_time = dag_run.queued_at + datetime.timedelta(seconds=deadline_alert.interval)
+            assert deadline.deadline_time == expected_time
+
+    assert recalculated_count == 2


### PR DESCRIPTION
bugfix - If the run has a deadline related to the queued_at time, then those should be recalculated when that timestamp is changed.

Manually tested by starting a dag with a deadline and watching the dagrun.queued_at and deadline.deadline_time columns before and after a run cleared via the Airflow UI.

cc @ramitkataria @seanghaeli 

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
