### PR TITLE
Override --dry-run mode for mkdir operations in release check

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_candidate_command.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_candidate_command.py
@@ -474,8 +474,10 @@ def clone_asf_repo(version, repo_root):
 
         if is_ci_environment():
             console_print("[info]Running in CI environment - simulating SVN checkout")
-            # Create empty directory structure to simulate svn checkout
-            run_command(["mkdir", "-p", f"{repo_root}/asf-dist/dev/airflow"], check=True)
+            # Create empty directory structure to simulate svn checkout (override dry-run if specified)
+            run_command(
+                ["mkdir", "-p", f"{repo_root}/asf-dist/dev/airflow"], check=True, dry_run_override=False
+            )
             console_print("[success]Simulated ASF repo checkout in CI")
             return
 
@@ -518,9 +520,11 @@ def move_artifacts_to_svn(
     if confirm_action("Do you want to move artifacts to SVN?"):
         os.chdir(f"{repo_root}/asf-dist/dev/airflow")
         if is_ci_environment():
-            console_print("[info]Running in CI environment - simulating SVN mkdir")
-            run_command(["mkdir", "-p", f"{version}"], check=True)
-            run_command(["mkdir", "-p", f"task-sdk/{task_sdk_version}"], check=True)
+            console_print(
+                "[info]Running in CI environment - executing mkdir (override dry-run mode if specified)"
+            )
+            run_command(["mkdir", "-p", f"{version}"], check=True, dry_run_override=False)
+            run_command(["mkdir", "-p", f"task-sdk/{task_sdk_version}"], dry_run_override=False, check=True)
         else:
             run_command(["svn", "mkdir", f"{version}"], check=True)
             run_command(["svn", "mkdir", f"task-sdk/{task_sdk_version}"], check=True)
@@ -550,23 +554,16 @@ def push_artifacts_to_asf_repo(version, task_sdk_version, repo_root):
         if not get_dry_run():
             os.chdir(base_dir)
 
-        if is_ci_environment():
-            console_print("[info]Running in CI environment - simulating SVN add and commit")
-            console_print(f"[info]Would run: svn add {version}/* task-sdk/{task_sdk_version}/*")
-            console_print(
-                f"[info]Would run: svn commit -m 'Add artifacts for Airflow {version} and Task SDK {task_sdk_version}'"
-            )
-        else:
-            run_command(f"svn add {version}/* task-sdk/{task_sdk_version}/*", check=True, shell=True)
-            run_command(
-                [
-                    "svn",
-                    "commit",
-                    "-m",
-                    f"Add artifacts for Airflow {version} and Task SDK {task_sdk_version}",
-                ],
-                check=True,
-            )
+        run_command(f"svn add {version}/* task-sdk/{task_sdk_version}/*", check=True, shell=True)
+        run_command(
+            [
+                "svn",
+                "commit",
+                "-m",
+                f"Add artifacts for Airflow {version} and Task SDK {task_sdk_version}",
+            ],
+            check=True,
+        )
         console_print("[success]Files pushed to svn")
         console_print(
             "Verify that the files are available here: https://dist.apache.org/repos/dist/dev/airflow/"
@@ -678,16 +675,11 @@ def remove_old_releases(version, task_sdk_version, repo_root):
     for old_release in old_releases:
         console_print(f"Removing old Airflow release {old_release}")
         if confirm_action(f"Remove old RC {old_release}?"):
-            if is_ci_environment():
-                console_print("[info]Running in CI environment - simulating SVN rm and commit")
-                console_print(f"[info]Would run: svn rm {old_release}")
-                console_print(f"[info]Would run: svn commit -m 'Remove old release: {old_release}'")
-            else:
-                run_command(["svn", "rm", old_release], check=True)
-                run_command(
-                    ["svn", "commit", "-m", f"Remove old release: {old_release}"],
-                    check=True,
-                )
+            run_command(["svn", "rm", old_release], check=True)
+            run_command(
+                ["svn", "commit", "-m", f"Remove old release: {old_release}"],
+                check=True,
+            )
 
     # Remove old Task SDK releases
     task_sdk_path = f"{repo_root}/asf-dist/dev/airflow/task-sdk"
@@ -705,18 +697,11 @@ def remove_old_releases(version, task_sdk_version, repo_root):
         for old_release in old_task_sdk_releases:
             console_print(f"Removing old Task SDK release {old_release}")
             if confirm_action(f"Remove old Task SDK RC {old_release}?"):
-                if is_ci_environment():
-                    console_print("[info]Running in CI environment - simulating SVN rm and commit")
-                    console_print(f"[info]Would run: svn rm {old_release}")
-                    console_print(
-                        f"[info]Would run: svn commit -m 'Remove old Task SDK release: {old_release}'"
-                    )
-                else:
-                    run_command(["svn", "rm", old_release], check=True)
-                    run_command(
-                        ["svn", "commit", "-m", f"Remove old Task SDK release: {old_release}"],
-                        check=True,
-                    )
+                run_command(["svn", "rm", old_release], check=True)
+                run_command(
+                    ["svn", "commit", "-m", f"Remove old Task SDK release: {old_release}"],
+                    check=True,
+                )
 
     console_print("[success]Old releases removed")
     os.chdir(repo_root)


### PR DESCRIPTION
In CI we are runing the release operation in --dry-run mode, and we have to make sure that the commands are executed without --dry-run in this case because we need to simulate the behaviour and change working directories to those directories created.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
