### PR TITLE
Guard type aliases and remove redundant imports in the postgres hook

### DIFF
--- a/providers/postgres/src/airflow/providers/postgres/hooks/postgres.py
+++ b/providers/postgres/src/airflow/providers/postgres/hooks/postgres.py
@@ -23,9 +23,8 @@ from contextlib import closing
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeAlias, cast, overload
 
-import psycopg2
-import psycopg2.extras
 from more_itertools import chunked
+from psycopg2 import connect as ppg2_connect
 from psycopg2.extras import DictCursor, NamedTupleCursor, RealDictCursor, execute_batch
 
 from airflow.providers.common.compat.sdk import (
@@ -65,8 +64,8 @@ if TYPE_CHECKING:
     if USE_PSYCOPG3:
         from psycopg.errors import Diagnostic
 
-CursorType: TypeAlias = DictCursor | RealDictCursor | NamedTupleCursor
-CursorRow: TypeAlias = dict[str, Any] | tuple[Any, ...]
+    CursorType: TypeAlias = DictCursor | RealDictCursor | NamedTupleCursor
+    CursorRow: TypeAlias = dict[str, Any] | tuple[Any, ...]
 
 
 class CompatConnection(Protocol):
@@ -221,9 +220,9 @@ class PostgresHook(DbApiHook):
             raise ValueError(f"Invalid cursor passed {_cursor}. Valid options are: {valid_cursors}")
 
         cursor_types = {
-            "dictcursor": psycopg2.extras.DictCursor,
-            "realdictcursor": psycopg2.extras.RealDictCursor,
-            "namedtuplecursor": psycopg2.extras.NamedTupleCursor,
+            "dictcursor": DictCursor,
+            "realdictcursor": RealDictCursor,
+            "namedtuplecursor": NamedTupleCursor,
         }
         if _cursor in cursor_types:
             return cursor_types[_cursor]
@@ -285,7 +284,7 @@ class PostgresHook(DbApiHook):
             if raw_cursor:
                 conn_args["cursor_factory"] = self._get_cursor(raw_cursor)
 
-            self.conn = cast("CompatConnection", psycopg2.connect(**conn_args))
+            self.conn = cast("CompatConnection", ppg2_connect(**conn_args))
 
         return self.conn
 

--- a/providers/postgres/tests/unit/postgres/hooks/test_postgres.py
+++ b/providers/postgres/tests/unit/postgres/hooks/test_postgres.py
@@ -94,7 +94,7 @@ def mock_connect(mocker):
     """Mock the connection object according to the correct psycopg version."""
     if USE_PSYCOPG3:
         return mocker.patch("airflow.providers.postgres.hooks.postgres.psycopg.connection.Connection.connect")
-    return mocker.patch("airflow.providers.postgres.hooks.postgres.psycopg2.connect")
+    return mocker.patch("airflow.providers.postgres.hooks.postgres.ppg2_connect")
 
 
 class TestPostgresHookConn:


### PR DESCRIPTION
This attempts to fix the below issue with doc generation in the _google_ provider [observed in CI](https://github.com/apache/airflow/actions/runs/21752675320/job/62755254976?pr=61532#step:6:4451) that happens while importing the postgres provider.

```python
Traceback (most recent call last):
  File 
  "/usr/python/lib/python3.10/site-packages/sphinx/ext/autodoc/importer.py", line 143, in import_module
    return importlib.import_module(modname)
  File "/usr/python/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return 
  _bootstrap._gcd_import(name, package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in 
  _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
 
  File "/opt/airflow/providers/google/src/airflow/providers/google/cloud/transfers/bigquery_to_postgres.py", line 31, in <module>
    from airflow.providers.postgres.hooks.postgres import PostgresHook
  File 
  "/opt/airflow/providers/postgres/src/airflow/providers/postgres/hooks/postgres.py", line 68, in <module>
    CursorType: TypeAlias = DictCursor | RealDictCursor | NamedTupleCursor
TypeError: unsupported operand type(s) for |: 'DictCursor' and 'RealDictCursor'
```

The fix is moving the two `TypeAlias` definitions into the existing `TYPE_CHECKING` block. Also, imports were cleaned up a bit.

related: #61532 
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
