### PR TITLE
feat: Add Hook Level Lineage to SQL hooks

### DIFF
--- a/providers/amazon/pyproject.toml
+++ b/providers/amazon/pyproject.toml
@@ -60,7 +60,7 @@ requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.13.0",
-    "apache-airflow-providers-common-sql>=1.27.0",
+    "apache-airflow-providers-common-sql>=1.27.0",  # use next version
     "apache-airflow-providers-http",
     # We should update minimum version of boto3 and here regularly to avoid `pip` backtracking with the number
     # of candidates to consider. Make sure to configure boto3 version here as well as in all the tools below

--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/athena.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/athena.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING, Any
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from airflow.providers.amazon.aws.utils.waiter_with_logging import wait
 from airflow.providers.common.compat.sdk import AirflowException
+from airflow.providers.common.sql.hooks.lineage import send_sql_hook_lineage
 
 if TYPE_CHECKING:
     from botocore.paginate import PageIterator
@@ -126,6 +127,11 @@ class AthenaHook(AwsBaseHook):
         response = self.get_conn().start_query_execution(**params)
         query_execution_id = response["QueryExecutionId"]
         self.log.info("Query execution id: %s", query_execution_id)
+        send_sql_hook_lineage(
+            context=self,
+            sql=query,
+            job_id=query_execution_id,
+        )
         return query_execution_id
 
     def get_query_info(self, query_execution_id: str, use_cache: bool = False) -> dict:

--- a/providers/apache/drill/pyproject.toml
+++ b/providers/apache/drill/pyproject.toml
@@ -59,7 +59,7 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.11.0",
-    "apache-airflow-providers-common-sql>=1.26.0",
+    "apache-airflow-providers-common-sql>=1.26.0",  # use next version
     "apache-airflow-providers-common-compat>=1.8.0",
     # Workaround until we get https://github.com/JohnOmernik/sqlalchemy-drill/issues/94 fixed.
     "sqlalchemy-drill>=1.1.0,!=1.1.6,!=1.1.7",

--- a/providers/apache/druid/pyproject.toml
+++ b/providers/apache/druid/pyproject.toml
@@ -59,7 +59,7 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.11.0",
-    "apache-airflow-providers-common-sql>=1.26.0",
+    "apache-airflow-providers-common-sql>=1.26.0",  # use next version
     "apache-airflow-providers-common-compat>=1.10.1",
     "pydruid>=0.6.6",
 ]

--- a/providers/apache/hive/pyproject.toml
+++ b/providers/apache/hive/pyproject.toml
@@ -60,7 +60,7 @@ requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.12.0",
-    "apache-airflow-providers-common-sql>=1.26.0",
+    "apache-airflow-providers-common-sql>=1.26.0",  # use next version
     "hmsclient>=0.1.0",
     'pandas>=2.1.2; python_version <"3.13"',
     'pandas>=2.2.3; python_version >="3.13"',

--- a/providers/apache/hive/src/airflow/providers/apache/hive/hooks/hive.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/hooks/hive.py
@@ -39,6 +39,7 @@ from airflow.providers.common.compat.sdk import (
     BaseHook,
     conf,
 )
+from airflow.providers.common.sql.hooks.lineage import send_sql_hook_lineage
 from airflow.providers.common.sql.hooks.sql import DbApiHook
 from airflow.security import utils
 from airflow.utils.helpers import as_flattened_list
@@ -331,6 +332,8 @@ class HiveCliHook(BaseHook):
 
             if sub_process.returncode:
                 raise AirflowException(stdout)
+
+            send_sql_hook_lineage(context=self, sql=hql)
 
             return stdout
 
@@ -916,6 +919,7 @@ class HiveServer2Hook(DbApiHook):
 
             for statement in sql:
                 cur.execute(statement)
+                send_sql_hook_lineage(context=self, sql=statement, cur=cur, default_schema=schema)
                 # we only get results of statements that returns
                 lowered_statement = statement.lower().strip()
                 if lowered_statement.startswith(("select", "with", "show")) or (

--- a/providers/apache/impala/pyproject.toml
+++ b/providers/apache/impala/pyproject.toml
@@ -60,7 +60,7 @@ requires-python = ">=3.10"
 dependencies = [
     "impyla>=0.22.0,<1.0",
     "apache-airflow-providers-common-compat>=1.12.0",
-    "apache-airflow-providers-common-sql>=1.26.0",
+    "apache-airflow-providers-common-sql>=1.26.0",  # use next version
     "apache-airflow>=2.11.0",
 ]
 

--- a/providers/apache/pinot/pyproject.toml
+++ b/providers/apache/pinot/pyproject.toml
@@ -60,7 +60,7 @@ requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.10.1",
-    "apache-airflow-providers-common-sql>=1.26.0",
+    "apache-airflow-providers-common-sql>=1.26.0",  # use next version
     "pinotdb>=5.1.0",
 ]
 

--- a/providers/apache/pinot/src/airflow/providers/apache/pinot/hooks/pinot.py
+++ b/providers/apache/pinot/src/airflow/providers/apache/pinot/hooks/pinot.py
@@ -26,6 +26,7 @@ from urllib.parse import quote_plus
 from pinotdb import connect
 
 from airflow.providers.common.compat.sdk import AirflowException, BaseHook
+from airflow.providers.common.sql.hooks.lineage import send_sql_hook_lineage
 from airflow.providers.common.sql.hooks.sql import DbApiHook
 
 if TYPE_CHECKING:
@@ -335,6 +336,7 @@ class PinotDbApiHook(DbApiHook):
         """
         with self.get_conn() as cur:
             cur.execute(sql)
+            send_sql_hook_lineage(context=self, sql=sql, sql_parameters=parameters, cur=cur)
             return cur.fetchall()
 
     def get_first(self, sql: str | list[str], parameters: Iterable | Mapping[str, Any] | None = None) -> Any:
@@ -347,6 +349,7 @@ class PinotDbApiHook(DbApiHook):
         """
         with self.get_conn() as cur:
             cur.execute(sql)
+            send_sql_hook_lineage(context=self, sql=sql, sql_parameters=parameters, cur=cur)
             return cur.fetchone()
 
     def set_autocommit(self, conn: Connection, autocommit: Any) -> Any:

--- a/providers/common/sql/provider.yaml
+++ b/providers/common/sql/provider.yaml
@@ -110,6 +110,7 @@ hooks:
   - integration-name: Common SQL
     python-modules:
       - airflow.providers.common.sql.hooks.handlers
+      - airflow.providers.common.sql.hooks.lineage
       - airflow.providers.common.sql.hooks.sql
 
 triggers:

