### PR TITLE
Suggested example GIT URL repository is in invalid format.

### DIFF
--- a/providers/git/docs/connections/git.rst
+++ b/providers/git/docs/connections/git.rst
@@ -42,7 +42,7 @@ Username
     Specify the git ``username``.
 
 Repository URL (optional)
-    Specify the repository url e.g ``git@github.com/apache/airflow.git``.
+    Specify the repository url e.g ``git@github.com:/apache/airflow.git``.
 
 Password (optional)
     Specify the git ``password`` a.k.a ``ACCESS TOKEN`` if using https.


### PR DESCRIPTION
I believe the example given in documentation is wrong and misleading.

Git handles either:
`ssh://[<user>@]<host>[:<port>]/<path-to-git-repo>` or
`[<user>@]<host>:/<path-to-git-repo>`
The suggested example was a mix between those two.

Still after checking all options we eventually mounted key into .ssh and used it that way. We couldn't get it to work after few hours of work

---

##### Was generative AI tooling used to co-author this PR?
- [ ] Yes (please specify the tool below)
(No)