### PR TITLE
Deprecate BackfillDetails and use DagAcccessEntity.Run for backfill p…

### DIFF
--- a/airflow-core/docs/core-concepts/auth-manager/index.rst
+++ b/airflow-core/docs/core-concepts/auth-manager/index.rst
@@ -136,7 +136,6 @@ These authorization methods are:
   Also, ``is_authorized_dag`` is called for any entity related to Dags (e.g. task instances, Dag runs, ...). This information is passed in ``access_entity``.
   Example: ``auth_manager.is_authorized_dag(method="GET", access_entity=DagAccessEntity.Run, details=DagDetails(id="dag-1"))`` asks
   whether the user has permission to read the Dag runs of the Dag "dag-1".
-* ``is_authorized_backfill``: Return whether the user is authorized to access Airflow backfills. Some details about the backfill can be provided (e.g. the backfill ID).
 * ``is_authorized_asset``: Return whether the user is authorized to access Airflow assets. Some details about the asset can be provided (e.g. the asset ID).
 * ``is_authorized_asset_alias``: Return whether the user is authorized to access Airflow asset aliases. Some details about the asset alias can be provided (e.g. the asset alias ID).
 * ``is_authorized_pool``: Return whether the user is authorized to access Airflow pools. Some details about the pool can be provided (e.g. the pool name).

--- a/airflow-core/newsfragments/61400.significant.rst
+++ b/airflow-core/newsfragments/61400.significant.rst
@@ -1,0 +1,19 @@
+AuthManager Backfill permissions are now handled by the ``requires_access_dag`` on the ``DagAccessEntity.Run``
+
+``is_authorized_backfill`` of the ``BaseAuthManager`` interface has been deprecated.
+Permissions for backfill operations are now checked against the ``DagAccessEntity.Run`` permission using the existing
+``requires_access_dag`` decorator. In other words, if a user has permission to run a DAG, they can perform backfill operations on it.
+
+Please update your security policies to ensure that users who need to perform backfill operations have the appropriate ``DagAccessEntity.Run`` permissions. (Users
+having the Backfill permissions without having the DagRun ones will no longer be able to perform backfill operations without any update)
+
+* Types of change
+
+  * [ ] Dag changes
+  * [ ] Config changes
+  * [x] API changes
+  * [ ] CLI changes
+  * [x] Behaviour changes
+  * [ ] Plugin changes
+  * [ ] Dependency changes
+  * [ ] Code interface changes

--- a/airflow-core/newsfragments/61400.significant.rst
+++ b/airflow-core/newsfragments/61400.significant.rst
@@ -1,6 +1,7 @@
 AuthManager Backfill permissions are now handled by the ``requires_access_dag`` on the ``DagAccessEntity.Run``
 
-``is_authorized_backfill`` of the ``BaseAuthManager`` interface has been deprecated.
+``is_authorized_backfill`` of the ``BaseAuthManager`` interface has been removed. Core will no longer call this method and their
+provider counterpart implementation will be marked as deprecated.
 Permissions for backfill operations are now checked against the ``DagAccessEntity.Run`` permission using the existing
 ``requires_access_dag`` decorator. In other words, if a user has permission to run a DAG, they can perform backfill operations on it.
 

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/base_auth_manager.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/base_auth_manager.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 from enum import Enum
@@ -230,7 +231,6 @@ class BaseAuthManager(Generic[T], LoggingMixin, metaclass=ABCMeta):
         :param details: optional details about the DAG
         """
 
-    @abstractmethod
     def is_authorized_backfill(
         self,
         *,
@@ -244,7 +244,18 @@ class BaseAuthManager(Generic[T], LoggingMixin, metaclass=ABCMeta):
         :param method: the method to perform
         :param user: the user to performing the action
         :param details: optional details about the backfill
+
+
+        .. deprecated:: 3.1.8
+            Use ``is_authorized_dag`` on ``DagAccessEntity.RUN`` instead for a dag level access control.
         """
