### PR TITLE
Unify get_permissions pagination with other list endpoints

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/openapi/v2-fab-auth-manager-generated.yaml
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/openapi/v2-fab-auth-manager-generated.yaml
@@ -409,20 +409,24 @@ paths:
       - OAuth2PasswordBearer: []
       - HTTPBearer: []
       parameters:
-      - name: limit
-        in: query
-        required: false
-        schema:
-          type: integer
-          default: 100
-          title: Limit
       - name: offset
         in: query
         required: false
         schema:
           type: integer
+          minimum: 0
+          description: Number of items to skip before starting to collect results.
           default: 0
           title: Offset
+        description: Number of items to skip before starting to collect results.
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+          default: 100
+          title: Limit
       responses:
         '200':
           description: Successful Response

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/routes/roles.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/routes/roles.py
@@ -150,7 +150,10 @@ def patch_role(
     ),
     dependencies=[Depends(requires_fab_custom_view("GET", permissions.RESOURCE_ROLE))],
 )
-def get_permissions(limit: int = Query(100), offset: int = Query(0)):
+def get_permissions(
+    limit: int = Depends(get_effective_limit()),
+    offset: int = Query(0, ge=0, description="Number of items to skip before starting to collect results."),
+):
     """List all action-resource (permission) pairs."""
     with get_application_builder():
         return FABAuthManagerRoles.get_permissions(limit=limit, offset=offset)


### PR DESCRIPTION
## Changes

- Use get_effective_limit for limit parameter
- Add ge=0 constraint to offset
- Ensure consistent pagination behavior across all FAB API list endpoints


##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
