### PR TITLE
Fix EksPodOperator POSIX shell compatibility and update ExecCredential API version

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/eks.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/eks.py
@@ -36,7 +36,7 @@ from airflow.providers.amazon.aws.hooks.sts import StsHook
 from airflow.utils import yaml
 
 DEFAULT_PAGINATION_TOKEN = ""
-AUTHENTICATION_API_VERSION = "client.authentication.k8s.io/v1alpha1"
+AUTHENTICATION_API_VERSION = "client.authentication.k8s.io/v1"
 _POD_USERNAME = "aws"
 _CONTEXT_NAME = "aws"
 
@@ -80,7 +80,7 @@ COMMAND = """
             export PYTHON_OPERATORS_VIRTUAL_ENV_MODE=1
 
             # Source credentials from secure file
-            source {credentials_file}
+            . {credentials_file}
 
             output=$({python_executable} -m airflow.providers.amazon.aws.utils.eks_get_token \
                 --cluster-name {eks_cluster_name} --sts-url '{sts_url}' {args} 2>&1)
@@ -95,7 +95,7 @@ COMMAND = """
                 exit "$status"
             fi
 
-            # Use pure bash below to parse so that it's posix compliant
+            # Use POSIX-compliant shell below to parse
 
             last_line=${{output##*$'\\n'}}  # strip everything up to the last newline
 
@@ -105,7 +105,7 @@ COMMAND = """
             token=${{last_line##*, token: }}  # text after ", token: "
 
             json_string=$(printf '{{"kind": "ExecCredential","apiVersion": \
-                "client.authentication.k8s.io/v1alpha1","spec": {{}},"status": \
+                "client.authentication.k8s.io/v1","spec": {{}},"status": \
                 {{"expirationTimestamp": "%s","token": "%s"}}}}' "$timestamp" "$token")
             echo $json_string
             """

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_eks.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_eks.py
@@ -1261,13 +1261,13 @@ class TestEksHook:
             user = config["users"][0]
             assert user["name"] == "aws"
             exec_config = user["user"]["exec"]
-            assert exec_config["apiVersion"] == "client.authentication.k8s.io/v1alpha1"
+            assert exec_config["apiVersion"] == "client.authentication.k8s.io/v1"
             assert exec_config["command"] == "sh"
             assert exec_config["interactiveMode"] == "Never"
 
             # Verify the command references a credential file (not inline creds)
             command_arg = exec_config["args"][1]  # The -c argument content
-            assert f"source {credentials_file}" in command_arg
+            assert f". {credentials_file}" in command_arg
 
             # Verify region arguments are properly included
             if expected_region_args:


### PR DESCRIPTION
Fix two bugs in the EKS hook's kubeconfig exec credential plugin:

  1. **`source` → `.` (POSIX dot command):** The `COMMAND` template uses `source` to load credentials, but `source` is a bash builtin that doesn't exist in `dash`, which is the default `/bin/sh` on Debian/Ubuntu-based containers
  (Astronomer, official Airflow images). This causes silent credential loading failures, leading to 401 Unauthorized errors in cloud environments where no fallback AWS credentials exist.

  2. **ExecCredential `apiVersion` `v1alpha1` → `v1`:** `v1alpha1` was removed from Kubernetes client-go in K8s 1.24 (June 2022). `v1` has been available since K8s 1.22 and all currently supported EKS versions support it. This is
  client-side only — the EKS cluster never sees the ExecCredential apiVersion.

  closes: #60269

  ---

  ##### Was generative AI tooling used to co-author this PR?

  - [X] Yes — Claude Code (Claude Opus 4.6)

  Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
