### PR TITLE
Fix scheduler crash when enqueuing TI with null dag_version_id

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -922,7 +922,8 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 continue
             if not ti.dag_version_id:
                 self.log.warning(
-                    "TaskInstance %s does not have a dag_version_id set, cannot be enqueued. This would get unstuck and dag_version_id updated.",
+                    "TaskInstance %s does not have a dag_version_id set, cannot be enqueued. "
+                    "This would get unstuck and dag_version_id updated.",
                     ti,
                 )
                 continue

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -921,8 +921,8 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 ti.set_state(None, session=session)
                 continue
             if not ti.dag_version_id:
-                self.log.error(
-                    "TaskInstance %s does not have a dag_version_id set, cannot be enqueued",
+                self.log.warning(
+                    "TaskInstance %s does not have a dag_version_id set, cannot be enqueued. This would get unstuck and dag_version_id updated.",
                     ti,
                 )
                 continue

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -920,6 +920,12 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             if ti.dag_run.state in State.finished_dr_states:
                 ti.set_state(None, session=session)
                 continue
+            if not ti.dag_version_id:
+                self.log.error(
+                    "TaskInstance %s does not have a dag_version_id set, cannot be enqueued",
+                    ti,
+                )
+                continue
 
             workload = workloads.ExecuteTask.make(
                 ti,

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -2312,7 +2312,7 @@ class TestSchedulerJob:
         session.commit()
 
         with patch.object(BaseExecutor, "queue_workload") as mock_queue_workload:
-            with caplog.at_level("ERROR", logger="airflow.jobs.scheduler_job_runner"):
+            with caplog.at_level("WARNING", logger="airflow.jobs.scheduler_job_runner"):
                 self.job_runner._enqueue_task_instances_with_queued_state(
                     [ti], executor=scheduler_job.executor, session=session
                 )

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -2293,6 +2293,36 @@ class TestSchedulerJob:
         assert ti.state == State.NONE
         mock_queue_workload.assert_not_called()
 
+    def test_enqueue_task_instances_skips_ti_without_dag_version_id(self, dag_maker, session, caplog):
+        """Task instances without dag_version_id are not enqueued and an error is logged."""
+        dag_id = "SchedulerJobTest.test_enqueue_task_instances_skips_ti_without_dag_version_id"
+        task_id_1 = "dummy"
+        session = settings.Session()
+        with dag_maker(dag_id=dag_id, start_date=DEFAULT_DATE, session=session):
+            task1 = EmptyOperator(task_id=task_id_1)
+
+        scheduler_job = Job(executor=self.null_exec)
+        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+
+        dr1 = dag_maker.create_dagrun()
+        ti = dr1.get_task_instance(task1.task_id, session)
+        ti.state = State.SCHEDULED
+        ti.dag_version_id = None
+        session.merge(ti)
+        session.commit()
+
+        with patch.object(BaseExecutor, "queue_workload") as mock_queue_workload:
+            with caplog.at_level("ERROR", logger="airflow.jobs.scheduler_job_runner"):
+                self.job_runner._enqueue_task_instances_with_queued_state(
+                    [ti], executor=scheduler_job.executor, session=session
+                )
+
+        mock_queue_workload.assert_not_called()
+        assert any(
+            "does not have a dag_version_id set, cannot be enqueued" in rec.message for rec in caplog.records
+        )
+        session.rollback()
+
     @pytest.mark.parametrize(
         ("task1_exec", "task2_exec"),
         [


### PR DESCRIPTION
After upgrade from AF2, TIs might be without dag_version_id since we don't enforce this at the DB level. The solution here is to skip enqueing such TIs until the verify_integrity runs which would update the dag_version_id of the TI.

Initially, the TI would be stuck but would later be cleared when the handle tasks stuck in queued deems it fit.

