### PR TITLE
Fix ASYNC240: replace blocking filesystem calls with anyio

### DIFF
--- a/airflow-core/newsfragments/61418.significant.rst
+++ b/airflow-core/newsfragments/61418.significant.rst
@@ -1,5 +1,0 @@
-Replace blocking filesystem calls in async functions with ``anyio`` equivalents
-
-Blocking ``os.path`` and ``pathlib.Path`` calls inside async functions have been replaced
-with their async-safe ``anyio.Path`` counterparts, fixing all ASYNC240 lint violations.
-This prevents blocking the event loop during filesystem I/O in triggers and other async code paths.

--- a/airflow-core/newsfragments/61418.significant.rst
+++ b/airflow-core/newsfragments/61418.significant.rst
@@ -1,0 +1,5 @@
+Replace blocking filesystem calls in async functions with ``anyio`` equivalents
+
+Blocking ``os.path`` and ``pathlib.Path`` calls inside async functions have been replaced
+with their async-safe ``anyio.Path`` counterparts, fixing all ASYNC240 lint violations.
+This prevents blocking the event loop during filesystem I/O in triggers and other async code paths.

--- a/airflow-core/tests/unit/api_fastapi/auth/test_tokens.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/test_tokens.py
@@ -23,6 +23,7 @@ from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
+import anyio
 import httpx
 import jwt
 import pytest
