### PR TITLE
chart: add api-server rollout restart cronjob

### DIFF
--- a/chart/docs/production-guide.rst
+++ b/chart/docs/production-guide.rst
@@ -111,6 +111,24 @@ Several additional options can be configured and passed to the ``airflow db clea
 
 See :ref:`db clean usage <cli-db-clean>` for more details.
 
+API server periodic restarts
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When running the API server in Kubernetes (especially with the default Uvicorn mode), you may want to periodically
+restart the API server Pods to keep long-running processes fresh. The chart can create an optional CronJob that
+runs a ``kubectl rollout restart`` against the API server Deployment.
+
+.. code-block:: yaml
+
+  apiServer:
+    rolloutRestart:
+      enabled: true
+      schedule: "0 3 * * *"
+
+By default, the CronJob targets the API server Deployment created by the chart. If you need a custom target, set
+``apiServer.rolloutRestart.deploymentName`` or override ``command``/``args``. The CronJob uses the ``images.kubectl``
+image, so ensure the tag is compatible with your cluster.
+
 PgBouncer
 ---------
 

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -412,6 +412,10 @@ If release name contains chart name it will be used as a full name.
   {{- printf "%s:%s" .Values.images.gitSync.repository .Values.images.gitSync.tag }}
 {{- end }}
 
+{{- define "kubectl_image" -}}
+  {{- printf "%s:%s" .Values.images.kubectl.repository .Values.images.kubectl.tag }}
+{{- end }}
+
 {{- define "fernet_key_secret" -}}
   {{- default (printf "%s-fernet-key" (include "airflow.fullname" .)) .Values.fernetKeySecretName }}
 {{- end }}
@@ -673,6 +677,16 @@ server_tls_key_file = /etc/pgbouncer/server.key
 {{/* Create the name of the API server service account to use */}}
 {{- define "apiServer.serviceAccountName" -}}
   {{- include "_serviceAccountName" (merge (dict "key" "apiServer" "nameSuffix" "api-server" ) .) -}}
+{{- end }}
+
+{{/* Create the name of the API server rollout restart service account to use */}}
+{{- define "apiServerRolloutRestart.serviceAccountName" -}}
+  {{- $sa := .Values.apiServer.rolloutRestart.serviceAccount }}
+  {{- if $sa.create }}
+    {{- default (printf "%s-%s" (include "airflow.serviceAccountName" .) "api-server-rollout-restart") $sa.name | quote }}
+  {{- else }}
+    {{- default "default" $sa.name | quote }}
+  {{- end }}
 {{- end }}
 
 {{/* Create the name of the redis service account to use */}}

