### PR TITLE
Support string update_mask in FABAuthManagerRoles.patch_role

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/services/roles.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/services/roles.py
@@ -138,9 +138,10 @@ class FABAuthManagerRoles:
             )
 
         if update_mask:
+            fields_to_update = {f.strip() for f in update_mask.split(",") if f.strip()}
             update_data = RoleResponse.model_validate(existing)
 
-            for field in update_mask:
+            for field in fields_to_update:
                 if field == "actions":
                     update_data.permissions = body.permissions
                 elif hasattr(body, field):

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_roles.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_roles.py
@@ -320,7 +320,7 @@ class TestRolesService:
         out = FABAuthManagerRoles.patch_role(
             body=body,
             name="viewer",
-            update_mask=["actions"],
+            update_mask="actions",
         )
         assert out.name == "viewer"
         assert out.permissions
@@ -346,7 +346,7 @@ class TestRolesService:
         out = FABAuthManagerRoles.patch_role(
             body=body,
             name="viewer",
-            update_mask=["name"],
+            update_mask="name",
         )
         assert out.name == "viewer1"
         assert out.permissions


### PR DESCRIPTION
## What

Update `FABAuthManagerRoles.patch_role` to consistently support str types for the `update_mask` parameter.

## Why

This change ensures consistent handling of the `update_mask` parameter across user and role service layers, preventing type errors and improving robustness.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