--- a/providers/common/sql/src/airflow/providers/common/sql/get_provider_info.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/get_provider_info.py
@@ -55,6 +55,7 @@ def get_provider_info():
                 "integration-name": "Common SQL",
                 "python-modules": [
                     "airflow.providers.common.sql.hooks.handlers",
+                    "airflow.providers.common.sql.hooks.lineage",
                     "airflow.providers.common.sql.hooks.sql",
                 ],
             }

--- a/providers/common/sql/src/airflow/providers/common/sql/hooks/handlers.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/hooks/handlers.py
@@ -51,6 +51,15 @@ def return_single_query_results(
     return isinstance(sql, str) and return_last
 
 
+def get_row_count(cursor) -> int | None:
+    # According to PEP 249, this is -1 or None when query result is not applicable.
+    # We standardize so it's either None (when not applicable) or positive integer / 0 (when applicable)
+    row_count = getattr(cursor, "rowcount", None)
+    if isinstance(row_count, int) and row_count >= 0:
+        return row_count
+    return None
+
+
 def fetch_all_handler(cursor) -> list[tuple] | None:
     """Return results for DbApiHook.run()."""
     if not hasattr(cursor, "description"):

--- a/providers/common/sql/src/airflow/providers/common/sql/hooks/lineage.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/hooks/lineage.py
@@ -1,0 +1,136 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import logging
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+from airflow.providers.common.compat.lineage.hook import get_hook_lineage_collector
+from airflow.providers.common.sql.hooks.handlers import get_row_count
+
+if TYPE_CHECKING:
+    from airflow.providers.common.compat.lineage.hook import LineageContext
+
+
+log = logging.getLogger(__name__)
+
+
+class SqlJobHookLineageExtra(str, Enum):
+    """
+    Keys for the SQL job hook-level lineage extra entry.
+
+    Reported via ``get_hook_lineage_collector().add_extra()``. ``KEY`` is the
+    extra entry key; ``VALUE__*`` are the keys inside the value dict (one entry
+    per SQL statement so job_id, SQL text, row count, default_db, etc. stay stitched).
+    """
+
+    KEY = "sql_job"
+    VALUE__SQL_STATEMENT = "sql"
+    VALUE__SQL_STATEMENT_PARAMETERS = "sql_parameters"
+    VALUE__JOB_ID = "job_id"
+    VALUE__ROW_COUNT = "row_count"
+    VALUE__DEFAULT_DB = "default_db"
+    VALUE__DEFAULT_SCHEMA = "default_schema"
+    VALUE__EXTRA = "extra"
+
+    @classmethod
+    def value_keys(cls) -> tuple[SqlJobHookLineageExtra, ...]:
+        """Value-dict keys only (KEY excluded). Use when iterating or validating the value dict."""
+        return (
+            cls.VALUE__SQL_STATEMENT,
+            cls.VALUE__SQL_STATEMENT_PARAMETERS,
+            cls.VALUE__JOB_ID,
+            cls.VALUE__ROW_COUNT,
+            cls.VALUE__DEFAULT_DB,
+            cls.VALUE__DEFAULT_SCHEMA,
+            cls.VALUE__EXTRA,
+        )
+
+
+def send_sql_hook_lineage(
+    *,
+    context: LineageContext,
+    sql: str | list[str],
+    sql_parameters: Any = None,
+    cur: Any = None,
+    job_id: str | None = None,
+    row_count: int | None = None,
+    default_db: str | None = None,
+    default_schema: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    """
+    Report a single SQL execution to the hook lineage collector.
+
+    Call this after running a SQL statement so that hook lineage collectors can associate the execution
+    with the task. Each call produces one extra entry in the collector; when executing multiple statements
+    in one hook run, one should call this function separately for each sql job, so that job_id, SQL text,
+    row count, and other fields stay tied together per statement.
+
+    Usable from any hook: pass the hook instance as ``context``. Not limited to
+    ``DbApiHook`` subclasses.
+
+    :param context: Lineage context, typically the hook instance. Must be valid for
+        ``get_hook_lineage_collector().add_extra(context=..., ...)``.
+    :param sql: The SQL statement that was executed (or a representative string).
+    :param sql_parameters: Optional parameters bound to the statement.
+    :param cur: Optional DB-API cursor after execution. If given, job_id is taken
+        from ``query_id`` or ``sfqid`` when not provided explicitly, and row_count
+        from ``cur.rowcount`` when applicable (PEP 249).
+    :param job_id: Explicit job ID; used instead of cursor-derived value when set.
+    :param row_count: Explicit row count; used instead of cursor-derived value when set.
+    :param default_db: Default database/catalog name for this execution context.
+    :param default_schema: Default schema name for this execution context.
+    :param extra: Optional additional key-value data to attach to this lineage entry.
+    """
+    try:
+        sql = "; ".join(sql) if isinstance(sql, list) else sql
+        value: dict[str, Any] = {SqlJobHookLineageExtra.VALUE__SQL_STATEMENT.value: sql}
+        if sql_parameters:
+            value[SqlJobHookLineageExtra.VALUE__SQL_STATEMENT_PARAMETERS.value] = sql_parameters
+
+        # Get SQL job_id: either explicitly or from cursor
+        if job_id is not None:
+            value[SqlJobHookLineageExtra.VALUE__JOB_ID.value] = job_id
+        elif cur is not None:
+            for attr in ("query_id", "sfqid"):
+                if (cursor_job_id := getattr(cur, attr, None)) is not None:
+                    value[SqlJobHookLineageExtra.VALUE__JOB_ID.value] = cursor_job_id
+                    break
+
+        # Get row count: either explicitly or from cursor
+        if row_count is None and cur is not None:
+            row_count = get_row_count(cur)
+        if row_count is not None and row_count >= 0:
+            value[SqlJobHookLineageExtra.VALUE__ROW_COUNT.value] = row_count
+
+        if default_db is not None:
+            value[SqlJobHookLineageExtra.VALUE__DEFAULT_DB.value] = default_db
+        if default_schema is not None:
+            value[SqlJobHookLineageExtra.VALUE__DEFAULT_SCHEMA.value] = default_schema
+        if extra:
+            value[SqlJobHookLineageExtra.VALUE__EXTRA.value] = extra
+
+        get_hook_lineage_collector().add_extra(
+            context=context,
+            key=SqlJobHookLineageExtra.KEY.value,
+            value=value,
+        )
+    except Exception as e:
+        log.warning("Sending SQL hook level lineage failed: %s", f"{e.__class__.__name__}: {str(e)}")
+        log.debug("Exception details:", exc_info=True)

--- a/providers/common/sql/src/airflow/providers/common/sql/hooks/lineage.pyi
+++ b/providers/common/sql/src/airflow/providers/common/sql/hooks/lineage.pyi
@@ -29,14 +29,35 @@
 #
 """
 Definition of the public interface for
-airflow.providers.common.sql.src.airflow.providers.common.sql.hooks.handlers.
+airflow.providers.common.sql.src.airflow.providers.common.sql.hooks.lineage.
 """
 
-from collections.abc import Iterable
+from enum import Enum
+from typing import Any
 
-def return_single_query_results(
-    sql: str | Iterable[str], return_last: bool, split_statements: bool | None
-): ...
-def get_row_count(cursor) -> int | None: ...
-def fetch_all_handler(cursor) -> list[tuple] | None: ...
-def fetch_one_handler(cursor) -> tuple | None: ...
+from airflow.providers.common.compat.lineage.hook import LineageContext
+
+class SqlJobHookLineageExtra(str, Enum):
+    KEY = "sql_job"
+    VALUE__SQL_STATEMENT = "sql"
+    VALUE__SQL_STATEMENT_PARAMETERS = "sql_parameters"
+    VALUE__JOB_ID = "job_id"
+    VALUE__ROW_COUNT = "row_count"
+    VALUE__DEFAULT_DB = "default_db"
+    VALUE__DEFAULT_SCHEMA = "default_schema"
+    VALUE__EXTRA = "extra"
+    @classmethod
+    def value_keys(cls) -> tuple[SqlJobHookLineageExtra, ...]: ...
+
+def send_sql_hook_lineage(
+    *,
+    context: LineageContext,
+    sql: str | list[str],
+    sql_parameters: Any = None,
+    cur: Any = None,
+    job_id: str | None = None,
+    row_count: int | None = None,
+    default_db: str | None = None,
+    default_schema: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> None: ...

--- a/providers/common/sql/tests/unit/common/sql/hooks/test_lineage.py
+++ b/providers/common/sql/tests/unit/common/sql/hooks/test_lineage.py
@@ -1,0 +1,201 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import logging
+from unittest import mock
+
+from airflow.providers.common.sql.hooks.lineage import (
+    SqlJobHookLineageExtra,
+    send_sql_hook_lineage,
+)
+
+
+class TestSqlJobHookLineageExtra:
+    def test_key_value(self):
+        assert SqlJobHookLineageExtra.KEY.value == "sql_job"
+
+    def test_value_keys_includes_all_value_members(self):
+        keys = SqlJobHookLineageExtra.value_keys()
+        assert len(keys) == 7
+        assert keys == (
+            SqlJobHookLineageExtra.VALUE__SQL_STATEMENT,
+            SqlJobHookLineageExtra.VALUE__SQL_STATEMENT_PARAMETERS,
+            SqlJobHookLineageExtra.VALUE__JOB_ID,
+            SqlJobHookLineageExtra.VALUE__ROW_COUNT,
+            SqlJobHookLineageExtra.VALUE__DEFAULT_DB,
+            SqlJobHookLineageExtra.VALUE__DEFAULT_SCHEMA,
+            SqlJobHookLineageExtra.VALUE__EXTRA,
+        )
+
+
+class TestSendSqlHookLineage:
+    """Test send_sql_hook_lineage calls get_hook_lineage_collector().add_extra with correct params."""
+
+    @mock.patch("airflow.providers.common.sql.hooks.lineage.get_hook_lineage_collector")
+    def test_add_extra_called_with_minimal_args(self, mock_get_collector):
+        mock_collector = mock.MagicMock()
+        mock_get_collector.return_value = mock_collector
+        mock_context = mock.MagicMock()
+
+        send_sql_hook_lineage(context=mock_context, sql="SELECT 1")
+
+        mock_collector.add_extra.assert_called_once()
+        call_kw = mock_collector.add_extra.call_args.kwargs
+        assert len(call_kw) == 3
+        assert call_kw["context"] is mock_context
+        assert call_kw["key"] == "sql_job"
+        assert len(call_kw["value"]) == 1
+        assert call_kw["value"] == {"sql": "SELECT 1"}
+
+    @mock.patch("airflow.providers.common.sql.hooks.lineage.get_hook_lineage_collector")
+    def test_add_extra_called_with_sql_list_joined(self, mock_get_collector):
+        mock_collector = mock.MagicMock()
+        mock_get_collector.return_value = mock_collector
+        mock_context = mock.MagicMock()
+
+        send_sql_hook_lineage(context=mock_context, sql=["SELECT 1", "SELECT 2"])
+
+        mock_collector.add_extra.assert_called_once()
+        call_kw = mock_collector.add_extra.call_args.kwargs
+        assert len(call_kw) == 3
+        assert call_kw["context"] is mock_context
+        assert call_kw["key"] == "sql_job"
+        assert len(call_kw["value"]) == 1
+        assert call_kw["value"] == {"sql": "SELECT 1; SELECT 2"}
+
+    @mock.patch("airflow.providers.common.sql.hooks.lineage.get_hook_lineage_collector")
+    def test_add_extra_called_with_all_args_no_cursor(self, mock_get_collector):
+        mock_collector = mock.MagicMock()
+        mock_get_collector.return_value = mock_collector
+        mock_context = mock.MagicMock()
+
+        send_sql_hook_lineage(
+            context=mock_context,
+            sql="INSERT INTO t VALUES (%s)",
+            sql_parameters=("x",),
+            job_id="job-123",
+            row_count=42,
+            default_db="mydb",
+            default_schema="myschema",
+            extra={"custom": "data"},
+        )
+
+        mock_collector.add_extra.assert_called_once()
+        call_kw = mock_collector.add_extra.call_args.kwargs
+        assert len(call_kw) == 3
+        assert call_kw["context"] is mock_context
+        assert call_kw["key"] == "sql_job"
+        value = call_kw["value"]
+        assert len(value) == 7
+        assert value == {
+            "sql": "INSERT INTO t VALUES (%s)",
+            "sql_parameters": ("x",),
+            "job_id": "job-123",
+            "row_count": 42,
+            "default_db": "mydb",
+            "default_schema": "myschema",
+            "extra": {"custom": "data"},
+        }
+
+    @mock.patch("airflow.providers.common.sql.hooks.lineage.get_hook_lineage_collector")
+    def test_add_extra_job_id_from_cursor(self, mock_get_collector):
+        mock_collector = mock.MagicMock()
+        mock_get_collector.return_value = mock_collector
+        mock_context = mock.MagicMock()
+        mock_cur = mock.MagicMock()
+        mock_cur.query_id = "cursor-query-id"
+
+        send_sql_hook_lineage(context=mock_context, sql="SELECT 1", cur=mock_cur)
+
+        call_kw = mock_collector.add_extra.call_args.kwargs
+        assert len(call_kw) == 3
+        assert call_kw["context"] is mock_context
+        assert call_kw["key"] == "sql_job"
+        value = call_kw["value"]
+        assert len(value) == 2
+        assert value == {"sql": "SELECT 1", "job_id": "cursor-query-id"}
+
+    @mock.patch("airflow.providers.common.sql.hooks.lineage.get_hook_lineage_collector")
+    def test_add_extra_row_count_from_cursor(self, mock_get_collector):
+        mock_collector = mock.MagicMock()
+        mock_get_collector.return_value = mock_collector
+        mock_context = mock.MagicMock()
+        mock_cur = mock.MagicMock()
+        mock_cur.rowcount = 10
+        mock_cur.query_id = "123"
+
+        send_sql_hook_lineage(context=mock_context, sql="SELECT 1", cur=mock_cur)
+
+        call_kw = mock_collector.add_extra.call_args.kwargs
+        assert len(call_kw) == 3
+        assert call_kw["context"] is mock_context
+        assert call_kw["key"] == "sql_job"
+        value = call_kw["value"]
+        assert len(value) == 3
+        assert value == {"sql": "SELECT 1", "row_count": 10, "job_id": "123"}
+
+    @mock.patch("airflow.providers.common.sql.hooks.lineage.get_hook_lineage_collector")
+    def test_explicit_job_id_overrides_cursor(self, mock_get_collector):
+        mock_collector = mock.MagicMock()
+        mock_get_collector.return_value = mock_collector
+        mock_context = mock.MagicMock()
+        mock_cur = mock.MagicMock()
+        mock_cur.query_id = "cursor-id"
+
+        send_sql_hook_lineage(context=mock_context, sql="SELECT 1", cur=mock_cur, job_id="explicit-id")
+
+        call_kw = mock_collector.add_extra.call_args.kwargs
+        assert len(call_kw) == 3
+        assert call_kw["context"] is mock_context
+        assert call_kw["key"] == "sql_job"
+        value = call_kw["value"]
+        assert len(value) == 2
+        assert value == {"sql": "SELECT 1", "job_id": "explicit-id"}
+
+    @mock.patch("airflow.providers.common.sql.hooks.lineage.get_hook_lineage_collector")
+    def test_explicit_row_count_overrides_cursor(self, mock_get_collector):
+        mock_collector = mock.MagicMock()
+        mock_get_collector.return_value = mock_collector
+        mock_context = mock.MagicMock()
+        mock_cur = mock.MagicMock()
+        mock_cur.rowcount = 99
+        del mock_cur.query_id
+        del mock_cur.sfqid
+
+        send_sql_hook_lineage(context=mock_context, sql="SELECT 1", cur=mock_cur, row_count=1)
+
+        call_kw = mock_collector.add_extra.call_args.kwargs
+        assert len(call_kw) == 3
+        assert call_kw["context"] is mock_context
+        assert call_kw["key"] == "sql_job"
+        value = call_kw["value"]
+        assert len(value) == 2
+        assert value == {"sql": "SELECT 1", "row_count": 1}
+
+    @mock.patch("airflow.providers.common.sql.hooks.lineage.get_hook_lineage_collector")
+    def test_exception_is_swallowed_and_logged(self, mock_get_collector, caplog):
+        mock_collector = mock.MagicMock()
+        mock_collector.add_extra.side_effect = RuntimeError("collector broke")
+        mock_get_collector.return_value = mock_collector
+
+        with caplog.at_level(logging.WARNING, logger="airflow.providers.common.sql.hooks.lineage"):
+            send_sql_hook_lineage(context=mock.MagicMock(), sql="SELECT 1")
+
+        assert "Sending SQL hook level lineage failed" in caplog.text
+        assert "RuntimeError: collector broke" in caplog.text

--- a/providers/databricks/pyproject.toml
+++ b/providers/databricks/pyproject.toml
@@ -60,7 +60,7 @@ requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.13.0",
-    "apache-airflow-providers-common-sql>=1.27.0",
+    "apache-airflow-providers-common-sql>=1.27.0",  # use next version
     "requests>=2.32.0,<3",
     "databricks-sql-connector>=4.0.0",
     "aiohttp>=3.9.2, <4",

--- a/providers/databricks/src/airflow/providers/databricks/hooks/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/hooks/databricks.py
@@ -35,6 +35,7 @@ from typing import Any
 from requests import exceptions as requests_exceptions
 
 from airflow.providers.common.compat.sdk import AirflowException
+from airflow.providers.common.sql.hooks.lineage import send_sql_hook_lineage
 from airflow.providers.databricks.hooks.databricks_base import BaseDatabricksHook
 
 GET_CLUSTER_ENDPOINT = ("GET", "2.1/clusters/get")
@@ -800,7 +801,17 @@ class DatabricksHook(BaseDatabricksHook):
         :return: The statement_id as a string.
         """
         response = self._do_api_call(("POST", f"{SQL_STATEMENTS_ENDPOINT}"), json)
-        return response["statement_id"]
+        statement_id = response["statement_id"]
+        if (sql_statement := json.get("statement")) is not None:
+            send_sql_hook_lineage(
+                context=self,
+                sql=sql_statement,
+                sql_parameters=json.get("parameters"),
+                job_id=statement_id,
+                default_db=json.get("catalog"),
+                default_schema=json.get("schema"),
+            )
+        return statement_id
 
     def get_sql_statement_state(self, statement_id: str) -> SQLStatementState:
         """

--- a/providers/databricks/tests/unit/databricks/hooks/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/hooks/test_databricks.py
@@ -1226,6 +1226,31 @@ class TestDatabricksHook:
             timeout=self.hook.timeout_seconds,
         )
 
+    @mock.patch("airflow.providers.databricks.hooks.databricks.send_sql_hook_lineage")
+    @mock.patch("airflow.providers.databricks.hooks.databricks_base.requests")
+    def test_post_sql_statement_hook_lineage(self, mock_requests, mock_send_lineage):
+        mock_requests.post.return_value.json.return_value = {
+            "statement_id": "01f00ed2-04e2-15bd-a944-a8ae011dac69"
+        }
+        json_payload = {
+            "statement": "select * from test.test;",
+            "warehouse_id": WAREHOUSE_ID,
+            "catalog": "some_catalog",
+            "schema": "some_schema",
+            "parameters": {"a": 1},
+            "wait_timeout": "0s",
+        }
+        self.hook.post_sql_statement(json_payload)
+
+        mock_send_lineage.assert_called_once()
+        call_kw = mock_send_lineage.call_args.kwargs
+        assert call_kw["context"] is self.hook
+        assert call_kw["sql"] == "select * from test.test;"
+        assert call_kw["job_id"] == "01f00ed2-04e2-15bd-a944-a8ae011dac69"
+        assert call_kw["sql_parameters"] == {"a": 1}
+        assert call_kw["default_db"] == "some_catalog"
+        assert call_kw["default_schema"] == "some_schema"
+
     @mock.patch("airflow.providers.databricks.hooks.databricks_base.requests")
     def test_get_sql_statement_state(self, mock_requests):
         mock_requests.codes.ok = 200

--- a/providers/elasticsearch/pyproject.toml
+++ b/providers/elasticsearch/pyproject.toml
@@ -60,7 +60,7 @@ requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.12.0",
-    "apache-airflow-providers-common-sql>=1.27.0",
+    "apache-airflow-providers-common-sql>=1.27.0",  # use next version
     "elasticsearch>=8.10,<9",
 ]
 

--- a/providers/exasol/pyproject.toml
+++ b/providers/exasol/pyproject.toml
@@ -60,7 +60,7 @@ requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.12.0",
-    "apache-airflow-providers-common-sql>=1.26.0",
+    "apache-airflow-providers-common-sql>=1.26.0",  # use next version
     "pyexasol>=0.26.0",
     'pandas>=2.1.2; python_version <"3.13"',
     'pandas>=2.2.3; python_version >="3.13"',

--- a/providers/google/pyproject.toml
+++ b/providers/google/pyproject.toml
@@ -60,7 +60,7 @@ requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.13.0",
-    "apache-airflow-providers-common-sql>=1.27.0",
+    "apache-airflow-providers-common-sql>=1.27.0",  # use next version
     "asgiref>=3.5.2",
     "dill>=0.2.3",
     "gcloud-aio-auth>=5.2.0",

--- a/providers/google/src/airflow/providers/google/cloud/hooks/spanner.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/spanner.py
@@ -28,6 +28,7 @@ from google.cloud.spanner_v1.client import Client
 from sqlalchemy import create_engine
 
 from airflow.providers.common.compat.sdk import AirflowException
+from airflow.providers.common.sql.hooks.lineage import send_sql_hook_lineage
 from airflow.providers.common.sql.hooks.sql import DbApiHook
 from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import GoogleBaseHook, get_field
@@ -421,6 +422,11 @@ class SpannerHook(GoogleBaseHook, DbApiHook):
                 preview = sql if len(sql) <= 300 else sql[:300] + "…"
                 self.log.info("[DML %d/%d] affected rows=%d | %s", i, len(result), rc, preview)
                 result_rows_count_per_query.append(rc)
+            send_sql_hook_lineage(
+                context=self,
+                sql=sql,
+                row_count=rc,
+            )
         return result_rows_count_per_query
 
     @staticmethod

--- a/providers/jdbc/pyproject.toml
+++ b/providers/jdbc/pyproject.toml
@@ -59,8 +59,8 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.11.0",
-    "apache-airflow-providers-common-compat>=1.10.1", #use next version
-    "apache-airflow-providers-common-sql>=1.20.0",
+    "apache-airflow-providers-common-compat>=1.10.1", # use next version
+    "apache-airflow-providers-common-sql>=1.20.0",  # use next version
     "jaydebeapi>=1.1.1",
 ]
 

