### PR TITLE
Docs: clarify JSON list and dict usage in Variables

### DIFF
--- a/airflow-core/docs/core-concepts/variables.rst
+++ b/airflow-core/docs/core-concepts/variables.rst
@@ -30,6 +30,13 @@ To use them, just import and call ``get`` on the Variable model::
     # Auto-deserializes a JSON value
     bar = Variable.get("bar", deserialize_json=True)
 
+.. note::
+
+   Variable values that represent lists or dictionaries must be stored as
+   valid JSON strings. When ``deserialize_json=True`` is used, Airflow will
+   automatically deserialize the stored JSON value into a native Python
+   object when accessed.
+
     # Returns the value of default (None) if the variable is not set
     baz = Variable.get("baz", default=None)
 

--- a/airflow-core/docs/core-concepts/variables.rst
+++ b/airflow-core/docs/core-concepts/variables.rst
@@ -37,6 +37,14 @@ To use them, just import and call ``get`` on the Variable model::
    automatically deserialize the stored JSON value into a native Python
    object when accessed.
 
+Example of a JSON list stored as a Variable::
+
+   [
+     {"foo": "bar"},
+     {"bar": "foo"}
+   ]
+
+
     # Returns the value of default (None) if the variable is not set
     baz = Variable.get("baz", default=None)
 


### PR DESCRIPTION
### What does this PR do?

Clarifies how Airflow Variables should store list and dictionary values using valid JSON, and adds a small example to demonstrate correct usage with `deserialize_json=True`.

### Why is this needed?

This avoids confusion for users who attempt to store complex values in Variables and are unsure of the required JSON format.

### How was this tested?

Documentation-only change. No code behavior is modified.
