### PR TITLE
Add LOG_MAX_SIZE environment variables to log groomer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1641,21 +1641,49 @@ set -euo pipefail
 readonly DIRECTORY="${AIRFLOW_HOME:-/usr/local/airflow}"
 readonly RETENTION="${AIRFLOW__LOG_RETENTION_DAYS:-15}"
 readonly FREQUENCY="${AIRFLOW__LOG_CLEANUP_FREQUENCY_MINUTES:-15}"
+readonly MAX_PERCENT="${AIRFLOW__LOG_MAX_SIZE_PERCENT:-0}"
 
 trap "exit" INT TERM
+
+MAX_SIZE_BYTES="${AIRFLOW__LOG_MAX_SIZE_BYTES:-0}"
+if [[ "$MAX_SIZE_BYTES" -eq 0 && "$MAX_PERCENT" -gt 0 ]]; then
+  total_space=$(df -k "${DIRECTORY}"/logs 2>/dev/null | tail -1 | awk '{print $2}' || echo "0")
+  MAX_SIZE_BYTES=$(( total_space * 1024 * MAX_PERCENT / 100 ))
+  echo "Computed MAX_SIZE_BYTES from ${MAX_PERCENT}% of disk: ${MAX_SIZE_BYTES} bytes"
+fi
+
+readonly MAX_SIZE_BYTES
 
 readonly EVERY=$((FREQUENCY*60))
 
 echo "Cleaning logs every $EVERY seconds"
+if [[ "$MAX_SIZE_BYTES" -gt 0 ]]; then
+  echo "Max log size limit: $MAX_SIZE_BYTES bytes"
+fi
+
+retention_days="${RETENTION}"
 
 while true; do
-  echo "Trimming airflow logs to ${RETENTION} days."
+  echo "Trimming airflow logs to ${retention_days} days."
   find "${DIRECTORY}"/logs \
     -type d -name 'lost+found' -prune -o \
-    -type f -mtime +"${RETENTION}" -name '*.log' -print0 | \
+    -type f -mtime +"${retention_days}" -name '*.log' -print0 | \
     xargs -0 rm -f || true
 
+  if [[ "$MAX_SIZE_BYTES" -gt 0 && "$retention_days" -ge 0 ]]; then
+    current_size=$(df -k "${DIRECTORY}"/logs 2>/dev/null | tail -1 | awk '{print $3}' || echo "0")
+    current_size=$(( current_size * 1024 ))
+
+    if [[ "$current_size" -gt "$MAX_SIZE_BYTES" ]]; then
+      retention_days=$((retention_days - 1))
+      echo "Size ($current_size bytes) exceeds limit ($MAX_SIZE_BYTES bytes). Reducing retention to ${retention_days} days."
+      continue
+    fi
+  fi
+
   find "${DIRECTORY}"/logs -type d -empty -delete || true
+
+  retention_days="${RETENTION}"
 
   seconds=$(( $(date -u +%s) % EVERY))
   (( seconds < 1 )) || sleep $((EVERY - seconds - 1))

--- a/airflow-core/tests/unit/charts/log_groomer.py
+++ b/airflow-core/tests/unit/charts/log_groomer.py
@@ -218,6 +218,74 @@ class LogGroomerTestBase:
         else:
             assert len(jmespath.search("spec.template.spec.containers[1].env", docs[0])) == 2
 
