### PR TITLE
fix: fixing minimap on DAG graph view not showing DAG nodes

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/Graph/reactflowUtils.ts
+++ b/airflow-core/src/airflow/ui/src/components/Graph/reactflowUtils.ts
@@ -71,12 +71,14 @@ export const flattenGraph = ({
     const y = (parent?.position.y ?? 0) + (node.y ?? 0);
     const newNode = {
       data: { ...node, depth: level },
+      height: node.height,
       id: node.id,
       position: {
         x,
         y,
       },
       type: node.type,
+      width: node.width,
       ...parentNode,
     } satisfies NodeType;
 


### PR DESCRIPTION
tiny bug fix for DAG graph view minimap not showing DAG nodes

before:
<img width="456" height="582" alt="image" src="https://github.com/user-attachments/assets/39468b6e-edee-49d1-89a5-87db8c71ffcf" />

after:
<img width="469" height="645" alt="image" src="https://github.com/user-attachments/assets/40ad7f30-1476-4a04-a3bf-f40d001acf13" />

* closes: #61450 

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: [Cursor] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)