### PR TITLE
Fix GitDagBundle re-cloning on every task when prune_dotgit_folder is True

### DIFF
--- a/providers/git/src/airflow/providers/git/bundles/git.py
+++ b/providers/git/src/airflow/providers/git/bundles/git.py
@@ -168,11 +168,14 @@ class GitDagBundle(BaseDagBundle):
                             raise RuntimeError("Error pulling submodule from repository") from e
 
                 if self.prune_dotgit_folder:
+                    self.repo.close()
                     shutil.rmtree(self.repo_path / ".git")
+                    self.repo = None
             else:
                 self.refresh()
 
-            self.repo.close()
+            if self.repo is not None:
+                self.repo.close()
 
     def initialize(self) -> None:
         if not self.repo_url:
@@ -263,7 +266,7 @@ class GitDagBundle(BaseDagBundle):
         )
 
     def get_current_version(self) -> str:
-        if self.version is not None:
+        if self.version is not None and getattr(self, "repo", None) is None:
             return self.version
         with self.repo as repo:
             return repo.head.commit.hexsha

--- a/providers/git/src/airflow/providers/git/bundles/git.py
+++ b/providers/git/src/airflow/providers/git/bundles/git.py
@@ -115,8 +115,25 @@ class GitDagBundle(BaseDagBundle):
             self.repo_url = self.hook.repo_url
             self._log.debug("repo_url updated from hook")
 
+    def _is_pruned_worktree(self) -> bool:
+        # True if version path exists and has no .git
+        if not self.version:
+            return False
+        if not self.repo_path.exists() or not self.repo_path.is_dir():
+            return False
+        return not (self.repo_path / ".git").exists()
+
     def _initialize(self):
         with self.lock():
+            # Avoids re-cloning on every task run when prune_dotgit_folder=True.
+            if self._is_pruned_worktree():
+                self._log.debug(
+                    "Using existing pruned worktree",
+                    repo_path=self.repo_path,
+                    version=self.version,
+                )
+                return
+
             cm = self.hook.configure_hook_env() if self.hook else nullcontext()
             with cm:
                 try:
@@ -246,6 +263,8 @@ class GitDagBundle(BaseDagBundle):
         )
 
     def get_current_version(self) -> str:
+        if self.version is not None:
+            return self.version
         with self.repo as repo:
             return repo.head.commit.hexsha
 

--- a/providers/git/tests/unit/git/bundles/test_git.py
+++ b/providers/git/tests/unit/git/bundles/test_git.py
@@ -67,6 +67,9 @@ def git_repo(tmp_path_factory):
 
 
 def assert_repo_is_closed(bundle: GitDagBundle):
+    # When .git was pruned, repo is cleared and there is nothing to close
+    if getattr(bundle, "repo", None) is None:
+        return
     # cat-file processes get left around if the repo is not closed, so check it was
     assert bundle.repo.git.cat_file_all is None
     assert bundle.bare_repo.git.cat_file_all is None


### PR DESCRIPTION
When a version directory already existed without a .git folder, workers treated it as invalid and deleted it then re-cloned. Tasks using the same bundle version would trigger a full clone on every run.

Detect an existing pruned worktree and reuse it instead of cloning again

closes: https://github.com/apache/airflow/issues/61396