### PR TITLE
Add documentation for running Uvicorn on Kubernetes

### DIFF
--- a/airflow-core/docs/administration-and-deployment/web-stack.rst
+++ b/airflow-core/docs/administration-and-deployment/web-stack.rst
@@ -156,7 +156,7 @@ Recommended approaches include:
 
 - **Kubernetes rolling restarts** of the API server Deployment to recycle pods
   without downtime.
-- **Helm-based restarts**, such as triggering a `rollout` during a Helm upgrade
+- ``Helm-based restarts``, such as triggering a ``rollout`` during a Helm upgrade
   or by changing a restart annotation.
 - **Cluster-level mechanisms** (for example, scheduled restarts) when running
   uvicorn for extended periods.

--- a/airflow-core/docs/administration-and-deployment/web-stack.rst
+++ b/airflow-core/docs/administration-and-deployment/web-stack.rst
@@ -138,3 +138,36 @@ Use the default uvicorn when:
 - Running on Windows
 - Running in development or testing environments
 - Running short-lived containers (e.g., Kubernetes pods that get recycled)
+
+.. _running-uvicorn-on-kubernetes:
+
+Running Uvicorn on Kubernetes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When running the API server with ``server_type = uvicorn`` on Kubernetes,
+the API server runs as a single long-lived process per pod and does not
+support rolling worker restarts like ``gunicorn``.
+
+In long-running Kubernetes deployments, this may lead to gradual memory
+growth or stale internal state over time. For this reason, it is recommended
+to periodically restart API server pods when using uvicorn.
+
+Recommended approaches include:
+
+- **Kubernetes rolling restarts** of the API server Deployment to recycle pods
+  without downtime.
+- **Helm-based restarts**, such as triggering a rollout during a Helm upgrade
+  or by changing a restart annotation.
+- **Cluster-level mechanisms** (for example, scheduled restarts) when running
+  uvicorn for extended periods.
+
+For example, to trigger a rolling restart of the API server pods:
+
+.. code-block:: bash
+
+   kubectl rollout restart deployment airflow-api-server
+
+In many Kubernetes environments, relying solely on Kubernetes OOM kills or
+crash restarts is not recommended, as memory growth may not always trigger an
+OOM event. For production deployments that require automatic worker recycling
+without pod restarts, consider using ``server_type = gunicorn`` instead.

--- a/airflow-core/docs/administration-and-deployment/web-stack.rst
+++ b/airflow-core/docs/administration-and-deployment/web-stack.rst
@@ -156,7 +156,7 @@ Recommended approaches include:
 
 - **Kubernetes rolling restarts** of the API server Deployment to recycle pods
   without downtime.
-- **Helm-based restarts**, such as triggering a rollout during a Helm upgrade
+- **Helm-based restarts**, such as triggering a `rollout` during a Helm upgrade
   or by changing a restart annotation.
 - **Cluster-level mechanisms** (for example, scheduled restarts) when running
   uvicorn for extended periods.


### PR DESCRIPTION
closes: #61431

### Description

This PR adds documentation about running the API server with `server_type = uvicorn` on Kubernetes.

Unlike `gunicorn`, uvicorn runs as a single long-lived process per pod and does not support rolling worker restarts. In long-running Kubernetes environments this can lead to gradual memory growth or stale internal state. The new section explains recommended operational practices such as Kubernetes rolling restarts, Helm-based restarts, and scheduled pod recycling.

The goal is to help users operating Airflow on Kubernetes understand when periodic pod restarts are necessary and when switching to `gunicorn` may be a better production choice.

### What is included

* New documentation section: **Running Uvicorn on Kubernetes**
* Operational best practices for long-running deployments
* Example `kubectl rollout restart` command
* Guidance on uvicorn vs gunicorn behavior

### Why this change

Users deploying with uvicorn on Kubernetes may assume automatic worker recycling similar to gunicorn. This clarification improves reliability guidance and reduces confusion for production setups.

### Testing

* Documentation build checked locally
* RST formatting verified
* No functional code changes

### Notes

This is a documentation-only change.