+    @pytest.mark.parametrize(("max_size_bytes", "max_size_result"), [(None, None), (1234567890, "1234567890")])
+    def test_log_groomer_max_size_bytes_overrides(self, max_size_bytes, max_size_result):
+        if self.obj_name == "dag-processor":
+            values = {
+                "dagProcessor": {
+                    "enabled": True,
+                    "logGroomerSidecar": {"maxSizeBytes": max_size_bytes},
+                }
+            }
+        else:
+            values = {f"{self.folder}": {"logGroomerSidecar": {"maxSizeBytes": max_size_bytes}}}
+
+        docs = render_chart(
+            values=values,
+            show_only=[f"templates/{self.folder}/{self.obj_name}-deployment.yaml"],
+        )
+
+        if max_size_result:
+            assert (
+                jmespath.search(
+                    "spec.template.spec.containers[1].env[?name=='AIRFLOW__LOG_MAX_SIZE_BYTES'].value | [0]",
+                    docs[0],
+                )
+                == max_size_result
+            )
+        else:
+            assert (
+                jmespath.search(
+                    "spec.template.spec.containers[1].env[?name=='AIRFLOW__LOG_MAX_SIZE_BYTES'].value | [0]",
+                    docs[0],
+                )
+                is None
+            )
+
+    @pytest.mark.parametrize(("max_size_percent", "max_size_result"), [(None, None), (80, "80")])
+    def test_log_groomer_max_size_percent_overrides(self, max_size_percent, max_size_result):
+        if self.obj_name == "dag-processor":
+            values = {
+                "dagProcessor": {
+                    "enabled": True,
+                    "logGroomerSidecar": {"maxSizePercent": max_size_percent},
+                }
+            }
+        else:
+            values = {f"{self.folder}": {"logGroomerSidecar": {"maxSizePercent": max_size_percent}}}
+
+        docs = render_chart(
+            values=values,
+            show_only=[f"templates/{self.folder}/{self.obj_name}-deployment.yaml"],
+        )
+
+        if max_size_result:
+            assert (
+                jmespath.search(
+                    "spec.template.spec.containers[1].env[?name=='AIRFLOW__LOG_MAX_SIZE_PERCENT'].value | [0]",
+                    docs[0],
+                )
+                == max_size_result
+            )
+        else:
+            assert (
+                jmespath.search(
+                    "spec.template.spec.containers[1].env[?name=='AIRFLOW__LOG_MAX_SIZE_PERCENT'].value | [0]",
+                    docs[0],
+                )
+                is None
+            )
+
     def test_log_groomer_resources(self):
         if self.obj_name == "dag-processor":
             values = {

--- a/airflow-core/tests/unit/charts/log_groomer.py
+++ b/airflow-core/tests/unit/charts/log_groomer.py
@@ -218,7 +218,9 @@ class LogGroomerTestBase:
         else:
             assert len(jmespath.search("spec.template.spec.containers[1].env", docs[0])) == 2
 
-    @pytest.mark.parametrize(("max_size_bytes", "max_size_result"), [(None, None), (1234567890, "1234567890")])
+    @pytest.mark.parametrize(
+        ("max_size_bytes", "max_size_result"), [(None, None), (1234567890, "1234567890")]
+    )
     def test_log_groomer_max_size_bytes_overrides(self, max_size_bytes, max_size_result):
         if self.obj_name == "dag-processor":
             values = {

--- a/chart/templates/dag-processor/dag-processor-deployment.yaml
+++ b/chart/templates/dag-processor/dag-processor-deployment.yaml
@@ -219,6 +219,14 @@ spec:
             - name: AIRFLOW__LOG_CLEANUP_FREQUENCY_MINUTES
               value: "{{ .Values.dagProcessor.logGroomerSidecar.frequencyMinutes }}"
           {{- end }}
+          {{- if .Values.dagProcessor.logGroomerSidecar.maxSizeBytes }}
+            - name: AIRFLOW__LOG_MAX_SIZE_BYTES
+              value: "{{ .Values.dagProcessor.logGroomerSidecar.maxSizeBytes | int64 }}"
+          {{- end }}
+          {{- if .Values.dagProcessor.logGroomerSidecar.maxSizePercent }}
+            - name: AIRFLOW__LOG_MAX_SIZE_PERCENT
+              value: "{{ .Values.dagProcessor.logGroomerSidecar.maxSizePercent }}"
+          {{- end }}
             - name: AIRFLOW_HOME
               value: "{{ .Values.airflowHome }}"
           {{- if .Values.dagProcessor.logGroomerSidecar.env }}

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -294,6 +294,14 @@ spec:
             - name: AIRFLOW__LOG_CLEANUP_FREQUENCY_MINUTES
               value: "{{ .Values.scheduler.logGroomerSidecar.frequencyMinutes }}"
           {{- end }}
+          {{- if .Values.scheduler.logGroomerSidecar.maxSizeBytes }}
+            - name: AIRFLOW__LOG_MAX_SIZE_BYTES
+              value: "{{ .Values.scheduler.logGroomerSidecar.maxSizeBytes | int64 }}"
+          {{- end }}
+          {{- if .Values.scheduler.logGroomerSidecar.maxSizePercent }}
+            - name: AIRFLOW__LOG_MAX_SIZE_PERCENT
+              value: "{{ .Values.scheduler.logGroomerSidecar.maxSizePercent }}"
+          {{- end }}
             - name: AIRFLOW_HOME
               value: "{{ .Values.airflowHome }}"
           {{- if .Values.scheduler.logGroomerSidecar.env }}

--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -254,6 +254,14 @@ spec:
             - name: AIRFLOW__LOG_CLEANUP_FREQUENCY_MINUTES
               value: "{{ .Values.triggerer.logGroomerSidecar.frequencyMinutes }}"
           {{- end }}
+          {{- if .Values.triggerer.logGroomerSidecar.maxSizeBytes }}
+            - name: AIRFLOW__LOG_MAX_SIZE_BYTES
+              value: "{{ .Values.triggerer.logGroomerSidecar.maxSizeBytes | int64 }}"
+          {{- end }}
+          {{- if .Values.triggerer.logGroomerSidecar.maxSizePercent }}
+            - name: AIRFLOW__LOG_MAX_SIZE_PERCENT
+              value: "{{ .Values.triggerer.logGroomerSidecar.maxSizePercent }}"
+          {{- end }}
             - name: AIRFLOW_HOME
               value: "{{ .Values.airflowHome }}"
           {{- if .Values.triggerer.logGroomerSidecar.env }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -365,6 +365,14 @@ spec:
             - name: AIRFLOW__LOG_CLEANUP_FREQUENCY_MINUTES
               value: "{{ .Values.workers.logGroomerSidecar.frequencyMinutes }}"
           {{- end }}
+          {{- if .Values.workers.logGroomerSidecar.maxSizeBytes }}
+            - name: AIRFLOW__LOG_MAX_SIZE_BYTES
+              value: "{{ .Values.workers.logGroomerSidecar.maxSizeBytes | int64 }}"
+          {{- end }}
+          {{- if .Values.workers.logGroomerSidecar.maxSizePercent }}
+            - name: AIRFLOW__LOG_MAX_SIZE_PERCENT
+              value: "{{ .Values.workers.logGroomerSidecar.maxSizePercent }}"
+          {{- end }}
             - name: AIRFLOW_HOME
               value: "{{ .Values.airflowHome }}"
           {{- if .Values.workers.logGroomerSidecar.env }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -13732,6 +13732,19 @@
                     "type": "integer",
                     "default": 15
                 },
+                "maxSizeBytes": {
+                    "description": "Max size of logs directory in bytes. When exceeded, the log groomer reduces retention until size is under limit. 0 = disabled.",
+                    "type": "integer",
+                    "default": 0,
+                    "minimum": 0
+                },
+                "maxSizePercent": {
+                    "description": "Max size of logs as a percentage of total disk space. When exceeded, the log groomer reduces retention until size is under limit. 0 = disabled. Ignored if maxSizeBytes is set.",
+                    "type": "integer",
+                    "default": 0,
+                    "minimum": 0,
+                    "maximum": 100
+                },
                 "env": {
                     "description": "Add additional env vars to log groomer sidecar container (templated).",
                     "items": {

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -984,6 +984,12 @@ workers:
     # Frequency to attempt to groom logs (in minutes)
     frequencyMinutes: 15
 
+    # Max size of logs in bytes. 0 = disabled
+    maxSizeBytes: 0
+
+    # Max size of logs as a percent of disk usage. 0 = disabled. Ignored if maxSizeBytes is set.
+    maxSizePercent: 0
+
     resources: {}
     #  limits:
     #   cpu: 100m
@@ -1363,6 +1369,10 @@ scheduler:
     retentionDays: 15
     # frequency to attempt to groom logs, in minutes
     frequencyMinutes: 15
+    # Max size of logs in bytes. 0 = disabled
+    maxSizeBytes: 0
+    # Max size of logs as a percent of disk usage. 0 = disabled. Ignored if maxSizeBytes is set.
+    maxSizePercent: 0
     resources: {}
     #  limits:
     #   cpu: 100m
@@ -2203,6 +2213,10 @@ triggerer:
     retentionDays: 15
     # frequency to attempt to groom logs, in minutes
     frequencyMinutes: 15
+    # Max size of logs in bytes. 0 = disabled
+    maxSizeBytes: 0
+    # Max size of logs as a percent of disk usage. 0 = disabled. Ignored if maxSizeBytes is set.
+    maxSizePercent: 0
     resources: {}
     #  limits:
     #   cpu: 100m
@@ -2429,6 +2443,10 @@ dagProcessor:
     retentionDays: 15
     # frequency to attempt to groom logs, in minutes
     frequencyMinutes: 15
+    # Max size of logs in bytes. 0 = disabled
+    maxSizeBytes: 0
+    # Max size of logs as a percent of disk usage. 0 = disabled. Ignored if maxSizeBytes is set.
+    maxSizePercent: 0
     resources: {}
     #  limits:
     #   cpu: 100m

--- a/helm-tests/tests/chart_utils/log_groomer.py
+++ b/helm-tests/tests/chart_utils/log_groomer.py
@@ -219,6 +219,74 @@ class LogGroomerTestBase:
         else:
             assert len(jmespath.search("spec.template.spec.containers[1].env", docs[0])) == 2
 
+    @pytest.mark.parametrize(("max_size_bytes", "max_size_result"), [(None, None), (1234567890, "1234567890")])
+    def test_log_groomer_max_size_bytes_overrides(self, max_size_bytes, max_size_result):
+        if self.obj_name == "dag-processor":
+            values = {
+                "dagProcessor": {
+                    "enabled": True,
+                    "logGroomerSidecar": {"maxSizeBytes": max_size_bytes},
+                }
+            }
+        else:
+            values = {f"{self.folder}": {"logGroomerSidecar": {"maxSizeBytes": max_size_bytes}}}
+
+        docs = render_chart(
+            values=values,
+            show_only=[f"templates/{self.folder}/{self.obj_name}-deployment.yaml"],
+        )
+
+        if max_size_result:
+            assert (
+                jmespath.search(
+                    "spec.template.spec.containers[1].env[?name=='AIRFLOW__LOG_MAX_SIZE_BYTES'].value | [0]",
+                    docs[0],
+                )
+                == max_size_result
+            )
+        else:
+            assert (
+                jmespath.search(
+                    "spec.template.spec.containers[1].env[?name=='AIRFLOW__LOG_MAX_SIZE_BYTES'].value | [0]",
+                    docs[0],
+                )
+                is None
+            )
+
+    @pytest.mark.parametrize(("max_size_percent", "max_size_result"), [(None, None), (80, "80")])
+    def test_log_groomer_max_size_percent_overrides(self, max_size_percent, max_size_result):
+        if self.obj_name == "dag-processor":
+            values = {
+                "dagProcessor": {
+                    "enabled": True,
+                    "logGroomerSidecar": {"maxSizePercent": max_size_percent},
+                }
+            }
+        else:
+            values = {f"{self.folder}": {"logGroomerSidecar": {"maxSizePercent": max_size_percent}}}
+
+        docs = render_chart(
+            values=values,
+            show_only=[f"templates/{self.folder}/{self.obj_name}-deployment.yaml"],
+        )
+
+        if max_size_result:
+            assert (
+                jmespath.search(
+                    "spec.template.spec.containers[1].env[?name=='AIRFLOW__LOG_MAX_SIZE_PERCENT'].value | [0]",
+                    docs[0],
+                )
+                == max_size_result
+            )
+        else:
+            assert (
+                jmespath.search(
+                    "spec.template.spec.containers[1].env[?name=='AIRFLOW__LOG_MAX_SIZE_PERCENT'].value | [0]",
+                    docs[0],
+                )
+                is None
+            )
+
     def test_log_groomer_resources(self):
         if self.obj_name == "dag-processor":
             values = {

--- a/helm-tests/tests/chart_utils/log_groomer.py
+++ b/helm-tests/tests/chart_utils/log_groomer.py
@@ -219,7 +219,9 @@ class LogGroomerTestBase:
         else:
             assert len(jmespath.search("spec.template.spec.containers[1].env", docs[0])) == 2
 
-    @pytest.mark.parametrize(("max_size_bytes", "max_size_result"), [(None, None), (1234567890, "1234567890")])
+    @pytest.mark.parametrize(
+        ("max_size_bytes", "max_size_result"), [(None, None), (1234567890, "1234567890")]
+    )
     def test_log_groomer_max_size_bytes_overrides(self, max_size_bytes, max_size_result):
         if self.obj_name == "dag-processor":
             values = {

--- a/scripts/docker/clean-logs.sh
+++ b/scripts/docker/clean-logs.sh
@@ -22,9 +22,18 @@ set -euo pipefail
 readonly DIRECTORY="${AIRFLOW_HOME:-/usr/local/airflow}"
 readonly RETENTION="${AIRFLOW__LOG_RETENTION_DAYS:-15}"
 readonly FREQUENCY="${AIRFLOW__LOG_CLEANUP_FREQUENCY_MINUTES:-15}"
-readonly MAX_SIZE_BYTES="${AIRFLOW__LOG_MAX_SIZE_BYTES:-0}"
+readonly MAX_PERCENT="${AIRFLOW__LOG_MAX_SIZE_PERCENT:-0}"
 
 trap "exit" INT TERM
+
+MAX_SIZE_BYTES="${AIRFLOW__LOG_MAX_SIZE_BYTES:-0}"
+if [[ "$MAX_SIZE_BYTES" -eq 0 && "$MAX_PERCENT" -gt 0 ]]; then
+  total_space=$(df -k "${DIRECTORY}"/logs 2>/dev/null | tail -1 | awk '{print $2}' || echo "0")
+  MAX_SIZE_BYTES=$(( total_space * 1024 * MAX_PERCENT / 100 ))
+  echo "Computed MAX_SIZE_BYTES from ${MAX_PERCENT}% of disk: ${MAX_SIZE_BYTES} bytes"
+fi
+
+readonly MAX_SIZE_BYTES
 
 readonly EVERY=$((FREQUENCY*60))
 
@@ -43,7 +52,8 @@ while true; do
     xargs -0 rm -f || true
 
   if [[ "$MAX_SIZE_BYTES" -gt 0 && "$retention_days" -ge 0 ]]; then
-    current_size=$(du -sb "${DIRECTORY}"/logs 2>/dev/null | cut -f1 || echo "0")
+    current_size=$(df -k "${DIRECTORY}"/logs 2>/dev/null | tail -1 | awk '{print $3}' || echo "0")
+    current_size=$(( current_size * 1024 ))
 
     if [[ "$current_size" -gt "$MAX_SIZE_BYTES" ]]; then
       retention_days=$((retention_days - 1))

--- a/scripts/docker/clean-logs.sh
+++ b/scripts/docker/clean-logs.sh
@@ -22,21 +22,39 @@ set -euo pipefail
 readonly DIRECTORY="${AIRFLOW_HOME:-/usr/local/airflow}"
 readonly RETENTION="${AIRFLOW__LOG_RETENTION_DAYS:-15}"
 readonly FREQUENCY="${AIRFLOW__LOG_CLEANUP_FREQUENCY_MINUTES:-15}"
+readonly MAX_SIZE_BYTES="${AIRFLOW__LOG_MAX_SIZE_BYTES:-0}"
 
 trap "exit" INT TERM
 
 readonly EVERY=$((FREQUENCY*60))
 
 echo "Cleaning logs every $EVERY seconds"
+if [[ "$MAX_SIZE_BYTES" -gt 0 ]]; then
+  echo "Max log size limit: $MAX_SIZE_BYTES bytes"
+fi
+
+retention_days="${RETENTION}"
 
 while true; do
-  echo "Trimming airflow logs to ${RETENTION} days."
+  echo "Trimming airflow logs to ${retention_days} days."
   find "${DIRECTORY}"/logs \
     -type d -name 'lost+found' -prune -o \
-    -type f -mtime +"${RETENTION}" -name '*.log' -print0 | \
+    -type f -mtime +"${retention_days}" -name '*.log' -print0 | \
     xargs -0 rm -f || true
 
+  if [[ "$MAX_SIZE_BYTES" -gt 0 && "$retention_days" -ge 0 ]]; then
+    current_size=$(du -sb "${DIRECTORY}"/logs 2>/dev/null | cut -f1 || echo "0")
+
+    if [[ "$current_size" -gt "$MAX_SIZE_BYTES" ]]; then
+      retention_days=$((retention_days - 1))
+      echo "Size ($current_size bytes) exceeds limit ($MAX_SIZE_BYTES bytes). Reducing retention to ${retention_days} days."
+      continue
+    fi
+  fi
+
   find "${DIRECTORY}"/logs -type d -empty -delete || true
+
+  retention_days="${RETENTION}"
 
   seconds=$(( $(date -u +%s) % EVERY))
   (( seconds < 1 )) || sleep $((EVERY - seconds - 1))


### PR DESCRIPTION
Adds two optional environment variables to the `clean-logs.sh` script to to delete logs once a `AIRFLOW__LOG_MAX_SIZE_PERCENT` threshold has been breached or a `AIRFLOW__LOG_MAX_SIZE_BYTES` has been breached. If either environment variable is present and the threshold has been breached the retention days is reduced until the threshold is met and then resets. This makes it easier to avoid out of disk space issues.

`airflow-core/tests/unit/charts/log_groomer.py` was updated in parallel with `helm-tests/tests/chart_utils/log_groomer.py` but both files appear to be duplicates of one another. Removing the `airflow-core/tests/unit/charts/log_groomer.py` files felt out of scope for this PR but I'm happy to delete it if it's no longer in use.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: [Cursor + Claude Opus 4.5] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

The code has been heavily modified after generation and has been reviewed by a human (me). Code has been tested in our local environment.

