### PR TITLE
Fix grid view crash when task groups change across DAG runs

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/services/ui/grid.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/ui/grid.py
@@ -112,7 +112,7 @@ def _find_aggregates(
                     if child_node.get("details"):
                         children_details.extend(child_node["details"])
                 yield child_node
-        if node_id:
+        if node_id and children_details:
             yield {
                 "task_id": node_id,
                 "task_display_name": node_id,


### PR DESCRIPTION
### What does this PR do?

Fixes a crash in the Grid View UI when task group structure changes across DAG runs.
Previously, empty task groups could be yielded without any task instance details,
leading to inconsistent aggregation and a UI failure.

### Why is this needed?

When a task group exists in one DAG run but has no task instances in another,
the grid aggregation logic attempted to render an empty group, which caused
the grid view to break.

### How was this fixed?

The task group node is now yielded only when it has at least one child with
task instance details, ensuring aggregation data is always consistent.

### Related issue

Fixes #61208

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
