### PR TITLE
Fix OtelTrace crash on None/empty context carrier

### DIFF
--- a/shared/observability/src/airflow_shared/observability/traces/otel_tracer.py
+++ b/shared/observability/src/airflow_shared/observability/traces/otel_tracer.py
@@ -217,9 +217,10 @@ class OtelTrace:
             parent_span_context = trace.get_current_span().get_span_context()
             parent_context = trace.set_span_in_context(NonRecordingSpan(parent_span_context))
         else:
-            context_val = next(iter(parent_context.values()))
+            # Handle empty context (e.g., from empty carrier {})
+            context_val = next(iter(parent_context.values()), None)
             parent_span_context = None
-            if isinstance(context_val, NonRecordingSpan):
+            if context_val is not None and isinstance(context_val, NonRecordingSpan):
                 parent_span_context = context_val.get_span_context()
 
         if links is None:
@@ -291,8 +292,10 @@ class OtelTrace:
         TraceContextTextMapPropagator().inject(carrier)
         return carrier
 
-    def extract(self, carrier: dict) -> Context:
+    def extract(self, carrier: dict | None) -> Context:
         """Extract the span context from a provided carrier."""
+        if carrier is None:
+            return {}
         return TraceContextTextMapPropagator().extract(carrier)
 
 

--- a/shared/observability/tests/observability/traces/__init__.py
+++ b/shared/observability/tests/observability/traces/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/shared/observability/tests/observability/traces/test_otel_tracer.py
+++ b/shared/observability/tests/observability/traces/test_otel_tracer.py
@@ -1,0 +1,113 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from opentelemetry.context import Context
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
+
+from airflow_shared.observability.traces.otel_tracer import OtelTrace
+
+
+@pytest.fixture
+def otel_trace():
+    """Create an OtelTrace instance with mocked span exporter."""
+    mock_exporter = MagicMock()
+    return OtelTrace(
+        span_exporter=mock_exporter,
+        use_simple_processor=True,
+        otel_service="test-service",
+    )
+
+
+class TestOtelTraceExtract:
+    """Tests for OtelTrace.extract() method."""
+
+    def test_extract_with_none_carrier_returns_empty_dict(self, otel_trace):
+        """Test that extract() handles None carrier gracefully.
+
+        This can happen when context_carrier is NULL in DB (tasks created
+        before OTel was enabled, then cleared/backfilled).
+        """
+        result = otel_trace.extract(None)
+        assert result == {}
+
+    def test_extract_with_empty_carrier_returns_empty_context(self, otel_trace):
+        """Test that extract() handles empty dict carrier."""
+        result = otel_trace.extract({})
+        # Empty carrier should return an empty Context (no span info)
+        assert isinstance(result, Context)
+
+    def test_extract_with_valid_carrier(self, otel_trace):
+        """Test that extract() works with a valid traceparent carrier."""
+        carrier = {"traceparent": "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"}
+        result = otel_trace.extract(carrier)
+        assert isinstance(result, Context)
+
+
+class TestOtelTraceStartChildSpan:
+    """Tests for OtelTrace.start_child_span() method."""
+
+    def test_start_child_span_with_none_parent_context(self, otel_trace):
+        """Test that start_child_span() works when parent_context is None."""
+        # Should use current span context as parent
+        with patch.object(otel_trace, "_new_span") as mock_new_span:
+            mock_new_span.return_value = MagicMock()
+            otel_trace.start_child_span("test-span", parent_context=None)
+            mock_new_span.assert_called_once()
+
+    def test_start_child_span_with_empty_context(self, otel_trace):
+        """Test that start_child_span() handles empty Context gracefully.
+
+        This can happen when context_carrier is {} (empty dict), which causes
+        extract() to return an empty Context. Previously this would raise
+        StopIteration from next(iter(parent_context.values())).
+        """
+        empty_context = Context()
+
+        with patch.object(otel_trace, "_new_span") as mock_new_span:
+            mock_new_span.return_value = MagicMock()
+            # Should not raise StopIteration
+            otel_trace.start_child_span("test-span", parent_context=empty_context)
+            mock_new_span.assert_called_once()
+
+    def test_start_child_span_with_valid_parent_context(self, otel_trace):
+        """Test that start_child_span() works with a valid parent context."""
+        # Create a valid span context
+        span_context = SpanContext(
+            trace_id=0x0AF7651916CD43DD8448EB211C80319C,
+            span_id=0xB7AD6B7169203331,
+            is_remote=True,
+            trace_flags=TraceFlags(0x01),
+        )
+        non_recording_span = NonRecordingSpan(span_context)
+
+        # Create a context with the span
+        from opentelemetry import trace
+
+        parent_context = trace.set_span_in_context(non_recording_span)
+
+        with patch.object(otel_trace, "_new_span") as mock_new_span:
+            mock_new_span.return_value = MagicMock()
+            otel_trace.start_child_span("test-span", parent_context=parent_context)
+            mock_new_span.assert_called_once()
+            # Verify that links include the parent trace
+            call_kwargs = mock_new_span.call_args[1]
+            assert len(call_kwargs["links"]) == 1
+            assert call_kwargs["links"][0].attributes["from"] == "parenttrace"


### PR DESCRIPTION
 **Summary**

Fixes two bugs in `OtelTrace` that cause scheduler crashes when processing tasks with NULL or empty `context_carrier`.
 Bug 1: `OtelTrace.extract(None)` crashes with AttributeError
- **Symptom**: `AttributeError: 'NoneType' object has no attribute 'get'`
- **Cause**: When `context_carrier` is NULL in DB (tasks created before OTel was enabled, then cleared/backfilled), `TraceContextTextMapPropagator().extract(carrier)` calls `carrier.get()` which fails.
- **Fix**: Return empty dict `{}` when carrier is `None`.
 Bug 2: `OtelTrace.start_child_span()` crashes with StopIteration
- **Symptom**: `StopIteration` exception
- **Cause**: When `context_carrier` is `{}` (empty dict), `extract()` returns an empty `Context` object. `next(iter(parent_context.values()))` raises `StopIteration` on empty iterator.
- **Fix**: Use `next(..., None)` with default value and guard the `isinstance` check.
Both bugs are triggered in `base_executor.py:trigger_tasks()` when the scheduler enqueues a task whose `dag_run.context_carrier` is `None` or empty.
 Reproduction Path
1. Enable OTel tracing on an existing Airflow deployment
2. Tasks/dag_runs created before OTel was enabled have `context_carrier = NULL`
3. Clear or backfill those tasks
4. Scheduler crashes in `base_executor.py:trigger_tasks()` → `workloads.py` → `Trace.extract()`
 Testing
- Added unit tests: `shared/observability/tests/observability/traces/test_otel_tracer.py`
- All 6 tests passed in Breeze
- Verified fix in production Airflow 3.1.6 environment
<!--
Thank you for contributing!
Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/
Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.
Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.
In case of an existing issue, reference it using one of the following:
* closes: #ISSUE
* related: #ISSUE
-->
---
 Was generative AI tooling used to co-author this PR?
- [X] Yes (please specify the tool below)
Generated-by: Claude (Anthropic) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
---
* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
---