### PR TITLE
Fix/azure sso configurable role key

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/app.py
@@ -182,7 +182,7 @@ def init_middlewares(app: FastAPI) -> None:
         app.add_middleware(SimpleAllAdminMiddleware)
 
     # The GzipMiddleware should be the last middleware added as https://github.com/apache/airflow/issues/60165 points out.
-    app.add_middleware(GZipMiddleware, minimum_size=1024, compresslevel=5)
     # Compress responses greater than 1kB with optimal compression level as 5
     # with level ranging from 1 to 9 with 1 (fastest, least compression)
     # and 9 (slowest, most compression)
+    app.add_middleware(GZipMiddleware, minimum_size=1024, compresslevel=5)

--- a/providers/fab/docs/auth-manager/sso.rst
+++ b/providers/fab/docs/auth-manager/sso.rst
@@ -204,6 +204,75 @@ Provider Examples
    For Azure app registration and OAuth setup, see :doc:`apache-airflow-providers-microsoft-azure:connections/azure`
    and the `Azure OAuth2 documentation <https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow>`_.
 
+**Azure AD with Group-Based Authorization**
+
+By default, Azure OAuth retrieves user roles from the ``roles`` claim in the ID token.
+However, if your organization uses Azure AD groups instead of app roles for access control,
+you can configure Airflow to read group memberships from the ``groups`` claim.
+
+Add the following to your ``webserver_config.py``:
+
+.. code-block:: python
+
+   from flask_appbuilder.security.manager import AUTH_OAUTH
+
+   AUTH_TYPE = AUTH_OAUTH
+
+   # Configure Azure to use 'groups' claim instead of 'roles'
+   AUTH_OAUTH_ROLE_KEYS = {
+       "azure": "groups",  # Use 'groups' claim from Azure AD token
+   }
+
+   OAUTH_PROVIDERS = [
+       {
+           "name": "azure",
+           "token_key": "access_token",
+           "icon": "fa-windows",
+           "remote_app": {
+               "client_id": "your-client-id",
+               "client_secret": "your-client-secret",
+               "api_base_url": "https://login.microsoftonline.com/<tenant-id>/v2.0",
+               "client_kwargs": {
+                   "scope": "openid email profile groups",  # Include 'groups' scope
+                   "resource": "your-client-id",
+                   "verify_signature": True,
+               },
+               "request_token_url": None,
+               "access_token_url": "https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token",
+               "authorize_url": "https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/authorize",
+           },
+       }
+   ]
+
+   # Map Azure AD group names to Airflow roles
+   AUTH_ROLES_MAPPING = {
+       "airflow-admin-group": ["Admin"],
+       "airflow-op-group": ["Op"],
+       "airflow-user-group": ["User"],
+       "airflow-viewer-group": ["Viewer"],
+   }
+
+   # Automatically sync roles from OAuth groups at login
+   AUTH_ROLES_SYNC_AT_LOGIN = True
+
+   # Allow automatic user registration on first login
+   AUTH_USER_REGISTRATION = True
+   AUTH_USER_REGISTRATION_ROLE = "Viewer"
+
+.. note::
+   When using Azure AD groups:
+
+   - Ensure the ``groups`` scope is included in ``client_kwargs``
+   - Configure group claims in your Azure app registration
+   - The ``AUTH_OAUTH_ROLE_KEYS`` setting allows you to specify which claim field
+     contains the authorization information (``roles`` or ``groups``)
+   - Group names from Azure AD will be matched against ``AUTH_ROLES_MAPPING``
+
+.. important::
+   The ``AUTH_OAUTH_ROLE_KEYS`` configuration is provider-specific. For Azure,
+   you can set it to ``"roles"`` (default) or ``"groups"`` depending on your
+   Azure AD setup. Other OAuth providers may use different field names.
+
 **Google OAuth2**
 
 .. code-block:: bash

--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -2145,12 +2145,15 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
             me = self._decode_and_validate_azure_jwt(resp["id_token"])
             log.debug("User info from Azure: %s", me)
             # https://learn.microsoft.com/en-us/azure/active-directory/develop/id-token-claims-reference#payload-claims
+            # Get the role key field name from config, default to 'roles'
+            # This allows organizations to use 'groups' when Azure AD is configured with group-based access
+            role_key = current_app.config.get("AUTH_OAUTH_ROLE_KEYS", {}).get("azure", "roles")
             return {
                 "email": me["email"] if "email" in me else me["upn"],
                 "first_name": me.get("given_name", ""),
                 "last_name": me.get("family_name", ""),
                 "username": me["oid"],
-                "role_keys": me.get("roles", []),
+                "role_keys": me.get(role_key, []),
             }
         # for OpenShift
         if provider == "openshift":


### PR DESCRIPTION
This PR adds support for configurable role key mapping in Azure OAuth authentication, allowing organizations to use Azure AD groups instead of app roles for access control.

closes: #61567

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
