### PR TITLE
Change PythonOperator show_return_value_in_logs default to False

### DIFF
--- a/providers/standard/src/airflow/providers/standard/operators/python.py
+++ b/providers/standard/src/airflow/providers/standard/operators/python.py
@@ -163,9 +163,9 @@ class PythonOperator(BaseAsyncOperator):
     :param templates_exts: a list of file extensions to resolve while
         processing templated fields, for examples ``['.sql', '.hql']``
     :param show_return_value_in_logs: a bool value whether to show return_value
-        logs. Defaults to True, which allows return value log output.
-        It can be set to False to prevent log output of return value when you return huge data
-        such as transmission a large amount of XCom to TaskAPI.
+        logs. Defaults to False to prevent log output of return value when you return huge data,
+        which could cause out-of-memory (OOM) errors. Set to True if you want to see the return
+        value in logs for debugging purposes.
     """
 
     template_fields: Sequence[str] = ("templates_dict", "op_args", "op_kwargs")
@@ -185,7 +185,7 @@ class PythonOperator(BaseAsyncOperator):
         op_kwargs: Mapping[str, Any] | None = None,
         templates_dict: dict[str, Any] | None = None,
         templates_exts: Sequence[str] | None = None,
-        show_return_value_in_logs: bool = True,
+        show_return_value_in_logs: bool = False,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)

--- a/providers/standard/tests/unit/standard/operators/test_python.py
+++ b/providers/standard/tests/unit/standard/operators/test_python.py
@@ -335,7 +335,7 @@ class TestPythonOperator(BasePythonTest):
     @pytest.mark.parametrize(
         ("show_return_value_in_logs", "should_shown"),
         [
-            pytest.param(NOTSET, True, id="default"),
+            pytest.param(NOTSET, False, id="default"),
             pytest.param(True, True, id="show"),
             pytest.param(False, False, id="hide"),
         ],


### PR DESCRIPTION
The default value of `show_return_value_in_logs` parameter is changed from True to False to prevent out-of-memory (OOM) errors when operators return large amounts of data.

This change makes PythonOperator consistent with SQLExecuteQueryOperator, which also defaults to False for the same reason.

Users can still set show_return_value_in_logs=True explicitly if they want to see return values in logs for debugging purposes.

closes: #61639

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
