### PR TITLE
Update cassandra driver specification for various python versions

### DIFF
--- a/providers/apache/cassandra/docs/index.rst
+++ b/providers/apache/cassandra/docs/index.rst
@@ -96,14 +96,16 @@ Requirements
 
 The minimum Apache Airflow version supported by this provider distribution is ``2.11.0``.
 
-==========================================  ==================
+==========================================  ======================================
 PIP package                                 Version required
-==========================================  ==================
+==========================================  ======================================
 ``apache-airflow``                          ``>=2.11.0``
 ``apache-airflow-providers-common-compat``  ``>=1.8.0``
-``cassandra-driver``                        ``>=3.29.1``
+``cassandra-driver``                        ``>=3.29.3; python_version >= "3.13"``
+``cassandra-driver``                        ``>=3.29.2; python_version < "3.13"``
+``cassandra-driver``                        ``>=3.29.1; python_version < "3.12"``
 ``setuptools``                              ``<82.0.0``
-==========================================  ==================
+==========================================  ======================================
 
 Cross provider package dependencies
 -----------------------------------

--- a/providers/apache/cassandra/pyproject.toml
+++ b/providers/apache/cassandra/pyproject.toml
@@ -60,8 +60,12 @@ requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.8.0",
-    "cassandra-driver>=3.29.1",
-    "setuptools<82.0.0", # https://github.com/apache/cassandra-python-driver/pull/1268 remove this once new version of cassandra-driver is released with the fix
+    "cassandra-driver>=3.29.3; python_version >= '3.13'",
+    "cassandra-driver>=3.29.2; python_version < '3.13'",
+    "cassandra-driver>=3.29.1; python_version < '3.12'",
+    # https://github.com/apache/cassandra-python-driver/pull/1268 remove this once new version of
+    # cassandra-driver is released with the fix, and we depend on it as minimum version for all python versions
+    "setuptools<82.0.0",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
The official cassandra driver Python version support was not exactly in line with the version support - this PR adds proper version support. We still cannot remove setuptools limitation before the minimum version of cassandra driver supports it - but at least all the versions will use .whl distributions - which will make image builds and CI a bit faster.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
