### PR TITLE
Specify the mypy hook as part of the error message

### DIFF
--- a/scripts/ci/prek/mypy_folder.py
+++ b/scripts/ci/prek/mypy_folder.py
@@ -191,7 +191,7 @@ if res.returncode != 0:
                 "[yellow]You are running mypy with the folders selected. If you want to "
                 "reproduce it locally, you need to run the following command:\n"
             )
-            console.print("prek --hook-stage manual mypy-<folder> --all-files\n")
+            console.print(f"prek --hook-stage manual mypy-{mypy_folders[0]} --all-files\n")
         upgrading = os.environ.get("UPGRADE_TO_NEWER_DEPENDENCIES", "false") != "false"
         if upgrading:
             console.print(
@@ -212,7 +212,7 @@ if res.returncode != 0:
                 "You are running mypy with the folders selected. If you want to "
                 "reproduce it locally, you need to run the following command:\n"
             )
-            print("prek --hook-stage manual mypy-<folder> --all-files\n")
+            print(f"prek --hook-stage manual mypy-{mypy_folders[0]} --all-files\n")
         upgrading = os.environ.get("UPGRADE_TO_NEWER_DEPENDENCIES", "false") != "false"
         if upgrading:
             print("You are running mypy with the image that has dependencies upgraded automatically.\n")


### PR DESCRIPTION
We already know which mypy hook failed so better to provide the templated command to run.

Before:
<img width="1373" height="614" alt="Screenshot 2026-02-10 at 10 06 19" src="https://github.com/user-attachments/assets/285c2e17-0e4f-480b-86c5-4973708e656c" />

After:
<img width="1038" height="286" alt="Screenshot 2026-02-10 at 10 24 43" src="https://github.com/user-attachments/assets/fdeb1b00-161a-4379-b103-3e5629f0ca77" />
