### PR TITLE
Fix deferrable mode in CloudRunExecuteJobOperator

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -110,6 +110,7 @@ ast
 astroid
 Async
 async
+asyncio
 AsyncResult
 athena
 Atlassian

--- a/providers/google/docs/operators/cloud/cloud_run.rst
+++ b/providers/google/docs/operators/cloud/cloud_run.rst
@@ -126,6 +126,33 @@ or you can define the same operator in the deferrable mode:
     :start-after: [START howto_operator_cloud_run_execute_job_deferrable_mode]
     :end-before: [END howto_operator_cloud_run_execute_job_deferrable_mode]
 
+Transport
+^^^^^^^^^
+
+The :class:`~airflow.providers.google.cloud.operators.cloud_run.CloudRunExecuteJobOperator` accepts an optional ``transport``
+parameter to choose the underlying API transport.
+
+* ``transport="grpc"`` (default): use gRPC transport. If ``transport`` is not set, gRPC is used.
+* ``transport="rest"``: use REST/HTTP transport.
+
+In deferrable mode, when using gRPC (explicitly or by default), the trigger uses an async gRPC client internally; for
+non-deferrable execution, the operator uses the regular (synchronous) gRPC client.
+
+In general, it is better to use gRPC (or leave ``transport`` unset) unless there is a specific reason you must use REST (for example,
+if gRPC is not available or fails in your environment).
+
+.. rubric:: Deferrable mode considerations
+
+When using deferrable mode, the operator defers to an async trigger that polls the long-running operation status.
+
+* With gRPC (explicitly or by default), the trigger uses the native async gRPC client internally. The ``grpc_asyncio`` transport is
+    an implementation detail of the Google client library and is not a user-facing ``transport`` value.
+* With REST, the REST transport is synchronous-only in the Google Cloud library. To remain compatible with deferrable mode, the
+    trigger performs REST calls using the synchronous client wrapped in a background thread.
+
+REST can be used with deferrable mode, but it may be less efficient than gRPC and is generally best reserved for cases where gRPC
+cannot be used.
+
 You can also specify overrides that allow you to give a new entrypoint command to the job and more:
 
 :class:`~airflow.providers.google.cloud.operators.cloud_run.CloudRunExecuteJobOperator`

--- a/providers/google/src/airflow/providers/google/cloud/triggers/cloud_run.py
+++ b/providers/google/src/airflow/providers/google/cloud/triggers/cloud_run.py
@@ -149,5 +149,5 @@ class CloudRunJobFinishedTrigger(BaseTrigger):
         return CloudRunAsyncHook(
             gcp_conn_id=self.gcp_conn_id,
             impersonation_chain=self.impersonation_chain,
-            transport=self.transport or "grpc",
+            transport=self.transport,
         )


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---
<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->
related: #60394

## Bug description
PR #60394 introduced the `transport` parameter for `CloudRunExecuteJobOperator`, but unfortunately it broke its deferrable mode.
There were two underlying issues:
1. The default `transport` type of the async hook connection is `grpc_asyncio` (not `grpc`), which is more optimized to work with async logic (in fact, the only way - see below).
2. When providing any `transport` other than `grpc_asyncio` - the returned `Operation` object is not awaitable.

The combination of those issues caused the `TypeError: Operation can't be used in 'await' expression` when we ran the opeartor in deferrable mode.

## Proposed solutions
1. When running the operator in defferable mode with `grpc`, we now use `grpc_asyncio` in the underlying async client.
2. When running the operator in deferrable mode with `rest`, we now call the sync client on a backround thread when polling the operation. This is a workaround, as the returned `Operation` must be awaitable.

## Extra details
- System tests were updated (see screenshot below), with additional tests for the `rest` transport (sync + async).
- Docs were updated, including recommandation to prefer usage of `grpc` when possible and including the caveat of rest transport in deferrable mode.

## Discussion points
- Are we ok with supporting the deferrable `rest` in its current state? While we could revert to an implementation where I actually [prohibited](https://github.com/apache/airflow/pull/61546/changes/be42286e3ea540dd5fc2319e034799058ced23ff) it, I thought that would be useful as a "last resort" for those who can't run with `grpc` (which is probably the only reason people actually need `rest` transport at all).

@VladaZakharova @MaksYermak - As we had already released the `transport` feature, I wanted to avoid making sudden breaking changes by reverting the original PR, so I preferred just to fix the issue instead. I intend to include it in the upcoming release on Tuesday, so I'll appreciate if you could review it by Monday.

<img width="911" height="792" alt="image" src="https://github.com/user-attachments/assets/6f9d2071-668a-44e2-978a-d0331f78364f" />



##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Sonnet 4.5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
