### PR TITLE
fix(ui): Remove explicit bg color from filter buttons to fix pale appearance (#60346 backport fix)

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/DataTable/ToggleTableDisplay.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DataTable/ToggleTableDisplay.tsx
@@ -34,7 +34,6 @@ export const ToggleTableDisplay = ({ display, setDisplay }: Props) => {
     <ButtonGroup attached colorPalette="brand" pb={2} size="sm" variant="outline">
       <IconButton
         aria-label={translate("toggleCardView")}
-        bg={display === "card" ? "colorPalette.muted" : undefined}
         onClick={() => setDisplay("card")}
         title={translate("toggleCardView")}
         variant={display === "card" ? "solid" : "outline"}
@@ -43,7 +42,6 @@ export const ToggleTableDisplay = ({ display, setDisplay }: Props) => {
       </IconButton>
       <IconButton
         aria-label={translate("toggleTableView")}
-        bg={display === "table" ? "colorPalette.muted" : undefined}
         onClick={() => setDisplay("table")}
         title={translate("toggleTableView")}
         variant={display === "table" ? "solid" : "outline"}

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/FavoriteFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/FavoriteFilter.tsx
@@ -33,7 +33,6 @@ export const FavoriteFilter = ({ onFavoriteChange, showFavorites }: Props) => {
   return (
     <ButtonGroup attached size="sm" variant="outline">
       <Button
-        bg={currentValue === "all" ? "colorPalette.muted" : undefined}
         colorPalette="brand"
         onClick={onFavoriteChange}
         value="all"
@@ -42,7 +41,6 @@ export const FavoriteFilter = ({ onFavoriteChange, showFavorites }: Props) => {
         {translate("filters.favorite.all")}
       </Button>
       <Button
-        bg={currentValue === "true" ? "colorPalette.muted" : undefined}
         colorPalette="brand"
         onClick={onFavoriteChange}
         value="true"
@@ -54,7 +52,6 @@ export const FavoriteFilter = ({ onFavoriteChange, showFavorites }: Props) => {
         {translate("filters.favorite.favorite")}
       </Button>
       <Button
-        bg={currentValue === "false" ? "colorPalette.muted" : undefined}
         colorPalette="brand"
         onClick={onFavoriteChange}
         value="false"

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/PausedFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/PausedFilter.tsx
@@ -33,7 +33,6 @@ export const PausedFilter = ({ defaultShowPaused, onPausedChange, showPaused }: 
   return (
     <ButtonGroup attached size="sm" variant="outline">
       <Button
-        bg={currentValue === "all" ? "colorPalette.muted" : undefined}
         colorPalette="brand"
         onClick={onPausedChange}
         value="all"
@@ -42,7 +41,6 @@ export const PausedFilter = ({ defaultShowPaused, onPausedChange, showPaused }: 
         {translate("filters.paused.all")}
       </Button>
       <Button
-        bg={currentValue === "false" ? "colorPalette.muted" : undefined}
         colorPalette="brand"
         onClick={onPausedChange}
         value="false"
@@ -51,7 +49,6 @@ export const PausedFilter = ({ defaultShowPaused, onPausedChange, showPaused }: 
         {translate("filters.paused.active")}
       </Button>
       <Button
-        bg={currentValue === "true" ? "colorPalette.muted" : undefined}
         colorPalette="brand"
         onClick={onPausedChange}
         value="true"

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/StateFilters.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/StateFilters.tsx
@@ -46,7 +46,6 @@ export const StateFilters = ({
   return (
     <ButtonGroup attached size="sm" variant="outline">
       <Button
-        bg={isAll ? "colorPalette.muted" : undefined}
         colorPalette="brand"
         onClick={onStateChange}
         value="all"
@@ -55,7 +54,6 @@ export const StateFilters = ({
         {translate("dags:filters.paused.all")}
       </Button>
       <Button
-        bg={isFailed ? "colorPalette.muted" : undefined}
         colorPalette="brand"
         data-testid="dags-failed-filter"
         onClick={onStateChange}
@@ -66,7 +64,6 @@ export const StateFilters = ({
         {translate("common:states.failed")}
       </Button>
       <Button
-        bg={isQueued ? "colorPalette.muted" : undefined}
         colorPalette="brand"
         data-testid="dags-queued-filter"
         onClick={onStateChange}
@@ -77,7 +74,6 @@ export const StateFilters = ({
         {translate("common:states.queued")}
       </Button>
       <Button
-        bg={isRunning ? "colorPalette.muted" : undefined}
         colorPalette="brand"
         data-testid="dags-running-filter"
         onClick={onStateChange}
@@ -88,7 +84,6 @@ export const StateFilters = ({
         {translate("common:states.running")}
       </Button>
       <Button
-        bg={isSuccess ? "colorPalette.muted" : undefined}
         colorPalette="brand"
         data-testid="dags-success-filter"
         onClick={onStateChange}
@@ -99,7 +94,6 @@ export const StateFilters = ({
         {translate("common:states.success")}
       </Button>
       <Button
-        bg={needsReview ? "colorPalette.muted" : undefined}
         colorPalette="brand"
         data-testid="dags-needs-review-filter"
         onClick={onStateChange}

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/StateFilters.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/StateFilters.tsx
@@ -45,12 +45,7 @@ export const StateFilters = ({
 
   return (
     <ButtonGroup attached size="sm" variant="outline">
-      <Button
-        colorPalette="brand"
-        onClick={onStateChange}
-        value="all"
-        variant={isAll ? "solid" : "outline"}
-      >
+      <Button colorPalette="brand" onClick={onStateChange} value="all" variant={isAll ? "solid" : "outline"}>
         {translate("dags:filters.paused.all")}
       </Button>
       <Button


### PR DESCRIPTION
Follow-up fix for the backport of #60346 (#[60547](https://github.com/apache/airflow/pull/60547)) to v3-1-test.

Before:
<img width="3434" height="992" alt="image" src="https://github.com/user-attachments/assets/a1f3d973-7a0e-4537-b18b-62e3ebd8eed8" />

After:
<img width="3306" height="592" alt="image" src="https://github.com/user-attachments/assets/658fe676-ebc0-4769-a5ca-399c11b356f3" />



- [X] Yes (please specify the tool below)
   Claude

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
