### PR TITLE
Feature: Support bytes data values in xcom backend

### DIFF
--- a/providers/common/io/src/airflow/providers/common/io/xcom/backend.py
+++ b/providers/common/io/src/airflow/providers/common/io/xcom/backend.py
@@ -117,12 +117,13 @@ class XComObjectStorageBackend(BaseXCom):
         run_id: str | None = None,
         map_index: int | None = None,
     ) -> bytes | str:
-        # We will use this serialized value to write to the object store.
-        if not isinstance(value, bytes):
+        if isinstance(value, bytes):
+             # Store raw bytes as-is  
+            s_val_encoded = value
+        else:
+            # Default JSON serialization path 
             s_val = json.dumps(value, cls=XComEncoder)
             s_val_encoded = s_val.encode("utf-8")
-        else:
-            s_val_encoded = value
 
         if compression := _get_compression():
             suffix = f".{_get_compression_suffix(compression)}"
@@ -175,6 +176,7 @@ class XComObjectStorageBackend(BaseXCom):
         try:
             with path.open(mode="rb", compression="infer") as f:
                 data = f.read()
+                # Prefer JSON decoding; fall back to raw bytes if it fails.
                 return json.loads(data, cls=XComDecoder)
         except (FileNotFoundError, TypeError, ValueError, json.decoder.JSONDecodeError):
             return data

--- a/providers/common/io/src/airflow/providers/common/io/xcom/backend.py
+++ b/providers/common/io/src/airflow/providers/common/io/xcom/backend.py
@@ -118,8 +118,11 @@ class XComObjectStorageBackend(BaseXCom):
         map_index: int | None = None,
     ) -> bytes | str:
         # We will use this serialized value to write to the object store.
-        s_val = json.dumps(value, cls=XComEncoder)
-        s_val_encoded = s_val.encode("utf-8")
+        if not isinstance(value, bytes):
+            s_val = json.dumps(value, cls=XComEncoder)
+            s_val_encoded = s_val.encode("utf-8")
+        else:
+            s_val_encoded = value
 
         if compression := _get_compression():
             suffix = f".{_get_compression_suffix(compression)}"
@@ -171,8 +174,9 @@ class XComObjectStorageBackend(BaseXCom):
             return data
         try:
             with path.open(mode="rb", compression="infer") as f:
-                return json.load(f, cls=XComDecoder)
-        except (FileNotFoundError, TypeError, ValueError):
+                data = f.read()
+                return json.loads(data, cls=XComDecoder)
+        except (FileNotFoundError, TypeError, ValueError, json.decoder.JSONDecodeError):
             return data
 
     @staticmethod

--- a/providers/common/io/tests/unit/common/io/xcom/test_backend.py
+++ b/providers/common/io/tests/unit/common/io/xcom/test_backend.py
@@ -440,6 +440,7 @@ class TestXComObjectStorageBackend:
             pytest.param({"key": {"key": "value"}}, {"key": {"key": "value"}}, id="nested_dict"),
             pytest.param([1, 2, 3], [1, 2, 3], id="list"),
             pytest.param((1, 2, 3), (1, 2, 3), id="tuple"),
+            pytest.param(b'bytes', b'bytes', id="bytes"),
             pytest.param(None, None, id="none"),
         ],
     )


### PR DESCRIPTION
This PR will make it possible to store both JSON-serializable objects as well as plain - bytes data in the ObjectStorageBackend. This is a small feature that only required a few lines of code changes. Tell me if we need to do further discussions about this before considering it as a supported feature.

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)
