### PR TITLE
Fix secrets masking in Rendered Templates for complex objects

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -959,22 +959,11 @@ def _serialize_template_field(template_field: Any, name: str) -> str | dict | li
             return tuple(sort_dict_recursively(item) for item in obj)
         return obj
 
-    def to_serializable(obj: Any) -> Any:
-        """Convert objects to JSON serializable types."""
-        if obj is None or isinstance(obj, (str, int, float, bool)):
-            return obj
-
-        if isinstance(obj, dict):
-            return {k: to_serializable(v) for k, v in obj.items()}
-
-        if isinstance(obj, (list, tuple)):
-            return [to_serializable(item) for item in obj]
-
-        # Some objects like Kubernetes ones or boto3 ones have to_dict defined, try using them if they exist
+    def _fallback_serialization(obj):
+        """Serialize objects with to_dict() method (eg: k8s objects) for json.dumps() default parameter."""
         if hasattr(obj, "to_dict"):
             return obj.to_dict()
-
-        return obj
+        raise TypeError(f"cannot serialize {obj}")
 
     max_length = conf.getint("core", "max_templated_field_length")
 
@@ -984,7 +973,7 @@ def _serialize_template_field(template_field: Any, name: str) -> str | dict | li
         except AttributeError:
             # check if these objects can be converted to JSON serializable types
             try:
-                serialized = json.dumps(to_serializable(template_field))
+                serialized = json.dumps(template_field, default=_fallback_serialization)
             except (TypeError, ValueError):
                 # fall back to string representation if not
                 serialized = str(template_field)

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -959,13 +959,35 @@ def _serialize_template_field(template_field: Any, name: str) -> str | dict | li
             return tuple(sort_dict_recursively(item) for item in obj)
         return obj
 
+    def to_serializable(obj: Any) -> Any:
+        """Convert objects to JSON serializable types."""
+        if obj is None or isinstance(obj, (str, int, float, bool)):
+            return obj
+
+        if isinstance(obj, dict):
+            return {k: to_serializable(v) for k, v in obj.items()}
+
+        if isinstance(obj, (list, tuple)):
+            return [to_serializable(item) for item in obj]
+
+        # Some objects like Kubernetes ones or boto3 ones have to_dict defined, try using them if they exist
+        if hasattr(obj, "to_dict"):
+            return obj.to_dict()
+
+        return obj
+
     max_length = conf.getint("core", "max_templated_field_length")
 
     if not is_jsonable(template_field):
         try:
             serialized = template_field.serialize()
         except AttributeError:
-            serialized = str(template_field)
+            # check if these objects can be converted to JSON serializable types
+            try:
+                serialized = json.dumps(to_serializable(template_field))
+            except (TypeError, ValueError):
+                # fall back to string representation if not
+                serialized = str(template_field)
         if len(serialized) > max_length:
             rendered = redact(serialized, name)
             return (


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] No

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

### Problem

Secrets stored in complex objects (e.g., Kubernetes `V1EnvVar`, boto3 models) were not masked in the Rendered Templates UI when values contained _spaces_ or exceeded certain lengths.

The cause here is that when `_serialize_template_field()` encounters non JSON serializable objects, it uses `str()` for serialization. Python `__repr__` for these objects breaks long string values across multiple lines:

```
'value': 'This is a longer test phrase. We are checking if this handles '
          'regular sentences.'
```

Now if this value was registered with the masker without new lines in between, redaction wont happen since patterns do not match exactly.

### Fix

The fix is to attempt converting such objects to serializable formats by json. To do this, added a `to_serializable()` helper function that converts objects with `.to_dict()` methods (standard in Kubernetes, boto3, and other similar such objects) to plain dictionaries before serialization. Then use json.dumps() instead of str() to produce clean json output.


It works because json spec doesn't allow line breaks inside string values and `json.dumps()` works on these converted objects. This leads now to secret patterns matching correctly -> masking succeeds.


### Testing

Use a simple macro like this:
```python
def mask_str(value: str):
    """
    Mask a literal string value so it isn't exposed in logs or task instance details.
    """
    mask_secret(value)
    return value


class MyMacroMacros(AirflowPlugin):
    name = "my_macro"
    macros = [mask_str]
```

DAG:

```python
import logging
from datetime import datetime

from airflow.providers.standard.operators.bash import BashOperator
from airflow.sdk import DAG
from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
from airflow.providers.standard.operators.empty import EmptyOperator

logger = logging.getLogger(__name__)

DAG_ID = "my_dag"
default_args = {
    "start_date": datetime(2017, 8, 9, hour=5),
}


def create_dag(dag_id: str = DAG_ID) -> DAG:
    dag = DAG(
        dag_id=dag_id,
        default_args=default_args,
        schedule=None,
        doc_md=__doc__,
    )

    empty_task = EmptyOperator(dag=dag, task_id="empty_task")

    cmds = ["/bin/bash", "-c"]

    kpo = {
        "TEST_PHRASE1": f"{{{{ macros.my_macro.mask_str('This is a test phrase.') }}}}",
        "TEST_PHRASE2": f"{{{{ macros.my_macro.mask_str('This is a longer test phrase. We are checking if this handles regular sentences.') }}}}",
        "TEST_PHRASE3": f"{{{{ macros.my_macro.mask_str('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.') }}}}"
    }
    for i in range(50):
        kpo[f"TEST_URL_{i}"] = (
            f"{{{{ macros.my_macro.mask_str('postgresql+psycopg2://username:testpass123@test.domain.com/testdb') }}}}"
        )
    arguments = [f"echo '{key}: {value}'" for key, value in secrets_for_kpo.items()]
    debug_secret_for_kpo = KubernetesPodOperator(
        task_id="kpo-task",
        image="ubuntu",
        cmds=cmds,
        arguments=[" && ".join(arguments)],
        env_vars=kpo,
        dag=dag,
    )

    empty_task >> debug_secret_for_kpo

    return dag


dag = create_dag()

```

