### PR TITLE
Remove Keycloak access token from cookie to not exceed cookie size limit

### DIFF
--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
@@ -146,7 +146,7 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
         if not user.refresh_token:
             return None
 
-        if self._token_expired(user.access_token):
+        if not user.access_token or self._token_expired(user.access_token):
             tokens = self.refresh_tokens(user=user)
 
             if tokens:

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
@@ -368,6 +368,9 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
         elif method == "GET":
             method = "LIST"
 
+        # in case access token is expired or missing
+        self.refresh_user(user=user)
+
         resp = self.http_session.post(
             self._get_token_url(server_url, realm),
             data=self._get_payload(client_id, f"{resource_type.value}#{method}", context_attributes),

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/routes/login.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/routes/login.py
@@ -80,7 +80,8 @@ def login_callback(request: Request):
     user = KeycloakAuthManagerUser(
         user_id=userinfo["sub"],
         name=userinfo["preferred_username"],
-        access_token=tokens["access_token"],
+        # dont include access token in cookie to not exceed browser cookie limit of 4KB
+        access_token="",
         refresh_token=tokens["refresh_token"],
     )
     token = get_auth_manager().generate_jwt(user)

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/routes/test_login.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/routes/test_login.py
@@ -67,7 +67,7 @@ class TestLoginRouter:
         user = mock_auth_manager.generate_jwt.call_args[0][0]
         assert user.get_id() == "sub"
         assert user.get_name() == "preferred_username"
-        assert user.access_token == "access_token"
+        assert user.access_token == ""
         assert user.refresh_token == "refresh_token"
         assert response.status_code == 303
         assert "location" in response.headers


### PR DESCRIPTION
Closes: #61771

Removed access token from cookie for auth code flow in Keycloak provider. 

For large access tokens containing multiple realm roles, access token + refresh token exceeds browser cookie limit of 4KB. Passing only refresh token in cookie is sufficient, as with refresh_user() the access token can be retrieved via refresh token.