### PR TITLE
fix query to prevent long query when asset count is too much

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -3019,13 +3019,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         if not assets:
             return
 
-        active_assets = set(
-            session.execute(
-                select(AssetActive.name, AssetActive.uri).where(
-                    tuple_(AssetActive.name, AssetActive.uri).in_((a.name, a.uri) for a in assets)
-                )
-            )
-        )
+        active_assets = set(session.execute(select(AssetActive.name, AssetActive.uri)))
 
         active_name_to_uri: dict[str, str] = {name: uri for name, uri in active_assets}
         active_uri_to_name: dict[str, str] = {uri: name for name, uri in active_assets}


### PR DESCRIPTION
related: https://github.com/apache/airflow/issues/61453


## Why?

There was an issue where IN operations on a large number of rows in the assets table caused long-running queries.
This commit fixes that issue.

## How?

While we could improve this using CTEs, joins, etc., it would make the code messy and introduce side effects such as having to execute the orphan status query multiple times. Therefore, I decided to minimize (eliminate) the IN operations.

The rationale for this logic being equivalent to the original logic is as follows:

- `asset_reference_query` groups by the primary key of assets, so it is unique.
- The sets where `orphaned` is True and False are complements of each other.
    - The relationship is: not orphaned = active, not active = orphaned.
- In `self._orphan_unreferenced_assets`, orphaned rows from active_assets are deleted.
- Consequently, the IN operation performed in `self._activate_referenced_assets` is unnecessary.
    - This is because all rows that satisfy the negation of that condition have already been deleted.
    - In most cases, the number of orphaned assets is much smaller, so this is a significant performance improvement.

## More?

Nevertheless, if there are too many orphaned assets, performance degradation may still occur at this point.
```
session.execute(
    delete(AssetActive).where(
        tuple_(AssetActive.name, AssetActive.uri).in_((a.name, a.uri) for a in assets)
    )
)
```
If the number of orphaned assets is large (above a certain threshold), it would be good to display a DAG warning.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
