### PR TITLE
Chart: update artifacthub annotations for 1.19.0rc3

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -245,6 +245,11 @@ annotations:
       links:
       - name: '#56872'
         url: https://github.com/apache/airflow/pull/56872
+    - description: Remove ``kedaNetworkPolicySelector`` from helpers
+      kind: fixed
+      links:
+      - name: '#61564'
+        url: https://github.com/apache/airflow/pull/61564
     - description: Use the ``bitnamilegacy/postgresql`` image
       kind: fixed
       links:


### PR DESCRIPTION
Missed this when updating the release notes.