### PR TITLE
Make conn_type optional in task SDK Connection datamodel

### DIFF
--- a/task-sdk/src/airflow/sdk/definitions/connection.py
+++ b/task-sdk/src/airflow/sdk/definitions/connection.py
@@ -111,7 +111,7 @@ class Connection:
     """
 
     conn_id: str
-    conn_type: str
+    conn_type: str | None = None
     description: str | None = None
     host: str | None = None
     schema: str | None = None

--- a/task-sdk/tests/task_sdk/definitions/test_connection.py
+++ b/task-sdk/tests/task_sdk/definitions/test_connection.py
@@ -189,6 +189,25 @@ class TestConnections:
         assert connection.host == "localhost"
         assert connection.port == 5432
 
+    def test_from_json_without_conn_type(self):
+        """Test that from_json works without conn_type (backward compatibility with AF 2)."""
+        json_data = {
+            "host": "mydb.example.com",
+            "port": "5432",
+            "login": "admin",
+            "password": "secret",
+            "schema": "production",
+        }
+        connection = Connection.from_json(json.dumps(json_data), conn_id="test_conn")
+
+        assert connection.conn_id == "test_conn"
+        assert connection.conn_type is None
+        assert connection.host == "mydb.example.com"
+        assert connection.port == 5432
+        assert connection.login == "admin"
+        assert connection.password == "secret"
+        assert connection.schema == "production"
+
     def test_extra_dejson_property(self):
         """Test that extra_dejson property correctly deserializes JSON extra field."""
         connection = Connection(


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

closes: https://github.com/apache/airflow/issues/58529

## Why?

When workers retrieve connections from secrets backends like AWS Secrets Manager that don't include `conn_type`, the `Connection.from_json()` method fails during deserialization with error:

```python
TypeError: Connection.__init__() missing 1 required keyword-only argument: 'conn_type'
```

Simple test to show an example for this:

```shell
(apache-airflow) ➜  airflow git:(conn-type-optional-sdk) ✗ cat > /tmp/test_connections.json << 'EOF'
{
  "my_db": {
    "host": "mydb.us-east-1.rds.amazonaws.com",
    "port": 5432,
    "login": "admin",
    "password": "secret123",
    "schema": "production"
  }
}
EOF
```

Before:
```python
>>> import json
>>> json_from_aws = json.dumps({
...     "host": "mydb.us-east-1.rds.amazonaws.com",
...     "port": 5432,
...     "login": "admin",
...     "password": "secret123",
...     "schema": "production"
... })
>>> 
>>> from airflow.sdk import Connection
>>> conn = Connection.from_json(json_from_aws, conn_id="my_db")
Traceback (most recent call last):
  File "<python-input-10>", line 1, in <module>
    conn = Connection.from_json(json_from_aws, conn_id="my_db")
  File "/Users/amoghdesai/Documents/OSS/repos/airflow/task-sdk/src/airflow/sdk/definitions/connection.py", line 307, in from_json
    return cls(conn_id=conn_id, **kwargs)
TypeError: Connection.__init__() missing 1 required positional argument: 'conn_type'
```

After:

```python
>>> import json
>>> from airflow.sdk import Connection
>>> 
>>> json_from_aws = json.dumps({
...     "host": "mydb.us-east-1.rds.amazonaws.com",
...     "port": 5432,
...     "login": "admin",
...     "password": "secret123",
...     "schema": "production"
... })
>>> conn = Connection.from_json(json_from_aws, conn_id="my_db")
>>> conn
Connection(conn_id='my_db', conn_type=None, description=None, host='mydb.us-east-1.rds.amazonaws.com', schema='production', login='admin', password='secret123', port=5432, extra=None)
```


## What

Making `conn_type` optional in task SDK Connection datamodel to restore backward compatibility with Airflow 2 for connections stored in secrets backends without `conn_type`.

For example: connections in AWS Secrets Manager (and other external secrets backends) fail to load on workers when `conn_type` field is missing and that breaks compat with Airflow 3 for certain providers.

This will later block users migrating from Airflow 2 to Airflow 3 who have hundreds/thousands of secrets stored without conn_type (which worked fine in Airflow 2).


## Solution

Make `conn_type` optional in task SDK `Connection` class. Let me explain why this is safe.

1. Secrets backends run only on workers - connections without `conn_type` exist only in worker context, never sent via Execution API
2. The responses that are sent by the API server always has conn_type - connections from database always have conn_type (NOT NULL column), so execution API `ConnectionResponse` doesn't need changes at all (cadwyn migration etc)

For testing, I have added one scenario that would break earlier but doesn't anymore.





---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
