### PR TITLE
Minor fixes to the release candidate command

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_candidate_command.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_candidate_command.py
@@ -534,9 +534,7 @@ def move_artifacts_to_svn(
             check=True,
             shell=True,
         )
-        console_print("[success]Moved artifacts to SVN:")
-        run_command([f"ls {version}/"])
-        run_command([f"ls task-sdk/{task_sdk_version}/"])
+        console_print("[success]Moved artifacts to SVN")
 
 
 def push_artifacts_to_asf_repo(version, task_sdk_version, repo_root):

--- a/dev/breeze/tests/test_release_candidate_command.py
+++ b/dev/breeze/tests/test_release_candidate_command.py
@@ -621,10 +621,7 @@ def test_move_artifacts_to_svn_completes_successfully(monkeypatch, rc_cmd):
         and kwargs.get("shell") is True
         for cmd, kwargs in run_command_calls
     )
-    assert "[success]Moved artifacts to SVN:" in console_messages
-    # Verify ls commands
-    assert any(cmd == [f"ls {version}/"] for cmd, kwargs in run_command_calls)
-    assert any(cmd == [f"ls task-sdk/{task_sdk_version}/"] for cmd, kwargs in run_command_calls)
+    assert "[success]Moved artifacts to SVN" in console_messages
 
 
 def test_push_artifacts_to_asf_repo_returns_early_when_user_declines(monkeypatch, rc_cmd):


### PR DESCRIPTION
Not sure why the `ls` was failing but we can do without it
