### PR TITLE
[v2-11-test] Add pool name validation to avoid XSS from the DAG file

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1010,6 +1010,9 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         self.run_as_user = run_as_user
         self.retries = parse_retries(retries)
         self.queue = queue
+
+        if pool is not None and pool != Pool.DEFAULT_POOL_NAME:
+            validate_key(pool)
         self.pool = Pool.DEFAULT_POOL_NAME if pool is None else pool
         self.pool_slots = pool_slots
         if self.pool_slots < 1:

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -872,6 +872,19 @@ class TestBaseOperator:
 
         mock_validate_instance_args.assert_called_once_with(operator, BASEOPERATOR_ARGS_EXPECTED_TYPES)
 
+    def test_valid_pool_arg(self):
+        my_pool = "my-pool"
+        op = BaseOperator(task_id="test_pool_arg", pool=my_pool)
+        assert op.pool == my_pool
+
+    def test_invalid_pool_arg(self):
+        pool_name = """'><script src=\"https://example.com/exploit.js\"></script>"""
+        error_msg = (
+            "The key (.*) has to be made of alphanumeric characters, dashes, dots and underscores exclusively"
+        )
+        with pytest.raises(AirflowException, match=error_msg):
+            BaseOperator(task_id="test_pool_validation_xss", pool=pool_name)
+
 
 def test_init_subclass_args():
     class InitSubclassOp(BaseOperator):


### PR DESCRIPTION
This PR adds a validation for pool name for the operators.

An external researcher find the following XSS vulnerability in the [composer-airflow](https://github.com/GoogleCloudPlatform/composer-airflow) repository.

Accepting the value of the pool name as a string without validation is causing the XSS vulnerability.
Users can inject a javascript file as a value to the pool argument and escalate their role as `Admin` by targeting the Admin users.

Sample DAG:
```python
js_file_url = "https://example.com/exploit.js"
pool_name = """'><script src=\"""" + js_file_url + """\"></script>"""

with DAG(
    dag_id="my_dag",
) as dag:
    EmptyOperator(task_id="elevate", pool=pool_name)
```

In this PR, I use the `validate_key` method to validate the `pool` argument and from now on, we will give a DAG import error if the value of the `pool` argument is not valid.


> I created this PR for Airflow 2.11, however the prior versions also suffer from this problem. I am not sure if we need to patch the problem for the previous versions as well.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
