### PR TITLE
Prepare bteq command with subprocess arg list instead of string

### DIFF
--- a/providers/teradata/src/airflow/providers/teradata/hooks/bteq.py
+++ b/providers/teradata/src/airflow/providers/teradata/hooks/bteq.py
@@ -250,7 +250,7 @@ class BteqHook(TtuHook):
         temp_file_read_encoding: str | None,
     ) -> int | None:
         verify_bteq_installed()
-        bteq_command_str = prepare_bteq_command_for_local_execution(
+        bteq_command_list = prepare_bteq_command_for_local_execution(
             self.get_conn(),
             timeout=timeout,
             bteq_script_encoding=bteq_script_encoding or "",
@@ -258,11 +258,11 @@ class BteqHook(TtuHook):
             timeout_rc=timeout_rc or -1,
         )
         process = subprocess.Popen(
-            bteq_command_str,
+            bteq_command_list,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            shell=True,
+            shell=False,
             start_new_session=True,
         )
         encode_bteq_script = bteq_script.encode(str(temp_file_read_encoding or "UTF-8"))

--- a/providers/teradata/tests/unit/teradata/hooks/test_bteq.py
+++ b/providers/teradata/tests/unit/teradata/hooks/test_bteq.py
@@ -115,8 +115,8 @@ def test_execute_bteq_script_at_local_timeout(
         "sp": None,
     },
 )
-@patch("airflow.providers.teradata.hooks.bteq.verify_bteq_installed")  # <- patch here
-@patch("airflow.providers.teradata.hooks.bteq.prepare_bteq_command_for_local_execution")  # <- patch here too
+@patch("airflow.providers.teradata.hooks.bteq.verify_bteq_installed")
+@patch("airflow.providers.teradata.hooks.bteq.prepare_bteq_command_for_local_execution")
 def test_execute_bteq_script_at_local_success(
     mock_prepare_cmd,
     mock_verify_bteq,
@@ -149,7 +149,7 @@ def test_execute_bteq_script_at_local_success(
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-        shell=True,
+        shell=False,
         start_new_session=True,
     )
     assert ret_code == 0


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] No

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->


Fixing the subprocess execution for bteq command execution to use arg list intead of shell interpreted strings and using
shell=False, to harden the bteq execution from badly configured connection fields.

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
