### PR TITLE
Fix(Amazon): Restore wait_policy in EmrCreateJobFlowOperator

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/emr.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/emr.py
@@ -701,25 +701,12 @@ class EmrCreateJobFlowOperator(AwsBaseOperator[EmrHook]):
         self.waiter_max_attempts = waiter_max_attempts or 60
         self.waiter_delay = waiter_delay or 60
         self.deferrable = deferrable
+        self.wait_policy = wait_policy
 
         if wait_policy is not None:
-            warnings.warn(
-                "`wait_policy` parameter is deprecated and will be removed in a future release; "
-                "please use `wait_for_completion` (bool) instead.",
-                AirflowProviderDeprecationWarning,
-                stacklevel=2,
-            )
-
-            if wait_for_completion is not None:
-                raise ValueError(
-                    "Cannot specify both `wait_for_completion` and deprecated `wait_policy`. "
-                    "Please use `wait_for_completion` (bool)."
-                )
-
-            self.wait_for_completion = wait_policy in (
-                WaitPolicy.WAIT_FOR_COMPLETION,
-                WaitPolicy.WAIT_FOR_STEPS_COMPLETION,
-            )
+            if wait_for_completion is False:
+                raise ValueError("Cannot specify wait_policy with wait_for_completion=False")
+            self.wait_for_completion = True
 
     @property
     def _hook_parameters(self):
@@ -758,7 +745,7 @@ class EmrCreateJobFlowOperator(AwsBaseOperator[EmrHook]):
                 log_uri=get_log_uri(emr_client=self.hook.conn, job_flow_id=self._job_flow_id),
             )
         if self.wait_for_completion:
-            waiter_name = WAITER_POLICY_NAME_MAPPING[WaitPolicy.WAIT_FOR_COMPLETION]
+            waiter_name = WAITER_POLICY_NAME_MAPPING[self.wait_policy or WaitPolicy.WAIT_FOR_COMPLETION]
 
             if self.deferrable:
                 self.defer(

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_emr_create_job_flow.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_emr_create_job_flow.py
@@ -254,10 +254,20 @@ class TestEmrCreateJobFlowOperator:
     def test_template_fields(self):
         validate_template_fields(self.operator)
 
-    def test_wait_policy_deprecation_warning(self):
-        """Test that using wait_policy raises a deprecation warning."""
-        with pytest.warns(AirflowProviderDeprecationWarning, match="`wait_policy` parameter is deprecated"):
-            EmrCreateJobFlowOperator(
-                task_id=TASK_ID,
-                wait_policy=WaitPolicy.WAIT_FOR_COMPLETION,
-            )
+    @mock.patch("botocore.waiter.get_service_module_name", return_value="emr")
+    @mock.patch.object(Waiter, "wait")
+    def test_execute_with_wait_policy(self, mock_waiter, _, mocked_hook_client):
+        mocked_hook_client.run_job_flow.return_value = RUN_JOB_FLOW_SUCCESS_RETURN
+
+        # Test that providing wait_policy uses the correct waiter
+        op = EmrCreateJobFlowOperator(
+            task_id="test_wait_policy",
+            aws_conn_id="aws_default",
+            emr_conn_id="emr_default",
+            wait_policy=WaitPolicy.WAIT_FOR_STEPS_COMPLETION,
+        )
+        
+        op.execute(self.mock_context)
+        
+        mock_waiter.assert_called_once_with(mock.ANY, ClusterId=JOB_FLOW_ID, WaiterConfig=mock.ANY)
+        assert_expected_waiter_type(mock_waiter, WAITER_POLICY_NAME_MAPPING[WaitPolicy.WAIT_FOR_STEPS_COMPLETION])


### PR DESCRIPTION
**Description**
Restores the functionality of the `wait_policy` parameter in `EmrCreateJobFlowOperator`.
Previously, `wait_policy` was deprecated and ignored in favor of a hardcoded 'running' state check when `wait_for_completion` was True.
This change allows users to explicitly specify policies like `WAIT_FOR_STEPS_COMPLETION` (to wait for cluster termination) while maintaining backward compatibility (implied `wait_for_completion=True`).

**Related Issue**
Closes #61180

**Tests**
Added `test_execute_with_wait_policy` to verify the correct waiter is used.
Removed `test_wait_policy_deprecation_warning` as the parameter is no longer deprecated.