--- a/chart/templates/api-server/api-server-rollout-restart-cronjob.yaml
+++ b/chart/templates/api-server/api-server-rollout-restart-cronjob.yaml
@@ -1,0 +1,113 @@
+{{/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/}}
+
+##############################################
+## Airflow API Server Rollout Restart CronJob
+##############################################
+{{- if and (semverCompare ">=3.0.0" .Values.airflowVersion) .Values.apiServer.enabled .Values.apiServer.rolloutRestart.enabled }}
+{{- $nodeSelector := or .Values.apiServer.rolloutRestart.nodeSelector .Values.nodeSelector }}
+{{- $affinity := or .Values.apiServer.rolloutRestart.affinity .Values.affinity }}
+{{- $tolerations := or .Values.apiServer.rolloutRestart.tolerations .Values.tolerations }}
+{{- $topologySpreadConstraints := or .Values.apiServer.rolloutRestart.topologySpreadConstraints .Values.topologySpreadConstraints }}
+{{- $securityContext := include "airflowPodSecurityContext" (list .Values.apiServer.rolloutRestart .Values) }}
+{{- $containerSecurityContext := include "containerSecurityContext" (list .Values.apiServer.rolloutRestart .Values) }}
+{{- $deploymentName := default (printf "%s-api-server" (include "airflow.fullname" .)) .Values.apiServer.rolloutRestart.deploymentName }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "airflow.fullname" . }}-api-server-rollout-restart
+  labels:
+    tier: airflow
+    component: api-server-rollout-restart
+    release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+    {{- with .Values.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.apiServer.rolloutRestart.jobAnnotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  schedule: "{{ tpl .Values.apiServer.rolloutRestart.schedule . }}"
+  # The cron job does not allow concurrent runs; if it is time for a new job run and the previous job run hasn't finished yet, the cron job skips the new job run
+  concurrencyPolicy: Forbid
+  {{- if not ( eq .Values.apiServer.rolloutRestart.failedJobsHistoryLimit nil) }}
+  failedJobsHistoryLimit: {{ .Values.apiServer.rolloutRestart.failedJobsHistoryLimit }}
+  {{- end }}
+  {{- if not (eq .Values.apiServer.rolloutRestart.successfulJobsHistoryLimit nil) }}
+  successfulJobsHistoryLimit: {{ .Values.apiServer.rolloutRestart.successfulJobsHistoryLimit }}
+  {{- end }}
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        metadata:
+          labels:
+            tier: airflow
+            component: api-server-rollout-restart
+            release: {{ .Release.Name }}
+            {{- if or (.Values.labels) (.Values.apiServer.rolloutRestart.labels) }}
+              {{- mustMerge .Values.apiServer.rolloutRestart.labels .Values.labels | toYaml | nindent 12 }}
+            {{- end }}
+          annotations:
+            {{- if .Values.airflowPodAnnotations }}
+              {{- toYaml .Values.airflowPodAnnotations | nindent 12 }}
+            {{- end }}
+            {{- if .Values.apiServer.rolloutRestart.podAnnotations }}
+              {{- toYaml .Values.apiServer.rolloutRestart.podAnnotations | nindent 12 }}
+            {{- end }}
+        spec:
+          restartPolicy: Never
+          {{- if .Values.apiServer.rolloutRestart.priorityClassName }}
+          priorityClassName: {{ .Values.apiServer.rolloutRestart.priorityClassName }}
+          {{- end }}
+          nodeSelector: {{- toYaml $nodeSelector | nindent 12 }}
+          affinity: {{- toYaml $affinity | nindent 12 }}
+          {{- if .Values.schedulerName }}
+          schedulerName: {{ .Values.schedulerName }}
+          {{- end }}
+          tolerations: {{- toYaml $tolerations | nindent 12 }}
+          topologySpreadConstraints: {{- toYaml $topologySpreadConstraints | nindent 12 }}
+          serviceAccountName: {{ include "apiServerRolloutRestart.serviceAccountName" . }}
+          imagePullSecrets: {{- include "image_pull_secrets" . | nindent 12 }}
+          securityContext: {{ $securityContext | nindent 12 }}
+          containers:
+            - name: api-server-rollout-restart
+              image: {{ template "kubectl_image" . }}
+              imagePullPolicy: {{ .Values.images.kubectl.pullPolicy }}
+              securityContext: {{ $containerSecurityContext | nindent 16 }}
+              {{- if .Values.apiServer.rolloutRestart.command }}
+              command: {{ tpl (toYaml .Values.apiServer.rolloutRestart.command) . | nindent 16 }}
+              {{- else }}
+              command:
+                - "kubectl"
+              {{- end }}
+              {{- if .Values.apiServer.rolloutRestart.args }}
+              args: {{ tpl (toYaml .Values.apiServer.rolloutRestart.args) . | nindent 16 }}
+              {{- else }}
+              args:
+                - "rollout"
+                - "restart"
+                - "deployment/{{ $deploymentName }}"
+                - "--namespace"
+                - "{{ .Release.Namespace }}"
+              {{- end }}
+              resources: {{- toYaml .Values.apiServer.rolloutRestart.resources | nindent 16 }}
+{{- end }}

--- a/chart/templates/api-server/api-server-rollout-restart-serviceaccount.yaml
+++ b/chart/templates/api-server/api-server-rollout-restart-serviceaccount.yaml
@@ -1,0 +1,43 @@
+{{/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/}}
+
+#########################################################
+## Airflow API Server Rollout Restart ServiceAccount
+#########################################################
+{{- if and (semverCompare ">=3.0.0" .Values.airflowVersion) .Values.apiServer.enabled .Values.apiServer.rolloutRestart.enabled }}
+{{- if .Values.apiServer.rolloutRestart.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.apiServer.rolloutRestart.serviceAccount.automountServiceAccountToken }}
+metadata:
+  name: {{ include "apiServerRolloutRestart.serviceAccountName" . }}
+  labels:
+    tier: airflow
+    component: api-server-rollout-restart
+    release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+    {{- if or (.Values.labels) (.Values.apiServer.rolloutRestart.labels) }}
+      {{- mustMerge .Values.apiServer.rolloutRestart.labels .Values.labels | toYaml | nindent 4 }}
+    {{- end }}
+  {{- with .Values.apiServer.rolloutRestart.serviceAccount.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/chart/templates/rbac/api-server-rollout-restart-role.yaml
+++ b/chart/templates/rbac/api-server-rollout-restart-role.yaml
@@ -1,0 +1,47 @@
+{{/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/}}
+
+#########################################################
+## Airflow API Server Rollout Restart Role
+#########################################################
+{{- if and .Values.rbac.create (semverCompare ">=3.0.0" .Values.airflowVersion) .Values.apiServer.enabled .Values.apiServer.rolloutRestart.enabled }}
+{{- $deploymentName := default (printf "%s-api-server" (include "airflow.fullname" .)) .Values.apiServer.rolloutRestart.deploymentName }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "airflow.fullname" . }}-api-server-rollout-restart-role
+  labels:
+    tier: airflow
+    release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+    {{- with .Values.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+rules:
+  - apiGroups:
+      - "apps"
+    resources:
+      - "deployments"
+    resourceNames:
+      - {{ $deploymentName | quote }}
+    verbs:
+      - "get"
+      - "patch"
+{{- end }}

--- a/chart/templates/rbac/api-server-rollout-restart-rolebinding.yaml
+++ b/chart/templates/rbac/api-server-rollout-restart-rolebinding.yaml
@@ -1,0 +1,44 @@
+{{/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/}}
+
+############################################################
+## Airflow API Server Rollout Restart Role Binding
+############################################################
+{{- if and .Values.rbac.create (semverCompare ">=3.0.0" .Values.airflowVersion) .Values.apiServer.enabled .Values.apiServer.rolloutRestart.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "airflow.fullname" . }}-api-server-rollout-restart-rolebinding
+  labels:
+    tier: airflow
+    release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+    {{- with .Values.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "airflow.fullname" . }}-api-server-rollout-restart-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "apiServerRolloutRestart.serviceAccountName" . }}
+    namespace: "{{ .Release.Namespace }}"
+{{- end }}

--- a/chart/templates/rbac/security-context-constraint-rolebinding.yaml
+++ b/chart/templates/rbac/security-context-constraint-rolebinding.yaml
@@ -98,6 +98,11 @@ subjects:
     name: {{ include "cleanup.serviceAccountName" . }}
     namespace: "{{ .Release.Namespace }}"
   {{- end }}
+  {{- if and (semverCompare ">=3.0.0" .Values.airflowVersion) .Values.apiServer.enabled .Values.apiServer.rolloutRestart.enabled }}
+  - kind: ServiceAccount
+    name: {{ include "apiServerRolloutRestart.serviceAccountName" . }}
+    namespace: "{{ .Release.Namespace }}"
+  {{- end }}
   {{- if .Values.databaseCleanup.enabled }}
   - kind: ServiceAccount
     name: {{ include "databaseCleanup.serviceAccountName" . }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1089,6 +1089,33 @@
                             "default": "IfNotPresent"
                         }
                     }
+                },
+                "kubectl": {
+                    "description": "Configuration of the kubectl image.",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "repository": {
+                            "description": "The kubectl image repository.",
+                            "type": "string",
+                            "default": "bitnami/kubectl"
+                        },
+                        "tag": {
+                            "description": "The kubectl image tag.",
+                            "type": "string",
+                            "default": "1.30.0"
+                        },
+                        "pullPolicy": {
+                            "description": "The kubectl image pull policy.",
+                            "type": "string",
+                            "enum": [
+                                "Always",
+                                "Never",
+                                "IfNotPresent"
+                            ],
+                            "default": "IfNotPresent"
+                        }
+                    }
                 }
             }
         },
