### PR TITLE
Add missing bundles entries to Amazon and Google provider.yaml

### DIFF
--- a/providers/amazon/provider.yaml
+++ b/providers/amazon/provider.yaml
@@ -725,6 +725,11 @@ hooks:
     python-modules:
       - airflow.providers.amazon.aws.hooks.neptune
 
+bundles:
+  - integration-name: Amazon Simple Storage Service (S3)
+    python-modules:
+      - airflow.providers.amazon.aws.bundles.s3
+
 triggers:
   - integration-name: Amazon Web Services
     python-modules:

--- a/providers/amazon/src/airflow/providers/amazon/get_provider_info.py
+++ b/providers/amazon/src/airflow/providers/amazon/get_provider_info.py
@@ -806,6 +806,12 @@ def get_provider_info():
                 "python-modules": ["airflow.providers.amazon.aws.hooks.neptune"],
             },
         ],
+        "bundles": [
+            {
+                "integration-name": "Amazon Simple Storage Service (S3)",
+                "python-modules": ["airflow.providers.amazon.aws.bundles.s3"],
+            }
+        ],
         "triggers": [
             {
                 "integration-name": "Amazon Web Services",

--- a/providers/google/provider.yaml
+++ b/providers/google/provider.yaml
@@ -906,6 +906,10 @@ hooks:
     python-modules:
       - airflow.providers.google.cloud.hooks.gen_ai
 
+bundles:
+  - integration-name: Google Cloud Storage (GCS)
+    python-modules:
+      - airflow.providers.google.cloud.bundles.gcs
 
 triggers:
   - integration-name: Google BigQuery Data Transfer Service

--- a/providers/google/src/airflow/providers/google/get_provider_info.py
+++ b/providers/google/src/airflow/providers/google/get_provider_info.py
@@ -1056,6 +1056,12 @@ def get_provider_info():
                 "python-modules": ["airflow.providers.google.cloud.hooks.gen_ai"],
             },
         ],
+        "bundles": [
+            {
+                "integration-name": "Google Cloud Storage (GCS)",
+                "python-modules": ["airflow.providers.google.cloud.bundles.gcs"],
+            }
+        ],
         "triggers": [
             {
                 "integration-name": "Google BigQuery Data Transfer Service",

--- a/scripts/in_container/run_provider_yaml_files_check.py
+++ b/scripts/in_container/run_provider_yaml_files_check.py
@@ -342,14 +342,14 @@ def check_integration_duplicates(yaml_files: dict[str, dict]) -> tuple[int, int]
     return num_integrations, num_errors
 
 
-@run_check("Checking completeness of list of {sensors, hooks, operators, triggers}")
+@run_check("Checking completeness of list of {sensors, hooks, operators, triggers, bundles}")
 def check_correctness_of_list_of_sensors_operators_hook_trigger_modules(
     yaml_files: dict[str, dict],
 ) -> tuple[int, int]:
     num_errors = 0
     num_modules = 0
     for (yaml_file_path, provider_data), resource_type in itertools.product(
-        yaml_files.items(), ["sensors", "operators", "hooks", "triggers"]
+        yaml_files.items(), ["sensors", "operators", "hooks", "triggers", "bundles"]
     ):
         expected_modules, provider_package, resource_data = parse_module_data(
             provider_data, resource_type, yaml_file_path
@@ -381,14 +381,14 @@ def check_correctness_of_list_of_sensors_operators_hook_trigger_modules(
     return num_modules, num_errors
 
 
-@run_check("Checking for duplicates in list of {sensors, hooks, operators, triggers}")
+@run_check("Checking for duplicates in list of {sensors, hooks, operators, triggers, bundles}")
 def check_duplicates_in_integrations_names_of_hooks_sensors_operators(
     yaml_files: dict[str, dict],
 ) -> tuple[int, int]:
     num_errors = 0
     num_integrations = 0
     for (yaml_file_path, provider_data), resource_type in itertools.product(
-        yaml_files.items(), ["sensors", "operators", "hooks", "triggers"]
+        yaml_files.items(), ["sensors", "operators", "hooks", "triggers", "bundles"]
     ):
         resource_data = provider_data.get(resource_type, [])
         count_integrations = Counter(r.get("integration-name", "") for r in resource_data)
@@ -536,7 +536,7 @@ def check_invalid_integration(yaml_files: dict[str, dict]) -> tuple[int, int]:
     num_errors = 0
     num_integrations = len(all_integration_names)
     for (yaml_file_path, provider_data), resource_type in itertools.product(
-        yaml_files.items(), ["sensors", "operators", "hooks", "triggers"]
+        yaml_files.items(), ["sensors", "operators", "hooks", "triggers", "bundles"]
     ):
         resource_data = provider_data.get(resource_type, [])
         current_names = {r["integration-name"] for r in resource_data}


### PR DESCRIPTION
The Amazon S3 and Google GCS DAG bundle implementations exist but were not declared in their respective `provider.yaml` files. The Git provider already had its bundle listed — this brings Amazon and Google in line.

Also adds `"bundles"` to the three provider.yaml validation checks in `run_provider_yaml_files_check.py` (completeness, duplicates, integration-name validation), matching how operators, sensors, hooks, and triggers are already validated.