### PR TITLE
Add /files/dags to PYTHONPATH in Breeze

### DIFF
--- a/scripts/in_container/configure_environment.sh
+++ b/scripts/in_container/configure_environment.sh
@@ -23,12 +23,15 @@ readonly TMUX_CONF_FILE=".tmux.conf"
 
 if [[ -d "${FILES_DIR}" ]]; then
     export AIRFLOW__CORE__DAGS_FOLDER="/files/dags"
+    # Add `/files/dags` to `PYTHONPATH` so that start_airflow can import any custom Trigger classes defined in Dag files under `/files/dags`.
+    export PYTHONPATH=${PYTHONPATH:=}:"/files/dags"
     mkdir -pv "${AIRFLOW__CORE__DAGS_FOLDER}"
     if [[ ${HOST_OS} == "linux" && ${DOCKER_IS_ROOTLESS} != "true" ]]; then
         sudo chown "${HOST_USER_ID}":"${HOST_GROUP_ID}" "${AIRFLOW__CORE__DAGS_FOLDER}" || true
     fi
 else
     export AIRFLOW__CORE__DAGS_FOLDER="${AIRFLOW_HOME}/dags"
+    export PYTHONPATH=${PYTHONPATH:=}:"${AIRFLOW_HOME}/dags"
 fi
 
 


### PR DESCRIPTION
## Why

The default dags path in Breeze will be `/files/dags`, but `/files/dags` is not in `PYTHONPATH`, which cause the triggers defined in Dag file are not able to import by Triggerer, and have to workaround by copying Dag file to some directories that are in `PYTHONPATH`. Pointed out in: https://github.com/apache/airflow/issues/58676#issuecomment-3845092376

## What

We should add `/files/dags` to `PYTHONPATH` in Breeze in case the triggers are defined in dags, and cause "unable to import trigger" during Triggerer runtime.


**Before**: `/files/dags` is not in `PYTHONPATH`
```bash
>>> import sys; import pprint; pprint.pprint(sys.path)
['',
 '/opt/airflow',
 '/opt/airflow/providers/standard/tests',
 '/usr/python/lib/python310.zip',
 '/usr/python/lib/python3.10',
# ...
 '/opt/airflow/providers/yandex/src',
```

**After**: `/files/dags` is now in `PYTHONPATH`

```bash
>>> import sys; import pprint; pprint.pprint(sys.path)
['',
 '/opt/airflow',
 '/files/dags',  # <----------------------------- added!
 '/opt/airflow/providers/standard/tests',
 '/usr/python/lib/python310.zip',
 '/usr/python/lib/python3.10',
 '/usr/python/lib/python3.10/lib-dynload',
 '/usr/python/lib/python3.10/site-packages',
 '/opt/airflow/airflow-core/src',
 '/opt/airflow/airflow-ctl/src',
 ...
```