### PR TITLE
[v2-11-test] Fix root logger level cache invalidation in LoggerMutationHelper

### DIFF
--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -794,7 +794,7 @@ class LoggerMutationHelper:
             for h in self.handlers:
                 if h not in logger.handlers:
                     logger.addHandler(h)
-        logger.level = self.level
+        logger.setLevel(self.level)
         if logger is not logging.getLogger():
             logger.propagate = self.propagate
 


### PR DESCRIPTION
### Why
Currently, the code assigns the log level directly to the `.level` attribute.
This violates the [official Python documentation](https://docs.python.org/3/library/logging.html#logging.Logger.level), which explicitly states:
- Note: Do not set this attribute directly - always use `setLevel()`, which has checks for the level passed to it.

This direct assignment bypasses the Python logging module's cache invalidation mechanism. If the root logger was previously initialized with a different level (e.g., WARNING), the stale cache persists. This causes logs (e.g., INFO) to be suppressed during task execution even after the level update.

### What
Change the assignment to use the standard method `.setLevel()`.
This ensures the internal cache is cleared via `_clear_cache()` and the new level takes effect immediately.