### PR TITLE
Do not execute svn commands in CI runs

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_command.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_command.py
@@ -53,7 +53,6 @@ def clone_asf_repo(working_dir):
                         "asf-dist",
                     ],
                     check=True,
-                    dry_run_override=False,
                 )
                 break
             except CalledProcessError:
@@ -66,10 +65,8 @@ def clone_asf_repo(working_dir):
 
         dev_dir = f"{working_dir}/asf-dist/dev/airflow"
         release_dir = f"{working_dir}/asf-dist/release/airflow"
-        run_command(["svn", "update", "--set-depth", "infinity", dev_dir], dry_run_override=False, check=True)
-        run_command(
-            ["svn", "update", "--set-depth", "infinity", release_dir], dry_run_override=False, check=True
-        )
+        run_command(["svn", "update", "--set-depth", "infinity", dev_dir], check=True)
+        run_command(["svn", "update", "--set-depth", "infinity", release_dir], check=True)
 
 
 def find_latest_release_candidate(version, svn_dev_repo, component="airflow"):


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

SVN commands in clone_asf_repo were ignoring the --dry-run flag due to `dry_run_override=False`, causing CI to attempt actual SVN checkouts and resulting in connection timeout failures. Remove the override to allow
these commands to be properly skipped in dry-run mode.


Error example: https://github.com/apache/airflow/actions/runs/21896731157/job/63214509195

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
