### PR TITLE
Add documentation for Dag versioning behavior

### DIFF
--- a/airflow-core/docs/core-concepts/dags.rst
+++ b/airflow-core/docs/core-concepts/dags.rst
@@ -249,17 +249,14 @@ date would then be the logical date + scheduled interval.
     For more information on ``logical date``, see :ref:`data-interval` and
     :ref:`faq:what-does-execution-date-mean`.
 
-DAG Versioning
+Dag Versioning
 ~~~~~~~~~~~~~~
 
-In Airflow 3, DAGs are versioned automatically when their definition changes.
-A new DAG version is created whenever the DAG structure is modified, for example
-when tasks or dependencies are added, removed, or updated.
+In Airflow 3, Dags are versioned automatically when their definition changes.
+A new Dag version is created whenever the DAG structure is modified, for example when tasks or dependencies are added, removed, or updated.
 
-Each DAG run is associated with the version of the DAG that existed at the time
-the run was scheduled. Changes made to a DAG after a run has been scheduled do
-not affect already running or completed DAG runs.
-
+Each Dag run is associated with the version of the Dag that existed at the time
+the run was scheduled. Changes made to a Dag after a run has been scheduled do not affect already running or completed DAG runs.
 Dag Assignment
 --------------
 

--- a/airflow-core/docs/core-concepts/dags.rst
+++ b/airflow-core/docs/core-concepts/dags.rst
@@ -249,6 +249,17 @@ date would then be the logical date + scheduled interval.
     For more information on ``logical date``, see :ref:`data-interval` and
     :ref:`faq:what-does-execution-date-mean`.
 
+DAG Versioning
+~~~~~~~~~~~~~~
+
+In Airflow 3, DAGs are versioned automatically when their definition changes.
+A new DAG version is created whenever the DAG structure is modified, for example
+when tasks or dependencies are added, removed, or updated.
+
+Each DAG run is associated with the version of the DAG that existed at the time
+the run was scheduled. Changes made to a DAG after a run has been scheduled do
+not affect already running or completed DAG runs.
+
 Dag Assignment
 --------------
 


### PR DESCRIPTION
Adds documentation explaining DAG versioning behavior in Airflow 3,
clarifying how DAG runs are associated with DAG versions when
definitions change.

This improves clarity around DAG versioning for users reading
the core DAG concepts documentation.

related: #61344