### PR TITLE
Remove core imports in shared observability tests

### DIFF
--- a/shared/observability/tests/observability/metrics/test_stats.py
+++ b/shared/observability/tests/observability/metrics/test_stats.py
@@ -30,14 +30,13 @@ import statsd
 import airflow_shared
 import airflow_shared.observability.metrics.stats
 import airflow_shared.observability.metrics.validators
-from airflow._shared.configuration import AirflowConfigException
-from airflow._shared.observability.metrics.validators import (
-    PatternAllowListValidator,
-    PatternBlockListValidator,
-)
 from airflow_shared.observability.exceptions import InvalidStatsNameException
 from airflow_shared.observability.metrics.datadog_logger import SafeDogStatsdLogger
 from airflow_shared.observability.metrics.statsd_logger import SafeStatsdLogger
+from airflow_shared.observability.metrics.validators import (
+    PatternAllowListValidator,
+    PatternBlockListValidator,
+)
 
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.markers import skip_if_force_lowest_dependencies_marker
@@ -149,7 +148,8 @@ class TestStats:
                 "Your custom StatsD client must extend the statsd."
                 "StatsClient in order to ensure backwards compatibility."
             )
-            with pytest.raises(AirflowConfigException, match=error_message):
+            # we assert for Exception here instead of AirflowConfigException to not import from shared configuration
+            with pytest.raises(Exception, match=error_message):
                 airflow_shared.observability.metrics.stats.Stats.incr("empty_key")
         importlib.reload(airflow_shared.observability.metrics.stats)
 
@@ -166,9 +166,9 @@ class TestStats:
                 is_statsd_on=True,
                 is_otel_on=False,
             )
-            assert (
-                type(airflow_shared.observability.metrics.stats.Stats.metrics_validator)
-                is PatternAllowListValidator
+            assert isinstance(
+                airflow_shared.observability.metrics.stats.Stats.metrics_validator,
+                PatternAllowListValidator,
             )
             assert airflow_shared.observability.metrics.stats.Stats.metrics_validator.validate_list == (
                 "name1",
@@ -190,9 +190,9 @@ class TestStats:
                 is_statsd_on=True,
                 is_otel_on=False,
             )
-            assert (
-                type(airflow_shared.observability.metrics.stats.Stats.metrics_validator)
-                is PatternBlockListValidator
+            assert isinstance(
+                airflow_shared.observability.metrics.stats.Stats.metrics_validator,
+                PatternBlockListValidator,
             )
             assert airflow_shared.observability.metrics.stats.Stats.metrics_validator.validate_list == (
                 "name1",
@@ -215,9 +215,9 @@ class TestStats:
                 is_statsd_on=True,
                 is_otel_on=False,
             )
-            assert (
-                type(airflow_shared.observability.metrics.stats.Stats.metrics_validator)
-                is PatternAllowListValidator
+            assert isinstance(
+                airflow_shared.observability.metrics.stats.Stats.metrics_validator,
+                PatternAllowListValidator,
             )
             assert airflow_shared.observability.metrics.stats.Stats.metrics_validator.validate_list == (
                 "name1",
@@ -438,8 +438,8 @@ class TestPatternValidatorConfigOption:
             )
 
             assert isinstance(airflow_shared.observability.metrics.stats.Stats.statsd, statsd.StatsClient)
-            assert (
-                type(airflow_shared.observability.metrics.stats.Stats.instance.metrics_validator) is expected
+            assert isinstance(
+                airflow_shared.observability.metrics.stats.Stats.instance.metrics_validator, expected
             )
 
     @conf_vars({**stats_on, **block_list, ("metrics", "metrics_allow_list"): "baz,qux"})
@@ -453,9 +453,9 @@ class TestPatternValidatorConfigOption:
             )
 
             assert isinstance(airflow_shared.observability.metrics.stats.Stats.statsd, statsd.StatsClient)
-            assert (
-                type(airflow_shared.observability.metrics.stats.Stats.instance.metrics_validator)
-                is PatternAllowListValidator
+            assert isinstance(
+                airflow_shared.observability.metrics.stats.Stats.instance.metrics_validator,
+                PatternAllowListValidator,
             )
             assert "Ignoring metrics_block_list" in caplog.text
 


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] No

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

The shared observability tests were importing from `airflow._shared` which pulled in the entire `airflow-core` package with some dependencies with failures such as these:

```python
ERROR tests/observability/metrics/test_stats.py - ImportError while importing test module '/home/runner/work/airflow/airflow/shared/observability/tests/observability/metrics/test_stats.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../.venv/lib/python3.10/site-packages/_pytest/python.py:507: in importtestmodule
    mod = import_path(
../../.venv/lib/python3.10/site-packages/_pytest/pathlib.py:587: in import_path
    importlib.import_module(module_name)
/usr/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1050: in _gcd_import
    ???
<frozen importlib._bootstrap>:1027: in _find_and_load
    ???
<frozen importlib._bootstrap>:1006: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:688: in _load_unlocked
    ???
../../.venv/lib/python3.10/site-packages/_pytest/assertion/rewrite.py:197: in exec_module
    exec(co, module.__dict__)
tests/observability/metrics/test_stats.py:33: in <module>
    from airflow._shared.configuration import AirflowConfigException
../../airflow-core/src/airflow/__init__.py:64: in <module>
    from airflow import configuration, settings
../../airflow-core/src/airflow/configuration.py:935: in <module>
    secrets_backend_list = initialize_secrets_backends()
../../airflow-core/src/airflow/configuration.py:881: in initialize_secrets_backends
    from airflow.models import Connection
../../airflow-core/src/airflow/models/__init__.py:88: in __getattr__
    val = import_string(f"{path}.{name}")
../../airflow-core/src/airflow/_shared/module_loading/__init__.py:58: in import_string
    module = import_module(module_path)
/usr/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
../../airflow-core/src/airflow/models/connection.py:39: in <module>
    from airflow.utils.helpers import prune_dict
../../airflow-core/src/airflow/utils/helpers.py:29: in <module>
    from lazy_object_proxy import Proxy
E   ModuleNotFoundError: No module named 'lazy_object_proxy'
```

Example: https://github.com/apache/airflow/actions/runs/21914519496/job/63277989205?pr=61523

This caused test failures when running the shared observability package in isolation.

Changed test imports to use same namespace directly. For this, some changes I made included making change to validator type checks to use` isinstance()` instead of identity checks to handle cases where classes may be loaded from different module paths, which does a good enough job.

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