--- a/providers/microsoft/mssql/pyproject.toml
+++ b/providers/microsoft/mssql/pyproject.toml
@@ -59,7 +59,7 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.11.0",
-    "apache-airflow-providers-common-sql>=1.23.0",
+    "apache-airflow-providers-common-sql>=1.23.0",  # use next version
     "pymssql>=2.3.5",
     "methodtools>=0.4.7",
 ]

--- a/providers/mysql/pyproject.toml
+++ b/providers/mysql/pyproject.toml
@@ -60,7 +60,7 @@ requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.12.0",
-    "apache-airflow-providers-common-sql>=1.20.0",
+    "apache-airflow-providers-common-sql>=1.20.0",  # use next version
     # The mysqlclient package creates friction when installing on MacOS as it needs pkg-config to
     # Install and compile, and it's really only used by MySQL provider, so we can skip it on MacOS
     # Instead, if someone attempts to use it on MacOS, they will get explanatory error on how to install it

--- a/providers/odbc/pyproject.toml
+++ b/providers/odbc/pyproject.toml
@@ -60,7 +60,7 @@ requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.12.0",
-    "apache-airflow-providers-common-sql>=1.20.0",
+    "apache-airflow-providers-common-sql>=1.20.0",  # use next version
     "pyodbc>=5.0.0; python_version < '3.13'",
     "pyodbc>=5.2.0; python_version >= '3.13'",
 ]

