### PR TITLE
fix(airflowctl): allow listing dag runs without specifying dag_id

### DIFF
--- a/airflow-ctl/src/airflowctl/api/operations.py
+++ b/airflow-ctl/src/airflowctl/api/operations.py
@@ -554,20 +554,36 @@ class DagRunOperations(BaseOperations):
 
     def list(
         self,
-        dag_id: str,
-        start_date: datetime.datetime,
-        end_date: datetime.datetime,
         state: str,
         limit: int,
+        start_date: datetime.datetime | None = None,
+        end_date: datetime.datetime | None = None,
+        dag_id: str | None = None,
     ) -> DAGRunCollectionResponse | ServerResponseError:
-        """List all dag runs."""
-        params = {
-            "start_date": start_date,
-            "end_date": end_date,
+        """
+        List all dag runs.
+
+        Args:
+            state: Filter dag runs by state
+            start_date: Filter dag runs by start date (optional)
+            end_date: Filter dag runs by end date (optional)
+            state: Filter dag runs by state
+            limit: Limit the number of results
+            dag_id: The DAG ID to filter by. If None, retrieves dag runs for all DAGs (using "~").
+        """
+        # Use "~" for all DAGs if dag_id is not specified
+        if not dag_id:
+            dag_id = "~"
+
+        params: dict[str, object] = {
             "state": state,
             "limit": limit,
-            "dag_id": dag_id,
         }
+        if start_date is not None:
+            params["start_date"] = start_date
+        if end_date is not None:
+            params["end_date"] = end_date
+
         return super().execute_list(
             path=f"/dags/{dag_id}/dagRuns", data_model=DAGRunCollectionResponse, params=params
         )

--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -464,7 +464,10 @@ class CommandFactory:
             "set",
             "datetime.datetime",
         }
-        return type_name in primitive_types
+        # Handle Optional types (e.g., "datetime.datetime | None", "str | None")
+        # Strip " | None" suffix to check the base type
+        base_type = type_name.replace(" | None", "").strip()
+        return base_type in primitive_types
 
     @staticmethod
     def _python_type_from_string(type_name: str | type) -> type | Callable:


### PR DESCRIPTION
## what
1. Modified `DagRunOperations.list()` method signature:
   - Made all parameters optional with `None` defaults: `dag_id`, start_date`, `end_date`
   - Added automatic conversion: when `dag_id` is `None`, it defaults to `"~"` (which queries all DAGs)
   - Only non-`None` parameters are included in the API request query params

2. Updated `cli_config.py` to handle Optional primitive types:
   - Enhanced `_is_primitive_type()` to recognize types like `datetime.datetime | None` as primitive types

3. Added comprehensive test coverage:
   - `test_list_all_dags()`: validates listing dag runs across all DAGs using default `dag_id="~"`
   - `test_list_with_optional_parameters()`: validates partial parameter usage with specific dag_id

## Why
Users reported that the CLI command `airflowctl dagrun list --state=queued --limit=5` fails with error

closes: #61513


---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
