### PR TITLE
fix: allow list/dict variable values in JSON and YAML import

### DIFF
--- a/airflow-core/src/airflow/secrets/local_filesystem.py
+++ b/airflow-core/src/airflow/secrets/local_filesystem.py
@@ -231,7 +231,7 @@ def _create_connection(conn_id: str, value: Any):
     )
 
 
-def load_variables(file_path: str) -> dict[str, str]:
+def load_variables(file_path: str) -> dict[str, Any]:
     """
     Load variables from a text file.
 
@@ -242,10 +242,25 @@ def load_variables(file_path: str) -> dict[str, str]:
     log.debug("Loading variables from a text file")
 
     secrets = _parse_secret_file(file_path)
-    invalid_keys = [key for key, values in secrets.items() if isinstance(values, list) and len(values) != 1]
-    if invalid_keys:
-        raise VariableNotUnique(f'The "{file_path}" file contains multiple values for keys: {invalid_keys}')
-    variables = {key: values[0] if isinstance(values, list) else values for key, values in secrets.items()}
+    ext = Path(file_path).suffix.lstrip(".").lower()
+
+    if ext == "env":
+        # .env files use lists to represent duplicate keys (a key appearing multiple times).
+        # A list with more than one element means the same key was defined multiple times.
+        invalid_keys = [
+            key for key, values in secrets.items() if isinstance(values, list) and len(values) != 1
+        ]
+        if invalid_keys:
+            raise VariableNotUnique(
+                f'The "{file_path}" file contains multiple values for keys: {invalid_keys}'
+            )
+        variables = {
+            key: values[0] if isinstance(values, list) else values for key, values in secrets.items()
+        }
+    else:
+        # For JSON and YAML files, values are returned as-is. Non-string values
+        # (lists, dicts, numbers, booleans) are valid variable values.
+        variables = dict(secrets)
     log.debug("Loaded %d variables: ", len(variables))
     return variables
 
@@ -326,7 +341,10 @@ class LocalFilesystemBackend(BaseSecretsBackend, LoggingMixin):
             # The user may not specify any file.
             return {}
         secrets = load_variables(self.variables_file)
-        return secrets
+        # Serialize non-string values to JSON strings for the secrets backend interface.
+        return {
+            key: json.dumps(value) if not isinstance(value, str) else value for key, value in secrets.items()
+        }
 
     @property
     def _local_connections(self) -> dict[str, Connection]:

--- a/airflow-core/tests/unit/always/test_secrets_local_filesystem.py
+++ b/airflow-core/tests/unit/always/test_secrets_local_filesystem.py
@@ -121,6 +121,18 @@ class TestLoadVariables:
             ({}, {}),
             ({"KEY": "AAA"}, {"KEY": "AAA"}),
             ({"KEY_A": "AAA", "KEY_B": "BBB"}, {"KEY_A": "AAA", "KEY_B": "BBB"}),
+            (
+                {"KEY_LIST": [{"foo": "bar"}, {"bar": "foo"}]},
+                {"KEY_LIST": [{"foo": "bar"}, {"bar": "foo"}]},
+            ),
+            (
+                {"KEY_STR": "hello", "KEY_LIST": [1, 2, 3]},
+                {"KEY_STR": "hello", "KEY_LIST": [1, 2, 3]},
+            ),
+            (
+                {"KEY_INT": 42, "KEY_BOOL": True},
+                {"KEY_INT": 42, "KEY_BOOL": True},
+            ),
         ],
     )
     def test_json_file_should_load_variables(self, file_content, expected_variables):
@@ -151,6 +163,14 @@ class TestLoadVariables:
             KEY_B: BBB
             """,
                 {"KEY_A": "AAA", "KEY_B": "BBB"},
+            ),
+            (
+                """
+            KEY_LIST:
+                - foo: bar
+                - bar: foo
+            """,
+                {"KEY_LIST": [{"foo": "bar"}, {"bar": "foo"}]},
             ),
         ],
     )


### PR DESCRIPTION
## Summary

- Fixes `airflow variables import` rejecting JSON/YAML files where a variable value is a list with multiple items (e.g., `[{"foo": "bar"}, {"bar": "foo"}]`)
- The duplicate-key check in `load_variables()` was designed for `.env` files but incorrectly applied to JSON/YAML, where list values are legitimate variable data
- This caused a round-trip failure: `airflow variables export` could produce files that `airflow variables import` refused to load

## Details

The `_parse_env_file` parser wraps values in lists when a key appears multiple times, so `isinstance(values, list) and len(values) != 1` correctly detects duplicate keys for `.env` files. However, `_parse_json_file` and `_parse_yaml_file` return raw parsed values, so a list value like `[{"foo": "bar"}, {"bar": "foo"}]` was incorrectly flagged as "multiple values for a key."

The fix limits the duplicate-key check to `.env` files only and passes JSON/YAML values through as-is. The `LocalFilesystemBackend._local_variables` property now condenses non-string values to JSON strings to maintain the `str` return type contract for the secrets backend interface.

## Test plan

Added parametrized tests for JSON files with list, int, and bool variable values
Added parametrized test for YAML files with list variable values
All 76 existing + new tests pass
 Pre-commit checks pass (ruff, codespell, bandit, etc.)

Closes #61490