### PR TITLE
fix(APDR): add asset events to partitioned DagRun

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -1846,7 +1846,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             asset_events = session.scalars(
                 select(AssetEvent).where(
                     PartitionedAssetKeyLog.asset_partition_dag_run_id == apdr.id,
-                    PartitionedAssetKeyLog.asset_event_id == AssetEvent.id
+                    PartitionedAssetKeyLog.asset_event_id == AssetEvent.id,
                 )
             )
             dag_run.consumed_asset_events.extend(asset_events)

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -1843,6 +1843,13 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 creating_job_id=self.job.id,
                 session=session,
             )
+            asset_events = session.scalars(
+                select(AssetEvent).where(
+                    PartitionedAssetKeyLog.asset_partition_dag_run_id == apdr.id,
+                    PartitionedAssetKeyLog.asset_event_id == AssetEvent.id
+                )
+            )
+            dag_run.consumed_asset_events.extend(asset_events)
             session.flush()
             apdr.created_dag_run_id = dag_run.id
             session.flush()

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -8786,46 +8786,15 @@ def test_partitioned_dag_run_with_customized_mapper(
     runner = SchedulerJobRunner(
         job=Job(job_type=SchedulerJobRunner.job_type, executor=MockExecutor(do_update=False))
     )
-
-    with dag_maker(dag_id="asset-event-producer", schedule=None, session=session) as dag:
-        EmptyOperator(task_id="hi", outlets=[asset_1])
-
-    dr = dag_maker.create_dagrun(partition_key="this-is-not-key-1-before-mapped", session=session)
-    [ti] = dr.get_task_instances(session=session)
-    session.commit()
-
-    serialized_outlets = dag.get_task("hi").outlets
     with custom_partition_mapper_patch():
-        TaskInstance.register_asset_changes_in_db(
-            ti=ti,
-            task_outlets=[o.asprofile() for o in serialized_outlets],
-            outlet_events=[],
+        apdr = _produce_and_register_asset_event(
+            dag_id="asset-event-producer",
+            asset=asset_1,
+            partition_key="this-is-not-key-1-before-mapped",
             session=session,
+            dag_maker=dag_maker,
+            expected_partition_key="key-1"
         )
-    session.commit()
-
-    event = session.scalar(
-        select(AssetEvent).where(
-            AssetEvent.source_dag_id == dag.dag_id,
-            AssetEvent.source_run_id == dr.run_id,
-        )
-    )
-    assert event is not None
-    assert event.partition_key == "this-is-not-key-1-before-mapped"
-
-    apdr = session.scalar(
-        select(AssetPartitionDagRun)
-        .join(
-            PartitionedAssetKeyLog,
-            PartitionedAssetKeyLog.asset_partition_dag_run_id == AssetPartitionDagRun.id,
-        )
-        .where(PartitionedAssetKeyLog.asset_event_id == event.id)
-    )
-    assert apdr is not None
-    assert apdr.created_dag_run_id is None
-    assert apdr.partition_key == "key-1"
-
-    with custom_partition_mapper_patch():
         partition_dags = runner._create_dagruns_for_partitioned_asset_dags(session=session)
     session.refresh(apdr)
     # Since asset event for Asset(name="asset-2") with key "key-1" has not yet been created,

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -8803,10 +8803,9 @@ def test_partitioned_dag_run_with_customized_mapper(
     assert len(partition_dags) == 1
     assert partition_dags == {"asset-event-consumer"}
 
-    asset_event = session.scalar(
-        select(DagRun).where(DagRun.id == apdr.created_dag_run_id)
-    ).consumed_asset_events[0]
-
+    dag_run = session.scalar(select(DagRun).where(DagRun.id == apdr.created_dag_run_id))
+    assert dag_run is not None
+    asset_event = dag_run.consumed_asset_events[0]
     assert asset_event.source_task_id == "hi"
     assert asset_event.source_dag_id == "asset-event-producer"
     assert asset_event.source_run_id == "test"

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -8955,9 +8955,9 @@ def test_consumer_dag_listen_to_two_partitioned_asset_with_key_1_mapper(
     assert len(partition_dags) == 1
     assert partition_dags == {"asset-event-consumer"}
 
-    asset_event = session.scalar(
-        select(DagRun).where(DagRun.id == apdr.created_dag_run_id)
-    ).consumed_asset_events[0]
-    assert asset_event.source_task_id == "hi"
-    assert asset_event.source_dag_id == "asset-event-producer-2"
-    assert asset_event.source_run_id == "test"
+    dag_run = session.scalar(select(DagRun).where(DagRun.id == apdr.created_dag_run_id))
+    assert dag_run is not None
+    for asset_event in dag_run.consumed_asset_events:
+        assert asset_event.source_task_id == "hi"
+        assert "asset-event-producer-" in asset_event.source_dag_id
+        assert asset_event.source_run_id == "test"

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -8803,6 +8803,14 @@ def test_partitioned_dag_run_with_customized_mapper(
     assert len(partition_dags) == 1
     assert partition_dags == {"asset-event-consumer"}
 
+    asset_event = session.scalar(
+        select(DagRun).where(DagRun.id == apdr.created_dag_run_id)
+    ).consumed_asset_events[0]
+
+    assert asset_event.source_task_id == "hi"
+    assert asset_event.source_dag_id == "asset-event-producer"
+    assert asset_event.source_run_id == "test"
+
 
 @pytest.mark.need_serialized_dag
 @pytest.mark.usefixtures("clear_asset_partition_rows")
@@ -8877,6 +8885,15 @@ def test_consumer_dag_listen_to_two_partitioned_asset(
     assert partition_dags == {"asset-event-consumer"}
 
 
+
+    for asset_event in session.scalar(
+        select(DagRun).where(DagRun.id == apdr.created_dag_run_id)
+    ).consumed_asset_events:
+        assert asset_event.source_task_id == "hi"
+        assert "asset-event-producer-" in asset_event.source_dag_id
+        assert asset_event.source_run_id == "test"
+
+
 @pytest.mark.need_serialized_dag
 @pytest.mark.usefixtures("clear_asset_partition_rows")
 def test_consumer_dag_listen_to_two_partitioned_asset_with_key_1_mapper(
@@ -8940,3 +8957,10 @@ def test_consumer_dag_listen_to_two_partitioned_asset_with_key_1_mapper(
     assert apdr.created_dag_run_id is not None
     assert len(partition_dags) == 1
     assert partition_dags == {"asset-event-consumer"}
+
+    asset_event = session.scalar(
+        select(DagRun).where(DagRun.id == apdr.created_dag_run_id)
+    ).consumed_asset_events[0]
+    assert asset_event.source_task_id == "hi"
+    assert asset_event.source_dag_id == "asset-event-producer-2"
+    assert asset_event.source_run_id == "test"

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -8793,7 +8793,7 @@ def test_partitioned_dag_run_with_customized_mapper(
             partition_key="this-is-not-key-1-before-mapped",
             session=session,
             dag_maker=dag_maker,
-            expected_partition_key="key-1"
+            expected_partition_key="key-1",
         )
         partition_dags = runner._create_dagruns_for_partitioned_asset_dags(session=session)
     session.refresh(apdr)

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -8883,11 +8883,9 @@ def test_consumer_dag_listen_to_two_partitioned_asset(
     assert len(partition_dags) == 1
     assert partition_dags == {"asset-event-consumer"}
 
-
-
-    for asset_event in session.scalar(
-        select(DagRun).where(DagRun.id == apdr.created_dag_run_id)
-    ).consumed_asset_events:
+    dag_run = session.scalar(select(DagRun).where(DagRun.id == apdr.created_dag_run_id))
+    assert dag_run is not None
+    for asset_event in dag_run.consumed_asset_events:
         assert asset_event.source_task_id == "hi"
         assert "asset-event-producer-" in asset_event.source_dag_id
         assert asset_event.source_run_id == "test"


### PR DESCRIPTION
## Why
consumed_asset_evnets was not appended for the partitioned DagRun

## What
Ensure asset events are not missed for the partitioned DagRun 

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
