### PR TITLE
Add session cleanup middleware to FAB FastAPI app

### DIFF
--- a/providers/fab/newsfragments/61480.bugfix.rst
+++ b/providers/fab/newsfragments/61480.bugfix.rst
@@ -1,1 +1,0 @@
-Fix ``PendingRollbackError`` on FAB admin pages by adding session cleanup middleware to the FAB FastAPI app.

--- a/providers/fab/newsfragments/61480.bugfix.rst
+++ b/providers/fab/newsfragments/61480.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``PendingRollbackError`` on FAB admin pages by adding session cleanup middleware to the FAB FastAPI app.

--- a/providers/fab/tests/unit/fab/auth_manager/test_fab_auth_manager.py
+++ b/providers/fab/tests/unit/fab/auth_manager/test_fab_auth_manager.py
@@ -957,3 +957,85 @@ def test_resetdb(
         mock_init.assert_not_called()
     else:
         mock_init.assert_called_once()
+
+
+class TestFabAuthManagerSessionCleanup:
+    """Test session cleanup middleware in FAB auth manager FastAPI app.
+
+    Background:
+    FAB auth manager's FastAPI app has the following route structure:
+    - /token, /logout: FastAPI routes (login_router)
+    - /users/*, /roles/*: FastAPI API routes
+    - /*: WSGIMiddleware -> Flask App (FAB views like /users/list/, /roles/list/)
+
+    Problem:
+    FAB's Flask views (e.g., /users/list/, /roles/list/) use settings.Session
+    (SQLAlchemy scoped_session). In a normal Flask app, teardown_appcontext
+    automatically calls Session.remove() after each request. However, when Flask
+    is mounted via WSGIMiddleware in FastAPI, teardown_appcontext does NOT trigger.
+
+    This leaves database sessions in "idle in transaction" state. When the database
+    connection times out (e.g., PostgreSQL's idle_in_transaction_session_timeout),
+    subsequent requests reusing the invalidated session raise PendingRollbackError.
+
+    Solution:
+    Add a FastAPI middleware that calls Session.remove() in the finally block,
+    ensuring session cleanup for ALL requests including those forwarded to Flask via WSGI.
+    """
+
+    @mock.patch("airflow.providers.fab.auth_manager.fab_auth_manager.create_app")
+    def test_session_cleanup_middleware_on_wsgi_route(self, mock_create_app):
+        """Test Session.remove() is called after requests to WSGI-mounted Flask routes.
+
+        This is the critical scenario: requests to Flask AppBuilder views like
+        /users/list/ and /roles/list/ go through WSGIMiddleware. Without the
+        cleanup middleware, these requests leave sessions in "idle in transaction"
+        state, eventually causing PendingRollbackError.
+        """
+        from unittest.mock import patch
+
+        from fastapi.testclient import TestClient
+
+        # Setup mock Flask app (simulates FAB's Flask app)
+        mock_flask_app = MagicMock()
+        mock_create_app.return_value = mock_flask_app
+
+        auth_manager = FabAuthManager()
+        fastapi_app = auth_manager.get_fastapi_app()
+
+        client = TestClient(fastapi_app, raise_server_exceptions=False)
+
+        with patch("airflow.settings.Session") as mock_session:
+            # Request to a path not handled by FastAPI routers goes to WSGIMiddleware -> Flask
+            # This simulates accessing /users/list/ or /roles/list/ which caused the original bug
+            client.get("/users/list/")
+
+            # Verify Session.remove() was called by the cleanup middleware
+            mock_session.remove.assert_called()
+
+    @mock.patch("airflow.providers.fab.auth_manager.fab_auth_manager.create_app")
+    def test_session_cleanup_middleware_on_fastapi_route(self, mock_create_app):
+        """Test Session.remove() is also called after FastAPI route requests.
+
+        Even though FastAPI routes may not directly use settings.Session,
+        the middleware should clean up any session that might have been
+        used during request processing (e.g., by dependencies or nested calls).
+        """
+        from unittest.mock import patch
+
+        from fastapi.testclient import TestClient
+
+        mock_flask_app = MagicMock()
+        mock_create_app.return_value = mock_flask_app
+
+        auth_manager = FabAuthManager()
+        fastapi_app = auth_manager.get_fastapi_app()
+
+        client = TestClient(fastapi_app, raise_server_exceptions=False)
+
+        with patch("airflow.settings.Session") as mock_session:
+            # Request to a FastAPI route (login endpoint)
+            client.post("/token", json={"username": "test", "password": "test"})
+
+            # Verify Session.remove() was called
+            mock_session.remove.assert_called()


### PR DESCRIPTION
## Summary
Fix `PendingRollbackError` on FAB admin pages (`/auth/users/list/`, `/auth/roles/list/`) by adding session cleanup middleware to the FAB auth manager's FastAPI app.
## Problem
FAB auth manager's FastAPI app has this route structure:
- `/token`, `/logout` → FastAPI routes
- `/users/*`, `/roles/*` → FastAPI API routes
- `/*` (catch-all) → `WSGIMiddleware` → Flask App (FAB views)
The **Flask AppBuilder views** (e.g., `/users/list/`, `/roles/list/`) use `settings.Session` (SQLAlchemy `scoped_session`) for database access. In a native Flask app, `teardown_appcontext` automatically calls `Session.remove()` after each request. However, when Flask is mounted via `WSGIMiddleware` inside FastAPI, **Flask's teardown hooks do not trigger**.
This causes sessions to remain in **"idle in transaction"** state. When the database connection times out (e.g., PostgreSQL's `idle_in_transaction_session_timeout`), subsequent requests that reuse the invalidated session raise `PendingRollbackError` (500 error).
### Steps to reproduce
1. Deploy Airflow 3.x with FAB auth manager and PostgreSQL
2. Access `/auth/users/list/` or `/auth/roles/list/`
3. Wait for PostgreSQL to timeout idle transactions
4. Refresh the page → **500 PendingRollbackError**
## Solution
Add a FastAPI HTTP middleware in `get_fastapi_app()` that calls `Session.remove()` in the `finally` block after every request. This ensures session cleanup for **all** requests, including those forwarded to Flask via WSGI — closing the gap left by the missing `teardown_appcontext`.
### Why this is safe
- `settings.Session` is a `scoped_session` (thread-local) — `remove()` only affects the current thread
- The `finally` block runs after the response is fully constructed, so it doesn't interfere with request processing
- All 585 existing FAB provider tests pass with this change
## Testing
- Added `TestFabAuthManagerSessionCleanup` with 2 tests:
  - `test_session_cleanup_middleware_on_wsgi_route`: Verifies `Session.remove()` is called after WSGI (Flask) route requests — the exact scenario that caused the bug
  - `test_session_cleanup_middleware_on_fastapi_route`: Verifies cleanup also runs after FastAPI route requests
- Verified fix resolves the issue in a production environment with PostgreSQL (idle transactions drop to 0 after patch)
## AI Disclosure
This PR was developed with AI assistance (Claude).