### PR TITLE
Fix dry run override for rc command

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_candidate_command.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_candidate_command.py
@@ -474,8 +474,10 @@ def clone_asf_repo(version, repo_root):
 
         if is_ci_environment():
             console_print("[info]Running in CI environment - simulating SVN checkout")
-            # Create empty directory structure to simulate svn checkout
-            run_command(["mkdir", "-p", f"{repo_root}/asf-dist/dev/airflow"], check=True)
+            # Create empty directory structure to simulate svn checkout (override dry-run if specified)
+            run_command(
+                ["mkdir", "-p", f"{repo_root}/asf-dist/dev/airflow"], check=True, dry_run_override=False
+            )
             console_print("[success]Simulated ASF repo checkout in CI")
             return
 
@@ -518,9 +520,11 @@ def move_artifacts_to_svn(
     if confirm_action("Do you want to move artifacts to SVN?"):
         os.chdir(f"{repo_root}/asf-dist/dev/airflow")
         if is_ci_environment():
-            console_print("[info]Running in CI environment - simulating SVN mkdir")
-            run_command(["mkdir", "-p", f"{version}"], check=True)
-            run_command(["mkdir", "-p", f"task-sdk/{task_sdk_version}"], check=True)
+            console_print(
+                "[info]Running in CI environment - executing mkdir (override dry-run mode if specified)"
+            )
+            run_command(["mkdir", "-p", f"{version}"], check=True, dry_run_override=False)
+            run_command(["mkdir", "-p", f"task-sdk/{task_sdk_version}"], dry_run_override=False, check=True)
         else:
             run_command(["svn", "mkdir", f"{version}"], check=True)
             run_command(["svn", "mkdir", f"task-sdk/{task_sdk_version}"], check=True)
@@ -550,23 +554,16 @@ def push_artifacts_to_asf_repo(version, task_sdk_version, repo_root):
         if not get_dry_run():
             os.chdir(base_dir)
 
-        if is_ci_environment():
-            console_print("[info]Running in CI environment - simulating SVN add and commit")
-            console_print(f"[info]Would run: svn add {version}/* task-sdk/{task_sdk_version}/*")
-            console_print(
-                f"[info]Would run: svn commit -m 'Add artifacts for Airflow {version} and Task SDK {task_sdk_version}'"
-            )
-        else:
-            run_command(f"svn add {version}/* task-sdk/{task_sdk_version}/*", check=True, shell=True)
-            run_command(
-                [
-                    "svn",
-                    "commit",
-                    "-m",
-                    f"Add artifacts for Airflow {version} and Task SDK {task_sdk_version}",
-                ],
-                check=True,
-            )
+        run_command(f"svn add {version}/* task-sdk/{task_sdk_version}/*", check=True, shell=True)
+        run_command(
+            [
+                "svn",
+                "commit",
+                "-m",
+                f"Add artifacts for Airflow {version} and Task SDK {task_sdk_version}",
+            ],
+            check=True,
+        )
         console_print("[success]Files pushed to svn")
         console_print(
             "Verify that the files are available here: https://dist.apache.org/repos/dist/dev/airflow/"
@@ -678,16 +675,11 @@ def remove_old_releases(version, task_sdk_version, repo_root):
     for old_release in old_releases:
         console_print(f"Removing old Airflow release {old_release}")
         if confirm_action(f"Remove old RC {old_release}?"):
-            if is_ci_environment():
-                console_print("[info]Running in CI environment - simulating SVN rm and commit")
-                console_print(f"[info]Would run: svn rm {old_release}")
-                console_print(f"[info]Would run: svn commit -m 'Remove old release: {old_release}'")
-            else:
-                run_command(["svn", "rm", old_release], check=True)
-                run_command(
-                    ["svn", "commit", "-m", f"Remove old release: {old_release}"],
-                    check=True,
-                )
+            run_command(["svn", "rm", old_release], check=True)
+            run_command(
+                ["svn", "commit", "-m", f"Remove old release: {old_release}"],
+                check=True,
+            )
 
     # Remove old Task SDK releases
     task_sdk_path = f"{repo_root}/asf-dist/dev/airflow/task-sdk"
@@ -705,18 +697,11 @@ def remove_old_releases(version, task_sdk_version, repo_root):
         for old_release in old_task_sdk_releases:
             console_print(f"Removing old Task SDK release {old_release}")
             if confirm_action(f"Remove old Task SDK RC {old_release}?"):
-                if is_ci_environment():
-                    console_print("[info]Running in CI environment - simulating SVN rm and commit")
-                    console_print(f"[info]Would run: svn rm {old_release}")
-                    console_print(
-                        f"[info]Would run: svn commit -m 'Remove old Task SDK release: {old_release}'"
-                    )
-                else:
-                    run_command(["svn", "rm", old_release], check=True)
-                    run_command(
-                        ["svn", "commit", "-m", f"Remove old Task SDK release: {old_release}"],
-                        check=True,
-                    )
+                run_command(["svn", "rm", old_release], check=True)
+                run_command(
+                    ["svn", "commit", "-m", f"Remove old Task SDK release: {old_release}"],
+                    check=True,
+                )
 
     console_print("[success]Old releases removed")
     os.chdir(repo_root)

--- a/dev/breeze/tests/test_release_candidate_command.py
+++ b/dev/breeze/tests/test_release_candidate_command.py
@@ -440,54 +440,57 @@ def test_remove_old_releases_removes_both_airflow_and_task_sdk_releases(monkeypa
         # In CI, should simulate SVN commands
         assert "The following old Airflow releases should be removed: ['3.1.5rc2']" in console_messages
         assert "Removing old Airflow release 3.1.5rc2" in console_messages
-        assert "The following old Task SDK releases should be removed: ['1.0.6rc1', '1.0.6rc2']" in console_messages
+        assert (
+            "The following old Task SDK releases should be removed: ['1.0.6rc1', '1.0.6rc2']"
+            in console_messages
+        )
         assert "Removing old Task SDK release 1.0.6rc1" in console_messages
 
         # Should NOT have any actual svn commands
-        assert run_command_calls ==    [
-       (
-           [
-               'svn',
-               'rm',
-               '3.1.5rc2',
-           ],
-           {
-               'check': True,
-           },
-       ),
-       (
-           [
-               'svn',
-               'commit',
-               '-m',
-               'Remove old release: 3.1.5rc2',
-           ],
-           {
-               'check': True,
-           },
-       ),
-       (
-           [
-               'svn',
-               'rm',
-               '1.0.6rc1',
-           ],
-           {
-               'check': True,
-           },
-       ),
-       (
-           [
-               'svn',
-               'commit',
-               '-m',
-               'Remove old Task SDK release: 1.0.6rc1',
-           ],
-           {
-               'check': True,
-           },
-       ),
-   ]
+        assert run_command_calls == [
+            (
+                [
+                    "svn",
+                    "rm",
+                    "3.1.5rc2",
+                ],
+                {
+                    "check": True,
+                },
+            ),
+            (
+                [
+                    "svn",
+                    "commit",
+                    "-m",
+                    "Remove old release: 3.1.5rc2",
+                ],
+                {
+                    "check": True,
+                },
+            ),
+            (
+                [
+                    "svn",
+                    "rm",
+                    "1.0.6rc1",
+                ],
+                {
+                    "check": True,
+                },
+            ),
+            (
+                [
+                    "svn",
+                    "commit",
+                    "-m",
+                    "Remove old Task SDK release: 1.0.6rc1",
+                ],
+                {
+                    "check": True,
+                },
+            ),
+        ]
     else:
         # Both Airflow and Task SDK removals were confirmed
         assert run_command_calls == [
@@ -576,7 +579,10 @@ def test_move_artifacts_to_svn_completes_successfully(monkeypatch, rc_cmd):
 
     if is_ci:
         # In CI, should use mkdir -p instead of svn mkdir
-        assert "[info]Running in CI environment - executing mkdir (override dry-run mode if specified)" in console_messages
+        assert (
+            "[info]Running in CI environment - executing mkdir (override dry-run mode if specified)"
+            in console_messages
+        )
         assert any(
             cmd == ["mkdir", "-p", version] and kwargs.get("check") is True
             for cmd, kwargs in run_command_calls
@@ -704,7 +710,10 @@ def test_push_artifacts_to_asf_repo_completes_successfully(monkeypatch, rc_cmd):
         assert "Airflow Version Files to push to svn:" in console_messages
         assert "Task SDK Version Files to push to svn:" in console_messages
         assert "[success]Files pushed to svn" in console_messages
-        assert "Verify that the files are available here: https://dist.apache.org/repos/dist/dev/airflow/" in console_messages
+        assert (
+            "Verify that the files are available here: https://dist.apache.org/repos/dist/dev/airflow/"
+            in console_messages
+        )
         # There are some SVN traces in the code but still they are just printing and not actually running any SVN commands in CI
     else:
         # In normal environment, should execute SVN commands

--- a/dev/breeze/tests/test_release_candidate_command.py
+++ b/dev/breeze/tests/test_release_candidate_command.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import os
+from unittest import mock
 
 import pytest
 
@@ -181,6 +182,7 @@ def test_remove_old_releases_returns_early_when_user_declines(monkeypatch, rc_cm
     assert confirm_prompts == ["Do you want to look for old RCs to remove?"]
 
 
+@mock.patch.dict(os.environ, {"CI": "true"})
 def test_remove_old_releases_removes_confirmed_old_releases(monkeypatch, rc_cmd):
     """Test that remove_old_releases works correctly based on CI environment."""
     version = "3.1.5rc3"
@@ -244,12 +246,38 @@ def test_remove_old_releases_removes_confirmed_old_releases(monkeypatch, rc_cmd)
 
     if is_ci:
         # In CI, should simulate SVN commands
-        assert "[info]Running in CI environment - simulating SVN rm and commit" in console_messages
-        assert "[info]Would run: svn rm 3.1.0rc1" in console_messages
-        assert "[info]Would run: svn commit -m 'Remove old release: 3.1.0rc1'" in console_messages
+        assert "[success]Old releases removed" in console_messages
+        assert (
+            "The following old Airflow releases should be removed: ['3.1.0rc1', '3.1.5rc2']"
+            in console_messages
+        )
+        assert "Removing old Airflow release 3.1.0rc1" in console_messages
+        assert "Removing old Airflow release 3.1.5rc2" in console_messages
 
         # Should NOT have any actual svn commands (only rc1 was confirmed)
-        assert run_command_calls == []
+        assert run_command_calls == [
+            (
+                [
+                    "svn",
+                    "rm",
+                    "3.1.0rc1",
+                ],
+                {
+                    "check": True,
+                },
+            ),
+            (
+                [
+                    "svn",
+                    "commit",
+                    "-m",
+                    "Remove old release: 3.1.0rc1",
+                ],
+                {
+                    "check": True,
+                },
+            ),
+        ]
     else:
         # Only rc1 was confirmed, so we should run rm+commit for rc1 only.
         assert run_command_calls == [
@@ -326,6 +354,7 @@ def test_remove_old_releases_removes_task_sdk_releases(monkeypatch, rc_cmd):
     assert run_command_calls == []
 
 
+@mock.patch.dict(os.environ, {"CI": "true"})
 def test_remove_old_releases_removes_both_airflow_and_task_sdk_releases(monkeypatch, rc_cmd):
     """Test that remove_old_releases works correctly based on CI environment."""
     version = "3.1.5rc3"
@@ -409,14 +438,56 @@ def test_remove_old_releases_removes_both_airflow_and_task_sdk_releases(monkeypa
 
     if is_ci:
         # In CI, should simulate SVN commands
-        assert "[info]Running in CI environment - simulating SVN rm and commit" in console_messages
-        assert "[info]Would run: svn rm 3.1.5rc2" in console_messages
-        assert "[info]Would run: svn commit -m 'Remove old release: 3.1.5rc2'" in console_messages
-        assert "[info]Would run: svn rm 1.0.6rc1" in console_messages
-        assert "[info]Would run: svn commit -m 'Remove old Task SDK release: 1.0.6rc1'" in console_messages
+        assert "The following old Airflow releases should be removed: ['3.1.5rc2']" in console_messages
+        assert "Removing old Airflow release 3.1.5rc2" in console_messages
+        assert "The following old Task SDK releases should be removed: ['1.0.6rc1', '1.0.6rc2']" in console_messages
+        assert "Removing old Task SDK release 1.0.6rc1" in console_messages
 
         # Should NOT have any actual svn commands
-        assert run_command_calls == []
+        assert run_command_calls ==    [
+       (
+           [
+               'svn',
+               'rm',
+               '3.1.5rc2',
+           ],
+           {
+               'check': True,
+           },
+       ),
+       (
+           [
+               'svn',
+               'commit',
+               '-m',
+               'Remove old release: 3.1.5rc2',
+           ],
+           {
+               'check': True,
+           },
+       ),
+       (
+           [
+               'svn',
+               'rm',
+               '1.0.6rc1',
+           ],
+           {
+               'check': True,
+           },
+       ),
+       (
+           [
+               'svn',
+               'commit',
+               '-m',
+               'Remove old Task SDK release: 1.0.6rc1',
+           ],
+           {
+               'check': True,
+           },
+       ),
+   ]
     else:
         # Both Airflow and Task SDK removals were confirmed
         assert run_command_calls == [
@@ -460,6 +531,7 @@ def test_move_artifacts_to_svn_returns_early_when_user_declines(monkeypatch, rc_
     assert confirm_prompts == ["Do you want to move artifacts to SVN?"]
 
 
+@mock.patch.dict(os.environ, {"CI": "true"})
 def test_move_artifacts_to_svn_completes_successfully(monkeypatch, rc_cmd):
     """Test that function completes successfully when user confirms based on CI environment."""
     version = "2.10.0rc3"
@@ -504,7 +576,7 @@ def test_move_artifacts_to_svn_completes_successfully(monkeypatch, rc_cmd):
 
     if is_ci:
         # In CI, should use mkdir -p instead of svn mkdir
-        assert "[info]Running in CI environment - simulating SVN mkdir" in console_messages
+        assert "[info]Running in CI environment - executing mkdir (override dry-run mode if specified)" in console_messages
         assert any(
             cmd == ["mkdir", "-p", version] and kwargs.get("check") is True
             for cmd, kwargs in run_command_calls
@@ -580,6 +652,7 @@ def test_push_artifacts_to_asf_repo_returns_early_when_user_declines(monkeypatch
     assert confirm_prompts == ["Do you want to push artifacts to ASF repo?"]
 
 
+@mock.patch.dict(os.environ, {"CI": "true"})
 def test_push_artifacts_to_asf_repo_completes_successfully(monkeypatch, rc_cmd):
     """Test that function completes successfully when user confirms all prompts based on CI environment."""
     version = "2.10.0rc3"
@@ -628,18 +701,11 @@ def test_push_artifacts_to_asf_repo_completes_successfully(monkeypatch, rc_cmd):
 
     if is_ci:
         # In CI, should simulate SVN commands
-        assert "[info]Running in CI environment - simulating SVN add and commit" in console_messages
-        assert f"[info]Would run: svn add {version}/* task-sdk/{task_sdk_version}/*" in console_messages
-        assert (
-            f"[info]Would run: svn commit -m 'Add artifacts for Airflow {version} and Task SDK {task_sdk_version}'"
-            in console_messages
-        )
-
-        # Should NOT have any actual svn commands
-        assert not any(
-            isinstance(cmd, list) and len(cmd) >= 1 and cmd[0] == "svn" for cmd, kwargs in run_command_calls
-        )
-        assert not any(isinstance(cmd, str) and cmd.startswith("svn ") for cmd, kwargs in run_command_calls)
+        assert "Airflow Version Files to push to svn:" in console_messages
+        assert "Task SDK Version Files to push to svn:" in console_messages
+        assert "[success]Files pushed to svn" in console_messages
+        assert "Verify that the files are available here: https://dist.apache.org/repos/dist/dev/airflow/" in console_messages
+        # There are some SVN traces in the code but still they are just printing and not actually running any SVN commands in CI
     else:
         # In normal environment, should execute SVN commands
         assert any(


### PR DESCRIPTION
Jarek's solution + tests: #61727
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
