### PR TITLE
Fix CloudDataTransferServiceUpdateJobOperator AWS credential injection for S3 sources

### DIFF
--- a/providers/google/docs/operators/cloud/cloud_storage_transfer_service.rst
+++ b/providers/google/docs/operators/cloud/cloud_storage_transfer_service.rst
@@ -52,8 +52,8 @@ The function accepts time in two formats:
 
 - as an :class:`~datetime.time` object
 
-If you want to create a job transfer that copies data from AWS S3 then you must have a connection configured. Information about configuration for AWS is available: :doc:`apache-airflow-providers-amazon:connections/aws`
-The selected connection for AWS can be indicated by the parameter ``aws_conn_id``.
+If you want to create a transfer job that copies data from AWS S3, you must have an AWS connection configured.
+Information about configuration for AWS is available in :doc:`apache-airflow-providers-amazon:connections/aws`.
 
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.cloud_storage_transfer_service.CloudDataTransferServiceCreateJobOperator`.
@@ -66,6 +66,8 @@ Using the operator
       :language: python
       :start-after: [START howto_operator_gcp_transfer_create_job_body_gcp]
       :end-before: [END howto_operator_gcp_transfer_create_job_body_gcp]
+
+.. note:: For AWS S3 sources, pass ``aws_conn_id`` to the operator.
 
 .. exampleinclude:: /../../google/tests/system/google/cloud/storage_transfer/example_cloud_storage_transfer_service_aws.py
       :language: python
@@ -128,7 +130,7 @@ More information
 See `Google Cloud Transfer Service - REST Resource: transferJobs - Status
 <https://cloud.google.com/storage-transfer/docs/reference/rest/v1/transferJobs#Status>`_
 
-.. _howto/operator:CloudDataTransferServiceUpdateJobOperator:
+.. _howto/operator:CloudDataTransferServiceRunJobOperator:
 
 CloudDataTransferServiceRunJobOperator
 -----------------------------------------
@@ -163,12 +165,15 @@ More information
 See `Google Cloud Transfer Service - REST Resource: transferJobs - Run
 <https://cloud.google.com/storage-transfer/docs/reference/rest/v1/transferJobs/run>`_
 
-.. _howto/operator:CloudDataTransferServiceRunJobOperator:
+.. _howto/operator:CloudDataTransferServiceUpdateJobOperator:
 
 CloudDataTransferServiceUpdateJobOperator
 -----------------------------------------
 
 Updates a transfer job.
+
+For AWS S3 sources you must have an AWS connection configured.
+Information about configuration for AWS is available in :doc:`apache-airflow-providers-amazon:connections/aws`.
 
 For parameter definition, take a look at
 :class:`~airflow.providers.google.cloud.operators.cloud_storage_transfer_service.CloudDataTransferServiceUpdateJobOperator`.
@@ -183,6 +188,20 @@ Using the operator
       :end-before: [END howto_operator_gcp_transfer_update_job_body]
 
 .. exampleinclude:: /../../google/tests/system/google/cloud/storage_transfer/example_cloud_storage_transfer_service_gcp.py
+      :language: python
+      :dedent: 4
+      :start-after: [START howto_operator_gcp_transfer_update_job]
+      :end-before: [END howto_operator_gcp_transfer_update_job]
+
+.. note:: For AWS S3 updates, pass ``aws_conn_id`` and include ``transferSpec`` in the update payload.
+          If your spec uses an IAM role (for example ``roleArn``), static credentials are not injected.
+
+.. exampleinclude:: /../../google/tests/system/google/cloud/storage_transfer/example_cloud_storage_transfer_service_aws.py
+      :language: python
+      :start-after: [START howto_operator_gcp_transfer_update_job_body_aws]
+      :end-before: [END howto_operator_gcp_transfer_update_job_body_aws]
+
+.. exampleinclude:: /../../google/tests/system/google/cloud/storage_transfer/example_cloud_storage_transfer_service_aws.py
       :language: python
       :dedent: 4
       :start-after: [START howto_operator_gcp_transfer_update_job]


### PR DESCRIPTION
## Description

Fixes #22021

The `CloudDataTransferServiceUpdateJobOperator` was passing the full patch request body to `TransferJobPreprocessor`, but that body wraps the `TransferJob` under a `transfer_job` (or `transferJob`) key. The preprocessor looks for `transferSpec` at the top level and thus never found it, skipping AWS credential injection for S3 sources.

### Changes

1. **Operator Fix** (`cloud_storage_transfer_service.py`):
   - Added `_get_transfer_job_body()` method that extracts the inner `TransferJob` dict from the patch request body
   - Supports both snake_case (`transfer_job`) and camelCase (`transferJob`) key variants  
   - Updated `_validate_inputs()` and `execute()` to use the extracted body for preprocessing and validation

2. **Test Coverage** (`test_cloud_storage_transfer_service.py`):
   - Added `test_job_update_with_aws_s3_source_camel_case`: Verifies AWS credentials are injected with camelCase body
   - Added `test_job_update_with_aws_s3_source_snake_case`: Verifies AWS credentials are injected with snake_case body
   - Added `test_job_update_with_aws_role_arn_does_not_inject_credentials`: Verifies role ARN credentials are not overridden

### Testing

All 74 tests in the operators test suite pass, including the 3 new tests and the existing update operator tests.

---

- [X] Yes (please specify the tool below)

Generated-by: GitHub Copilot following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)