### PR TITLE
Remove to_upstream contract from PartitionMapper

### DIFF
--- a/airflow-core/src/airflow/partition_mapper/base.py
+++ b/airflow-core/src/airflow/partition_mapper/base.py
@@ -14,13 +14,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    from collections.abc import Iterable
+from typing import Any
 
 
 class PartitionMapper(ABC):
@@ -33,10 +31,6 @@ class PartitionMapper(ABC):
     @abstractmethod
     def to_downstream(self, key: str) -> str:
         """Return the target key that the given source partition key maps to."""
-
-    @abstractmethod
-    def to_upstream(self, key: str) -> Iterable[str]:
-        """Yield the source keys that map to the given target partition key."""
 
     def serialize(self) -> dict[str, Any]:
         return {}

--- a/airflow-core/src/airflow/partition_mapper/identity.py
+++ b/airflow-core/src/airflow/partition_mapper/identity.py
@@ -14,14 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from airflow.partition_mapper.base import PartitionMapper
-
-if TYPE_CHECKING:
-    from collections.abc import Iterable
 
 
 class IdentityMapper(PartitionMapper):
@@ -29,6 +25,3 @@ class IdentityMapper(PartitionMapper):
 
     def to_downstream(self, key: str) -> str:
         return key
-
-    def to_upstream(self, key: str) -> Iterable[str]:
-        yield key

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -22,7 +22,7 @@ import datetime
 import logging
 import os
 from collections import Counter, deque
-from collections.abc import Callable, Generator, Iterable, Iterator
+from collections.abc import Callable, Generator, Iterator
 from contextlib import ExitStack
 from datetime import timedelta
 from pathlib import Path
@@ -8639,9 +8639,6 @@ class Key1Mapper(CorePartitionMapper):
 
     def to_downstream(self, key: str) -> str:
         return "key-1"
-
-    def to_upstream(self, key: str) -> Iterable[str]:
-        yield key
 
 
 def _find_registered_custom_partition_mapper(import_string: str) -> type[CorePartitionMapper]:


### PR DESCRIPTION
We're not going to need it for 3.2, and it is better to delay introducing it to avoid confusion.

See https://github.com/apache/airflow/issues/59294