+        warnings.warn(
+            "You have a plugin that is using a FAB view or Flask Blueprint, which was used for the Airflow 2 UI,"
+            "and is now deprecated. Please update your plugin to be compatible with the Airflow 3 UI.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return False
 
     @abstractmethod
     def is_authorized_asset(

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/base_auth_manager.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/base_auth_manager.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import logging
-import warnings
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 from enum import Enum
@@ -30,7 +29,6 @@ from sqlalchemy import select
 
 from airflow.api_fastapi.auth.managers.models.base_user import BaseUser
 from airflow.api_fastapi.auth.managers.models.resource_details import (
-    BackfillDetails,
     ConnectionDetails,
     DagDetails,
     PoolDetails,
@@ -230,32 +228,6 @@ class BaseAuthManager(Generic[T], LoggingMixin, metaclass=ABCMeta):
             If not provided, the authorization request is about the DAG itself
         :param details: optional details about the DAG
         """
-
-    def is_authorized_backfill(
-        self,
-        *,
-        method: ResourceMethod,
-        user: T,
-        details: BackfillDetails | None = None,
-    ) -> bool:
-        """
-        Return whether the user is authorized to perform a given action on a backfill.
-
-        :param method: the method to perform
-        :param user: the user to performing the action
-        :param details: optional details about the backfill
-
-
-        .. deprecated:: 3.1.8
-            Use ``is_authorized_dag`` on ``DagAccessEntity.RUN`` instead for a dag level access control.
-        """
-        warnings.warn(
-            "You have a plugin that is using a FAB view or Flask Blueprint, which was used for the Airflow 2 UI,"
-            "and is now deprecated. Please update your plugin to be compatible with the Airflow 3 UI.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return False
 
     @abstractmethod
     def is_authorized_asset(

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/models/resource_details.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/models/resource_details.py
@@ -48,7 +48,12 @@ class DagDetails:
 
 @dataclass
 class BackfillDetails:
-    """Represents the details of a backfill."""
+    """
+    Represents the details of a backfill.
+
+    .. deprecated:: 3.1.8
+        Use DagAccessEntity.BACKFILL instead for a dag level access control.
+    """
 
     id: NonNegativeInt | None = None
 

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/models/resource_details.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/models/resource_details.py
@@ -52,7 +52,7 @@ class BackfillDetails:
     Represents the details of a backfill.
 
     .. deprecated:: 3.1.8
-        Use DagAccessEntity.BACKFILL instead for a dag level access control.
+        Use DagAccessEntity.Run instead for a dag level access control.
     """
 
     id: NonNegativeInt | None = None

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
@@ -36,7 +36,7 @@ from termcolor import colored
 
 from airflow.api_fastapi.app import AUTH_MANAGER_FASTAPI_APP_PREFIX
 from airflow.api_fastapi.auth.managers.base_auth_manager import BaseAuthManager
-from airflow.api_fastapi.auth.managers.models.resource_details import BackfillDetails, TeamDetails
+from airflow.api_fastapi.auth.managers.models.resource_details import TeamDetails
 from airflow.api_fastapi.auth.managers.simple.user import SimpleAuthManagerUser
 from airflow.api_fastapi.common.types import MenuItem
 from airflow.configuration import AIRFLOW_HOME, conf
@@ -191,20 +191,6 @@ class SimpleAuthManager(BaseAuthManager[SimpleAuthManagerUser]):
             method=method,
             allow_get_role=SimpleAuthManagerRole.VIEWER,
             allow_role=SimpleAuthManagerRole.USER,
-            user=user,
-        )
-
-    def is_authorized_backfill(
-        self,
-        *,
-        method: ResourceMethod,
-        user: SimpleAuthManagerUser,
-        details: BackfillDetails | None = None,
-    ) -> bool:
-        return self._is_authorized(
-            method=method,
-            allow_get_role=SimpleAuthManagerRole.VIEWER,
-            allow_role=SimpleAuthManagerRole.OP,
             user=user,
         )
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/backfills.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/backfills.py
@@ -25,7 +25,6 @@ from sqlalchemy import select, update
 from sqlalchemy.orm import joinedload
 
 from airflow._shared.timezones import timezone
-from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity
 from airflow.api_fastapi.common.db.common import (
     SessionDep,
     paginated_select,
@@ -42,7 +41,7 @@ from airflow.api_fastapi.core_api.datamodels.backfills import (
 from airflow.api_fastapi.core_api.openapi.exceptions import (
     create_openapi_http_exception_doc,
 )
-from airflow.api_fastapi.core_api.security import GetUserDep, requires_access_backfill, requires_access_dag
+from airflow.api_fastapi.core_api.security import GetUserDep, requires_access_backfill
 from airflow.api_fastapi.logging.decorators import action_logging
 from airflow.exceptions import DagNotFound
 from airflow.models import DagRun
@@ -121,7 +120,6 @@ def get_backfill(
     dependencies=[
         Depends(action_logging()),
         Depends(requires_access_backfill(method="PUT")),
-        Depends(requires_access_dag(method="PUT", access_entity=DagAccessEntity.RUN)),
     ],
 )
 def pause_backfill(backfill_id: NonNegativeInt, session: SessionDep) -> BackfillResponse:
@@ -149,7 +147,6 @@ def pause_backfill(backfill_id: NonNegativeInt, session: SessionDep) -> Backfill
     dependencies=[
         Depends(action_logging()),
         Depends(requires_access_backfill(method="PUT")),
-        Depends(requires_access_dag(method="PUT", access_entity=DagAccessEntity.RUN)),
     ],
 )
 def unpause_backfill(backfill_id: NonNegativeInt, session: SessionDep) -> BackfillResponse:
@@ -175,7 +172,6 @@ def unpause_backfill(backfill_id: NonNegativeInt, session: SessionDep) -> Backfi
     ),
     dependencies=[
         Depends(action_logging()),
-        Depends(requires_access_dag(method="PUT", access_entity=DagAccessEntity.RUN)),
         Depends(requires_access_backfill(method="PUT")),
     ],
 )
@@ -222,7 +218,6 @@ def cancel_backfill(backfill_id: NonNegativeInt, session: SessionDep) -> Backfil
     responses=create_openapi_http_exception_doc([status.HTTP_404_NOT_FOUND, status.HTTP_409_CONFLICT]),
     dependencies=[
         Depends(action_logging()),
-        Depends(requires_access_dag(method="POST", access_entity=DagAccessEntity.RUN)),
         Depends(requires_access_backfill(method="POST")),
     ],
 )