--- a/providers/oracle/pyproject.toml
+++ b/providers/oracle/pyproject.toml
@@ -60,7 +60,7 @@ requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.8.0",
-    "apache-airflow-providers-common-sql>=1.20.0",
+    "apache-airflow-providers-common-sql>=1.20.0",  # use next version
     "oracledb>=2.0.0",
 ]
 

--- a/providers/pgvector/pyproject.toml
+++ b/providers/pgvector/pyproject.toml
@@ -60,7 +60,7 @@ requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.8.0",
-    "apache-airflow-providers-postgres>=5.7.1",
+    "apache-airflow-providers-postgres>=5.7.1",  # use next version
     "pgvector>=0.3.1",
 ]
 

--- a/providers/postgres/pyproject.toml
+++ b/providers/postgres/pyproject.toml
@@ -60,7 +60,7 @@ requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.12.0",
-    "apache-airflow-providers-common-sql>=1.23.0",
+    "apache-airflow-providers-common-sql>=1.23.0",  # use next version
     "psycopg2-binary>=2.9.9; python_version < '3.13'",
     "psycopg2-binary>=2.9.10; python_version >= '3.13'",
     "asyncpg>=0.30.0",

--- a/providers/postgres/tests/unit/postgres/hooks/test_postgres.py
+++ b/providers/postgres/tests/unit/postgres/hooks/test_postgres.py
@@ -842,6 +842,63 @@ class TestPostgresHookPPG2:
         self.cur.copy_expert.assert_called_once_with(statement, open_mock.return_value)
         assert open_mock.call_args.args == (filename, "r+")
 
