### PR TITLE
Expose Stats in sdk API and handle core backcompat

### DIFF
--- a/airflow-core/.pre-commit-config.yaml
+++ b/airflow-core/.pre-commit-config.yaml
@@ -362,6 +362,7 @@ repos:
           ^src/airflow/models/taskmixin\.py$|
           ^src/airflow/models/taskreschedule\.py$|
           ^src/airflow/models/trigger\.py$|
+          ^src/airflow/stats\.py$|
           ^src/airflow/models/variable\.py$|
           ^src/airflow/models/xcom\.py$|
           ^src/airflow/models/xcom_arg\.py$|

--- a/airflow-core/src/airflow/observability/stats.py
+++ b/airflow-core/src/airflow/observability/stats.py
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Re-exports from airflow._shared.observability.metrics.stats for compatibility."""
+
+from __future__ import annotations
+
+from airflow._shared.observability.metrics.stats import Stats as Stats

--- a/airflow-core/src/airflow/stats.py
+++ b/airflow-core/src/airflow/stats.py
@@ -1,0 +1,31 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Deprecated module - Stats moved to airflow.observability.stats but we have to retain compat."""
+
+from __future__ import annotations
+
+import warnings
+
+from airflow.observability.stats import Stats as Stats
+from airflow.utils.deprecation_tools import DeprecatedImportWarning
+
+warnings.warn(
+    "Importing from 'airflow.stats' is deprecated. Please use 'airflow.observability.stats' instead.",
+    DeprecatedImportWarning,
+    stacklevel=2,
+)

--- a/airflow-core/src/airflow/stats.py
+++ b/airflow-core/src/airflow/stats.py
@@ -21,11 +21,11 @@ from __future__ import annotations
 
 import warnings
 
-from airflow.observability.stats import Stats as Stats
+from airflow.sdk.observability.stats import Stats as Stats
 from airflow.utils.deprecation_tools import DeprecatedImportWarning
 
 warnings.warn(
-    "Importing from 'airflow.stats' is deprecated. Please use 'airflow.observability.stats' instead.",
+    "Importing from 'airflow.stats' is deprecated. Please use 'airflow.sdk.observability.stats' instead.",
     DeprecatedImportWarning,
     stacklevel=2,
 )

--- a/contributing-docs/05_pull_requests.rst
+++ b/contributing-docs/05_pull_requests.rst
@@ -308,11 +308,7 @@ will be timed and submitted automatically:
 
 .. code-block:: python
 
-    # If importing from airflow-core
-    from airflow._shared.observability.metrics.stats import Stats
-
-    # Else if importing from task-sdk
-    from airflow.sdk._shared.observability.metrics.stats import Stats
+    from airflow.sdk.observability import Stats
 
     ...
 
@@ -323,11 +319,7 @@ or to time but not send a metric:
 
 .. code-block:: python
 
-    # If importing from airflow-core
-    from airflow._shared.observability.metrics.stats import Stats
-
-    # Else if importing from task-sdk
-    from airflow.sdk._shared.observability.metrics.stats import Stats
+    from airflow.sdk.observability.stats import Stats
 
     ...
 

--- a/contributing-docs/05_pull_requests.rst
+++ b/contributing-docs/05_pull_requests.rst
@@ -308,7 +308,7 @@ will be timed and submitted automatically:
 
 .. code-block:: python
 
-    from airflow.sdk.observability import Stats
+    from airflow.sdk.observability.stats import Stats
 
     ...
 

--- a/task-sdk/src/airflow/sdk/observability/stats.py
+++ b/task-sdk/src/airflow/sdk/observability/stats.py
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Stats module - re-exports from airflow.sdk._shared.observability.metrics.stats."""
+
+from __future__ import annotations
+
+from airflow.sdk._shared.observability.metrics.stats import Stats, normalize_name_for_stats
+
+__all__ = ["Stats", "normalize_name_for_stats"]


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] No

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

Stats somehow lost compat with few of the older import patterns. For example, I am adding this back:

- `airflow.stats`: deprecated re-export for earliest path
- `airflow.observability.stats`: canonical path for core (re export from` _shared`)
- `airflow.sdk.observability`: export Stats for task-sdk users like providers (re export from` _shared`)

Current state:

```python

>>> from airflow.stats import Stats
<python-input-0>:1 DeprecatedImportWarning: Importing from 'airflow.stats' is deprecated. Please use 'airflow.observability.stats' instead.
>>> 
>>> 
>>> from airflow.observability.stats import Stats
>>> 
>>> 
>>> from airflow.sdk.observability.stats import Stats

```
---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
