### PR TITLE
Fix use correct PATCH permission for /users/{username} endpoint

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/routes/roles.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/routes/roles.py
@@ -126,7 +126,7 @@ def get_role(name: str = Path(..., min_length=1)) -> RoleResponse:
             status.HTTP_404_NOT_FOUND,
         ]
     ),
-    dependencies=[Depends(requires_fab_custom_view("PATCH", permissions.RESOURCE_ROLE))],
+    dependencies=[Depends(requires_fab_custom_view("PUT", permissions.RESOURCE_ROLE))],
 )
 def patch_role(
     body: RoleBody,


### PR DESCRIPTION
## What
This PR updates the permission check for the `PATCH /roles/{user}` endpoint in the FAB Auth Manager FastAPI routes.
Specifically, it changes the permission check from `PATCH` to `PUT` in the `requires_fab_custom_view` dependency.

## Why
Previously, the endpoint was using `requires_fab_custom_view("PATCH", ...)` for a `PATCH` route, which caused a mismatch between the HTTP method and the required permission.
Aligning the permission check with the actual HTTP method ensures correct and predictable access control.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
