### PR TITLE
fix(asset-event): add missing partition key to asset event page

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/Assets/AssetEvent.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Assets/AssetEvent.tsx
@@ -36,6 +36,7 @@ export const AssetEvent = ({
   readonly event: AssetEventResponse;
 }) => {
   const { t: translate } = useTranslation("dashboard");
+  const { t: rootTranslate } = useTranslation();
   let source = "";
 
   const { from_rest_api: fromRestAPI, from_trigger: fromTrigger, ...extra } = event.extra ?? {};
@@ -94,6 +95,13 @@ export const AssetEvent = ({
       <HStack>
         <TriggeredRuns dagRuns={event.created_dagruns} />
       </HStack>
+      {event.partition_key == undefined ? null : (
+        <HStack>
+          <Text>
+            {rootTranslate("dagRun.partitionKey")}: {event.partition_key}
+          </Text>
+        </HStack>
+      )}
       {Object.keys(extra).length >= 1 ? (
         <RenderedJsonField content={extra} jsonProps={{ collapsed: true }} />
       ) : undefined}

--- a/airflow-core/src/airflow/ui/src/components/Assets/AssetEvent.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Assets/AssetEvent.tsx
@@ -95,7 +95,7 @@ export const AssetEvent = ({
       <HStack>
         <TriggeredRuns dagRuns={event.created_dagruns} />
       </HStack>
-      {event.partition_key == undefined ? null : (
+      {event.partition_key === undefined ? undefined : (
         <HStack>
           <Text>
             {rootTranslate("dagRun.partitionKey")}: {event.partition_key}


### PR DESCRIPTION
## Why
Partition Key is not shown on asset event page

## What
<img width="280" height="120" alt="image" src="https://github.com/user-attachments/assets/9babb01a-806b-43c5-8221-c3d5b0aa3e4f" />
It's now shown if asset event contains partition key


<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
