### PR TITLE
fix: log CRITICAL when Celery task killed by OOM (exit_code=-9)

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
@@ -265,11 +265,7 @@ class FabAuthManager(BaseAuthManager[User]):
 
     @cachedmethod(lambda self: self.cache, key=lambda _, token: int(token["sub"]))
     def deserialize_user(self, token: dict[str, Any]) -> User:
-        try:
-            return self.session.scalars(select(User).where(User.id == int(token["sub"]))).one()
-        except Exception:
-            self.session.rollback()
-            raise
+        return self.session.scalars(select(User).where(User.id == int(token["sub"]))).one()
 
     def serialize_user(self, user: User) -> dict[str, Any]:
         return {"sub": str(user.id)}

--- a/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
@@ -265,7 +265,11 @@ class FabAuthManager(BaseAuthManager[User]):
 
     @cachedmethod(lambda self: self.cache, key=lambda _, token: int(token["sub"]))
     def deserialize_user(self, token: dict[str, Any]) -> User:
-        return self.session.scalars(select(User).where(User.id == int(token["sub"]))).one()
+        try:
+            return self.session.scalars(select(User).where(User.id == int(token["sub"]))).one()
+        except Exception:
+            self.session.rollback()
+            raise
 
     def serialize_user(self, user: User) -> dict[str, Any]:
         return {"sub": str(user.id)}

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -2080,13 +2080,22 @@ def supervise(
 
         exit_code = process.wait()
         end = time.monotonic()
-        log.info(
-            "Task finished",
-            task_instance_id=str(ti.id),
-            exit_code=exit_code,
-            duration=end - start,
-            final_state=process.final_state,
-        )
+
+        if exit_code == -9:
+            log.critical(
+                "Task killed by OOM (exit_code=-9)!",
+                task_instance_id=str(ti.id),
+                duration=end - start,
+                final_state=process.final_state,
+    )
+        else:
+            log.info(
+                "Task finished",
+                task_instance_id=str(ti.id),
+                exit_code=exit_code,
+                duration=end - start,
+                final_state=process.final_state,
+            ) 
         return exit_code
     finally:
         if log_path and log_file_descriptor:

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -2095,7 +2095,7 @@ def supervise(
                 exit_code=exit_code,
                 duration=end - start,
                 final_state=process.final_state,
-            ) 
+            )
         return exit_code
     finally:
         if log_path and log_file_descriptor:

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -2087,7 +2087,7 @@ def supervise(
                 task_instance_id=str(ti.id),
                 duration=end - start,
                 final_state=process.final_state,
-    )
+            )
         else:
             log.info(
                 "Task finished",

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -2083,7 +2083,7 @@ def supervise(
 
         if exit_code == -9:
             log.critical(
-                "Task killed by OOM (exit_code=-9)!",
+                "Task killed after receiving SIGKILL (exit_code=-9). OOM is a likely cause.",
                 task_instance_id=str(ti.id),
                 duration=end - start,
                 final_state=process.final_state,


### PR DESCRIPTION
### What

Currently, when a Celery worker task is killed due to an out-of-memory (OOM) situation 
(exit_code=-9), the Airflow UI does not always show the cause of the failure. This 
change ensures that such tasks log a CRITICAL message specifying the OOM kill.

### Why

Referencing issue #61521:  
Some tasks silently fail due to OOM, making debugging difficult. This change improves 
observability by logging a CRITICAL message when a task is killed with exit_code=-9.

### Changes

- Updated `supervisor.py` in `ActivitySubprocess.wait()`:
  - If `exit_code == -9`, log a `CRITICAL` message with task_instance_id, duration, and final_state.
  - Otherwise, continue logging task finish as `INFO`.

### Testing

- Manually verified that tasks killed by OOM now produce a CRITICAL log.
- Normal task completion still logs as INFO.