+    @mock.patch("airflow.providers.postgres.hooks.postgres.send_sql_hook_lineage")
+    def test_copy_expert_hook_lineage(self, mock_send_lineage, mocker):
+        open_mock = mocker.mock_open(read_data='{"some": "json"}')
+        mocker.patch("airflow.providers.postgres.hooks.postgres.open", open_mock)
+        statement = "COPY t FROM STDIN"
+        filename = "file"
+
+        self.db_hook.copy_expert(statement, filename)
+
+        mock_send_lineage.assert_called_once()
+        call_kw = mock_send_lineage.call_args.kwargs
+        assert call_kw["context"] is self.db_hook
+        assert call_kw["sql"] == statement
+        assert call_kw["sql_parameters"] == (filename,)
+        assert call_kw["cur"] is self.cur
+
+    @mock.patch("airflow.providers.common.sql.hooks.sql.send_sql_hook_lineage")
+    def test_run_hook_lineage(self, mock_send_lineage):
+        statement = "SELECT 1"
+        self.cur.fetchall.return_value = []
+
+        self.db_hook.run(statement)
+
+        mock_send_lineage.assert_called()
+        call_kw = mock_send_lineage.call_args.kwargs
+        assert call_kw["context"] is self.db_hook
+        assert call_kw["sql"] == statement
+        assert call_kw["sql_parameters"] is None
+        assert call_kw["cur"] is self.cur
+
+    @mock.patch("airflow.providers.postgres.hooks.postgres.send_sql_hook_lineage")
+    @mock.patch("pandas.io.sql.read_sql", return_value=pd.DataFrame({"a": [1]}))
+    @mock.patch("airflow.providers.postgres.hooks.postgres.PostgresHook.get_sqlalchemy_engine")
+    def test_get_df_hook_lineage(self, mock_engine, mock_read_sql, mock_send_lineage):
+        sql = "SELECT 1"
+        parameters = ("x",)
+        self.db_hook.get_df(sql, parameters=parameters)
+
+        mock_send_lineage.assert_called_once()
+        call_kw = mock_send_lineage.call_args.kwargs
+        assert call_kw["context"] is self.db_hook
+        assert call_kw["sql"] == sql
+        assert call_kw["sql_parameters"] == parameters
+
+    @mock.patch("airflow.providers.common.sql.hooks.sql.send_sql_hook_lineage")
+    @mock.patch("airflow.providers.common.sql.hooks.sql.DbApiHook._get_pandas_df_by_chunks")
+    def test_get_df_by_chunks_hook_lineage(self, mock_get_pandas_df_by_chunks, mock_send_lineage):
+        sql = "SELECT 1"
+        parameters = ("x",)
+        self.db_hook.get_df_by_chunks(sql, parameters=parameters, chunksize=1)
+
+        mock_send_lineage.assert_called_once()
+        call_kw = mock_send_lineage.call_args.kwargs
+        assert call_kw["context"] is self.db_hook
+        assert call_kw["sql"] == sql
+        assert call_kw["sql_parameters"] == parameters
+
     def test_insert_rows(self, postgres_hook_setup):
         setup = postgres_hook_setup
         table = "table"
