### PR TITLE
Update helm chart 1.19.0 release date

### DIFF
--- a/chart/RELEASE_NOTES.rst
+++ b/chart/RELEASE_NOTES.rst
@@ -23,7 +23,7 @@ Run ``helm repo update`` before upgrading the chart to the latest version.
 
 .. towncrier release notes start
 
-Airflow Helm Chart 1.19.0 (2026-02-15)
+Airflow Helm Chart 1.19.0 (2026-02-17)
 --------------------------------------
 
 Significant Changes

--- a/chart/reproducible_build.yaml
+++ b/chart/reproducible_build.yaml
@@ -1,2 +1,2 @@
-release-notes-hash: 891258b8345319feec4e0dbd29cae99a
-source-date-epoch: 1770873309
+release-notes-hash: 0a0b32fd2bcfd2fd51cdfa85db083041
+source-date-epoch: 1770998156


### PR DESCRIPTION
I didn't get the RC cut early enough today - had to update the expiration date on my gpg signing key.