### PR TITLE
Make code compatible with setuptools v82++

### DIFF
--- a/providers/openlineage/tests/unit/openlineage/plugins/test_utils.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_utils.py
@@ -26,7 +26,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from attrs import define
 from openlineage.client.utils import RedactMixin
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 from airflow.providers.common.compat.assets import Asset
 from airflow.providers.common.compat.sdk import timezone


### PR DESCRIPTION
Setuptools v82.0.0 ~deprecated~ **removed** `pkg_resources` - see https://setuptools.pypa.io/en/stable/history.html#v82-0-0

This fixes broken canary and all PRs failing on https://github.com/apache/airflow/actions/runs/21800753818

---

##### Was generative AI tooling used to co-author this PR?

- [ ] No (please specify the tool below)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
