### PR TITLE
Cache dag access and teams check to be reused in grid ti_summary API calls

### DIFF
--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -82,6 +82,7 @@ dependencies = [
     "argcomplete>=1.10",
     "asgiref>=2.3.0",
     "attrs>=22.1.0, !=25.2.0",
+    "cachetools>=6.2.4",
     "cadwyn>=6.0.0",
     "colorlog>=6.8.2",
     "cron-descriptor>=1.2.24",

--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any, cast
 import pendulum
 import sqlalchemy as sa
 import structlog
+from cachetools import TTLCache, cached
 from dateutil.relativedelta import relativedelta
 from sqlalchemy import (
     Boolean,
@@ -102,6 +103,8 @@ if TYPE_CHECKING:
 log = structlog.getLogger(__name__)
 
 TAG_MAX_LEN = 100
+CACHE_TTL = airflow_conf.getint("fab", "cache_ttl", fallback=30)
+cache: TTLCache = TTLCache(maxsize=1024, ttl=CACHE_TTL)
 
 
 def infer_automated_data_interval(timetable: Timetable, logical_date: datetime) -> DataInterval:
@@ -774,6 +777,7 @@ class DagModel(Base):
 
     @staticmethod
     @provide_session
+    @cached(cache, key=lambda dag_id, session: dag_id)
     def get_team_name(dag_id: str, session: Session = NEW_SESSION) -> str | None:
         """Return the team name associated to a Dag or None if it is not owned by a specific team."""
         stmt = (

--- a/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
@@ -323,6 +323,15 @@ class FabAuthManager(BaseAuthManager[User]):
     ) -> bool:
         return self._is_authorized(method=method, resource_type=RESOURCE_CONNECTION, user=user)
 
+    @cachedmethod(
+        lambda self: self.cache,
+        key=lambda _, method, user, access_entity, details: (
+            method,
+            user,
+            access_entity,
+            details.id if details else None,
+        ),
+    )
     def is_authorized_dag(
         self,
         *,


### PR DESCRIPTION
requires_access_dag is used in the ti_summary endpoint. When this method returns a result then this can be cached and reused for other API calls since access to a dag doesn't change based on taskinstance. On a similar note for dags that don't have many changes the serialized dag entry also remains the same.

This PR adds caching to airflow-core which is independent from `fab` provider. Hence the fab related ttl cannot be always used and this might need a new config if the approach is accepted.

command with 10 concurrent requests since the grid loads 10 dagruns by default.

```
hey -c 10 -H 'Cookie: _token=<token>' 'http://localhost:8000/ui/grid/ti_summaries/asset_produces_2/manual__2026-01-31T06:15:30.690694+00:00'
```

Main branch

```
Summary:
  Total:	1.0294 secs
  Slowest:	0.0801 secs
  Fastest:	0.0160 secs
  Average:	0.0460 secs
  Requests/sec:	194.2854
 
Latency distribution:
  10% in 0.0335 secs
  25% in 0.0385 secs
  50% in 0.0438 secs
  75% in 0.0537 secs
  90% in 0.0626 secs
  95% in 0.0667 secs
  99% in 0.0758 secs
```

cache only `is_authorized_dag` in fab auth manager used in `requires_access_dag` check

```
Summary:
  Total:	0.9620 secs
  Slowest:	0.0741 secs
  Fastest:	0.0163 secs
  Average:	0.0410 secs
  Requests/sec:	207.8980
  
Latency distribution:
  10% in 0.0295 secs
  25% in 0.0328 secs
  50% in 0.0403 secs
  75% in 0.0496 secs
  90% in 0.0537 secs
  95% in 0.0560 secs
  99% in 0.0630 secs

```
cache `get_team_name` and `is_authorized_dag` in fab auth manager used in `requires_access_dag` check

```
Summary:
  Total:	0.8245 secs
  Slowest:	0.0813 secs
  Fastest:	0.0115 secs
  Average:	0.0304 secs
  Requests/sec:	242.5708
  
Latency distribution:
  10% in 0.0204 secs
  25% in 0.0234 secs
  50% in 0.0262 secs
  75% in 0.0365 secs
  90% in 0.0497 secs
  95% in 0.0531 secs
  99% in 0.0628 secs
```

cache `get_team_name` and `is_authorized_dag` in fab auth manager used in `requires_access_dag` check and `_get_serdag`.

```
Summary:
  Total:	0.6000 secs
  Slowest:	0.0532 secs
  Fastest:	0.0100 secs
  Average:	0.0249 secs
  Requests/sec:	333.3144
  
Latency distribution:
  10% in 0.0176 secs
  25% in 0.0198 secs
  50% in 0.0240 secs
  75% in 0.0305 secs
  90% in 0.0341 secs
  95% in 0.0367 secs
  99% in 0.0402 secs
```

related: #61485

##### Was generative AI tooling used to co-author this PR?

No