### PR TITLE
Restore accidentally removed variable assignment in the `scheduler_job_runner`

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2639,6 +2639,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             for prev_key in self.previous_ti_metrics[state]:
                 # Reset previously exported stats that are no longer present in current metrics to zero
                 if prev_key not in ti_metrics:
+                    dag_id, task_id, queue = prev_key
                     DualStatsManager.gauge(
                         f"ti.{state}",
                         0,


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

While running some manual tests with the metrics enabled, I noticed that the scheduler started exiting after triggering a few dags.

This is the stacktrace that I'm seeing in the logs
```bash
2026-02-10T10:21:07.655259Z [error    ] Exception when executing SchedulerJob._run_scheduler_loop
p [airflow.jobs.scheduler_job_runner.SchedulerJobRunner] loc=scheduler_job_runner.py:1324
Traceback (most recent call last):
  File "/opt/airflow/airflow-core/src/airflow/jobs/scheduler_job_runner.py", line 1319, in _execute
    self._run_scheduler_loop()
  File "/opt/airflow/airflow-core/src/airflow/jobs/scheduler_job_runner.py", line 1666, in _run_scheduler_loop
    next_event = timers.run(blocking=False)
  File "/usr/python/lib/python3.10/sched.py", line 151, in run
    action(*argument, **kwargs)
  File "/opt/airflow/airflow-core/src/airflow/utils/event_scheduler.py", line 40, in repeat
    action(*args, **kwargs)
  File "/opt/airflow/airflow-core/src/airflow/utils/session.py", line 100, in wrapper
    return func(*args, session=session, **kwargs)  # type: ignore[arg-type]
  File "/opt/airflow/airflow-core/src/airflow/jobs/scheduler_job_runner.py", line 2647, in _emit_ti_metrics
    extra_tags={"queue": queue, "dag_id": dag_id, "task_id": task_id},
UnboundLocalError: local variable 'queue' referenced before assignment
2026-02-10T10:21:07.699406Z [info     ] Shutting down LocalExecutor; waiting for running tasks t
```

This is actually my fault because in a previous PR of mine, https://github.com/apache/airflow/pull/53722, I accidentally removed the variable assignment

This is the exact diff from the PR
```diff
-  dag_id, task_id, queue = prev_key
-  Stats.gauge(f"ti.{state}.{queue}.{dag_id}.{task_id}", 0)
-  Stats.gauge(f"ti.{state}", 0, tags={"queue": queue, "dag_id": dag_id, "task_id": task_id})
+  DualStatsManager.gauge(
+          f"ti.{state}",
+          0,
+          tags={},
+          extra_tags={"queue": queue, "dag_id": dag_id, "task_id": task_id},
+  )
```

This is the line that shouldn't have been removed
```
dag_id, task_id, queue = prev_key
```

I tested it manually and the error is gone.

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
