### PR TITLE
Generate TaskSDK datamodels

### DIFF
--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -371,6 +371,8 @@ class ValidationError(BaseModel):
     loc: Annotated[list[str | int], Field(title="Location")]
     msg: Annotated[str, Field(title="Message")]
     type: Annotated[str, Field(title="Error Type")]
+    input: Annotated[Any | None, Field(title="Input")] = None
+    ctx: Annotated[dict[str, Any] | None, Field(title="Context")] = None
 
 
 class VariablePostBody(BaseModel):


### PR DESCRIPTION
This PR updates the auto-generated TaskSDK datamodels to match the current schema.

The changes are produced by the `generate-tasksdk-datamodels` prek hook and ensure the generated code is in sync with the source definitions.