@@ -213,10 +214,10 @@ async def test_jwt_generate_validate_roundtrip_with_jwks(private_key, algorithm,
     jwk_content = json.dumps({"keys": [key_to_jwk_dict(private_key, "custom-kid")]})
 
     jwks = tmp_path.joinpath("jwks.json")
-    jwks.write_text(jwk_content)
+    await anyio.Path(jwks).write_text(jwk_content)
 
     priv_key = tmp_path.joinpath("key.pem")
-    priv_key.write_bytes(key_to_pem(private_key))
+    await anyio.Path(priv_key).write_bytes(key_to_pem(private_key))
 
     with conf_vars(
         {

--- a/devel-common/src/sphinx_exts/pagefind_search/builder.py
+++ b/devel-common/src/sphinx_exts/pagefind_search/builder.py
@@ -119,6 +119,7 @@ async def build_pagefind_index(app: Sphinx) -> dict[str, int]:
         skipped = 0
 
         async with PagefindIndex(config=config) as index:
+
             def _glob_html_files():
                 return list(output_dir.glob(app.config.pagefind_glob))
 

--- a/devel-common/src/sphinx_exts/pagefind_search/builder.py
+++ b/devel-common/src/sphinx_exts/pagefind_search/builder.py
@@ -25,6 +25,7 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import anyio
 from pagefind.index import IndexConfig, PagefindIndex
 from sphinx.util.fileutil import copy_asset
 
@@ -118,8 +119,8 @@ async def build_pagefind_index(app: Sphinx) -> dict[str, int]:
         skipped = 0
 
         async with PagefindIndex(config=config) as index:
-            for html_file in output_dir.glob(app.config.pagefind_glob):
-                if not html_file.is_file():
+            for html_file in await anyio.Path(output_dir).glob(app.config.pagefind_glob):
+                if not await anyio.Path(html_file).is_file():
                     continue
 
                 relative_path = html_file.relative_to(output_dir)
@@ -131,7 +132,7 @@ async def build_pagefind_index(app: Sphinx) -> dict[str, int]:
                     continue
 
                 try:
-                    content = html_file.read_text(encoding="utf-8")
+                    content = await anyio.Path(html_file).read_text(encoding="utf-8")
                     await index.add_html_file(
                         content=content,
                         source_path=str(html_file),

--- a/devel-common/src/sphinx_exts/pagefind_search/builder.py
+++ b/devel-common/src/sphinx_exts/pagefind_search/builder.py
@@ -119,7 +119,11 @@ async def build_pagefind_index(app: Sphinx) -> dict[str, int]:
         skipped = 0
 
         async with PagefindIndex(config=config) as index:
-            for html_file in await anyio.Path(output_dir).glob(app.config.pagefind_glob):
+            def _glob_html_files():
+                return list(output_dir.glob(app.config.pagefind_glob))
+
+            html_files = await anyio.to_thread.run_sync(_glob_html_files)
+            for html_file in html_files:
                 if not await anyio.Path(html_file).is_file():
                     continue
 

--- a/providers/edge3/tests/unit/edge3/cli/test_worker.py
+++ b/providers/edge3/tests/unit/edge3/cli/test_worker.py
@@ -322,9 +322,10 @@ class TestEdgeWorker:
     @pytest.mark.asyncio
     async def test_check_running_jobs_log_push_increment(self, mock_logs_push, worker_with_job: EdgeWorker):
         job = EdgeWorker.jobs[0]
-        await anyio.Path(job.logfile).write_text("hello ")
-        job.logsize = (await anyio.Path(job.logfile).stat()).st_size
-        await anyio.Path(job.logfile).write_text("hello world")
+        aio_logfile = anyio.Path(job.logfile)
+        await aio_logfile.write_text("hello ")
+        job.logsize = (await aio_logfile.stat()).st_size
+        await aio_logfile.write_text("hello world")
         with conf_vars({("edge", "api_url"): "https://invalid-api-test-endpoint"}):
             await worker_with_job._push_logs_in_chunks(job)
         assert len(EdgeWorker.jobs) == 1

--- a/providers/edge3/tests/unit/edge3/cli/test_worker.py
+++ b/providers/edge3/tests/unit/edge3/cli/test_worker.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from unittest import mock
 from unittest.mock import call, patch
 
+import anyio
 import pytest
 import time_machine
 from aiohttp import ClientResponseError, RequestInfo
@@ -307,7 +308,7 @@ class TestEdgeWorker:
     @pytest.mark.asyncio
     async def test_push_logs_in_chunks(self, mock_logs_push, worker_with_job: EdgeWorker):
         job = EdgeWorker.jobs[0]
-        job.logfile.write_text("some log content")
+        await anyio.Path(job.logfile).write_text("some log content")
         with conf_vars({("edge", "api_url"): "https://invalid-api-test-endpoint"}):
             await worker_with_job._push_logs_in_chunks(job)
 
@@ -321,9 +322,9 @@ class TestEdgeWorker:
     @pytest.mark.asyncio
     async def test_check_running_jobs_log_push_increment(self, mock_logs_push, worker_with_job: EdgeWorker):
         job = EdgeWorker.jobs[0]
-        job.logfile.write_text("hello ")
-        job.logsize = job.logfile.stat().st_size
-        job.logfile.write_text("hello world")
+        await anyio.Path(job.logfile).write_text("hello ")
+        job.logsize = (await anyio.Path(job.logfile).stat()).st_size
+        await anyio.Path(job.logfile).write_text("hello world")
         with conf_vars({("edge", "api_url"): "https://invalid-api-test-endpoint"}):
             await worker_with_job._push_logs_in_chunks(job)
         assert len(EdgeWorker.jobs) == 1

--- a/providers/standard/tests/unit/standard/triggers/test_file.py
+++ b/providers/standard/tests/unit/standard/triggers/test_file.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 
+import anyio
 import pytest
 
 from airflow.providers.standard.triggers.file import FileDeleteTrigger, FileTrigger
@@ -43,7 +44,7 @@ class TestFileTrigger:
     async def test_task_file_trigger(self, tmp_path):
         """Asserts that the trigger only goes off on or after file is found"""
         tmp_dir = tmp_path / "test_dir"
-        tmp_dir.mkdir()
+        await anyio.Path(tmp_dir).mkdir()
         p = tmp_dir / "hello.txt"
 
         trigger = FileTrigger(
@@ -84,7 +85,7 @@ class TestFileDeleteTrigger:
     async def test_file_delete_trigger(self, tmp_path):
         """Asserts that the trigger goes off on or after file is found and that the files gets deleted."""
         tmp_dir = tmp_path / "test_dir"
-        tmp_dir.mkdir()
+        await anyio.Path(tmp_dir).mkdir()
         p = tmp_dir / "hello.txt"
 
         trigger = FileDeleteTrigger(
@@ -101,7 +102,7 @@ class TestFileDeleteTrigger:
         p.touch()
 
         await asyncio.sleep(0.5)
-        assert p.exists() is False
+        assert await anyio.Path(p).exists() is False
 
         # Prevents error when task is destroyed while in "pending" state
         asyncio.get_event_loop().stop()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -679,7 +679,6 @@ ignore = [
     "COM819",
     "E501", # Formatted code may exceed the line length, leading to line-too-long (E501) errors.
     "ASYNC110", # TODO: Use `anyio.Event` instead of awaiting `anyio.sleep` in a `while` loop
-    "ASYNC240", # TODO: Async functions should not use os.path methods, use trio.Path or anyio.path
     "SIM105", # Use contextlib.suppress({exception}) instead of try-except-pass
 ]
 unfixable = [


### PR DESCRIPTION
## Summary

Replace blocking `os.path` and `pathlib.Path` calls inside async functions with async-safe `anyio.Path` equivalents, fixing all ASYNC240 lint violations and re-enabling the rule.

- **`providers/standard/triggers/file.py`**: Replace `os.path.isfile()`, `os.path.getmtime()`, `os.walk()`, `os.remove()` with `anyio.Path` and `anyio.to_thread.run_sync()`
- **`providers/edge3/cli/worker.py`**: Replace `pathlib.exists()`, `pathlib.stat()` with `anyio.Path`
- **`devel-common/sphinx_exts/pagefind_search/builder.py`**: Replace `pathlib.glob()`, `pathlib.is_file()`, `pathlib.read_text()` with `anyio.Path`
- **Test files**: Convert blocking pathlib calls in async tests to `anyio.Path`
- **`pyproject.toml`**: Remove `ASYNC240` from the ruff ignore list

closes #61418
Related: #61417

## Decision context

`anyio` was chosen as the async filesystem library per discussion on the issue (approved by @jscheffl). It is already a transitive dependency of the project via httpx, sqlalchemy async, etc.

## Test plan

- [ ] Verify `ruff check --select ASYNC240` passes with zero violations
- [ ] Run `providers/standard/tests/unit/standard/triggers/test_file.py`
- [ ] Run `providers/edge3/tests/unit/edge3/cli/test_worker.py`
- [ ] Run `airflow-core/tests/unit/api_fastapi/auth/test_tokens.py`