### PR TITLE
Fix GZipMiddleware with correct comment placement

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/app.py
@@ -182,7 +182,7 @@ def init_middlewares(app: FastAPI) -> None:
         app.add_middleware(SimpleAllAdminMiddleware)
 
     # The GzipMiddleware should be the last middleware added as https://github.com/apache/airflow/issues/60165 points out.
-    app.add_middleware(GZipMiddleware, minimum_size=1024, compresslevel=5)
     # Compress responses greater than 1kB with optimal compression level as 5
     # with level ranging from 1 to 9 with 1 (fastest, least compression)
     # and 9 (slowest, most compression)
+    app.add_middleware(GZipMiddleware, minimum_size=1024, compresslevel=5)


### PR DESCRIPTION
Add GZipMiddleware with correct comment placement, as suggested in issue #61043.

### Changes
- Ensured comments are correctly placed above the middleware definition to comply with review feedback.
