### PR TITLE
Fix ExternalTaskSensor "External DAG" link using wrong run_id

### DIFF
--- a/providers/standard/src/airflow/providers/standard/sensors/external_task.py
+++ b/providers/standard/src/airflow/providers/standard/sensors/external_task.py
@@ -74,6 +74,55 @@ class ExternalDagLink(BaseOperatorLink):
 
     name = "External DAG"
 
+    @staticmethod
+    def _resolve_external_run_id(
+        operator: BaseOperator, ti_key: TaskInstanceKey, external_dag_id: str
+    ) -> str | None:
+        """
+        Resolve the run_id of the external DAG run that this operator targets.
+
+        When ``execution_delta`` or ``execution_date_fn`` is used, the external DAG's
+        logical date differs from the current DAG run's logical date, which means the
+        external DAG run has a different run_id. This method queries the database to
+        find the correct run_id for the external DAG run.
+
+        Returns None if the external run_id cannot be determined.
+        """
+        try:
+            from sqlalchemy import select
+
+            from airflow.models.dagrun import DagRun
+            from airflow.utils.session import create_session
+
+            with create_session() as session:
+                # Look up the current DAG run to find its logical_date
+                current_dr = session.scalar(
+                    select(DagRun).where(DagRun.dag_id == ti_key.dag_id, DagRun.run_id == ti_key.run_id)
+                )
+                if not current_dr or not current_dr.logical_date:
+                    return None
+
+                target_logical_date = current_dr.logical_date
+
+                # If the operator has an execution_delta, apply it to compute the
+                # target logical date for the external DAG
+                execution_delta = getattr(operator, "execution_delta", None)
+                if isinstance(execution_delta, datetime.timedelta):
+                    target_logical_date = target_logical_date - execution_delta
+
+                # Look up the external DAG run by logical_date to get its actual run_id
+                external_dr = session.scalar(
+                    select(DagRun).where(
+                        DagRun.dag_id == external_dag_id, DagRun.logical_date == target_logical_date
+                    )
+                )
+                if external_dr:
+                    return external_dr.run_id
+        except Exception:
+            pass
+
+        return None
+
     def get_link(self, operator: BaseOperator, *, ti_key: TaskInstanceKey) -> str:
         if TYPE_CHECKING:
             assert isinstance(operator, (ExternalTaskMarker, ExternalTaskSensor))
@@ -98,10 +147,12 @@ class ExternalDagLink(BaseOperatorLink):
         if AIRFLOW_V_3_0_PLUS:
             from airflow.utils.helpers import build_airflow_dagrun_url
 
-            return build_airflow_dagrun_url(dag_id=external_dag_id, run_id=ti_key.run_id)
+            external_run_id = self._resolve_external_run_id(operator, ti_key, external_dag_id)
+            return build_airflow_dagrun_url(dag_id=external_dag_id, run_id=external_run_id or ti_key.run_id)
         from airflow.utils.helpers import build_airflow_url_with_query  # type:ignore[attr-defined]
 
-        query = {"dag_id": external_dag_id, "run_id": ti_key.run_id}
+        external_run_id = self._resolve_external_run_id(operator, ti_key, external_dag_id)
+        query = {"dag_id": external_dag_id, "run_id": external_run_id or ti_key.run_id}
         return build_airflow_url_with_query(query)
 
 

--- a/providers/standard/src/airflow/providers/standard/sensors/external_task.py
+++ b/providers/standard/src/airflow/providers/standard/sensors/external_task.py
@@ -110,6 +110,15 @@ class ExternalDagLink(BaseOperatorLink):
                 if isinstance(execution_delta, datetime.timedelta):
                     target_logical_date = target_logical_date - execution_delta
 
+                # If the operator has an execution_date_fn, call it to compute the
+                # target logical date for the external DAG
+                elif callable(getattr(operator, "execution_date_fn", None)):
+                    result = operator.execution_date_fn(target_logical_date)
+                    if isinstance(result, list):
+                        target_logical_date = result[0] if result else target_logical_date
+                    elif isinstance(result, datetime.datetime):
+                        target_logical_date = result
+
                 # Look up the external DAG run by logical_date to get its actual run_id
                 external_dr = session.scalar(
                     select(DagRun).where(


### PR DESCRIPTION
**closes: #61850**

When `ExternalTaskSensor` uses `execution_delta` or `execution_date_fn` to wait for a
DAG run with a different logical date, the "External DAG" link in the UI points to a
non-existent run. This happens because the link was built using the *current* DAG run's
`run_id` (which embeds the current logical date) instead of the *external* DAG's actual
`run_id`.

For example, if DAG2 (scheduled at `22:35`) uses an `ExternalTaskSensor` with
`execution_delta` to wait on DAG1 (scheduled at `22:30`), the link would incorrectly
point to `/dags/dag1/runs/scheduled__2026-02-11T22:35:00+00:00` instead of the correct
`/dags/dag1/runs/scheduled__2026-02-11T22:30:00+00:00`.

### Changes

Added `ExternalDagLink._resolve_external_run_id()` which:
1. Looks up the current DAG run to get its logical date
2. Applies `execution_delta` if set to compute the target logical date
3. Queries for the external DAG run with that logical date to get its actual run_id
4. Falls back to the previous behavior (using the current run_id) if the lookup fails

This fix applies to both the Airflow 2.x and 3.x code paths.