### PR TITLE
Added functionality to list variable keys w optional prefix filter via task-sdk

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/variable.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/variable.py
@@ -34,3 +34,9 @@ class VariablePostBody(StrictBaseModel):
 
     value: str | None = Field(alias="val")
     description: str | None = Field(default=None)
+
+
+class VariableKeysResponse(StrictBaseModel):
+    """Variable keys list response."""
+
+    keys: list[str]

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/variables.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/variables.py
@@ -23,6 +23,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Path, Request, status
 
 from airflow.api_fastapi.execution_api.datamodels.variable import (
+    VariableKeysResponse,
     VariablePostBody,
     VariableResponse,
 )
@@ -47,12 +48,24 @@ async def has_variable_access(
     return True
 
 
-router = APIRouter(
-    responses={status.HTTP_404_NOT_FOUND: {"description": "Variable not found"}},
-    dependencies=[Depends(has_variable_access)],
-)
+router = APIRouter(responses={status.HTTP_404_NOT_FOUND: {"description": "Variable not found"}})
 
 log = logging.getLogger(__name__)
+
+
+@router.get(
+    "/keys/list",
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {"description": "Unauthorized"},
+        status.HTTP_403_FORBIDDEN: {"description": "Task does not have access to the variable"},
+    },
+)
+def list_keys(
+    prefix: str | None = None,
+    team_name: Annotated[str | None, Depends(get_team_name_dep)] = None,
+    token=JWTBearerDep,
+) -> VariableKeysResponse:
+    return VariableKeysResponse(keys=Variable.list_keys(prefix=prefix, team_name=team_name))
 
 
 @router.get(
@@ -61,6 +74,7 @@ log = logging.getLogger(__name__)
         status.HTTP_401_UNAUTHORIZED: {"description": "Unauthorized"},
         status.HTTP_403_FORBIDDEN: {"description": "Task does not have access to the variable"},
     },
