### PR TITLE
Fix ModuleNotFoundError in kubernetes cleanup cronjob

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/cli/kubernetes_command.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/cli/kubernetes_command.py
@@ -37,8 +37,6 @@ from airflow.utils import cli as cli_utils, yaml
 from airflow.utils.providers_configuration_loader import providers_configuration_loaded
 from airflow.utils.types import DagRunType
 
-from tests_common.test_utils.taskinstance import create_task_instance
-
 if AIRFLOW_V_3_1_PLUS:
     from airflow.utils.cli import get_bagged_dag
 else:
@@ -75,7 +73,8 @@ def generate_pod_yaml(args):
         if AIRFLOW_V_3_0_PLUS:
             from uuid6 import uuid7
 
-            ti = create_task_instance(task, run_id=dr.run_id, dag_version_id=uuid7())
+            ti = TaskInstance(task, run_id=dr.run_id)
+            ti.dag_version_id = uuid7()
         else:
             ti = TaskInstance(task, run_id=dr.run_id)
         ti.dag_run = dr

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/cli/kubernetes_command.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/cli/kubernetes_command.py
@@ -73,8 +73,10 @@ def generate_pod_yaml(args):
         if AIRFLOW_V_3_0_PLUS:
             from uuid6 import uuid7
 
-            ti = TaskInstance(task, run_id=dr.run_id)
-            ti.dag_version_id = uuid7()
+            from airflow.serialization.serialized_objects import create_scheduler_operator
+
+            serialized_task = create_scheduler_operator(task)
+            ti = TaskInstance(serialized_task, run_id=dr.run_id, dag_version_id=uuid7())
         else:
             ti = TaskInstance(task, run_id=dr.run_id)
         ti.dag_run = dr

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/cli/kubernetes_command.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/cli/kubernetes_command.py
@@ -37,6 +37,11 @@ from airflow.utils import cli as cli_utils, yaml
 from airflow.utils.providers_configuration_loader import providers_configuration_loaded
 from airflow.utils.types import DagRunType
 
+try:
+    from airflow.serialization.serialized_objects import create_scheduler_operator
+except ImportError:
+    create_scheduler_operator = lambda t: t
+
 if AIRFLOW_V_3_1_PLUS:
     from airflow.utils.cli import get_bagged_dag
 else:
@@ -72,8 +77,6 @@ def generate_pod_yaml(args):
     for task in dag.tasks:
         if AIRFLOW_V_3_0_PLUS:
             from uuid6 import uuid7
-
-            from airflow.serialization.serialized_objects import create_scheduler_operator
 
             serialized_task = create_scheduler_operator(task)
             ti = TaskInstance(serialized_task, run_id=dr.run_id, dag_version_id=uuid7())


### PR DESCRIPTION
The cleanup cronjob in apache-airflow-providers-cncf-kubernetes >= 10.12.2 fails in production because it imports from tests_common.test_utils.taskinstance, which is not available outside the dev repository.

Solution: Remove test utility import and use TaskInstance directly, manually setting dag_version_id for Airflow 3.0+ compatibility.

related: #60112
closed: #61360

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
