### PR TITLE
Providers: JDBC provider updated for conf import migration

### DIFF
--- a/providers/jdbc/pyproject.toml
+++ b/providers/jdbc/pyproject.toml
@@ -59,7 +59,7 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.11.0",
-    "apache-airflow-providers-common-compat>=1.10.1",
+    "apache-airflow-providers-common-compat>=1.10.1", #use next version
     "apache-airflow-providers-common-sql>=1.20.0",
     "jaydebeapi>=1.1.1",
 ]

--- a/providers/jdbc/src/airflow/providers/jdbc/hooks/jdbc.py
+++ b/providers/jdbc/src/airflow/providers/jdbc/hooks/jdbc.py
@@ -111,7 +111,7 @@ class JdbcHook(DbApiHook):
 
     @property
     def driver_path(self) -> str | None:
-        from airflow.configuration import conf
+        from airflow.providers.common.compat.sdk import conf
 
         extra_driver_path = self.connection_extra_lower.get("driver_path")
         if extra_driver_path:
@@ -131,7 +131,7 @@ class JdbcHook(DbApiHook):
 
     @property
     def driver_class(self) -> str | None:
-        from airflow.configuration import conf
+        from airflow.providers.common.compat.sdk import conf
 
         extra_driver_class = self.connection_extra_lower.get("driver_class")
         if extra_driver_class:


### PR DESCRIPTION
This PR updates the JDBC provider to import conf from airflow.providers.common.compat.sdk instead of airflow.configuration. The previous PR was not based on a clean upstream/main, so this PR is opened on top of the latest upstream with only the intended JDBC provider change.
Fixes #60050 
