### PR TITLE
Fix update_pyproject_dependency to include python_version

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/constraints_version_check.py
+++ b/dev/breeze/src/airflow_breeze/utils/constraints_version_check.py
@@ -318,21 +318,22 @@ def print_explanations(explanations: list[str]):
         get_console().print(explanation)
 
 
-def update_pyproject_dependency(pyproject_path: Path, pkg: str, latest_version: str):
+def update_pyproject_dependency(pyproject_path: Path, pkg: str, latest_version: str, python_version: str):
     lines = pyproject_path.read_text().splitlines()
     new_lines = []
     in_deps = False
     dep_added = False
+    dep_string = f"    \"{pkg}=={latest_version}; python_version=='{python_version}'\","
     for line in lines:
         new_lines.append(line)
         if line.strip() == "dependencies = [":
             in_deps = True
         elif in_deps and line.strip().startswith("]") and not dep_added:
-            new_lines.insert(-1, f'    "{pkg}=={latest_version}",')
+            new_lines.insert(-1, dep_string)
             dep_added = True
             in_deps = False
     if not dep_added:
-        new_lines.append(f'    "{pkg}=={latest_version}",')
+        new_lines.append(dep_string)
     pyproject_path.write_text("\n".join(new_lines) + "\n")
     if get_verbose():
         get_console().print(
@@ -515,7 +516,7 @@ def explain_package_upgrade(
             output=output_before,
             signal_error=False,
         )
-        update_pyproject_dependency(airflow_pyproject, pkg, latest_version)
+        update_pyproject_dependency(airflow_pyproject, pkg, latest_version, python_version)
         if get_verbose():
             syntax = Syntax(
                 airflow_pyproject.read_text(), "toml", theme="monokai", line_numbers=True, word_wrap=False


### PR DESCRIPTION
Running
`breeze release-management constraints-version-check --python 3.13 --package async-timeout --explain-why
`
Resulted with
```
× No solution found when resolving dependencies for split (markers:
  │ python_full_version >= '3.14' and sys_platform == 'win32'):
  ╰─▶ Because gremlinpython>=3.7.3 depends on async-timeout>=4.0.3,<5.0.0 and
      only the following versions of gremlinpython are available:
          gremlinpython<=3.7.3
          gremlinpython==3.7.4
          gremlinpython==3.7.5
          gremlinpython==3.8.0
      we can conclude that gremlinpython>=3.7.3 depends on
      async-timeout>=4.0.3,<5.0.0.
      And because apache-airflow-providers-apache-tinkerpop depends on
      gremlinpython>=3.7.3 and apache-airflow depends on async-timeout==5.0.1,
      we can conclude that apache-airflow-providers-apache-tinkerpop and
      apache-airflow are incompatible.
      And because your workspace requires apache-airflow and
      apache-airflow-providers-apache-tinkerpop, we can conclude that your
      workspace's requirements are unsatisfiable.

      hint: While the active Python version is 3.13, the resolution failed for
      other Python versions supported by your project. Consider limiting your
      project's supported Python versions using `requires-python`.

      hint: Pre-releases are available for `gremlinpython` in the requested
      range (e.g., 4.0.0b1), but pre-releases weren't enabled (try:
      `--prerelease=allow`)
      
```

The hint means that the real error is hidden as when we find resolution for Python 3.13 other Python versions are not related. The fix is to specify python_version when we attempt to update dependencies.