### PR TITLE
Fix paused DAG filtering when hide_paused_dags_by_default is enabled

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/DagsFilters.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/DagsFilters.tsx
@@ -75,7 +75,8 @@ export const DagsFilters = () => {
     tagNamePattern: pattern,
   });
 
-  const hidePausedDagsByDefault = Boolean(useConfig("hide_paused_dags_by_default"));
+  const configValue = useConfig("hide_paused_dags_by_default");
+  const hidePausedDagsByDefault = configValue === true || configValue === "true";
   const defaultShowPaused: BooleanFilterValue = hidePausedDagsByDefault ? "false" : "all";
 
   const { setTableURLState, tableURLState } = useTableURLState();

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -206,8 +206,8 @@ export const DagsList = () => {
   const [display, setDisplay] = useLocalStorage<"card" | "table">(DAGS_LIST_DISPLAY, "card");
   const dagRunsLimit = display === "card" ? 14 : 1;
 
-  const hidePausedDagsByDefault = Boolean(useConfig("hide_paused_dags_by_default"));
-  const defaultShowPaused = hidePausedDagsByDefault ? false : undefined;
+  const configValue = useConfig("hide_paused_dags_by_default");
+  const hidePausedDagsByDefault = configValue === true || configValue === "true";
 
   const showPaused = searchParams.get(PAUSED);
   const showFavorites = searchParams.get(FAVORITE);
@@ -242,16 +242,18 @@ export const DagsList = () => {
     setSearchParams(searchParams);
   };
 
-  let paused = defaultShowPaused;
+  let paused: boolean | undefined;
   let isFavorite = undefined;
   let pendingHitl = undefined;
 
-  if (showPaused === "all") {
-    paused = undefined;
-  } else if (showPaused === "true") {
+  if (showPaused === "true") {
     paused = true;
   } else if (showPaused === "false") {
     paused = false;
+  } else if (showPaused === null && hidePausedDagsByDefault) {
+    paused = false;
+  } else {
+    paused = undefined;
   }
 
   if (showFavorites === "true") {


### PR DESCRIPTION
Fixes #61504

When `hide_paused_dags_by_default` is enabled, selecting the “All” paused filter
incorrectly continues to hide paused DAGs.

This change ensures that:
- The configuration only affects the default behavior when no filter is selected
- Explicit user-selected filters always take precedence over defaults
- The “All” filter consistently displays both active and paused DAGs

No UI changes were required. The fix is limited to default filter handling and
backend query parameter resolution.