### PR TITLE
Remove flaky "Download GPG keys" step from CI

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -119,10 +119,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-      - name: "Download GPG keys"
-        run: |
-          wget -q -O /tmp/KEYS https://dist.apache.org/repos/dist/release/airflow/KEYS
-          gpg --import /tmp/KEYS || true
       - name: "Install hatch"
         run: uv tool install hatch
       - name: "Run integration tests"


### PR DESCRIPTION
The run-breeze-integration-tests job in .github/workflows/basic-tests.yml (line 122-125) downloads GPG keys from https://dist.apache.org/repos/dist/release/airflow/KEYS via wget. This network call frequently fails when the Apache SVN infrastructure is under high load, causing the CI step to fail (the || true only covers gpg --import, not wget itself).

The only consumer of these imported GPG keys is one integration test class: TestValidateSignaturesIntegration in dev/breeze/tests/test_airflow_release_validator_integration.py:199-217. This test already handles missing keys gracefully — when gpg --verify fails due to missing public keys, the test asserts that the failure details contain hints about downloading keys, and the test passes either way.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: Claude Opus 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
