### PR TITLE
Fix breeze start-airflow --dev-mode hanging on stale asset compile lock

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/run_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_utils.py
@@ -448,6 +448,8 @@ def _run_compile_internally(
 
     env = os.environ.copy()
     if dev:
+        # Clean up stale lock file
+        compile_lock.unlink(missing_ok=True)
         with open(UI_ASSET_OUT_DEV_MODE_FILE, "w") as output_file:
             return run_command(
                 command_to_execute,


### PR DESCRIPTION
## Summary
Fix `breeze start-airflow --dev-mode` hanging at "Still waiting....." when a stale lock file exists from a previous non-dev run.

## Why
When running asset compilation in non-dev mode, a lock file(.build/ui/.asset_compile.lock) is created to prevent concurrent compilations. 
If the process terminates abnormally (Ctrl+C, crash, etc.), this lock file remains.

The problem is that dev-mode never cleans up this lock file, while the container's wait_for_asset_compilation() function waits for it to be deleted - causing an infinite wait


## Before(How to reproduction)
1. Run breeze start-airflow (non-dev mode) 
2. Terminate abnormally (Ctrl+C during compilation) 
3. Run breeze start-airflow --dev-mode 
4. Container hangs at "Still waiting....."

https://github.com/user-attachments/assets/492d171e-691b-489b-960d-c58c3bb38a38


## After

https://github.com/user-attachments/assets/764f5da4-0cf0-4864-94a9-cf3e0f55ce64


<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
