### PR TITLE
fix(ui): Fix star icon visibility in Favorite filter buttons when selected

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/FavoriteFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/FavoriteFilter.tsx
@@ -29,6 +29,8 @@ export const FavoriteFilter = ({ onFavoriteChange, showFavorites }: Props) => {
   const { t: translate } = useTranslation("dags");
 
   const currentValue = showFavorites ?? "all";
+  const isFavoriteSelected = currentValue === "true";
+  const isUnfavoriteSelected = currentValue === "false";
 
   return (
     <ButtonGroup attached size="sm" variant="outline">
@@ -44,9 +46,9 @@ export const FavoriteFilter = ({ onFavoriteChange, showFavorites }: Props) => {
         colorPalette="brand"
         onClick={onFavoriteChange}
         value="true"
-        variant={currentValue === "true" ? "solid" : "outline"}
+        variant={isFavoriteSelected ? "solid" : "outline"}
       >
-        <Icon asChild color="brand.solid">
+        <Icon asChild color={isFavoriteSelected ? "brand.contrast" : "brand.solid"}>
           <FiStar style={{ fill: "currentColor" }} />
         </Icon>
         {translate("filters.favorite.favorite")}
@@ -55,9 +57,9 @@ export const FavoriteFilter = ({ onFavoriteChange, showFavorites }: Props) => {
         colorPalette="brand"
         onClick={onFavoriteChange}
         value="false"
-        variant={currentValue === "false" ? "solid" : "outline"}
+        variant={isUnfavoriteSelected ? "solid" : "outline"}
       >
-        <Icon asChild color="fg.muted">
+        <Icon asChild color={isUnfavoriteSelected ? "brand.contrast" : "brand.solid"}>
           <FiStar />
         </Icon>
         {translate("filters.favorite.unfavorite")}


### PR DESCRIPTION
Fix star icon visibility in Favorite/Unfavorite filter buttons when selected.


Before:
<img width="367" height="138" alt="image" src="https://github.com/user-attachments/assets/f73cf9be-1daf-49f0-8aeb-439fe48b68fa" />

After:
<img width="429" height="212" alt="image" src="https://github.com/user-attachments/assets/b82472ee-4db8-4537-9899-0643c74143b7" />

- [x] Yes (please specify the tool below)
   claude


* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
