### PR TITLE
i18n(Ko): add missing translations (Feb 11)

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/admin.json
@@ -93,9 +93,9 @@
     "filters": {
       "allStates": "모든 상태",
       "allTypes": "모든 유형",
-      "dagProcessorJob": "DagProcessorJob",
-      "schedulerJob": "SchedulerJob",
-      "triggererJob": "TriggererJob"
+      "dagProcessorJob": "Dag 프로세서 Job",
+      "schedulerJob": "스케줄러 Job",
+      "triggererJob": "트리거러 Job"
     }
   },
   "plugins": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/admin.json
@@ -3,6 +3,7 @@
     "description": "설명",
     "key": "키",
     "name": "이름",
+    "team": "팀",
     "value": "값"
   },
   "config": {
@@ -79,6 +80,23 @@
   },
   "formActions": {
     "save": "저장"
+  },
+  "jobs": {
+    "columns": {
+      "executorClass": "실행기 클래스",
+      "hostname": "호스트 이름",
+      "id": "ID",
+      "jobType": "Job 유형",
+      "latestHeartbeat": "최신 Heartbeat",
+      "unixname": "유닉스 이름"
+    },
+    "filters": {
+      "allStates": "모든 상태",
+      "allTypes": "모든 유형",
+      "dagProcessorJob": "DagProcessorJob",
+      "schedulerJob": "SchedulerJob",
+      "triggererJob": "TriggererJob"
+    }
   },
   "plugins": {
     "columns": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/admin.json
@@ -86,16 +86,16 @@
       "executorClass": "실행기 클래스",
       "hostname": "호스트 이름",
       "id": "ID",
-      "jobType": "Job 유형",
+      "jobType": "잡 유형",
       "latestHeartbeat": "최신 Heartbeat",
       "unixname": "유닉스 이름"
     },
     "filters": {
       "allStates": "모든 상태",
       "allTypes": "모든 유형",
-      "dagProcessorJob": "Dag 프로세서 Job",
-      "schedulerJob": "스케줄러 Job",
-      "triggererJob": "트리거러 Job"
+      "dagProcessorJob": "Dag 프로세서 잡",
+      "schedulerJob": "스케줄러 잡",
+      "triggererJob": "트리거러 잡"
     }
   },
   "plugins": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/assets.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/assets.json
@@ -31,5 +31,7 @@
   "name": "이름",
   "producingTasks": "생성하는 태스크",
   "scheduledDags": "스케줄 된 Dags",
-  "searchPlaceholder": "에셋 검색"
+  "scheduling": "스케줄링",
+  "searchPlaceholder": "에셋 검색",
+  "taskDependencies": "태스크 종속성"
 }

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/common.json
@@ -22,6 +22,7 @@
   "backfill_other": "백필들",
   "browse": {
     "auditLog": "감사 로그",
+    "jobs": "Jobs",
     "requiredActions": "필수 작업",
     "xcoms": "XComs"
   },

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/common.json
@@ -22,7 +22,7 @@
   "backfill_other": "백필들",
   "browse": {
     "auditLog": "감사 로그",
-    "jobs": "Jobs",
+    "jobs": "잡",
     "requiredActions": "필수 작업",
     "xcoms": "XComs"
   },

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/dag.json
@@ -73,6 +73,12 @@
     "navigation": "탐색: {{arrow}}",
     "toggleGroup": "그룹 전환: Space"
   },
+  "notFound": {
+    "back": "뒤로",
+    "backToDags": "Dags로 돌아가기",
+    "message": "Dag \"{{dagId}}\"이(가) 존재하지 않습니다.",
+    "title": "Dag를 찾을 수 없습니다"
+  },
   "overview": {
     "buttons": {
       "failedRun_one": "실패한 실행",
@@ -123,6 +129,7 @@
       "direction": "방향",
       "label": "필터",
       "mode": "모드",
+      "modeTooltip": "정적 모드는 다른 태스크로 이동할 때 현재 뷰를 유지하고, 탐색 모드는 클릭한 태스크에 맞게 활성 필터를 자동으로 업데이트하여 DAG를 쉽게 탐색할 수 있게 합니다.",
       "modes": {
         "static": "정적",
         "traverse": "탐색"


### PR DESCRIPTION
Added missing Korean Translations
Please review this translations.
/cc @choo121600  @kgw7401 @onestn  @noeunkim 

## Before
<img width="690" height="718" alt="91D7DDFA-F891-4362-B970-7A0324D62EEF" src="https://github.com/user-attachments/assets/eb1e7f92-8bb8-4cc0-9a30-c0c2970338bc" />

## After
<img width="629" height="422" alt="8D94ECAE-29D0-4795-A124-3688884A1CDB" src="https://github.com/user-attachments/assets/bd2a295b-e709-4ea5-8862-31c4a311fc79" />

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
