### PR TITLE
Fix/expose taskinstance api 60478

### DIFF
--- a/task-sdk/docs/api.rst
+++ b/task-sdk/docs/api.rst
@@ -117,7 +117,7 @@ Tasks & Operators
 -----------------
 .. autoapiclass:: airflow.sdk.TaskGroup
 
-.. autoapiclass:: airflow.sdk.TaskInstance
+
 
 .. autoapiclass:: airflow.sdk.XComArg
 
@@ -240,7 +240,7 @@ Everything else
 .. autoapimodule:: airflow.sdk
   :members:
   :special-members: __version__
-  :exclude-members: BaseAsyncOperator, BaseOperator, DAG, dag, asset, Asset, AssetAlias, AssetAll, AssetAny, AssetWatcher, TaskGroup, TaskInstance, XComArg, get_current_context, get_parsing_context
+  :exclude-members: BaseAsyncOperator, BaseOperator, DAG, dag, asset, Asset, AssetAlias, AssetAll, AssetAny, AssetWatcher, TaskGroup, XComArg, get_current_context, get_parsing_context
   :undoc-members:
   :imported-members:
   :no-index:

--- a/task-sdk/docs/api.rst
+++ b/task-sdk/docs/api.rst
@@ -117,7 +117,7 @@ Tasks & Operators
 -----------------
 .. autoapiclass:: airflow.sdk.TaskGroup
 
-
+.. autoapiclass:: airflow.sdk.TaskInstance
 
 .. autoapiclass:: airflow.sdk.XComArg
 
@@ -240,7 +240,7 @@ Everything else
 .. autoapimodule:: airflow.sdk
   :members:
   :special-members: __version__
-  :exclude-members: BaseAsyncOperator, BaseOperator, DAG, dag, asset, Asset, AssetAlias, AssetAll, AssetAny, AssetWatcher, TaskGroup, XComArg, get_current_context, get_parsing_context
+  :exclude-members: BaseAsyncOperator, BaseOperator, DAG, dag, asset, Asset, AssetAlias, AssetAll, AssetAny, AssetWatcher, TaskGroup, TaskInstance, XComArg, get_current_context, get_parsing_context
   :undoc-members:
   :imported-members:
   :no-index:

--- a/task-sdk/docs/api.rst
+++ b/task-sdk/docs/api.rst
@@ -117,7 +117,7 @@ Tasks & Operators
 -----------------
 .. autoapiclass:: airflow.sdk.TaskGroup
 
-.. autoapiclass:: airflow.sdk.TaskInstance
+.. autoclass:: airflow.sdk.TaskInstance
 
 .. autoapiclass:: airflow.sdk.XComArg
 

--- a/task-sdk/docs/api.rst
+++ b/task-sdk/docs/api.rst
@@ -117,6 +117,8 @@ Tasks & Operators
 -----------------
 .. autoapiclass:: airflow.sdk.TaskGroup
 
+.. autoapiclass:: airflow.sdk.TaskInstance
+
 .. autoapiclass:: airflow.sdk.XComArg
 
 .. autoapifunction:: airflow.sdk.literal

--- a/task-sdk/docs/api.rst
+++ b/task-sdk/docs/api.rst
@@ -240,7 +240,7 @@ Everything else
 .. autoapimodule:: airflow.sdk
   :members:
   :special-members: __version__
-  :exclude-members: BaseAsyncOperator, BaseOperator, DAG, dag, asset, Asset, AssetAlias, AssetAll, AssetAny, AssetWatcher, TaskGroup, XComArg, get_current_context, get_parsing_context
+  :exclude-members: BaseAsyncOperator, BaseOperator, DAG, dag, asset, Asset, AssetAlias, AssetAll, AssetAny, AssetWatcher, TaskGroup, TaskInstance, XComArg, get_current_context, get_parsing_context
   :undoc-members:
   :imported-members:
   :no-index:

