### PR TITLE
fix timetable serialization error when decoding relative delta

### DIFF
--- a/airflow-core/src/airflow/serialization/decoders.py
+++ b/airflow-core/src/airflow/serialization/decoders.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 import datetime
+from copy import deepcopy
 from typing import TYPE_CHECKING, Any, TypeVar
 
 import dateutil.relativedelta
@@ -56,9 +57,10 @@ R = TypeVar("R")
 
 def decode_relativedelta(var: dict[str, Any]) -> dateutil.relativedelta.relativedelta:
     """Dencode a relativedelta object."""
-    if "weekday" in var:
-        var["weekday"] = dateutil.relativedelta.weekday(*var["weekday"])
-    return dateutil.relativedelta.relativedelta(**var)
+    copy_var = deepcopy(var)
+    if "weekday" in copy_var:
+        copy_var["weekday"] = dateutil.relativedelta.weekday(*copy_var["weekday"])
+    return dateutil.relativedelta.relativedelta(**copy_var)
 
 
 def decode_interval(value: int | dict) -> datetime.timedelta | dateutil.relativedelta.relativedelta:

--- a/airflow-core/src/airflow/serialization/decoders.py
+++ b/airflow-core/src/airflow/serialization/decoders.py
@@ -19,7 +19,6 @@
 from __future__ import annotations
 
 import datetime
-from copy import deepcopy
 from typing import TYPE_CHECKING, Any, TypeVar
 
 import dateutil.relativedelta
@@ -57,7 +56,7 @@ R = TypeVar("R")
 
 def decode_relativedelta(var: dict[str, Any]) -> dateutil.relativedelta.relativedelta:
     """Dencode a relativedelta object."""
-    copy_var = deepcopy(var)
+    copy_var = var.copy()
     if "weekday" in copy_var:
         copy_var["weekday"] = dateutil.relativedelta.weekday(*copy_var["weekday"])
     return dateutil.relativedelta.relativedelta(**copy_var)

--- a/airflow-core/tests/unit/serialization/test_serialized_objects.py
+++ b/airflow-core/tests/unit/serialization/test_serialized_objects.py
@@ -656,6 +656,24 @@ def test_hash_property():
     assert lazy_serialized_dag.hash == SerializedDagModel.hash(data)
 
 
+def test_timetable_property_serialize():
+    data = {
+        "dag": {
+            "timetable": {
+                "__type": "airflow.timetables.trigger.DeltaTriggerTimetable",
+                "__var": {"delta": {"weekday": [6]}, "interval": 0.0},
+            }
+        }
+    }
+    lazy_serialized_dag = LazyDeserializedDAG(data=data)
+    before_get_timetable_property = json.dumps(lazy_serialized_dag.data["dag"]["timetable"]["__var"]["delta"])
+    _ = lazy_serialized_dag.timetable
+    assert (
+        json.dumps(lazy_serialized_dag.data["dag"]["timetable"]["__var"]["delta"])
+        == before_get_timetable_property
+    )
+
+
 @pytest.mark.parametrize(
     ("payload", "expected_cls"),
     [


### PR DESCRIPTION
related: https://apache-airflow.slack.com/archives/CCQ7EGB1P/p1770622588017049

## Problem

When using the following relative syntax, the dag-processor crashes if weekday is used.
```python
dag = DAG(
    dag_id=dag_id,
    default_args=default_args,
    description=f'dynamic_dag_id',
    schedule=relativedelta(weekday=SU) # problem
)
```
```bash
File "/home/airflow/.local/lib/python3.12/site-packages/airflow/serialization/serialized_objects.py", line 4000, in timetable
    return decode_timetable(self.data["dag"]["timetable"])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/serialization/serialized_objects.py", line 459, in decode_timetable
    return timetable_class.deserialize(var[Encoding.VAR])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/timetables/trigger.py", line 154, in deserialize
    _deserialize_interval(data["delta"]),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/timetables/trigger.py", line 51, in _deserialize_interval
    return decode_relativedelta(value)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/serialization/serialized_objects.py", line 179, in decode_relativedelta
    var["weekday"] = relativedelta.weekday(*var["weekday"])
```

## Why?

The root cause is that the initial state of the timetable in serialized dag is `'timetable': {'__type': 'airflow.timetables.trigger.DeltaTriggerTimetable', '__var': {'delta': {'weekday': [6]}, 'interval': 0.0}}`, but during the serialization process, the value gets modified when the function `decode_relativedelta` is called. The modified value becomes `'timetable': {'__type': 'airflow.timetables.trigger.DeltaTriggerTimetable', '__var': {'delta': {'weekday': SU}, 'interval': 0.0}`, where it's updated to an object value.

## Solution

Fixed by using `deepcopy` to prevent modification of the original value (serialized dag).

## 



<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
