### PR TITLE
Docs: add review checklist for example DAGs

### DIFF
--- a/contributing-docs/03a_contributors_quick_start_beginners.rst
+++ b/contributing-docs/03a_contributors_quick_start_beginners.rst
@@ -172,6 +172,14 @@ Review & Merge
 Respond to reviewer comments, push updates (same commands as above).  Once
 CI is green and reviews are ✅, a committer will merge.  🎉
 
+Example DAG Review Checklist
+----------------------------
+
+To help maintain consistency and quality across example DAGs,
+please refer to the example DAG review checklist:
+
+:doc:`example_dag_review_checklist`
+
 Next Steps
 ----------
 * Need a full development environment? See the `Development Environments Guide <https://github.com/apache/airflow/blob/main/contributing-docs/06_development_environments.rst>`_.

--- a/contributing-docs/03a_contributors_quick_start_beginners.rst
+++ b/contributing-docs/03a_contributors_quick_start_beginners.rst
@@ -172,7 +172,7 @@ Review & Merge
 Respond to reviewer comments, push updates (same commands as above).  Once
 CI is green and reviews are ✅, a committer will merge.  🎉
 
-Example DAG Review Checklist
+Example Dag Review Checklist
 ----------------------------
 
 To help maintain consistency and quality across example DAGs,

--- a/contributing-docs/example_dag_review_checklist.rst
+++ b/contributing-docs/example_dag_review_checklist.rst
@@ -1,8 +1,8 @@
-Example DAG Review Checklist
+Example Dag Review Checklist
 ============================
 
-This document provides a checklist for reviewing example DAGs submitted to
-Apache Airflow. The goal is to ensure that example DAGs are clean, consistent,
+This document provides a checklist for reviewing example Dags submitted to
+Apache Airflow. The goal is to ensure that example Dags are clean, consistent,
 and follow best practices while serving their multiple purposes:
 
 * Clean and consistent
@@ -14,16 +14,16 @@ and follow best practices while serving their multiple purposes:
 General Guidelines
 ------------------
 
-- [ ] The DAG has a clear and descriptive file name.
-- [ ] The purpose of the DAG is documented at the top of the file.
-- [ ] The DAG demonstrates a single feature or concept.
+- [ ] The Dag has a clear and descriptive file name.
+- [ ] The purpose of the Dag is documented at the top of the file.
+- [ ] The Dag demonstrates a single feature or concept.
 - [ ] Examples do not duplicate functionality across the repo.
 - [ ] Example runs in a reasonable amount of time (suitable for tutorials & CI).
 
 Example Categorization
 ----------------------
 
-Example DAGs should clearly indicate which category they belong to:
+Example Dags should clearly indicate which category they belong to:
 
 - [ ] **Tutorial Examples** — educational, simple to read and follow.
 - [ ] **Documentation Snippets** — aligned with docs examples.
@@ -33,8 +33,8 @@ Example DAGs should clearly indicate which category they belong to:
 Structure & Readability
 -----------------------
 
-- [ ] The DAG and task IDs are meaningful and consistent.
-- [ ] The code follows PEP 8 formatting.
+- [ ] The Dag and task IDs are meaningful and consistent.
+- [ ] The code follows `PEP 8 <https://peps.python.org/pep-0008/>` formatting.
 - [ ] Imports are organized, minimal, and sorted.
 - [ ] Reusable logic is factored into helper functions or modules.
 - [ ] Example layout is consistent with other examples of the same category.
@@ -42,18 +42,18 @@ Structure & Readability
 Documentation
 -------------
 
-- [ ] The DAG contains a module-level docstring explaining:
-  * What the DAG does
+- [ ] The Dag contains a module-level docstring explaining:
+  * What the Dag does
   * Why it exists
   * When and how to use it
   * Any prerequisites or expected services
-- [ ] The DAG contains ``doc_md`` for in-UI documentation where appropriate.
+- [ ] The Dag contains ``doc_md`` for in-UI documentation where appropriate.
 - [ ] Inline comments explain complex or non-obvious logic.
 
 Best Practices
 --------------
 