@@ -857,6 +914,20 @@ class TestPostgresHookPPG2:
 
         sql = f"INSERT INTO {table}  VALUES (%s)"
         setup.cur.executemany.assert_any_call(sql, rows)
+
+    @mock.patch("airflow.providers.common.sql.hooks.sql.send_sql_hook_lineage")
+    def test_insert_rows_hook_lineage(self, mock_send_lineage, postgres_hook_setup):
+        setup = postgres_hook_setup
+        table = "table"
+        rows = [("hello",), ("world",)]
+
+        setup.db_hook.insert_rows(table, rows)
+
+        mock_send_lineage.assert_called_once()
+        call_kw = mock_send_lineage.call_args.kwargs
+        assert call_kw["context"] is setup.db_hook
+        assert call_kw["sql"] == f"INSERT INTO {table}  VALUES (%s)"
+        assert call_kw["row_count"] == 2
 
     @mock.patch("airflow.providers.postgres.hooks.postgres.execute_batch")
     def test_insert_rows_fast_executemany(self, mock_execute_batch, postgres_hook_setup):
@@ -881,6 +952,23 @@ class TestPostgresHookPPG2:
 
         # executemany should NOT be called in this mode
         setup.cur.executemany.assert_not_called()
+
+    @mock.patch("airflow.providers.postgres.hooks.postgres.send_sql_hook_lineage")
+    @mock.patch("airflow.providers.postgres.hooks.postgres.execute_batch")
+    def test_insert_rows_fast_executemany_hook_lineage(
+        self, mock_execute_batch, mock_send_lineage, postgres_hook_setup
+    ):
+        setup = postgres_hook_setup
+        table = "table"
+        rows = [("hello",), ("world",)]
+
+        setup.db_hook.insert_rows(table, rows, fast_executemany=True)
+
+        mock_send_lineage.assert_called_once()
+        call_kw = mock_send_lineage.call_args.kwargs
+        assert call_kw["context"] is setup.db_hook
+        assert call_kw["sql"] == f"INSERT INTO {table}  VALUES (%s)"
+        assert call_kw["row_count"] == 2
 
     def test_insert_rows_replace(self, postgres_hook_setup):
         setup = postgres_hook_setup

--- a/providers/presto/pyproject.toml
+++ b/providers/presto/pyproject.toml
@@ -60,7 +60,7 @@ requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.12.0",
-    "apache-airflow-providers-common-sql>=1.26.0",
+    "apache-airflow-providers-common-sql>=1.26.0",  # use next version
     "presto-python-client>=0.8.4",
     'pandas>=2.1.2; python_version <"3.13"',
     'pandas>=2.2.3; python_version >="3.13"',

--- a/providers/presto/tests/unit/presto/hooks/test_presto.py
+++ b/providers/presto/tests/unit/presto/hooks/test_presto.py
@@ -236,6 +236,7 @@ class TestPrestoHook:
                 return IsolationLevel.READ_COMMITTED
 
         self.db_hook = UnitTestPrestoHook()
+        self.db_hook.get_connection = mock.Mock(return_value=Connection(conn_type="presto"))
 
     @patch("airflow.providers.common.sql.hooks.sql.DbApiHook.insert_rows")
     def test_insert_rows(self, mock_insert_rows):
@@ -297,3 +298,56 @@ class TestPrestoHook:
     def test_serialize_cell(self):
         assert self.db_hook._serialize_cell("foo", None) == "foo"
         assert self.db_hook._serialize_cell(1, None) == 1
