### PR TITLE
Remove align param from iter dagrun infos

### DIFF
--- a/airflow-core/src/airflow/api/common/mark_tasks.py
+++ b/airflow-core/src/airflow/api/common/mark_tasks.py
@@ -185,11 +185,12 @@ def get_run_ids(dag: SerializedDAG, run_id: str, future: bool, past: bool, sessi
     elif not dag.timetable.periodic:
         run_ids = [run_id]
     else:
-        dates = [
+        dates = {current_logical_date}
+        dates.update(
             info.logical_date
             for info in dag.iter_dagrun_infos_between(start_date, end_date)
             if info.logical_date  # todo: AIP-76 this will not find anything where logical date is null
-        ]
+        )
         run_ids = [dr.run_id for dr in DagRun.find(dag_id=dag.dag_id, logical_date=dates, session=session)]
     return run_ids
 

--- a/airflow-core/src/airflow/api/common/mark_tasks.py
+++ b/airflow-core/src/airflow/api/common/mark_tasks.py
@@ -187,7 +187,7 @@ def get_run_ids(dag: SerializedDAG, run_id: str, future: bool, past: bool, sessi
     else:
         dates = [
             info.logical_date
-            for info in dag.iter_dagrun_infos_between(start_date, end_date, align=False)
+            for info in dag.iter_dagrun_infos_between(start_date, end_date)
             if info.logical_date  # todo: AIP-76 this will not find anything where logical date is null
         ]
         run_ids = [dr.run_id for dr in DagRun.find(dag_id=dag.dag_id, logical_date=dates, session=session)]

--- a/airflow-core/tests/unit/models/test_dag.py
+++ b/airflow-core/tests/unit/models/test_dag.py
@@ -2746,7 +2746,6 @@ def test_iter_dagrun_infos_between(start_date, expected_infos):
     iterator = create_scheduler_dag(dag).iter_dagrun_infos_between(
         earliest=pendulum.instance(start_date),
         latest=pendulum.instance(DEFAULT_DATE),
-        align=True,
     )
     assert expected_infos == list(iterator)
 
@@ -2783,7 +2782,7 @@ def test_iter_dagrun_infos_between_error(caplog):
     ):
         scheduler_dag = create_scheduler_dag(dag)
 
-    iterator = scheduler_dag.iter_dagrun_infos_between(earliest=start, latest=end, align=True)
+    iterator = scheduler_dag.iter_dagrun_infos_between(earliest=start, latest=end)
     with caplog.at_level(logging.ERROR):
         infos = list(iterator)
 


### PR DESCRIPTION
I don't think this param does anything. It's only set to False when called from within get_run_ids, within set_state, which is only called when marking tasks as failed. At best it seems it is called in an extremely odd and impossible to understand edge case.  But let's see what the tests say.
