### PR TITLE
Fix test connection to ignore masked password placeholder

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/connections.py
@@ -16,6 +16,8 @@
 # under the License.
 from __future__ import annotations
 
+from airflow._shared.secrets_masker import MASKED_VALUE
+
 import os
 from typing import Annotated
 
@@ -235,6 +237,11 @@ def test_connection(test_body: ConnectionBody) -> ConnectionTestResponse:
         try:
             existing_conn = Connection.get_connection_from_secrets(test_body.connection_id)
             existing_conn.conn_id = transient_conn_id
+
+        # If password is masked placeholder, do not override stored secret
+            if test_body.password == MASKED_VALUE:
+                test_body = test_body.model_copy(update={"password": None})
+
             update_orm_from_pydantic(existing_conn, test_body)
             conn = existing_conn
         except AirflowNotFoundException:


### PR DESCRIPTION
### What does this PR do?

Fixes an issue where the **Test Connection** API endpoint uses the masked password placeholder (`***`)
instead of the stored secret when testing an existing connection from the UI.

When the password field is left unchanged in the UI, the masked value is sent in the request payload,
causing authentication to fail even though the stored password is correct.

### How was this fixed?

- Detects the masked placeholder using Airflow’s `MASKED_VALUE`
- Prevents overriding the stored secret when the masked value is received
- Reuses the existing password from the secrets backend for the test

### Why is this safe?

- No secrets are exposed
- Behavior only changes when the masked placeholder is used
- Explicit user-entered passwords still override correctly

### Related issue
Fixes #61670

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