+
+    @patch("airflow.providers.common.sql.hooks.sql.send_sql_hook_lineage")
+    def test_run_hook_lineage(self, mock_send_lineage):
+        statement = "SELECT 1"
+        self.cur.fetchall.return_value = []
+
+        self.db_hook.run(statement)
+
+        mock_send_lineage.assert_called()
+        call_kw = mock_send_lineage.call_args.kwargs
+        assert call_kw["context"] is self.db_hook
+        assert call_kw["sql"] == statement
+        assert call_kw["sql_parameters"] is None
+        assert call_kw["cur"] is self.cur
+
+    @patch("airflow.providers.common.sql.hooks.sql.send_sql_hook_lineage")
+    def test_insert_rows_hook_lineage(self, mock_send_lineage):
+        table = "table"
+        rows = [("hello",), ("world",)]
+
+        self.db_hook.insert_rows(table, rows)
+
+        mock_send_lineage.assert_called()
+        call_kw = mock_send_lineage.call_args.kwargs
+        assert call_kw["context"] is self.db_hook
+        assert call_kw["sql"] == "INSERT INTO table  VALUES (?)"
+        assert call_kw["row_count"] == 2
+
+    @patch("airflow.providers.common.sql.hooks.sql.send_sql_hook_lineage")
+    @patch("airflow.providers.common.sql.hooks.sql.DbApiHook._get_pandas_df")
+    def test_get_df_hook_lineage(self, mock_get_pandas_df, mock_send_lineage):
+        sql = "SELECT 1"
+        parameters = ("x",)
+        self.db_hook.get_df(sql, parameters=parameters)
+
+        mock_send_lineage.assert_called_once()
+        call_kw = mock_send_lineage.call_args.kwargs
+        assert call_kw["context"] is self.db_hook
+        assert call_kw["sql"] == sql
+        assert call_kw["sql_parameters"] == parameters
+
+    @patch("airflow.providers.common.sql.hooks.sql.send_sql_hook_lineage")
+    @patch("airflow.providers.common.sql.hooks.sql.DbApiHook._get_pandas_df_by_chunks")
+    def test_get_df_by_chunks_hook_lineage(self, mock_get_pandas_df_by_chunks, mock_send_lineage):
+        sql = "SELECT 1"
+        parameters = ("x",)
+        self.db_hook.get_df_by_chunks(sql, parameters=parameters, chunksize=1)
+
+        mock_send_lineage.assert_called_once()
+        call_kw = mock_send_lineage.call_args.kwargs
+        assert call_kw["context"] is self.db_hook
+        assert call_kw["sql"] == sql
+        assert call_kw["sql_parameters"] == parameters

--- a/providers/snowflake/pyproject.toml
+++ b/providers/snowflake/pyproject.toml
@@ -60,7 +60,7 @@ requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.12.0",
-    "apache-airflow-providers-common-sql>=1.27.5",
+    "apache-airflow-providers-common-sql>=1.27.5",  # use next version
     'pandas>=2.1.2; python_version <"3.13"',
     'pandas>=2.2.3; python_version >="3.13"',
     "pyarrow>=16.1.0; python_version < '3.13'",

--- a/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake.py
@@ -790,7 +790,7 @@ class SnowflakeHook(DbApiHook):
     def get_openlineage_database_info(self, connection) -> DatabaseInfo:
         from airflow.providers.openlineage.sqlparser import DatabaseInfo
 
-        database = self.database or self._get_field(connection.extra_dejson, "database")
+        database = self._get_conn_params()["database"]
 
         return DatabaseInfo(
             scheme=self.get_openlineage_database_dialect(connection),
@@ -803,7 +803,7 @@ class SnowflakeHook(DbApiHook):
                 "data_type",
                 "table_catalog",
             ],
-            database=database,
+            database=database or None,
             is_information_schema_cross_db=True,
             is_uppercase_names=True,
         )
@@ -812,7 +812,7 @@ class SnowflakeHook(DbApiHook):
         return "snowflake"
 
     def get_openlineage_default_schema(self) -> str | None:
-        return self._get_conn_params()["schema"]
+        return self._get_conn_params()["schema"] or None
 
     def _get_openlineage_authority(self, _) -> str | None:
         uri = fix_snowflake_sqlalchemy_uri(self.get_uri())

--- a/providers/sqlite/pyproject.toml
+++ b/providers/sqlite/pyproject.toml
@@ -59,7 +59,7 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.11.0",
-    "apache-airflow-providers-common-sql>=1.26.0",
+    "apache-airflow-providers-common-sql>=1.26.0",  # use next version
 ]
 
 [dependency-groups]

--- a/providers/teradata/pyproject.toml
+++ b/providers/teradata/pyproject.toml
@@ -60,7 +60,7 @@ requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.12.0",
-    "apache-airflow-providers-common-sql>=1.20.0",
+    "apache-airflow-providers-common-sql>=1.20.0",  # use next version
     "teradatasqlalchemy>=17.20.0.0",
     "teradatasql>=17.20.0.28",
 ]

--- a/providers/trino/pyproject.toml
+++ b/providers/trino/pyproject.toml
@@ -60,7 +60,7 @@ requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.12.0",
-    "apache-airflow-providers-common-sql>=1.20.0",
+    "apache-airflow-providers-common-sql>=1.20.0",  # use next version
     'pandas>=2.1.2; python_version <"3.13"',
     'pandas>=2.2.3; python_version >="3.13"',
     "trino>=0.319.0",

--- a/providers/trino/tests/unit/trino/hooks/test_trino.py
+++ b/providers/trino/tests/unit/trino/hooks/test_trino.py
@@ -333,6 +333,7 @@ class TestTrinoHook:
                 return IsolationLevel.READ_COMMITTED
 
         self.db_hook = UnitTestTrinoHook()
+        self.db_hook.get_connection = mock.Mock(return_value=Connection(conn_type="trino"))
 
     @patch("airflow.providers.common.sql.hooks.sql.DbApiHook.insert_rows")
     def test_insert_rows(self, mock_insert_rows):
@@ -432,6 +433,59 @@ class TestTrinoHook:
         sql = "SELECT 1; SELECT 2"
         self.db_hook.run(sql)
         super_run.assert_called_once_with(sql, False, None, None, True, True)
+
+    @patch("airflow.providers.common.sql.hooks.sql.send_sql_hook_lineage")
+    def test_run_hook_lineage(self, mock_send_lineage):
+        statement = "SELECT 1"
+        self.cur.fetchall.return_value = []
+
+        self.db_hook.run(statement)
+
+        mock_send_lineage.assert_called()
+        call_kw = mock_send_lineage.call_args.kwargs
+        assert call_kw["context"] is self.db_hook
+        assert call_kw["sql"] == statement
+        assert call_kw["sql_parameters"] is None
+        assert call_kw["cur"] is self.cur
+
+    @patch("airflow.providers.common.sql.hooks.sql.send_sql_hook_lineage")
+    def test_insert_rows_hook_lineage(self, mock_send_lineage):
+        table = "table"
+        rows = [("hello",), ("world",)]
+
+        self.db_hook.insert_rows(table, rows)
+
+        mock_send_lineage.assert_called()
+        call_kw = mock_send_lineage.call_args.kwargs
+        assert call_kw["context"] is self.db_hook
+        assert call_kw["sql"] == "INSERT INTO table  VALUES (?)"
+        assert call_kw["row_count"] == 2
+
+    @patch("airflow.providers.common.sql.hooks.sql.send_sql_hook_lineage")
+    @patch("airflow.providers.common.sql.hooks.sql.DbApiHook._get_pandas_df")
+    def test_get_df_hook_lineage(self, mock_get_pandas_df, mock_send_lineage):
+        sql = "SELECT 1"
+        parameters = ("x",)
+        self.db_hook.get_df(sql, parameters=parameters)
+
+        mock_send_lineage.assert_called_once()
+        call_kw = mock_send_lineage.call_args.kwargs
+        assert call_kw["context"] is self.db_hook
+        assert call_kw["sql"] == sql
+        assert call_kw["sql_parameters"] == parameters
+
+    @patch("airflow.providers.common.sql.hooks.sql.send_sql_hook_lineage")
+    @patch("airflow.providers.common.sql.hooks.sql.DbApiHook._get_pandas_df_by_chunks")
+    def test_get_df_by_chunks_hook_lineage(self, mock_get_pandas_df_by_chunks, mock_send_lineage):
+        sql = "SELECT 1"
+        parameters = ("x",)
+        self.db_hook.get_df_by_chunks(sql, parameters=parameters, chunksize=1)
+
+        mock_send_lineage.assert_called_once()
+        call_kw = mock_send_lineage.call_args.kwargs
+        assert call_kw["context"] is self.db_hook
+        assert call_kw["sql"] == sql
+        assert call_kw["sql_parameters"] == parameters
 
     def test_connection_success(self):
         status, msg = self.db_hook.test_connection()

