### PR TITLE
fix(ui): show active backfill in banner instead of first one

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/Banner/BackfillBanner.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Banner/BackfillBanner.tsx
@@ -54,6 +54,7 @@ const BackfillBanner = ({ dagId }: Props) => {
 
   const { data, isLoading } = useBackfillServiceListBackfillsUi(
     {
+      active: true,
       dagId,
     },
     undefined,
@@ -108,7 +109,7 @@ const BackfillBanner = ({ dagId }: Props) => {
         <Text key="backfill">{translate("banner.backfillInProgress")}:</Text>
         <Text fontSize="sm">
           {" "}
-          <Time datetime={data?.backfills[0]?.from_date} /> - <Time datetime={data?.backfills[0]?.to_date} />
+          <Time datetime={backfill.from_date} /> - <Time datetime={backfill.to_date} />
         </Text>
 
         <Spacer flex="max-content" />


### PR DESCRIPTION
## Summary

Fixes #61811.

When multiple backfills exist for a DAG, the "Backfill in progress" banner was incorrectly displaying the first/oldest backfill rather than the currently active one. This happened due to two issues in `BackfillBanner.tsx`:

1. The API query fetched all backfills without filtering by active status, even though the `list_backfills_ui` endpoint already supports an `active` parameter that filters by `completed_at IS NULL`.
2. The date range display hardcoded `data?.backfills[0]` instead of using the `backfill` variable that was already filtered for active backfills.

## Changes

- Pass `active: true` to `useBackfillServiceListBackfillsUi` so only non-completed backfills are returned from the API
- Use the filtered `backfill` variable for `from_date` and `to_date` in the banner display instead of `data?.backfills[0]`

## How to test

1. Create a DAG and trigger a backfill, wait for it to complete
2. Trigger a second backfill
3. Verify the banner shows the date range of the second (active) backfill, not the first (completed) one