--- a/task-sdk/src/airflow/sdk/__init__.py
+++ b/task-sdk/src/airflow/sdk/__init__.py
@@ -62,6 +62,7 @@ __all__ = [
     "QuarterlyMapper",
     "SyncCallback",
     "TaskGroup",
+    "TaskInstance",
     "TaskInstanceState",
     "Trace",
     "TriggerRule",
@@ -146,6 +147,7 @@ if TYPE_CHECKING:
     from airflow.sdk.execution_time import macros
     from airflow.sdk.io.path import ObjectStoragePath
     from airflow.sdk.observability.trace import Trace
+    from airflow.sdk.types import TaskInstance
 
     conf: AirflowSDKConfigParser
 
@@ -193,6 +195,7 @@ __lazy_imports: dict[str, str] = {
     "SecretCache": ".execution_time.cache",
     "SyncCallback": ".definitions.callback",
     "TaskGroup": ".definitions.taskgroup",
+    "TaskInstance": ".types",
     "TaskInstanceState": ".api.datamodels._generated",
     "Trace": ".observability.trace",
     "TriggerRule": ".api.datamodels._generated",

--- a/task-sdk/src/airflow/sdk/types.py
+++ b/task-sdk/src/airflow/sdk/types.py
@@ -24,8 +24,6 @@ from typing import TYPE_CHECKING, Any, NamedTuple, Protocol, TypeAlias
 from airflow.sdk.bases.xcom import BaseXCom
 from airflow.sdk.definitions._internal.types import NOTSET, ArgNotSet
 
-__all__ = ["TaskInstance", "TaskInstanceKey"]
-
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
@@ -168,13 +166,8 @@ class RuntimeTaskInstanceProtocol(Protocol):
 
 
 # Public alias for RuntimeTaskInstanceProtocol
-class TaskInstance(RuntimeTaskInstanceProtocol):
-    """
-    Protocol for TaskInstance available during runtime.
-
-    This class provides the interface for interacting with TaskInstance attributes
-    and methods (like xcom_pull/push) within the Task SDK.
-    """
+class TaskInstance(RuntimeTaskInstanceProtocol, Protocol):
+    """Public alias for RuntimeTaskInstanceProtocol."""
 
 
 class OutletEventAccessorProtocol(Protocol):

--- a/task-sdk/src/airflow/sdk/types.py
+++ b/task-sdk/src/airflow/sdk/types.py
@@ -165,6 +165,10 @@ class RuntimeTaskInstanceProtocol(Protocol):
     def get_dagrun_state(dag_id: str, run_id: str) -> str: ...
 
 
+# Public alias for RuntimeTaskInstanceProtocol
+TaskInstance = RuntimeTaskInstanceProtocol
+
+
 class OutletEventAccessorProtocol(Protocol):
     """Protocol for managing access to a specific outlet event accessor."""
 

--- a/task-sdk/src/airflow/sdk/types.py
+++ b/task-sdk/src/airflow/sdk/types.py
@@ -166,7 +166,8 @@ class RuntimeTaskInstanceProtocol(Protocol):
 
 
 # Public alias for RuntimeTaskInstanceProtocol
-TaskInstance = RuntimeTaskInstanceProtocol
+class TaskInstance(RuntimeTaskInstanceProtocol, Protocol):
+    """Public alias for RuntimeTaskInstanceProtocol."""
 
 
 class OutletEventAccessorProtocol(Protocol):

--- a/task-sdk/src/airflow/sdk/types.py
+++ b/task-sdk/src/airflow/sdk/types.py
@@ -24,6 +24,8 @@ from typing import TYPE_CHECKING, Any, NamedTuple, Protocol, TypeAlias
 from airflow.sdk.bases.xcom import BaseXCom
 from airflow.sdk.definitions._internal.types import NOTSET, ArgNotSet
 
+__all__ = ["TaskInstance", "TaskInstanceKey"]
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
@@ -166,8 +168,13 @@ class RuntimeTaskInstanceProtocol(Protocol):
 
 
 # Public alias for RuntimeTaskInstanceProtocol
-class TaskInstance(RuntimeTaskInstanceProtocol, Protocol):
-    """Public alias for RuntimeTaskInstanceProtocol."""
+class TaskInstance(RuntimeTaskInstanceProtocol):
+    """
+    Protocol for TaskInstance available during runtime.
+
+    This class provides the interface for interacting with TaskInstance attributes
+    and methods (like xcom_pull/push) within the Task SDK.
+    """
 
 
 class OutletEventAccessorProtocol(Protocol):

--- a/task-sdk/tests/task_sdk/docs/test_public_api.py
+++ b/task-sdk/tests/task_sdk/docs/test_public_api.py
@@ -64,6 +64,7 @@ def test_airflow_sdk_no_unexpected_exports():
         "crypto",
         "providers_manager_runtime",
         "lineage",
+        "types",
     }
     unexpected = actual - public - ignore
     assert not unexpected, f"Unexpected exports in airflow.sdk: {sorted(unexpected)}"


### PR DESCRIPTION
Closes #60478

This PR exposes TaskInstance in the Task SDK public API.

It aliases RuntimeTaskInstanceProtocol to TaskInstance in airflow.sdk.types, and exports it via airflow.sdk so that it is available for import by DAG authors and custom operator developers.

This allows users to use from airflow.sdk import TaskInstance for type hinting, consistent with the public API documentation.