### PR TITLE
Add warning about AWS auth manager being in alpha stage in identity-c…

### DIFF
--- a/providers/amazon/docs/auth-manager/setup/identity-center.rst
+++ b/providers/amazon/docs/auth-manager/setup/identity-center.rst
@@ -19,6 +19,9 @@
 Configure AWS IAM Identity Center
 =================================
 
+.. warning::
+  The AWS auth manager is alpha/experimental at the moment and may be subject to change without warning.
+
 In order to use the AWS auth manager, you first need to configure `AWS IAM Identity Center <https://aws.amazon.com/iam/identity-center/>`_.
 AWS IAM Identity Center is used by the AWS auth manager for authentication purposes (login and logout).
 Following configuration, the Airflow environment administrator can manage users and groups with Identity Center service.


### PR DESCRIPTION
### Description

This PR updates the AWS IAM Identity Center setup documentation to clearly inform users that the AWS Auth Manager is currently alpha, experimental, and may change without notice.

This clarification helps prevent users from assuming the feature is stable when following the setup guide.

### Changes

Documentation update

- Added a warning notice at the top of
  `providers/amazon/docs/auth-manager/setup/identity-center.rst`
- The notice explicitly states that the AWS Auth Manager is experimental and subject to change

### Related issue

- closes: https://github.com/apache/airflow/issues/61720