--- a/providers/vertica/pyproject.toml
+++ b/providers/vertica/pyproject.toml
@@ -60,7 +60,7 @@ requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.12.0",
-    "apache-airflow-providers-common-sql>=1.26.0",
+    "apache-airflow-providers-common-sql>=1.26.0",  # use next version
     "vertica-python>=1.3.0",
 ]
 

--- a/providers/vertica/tests/unit/vertica/hooks/test_vertica.py
+++ b/providers/vertica/tests/unit/vertica/hooks/test_vertica.py
@@ -197,3 +197,80 @@ class TestVerticaHook:
         assert column == df.columns[0]
         assert result_sets[0][0] == df.row(0)[0]
         assert result_sets[1][0] == df.row(1)[0]
+
+
+class TestVerticaHookLineage:
+    def setup_method(self):
+        self.cur = mock.MagicMock(rowcount=0)
+        self.conn = mock.MagicMock()
+        self.conn.cursor.return_value = self.cur
+        conn = self.conn
+
+        class UnitTestVerticaHook(VerticaHook):
+            conn_name_attr = "vertica_conn_id"
+
+            def get_conn(self):
+                return conn
+
+        self.db_hook = UnitTestVerticaHook()
+        self.db_hook.get_connection = mock.Mock(
+            return_value=Connection(
+                login="login",
+                password="password",
+                host="host",
+                schema="vertica",
+            )
+        )
+
+    @mock.patch("airflow.providers.common.sql.hooks.sql.send_sql_hook_lineage")
+    def test_run_hook_lineage(self, mock_send_lineage):
+        statement = "SELECT 1"
+        self.cur.fetchall.return_value = []
+
+        self.db_hook.run(statement)
+
+        mock_send_lineage.assert_called()
+        call_kw = mock_send_lineage.call_args.kwargs
+        assert call_kw["context"] is self.db_hook
+        assert call_kw["sql"] == statement
+        assert call_kw["sql_parameters"] is None
+        assert call_kw["cur"] is self.cur
+
+    @mock.patch("airflow.providers.common.sql.hooks.sql.send_sql_hook_lineage")
+    def test_insert_rows_hook_lineage(self, mock_send_lineage):
+        table = "table"
+        rows = [("hello",), ("world",)]
+
+        self.db_hook.insert_rows(table, rows)
+
+        mock_send_lineage.assert_called()
+        call_kw = mock_send_lineage.call_args.kwargs
+        assert call_kw["context"] is self.db_hook
+        assert call_kw["sql"] == "INSERT INTO table  VALUES (%s)"
+        assert call_kw["row_count"] == 2
+
+    @mock.patch("airflow.providers.common.sql.hooks.sql.send_sql_hook_lineage")
+    @mock.patch("airflow.providers.common.sql.hooks.sql.DbApiHook._get_pandas_df")
+    def test_get_df_hook_lineage(self, mock_get_pandas_df, mock_send_lineage):
+        sql = "SELECT 1"
+        parameters = ("x",)
+        self.db_hook.get_df(sql, parameters=parameters)
+
+        mock_send_lineage.assert_called_once()
+        call_kw = mock_send_lineage.call_args.kwargs
+        assert call_kw["context"] is self.db_hook
+        assert call_kw["sql"] == sql
+        assert call_kw["sql_parameters"] == parameters
+
+    @mock.patch("airflow.providers.common.sql.hooks.sql.send_sql_hook_lineage")
+    @mock.patch("airflow.providers.common.sql.hooks.sql.DbApiHook._get_pandas_df_by_chunks")
+    def test_get_df_by_chunks_hook_lineage(self, mock_get_pandas_df_by_chunks, mock_send_lineage):
+        sql = "SELECT 1"
+        parameters = ("x",)
+        self.db_hook.get_df_by_chunks(sql, parameters=parameters, chunksize=1)
+
+        mock_send_lineage.assert_called_once()
+        call_kw = mock_send_lineage.call_args.kwargs
+        assert call_kw["context"] is self.db_hook
+        assert call_kw["sql"] == sql
+        assert call_kw["sql_parameters"] == parameters

--- a/providers/ydb/pyproject.toml
+++ b/providers/ydb/pyproject.toml
@@ -60,7 +60,7 @@ requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.10.1",
-    "apache-airflow-providers-common-sql>=1.20.0",
+    "apache-airflow-providers-common-sql>=1.20.0",  # Use next version
     "ydb>=3.18.8",
     "ydb-dbapi>=0.1.0",
 ]


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

Add hook-level lineage (HLL) reporting to SQL hooks via send_sql_hook_lineage
This PR introduces a standardized mechanism for SQL hooks to report execution metadata - SQL text, query parameters, job IDs, row counts, default database/schema - to the hook lineage collector using add_extra.

I also bumped the required sql-common version for all modified providers, so that the HLL is being emitted.

I've also added tests for most Hooks that use DbApiHook as base class, to make sure that even when some methods will be overwritten in the future, the Hook Level Lineage will still be sent (so for now we are mostly testing DbApiHook implementation multiple times, but if some db decides to overwrite `run()`, I need my test to fail so that new implementation also calls HLL collector).

### Important context
The HLL collector is a no-op unless a collector is registered (e.g. by the OpenLineage provider). This means no runtime overhead for users who don't use lineage collection.

### Motivation
Black-box operators (e.g. PythonOperator calling PostgresHook.run(sql)) currently produce no lineage. With this change, any registered collector can capture the SQL being executed, parse it for input/output datasets, and attach query IDs to lineage events - dramatically improving lineage quality without requiring operator-level changes.

### Follow-up PRs

- OpenLineage consumer: modify the OL provider to consume these extras, parse SQL for datasets, and attach query_id to OL events
- BigQueryHook insert_job: mix of sql and non-sql lineage, will do in a separate PR.
- Additional non-SQL hooks: extend HLL to more hooks beyond SQL

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

Co-authored by: Cursor following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
