### PR TITLE
Fix DagRan typo in DagRun.set_state docstring

### DIFF
--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -464,7 +464,7 @@ class DagRun(Base, LoggingMixin):
 
     def set_state(self, state: DagRunState) -> None:
         """
-        Change the state of the DagRan.
+        Change the state of the DagRun.
 
         Changes to attributes are implemented in accordance with the following table
         (rows represent old states, columns represent new states):


### PR DESCRIPTION

---

##### Was generative AI tooling used to co-author this PR?


- [x] Yes (please specify the tool below)


Generated-by: Cursor CLI (Composer 1.5)
