### PR TITLE
UI variables page: added option to view text as multi lines

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Variables/Variables.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/Variables.tsx
@@ -54,9 +54,9 @@ const getColumns = ({
   multiTeam,
   onRowSelect,
   onSelectAll,
-  selectedRows,
   open,
-  translate
+  selectedRows,
+  translate,
 }: ColumnProps & GetColumnsParams): Array<ColumnDef<VariableResponse>> => {
   const columns: Array<ColumnDef<VariableResponse>> = [
     {
@@ -85,17 +85,29 @@ const getColumns = ({
     },
     {
       accessorKey: "key",
-      cell: ({ row }) => <TrimText isClickable onClickContent={row.original} text={row.original.key}/>,
+      cell: ({ row }) => <TrimText isClickable onClickContent={row.original} text={row.original.key} />,
       header: translate("columns.key"),
     },
     {
       accessorKey: "value",
-      cell: ({ row }) => <TrimText showTooltip text={row.original.value} charLimit={open? row.original.value.length : undefined}/>,
+      cell: ({ row }) => (
+        <TrimText
+          charLimit={open ? row.original.value.length : undefined}
+          showTooltip
+          text={row.original.value}
+        />
+      ),
       header: translate("columns.value"),
     },
     {
       accessorKey: "description",
-      cell: ({ row }) => <TrimText showTooltip text={row.original.description}/>,
+      cell: ({ row }) => (
+        <TrimText
+          charLimit={open ? row.original.description?.length : undefined}
+          showTooltip
+          text={row.original.description}
+        />
+      ),
       header: translate("columns.description"),
     },
     {
@@ -136,7 +148,7 @@ export const Variables = () => {
     sorting: [{ desc: false, id: "key" }],
   }); // To make multiselection smooth
   const [searchParams, setSearchParams] = useSearchParams();
-  const { onClose, onOpen, open } = useDisclosure()
+  const { onClose, onOpen, open } = useDisclosure();
   const { NAME_PATTERN, OFFSET }: SearchParamsKeysType = SearchParamsKeys;
   const [variableKeyPattern, setVariableKeyPattern] = useState(searchParams.get(NAME_PATTERN) ?? undefined);
   const { pagination, sorting } = tableURLState;
@@ -162,9 +174,9 @@ export const Variables = () => {
     multiTeam: multiTeamEnabled,
     onRowSelect: handleRowSelect,
     onSelectAll: handleSelectAll,
+    open,
     selectedRows,
     translate,
-    open
   });
 
   const handleSearchChange = (value: string) => {
@@ -194,10 +206,10 @@ export const Variables = () => {
           <ImportVariablesButton disabled={selectedRows.size > 0} />
           <Spacer />
           <ExpandCollapseButtons
-            collapseLabel = {translate("common:collapseAllExtra")}
-            expandLabel = {translate("common:expandAllExtra")}
-            onCollapse = {onClose}
-            onExpand = {onOpen}
+            collapseLabel={translate("common:expand.collapse")}
+            expandLabel={translate("common:expand.expand")}
+            onCollapse={onClose}
+            onExpand={onOpen}
           />
           <AddVariableButton disabled={selectedRows.size > 0} />
         </HStack>

--- a/airflow-core/src/airflow/ui/src/pages/Variables/Variables.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/Variables.tsx
@@ -16,8 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Flex, HStack, Spacer, VStack, IconButton } from "@chakra-ui/react";
-import { LuWrapText } from "react-icons/lu";
+import { Box, Flex, HStack, Spacer, useDisclosure, VStack } from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
 import type { TFunction } from "i18next";
 import { useState } from "react";
@@ -30,6 +29,7 @@ import { DataTable } from "src/components/DataTable";
 import { useRowSelection, type GetColumnsParams } from "src/components/DataTable/useRowSelection";
 import { useTableURLState } from "src/components/DataTable/useTableUrlState";
 import { ErrorAlert } from "src/components/ErrorAlert";
+import { ExpandCollapseButtons } from "src/components/ExpandCollapseButtons";
 import { SearchBar } from "src/components/SearchBar";
 import { Tooltip } from "src/components/ui";
 import { ActionBar } from "src/components/ui/ActionBar";
@@ -44,15 +44,20 @@ import AddVariableButton from "./ManageVariable/AddVariableButton";
 import DeleteVariableButton from "./ManageVariable/DeleteVariableButton";
 import EditVariableButton from "./ManageVariable/EditVariableButton";
 
+type ColumnProps = {
+  readonly open: boolean;
+  readonly translate: TFunction;
+};
+
 const getColumns = ({
   allRowsSelected,
   multiTeam,
   onRowSelect,
   onSelectAll,
   selectedRows,
-  translate,
-  wrapText,
-}: { translate: TFunction } & {wrapText: boolean} & GetColumnsParams): Array<ColumnDef<VariableResponse>> => {
+  open,
+  translate
+}: ColumnProps & GetColumnsParams): Array<ColumnDef<VariableResponse>> => {
   const columns: Array<ColumnDef<VariableResponse>> = [
     {
       accessorKey: "select",
@@ -80,17 +85,17 @@ const getColumns = ({
     },
     {
       accessorKey: "key",
-      cell: ({ row }) => <TrimText isClickable onClickContent={row.original} text={row.original.key} charLimit={wrapText ? undefined : row.original.key.length}/>,
+      cell: ({ row }) => <TrimText isClickable onClickContent={row.original} text={row.original.key}/>,
       header: translate("columns.key"),
     },
     {
       accessorKey: "value",
-      cell: ({ row }) => <TrimText showTooltip text={row.original.value} charLimit={wrapText ? undefined : row.original.value.length}/>,
+      cell: ({ row }) => <TrimText showTooltip text={row.original.value} charLimit={open? row.original.value.length : undefined}/>,
       header: translate("columns.value"),
     },
     {
       accessorKey: "description",
-      cell: ({ row }) => <TrimText showTooltip text={row.original.description} charLimit={wrapText ? undefined : row.original.description?.length}/>,
+      cell: ({ row }) => <TrimText showTooltip text={row.original.description}/>,
       header: translate("columns.description"),
     },
     {
@@ -131,9 +136,9 @@ export const Variables = () => {
     sorting: [{ desc: false, id: "key" }],
   }); // To make multiselection smooth
   const [searchParams, setSearchParams] = useSearchParams();
+  const { onClose, onOpen, open } = useDisclosure()
   const { NAME_PATTERN, OFFSET }: SearchParamsKeysType = SearchParamsKeys;
   const [variableKeyPattern, setVariableKeyPattern] = useState(searchParams.get(NAME_PATTERN) ?? undefined);
-  const [wrapText, setWrapText] = useState(true);
   const { pagination, sorting } = tableURLState;
   const [sort] = sorting;
   const orderBy = sort ? [`${sort.desc ? "-" : ""}${sort.id === "value" ? "_val" : sort.id}`] : ["-key"];
@@ -159,7 +164,7 @@ export const Variables = () => {
     onSelectAll: handleSelectAll,
     selectedRows,
     translate,
-    wrapText,
+    open
   });
 
   const handleSearchChange = (value: string) => {
@@ -177,10 +182,6 @@ export const Variables = () => {
     setVariableKeyPattern(value);
   };
 
-  const handleWrapTextChange = () => {
-    setWrapText(!wrapText);
-  }
-
   return (
     <>
       <VStack alignItems="none">
@@ -191,8 +192,13 @@ export const Variables = () => {
         />
         <HStack gap={4} mt={2}>
           <ImportVariablesButton disabled={selectedRows.size > 0} />
-          <IconButton colorPalette={"brand"} onClick={handleWrapTextChange}> <LuWrapText /> </IconButton>
           <Spacer />
+          <ExpandCollapseButtons
+            collapseLabel = {translate("common:collapseAllExtra")}
+            expandLabel = {translate("common:expandAllExtra")}
+            onCollapse = {onClose}
+            onExpand = {onOpen}
+          />
           <AddVariableButton disabled={selectedRows.size > 0} />
         </HStack>
       </VStack>

--- a/airflow-core/src/airflow/ui/src/pages/Variables/Variables.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/Variables.tsx
@@ -16,7 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Flex, HStack, Spacer, VStack } from "@chakra-ui/react";
+import { Box, Flex, HStack, Spacer, VStack, IconButton } from "@chakra-ui/react";
+import { LuWrapText } from "react-icons/lu";
 import type { ColumnDef } from "@tanstack/react-table";
 import type { TFunction } from "i18next";
 import { useState } from "react";
@@ -50,7 +51,8 @@ const getColumns = ({
   onSelectAll,
   selectedRows,
   translate,
-}: { translate: TFunction } & GetColumnsParams): Array<ColumnDef<VariableResponse>> => {
+  wrapText,
+}: { translate: TFunction } & {wrapText: boolean} & GetColumnsParams): Array<ColumnDef<VariableResponse>> => {
   const columns: Array<ColumnDef<VariableResponse>> = [
     {
       accessorKey: "select",
@@ -78,17 +80,17 @@ const getColumns = ({
     },
     {
       accessorKey: "key",
-      cell: ({ row }) => <TrimText isClickable onClickContent={row.original} text={row.original.key} />,
+      cell: ({ row }) => <TrimText isClickable onClickContent={row.original} text={row.original.key} charLimit={wrapText ? undefined : row.original.key.length}/>,
       header: translate("columns.key"),
     },
     {
       accessorKey: "value",
-      cell: ({ row }) => <TrimText showTooltip text={row.original.value} />,
+      cell: ({ row }) => <TrimText showTooltip text={row.original.value} charLimit={wrapText ? undefined : row.original.value.length}/>,
       header: translate("columns.value"),
     },
     {
       accessorKey: "description",
-      cell: ({ row }) => <TrimText showTooltip text={row.original.description} />,
+      cell: ({ row }) => <TrimText showTooltip text={row.original.description} charLimit={wrapText ? undefined : row.original.description?.length}/>,
       header: translate("columns.description"),
     },
     {
@@ -131,6 +133,7 @@ export const Variables = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const { NAME_PATTERN, OFFSET }: SearchParamsKeysType = SearchParamsKeys;
   const [variableKeyPattern, setVariableKeyPattern] = useState(searchParams.get(NAME_PATTERN) ?? undefined);
+  const [wrapText, setWrapText] = useState(true);
   const { pagination, sorting } = tableURLState;
   const [sort] = sorting;
   const orderBy = sort ? [`${sort.desc ? "-" : ""}${sort.id === "value" ? "_val" : sort.id}`] : ["-key"];
@@ -156,6 +159,7 @@ export const Variables = () => {
     onSelectAll: handleSelectAll,
     selectedRows,
     translate,
+    wrapText,
   });
 
   const handleSearchChange = (value: string) => {
@@ -173,6 +177,10 @@ export const Variables = () => {
     setVariableKeyPattern(value);
   };
 
+  const handleWrapTextChange = () => {
+    setWrapText(!wrapText);
+  }
+
   return (
     <>
       <VStack alignItems="none">
@@ -183,6 +191,7 @@ export const Variables = () => {
         />
         <HStack gap={4} mt={2}>
           <ImportVariablesButton disabled={selectedRows.size > 0} />
+          <IconButton colorPalette={"brand"} onClick={handleWrapTextChange}> <LuWrapText /> </IconButton>
           <Spacer />
           <AddVariableButton disabled={selectedRows.size > 0} />
         </HStack>


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/25992

## Problem(?)
Variable info is trimmed, which makes it unable to be found via CTRL+F, unless hovered on.

Before
<img width="1234" height="509" alt="before" src="https://github.com/user-attachments/assets/39e355b2-f599-4761-ae71-c171c1378d98" />

## Solution
After 2.3.4 the behavior changed to trim text.
My suggested compromise between the new UX and the old functionality is a button to toggle a state of wrap / unwrap text.

After, initial state
<img width="1513" height="559" alt="after-fold" src="https://github.com/user-attachments/assets/ec85e6e0-f7f8-4f56-ad14-98091b20f718" />

After, first click
<img width="1681" height="620" alt="after-expand" src="https://github.com/user-attachments/assets/25c590e2-92dc-4d1c-a7c5-a09167315092" />