+    dependencies=[Depends(has_variable_access)],
 )
 def get_variable(
     variable_key: str, team_name: Annotated[str | None, Depends(get_team_name_dep)]
@@ -90,6 +104,7 @@ def get_variable(
         status.HTTP_401_UNAUTHORIZED: {"description": "Unauthorized"},
         status.HTTP_403_FORBIDDEN: {"description": "Task does not have access to the variable"},
     },
+    dependencies=[Depends(has_variable_access)],
 )
 def put_variable(
     variable_key: str, body: VariablePostBody, team_name: Annotated[str | None, Depends(get_team_name_dep)]

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -65,6 +65,7 @@ from airflow.sdk.execution_time.comms import (
     GetTaskStates,
     GetTICount,
     GetVariable,
+    GetVariableKeys,
     GetXCom,
     MaskSecret,
     OKResponse,
@@ -73,6 +74,7 @@ from airflow.sdk.execution_time.comms import (
     TaskStatesResult,
     TICount,
     UpdateHITLDetail,
+    VariableKeysResult,
     VariableResult,
     XComResult,
     _new_encoder,
@@ -253,6 +255,7 @@ ToTriggerRunner = Annotated[
     | messages.TriggerStateSync
     | ConnectionResult
     | VariableResult
+    | VariableKeysResult
     | XComResult
     | DagRunStateResult
     | DRCount
@@ -275,6 +278,7 @@ ToTriggerSupervisor = Annotated[
     | DeleteVariable
     | GetVariable
     | PutVariable
+    | GetVariableKeys
     | DeleteXCom
     | GetXCom
     | SetXCom
@@ -463,6 +467,8 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
                 resp = var
         elif isinstance(msg, PutVariable):
             self.client.variables.set(msg.key, msg.value, msg.description)
+        elif isinstance(msg, GetVariableKeys):
+            resp = self.client.variables.list_keys(msg.prefix)
         elif isinstance(msg, DeleteXCom):
             self.client.xcoms.delete(msg.dag_id, msg.run_id, msg.task_id, msg.key, msg.map_index)
         elif isinstance(msg, GetXCom):

--- a/airflow-core/src/airflow/models/variable.py
+++ b/airflow-core/src/airflow/models/variable.py
@@ -525,6 +525,44 @@ class Variable(Base, LoggingMixin):
         return var_val
 
     @staticmethod
+    def list_keys(
+        prefix: str | None = None, team_name: str | None = None, session: Session | None = None
+    ) -> list[str]:
+        """
+        List variable keys, optionally filtered by prefix.
+
+        :param prefix: Prefix to filter keys
+        :param team_name: Team name filter
+        """
+        if hasattr(sys.modules.get("airflow.sdk.execution_time.task_runner"), "SUPERVISOR_COMMS"):
+            warnings.warn(
+                "Using Variable.list_keys from `airflow.models` is deprecated. "
+                "Please use `list_keys` on Variable from sdk(`airflow.sdk.Variable`) instead",
+                DeprecationWarning,
+                stacklevel=1,
+            )
+            from airflow.sdk import Variable as TaskSDKVariable
+
+            return TaskSDKVariable.list_keys(prefix=prefix)
+
+        if team_name and not conf.getboolean("core", "multi_team"):
+            raise ValueError("Multi-team mode is not configured in the Airflow environment")
+
+        ctx: contextlib.AbstractContextManager
+        if session is not None:
+            ctx = contextlib.nullcontext(session)
+        else:
+            ctx = create_session()
+        with ctx as session:
+            stmt = select(Variable.key)
+            if team_name:
+                stmt = stmt.where(or_(Variable.team_name == team_name, Variable.team_name.is_(None)))
+            if prefix:
+                stmt = stmt.where(Variable.key.like(f"{prefix}%"))
+
+            return list(session.scalars(stmt).all())
+
+    @staticmethod
     @provide_session
     def get_team_name(variable_key: str, session=NEW_SESSION) -> str | None:
         stmt = select(Variable.team_name).where(Variable.key == variable_key)

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_variables.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_variables.py
@@ -276,3 +276,29 @@ class TestDeleteVariable:
 
         vars = session.scalars(select(Variable)).all()
         assert len(vars) == 1
+
+
+class TestGetVariableKeys:
+    def test_get_all_keys(self, client, session):
+        Variable.set(key="key1", value="value")
+        Variable.set(key="key2", value="value")
+        response = client.get("/execution/variables/keys/list")
+        keys = session.scalars(select(Variable.key)).all()
+        response_json = response.json()
+        assert len(response_json.get("keys")) == 2
+        assert sorted(response_json.get("keys")) == sorted(keys)
+
+    def test_get_keys_by_prefix(self, client):
+        Variable.set(key="key1", value="value")
+        Variable.set(key="test_key", value="value")
+        Variable.set(key="test_key2", value="value")
+        response = client.get("/execution/variables/keys/list", params={"prefix": "test_"})
+        response_json = response.json()
+        assert len(response_json.get("keys")) == 2
+        assert sorted(response_json.get("keys")) == ["test_key", "test_key2"]
+        assert "key1" not in response_json
+
+    def test_no_keys_with_prefix(self, client):
+        Variable.set(key="key1", value="value")
+        response = client.get("/execution/variables/keys/list", params={"prefix": "api_"})
+        assert not response.json().get("keys")

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -68,6 +68,7 @@ from airflow.sdk.api.datamodels._generated import (
     TITerminalStatePayload,
     TriggerDAGRunPayload,
     ValidationError as RemoteValidationError,
+    VariableKeysResponse,
     VariablePostBody,
     VariableResponse,
     XComResponse,
@@ -452,6 +453,14 @@ class VariableOperations:
         # so we choose to send a generic response to the supervisor over the server response to
         # decouple from the server response string
         return OKResponse(ok=True)
+
+    def list_keys(self, prefix: str | None = None) -> VariableKeysResponse:
+        """List variable keys from the API server."""
+        params = {}
+        if prefix is not None:
+            params["prefix"] = prefix
+        resp = self.client.get("variables/keys/list", params=params)
+        return VariableKeysResponse.model_validate_json(resp.read())
 
 
 class XComOperations:

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -376,6 +376,17 @@ class ValidationError(BaseModel):
     ctx: Annotated[dict[str, Any] | None, Field(title="Context")] = None
 
 
+class VariableKeysResponse(BaseModel):
+    """
+    Variable keys list response.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    keys: Annotated[list[str], Field(title="Keys")]
+
+
 class VariablePostBody(BaseModel):
     """
     Request body schema for creating variables.

--- a/task-sdk/src/airflow/sdk/definitions/variable.py
+++ b/task-sdk/src/airflow/sdk/definitions/variable.py
@@ -76,3 +76,13 @@ class Variable:
             _delete_variable(key=key)
         except AirflowRuntimeError as e:
             log.exception(e)
+
+    @classmethod
+    def list_keys(cls, prefix: str | None = None):
+        from airflow.sdk.exceptions import AirflowRuntimeError
+        from airflow.sdk.execution_time.context import _list_variable_keys
+
+        try:
+            return _list_variable_keys(prefix=prefix)
+        except AirflowRuntimeError as e:
+            log.exception(e)

--- a/task-sdk/src/airflow/sdk/execution_time/comms.py
+++ b/task-sdk/src/airflow/sdk/execution_time/comms.py
@@ -89,6 +89,7 @@ from airflow.sdk.api.datamodels._generated import (
     TISuccessStatePayload,
     TriggerDAGRunPayload,
     UpdateHITLDetailPayload,
+    VariableKeysResponse,
     VariableResponse,
     XComResponse,
     XComSequenceIndexResponse,
@@ -544,6 +545,14 @@ class VariableResult(VariableResponse):
         return cls(**variable_response.model_dump(exclude_defaults=True), type="VariableResult")
 
 
+class VariableKeysResult(VariableKeysResponse):
+    type: Literal["VariableKeysResult"] = "VariableKeysResult"
+
+    @classmethod
+    def from_api_response(cls, response: VariableKeysResponse) -> VariableKeysResult:
+        return cls(**response.model_dump(exclude_defaults=True), type="VariableKeysResult")
+
+
 class DagRunResult(DagRun):
     type: Literal["DagRunResult"] = "DagRunResult"
 
@@ -711,6 +720,7 @@ ToTask = Annotated[
     | TaskBreadcrumbsResult
     | TaskStatesResult
     | VariableResult
+    | VariableKeysResult
     | XComCountResponse
     | XComResult
     | XComSequenceIndexResult
@@ -854,6 +864,11 @@ class PutVariable(BaseModel):
 class DeleteVariable(BaseModel):
     key: str
     type: Literal["DeleteVariable"] = "DeleteVariable"
+
+
+class GetVariableKeys(BaseModel):
+    prefix: str | None = None
+    type: Literal["GetVariableKeys"] = "GetVariableKeys"
 
 
 class ResendLoggingFD(BaseModel):
@@ -1021,6 +1036,7 @@ class MaskSecret(BaseModel):
 ToSupervisor = Annotated[
     DeferTask
     | DeleteXCom
+    | GetVariableKeys
     | GetAssetByName
     | GetAssetByUri
     | GetAssetEventByAsset

--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -341,6 +341,26 @@ def _delete_variable(key: str) -> None:
     SecretCache.invalidate_variable(key)
 
 
+def _list_variable_keys(prefix: str | None = None) -> list[str]:
+    from airflow.sdk.execution_time.supervisor import ensure_secrets_backend_loaded
+
+    backends = ensure_secrets_backend_loaded()
+    all_keys: set[str] = set()
+    for secrets_backend in backends:
+        try:
+            if hasattr(secrets_backend, "list_variable_keys"):
+                keys = secrets_backend.list_variable_keys(prefix=prefix)
+                if keys:
+                    all_keys.update(keys)
+        except Exception:
+            log.exception(
+                "Unable to list variable keys from secrets backend (%s).",
+                type(secrets_backend).__name__,
+            )
+
+    return list(all_keys)
+
+
 class ConnectionAccessor:
     """Wrapper to access Connection entries in template."""
 

--- a/task-sdk/src/airflow/sdk/execution_time/secrets/execution_api.py
+++ b/task-sdk/src/airflow/sdk/execution_time/secrets/execution_api.py
@@ -118,6 +118,21 @@ class ExecutionAPISecretsBackend(BaseSecretsBackend):
             # to allow fallback to other backends
             return None
 
+    def list_variable_keys(self, prefix: str | None = None, team_name: str | None = None) -> list | None:
+        from airflow.sdk.execution_time.comms import ErrorResponse, GetVariableKeys, VariableKeysResult
+        from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
+
+        try:
+            msg = SUPERVISOR_COMMS.send(GetVariableKeys(prefix=prefix))
+            if isinstance(msg, ErrorResponse):
+                return None
+            if isinstance(msg, VariableKeysResult):
+                return msg.keys
+        except Exception:
+            # If SUPERVISOR_COMMS fails for any reason, return None
+            # to allow fallback to other backends
+            return None
+
     async def aget_connection(self, conn_id: str) -> Connection | None:  # type: ignore[override]
         """
         Return connection object asynchronously via SUPERVISOR_COMMS.

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -88,6 +88,7 @@ from airflow.sdk.execution_time.comms import (
     GetTaskStates,
     GetTICount,
     GetVariable,
+    GetVariableKeys,
     GetXCom,
     GetXComCount,
     GetXComSequenceItem,
@@ -113,6 +114,7 @@ from airflow.sdk.execution_time.comms import (
     ToSupervisor,
     TriggerDagRun,
     ValidateInletsAndOutlets,
+    VariableKeysResult,
     VariableResult,
     XComResult,
     XComSequenceIndexResult,
@@ -1276,6 +1278,9 @@ class ActivitySubprocess(WatchedSubprocess):
                 dump_opts = {"exclude_unset": True}
             else:
                 resp = var
+        elif isinstance(msg, GetVariableKeys):
+            keys_response = self.client.variables.list_keys(msg.prefix)
+            resp = VariableKeysResult.from_api_response(keys_response)
         elif isinstance(msg, GetXCom):
             xcom = self.client.xcoms.get(
                 msg.dag_id, msg.run_id, msg.task_id, msg.key, msg.map_index, msg.include_prior_dates

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -95,6 +95,7 @@ from airflow.sdk.execution_time.comms import (
     GetTaskStates,
     GetTICount,
     GetVariable,
+    GetVariableKeys,
     GetXCom,
     GetXComCount,
     GetXComSequenceItem,
@@ -125,6 +126,7 @@ from airflow.sdk.execution_time.comms import (
     TriggerDagRun,
     UpdateHITLDetail,
     ValidateInletsAndOutlets,
+    VariableKeysResult,
     VariableResult,
     XComCountResponse,
     XComResult,
@@ -1473,6 +1475,16 @@ REQUEST_TEST_CASES = [
             args=("test_key", "test_value", "test_description"),
             response=OKResponse(ok=True),
         ),
+    ),
+    RequestTestCase(
+        message=GetVariableKeys(prefix="test_"),
+        test_id="get_variable",
+        client_mock=ClientMock(
+            method_path="variables.list_keys",
+            args=("test_",),
+            response=VariableKeysResult(keys=["test_key"]),
+        ),
+        expected_body={"keys": ["test_key"], "type": "VariableKeysResult"},
     ),
     RequestTestCase(
         message=DeleteVariable(key="test_key"),


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
related: #61166

Opened this PR to implement a way to list variable keys (optionally by prefix) via the task SDK. The ask in the issue was to support fetching variables where the keys might not be known beforehand.

I've implemented a `list_keys()` method in the Variable class with an optional prefix parameter. Example: `Variable.list_keys()` or `Variable.list_keys(prefix="api_")`

There were some architectural decisions I was unsure about. For example, whether a method like `list_keys()` should be part of the Variable class or if it should live elsewhere, given that variable represents a single k/v pair. Also, the existing router dependency expects a key as a path parameter, but that wouldn't work here, meaning I needed to move that to the function level and exclude it from the list keys endpoint. Lastly, there could be a path conflict with the existing `/{variable_key:path}` route. For now I just used `/keys/list`, but that's probably not ideal (maybe a separate router?). 

Anyways, opening this up for a discussion. 



---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)


Generated-by: [Claude Sonnet 4.5] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
