### PR TITLE
Remove logic that updates queued_at when it's already queued

### DIFF
--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -531,9 +531,6 @@ class DagRun(Base, LoggingMixin):
                 if state in State.finished_dr_states:
                     self.end_date = timezone.utcnow()
             self._state = state
-        else:
-            if state == DagRunState.QUEUED:
-                self.queued_at = timezone.utcnow()
 
     @declared_attr
     def state(self):


### PR DESCRIPTION
This advances the "queued_at" time beyond the initial value which, is wrong.

I'm not sure why we were doing this.
