### PR TITLE
Add support for multi-team in Simple auth manager

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/services/login.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/services/login.py
@@ -56,7 +56,7 @@ class SimpleAuthManagerLogin:
         found_users = [
             user
             for user in users
-            if user["username"] == body.username and passwords[user["username"]] == body.password
+            if user.username == body.username and passwords[user.username] == body.password
         ]
 
         if len(found_users) == 0:
@@ -67,7 +67,8 @@ class SimpleAuthManagerLogin:
 
         user = SimpleAuthManagerUser(
             username=body.username,
-            role=found_users[0]["role"],
+            role=found_users[0].role,
+            teams=found_users[0].teams,
         )
 
         return get_auth_manager().generate_jwt(

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/user.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/user.py
@@ -25,11 +25,13 @@ class SimpleAuthManagerUser(BaseUser):
 
     :param username: The username
     :param role: The role associated to the user. If not provided, the user has no permission
+    :param teams: The list of teams associated to the user
     """
 
-    def __init__(self, *, username: str, role: str | None) -> None:
+    def __init__(self, *, username: str, role: str | None, teams: list[str] | None = None) -> None:
         self.username = username
         self.role = role
+        self.teams = teams or []
 
     def get_id(self) -> str:
         return self.username
@@ -37,5 +39,10 @@ class SimpleAuthManagerUser(BaseUser):
     def get_name(self) -> str:
         return self.username
 
-    def get_role(self) -> str | None:
-        return self.role
+    def __eq__(self, other):
+        if not isinstance(other, SimpleAuthManagerUser):
+            return False
+        return self.username == other.username and self.role == other.role and self.teams == other.teams
+
+    def __hash__(self):
+        return hash(self.username)

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -90,6 +90,10 @@ core:
 
         List of user-role delimited with a comma. Each user-role is a colon delimited couple of username and
         role. Roles are predefined in simple auth managers: viewer, user, op, admin.
+
+        You can also associate users to teams by appending the list of teams (separated by "|") as third item
+        in the user-role definition. Example: ``bob:admin:marketing|hr``.
+        This can only be used if ``[core] multi_team`` is set to True.
       version_added: 3.0.0
       type: string
       example: "bob:admin,peter:viewer"

--- a/airflow-core/tests/unit/api_fastapi/auth/managers/simple/test_user.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/managers/simple/test_user.py
@@ -23,6 +23,3 @@ class TestSimpleAuthManagerUser:
 
     def test_get_name(self, test_admin):
         assert test_admin.get_name() == "test"
-
-    def test_get_role(self, test_admin):
-        assert test_admin.get_role() == "admin"

--- a/airflow-core/tests/unit/api_fastapi/conftest.py
+++ b/airflow-core/tests/unit/api_fastapi/conftest.py
@@ -74,7 +74,9 @@ def test_client(request):
             token = auth_manager._get_token_signer(
                 expiration_time_in_seconds=(time_after - time_very_before).total_seconds()
             ).generate(
-                auth_manager.serialize_user(SimpleAuthManagerUser(username="test", role="admin")),
+                auth_manager.serialize_user(
+                    SimpleAuthManagerUser(username="test", role="admin", teams=["team1"])
+                ),
             )
         with mock.patch("airflow.models.revoked_token.RevokedToken.is_revoked", return_value=False):
             yield TestClient(

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_teams.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_teams.py
@@ -55,14 +55,8 @@ class TestListTeams:
                 {
                     "name": "team1",
                 },
-                {
-                    "name": "team2",
-                },
-                {
-                    "name": "team3",
-                },
             ],
-            "total_entries": 3,
+            "total_entries": 1,
         }
 
     @conf_vars({("core", "multi_team"): "true"})


### PR DESCRIPTION
Make simple auth manager multi-team compatible. Simple auth manager is not intended for production purposes so I kept the support minimal to support multi-team.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
