### PR TITLE
Disable use of LogTemplate table by default

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -927,6 +927,20 @@ logging:
       default: "dag_id={{ ti.dag_id }}/run_id={{ ti.run_id }}/task_id={{ ti.task_id }}/\
                {%% if ti.map_index >= 0 %%}map_index={{ ti.map_index }}/{%% endif %%}\
                attempt={{ try_number }}.log"
+    use_historical_filename_templates:
+      description: |
+        When this parameter is set to ``True``, Airflow will use the old filename templates for historical
+        tasks. Similarly in this case elasticsearch_id is not properly set for historical tasks if you
+        change it. Both require access to the database to render the template filenames
+        by webserver, and it might lead to Dag Authors being able to execute code on the webserver, that's why
+        it's disabled by default - but it might lead to old logs not being displayed in the webserver UI.
+        You can enable it you change the value of ``log_filename_template`` in the past and want to be able
+        to see the logs for historical tasks, however you should only do that if you trust your Dag authors
+        to not abuse the capability of executing arbitrary code on the webserver through template rendering.
+      version_added: 2.11.1
+      type: boolean
+      example: ~
+      default: "False"
     log_processor_filename_template:
       description: |
         Formatting for how airflow generates file names for log

--- a/airflow/models/tasklog.py
+++ b/airflow/models/tasklog.py
@@ -17,6 +17,8 @@
 # under the License.
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from sqlalchemy import Column, Integer, Text
 
 from airflow.models.base import Base
@@ -42,3 +44,16 @@ class LogTemplate(Base):
     def __repr__(self) -> str:
         attrs = ", ".join(f"{k}={getattr(self, k)}" for k in ("filename", "elasticsearch_id"))
         return f"LogTemplate({attrs})"
+
+
+@dataclass
+class LogTemplateDataClass:
+    """
+    Dataclass for log template (used when log template is read from configuration, not database).
+
+    :field filename: log filename template
+    :field elasticsearch_id: Elasticsearch document ID for log template
+    """
+
+    filename: str
+    elasticsearch_id: str

--- a/newsfragments/61880.significant.rst
+++ b/newsfragments/61880.significant.rst
@@ -1,0 +1,17 @@
+Retrieving historical log templates is disabled in Airflow 2.11.1
+
+When you change the log template in Airflow 2.11.1, the historical log templates are not retrieved.
+This means that if you have existing logs that were generated using a different log template,
+they will not be accessible using the new log template.
+
+This change is due to potential security issues that could arise from retrieving historical log templates,
+which allow Dag Authors to execute arbitrary code in webserver when retrieving logs.
+By disabling the retrieval of historical log templates, Airflow 2.11.1 aims to enhance the security of the
+system and prevent potential vulnerabilities in case the potential of executing arbitrary code in webserver
+is important for Airflow deployment.
+
+Users who need to access historical logs generated with a different log template will need to manually
+update their log files to match the naming of their historical log files with the latest log template
+configured in Airflow configuration, or they can set the "core.use_historical_filename_templates"
+configuration option to True to enable the retrieval of historical log templates, if they are fine with
+the Dag Authors being able to execute arbitrary code in webserver when retrieving logs.

--- a/tests/utils/log/test_file_processor_handler.py
+++ b/tests/utils/log/test_file_processor_handler.py
@@ -25,6 +25,7 @@ import time_machine
 
 from airflow.utils import timezone
 from airflow.utils.log.file_processor_handler import FileProcessorHandler
+from tests.test_utils.config import conf_vars
 
 
 class TestFileProcessorHandler:
@@ -60,6 +61,7 @@ class TestFileProcessorHandler:
         handler.set_context(filename=os.path.join(self.dag_dir, "logfile"))
         assert os.path.exists(os.path.join(path, "logfile.log"))
 
+    @conf_vars({("core", "use_historical_filename_templates"): "True"})
     def test_symlink_latest_log_directory(self):
         handler = FileProcessorHandler(base_log_folder=self.base_log_folder, filename_template=self.filename)
         handler.dag_dir = self.dag_dir

--- a/tests/utils/log/test_log_reader.py
+++ b/tests/utils/log/test_log_reader.py
@@ -120,6 +120,7 @@ class TestLogView:
         session.delete(log_template)
         session.commit()
 
+    @conf_vars({("core", "use_historical_filename_templates"): "True"})
     def test_test_read_log_chunks_should_read_one_try(self):
         task_log_reader = TaskLogReader()
         ti = copy.copy(self.ti)
@@ -137,6 +138,7 @@ class TestLogView:
         ]
         assert metadatas == {"end_of_log": True, "log_pos": 13}
 
+    @conf_vars({("core", "use_historical_filename_templates"): "True"})
     def test_test_read_log_chunks_should_read_all_files(self):
         task_log_reader = TaskLogReader()
         ti = copy.copy(self.ti)
@@ -152,6 +154,7 @@ class TestLogView:
             assert f"try_number={i + 1}." in logs[i][0][1]
         assert metadatas == {"end_of_log": True, "log_pos": 13}
 
+    @conf_vars({("core", "use_historical_filename_templates"): "True"})
     def test_test_test_read_log_stream_should_read_one_try(self):
         task_log_reader = TaskLogReader()
         ti = copy.copy(self.ti)
@@ -163,6 +166,7 @@ class TestLogView:
             " INFO - ::endgroup::\ntry_number=1.\n"
         ]
 
+    @conf_vars({("core", "use_historical_filename_templates"): "True"})
     def test_test_test_read_log_stream_should_read_all_logs(self):
         task_log_reader = TaskLogReader()
         self.ti.state = TaskInstanceState.SUCCESS  # Ensure mocked instance is completed to return stream
@@ -262,6 +266,7 @@ class TestLogView:
         mock_prop.return_value = True
         assert task_log_reader.supports_external_link
 
+    @conf_vars({("core", "use_historical_filename_templates"): "True"})
     def test_task_log_filename_unique(self, dag_maker):
         """Ensure the default log_filename_template produces a unique filename.
 


### PR DESCRIPTION
Accessing the database when rendering log template might introduce unnecesary risks to execute code in webserver and we should disable it by default.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