@@ -270,7 +265,6 @@ def create_backfill(
     path="/dry_run",
     responses=create_openapi_http_exception_doc([status.HTTP_404_NOT_FOUND, status.HTTP_409_CONFLICT]),
     dependencies=[
-        Depends(requires_access_dag(method="POST", access_entity=DagAccessEntity.RUN)),
         Depends(requires_access_backfill(method="POST")),
     ],
 )

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/backfills.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/backfills.py
@@ -36,7 +36,7 @@ from airflow.api_fastapi.core_api.datamodels.backfills import BackfillCollection
 from airflow.api_fastapi.core_api.openapi.exceptions import (
     create_openapi_http_exception_doc,
 )
-from airflow.api_fastapi.core_api.security import requires_access_backfill, requires_access_dag
+from airflow.api_fastapi.core_api.security import requires_access_backfill
 from airflow.models.backfill import Backfill
 
 backfills_router = AirflowRouter(tags=["Backfill"], prefix="/backfills")
@@ -47,7 +47,6 @@ backfills_router = AirflowRouter(tags=["Backfill"], prefix="/backfills")
     responses=create_openapi_http_exception_doc([status.HTTP_404_NOT_FOUND]),
     dependencies=[
         Depends(requires_access_backfill(method="GET")),
-        Depends(requires_access_dag(method="GET")),
     ],
 )
 def list_backfills_ui(

--- a/airflow-core/src/airflow/api_fastapi/core_api/security.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/security.py
@@ -16,10 +16,10 @@
 # under the License.
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
 from json import JSONDecodeError
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, cast
+from typing import TYPE_CHECKING, Annotated, Any, cast
 from urllib.parse import ParseResult, unquote, urljoin, urlparse
 
 from fastapi import Depends, HTTPException, Request, status
@@ -150,13 +150,15 @@ GetUserDep = Annotated[BaseUser, Depends(get_user)]
 def requires_access_dag(
     method: ResourceMethod,
     access_entity: DagAccessEntity | None = None,
-    dag_id: str | None = None,
+    param_dag_id: str | None = None,
 ) -> Callable[[Request, BaseUser], None]:
     def inner(
         request: Request,
         user: GetUserDep,
     ) -> None:
-        nonlocal dag_id
+        # Required for the closure to capture the dag_id but still be able to mutate it.
+        # Prevent from using a nonlocal statement causing test failures.
+        dag_id = param_dag_id
         if dag_id is None:
             dag_id = request.path_params.get("dag_id") or request.query_params.get("dag_id")
             dag_id = dag_id if dag_id != "~" else None
@@ -270,7 +272,9 @@ ReadableTagsFilterDep = Annotated[
 ]
 
 
-def requires_access_backfill(method: ResourceMethod) -> Callable[[Request, BaseUser, Session], None]:
+def requires_access_backfill(
+    method: ResourceMethod,
+) -> Callable[[Request, BaseUser, Session], Coroutine[Any, Any, None]]:
     """Wrap ``requires_access_dag`` and extract the dag_id from the backfill_id."""
 
     async def inner(
@@ -282,7 +286,7 @@ def requires_access_backfill(method: ResourceMethod) -> Callable[[Request, BaseU
 
         # Try to retrieve the dag_id from the backfill_id path param
         backfill_id = request.path_params.get("backfill_id")
-        if backfill_id is not None:
+        if backfill_id is not None and isinstance(backfill_id, int):
             backfill = session.scalars(select(Backfill).where(Backfill.id == backfill_id)).one_or_none()
             dag_id = backfill.dag_id if backfill else None
 
@@ -295,8 +299,8 @@ def requires_access_backfill(method: ResourceMethod) -> Callable[[Request, BaseU
                 pass
 
         requires_access_dag(method, DagAccessEntity.RUN, dag_id)(
-            request=request,
-            user=user,
+            request,
+            user,
         )
 
     return inner

--- a/airflow-core/src/airflow/api_fastapi/core_api/security.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/security.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from json import JSONDecodeError
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, cast
 from urllib.parse import ParseResult, unquote, urljoin, urlparse
@@ -24,8 +25,8 @@ from urllib.parse import ParseResult, unquote, urljoin, urlparse
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer, OAuth2PasswordBearer
 from jwt import ExpiredSignatureError, InvalidTokenError
-from pydantic import NonNegativeInt
-from sqlalchemy import or_
+from sqlalchemy import or_, select
+from sqlalchemy.orm import Session
 
 from airflow.api_fastapi.app import get_auth_manager
 from airflow.api_fastapi.auth.managers.base_auth_manager import (
@@ -42,7 +43,6 @@ from airflow.api_fastapi.auth.managers.models.resource_details import (
     AccessView,
     AssetAliasDetails,
     AssetDetails,
-    BackfillDetails,
     ConfigurationDetails,
     ConnectionDetails,
     DagAccessEntity,
@@ -50,6 +50,7 @@ from airflow.api_fastapi.auth.managers.models.resource_details import (
     PoolDetails,
     VariableDetails,
 )
+from airflow.api_fastapi.common.db.common import SessionDep
 from airflow.api_fastapi.core_api.base import OrmClause
 from airflow.api_fastapi.core_api.datamodels.common import (
     BulkAction,
@@ -64,6 +65,7 @@ from airflow.api_fastapi.core_api.datamodels.pools import PoolBody
 from airflow.api_fastapi.core_api.datamodels.variables import VariableBody
 from airflow.configuration import conf
 from airflow.models import Connection, Pool, Variable
+from airflow.models.backfill import Backfill
 from airflow.models.dag import DagModel, DagRun, DagTag
 from airflow.models.dagwarning import DagWarning
 from airflow.models.log import Log
@@ -146,14 +148,19 @@ GetUserDep = Annotated[BaseUser, Depends(get_user)]
 
 
 def requires_access_dag(
-    method: ResourceMethod, access_entity: DagAccessEntity | None = None
+    method: ResourceMethod,
+    access_entity: DagAccessEntity | None = None,
+    dag_id: str | None = None,
 ) -> Callable[[Request, BaseUser], None]:
     def inner(
         request: Request,
         user: GetUserDep,
     ) -> None:
-        dag_id = request.path_params.get("dag_id") or request.query_params.get("dag_id")
-        dag_id = dag_id if dag_id != "~" else None
+        nonlocal dag_id
+        if dag_id is None:
+            dag_id = request.path_params.get("dag_id") or request.query_params.get("dag_id")
+            dag_id = dag_id if dag_id != "~" else None
+
         team_name = DagModel.get_team_name(dag_id) if dag_id else None
 
         _requires_access(
@@ -263,17 +270,33 @@ ReadableTagsFilterDep = Annotated[
 ]
 
 
-def requires_access_backfill(method: ResourceMethod) -> Callable[[Request, BaseUser], None]:
-    def inner(
+def requires_access_backfill(method: ResourceMethod) -> Callable[[Request, BaseUser, Session], None]:
+    """Wrap ``requires_access_dag`` and extract the dag_id from the backfill_id."""
+
+    async def inner(
         request: Request,
         user: GetUserDep,
+        session: SessionDep,
     ) -> None:
-        backfill_id: NonNegativeInt | None = request.path_params.get("backfill_id")
+        dag_id = None
 
-        _requires_access(
-            is_authorized_callback=lambda: get_auth_manager().is_authorized_backfill(
-                method=method, details=BackfillDetails(id=backfill_id), user=user
-            ),
+        # Try to retrieve the dag_id from the backfill_id path param
+        backfill_id = request.path_params.get("backfill_id")
+        if backfill_id is not None:
+            backfill = session.scalars(select(Backfill).where(Backfill.id == backfill_id)).one_or_none()
+            dag_id = backfill.dag_id if backfill else None
+
+        # Try to retrieve the dag_id from the request body (POST backfill)
+        if dag_id is None:
+            try:
+                dag_id = (await request.json()).get("dag_id")
+            except JSONDecodeError:
+                # Not a json body, ignore
+                pass
+
+        requires_access_dag(method, DagAccessEntity.RUN, dag_id)(
+            request=request,
+            user=user,
         )
 
     return inner

--- a/airflow-core/tests/unit/api_fastapi/auth/managers/simple/test_simple_auth_manager.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/managers/simple/test_simple_auth_manager.py
@@ -135,7 +135,6 @@ class TestSimpleAuthManager:
             "is_authorized_dag",
             "is_authorized_asset",
             "is_authorized_asset_alias",
-            "is_authorized_backfill",
             "is_authorized_pool",
             "is_authorized_variable",
         ],
@@ -191,7 +190,6 @@ class TestSimpleAuthManager:
             "is_authorized_connection",
             "is_authorized_asset",
             "is_authorized_asset_alias",
-            "is_authorized_backfill",
             "is_authorized_pool",
             "is_authorized_variable",
         ],
@@ -237,7 +235,6 @@ class TestSimpleAuthManager:
             "is_authorized_dag",
             "is_authorized_asset",
             "is_authorized_asset_alias",
-            "is_authorized_backfill",
             "is_authorized_pool",
         ],
     )

--- a/airflow-core/tests/unit/api_fastapi/auth/managers/test_base_auth_manager.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/managers/test_base_auth_manager.py
@@ -25,7 +25,6 @@ from jwt import InvalidTokenError
 from airflow.api_fastapi.auth.managers.base_auth_manager import BaseAuthManager, T
 from airflow.api_fastapi.auth.managers.models.base_user import BaseUser
 from airflow.api_fastapi.auth.managers.models.resource_details import (
-    BackfillDetails,
     ConnectionDetails,
     DagDetails,
     PoolDetails,
@@ -88,15 +87,6 @@ class EmptyAuthManager(BaseAuthManager[BaseAuthManagerUserTest]):
         method: ResourceMethod,
         access_entity: DagAccessEntity | None = None,
         details: DagDetails | None = None,
-        user: BaseAuthManagerUserTest | None = None,
-    ) -> bool:
-        raise NotImplementedError()
-
-    def is_authorized_backfill(
-        self,
-        *,
-        method: ResourceMethod,
-        details: BackfillDetails | None = None,
         user: BaseAuthManagerUserTest | None = None,
     ) -> bool:
         raise NotImplementedError()

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_backfills.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_backfills.py
@@ -126,7 +126,7 @@ class TestListBackfills(TestBackfillEndpoint):
         session.add(b)
         session.commit()
 
-        with assert_queries_count(2):
+        with assert_queries_count(3):
             response = test_client.get(f"/backfills?dag_id={dag.dag_id}")
 
         assert response.status_code == 200


### PR DESCRIPTION
part of https://github.com/apache/airflow/issues/60948

Deprecate `is_authorized_backfill` and `BackfillDetails` in favor of `DagAccessEntity.Run`.

Basically this will allow dag access level control on backfills, a backfill is always attached to a Dag, and shouldn't probably have been a sub `DagAccessEntity` in the auth model. We chose to simply re-use the existing `DagAccessEntity.Run` instead of creating a new one because 'creating a backfill' is basically similar to creating multiple dag runs. (A user with `Can create on Dag Runs` can simulate a backfill by triggering as many dag runs as needed with the appropriate conf and data).

From now on permissions granted on `DagRuns` will also allow similar permissions on 'Backfills' of a specific dag id.

Note: I plan a follow up PR for the providers.


- [ ] Did I used AI ? (no)