### PR TITLE
Add callback_source to context to differentiate DAG vs task callbacks

### DIFF
--- a/airflow-core/src/airflow/dag_processing/processor.py
+++ b/airflow-core/src/airflow/dag_processing/processor.py
@@ -346,6 +346,7 @@ def _execute_callbacks(
 
 def _execute_dag_callbacks(dagbag: DagBag, request: DagCallbackRequest, log: FilteringBoundLogger) -> None:
     from airflow.sdk.api.datamodels._generated import TIRunContext
+    from airflow.sdk.definitions.context import CallbackMeta, CallbackSource
 
     dag, _ = _get_dag_with_task(dagbag, request.dag_id)
     callbacks = dag.on_failure_callback if request.is_failure_callback else dag.on_success_callback
@@ -376,6 +377,8 @@ def _execute_dag_callbacks(dagbag: DagBag, request: DagCallbackRequest, log: Fil
             "reason": request.msg,
         }
 
+    context["callback"] = CallbackMeta(source=CallbackSource.DAG)
+
     for callback in callbacks:
         log.info(
             "Executing on_%s dag callback",
@@ -390,6 +393,8 @@ def _execute_dag_callbacks(dagbag: DagBag, request: DagCallbackRequest, log: Fil
 
 
 def _execute_task_callbacks(dagbag: DagBag, request: TaskCallbackRequest, log: FilteringBoundLogger) -> None:
+    from airflow.sdk.definitions.context import CallbackMeta, CallbackSource
+
     if not request.is_failure_callback:
         log.warning(
             "Task callback requested but is not a failure callback",
@@ -436,6 +441,7 @@ def _execute_task_callbacks(dagbag: DagBag, request: TaskCallbackRequest, log: F
             task=task,
         )
     context = runtime_ti.get_template_context()
+    context["callback"] = CallbackMeta(source=CallbackSource.TASK)
 
     def get_callback_representation(callback):
         with contextlib.suppress(AttributeError):

--- a/airflow-core/src/airflow/dag_processing/processor.py
+++ b/airflow-core/src/airflow/dag_processing/processor.py
@@ -326,6 +326,7 @@ def _execute_callbacks(
 
 def _execute_dag_callbacks(dagbag: DagBag, request: DagCallbackRequest, log: FilteringBoundLogger) -> None:
     from airflow.sdk.api.datamodels._generated import TIRunContext
+    from airflow.sdk.definitions.context import CallbackMeta, CallbackSource
 
     dag, _ = _get_dag_with_task(dagbag, request.dag_id)
     callbacks = dag.on_failure_callback if request.is_failure_callback else dag.on_success_callback
@@ -356,6 +357,8 @@ def _execute_dag_callbacks(dagbag: DagBag, request: DagCallbackRequest, log: Fil
             "reason": request.msg,
         }
 
+    context["callback"] = CallbackMeta(source=CallbackSource.DAG)
+
     for callback in callbacks:
         log.info(
             "Executing on_%s dag callback",
@@ -370,6 +373,8 @@ def _execute_dag_callbacks(dagbag: DagBag, request: DagCallbackRequest, log: Fil
 
 
 def _execute_task_callbacks(dagbag: DagBag, request: TaskCallbackRequest, log: FilteringBoundLogger) -> None:
+    from airflow.sdk.definitions.context import CallbackMeta, CallbackSource
+
     if not request.is_failure_callback:
         log.warning(
             "Task callback requested but is not a failure callback",
@@ -416,6 +421,7 @@ def _execute_task_callbacks(dagbag: DagBag, request: TaskCallbackRequest, log: F
             task=task,
         )
     context = runtime_ti.get_template_context()
+    context["callback"] = CallbackMeta(source=CallbackSource.TASK)
 
     def get_callback_representation(callback):
         with contextlib.suppress(AttributeError):

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -1406,6 +1406,7 @@ class DagRun(Base, LoggingMixin):
             TaskInstance as TIDataModel,
             TIRunContext,
         )
+        from airflow.sdk.definitions.context import CallbackMeta, CallbackSource
         from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
 
         if relevant_ti:
@@ -1432,6 +1433,7 @@ class DagRun(Base, LoggingMixin):
             }
 
         context["reason"] = reason
+        context["callback"] = CallbackMeta(source=CallbackSource.DAG)
 
         callbacks = dag.on_success_callback if success else dag.on_failure_callback
         if not callbacks:

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -1379,6 +1379,7 @@ class DagRun(Base, LoggingMixin):
             TaskInstance as TIDataModel,
             TIRunContext,
         )
+        from airflow.sdk.definitions.context import CallbackMeta, CallbackSource
         from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
 
         if relevant_ti:
@@ -1405,6 +1406,7 @@ class DagRun(Base, LoggingMixin):
             }
 
         context["reason"] = reason
+        context["callback"] = CallbackMeta(source=CallbackSource.DAG)
 
         callbacks = dag.on_success_callback if success else dag.on_failure_callback
         if not callbacks:

--- a/airflow-core/tests/unit/dag_processing/test_processor.py
+++ b/airflow-core/tests/unit/dag_processing/test_processor.py
@@ -847,6 +847,9 @@ class TestExecuteDagCallbacks:
         # Check that we have template context variables from RuntimeTaskInstance
         assert "ts" in context_received
         assert "params" in context_received
+        from airflow.sdk.definitions.context import CallbackSource
+
+        assert context_received["callback"].source is CallbackSource.DAG
 
     def test_execute_dag_callbacks_without_context_from_server(self, spy_agency):
         """Test _execute_dag_callbacks falls back to simple context when context_from_server is None"""
@@ -892,6 +895,9 @@ class TestExecuteDagCallbacks:
         # Should not have template context variables
         assert "ts" not in context_received
         assert "params" not in context_received
+        from airflow.sdk.definitions.context import CallbackSource
+
+        assert context_received["callback"].source is CallbackSource.DAG
 
     def test_execute_dag_callbacks_success_callback(self, spy_agency):
         """Test _execute_dag_callbacks executes success callback with context_from_server"""
@@ -1313,6 +1319,9 @@ class TestExecuteTaskCallbacks:
         assert context_received is not None
         assert context_received["dag"] == dag
         assert "ti" in context_received
+        from airflow.sdk.definitions.context import CallbackSource
+
+        assert context_received["callback"].source is CallbackSource.TASK
 
     def test_execute_task_callbacks_retry_callback(self, spy_agency):
         """Test _execute_task_callbacks executes retry callbacks"""

--- a/airflow-core/tests/unit/dag_processing/test_processor.py
+++ b/airflow-core/tests/unit/dag_processing/test_processor.py
@@ -844,6 +844,9 @@ class TestExecuteDagCallbacks:
         # Check that we have template context variables from RuntimeTaskInstance
         assert "ts" in context_received
         assert "params" in context_received
+        from airflow.sdk.definitions.context import CallbackSource
+
+        assert context_received["callback"].source is CallbackSource.DAG
 
     def test_execute_dag_callbacks_without_context_from_server(self, spy_agency):
         """Test _execute_dag_callbacks falls back to simple context when context_from_server is None"""
@@ -889,6 +892,9 @@ class TestExecuteDagCallbacks:
         # Should not have template context variables
         assert "ts" not in context_received
         assert "params" not in context_received
+        from airflow.sdk.definitions.context import CallbackSource
+
+        assert context_received["callback"].source is CallbackSource.DAG
 
     def test_execute_dag_callbacks_success_callback(self, spy_agency):
         """Test _execute_dag_callbacks executes success callback with context_from_server"""
@@ -1310,6 +1316,9 @@ class TestExecuteTaskCallbacks:
         assert context_received is not None
         assert context_received["dag"] == dag
         assert "ti" in context_received
+        from airflow.sdk.definitions.context import CallbackSource
+
+        assert context_received["callback"].source is CallbackSource.TASK
 
     def test_execute_task_callbacks_retry_callback(self, spy_agency):
         """Test _execute_task_callbacks executes retry callbacks"""

--- a/scripts/ci/prek/check_template_context_variable_in_sync.py
+++ b/scripts/ci/prek/check_template_context_variable_in_sync.py
@@ -161,8 +161,8 @@ def _compare_keys(retn_keys: set[str], hint_keys: set[str], docs_keys: set[str])
     retn_keys.add("test_mode")
 
     # Only present in callbacks. Not listed in templates-ref (that doc is for task execution).
-    retn_keys.update(("exception", "reason", "try_number"))
-    docs_keys.update(("exception", "reason", "try_number"))
+    retn_keys.update(("callback", "exception", "reason", "try_number"))
+    docs_keys.update(("callback", "exception", "reason", "try_number"))
 
     # Airflow 3 added:
     retn_keys.add("task_reschedule_count")

--- a/scripts/ci/prek/check_template_context_variable_in_sync.py
+++ b/scripts/ci/prek/check_template_context_variable_in_sync.py
@@ -158,8 +158,8 @@ def _compare_keys(retn_keys: set[str], hint_keys: set[str], docs_keys: set[str])
     retn_keys.add("test_mode")
 
     # Only present in callbacks. Not listed in templates-ref (that doc is for task execution).
-    retn_keys.update(("exception", "reason", "try_number"))
-    docs_keys.update(("exception", "reason", "try_number"))
+    retn_keys.update(("callback", "exception", "reason", "try_number"))
+    docs_keys.update(("callback", "exception", "reason", "try_number"))
 
     # Airflow 3 added:
     retn_keys.add("task_reschedule_count")

--- a/task-sdk/docs/api.rst
+++ b/task-sdk/docs/api.rst
@@ -109,6 +109,10 @@ Callbacks
 
 .. autoclass:: airflow.sdk.SyncCallback
 
+.. autoclass:: airflow.sdk.CallbackSource
+
+.. autoclass:: airflow.sdk.CallbackMeta
+
 Deadline Alerts
 ---------------
 .. autoclass:: airflow.sdk.DeadlineAlert

--- a/task-sdk/src/airflow/sdk/__init__.py
+++ b/task-sdk/src/airflow/sdk/__init__.py
@@ -38,6 +38,8 @@ __all__ = [
     "BaseSensorOperator",
     "BaseXCom",
     "BranchMixIn",
+    "CallbackMeta",
+    "CallbackSource",
     "ChainMapper",
     "Connection",
     "Context",
@@ -144,7 +146,13 @@ if TYPE_CHECKING:
     from airflow.sdk.definitions.asset.metadata import Metadata
     from airflow.sdk.definitions.callback import AsyncCallback, SyncCallback
     from airflow.sdk.definitions.connection import Connection
-    from airflow.sdk.definitions.context import Context, get_current_context, get_parsing_context
+    from airflow.sdk.definitions.context import (
+        CallbackMeta as CallbackMeta,
+        CallbackSource as CallbackSource,
+        Context,
+        get_current_context,
+        get_parsing_context,
+    )
     from airflow.sdk.definitions.dag import DAG, dag
     from airflow.sdk.definitions.deadline import DeadlineAlert, DeadlineReference
     from airflow.sdk.definitions.decorators import setup, task, teardown
@@ -227,6 +235,8 @@ __lazy_imports: dict[str, str] = {
     "BaseSensorOperator": ".bases.sensor",
     "BaseXCom": ".bases.xcom",
     "BranchMixIn": ".bases.branch",
+    "CallbackMeta": ".definitions.context",
+    "CallbackSource": ".definitions.context",
     "ChainMapper": ".definitions.partition_mappers.chain",
     "Connection": ".definitions.connection",
     "Context": ".definitions.context",

--- a/task-sdk/src/airflow/sdk/__init__.py
+++ b/task-sdk/src/airflow/sdk/__init__.py
@@ -37,6 +37,8 @@ __all__ = [
     "BaseSensorOperator",
     "BaseXCom",
     "BranchMixIn",
+    "CallbackMeta",
+    "CallbackSource",
     "ChainMapper",
     "Connection",
     "Context",
@@ -118,7 +120,13 @@ if TYPE_CHECKING:
     from airflow.sdk.definitions.asset.metadata import Metadata
     from airflow.sdk.definitions.callback import AsyncCallback, SyncCallback
     from airflow.sdk.definitions.connection import Connection
-    from airflow.sdk.definitions.context import Context, get_current_context, get_parsing_context
+    from airflow.sdk.definitions.context import (
+        CallbackMeta as CallbackMeta,
+        CallbackSource as CallbackSource,
+        Context,
+        get_current_context,
+        get_parsing_context,
+    )
     from airflow.sdk.definitions.dag import DAG, dag
     from airflow.sdk.definitions.deadline import DeadlineAlert, DeadlineReference
     from airflow.sdk.definitions.decorators import setup, task, teardown
@@ -181,6 +189,8 @@ __lazy_imports: dict[str, str] = {
     "BaseSensorOperator": ".bases.sensor",
     "BaseXCom": ".bases.xcom",
     "BranchMixIn": ".bases.branch",
+    "CallbackMeta": ".definitions.context",
+    "CallbackSource": ".definitions.context",
     "ChainMapper": ".definitions.partition_mappers.chain",
     "Connection": ".definitions.connection",
     "Context": ".definitions.context",

--- a/task-sdk/src/airflow/sdk/__init__.pyi
+++ b/task-sdk/src/airflow/sdk/__init__.pyi
@@ -53,6 +53,8 @@ from airflow.sdk.definitions.asset.decorators import asset as asset
 from airflow.sdk.definitions.asset.metadata import Metadata as Metadata
 from airflow.sdk.definitions.connection import Connection as Connection
 from airflow.sdk.definitions.context import (
+    CallbackMeta as CallbackMeta,
+    CallbackSource as CallbackSource,
     Context as Context,
     get_current_context as get_current_context,
     get_parsing_context as get_parsing_context,

--- a/task-sdk/src/airflow/sdk/__init__.pyi
+++ b/task-sdk/src/airflow/sdk/__init__.pyi
@@ -55,6 +55,8 @@ from airflow.sdk.definitions.asset.decorators import asset as asset
 from airflow.sdk.definitions.asset.metadata import Metadata as Metadata
 from airflow.sdk.definitions.connection import Connection as Connection
 from airflow.sdk.definitions.context import (
+    CallbackMeta as CallbackMeta,
+    CallbackSource as CallbackSource,
     Context as Context,
     get_current_context as get_current_context,
     get_parsing_context as get_parsing_context,

--- a/task-sdk/src/airflow/sdk/definitions/context.py
+++ b/task-sdk/src/airflow/sdk/definitions/context.py
@@ -18,11 +18,36 @@
 from __future__ import annotations
 
 import copy
+import enum
 import os
 from collections.abc import MutableMapping
 from typing import TYPE_CHECKING, Any, NamedTuple, TypedDict, cast
 
 from typing_extensions import NotRequired
+
+
+class CallbackSource(str, enum.Enum):
+    """Whether a callback was triggered at the DAG level or the task level."""
+
+    DAG = "dag"
+    TASK = "task"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+class CallbackMeta(NamedTuple):
+    """
+    Metadata about the callback that is being executed.
+
+    Present in the callback context as ``context["callback"]``.
+
+    ``source`` tells whether the callback was defined on the DAG or on a task.
+    More fields may be added in the future without breaking existing callbacks.
+    """
+
+    source: CallbackSource
+
 
 if TYPE_CHECKING:
     import jinja2
@@ -42,6 +67,7 @@ if TYPE_CHECKING:
 class Context(TypedDict, total=False):
     """Jinja2 template context for task rendering."""
 
+    callback: NotRequired[CallbackMeta]
     conn: Any
     dag: DAG
     dag_run: DagRunProtocol

--- a/task-sdk/src/airflow/sdk/definitions/context.py
+++ b/task-sdk/src/airflow/sdk/definitions/context.py
@@ -18,11 +18,36 @@
 from __future__ import annotations
 
 import copy
+import enum
 import os
 from collections.abc import MutableMapping
 from typing import TYPE_CHECKING, Any, NamedTuple, TypedDict, cast
 
 from typing_extensions import NotRequired
+
+
+class CallbackSource(str, enum.Enum):
+    """Whether a callback was triggered at the DAG level or the task level."""
+
+    DAG = "dag"
+    TASK = "task"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+class CallbackMeta(NamedTuple):
+    """
+    Metadata about the callback that is being executed.
+
+    Present in the callback context as ``context["callback"]``.
+
+    ``source`` tells whether the callback was defined on the DAG or on a task.
+    More fields may be added in the future without breaking existing callbacks.
+    """
+
+    source: CallbackSource
+
 
 if TYPE_CHECKING:
     import jinja2
@@ -46,6 +71,7 @@ if TYPE_CHECKING:
 class Context(TypedDict, total=False):
     """Jinja2 template context for task rendering."""
 
+    callback: NotRequired[CallbackMeta]
     conn: Any
     dag: DAG
     dag_run: DagRunProtocol

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1860,6 +1860,9 @@ def _run_task_state_change_callbacks(
     context: Context,
     log: Logger,
 ) -> None:
+    from airflow.sdk.definitions.context import CallbackMeta, CallbackSource
+
+    context["callback"] = CallbackMeta(source=CallbackSource.TASK)
     callback: Callable[[Context], None]
     for i, callback in enumerate(getattr(task, kind)):
         try:

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1561,6 +1561,9 @@ def _run_task_state_change_callbacks(
     context: Context,
     log: Logger,
 ) -> None:
+    from airflow.sdk.definitions.context import CallbackMeta, CallbackSource
+
+    context["callback"] = CallbackMeta(source=CallbackSource.TASK)
     callback: Callable[[Context], None]
     for i, callback in enumerate(getattr(task, kind)):
         try:

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -4635,6 +4635,40 @@ class TestTaskRunnerCallsCallbacks:
         )
         assert callback_data["duration"] >= 0, f"duration should be >= 0, got {callback_data['duration']}"
 
+    @pytest.mark.parametrize(
+        ("callback_kind", "expected_state"),
+        [
+            pytest.param("on_success_callback", TaskInstanceState.SUCCESS, id="success"),
+            pytest.param("on_failure_callback", TaskInstanceState.FAILED, id="failure"),
+        ],
+    )
+    def test_task_callback_context_has_callback_meta(self, create_runtime_ti, callback_kind, expected_state):
+        """Task-level callbacks should receive callback.source=TASK in the context."""
+        from airflow.sdk.definitions.context import CallbackSource
+
+        captured = {}
+
+        def capture_callback(context):
+            captured["callback"] = context.get("callback")
+
+        succeeds = callback_kind == "on_success_callback"
+
+        class CustomOperator(BaseOperator):
+            def execute(self, context):
+                if succeeds:
+                    return "ok"
+                raise AirflowException("boom")
+
+        task = CustomOperator(task_id="cb_task", **{callback_kind: capture_callback})
+        runtime_ti = create_runtime_ti(dag_id="dag", task=task)
+        log = mock.MagicMock()
+        context = runtime_ti.get_template_context()
+        state, _, error = run(runtime_ti, context, log)
+        finalize(runtime_ti, state, context, log, error)
+
+        assert state == expected_state
+        assert captured["callback"].source is CallbackSource.TASK
+
     def test_task_runner_both_callbacks_have_timing_info(self, create_runtime_ti):
         """Test that both success and failure callbacks receive accurate timing information."""
         import time

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -4302,6 +4302,40 @@ class TestTaskRunnerCallsCallbacks:
         )
         assert callback_data["duration"] >= 0, f"duration should be >= 0, got {callback_data['duration']}"
 
+    @pytest.mark.parametrize(
+        ("callback_kind", "expected_state"),
+        [
+            pytest.param("on_success_callback", TaskInstanceState.SUCCESS, id="success"),
+            pytest.param("on_failure_callback", TaskInstanceState.FAILED, id="failure"),
+        ],
+    )
+    def test_task_callback_context_has_callback_meta(self, create_runtime_ti, callback_kind, expected_state):
+        """Task-level callbacks should receive callback.source=TASK in the context."""
+        from airflow.sdk.definitions.context import CallbackSource
+
+        captured = {}
+
+        def capture_callback(context):
+            captured["callback"] = context.get("callback")
+
+        succeeds = callback_kind == "on_success_callback"
+
+        class CustomOperator(BaseOperator):
+            def execute(self, context):
+                if succeeds:
+                    return "ok"
+                raise AirflowException("boom")
+
+        task = CustomOperator(task_id="cb_task", **{callback_kind: capture_callback})
+        runtime_ti = create_runtime_ti(dag_id="dag", task=task)
+        log = mock.MagicMock()
+        context = runtime_ti.get_template_context()
+        state, _, error = run(runtime_ti, context, log)
+        finalize(runtime_ti, state, context, log, error)
+
+        assert state == expected_state
+        assert captured["callback"].source is CallbackSource.TASK
+
     def test_task_runner_both_callbacks_have_timing_info(self, create_runtime_ti):
         """Test that both success and failure callbacks receive accurate timing information."""
         import time


### PR DESCRIPTION
## Summary

Adds a `callback` key to the callback context that carries a `CallbackMeta` named tuple, letting shared callbacks tell whether they were triggered at the DAG level or the task level.

- New `CallbackSource` str enum (`"dag"` / `"task"`) and `CallbackMeta` named tuple in `airflow.sdk.definitions.context`
- Injects `context["callback"] = CallbackMeta(source=...)` in all four callback invocation paths
- The `Context` TypedDict field is `NotRequired` because it is only set during callback execution, not during normal task template rendering
- Both classes are exported from `airflow.sdk` for user access

### Usage example

```python
from airflow.sdk import CallbackMeta, CallbackSource

def my_callback(context):
    if context["callback"].source == CallbackSource.DAG:
        notify_team(f"DAG run finished: {context['reason']}")
    else:
        notify_team(f"Task {context['ti'].task_id} finished")
```

Using a `CallbackMeta` named tuple (instead of a bare enum) makes it easy to add more metadata fields in the future without breaking existing callbacks.

## Test plan

- New test `test_task_callback_context_has_callback_meta` covers success and failure task callbacks
- Assertions added to existing DAG callback processor tests (with and without `context_from_server`)
- Assertion added to existing task callback processor test

## Gen-AI disclosure

This PR was developed with the assistance of a generative AI coding tool (Cursor). All code was reviewed, understood, and validated by me before inclusion. I take full responsibility for the changes.

Closes #61119