@@ -5926,6 +5953,222 @@
                             "additionalProperties": {
                                 "type": "string"
                             }
+                        }
+                    }
+                },
+                "rolloutRestart": {
+                    "description": "Configuration for the optional API server rollout restart CronJob.",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "enabled": {
+                            "description": "Enable the API server rollout restart CronJob.",
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "schedule": {
+                            "description": "Rollout restart schedule (templated).",
+                            "type": "string",
+                            "default": "0 0 * * *"
+                        },
+                        "deploymentName": {
+                            "description": "Optional override for the deployment name to restart. Defaults to the chart's API server deployment name.",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "default": null
+                        },
+                        "command": {
+                            "description": "Command to use when running the rollout restart cronjob (templated).",
+                            "type": [
+                                "array",
+                                "null"
+                            ],
+                            "items": {
+                                "type": "string"
+                            },
+                            "default": null
+                        },
+                        "args": {
+                            "description": "Args to use when running the rollout restart cronjob (templated).",
+                            "type": [
+                                "array",
+                                "null"
+                            ],
+                            "items": {
+                                "type": "string"
+                            },
+                            "default": null
+                        },
+                        "jobAnnotations": {
+                            "description": "Annotations to add to the rollout restart cronjob.",
+                            "type": "object",
+                            "default": {},
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        },
+                        "nodeSelector": {
+                            "description": "Select certain nodes for rollout restart pods.",
+                            "type": "object",
+                            "default": {},
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        },
+                        "affinity": {
+                            "description": "Specify scheduling constraints for rollout restart pods.",
+                            "type": "object",
+                            "default": {},
+                            "$ref": "#/definitions/io.k8s.api.core.v1.Affinity"
+                        },
+                        "tolerations": {
+                            "description": "Specify tolerations for rollout restart pods.",
+                            "type": "array",
+                            "default": [],
+                            "items": {
+                                "type": "object",
+                                "$ref": "#/definitions/io.k8s.api.core.v1.Toleration"
+                            }
+                        },
+                        "topologySpreadConstraints": {
+                            "description": "Specify topology spread constraints for rollout restart pods.",
+                            "type": "array",
+                            "default": [],
+                            "items": {
+                                "type": "object",
+                                "$ref": "#/definitions/io.k8s.api.core.v1.TopologySpreadConstraint"
+                            }
+                        },
+                        "priorityClassName": {
+                            "description": "Specify priority for rollout restart pods.",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "default": null
+                        },
+                        "podAnnotations": {
+                            "description": "Annotations to add to rollout restart pods.",
+                            "type": "object",
+                            "default": {},
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        },
+                        "labels": {
+                            "description": "Labels to add to rollout restart pods.",
+                            "type": "object",
+                            "default": {},
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        },
+                        "resources": {
+                            "description": "Resources for rollout restart pods.",
+                            "type": "object",
+                            "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+                            "default": {},
+                            "examples": [
+                                {
+                                    "limits": {
+                                        "cpu": "100m",
+                                        "memory": "128Mi"
+                                    },
+                                    "requests": {
+                                        "cpu": "100m",
+                                        "memory": "128Mi"
+                                    }
+                                }
+                            ]
+                        },
+                        "serviceAccount": {
+                            "description": "Create ServiceAccount.",
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "automountServiceAccountToken": {
+                                    "description": "Specifies if ServiceAccount's API credentials should be mounted onto Pods.",
+                                    "type": "boolean",
+                                    "default": true
+                                },
+                                "create": {
+                                    "description": "Specifies whether a ServiceAccount should be created.",
+                                    "type": "boolean",
+                                    "default": true
+                                },
+                                "name": {
+                                    "description": "The name of the ServiceAccount to use. If not set and create is true, a name is generated using the release name.",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "default": null
+                                },
+                                "annotations": {
+                                    "description": "Annotations to add to the rollout restart CronJob Kubernetes ServiceAccount.",
+                                    "type": "object",
+                                    "default": {},
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "securityContexts": {
+                            "description": "Security context definition for the rollout restart CronJob. If not set, the values from global `securityContexts` will be used.",
+                            "type": "object",
+                            "x-docsSection": "Kubernetes",
+                            "properties": {
+                                "pod": {
+                                    "description": "Pod security context definition for the rollout restart CronJob.",
+                                    "type": "object",
+                                    "$ref": "#/definitions/io.k8s.api.core.v1.PodSecurityContext",
+                                    "default": {},
+                                    "x-docsSection": "Kubernetes",
+                                    "examples": [
+                                        {
+                                            "runAsUser": 50000,
+                                            "runAsGroup": 0,
+                                            "fsGroup": 0
+                                        }
+                                    ]
+                                },
+                                "container": {
+                                    "description": "Container security context definition for the rollout restart CronJob.",
+                                    "type": "object",
+                                    "$ref": "#/definitions/io.k8s.api.core.v1.SecurityContext",
+                                    "default": {},
+                                    "x-docsSection": "Kubernetes",
+                                    "examples": [
+                                        {
+                                            "allowPrivilegeEscalation": false,
+                                            "capabilities": {
+                                                "drop": [
+                                                    "ALL"
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        "failedJobsHistoryLimit": {
+                            "description": "Number of failed CronJob executions to retain.",
+                            "type": [
+                                "integer",
+                                "null"
+                            ],
+                            "default": null
+                        },
+                        "successfulJobsHistoryLimit": {
+                            "description": "Number of successful CronJob executions to retain.",
+                            "type": [
+                                "integer",
+                                "null"
+                            ],
+                            "default": null
                         }
                     }
                 },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -125,6 +125,10 @@ images:
     repository: registry.k8s.io/git-sync/git-sync
     tag: v4.4.2
     pullPolicy: IfNotPresent
+  kubectl:
+    repository: bitnami/kubectl
+    tag: 1.30.0
+    pullPolicy: IfNotPresent
 
 # Select certain nodes for airflow pods.
 nodeSelector: {}
@@ -1664,6 +1668,64 @@ apiServer:
 
     # Annotations to add to Airflow API server kubernetes service account.
     annotations: {}
+
+  # Optional CronJob to periodically restart API server pods (via kubectl rollout restart).
+  rolloutRestart:
+    enabled: false
+    # Run every day at midnight (templated).
+    schedule: "0 0 * * *"
+    # Optional override for the deployment name to restart.
+    deploymentName: ~
+    # Command/args to use for the rollout restart (templated). When unset, defaults to kubectl rollout restart.
+    command: ~
+    args: ~
+
+    # jobAnnotations are annotations on the rollout restart CronJob
+    jobAnnotations: {}
+
+    # Select certain nodes for api server rollout restart pods.
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+    topologySpreadConstraints: []
+    priorityClassName: ~
+
+    podAnnotations: {}
+
+    # Labels specific to api server rollout restart objects and pods
+    labels: {}
+
+    resources: {}
+    #  limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    #  requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+    # Create ServiceAccount
+    serviceAccount:
+      # default value is true
+      # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+      automountServiceAccountToken: true
+      # Specifies whether a ServiceAccount should be created
+      create: true
+      # The name of the ServiceAccount to use.
+      # If not set and create is true, a name is generated using the release name
+      name: ~
+
+      # Annotations to add to rollout restart cronjob kubernetes service account.
+      annotations: {}
+
+    # When not set, the values defined in the global securityContext will be used
+    securityContexts:
+      pod: {}
+      container: {}
+
+    # Specify history limit
+    # When set, overwrite the default k8s number of successful and failed CronJob executions that are saved.
+    failedJobsHistoryLimit: ~
+    successfulJobsHistoryLimit: ~
   service:
     type: ClusterIP
     ## service annotations


### PR DESCRIPTION
## Why
The new ‎gunicorn server type provides rolling worker restarts, but for users who continue to use the default ‎uvicorn mode on Kubernetes, it’s useful to have a first‑class mechanism in the Helm chart to periodically restart the API server pods.

  
## What
Add an optional CronJob (`runs ‎kubectl rollout restart deployment/airflow-api-server` )that runs for the API server deployment, with configurable schedule, target name, and RBAC.

closes: #61432 

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
Copilot

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