-- [ ] The DAG uses well-named variables and avoids hard-coded secrets.
+- [ ] The Dag uses well-named variables and avoids hard-coded secrets.
 - [ ] Default arguments are defined and minimal.
 - [ ] Tasks are idempotent and side-effect clean.
 - [ ] Uses modern Airflow APIs and operators.
@@ -63,12 +63,12 @@ Best Practices
 Testing & CI Compatibility
 --------------------------
 
-- [ ] The DAG parses cleanly (no import errors).
+- [ ] The Dag parses cleanly (no import errors).
 - [ ] Example does not depend on external services unless documented.
 - [ ] Example is uniquely identifiable and does not conflict with others.
 - [ ] Example respects AIRFLOW__* environment variables where applicable.
 
-Provider Example DAGs
+Provider Example Dags
 ---------------------
 
 Provider examples have slightly different expectations:

--- a/contributing-docs/example_dag_review_checklist.rst
+++ b/contributing-docs/example_dag_review_checklist.rst
@@ -1,0 +1,79 @@
+Example DAG Review Checklist
+============================
+
+This document provides a checklist for reviewing example DAGs submitted to
+Apache Airflow. The goal is to ensure that example DAGs are clean, consistent,
+and follow best practices while serving their multiple purposes:
+
+* Clean and consistent
+* Easy to understand
+* Useful for tutorials and documentation
+* Compatible with testing and CI processes
+* Properly structured across core and provider packages
+
+General Guidelines
+------------------
+
+- [ ] The DAG has a clear and descriptive file name.
+- [ ] The purpose of the DAG is documented at the top of the file.
+- [ ] The DAG demonstrates a single feature or concept.
+- [ ] Examples do not duplicate functionality across the repo.
+- [ ] Example runs in a reasonable amount of time (suitable for tutorials & CI).
+
+Example Categorization
+----------------------
+
+Example DAGs should clearly indicate which category they belong to:
+
+- [ ] **Tutorial Examples** — educational, simple to read and follow.
+- [ ] **Documentation Snippets** — aligned with docs examples.
+- [ ] **Testing/CI Examples** — used to exercise system features in CI.
+- [ ] Example type is noted in module-level docstring or metadata.
+
+Structure & Readability
+-----------------------
+
+- [ ] The DAG and task IDs are meaningful and consistent.
+- [ ] The code follows PEP 8 formatting.
+- [ ] Imports are organized, minimal, and sorted.
+- [ ] Reusable logic is factored into helper functions or modules.
+- [ ] Example layout is consistent with other examples of the same category.
+
+Documentation
+-------------
+
+- [ ] The DAG contains a module-level docstring explaining:
+  * What the DAG does
+  * Why it exists
+  * When and how to use it
+  * Any prerequisites or expected services
+- [ ] The DAG contains ``doc_md`` for in-UI documentation where appropriate.
+- [ ] Inline comments explain complex or non-obvious logic.
+
+Best Practices
+--------------
+
+- [ ] The DAG uses well-named variables and avoids hard-coded secrets.
+- [ ] Default arguments are defined and minimal.
+- [ ] Tasks are idempotent and side-effect clean.
+- [ ] Uses modern Airflow APIs and operators.
+- [ ] Avoids deprecated or discouraged features.
+- [ ] Providers examples import only allowed modules.
+
+Testing & CI Compatibility
+--------------------------
+
+- [ ] The DAG parses cleanly (no import errors).
+- [ ] Example does not depend on external services unless documented.
+- [ ] Example is uniquely identifiable and does not conflict with others.
+- [ ] Example respects AIRFLOW__* environment variables where applicable.
+
+Provider Example DAGs
+---------------------
+
+Provider examples have slightly different expectations:
+
+- [ ] The provider example uses provider-specific operators/hooks correctly.
+- [ ] Provider dependencies are clearly documented in the docstring.
+- [ ] Example is not auto-loaded unless intended.
+- [ ] Example naming follows provider naming conventions.


### PR DESCRIPTION
Adds a contributor-facing review checklist for example DAGs, based on the
Examples Refurbish initiative, to improve consistency and quality of example
DAGs across core and provider packages.

Links the checklist from the beginner contributor guide for discoverability.

Closes #52476
