### PR TITLE
Scheduler batch team resolution

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -350,7 +350,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             # Log the error, explicitly don't fail the scheduling loop
             self.log.exception("Failed to resolve team names for DAG IDs: %s", list(dag_ids))
             # Return dict with all None values to ensure graceful degradation
-            return {}
+            return {dag_id: None for dag_id in dag_ids}
 
     def _get_task_team_name(self, task_instance: TaskInstance, session: Session) -> str | None:
         """
@@ -793,7 +793,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                             continue
 
                 if executor_obj := self._try_to_load_executor(
-                    task_instance, session, team_name=dag_id_to_team_name.get(task_instance.dag_id, NOTSET)
+                    task_instance, session, team_name=dag_id_to_team_name.get(task_instance.dag_id)
                 ):
                     if TYPE_CHECKING:
                         # All executors should have a name if they are initted from the executor_loader.
@@ -2881,6 +2881,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
     def _purge_task_instances_without_heartbeats(
         self, task_instances_without_heartbeats: list[TI], *, session: Session
     ) -> None:
+        dag_id_to_team_name: dict[str, str | None] = {}
+        if conf.getboolean("core", "multi_team"):
+            unique_dag_ids = {ti.dag_id for ti in task_instances_without_heartbeats}
+            dag_id_to_team_name = self._get_team_names_for_dag_ids(unique_dag_ids, session)
+
         for ti in task_instances_without_heartbeats:
             task_instance_heartbeat_timeout_message_details = (
                 self._generate_task_instance_heartbeat_timeout_message_details(ti)
@@ -2925,7 +2930,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 request,
             )
             self.job.executor.send_callback(request)
-            if (executor := self._try_to_load_executor(ti, session)) is None:
+            if (
+                executor := self._try_to_load_executor(
+                    ti, session, team_name=dag_id_to_team_name.get(ti.dag_id)
+                )
+            ) is None:
                 self.log.warning(
                     "Cannot clean up task instance without heartbeat %r with non-existent executor %s",
                     ti,
@@ -3110,7 +3119,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         _executor_to_tis: defaultdict[BaseExecutor, list[TaskInstance]] = defaultdict(list)
         for ti in tis:
             if executor_obj := self._try_to_load_executor(
-                ti, session, team_name=dag_id_to_team_name.get(ti.dag_id, NOTSET)
+                ti, session, team_name=dag_id_to_team_name.get(ti.dag_id)
             ):
                 _executor_to_tis[executor_obj].append(ti)
 

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -3102,9 +3102,16 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         self, tis: Iterable[TaskInstance], session
     ) -> dict[BaseExecutor, list[TaskInstance]]:
         """Organize TIs into lists per their respective executor."""
+        dag_id_to_team_name: dict[str, str | None] = {}
+        if conf.getboolean("core", "multi_team"):
+            tis = list(tis)
+            dag_id_to_team_name = self._get_team_names_for_dag_ids({ti.dag_id for ti in tis}, session)
+
         _executor_to_tis: defaultdict[BaseExecutor, list[TaskInstance]] = defaultdict(list)
         for ti in tis:
-            if executor_obj := self._try_to_load_executor(ti, session):
+            if executor_obj := self._try_to_load_executor(
+                ti, session, team_name=dag_id_to_team_name.get(ti.dag_id, NOTSET)
+            ):
                 _executor_to_tis[executor_obj].append(ti)
 
         return _executor_to_tis

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -8186,6 +8186,80 @@ class TestSchedulerJob:
         assert result == mock_executors[1]
 
     @conf_vars({("core", "multi_team"): "true"})
+    def test_multi_team_executor_to_tis_batch_optimization(self, dag_maker, mock_executors, session):
+        """Test that _executor_to_tis resolves team names in a single batch for all input TIs."""
+        clear_db_teams()
+        clear_db_dag_bundles()
+
+        team1 = Team(name="team_a")
+        team2 = Team(name="team_b")
+        session.add_all([team1, team2])
+        session.flush()
+
+        bundle1 = DagBundleModel(name="bundle_a")
+        bundle2 = DagBundleModel(name="bundle_b")
+        bundle1.teams.append(team1)
+        bundle2.teams.append(team2)
+        session.add_all([bundle1, bundle2])
+        session.flush()
+
+        mock_executors[0].team_name = "team_a"
+        mock_executors[1].team_name = "team_b"
+
+        with dag_maker(dag_id="dag_a", bundle_name="bundle_a", session=session):
+            task_a = EmptyOperator(task_id="task_a")
+        dr1 = dag_maker.create_dagrun()
+
+        with dag_maker(dag_id="dag_b", bundle_name="bundle_b", session=session):
+            task_b = EmptyOperator(task_id="task_b")
+        dr2 = dag_maker.create_dagrun()
+
+        ti1 = dr1.get_task_instance(task_a.task_id, session)
+        ti2 = dr2.get_task_instance(task_b.task_id, session)
+
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+
+        with (
+            mock.patch.object(self.job_runner, "_get_team_names_for_dag_ids") as mock_batch,
+            mock.patch.object(self.job_runner, "_get_task_team_name") as mock_single,
+        ):
+            mock_batch.return_value = {"dag_a": "team_a", "dag_b": "team_b"}
+            executor_to_tis = self.job_runner._executor_to_tis([ti1, ti2], session)
+
+        mock_batch.assert_called_once_with({"dag_a", "dag_b"}, session)
+        mock_single.assert_not_called()
+        assert executor_to_tis[mock_executors[0]] == [ti1]
+        assert executor_to_tis[mock_executors[1]] == [ti2]
+
+    @conf_vars({("core", "multi_team"): "false"})
+    def test_multi_team_executor_to_tis_disabled_uses_legacy_behavior(
+        self, dag_maker, mock_executors, session
+    ):
+        """Test that _executor_to_tis does not run team resolution logic when multi-team is disabled."""
+        with dag_maker(dag_id="test_dag", session=session):
+            task1 = EmptyOperator(task_id="test_task1")
+            task2 = EmptyOperator(task_id="test_task2", executor="secondary_exec")
+
+        dr = dag_maker.create_dagrun()
+        ti1 = dr.get_task_instance(task1.task_id, session)
+        ti2 = dr.get_task_instance(task2.task_id, session)
+
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+
+        with (
+            mock.patch.object(self.job_runner, "_get_team_names_for_dag_ids") as mock_batch,
+            mock.patch.object(self.job_runner, "_get_task_team_name") as mock_single,
+        ):
+            executor_to_tis = self.job_runner._executor_to_tis([ti1, ti2], session)
+
+        mock_batch.assert_not_called()
+        mock_single.assert_not_called()
+        assert ti1 in executor_to_tis[scheduler_job.executor]
+        assert ti2 in executor_to_tis[mock_executors[1]]
+
+    @conf_vars({("core", "multi_team"): "true"})
     def test_multi_team_scheduling_loop_batch_optimization(self, dag_maker, mock_executors, session):
         """Test that the scheduling loop uses batch team resolution optimization."""
         clear_db_teams()

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -7855,8 +7855,8 @@ class TestSchedulerJob:
         with mock.patch.object(session, "execute", side_effect=Exception("Database error")):
             result = self.job_runner._get_team_names_for_dag_ids(["dag_test"], session)
 
-        # Should return empty dict and log the error
-        assert result == {}
+        # Should return None mapping for requested DAG IDs and log the error
+        assert result == {"dag_test": None}
         mock_log.exception.assert_called_once()
 
     def test_multi_team_get_task_team_name_success(self, dag_maker, session):
@@ -8184,80 +8184,6 @@ class TestSchedulerJob:
             mock_team_resolve.assert_not_called()  # We don't query for the team if it is pre-resolved
 
         assert result == mock_executors[1]
-
-    @conf_vars({("core", "multi_team"): "true"})
-    def test_multi_team_executor_to_tis_batch_optimization(self, dag_maker, mock_executors, session):
-        """Test that _executor_to_tis resolves team names in a single batch for all input TIs."""
-        clear_db_teams()
-        clear_db_dag_bundles()
-
-        team1 = Team(name="team_a")
-        team2 = Team(name="team_b")
-        session.add_all([team1, team2])
-        session.flush()
-
-        bundle1 = DagBundleModel(name="bundle_a")
-        bundle2 = DagBundleModel(name="bundle_b")
-        bundle1.teams.append(team1)
-        bundle2.teams.append(team2)
-        session.add_all([bundle1, bundle2])
-        session.flush()
-
-        mock_executors[0].team_name = "team_a"
-        mock_executors[1].team_name = "team_b"
-
-        with dag_maker(dag_id="dag_a", bundle_name="bundle_a", session=session):
-            task_a = EmptyOperator(task_id="task_a")
-        dr1 = dag_maker.create_dagrun()
-
-        with dag_maker(dag_id="dag_b", bundle_name="bundle_b", session=session):
-            task_b = EmptyOperator(task_id="task_b")
-        dr2 = dag_maker.create_dagrun()
-
-        ti1 = dr1.get_task_instance(task_a.task_id, session)
-        ti2 = dr2.get_task_instance(task_b.task_id, session)
-
-        scheduler_job = Job()
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
-
-        with (
-            mock.patch.object(self.job_runner, "_get_team_names_for_dag_ids") as mock_batch,
-            mock.patch.object(self.job_runner, "_get_task_team_name") as mock_single,
-        ):
-            mock_batch.return_value = {"dag_a": "team_a", "dag_b": "team_b"}
-            executor_to_tis = self.job_runner._executor_to_tis([ti1, ti2], session)
-
-        mock_batch.assert_called_once_with({"dag_a", "dag_b"}, session)
-        mock_single.assert_not_called()
-        assert executor_to_tis[mock_executors[0]] == [ti1]
-        assert executor_to_tis[mock_executors[1]] == [ti2]
-
-    @conf_vars({("core", "multi_team"): "false"})
-    def test_multi_team_executor_to_tis_disabled_uses_legacy_behavior(
-        self, dag_maker, mock_executors, session
-    ):
-        """Test that _executor_to_tis does not run team resolution logic when multi-team is disabled."""
-        with dag_maker(dag_id="test_dag", session=session):
-            task1 = EmptyOperator(task_id="test_task1")
-            task2 = EmptyOperator(task_id="test_task2", executor="secondary_exec")
-
-        dr = dag_maker.create_dagrun()
-        ti1 = dr.get_task_instance(task1.task_id, session)
-        ti2 = dr.get_task_instance(task2.task_id, session)
-
-        scheduler_job = Job()
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
-
-        with (
-            mock.patch.object(self.job_runner, "_get_team_names_for_dag_ids") as mock_batch,
-            mock.patch.object(self.job_runner, "_get_task_team_name") as mock_single,
-        ):
-            executor_to_tis = self.job_runner._executor_to_tis([ti1, ti2], session)
-
-        mock_batch.assert_not_called()
-        mock_single.assert_not_called()
-        assert ti1 in executor_to_tis[scheduler_job.executor]
-        assert ti2 in executor_to_tis[mock_executors[1]]
 
     @conf_vars({("core", "multi_team"): "true"})
     def test_multi_team_scheduling_loop_batch_optimization(self, dag_maker, mock_executors, session):


### PR DESCRIPTION
## Summary
Extend multi-team batching pattern found in #61471 to the `SchedulerJobRunner` so executor resolution consistently uses pre-resolved `dag_id -> team_name` mappings across remaining scheduler paths.

- Reduces repeated team-resolution work inside scheduler loops.
- Keeps executor-selection behavior consistent across core and non-core scheduler flows.
- Preserves legacy behavior when multi-team is disabled.
