### PR TITLE
Use attribute based trigger queue detection for triggers

### DIFF
--- a/airflow-core/src/airflow/triggers/base.py
+++ b/airflow-core/src/airflow/triggers/base.py
@@ -63,7 +63,7 @@ class BaseTrigger(abc.ABC, LoggingMixin):
     let them be re-instantiated elsewhere.
     """
 
-    uses_triggerer_queue: bool = True
+    supports_triggerer_queue: bool = True
 
     def __init__(self, **kwargs):
         # these values are set by triggerer when preparing to run the instance
@@ -136,7 +136,7 @@ class BaseEventTrigger(BaseTrigger):
     event-driven scheduling.
     """
 
-    uses_triggerer_queue: bool = False
+    supports_triggerer_queue: bool = False
 
     @staticmethod
     def hash(classpath: str, kwargs: dict[str, Any]) -> int:

--- a/airflow-core/src/airflow/triggers/base.py
+++ b/airflow-core/src/airflow/triggers/base.py
@@ -63,6 +63,8 @@ class BaseTrigger(abc.ABC, LoggingMixin):
     let them be re-instantiated elsewhere.
     """
 
+    uses_triggerer_queue: bool = True
+
     def __init__(self, **kwargs):
         # these values are set by triggerer when preparing to run the instance
         # when run, they are injected into logger record.
@@ -133,6 +135,8 @@ class BaseEventTrigger(BaseTrigger):
     ``BaseEventTrigger`` is a subclass of ``BaseTrigger`` designed to identify triggers compatible with
     event-driven scheduling.
     """
+
+    uses_triggerer_queue: bool = False
 
     @staticmethod
     def hash(classpath: str, kwargs: dict[str, Any]) -> int:

--- a/airflow-core/src/airflow/triggers/callback.py
+++ b/airflow-core/src/airflow/triggers/callback.py
@@ -35,6 +35,8 @@ PAYLOAD_BODY_KEY = "body"
 class CallbackTrigger(BaseTrigger):
     """Trigger that executes a callback function asynchronously."""
 
+    uses_triggerer_queue: bool = False
+
     def __init__(self, callback_path: str, callback_kwargs: dict[str, Any] | None = None):
         super().__init__()
         self.callback_path = callback_path

--- a/airflow-core/src/airflow/triggers/callback.py
+++ b/airflow-core/src/airflow/triggers/callback.py
@@ -35,7 +35,7 @@ PAYLOAD_BODY_KEY = "body"
 class CallbackTrigger(BaseTrigger):
     """Trigger that executes a callback function asynchronously."""
 
-    uses_triggerer_queue: bool = False
+    supports_triggerer_queue: bool = False
 
     def __init__(self, callback_path: str, callback_kwargs: dict[str, Any] | None = None):
         super().__init__()

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -121,8 +121,6 @@ from airflow.sdk.execution_time.sentry import Sentry
 from airflow.sdk.execution_time.xcom import XCom
 from airflow.sdk.listener import get_listener_manager
 from airflow.sdk.timezone import coerce_datetime
-from airflow.triggers.base import BaseEventTrigger
-from airflow.triggers.callback import CallbackTrigger
 
 if TYPE_CHECKING:
     import jinja2
@@ -1097,9 +1095,9 @@ def _defer_task(
     classpath, trigger_kwargs = defer.trigger.serialize()
     queue: str | None = None
     # Currently, only task-associated BaseTrigger instances may have a non-None queue,
-    # and only when triggerer.queues_enabled is True.
-    if not isinstance(defer.trigger, (BaseEventTrigger, CallbackTrigger)) and conf.getboolean(
-        "triggerer", "queues_enabled", fallback=False
+    # and only when triggerer.queues_enabled conf is True.
+    if conf.getboolean("triggerer", "queues_enabled", fallback=False) and getattr(
+        defer.trigger, "uses_triggerer_queue", True
     ):
         queue = ti.task.queue
 

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1097,7 +1097,7 @@ def _defer_task(
     # Currently, only task-associated BaseTrigger instances may have a non-None queue,
     # and only when triggerer.queues_enabled conf is True.
     if conf.getboolean("triggerer", "queues_enabled", fallback=False) and getattr(
-        defer.trigger, "uses_triggerer_queue", True
+        defer.trigger, "supports_triggerer_queue", True
     ):
         queue = ti.task.queue
 


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] No

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

Related: https://apache-airflow.slack.com/archives/C06K9Q5G2UA/p1770376076210459

Noticed these imports while working on client server separation and ensuring minimal import pattern from airflow core in task sdk. I am replacing the `isinstance` checks with a class based attribute to determine whether triggers types support trigger queues or not vs using isinstance to assert types which added runtime imports for `BaseEventTrigger` and `CallbackTrigger`

This enables task SDK to check queue support without importing trigger classes from core.

Triggers declare queue support via the `uses_triggerer_queue` attribute on the class itself.
- BaseTrigger defaults to True (supports queues)
- BaseEventTrigger and CallbackTrigger set to False (no queue support)


The config here looks like it is meant to be a feature flag to enable/disable the entire queue routing feature, which is retained.

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
