### PR TITLE
Make ray optional feature of Google provider

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/hooks/ray.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/ray.py
@@ -22,7 +22,15 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
-from ray.job_submission import JobSubmissionClient
+from airflow.exceptions import AirflowOptionalProviderFeatureException
+
+try:
+    from ray.job_submission import JobSubmissionClient
+except ImportError:
+    raise AirflowOptionalProviderFeatureException(
+        "Ray is not installed. Please install the 'ray' extra to use this feature."
+    )
+
 
 from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 

--- a/providers/google/src/airflow/providers/google/cloud/operators/ray.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/ray.py
@@ -25,7 +25,15 @@ from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
 from google.api_core.exceptions import NotFound
-from ray.dashboard.modules.job.common import JobStatus
+
+from airflow.exceptions import AirflowOptionalProviderFeatureException
+
+try:
+    from ray.dashboard.modules.job.common import JobStatus
+except ImportError:
+    raise AirflowOptionalProviderFeatureException(
+        "Ray is not installed. Please install the 'ray' extra to use this feature."
+    )
 
 from airflow.providers.common.compat.sdk import AirflowNotFoundException, AirflowTaskTimeout
 from airflow.providers.google.cloud.hooks.ray import RayJobHook


### PR DESCRIPTION
The #59558 added Ray to google provider but so far Python 3.13 does not allow to install ray as it has conflicting dependencies.

We should turn ray into optional feature.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
