### PR TITLE
Clarify ExternalTaskSensor path in dags.rst

### DIFF
--- a/airflow-core/docs/core-concepts/dags.rst
+++ b/airflow-core/docs/core-concepts/dags.rst
@@ -771,7 +771,7 @@ relationships, dependencies between Dags are a bit more complex. In general, the
 in which one Dag can depend on another:
 
 - triggering - :class:`~airflow.providers.standard.operators.trigger_dagrun.TriggerDagRunOperator`
-- waiting - :class:`~airflow.providers.standard.sensors.external_task_sensor.ExternalTaskSensor`
+- waiting - :class:`~airflow.providers.standard.sensors.external_task.ExternalTaskSensor`
 
 Additional difficulty is that one Dag could wait for or trigger several runs of the other Dag
 with different data intervals. The **Dag Dependencies** view


### PR DESCRIPTION
This pull request updates the documentation in `airflow-core/docs/core-concepts/dags.rst` to correct an import path for a sensor class. The change ensures that the documentation references the correct module for the `ExternalTaskSensor`.

Documentation correction:

* Updated the reference for the "waiting" dependency to use `airflow.providers.standard.sensors.external_task.ExternalTaskSensor` instead of the incorrect `external_task_sensor.ExternalTaskSensor`.

Closes #61540 

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)