Earlier:

<img width="799" height="299" alt="Screenshot 2026-01-29 at 1 09 47 PM" src="https://github.com/user-attachments/assets/c5460b25-3c80-4fe3-9587-b66f118eaf05" />


Now:

```python
[{"name": "TEST_PHRASE1", "value": "***", "value_from": null}, {"name": "TEST_PHRASE2", "value": "***", "value_from": null}, {"name": "TEST_PHRASE3", "value": "***", "value_from": null}, {"name": "RANDOM_100", "value": "***", "value_from": null}, {"name": "RANDOM_500", "value": "***", "value_from": null}, {"name": "RANDOM_1000", "value": "***", "value_from": null}, {"name": "RANDOM_1500", "value": "***", "value_from": null}, {"name": "RANDOM_2500", "value": "***", "value_from": null}, {"name": "TEST_URL_0", "value": "***", "value_from": null}, {"name": "TEST_URL_1", "value": "***", "value_from": null}, {"name": "TEST_URL_2", "value": "***", "value_from": null}, {"name": "TEST_URL_3", "value": "***", "value_from": null}, {"name": "TEST_URL_4", "value": "***", "value_from": null}, {"name": "TEST_URL_5", "value": "***", "value_from": null}, {"name": "TEST_URL_6", "value": "***", "value_from": null}, {"name": "TEST_URL_7", "value": "***", "value_from": null}, {"name": "TEST_URL_8", "value": "***", "value_from": null}, {"name": "TEST_URL_9", "value": "***", "value_from": null}, {"name": "TEST_URL_10", "value": "***", "value_from": null}, {"name": "TEST_URL_11", "value": "***", "value_from": null}, {"name": "TEST_URL_12", "value": "***", "value_from": null}, {"name": "TEST_URL_13", "value": "***", "value_from": null}, {"name": "TEST_URL_14", "value": "***", "value_from": null}, {"name": "TEST_URL_15", "value": "***", "value_from": null}, {"name": "TEST_URL_16", "value": "***", "value_from": null}, {"name": "TEST_URL_17", "value": "***", "value_from": null}, {"name": "TEST_URL_18", "value": "***", "value_from": null}, {"name": "TEST_URL_19", "value": "***", "value_from": null}, {"name": "TEST_URL_20", "value": "***", "value_from": null}, {"name": "TEST_URL_21", "value": "***", "value_from": null}, {"name": "TEST_URL_22", "value": "***", "value_from": null}, {"name": "TEST_URL_23", "value": "***", "value_from": null}, {"name": "TEST_URL_24", "value": "***", "value_from": null}, {"name": "TEST_URL_25", "value": "***", "value_from": null}, {"name": "TEST_URL_26", "value": "***", "value_from": null}, {"name": "TEST_URL_27", "value": "***", "value_from": null}, {"name": "TEST_URL_28", "value": "***", "value_from": null}, {"name": "TEST_URL_29", "value": "***", "value_from": null}, {"name": "TEST_URL_30", "value": "***", "value_from": null}, {"name": "TEST_URL_31", "value": "***", "value_from": null}, {"name": "TEST_URL_32", "value": "***", "value_from": null}, {"name": "TEST_URL_33", "value": "***", "value_from": null}, {"name": "TEST_URL_34", "value": "***", "value_from": null}, {"name": "TEST_URL_35", "value": "***", "value_from": null}, {"name": "TEST_URL_36", "value": "***", "value_from": null}, {"name": "TEST_URL_37", "value": "***", "value_from": null}, {"name": "TEST_URL_38", "value": "***", "value_from": null}, {"name": "TEST_URL_39", "value": "***", "value_from": null}, {"name": "TEST_URL_40", "value": "***", "value_from": null}, {"name": "TEST_URL_41", "value": "***", "value_from": null}, {"name": "TEST_URL_42", "value": "***", "value_from": null}, {"name": "TEST_URL_43", "value": "***", "value_from": null}, {"name": "TEST_URL_44", "value": "***", "value_from": null}, {"name": "TEST_URL_45", "value": "***", "value_from": null}, {"name": "TEST_URL_46", "value": "***", "value_from": null}, {"name": "TEST_URL_47", "value": "***", "value_from": null}, {"name": "TEST_URL_48", "value": "***", "value_from": null}, {"name": "TEST_URL_49", "value": "***", "value_from": null}]
```

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
