### PR TITLE
WIP: Add spans for task execution

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -94,6 +94,8 @@ log = structlog.get_logger(__name__)
 
 dag_run_router = AirflowRouter(tags=["DagRun"], prefix="/dags/{dag_id}/dagRuns")
 
+tracer = Trace.get_tracer("dagrun")
+
 
 @dag_run_router.get(
     "/{dag_run_id}",
@@ -441,6 +443,7 @@ def get_dag_runs(
         Depends(action_logging()),
     ],
 )
+@tracer.start_as_current_span("trigger_dag_run")
 def trigger_dag_run(
     dag_id,
     body: TriggerDAGRunPostBody,
@@ -450,59 +453,53 @@ def trigger_dag_run(
     request: Request,
 ) -> DAGRunResponse:
     """Trigger a DAG."""
-    with Trace.start_span(
-        span_name="trigger_dag_run",
-        component="api-server",
-    ) as span:
-        span.add_event("trigger_dag.start")
-        dm = session.scalar(select(DagModel).where(~DagModel.is_stale, DagModel.dag_id == dag_id).limit(1))
-        if not dm:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, f"DAG with dag_id: '{dag_id}' not found")
+    dm = session.scalar(select(DagModel).where(~DagModel.is_stale, DagModel.dag_id == dag_id).limit(1))
+    if not dm:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"DAG with dag_id: '{dag_id}' not found")
 
-        if dm.has_import_errors:
-            raise HTTPException(
-                status.HTTP_400_BAD_REQUEST,
-                f"DAG with dag_id: '{dag_id}' has import errors and cannot be triggered",
-            )
+    if dm.has_import_errors:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            f"DAG with dag_id: '{dag_id}' has import errors and cannot be triggered",
+        )
 
-        if dm.allowed_run_types is not None and DagRunType.MANUAL not in dm.allowed_run_types:
-            raise HTTPException(
-                status.HTTP_400_BAD_REQUEST,
-                f"Dag with dag_id: '{dag_id}' does not allow manual runs",
-            )
+    if dm.allowed_run_types is not None and DagRunType.MANUAL not in dm.allowed_run_types:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            f"Dag with dag_id: '{dag_id}' does not allow manual runs",
+        )
 
-        referer = request.headers.get("referer")
-        if referer:
-            triggered_by = DagRunTriggeredByType.UI
-        else:
-            triggered_by = DagRunTriggeredByType.REST_API
+    referer = request.headers.get("referer")
+    if referer:
+        triggered_by = DagRunTriggeredByType.UI
+    else:
+        triggered_by = DagRunTriggeredByType.REST_API
 
-        try:
-            dag = get_latest_version_of_dag(dag_bag, dag_id, session)
-            params = body.validate_context(dag)
+    try:
+        dag = get_latest_version_of_dag(dag_bag, dag_id, session)
+        params = body.validate_context(dag)
 
-            dag_run = dag.create_dagrun(
-                run_id=params["run_id"],
-                logical_date=params["logical_date"],
-                data_interval=params["data_interval"],
-                run_after=params["run_after"],
-                conf=params["conf"],
-                run_type=DagRunType.MANUAL,
-                triggered_by=triggered_by,
-                triggering_user_name=user.get_name(),
-                state=DagRunState.QUEUED,
-                partition_key=params["partition_key"],
-                session=session,
-            )
+        dag_run = dag.create_dagrun(
+            run_id=params["run_id"],
+            logical_date=params["logical_date"],
+            data_interval=params["data_interval"],
+            run_after=params["run_after"],
+            conf=params["conf"],
+            run_type=DagRunType.MANUAL,
+            triggered_by=triggered_by,
+            triggering_user_name=user.get_name(),
+            state=DagRunState.QUEUED,
+            partition_key=params["partition_key"],
+            session=session,
+        )
 
-            dag_run_note = body.note
-            if dag_run_note:
-                current_user_id = user.get_id()
-                dag_run.note = (dag_run_note, current_user_id)
-            span.add_event("trigger_dag.end")
-            return dag_run
-        except ValueError as e:
-            raise HTTPException(status.HTTP_400_BAD_REQUEST, str(e))
+        dag_run_note = body.note
+        if dag_run_note:
+            current_user_id = user.get_id()
+            dag_run.note = (dag_run_note, current_user_id)
+        return dag_run
+    except ValueError as e:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, str(e))
 
 
 @dag_run_router.get(

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -86,6 +86,7 @@ from airflow.listeners.listener import get_listener_manager
 from airflow.models import DagModel, DagRun
 from airflow.models.asset import AssetEvent
 from airflow.models.dag_version import DagVersion
+from airflow.observability.trace import Trace
 from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
@@ -449,53 +450,59 @@ def trigger_dag_run(
     request: Request,
 ) -> DAGRunResponse:
     """Trigger a DAG."""
-    dm = session.scalar(select(DagModel).where(~DagModel.is_stale, DagModel.dag_id == dag_id).limit(1))
-    if not dm:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, f"DAG with dag_id: '{dag_id}' not found")
+    with Trace.start_span(
+        span_name="trigger_dag_run",
+        component="api-server",
+    ) as span:
+        span.add_event("trigger_dag.start")
+        dm = session.scalar(select(DagModel).where(~DagModel.is_stale, DagModel.dag_id == dag_id).limit(1))
+        if not dm:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, f"DAG with dag_id: '{dag_id}' not found")
 
-    if dm.has_import_errors:
-        raise HTTPException(
-            status.HTTP_400_BAD_REQUEST,
-            f"DAG with dag_id: '{dag_id}' has import errors and cannot be triggered",
-        )
+        if dm.has_import_errors:
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST,
+                f"DAG with dag_id: '{dag_id}' has import errors and cannot be triggered",
+            )
 
-    if dm.allowed_run_types is not None and DagRunType.MANUAL not in dm.allowed_run_types:
-        raise HTTPException(
-            status.HTTP_400_BAD_REQUEST,
-            f"Dag with dag_id: '{dag_id}' does not allow manual runs",
-        )
+        if dm.allowed_run_types is not None and DagRunType.MANUAL not in dm.allowed_run_types:
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST,
+                f"Dag with dag_id: '{dag_id}' does not allow manual runs",
+            )
 
-    referer = request.headers.get("referer")
-    if referer:
-        triggered_by = DagRunTriggeredByType.UI
-    else:
-        triggered_by = DagRunTriggeredByType.REST_API
+        referer = request.headers.get("referer")
+        if referer:
+            triggered_by = DagRunTriggeredByType.UI
+        else:
+            triggered_by = DagRunTriggeredByType.REST_API
 
-    try:
-        dag = get_latest_version_of_dag(dag_bag, dag_id, session)
-        params = body.validate_context(dag)
+        try:
+            dag = get_latest_version_of_dag(dag_bag, dag_id, session)
+            params = body.validate_context(dag)
 
-        dag_run = dag.create_dagrun(
-            run_id=params["run_id"],
-            logical_date=params["logical_date"],
-            data_interval=params["data_interval"],
-            run_after=params["run_after"],
-            conf=params["conf"],
-            run_type=DagRunType.MANUAL,
-            triggered_by=triggered_by,
-            triggering_user_name=user.get_name(),
-            state=DagRunState.QUEUED,
-            partition_key=params["partition_key"],
-            session=session,
-        )
+            dag_run = dag.create_dagrun(
+                run_id=params["run_id"],
+                logical_date=params["logical_date"],
+                data_interval=params["data_interval"],
+                run_after=params["run_after"],
+                conf=params["conf"],
+                run_type=DagRunType.MANUAL,
+                triggered_by=triggered_by,
+                triggering_user_name=user.get_name(),
+                state=DagRunState.QUEUED,
+                partition_key=params["partition_key"],
+                session=session,
+            )
 
-        dag_run_note = body.note
-        if dag_run_note:
-            current_user_id = user.get_id()
-            dag_run.note = (dag_run_note, current_user_id)
-        return dag_run
-    except ValueError as e:
-        raise HTTPException(status.HTTP_400_BAD_REQUEST, str(e))
+            dag_run_note = body.note
+            if dag_run_note:
+                current_user_id = user.get_id()
+                dag_run.note = (dag_run_note, current_user_id)
+            span.add_event("trigger_dag.end")
+            return dag_run
+        except ValueError as e:
+            raise HTTPException(status.HTTP_400_BAD_REQUEST, str(e))
 
 
 @dag_run_router.get(

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -94,8 +94,6 @@ log = structlog.get_logger(__name__)
 
 dag_run_router = AirflowRouter(tags=["DagRun"], prefix="/dags/{dag_id}/dagRuns")
 
-tracer = Trace.get_tracer("dagrun")
-
 
 @dag_run_router.get(
     "/{dag_run_id}",
@@ -443,7 +441,7 @@ def get_dag_runs(
         Depends(action_logging()),
     ],
 )
-@tracer.start_as_current_span("trigger_dag_run")
+@Trace.start_span("trigger_dag_run")
 def trigger_dag_run(
     dag_id,
     body: TriggerDAGRunPostBody,

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -441,7 +441,6 @@ def get_dag_runs(
         Depends(action_logging()),
     ],
 )
-@Trace.start_span("trigger_dag_run")
 def trigger_dag_run(
     dag_id,
     body: TriggerDAGRunPostBody,
@@ -451,53 +450,54 @@ def trigger_dag_run(
     request: Request,
 ) -> DAGRunResponse:
     """Trigger a DAG."""
-    dm = session.scalar(select(DagModel).where(~DagModel.is_stale, DagModel.dag_id == dag_id).limit(1))
-    if not dm:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, f"DAG with dag_id: '{dag_id}' not found")
+    with Trace.start_span(f"trigger_dag_run.{dag_id}"):
+        dm = session.scalar(select(DagModel).where(~DagModel.is_stale, DagModel.dag_id == dag_id).limit(1))
+        if not dm:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, f"DAG with dag_id: '{dag_id}' not found")
 
-    if dm.has_import_errors:
-        raise HTTPException(
-            status.HTTP_400_BAD_REQUEST,
-            f"DAG with dag_id: '{dag_id}' has import errors and cannot be triggered",
-        )
+        if dm.has_import_errors:
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST,
+                f"DAG with dag_id: '{dag_id}' has import errors and cannot be triggered",
+            )
 
-    if dm.allowed_run_types is not None and DagRunType.MANUAL not in dm.allowed_run_types:
-        raise HTTPException(
-            status.HTTP_400_BAD_REQUEST,
-            f"Dag with dag_id: '{dag_id}' does not allow manual runs",
-        )
+        if dm.allowed_run_types is not None and DagRunType.MANUAL not in dm.allowed_run_types:
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST,
+                f"Dag with dag_id: '{dag_id}' does not allow manual runs",
+            )
 
-    referer = request.headers.get("referer")
-    if referer:
-        triggered_by = DagRunTriggeredByType.UI
-    else:
-        triggered_by = DagRunTriggeredByType.REST_API
+        referer = request.headers.get("referer")
+        if referer:
+            triggered_by = DagRunTriggeredByType.UI
+        else:
+            triggered_by = DagRunTriggeredByType.REST_API
 
-    try:
-        dag = get_latest_version_of_dag(dag_bag, dag_id, session)
-        params = body.validate_context(dag)
+        try:
+            dag = get_latest_version_of_dag(dag_bag, dag_id, session)
+            params = body.validate_context(dag)
 
-        dag_run = dag.create_dagrun(
-            run_id=params["run_id"],
-            logical_date=params["logical_date"],
-            data_interval=params["data_interval"],
-            run_after=params["run_after"],
-            conf=params["conf"],
-            run_type=DagRunType.MANUAL,
-            triggered_by=triggered_by,
-            triggering_user_name=user.get_name(),
-            state=DagRunState.QUEUED,
-            partition_key=params["partition_key"],
-            session=session,
-        )
+            dag_run = dag.create_dagrun(
+                run_id=params["run_id"],
+                logical_date=params["logical_date"],
+                data_interval=params["data_interval"],
+                run_after=params["run_after"],
+                conf=params["conf"],
+                run_type=DagRunType.MANUAL,
+                triggered_by=triggered_by,
+                triggering_user_name=user.get_name(),
+                state=DagRunState.QUEUED,
+                partition_key=params["partition_key"],
+                session=session,
+            )
 
-        dag_run_note = body.note
-        if dag_run_note:
-            current_user_id = user.get_id()
-            dag_run.note = (dag_run_note, current_user_id)
-        return dag_run
-    except ValueError as e:
-        raise HTTPException(status.HTTP_400_BAD_REQUEST, str(e))
+            dag_run_note = body.note
+            if dag_run_note:
+                current_user_id = user.get_id()
+                dag_run.note = (dag_run_note, current_user_id)
+            return dag_run
+        except ValueError as e:
+            raise HTTPException(status.HTTP_400_BAD_REQUEST, str(e))
 
 
 @dag_run_router.get(

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -461,11 +461,11 @@ def trigger_dag_run(
                 f"DAG with dag_id: '{dag_id}' has import errors and cannot be triggered",
             )
 
-        if dm.allowed_run_types is not None and DagRunType.MANUAL not in dm.allowed_run_types:
-            raise HTTPException(
-                status.HTTP_400_BAD_REQUEST,
-                f"Dag with dag_id: '{dag_id}' does not allow manual runs",
-            )
+        # if dm.allowed_run_types is not None and DagRunType.MANUAL not in dm.allowed_run_types:
+        #     raise HTTPException(
+        #         status.HTTP_400_BAD_REQUEST,
+        #         f"Dag with dag_id: '{dag_id}' does not allow manual runs",
+        #     )
 
         referer = request.headers.get("referer")
         if referer:

--- a/airflow-core/src/airflow/executors/base_executor.py
+++ b/airflow-core/src/airflow/executors/base_executor.py
@@ -38,7 +38,6 @@ from airflow.observability.metrics import stats_utils
 from airflow.observability.trace import DebugTrace, Trace, add_debug_span
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.state import TaskInstanceState
-from airflow.utils.thread_safe_dict import ThreadSafeDict
 
 PARALLELISM: int = conf.getint("core", "PARALLELISM")
 
@@ -141,8 +140,6 @@ class BaseExecutor(LoggingMixin):
     :param parallelism: how many jobs should run at one time.
     """
 
-    active_spans = ThreadSafeDict()
-
     supports_ad_hoc_ti_run: bool = False
     supports_multi_team: bool = False
     sentry_integration: str = ""
@@ -212,10 +209,6 @@ class BaseExecutor(LoggingMixin):
             _repr += f", team_name={self.team_name!r}"
         _repr += ")"
         return _repr
-
-    @classmethod
-    def set_active_spans(cls, active_spans: ThreadSafeDict):
-        cls.active_spans = active_spans
 
     def start(self):  # pragma: no cover
         """Executors may need to get things started."""
@@ -379,23 +372,21 @@ class BaseExecutor(LoggingMixin):
             if isinstance(item, workloads.ExecuteTask) and hasattr(item, "ti"):
                 ti = item.ti
 
-                # If it's None, then the span for the current id hasn't been started.
-                if self.active_spans is not None and self.active_spans.get("ti:" + str(ti.id)) is None:
-                    if isinstance(ti, workloads.TaskInstance):
-                        parent_context = Trace.extract(ti.parent_context_carrier)
-                    else:
-                        parent_context = Trace.extract(ti.dag_run.context_carrier)
-                    # Start a new span using the context from the parent.
-                    # Attributes will be set once the task has finished so that all
-                    # values will be available (end_time, duration, etc.).
+                if isinstance(ti, workloads.TaskInstance):
+                    parent_context = Trace.extract(ti.parent_context_carrier)
+                else:
+                    parent_context = Trace.extract(ti.dag_run.context_carrier)
+                # Start a new span using the context from the parent.
+                # Attributes will be set once the task has finished so that all
+                # values will be available (end_time, duration, etc.).
 
-                    span = Trace.start_child_span(
-                        span_name=f"{ti.task_id}",
-                        parent_context=parent_context,
-                        component="task",
-                        start_as_current=False,
-                    )
-                    self.active_spans.set("ti:" + str(ti.id), span)
+                tracer = Trace.get_tracer("dagrun")
+                with tracer.start_as_current_span("task", context=parent_context) as span:
+                    span.set_attribute("task_id", ti.task_id)
+                    span.set_attribute("dag_id", ti.dag_id)
+                    span.set_attribute("run_id", ti.run_id)
+                    span.set_attribute("component", "executor")
+                    span.add_event("task triggered")
                     # Inject the current context into the carrier.
                     carrier = Trace.inject()
                     ti.context_carrier = carrier

--- a/airflow-core/src/airflow/executors/base_executor.py
+++ b/airflow-core/src/airflow/executors/base_executor.py
@@ -18,7 +18,6 @@
 
 from __future__ import annotations
 
-import logging
 from collections import defaultdict, deque
 from collections.abc import Sequence
 from contextlib import contextmanager
@@ -27,6 +26,7 @@ from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
 import pendulum
+import structlog
 
 from airflow._shared.observability.metrics.stats import Stats
 from airflow._shared.observability.traces import NO_TRACE_ID
@@ -61,7 +61,7 @@ if TYPE_CHECKING:
     EventBufferValueType = tuple[str | None, Any]
 
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 @dataclass
@@ -391,11 +391,15 @@ class BaseExecutor(LoggingMixin):
 
             if isinstance(item, workloads.ExecuteTask) and hasattr(item, "ti"):
                 ti = item.ti
-                with start_ti_span(ti):
-                    # Inject the current context into the carrier.
-                    carrier = Trace.inject()
-                    ti.context_carrier = carrier
-                    workload_list.append(item)
+                if isinstance(ti, workloads.TaskInstance):
+                    item.ti.context_carrier = ti.parent_context_carrier
+                    log.info("setting carrier from parent", carrier=ti.parent_context_carrier)
+                else:
+                    item.ti.context_carrier = ti.dag_run.context_carrier
+                    log.info("setting carrier from dagrun", carrier=ti.dag_run.context_carrier)
+                if not item.ti.context_carrier:
+                    raise ValueError(f"carrier={item.ti.context_carrier}")
+                workload_list.append(item)
         if workload_list:
             self._process_workloads(workload_list)
 

--- a/airflow-core/src/airflow/executors/base_executor.py
+++ b/airflow-core/src/airflow/executors/base_executor.py
@@ -145,7 +145,7 @@ def start_ti_span(ti):
     # values will be available (end_time, duration, etc.).
 
     tracer = Trace.get_tracer("dagrun")
-    with tracer.start_as_current_span("task", context=parent_context) as span:
+    with tracer.start_as_current_span(f"task.triggered.{ti.task_id}", context=parent_context) as span:
         span.set_attribute("task_id", ti.task_id)
         span.set_attribute("dag_id", ti.dag_id)
         span.set_attribute("run_id", ti.run_id)

--- a/airflow-core/src/airflow/executors/base_executor.py
+++ b/airflow-core/src/airflow/executors/base_executor.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import logging
 from collections import defaultdict, deque
 from collections.abc import Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
@@ -131,6 +132,25 @@ class ExecutorConf:
 
     def get_mandatory_value(self, *args, **kwargs) -> str:
         return conf.get_mandatory_value(*args, **kwargs, team_name=self.team_name)
+
+
+@contextmanager
+def start_ti_span(ti):
+    if isinstance(ti, workloads.TaskInstance):
+        parent_context = Trace.extract(ti.parent_context_carrier)
+    else:
+        parent_context = Trace.extract(ti.dag_run.context_carrier)
+    # Start a new span using the context from the parent.
+    # Attributes will be set once the task has finished so that all
+    # values will be available (end_time, duration, etc.).
+
+    tracer = Trace.get_tracer("dagrun")
+    with tracer.start_as_current_span("task", context=parent_context) as span:
+        span.set_attribute("task_id", ti.task_id)
+        span.set_attribute("dag_id", ti.dag_id)
+        span.set_attribute("run_id", ti.run_id)
+        span.set_attribute("component", "executor")
+        yield span
 
 
 class BaseExecutor(LoggingMixin):
@@ -371,27 +391,11 @@ class BaseExecutor(LoggingMixin):
 
             if isinstance(item, workloads.ExecuteTask) and hasattr(item, "ti"):
                 ti = item.ti
-
-                if isinstance(ti, workloads.TaskInstance):
-                    parent_context = Trace.extract(ti.parent_context_carrier)
-                else:
-                    parent_context = Trace.extract(ti.dag_run.context_carrier)
-                # Start a new span using the context from the parent.
-                # Attributes will be set once the task has finished so that all
-                # values will be available (end_time, duration, etc.).
-
-                tracer = Trace.get_tracer("dagrun")
-                with tracer.start_as_current_span("task", context=parent_context) as span:
-                    span.set_attribute("task_id", ti.task_id)
-                    span.set_attribute("dag_id", ti.dag_id)
-                    span.set_attribute("run_id", ti.run_id)
-                    span.set_attribute("component", "executor")
-                    span.add_event("task triggered")
+                with start_ti_span(ti):
                     # Inject the current context into the carrier.
                     carrier = Trace.inject()
                     ti.context_carrier = carrier
-
-                workload_list.append(item)
+                    workload_list.append(item)
         if workload_list:
             self._process_workloads(workload_list)
 

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -103,7 +103,6 @@ from airflow.serialization.definitions.assets import SerializedAssetUniqueKey
 from airflow.serialization.definitions.notset import NOTSET
 from airflow.ti_deps.dependencies_states import EXECUTION_STATES
 from airflow.timetables.simple import AssetTriggeredTimetable
-from airflow.utils.dates import datetime_to_nano
 from airflow.utils.event_scheduler import EventScheduler
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.retries import MAX_DB_RETRIES, retry_db_transaction, run_with_db_retries
@@ -1266,38 +1265,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
         return len(event_buffer)
 
-    @classmethod
-    def set_ti_span_attrs(cls, span, state, ti):
-        span.set_attributes(
-            {
-                "airflow.category": "scheduler",
-                "airflow.task.id": ti.id,
-                "airflow.task.task_id": ti.task_id,
-                "airflow.task.dag_id": ti.dag_id,
-                "airflow.task.state": ti.state,
-                "airflow.task.error": state == TaskInstanceState.FAILED,
-                "airflow.task.start_date": str(ti.start_date),
-                "airflow.task.end_date": str(ti.end_date),
-                "airflow.task.duration": ti.duration,
-                "airflow.task.executor_config": str(ti.executor_config),
-                "airflow.task.logical_date": str(ti.logical_date),
-                "airflow.task.hostname": ti.hostname,
-                "airflow.task.log_url": ti.log_url,
-                "airflow.task.operator": str(ti.operator),
-                "airflow.task.try_number": ti.try_number,
-                "airflow.task.executor_state": state,
-                "airflow.task.pool": ti.pool,
-                "airflow.task.queue": ti.queue,
-                "airflow.task.priority_weight": ti.priority_weight,
-                "airflow.task.queued_dttm": str(ti.queued_dttm),
-                "airflow.task.queued_by_job_id": ti.queued_by_job_id,
-                "airflow.task.pid": ti.pid,
-            }
-        )
-        span.add_event(name="airflow.task.queued", timestamp=datetime_to_nano(ti.queued_dttm))
-        span.add_event(name="airflow.task.started", timestamp=datetime_to_nano(ti.start_date))
-        span.add_event(name="airflow.task.ended", timestamp=datetime_to_nano(ti.end_date))
-
     def _execute(self) -> int | None:
         import os
 
@@ -1515,29 +1482,22 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 # Run any pending timed events
                 next_event = timers.run(blocking=False)
                 self.log.debug("Next timed event is in %f", next_event)
+                self.log.debug("Ran scheduling loop in %.2f seconds", timer.duration / 1000.0)
 
-            self.log.debug("Ran scheduling loop in %.2f ms", timer.duration)
-            span.add_event(
-                name="Ran scheduling loop",
-                attributes={
-                    "duration in ms": timer.duration,
-                },
-            )
+                if not is_unit_test and not num_queued_tis and not num_finished_events:
+                    # If the scheduler is doing things, don't sleep. This means when there is work to do, the
+                    # scheduler will run "as quick as possible", but when it's stopped, it can sleep, dropping CPU
+                    # usage when "idle"
+                    time.sleep(min(self._scheduler_idle_sleep_time, next_event or 0))
 
-            if not is_unit_test and not num_queued_tis and not num_finished_events:
-                # If the scheduler is doing things, don't sleep. This means when there is work to do, the
-                # scheduler will run "as quick as possible", but when it's stopped, it can sleep, dropping CPU
-                # usage when "idle"
-                time.sleep(min(self._scheduler_idle_sleep_time, next_event or 0))
-
-            if loop_count >= self.num_runs > 0:
-                self.log.info(
-                    "Exiting scheduler loop as requested number of runs (%d - got to %d) has been reached",
-                    self.num_runs,
-                    loop_count,
-                )
-                span.add_event("Exiting scheduler loop as requested number of runs has been reached")
-                break
+                if loop_count >= self.num_runs > 0:
+                    self.log.info(
+                        "Exiting scheduler loop as requested number of runs (%d - got to %d) has been reached",
+                        self.num_runs,
+                        loop_count,
+                    )
+                    span.add_event("Exiting scheduler loop as requested number of runs has been reached")
+                    break
 
     def _do_scheduling(self, session: Session) -> int:
         """

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -268,7 +268,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         self,
         job: Job,
         num_runs: int = conf.getint("scheduler", "num_runs"),
-        scheduler_idle_sleep_time: float = 0.1,  # conf.getfloat("scheduler", "scheduler_idle_sleep_time"),
+        scheduler_idle_sleep_time: float = conf.getfloat("scheduler", "scheduler_idle_sleep_time"),
         log: Logger | None = None,
         executors: list[BaseExecutor] | None = None,
     ):
@@ -1841,7 +1841,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 run_after = next_info.run_after
                 # todo: AIP-76 partition date is not passed to dag run
                 #  See https://github.com/apache/airflow/issues/61167.
-
                 created_run = serdag.create_dagrun(
                     run_id=serdag.timetable.generate_run_id(
                         run_type=DagRunType.SCHEDULED,
@@ -2040,8 +2039,8 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             partial(self.scheduler_dag_bag.get_dag_for_run, session=session)
         )
 
+        span = Trace.get_current_span()
         for dag_run in dag_runs:
-            span = Trace.get_current_span()
             dag_id = dag_run.dag_id
             run_id = dag_run.run_id
             backfill_id = dag_run.backfill_id

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -52,6 +52,7 @@ from sqlalchemy.sql import expression
 from airflow import settings
 from airflow._shared.observability.metrics.dual_stats_manager import DualStatsManager
 from airflow._shared.observability.metrics.stats import Stats
+from airflow._shared.observability.traces.base_tracer import EMPTY_SPAN
 from airflow._shared.timezones import timezone
 from airflow.api_fastapi.execution_api.datamodels.taskinstance import DagRun as DRDataModel, TIRunContext
 from airflow.assets.evaluation import AssetEvaluator
@@ -142,17 +143,32 @@ PS = ParamSpec("PS")
 RT = TypeVar("RT")
 
 
-def add_span(func: Callable[PS, RT]) -> Callable[PS, RT]:
-    @wraps(func)
-    def wrapper(self, dag_run, *args, **kwargs) -> RT:
-        if dag_run.context_carrier:
-            context = Trace.extract(dag_run.context_carrier)
-            tracer = Trace.get_tracer("dagrun")
-            with tracer.start_as_current_span(func.__name__, context=context):
-                return func(self, dag_run, *args, **kwargs)
-        return func(self, dag_run, *args, **kwargs)
+def add_span(debug_only=False):
+    """
+    Add span to a function that takes a dag_run arg.
 
-    return wrapper
+    Depending on whether you set debug only to True or not,
+    it may only create the span when _trace_debug is set
+    in the dag run conf.
+    """
+
+    @wraps(add_span)
+    def _add_span(func: Callable[PS, RT]) -> Callable[PS, RT]:
+        @wraps(func)
+        def wrapper(self, dag_run, *args, **kwargs) -> RT:
+            should_add = True
+            if debug_only is True and not dag_run.conf.get("_trace_debug"):
+                should_add = False
+            if should_add and dag_run.context_carrier:
+                context = Trace.extract(dag_run.context_carrier)
+                tracer = Trace.get_tracer("dagrun")
+                with tracer.start_as_current_span(func.__name__, context=context) as span:
+                    return func(self, dag_run, *args, span=span, **kwargs)
+            return func(self, dag_run, *args, **kwargs)
+
+        return wrapper
+
+    return _add_span
 
 
 def _eager_load_dag_run_for_validation() -> tuple[LoaderOption, LoaderOption]:
@@ -2092,11 +2108,12 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         guard.commit()
         return callback_tuples
 
-    @add_span
+    @add_span(debug_only=True)
     def _schedule_dag_run(
         self,
         dag_run: DagRun,
         session: Session,
+        span=EMPTY_SPAN,
     ) -> DagCallbackRequest | None:
         """
         Make scheduling decisions about an individual dag run.
@@ -2104,16 +2121,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         :param dag_run: The DagRun to schedule
         :return: Callback that needs to be executed
         """
-        with DebugTrace.start_root_span(
-            span_name="_schedule_dag_run", component="SchedulerJobRunner"
-        ) as span:
-            span.set_attributes(
-                {
-                    "dag_id": dag_run.dag_id,
-                    "run_id": dag_run.run_id,
-                    "run_type": dag_run.run_type,
-                }
-            )
+        with nullcontext():  # TODO: this is just to keep diff clean for now
             callback: DagCallbackRequest | None = None
 
             dag = dag_run.dag = self.scheduler_dag_bag.get_dag_for_run(dag_run=dag_run, session=session)

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -1482,7 +1482,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 # Run any pending timed events
                 next_event = timers.run(blocking=False)
                 self.log.debug("Next timed event is in %f", next_event)
-                self.log.debug("Ran scheduling loop in %.2f seconds", timer.duration / 1000.0)
 
                 if not is_unit_test and not num_queued_tis and not num_finished_events:
                     # If the scheduler is doing things, don't sleep. This means when there is work to do, the

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2187,13 +2187,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             # query to update all the TIs across all the logical dates and dag
             # IDs in a single query, but it turns out that can be _very very slow_
             # see #11147/commit ee90807ac for more details
-            span.add_event(
-                name="schedule_tis",
-                attributes={
-                    "message": "dag_run scheduling its tis",
-                    "schedulable_tis": [_ti.task_id for _ti in schedulable_tis],
-                },
-            )
             dag_run.schedule_tis(schedulable_tis, session, max_tis_per_query=self.job.max_tis_per_query)
 
             return callback_to_run

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -1428,7 +1428,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         for loop_count in itertools.count(start=1):
             with (
                 DebugTrace.start_span(span_name="scheduler_job_loop", component="SchedulerJobRunner") as span,
-                Stats.timer("scheduler.scheduler_loop_duration") as timer,
+                Stats.timer("scheduler.scheduler_loop_duration"),
             ):
                 span.set_attributes(
                     {

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -29,10 +29,9 @@ from collections import Counter, defaultdict, deque
 from collections.abc import Callable, Collection, Iterable, Iterator
 from contextlib import ExitStack
 from datetime import date, datetime, timedelta
-from functools import lru_cache, partial
+from functools import lru_cache, partial, wraps
 from itertools import groupby
-from typing import TYPE_CHECKING, Any
-from uuid import UUID
+from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar
 
 from sqlalchemy import (
     and_,
@@ -94,7 +93,7 @@ from airflow.models.dagrun import DagRun
 from airflow.models.dagwarning import DagWarning, DagWarningType
 from airflow.models.pool import normalize_pool_name_for_stats
 from airflow.models.serialized_dag import SerializedDagModel
-from airflow.models.taskinstance import TaskInstance
+from airflow.models.taskinstance import TaskInstance, TaskInstance as TI
 from airflow.models.team import Team
 from airflow.models.trigger import TRIGGER_FAIL_REPR, Trigger, TriggerFailureReason
 from airflow.observability.metrics import stats_utils
@@ -108,7 +107,6 @@ from airflow.utils.event_scheduler import EventScheduler
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.retries import MAX_DB_RETRIES, retry_db_transaction, run_with_db_retries
 from airflow.utils.session import NEW_SESSION, create_session, provide_session
-from airflow.utils.span_status import SpanStatus
 from airflow.utils.sqlalchemy import (
     get_dialect_name,
     is_lock_not_available_error,
@@ -116,7 +114,6 @@ from airflow.utils.sqlalchemy import (
     with_row_locks,
 )
 from airflow.utils.state import DagRunState, State, TaskInstanceState
-from airflow.utils.thread_safe_dict import ThreadSafeDict
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 if TYPE_CHECKING:
@@ -134,12 +131,28 @@ if TYPE_CHECKING:
     from airflow.serialization.definitions.dag import SerializedDAG
     from airflow.utils.sqlalchemy import CommitProhibitorGuard
 
-TI = TaskInstance
 DR = DagRun
 DM = DagModel
 
 TASK_STUCK_IN_QUEUED_RESCHEDULE_EVENT = "stuck in queued reschedule"
 """:meta private:"""
+
+
+PS = ParamSpec("PS")
+RT = TypeVar("RT")
+
+
+def add_span(func: Callable[PS, RT]) -> Callable[PS, RT]:
+    @wraps(func)
+    def wrapper(self, dag_run, *args, **kwargs) -> RT:
+        if dag_run.context_carrier:
+            context = Trace.extract(dag_run.context_carrier)
+            tracer = Trace.get_tracer("dagrun")
+            with tracer.start_as_current_span(func.__name__, context=context):
+                return func(self, dag_run, *args, **kwargs)
+        return func(self, dag_run, *args, **kwargs)
+
+    return wrapper
 
 
 def _eager_load_dag_run_for_validation() -> tuple[LoaderOption, LoaderOption]:
@@ -235,19 +248,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
     job_type = "SchedulerJob"
 
-    # For a dagrun span
-    #   - key: dag_run.run_id | value: span
-    #   - dagrun keys will be prefixed with 'dr:'.
-    # For a ti span
-    #   - key: ti.id | value: span
-    #   - taskinstance keys will be prefixed with 'ti:'.
-    active_spans = ThreadSafeDict()
-
     def __init__(
         self,
         job: Job,
         num_runs: int = conf.getint("scheduler", "num_runs"),
-        scheduler_idle_sleep_time: float = conf.getfloat("scheduler", "scheduler_idle_sleep_time"),
+        scheduler_idle_sleep_time: float = 0.1,  # conf.getfloat("scheduler", "scheduler_idle_sleep_time"),
         log: Logger | None = None,
         executors: list[BaseExecutor] | None = None,
     ):
@@ -391,9 +396,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
     def _exit_gracefully(self, signum: int, frame: FrameType | None) -> None:
         """Clean up processor_agent to avoid leaving orphan processes."""
-        if self._is_tracing_enabled():
-            self._end_active_spans()
-
         if not _is_parent_process():
             # Only the parent process should perform the cleanup.
             return
@@ -1133,18 +1135,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 ti.pid,
             )
 
-            if (active_ti_span := cls.active_spans.get("ti:" + str(ti.id))) is not None:
-                cls.set_ti_span_attrs(span=active_ti_span, state=state, ti=ti)
-                # End the span and remove it from the active_spans dict.
-                active_ti_span.end(end_time=datetime_to_nano(ti.end_date))
-                cls.active_spans.delete("ti:" + str(ti.id))
-                ti.span_status = SpanStatus.ENDED
-            else:
-                if ti.span_status == SpanStatus.ACTIVE:
-                    # Another scheduler has started the span.
-                    # Update the SpanStatus to let the process know that it must end it.
-                    ti.span_status = SpanStatus.SHOULD_END
-
             # There are two scenarios why the same TI with the same try_number is queued
             # after executor is finished with it:
             # 1) the TI was killed externally and it had no time to mark itself failed
@@ -1288,10 +1278,9 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 "airflow.task.pid": ti.pid,
             }
         )
-        if span.is_recording():
-            span.add_event(name="airflow.task.queued", timestamp=datetime_to_nano(ti.queued_dttm))
-            span.add_event(name="airflow.task.started", timestamp=datetime_to_nano(ti.start_date))
-            span.add_event(name="airflow.task.ended", timestamp=datetime_to_nano(ti.end_date))
+        span.add_event(name="airflow.task.queued", timestamp=datetime_to_nano(ti.queued_dttm))
+        span.add_event(name="airflow.task.started", timestamp=datetime_to_nano(ti.start_date))
+        span.add_event(name="airflow.task.ended", timestamp=datetime_to_nano(ti.end_date))
 
     def _execute(self) -> int | None:
         import os
@@ -1316,12 +1305,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 executor.start()
 
             # local import due to type_checking.
-            from airflow.executors.base_executor import BaseExecutor
-
-            # Pass a reference to the dictionary.
-            # Any changes made by a dag_run instance, will be reflected to the dictionary of this class.
-            DagRun.set_active_spans(active_spans=self.active_spans)
-            BaseExecutor.set_active_spans(active_spans=self.active_spans)
 
             stats_factory = stats_utils.get_stats_factory(Stats)
             Stats.initialize(factory=stats_factory)
@@ -1371,162 +1354,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                         self._send_dag_callbacks_to_processor(dag, callback_to_run)
         except Exception as e:  # should not fail the scheduler
             self.log.exception("Failed to update dag run state for paused dags due to %s", e)
-
-    @provide_session
-    def _end_active_spans(self, session: Session = NEW_SESSION):
-        # No need to do a commit for every update. The annotation will commit all of them once at the end.
-        for prefixed_key, span in self.active_spans.get_all().items():
-            # Use partition to split on the first occurrence of ':'.
-            prefix, sep, key = prefixed_key.partition(":")
-
-            if prefix == "ti":
-                ti_result = session.get(TaskInstance, UUID(key))
-                if ti_result is None:
-                    continue
-                ti: TaskInstance = ti_result
-
-                if ti.state in State.finished:
-                    self.set_ti_span_attrs(span=span, state=ti.state, ti=ti)
-                    span.end(end_time=datetime_to_nano(ti.end_date))
-                    ti.span_status = SpanStatus.ENDED
-                else:
-                    span.end()
-                    ti.span_status = SpanStatus.NEEDS_CONTINUANCE
-            elif prefix == "dr":
-                dag_run: DagRun | None = session.scalars(
-                    select(DagRun).where(DagRun.id == int(key))
-                ).one_or_none()
-                if dag_run is None:
-                    continue
-                if dag_run.state in State.finished_dr_states:
-                    dag_run.set_dagrun_span_attrs(span=span)
-
-                    span.end(end_time=datetime_to_nano(dag_run.end_date))
-                    dag_run.span_status = SpanStatus.ENDED
-                else:
-                    span.end()
-                    dag_run.span_status = SpanStatus.NEEDS_CONTINUANCE
-                    initial_dag_run_context = Trace.extract(dag_run.context_carrier)
-                    with Trace.start_child_span(
-                        span_name="current_scheduler_exited", parent_context=initial_dag_run_context
-                    ) as s:
-                        s.set_attribute("trace_status", "needs continuance")
-            else:
-                self.log.error("Found key with unknown prefix: '%s'", prefixed_key)
-
-        # Even if there is a key with an unknown prefix, clear the dict.
-        # If this method has been called, the scheduler is exiting.
-        self.active_spans.clear()
-
-    def _end_spans_of_externally_ended_ops(self, session: Session):
-        # The scheduler that starts a dag_run or a task is also the one that starts the spans.
-        # Each scheduler should end the spans that it has started.
-        #
-        # Otel spans are implemented in a certain way so that the objects
-        # can't be shared between processes or get recreated.
-        # It is done so that the process that starts a span, is also the one that ends it.
-        #
-        # If another scheduler has finished processing a dag_run or a task and there is a reference
-        # on the active_spans dictionary, then the current scheduler started the span,
-        # and therefore must end it.
-        dag_runs_should_end: list[DagRun] = list(
-            session.scalars(select(DagRun).where(DagRun.span_status == SpanStatus.SHOULD_END))
-        )
-        tis_should_end: list[TaskInstance] = list(
-            session.scalars(select(TaskInstance).where(TaskInstance.span_status == SpanStatus.SHOULD_END))
-        )
-
-        for dag_run in dag_runs_should_end:
-            active_dagrun_span = self.active_spans.get("dr:" + str(dag_run.id))
-            if active_dagrun_span is not None:
-                if dag_run.state in State.finished_dr_states:
-                    dag_run.set_dagrun_span_attrs(span=active_dagrun_span)
-
-                    active_dagrun_span.end(end_time=datetime_to_nano(dag_run.end_date))
-                else:
-                    active_dagrun_span.end()
-                self.active_spans.delete("dr:" + str(dag_run.id))
-                dag_run.span_status = SpanStatus.ENDED
-
-        for ti in tis_should_end:
-            active_ti_span = self.active_spans.get(f"ti:{ti.id}")
-            if active_ti_span is not None:
-                if ti.state in State.finished:
-                    self.set_ti_span_attrs(span=active_ti_span, state=ti.state, ti=ti)
-                    active_ti_span.end(end_time=datetime_to_nano(ti.end_date))
-                else:
-                    active_ti_span.end()
-                self.active_spans.delete(f"ti:{ti.id}")
-                ti.span_status = SpanStatus.ENDED
-
-    def _recreate_unhealthy_scheduler_spans_if_needed(self, dag_run: DagRun, session: Session):
-        # There are two scenarios:
-        #   1. scheduler is unhealthy but managed to update span_status
-        #   2. scheduler is unhealthy and didn't manage to make any updates
-        # Check the span_status first, in case the 2nd db query can be avoided (scenario 1).
-
-        # If the dag_run is scheduled by a different scheduler, and it's still running and the span is active,
-        # then check the Job table to determine if the initial scheduler is still healthy.
-        if (
-            dag_run.scheduled_by_job_id != self.job.id
-            and dag_run.state in State.unfinished_dr_states
-            and dag_run.span_status == SpanStatus.ACTIVE
-        ):
-            initial_scheduler_id = dag_run.scheduled_by_job_id
-            job: Job | None = session.scalars(
-                select(Job).where(
-                    Job.id == initial_scheduler_id,
-                    Job.job_type == "SchedulerJob",
-                )
-            ).one_or_none()
-            if job is None:
-                return
-
-            if not job.is_alive():
-                # Start a new span for the dag_run.
-                dr_span = Trace.start_root_span(
-                    span_name=f"{dag_run.dag_id}_recreated",
-                    component="dag",
-                    start_time=dag_run.queued_at,
-                    start_as_current=False,
-                )
-                carrier = Trace.inject()
-                # Update the context_carrier and leave the SpanStatus as ACTIVE.
-                dag_run.context_carrier = carrier
-                self.active_spans.set("dr:" + str(dag_run.id), dr_span)
-
-                tis = dag_run.get_task_instances(session=session)
-
-                # At this point, any tis will have been adopted by the current scheduler,
-                # and ti.queued_by_job_id will point to the current id.
-                # Any tis that have been executed by the unhealthy scheduler, will need a new span
-                # so that it can be associated with the new dag_run span.
-                tis_needing_spans = [
-                    ti
-                    for ti in tis
-                    # If it has started and there is a reference on the active_spans dict,
-                    # then it was started by the current scheduler.
-                    if ti.start_date is not None and self.active_spans.get(f"ti:{ti.id}") is None
-                ]
-
-                dr_context = Trace.extract(dag_run.context_carrier)
-                for ti in tis_needing_spans:
-                    ti_span = Trace.start_child_span(
-                        span_name=f"{ti.task_id}_recreated",
-                        parent_context=dr_context,
-                        start_time=ti.queued_dttm,
-                        start_as_current=False,
-                    )
-                    ti_carrier = Trace.inject()
-                    ti.context_carrier = ti_carrier
-
-                    if ti.state in State.finished:
-                        self.set_ti_span_attrs(span=ti_span, state=ti.state, ti=ti)
-                        ti_span.end(end_time=datetime_to_nano(ti.end_date))
-                        ti.span_status = SpanStatus.ENDED
-                    else:
-                        ti.span_status = SpanStatus.ACTIVE
-                        self.active_spans.set(f"ti:{ti.id}", ti_span)
 
     def _run_scheduler_loop(self) -> None:
         """
@@ -1628,9 +1455,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 )
 
                 with create_session() as session:
-                    if self._is_tracing_enabled():
-                        self._end_spans_of_externally_ended_ops(session)
-
                     # This will schedule for as many executors as possible.
                     num_queued_tis = self._do_scheduling(session)
                     # Don't keep any objects alive -- we've possibly just looked at 500+ ORM objects!
@@ -1677,13 +1501,12 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 self.log.debug("Next timed event is in %f", next_event)
 
             self.log.debug("Ran scheduling loop in %.2f ms", timer.duration)
-            if span.is_recording():
-                span.add_event(
-                    name="Ran scheduling loop",
-                    attributes={
-                        "duration in ms": timer.duration,
-                    },
-                )
+            span.add_event(
+                name="Ran scheduling loop",
+                attributes={
+                    "duration in ms": timer.duration,
+                },
+            )
 
             if not is_unit_test and not num_queued_tis and not num_finished_events:
                 # If the scheduler is doing things, don't sleep. This means when there is work to do, the
@@ -1697,8 +1520,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     self.num_runs,
                     loop_count,
                 )
-                if span.is_recording():
-                    span.add_event("Exiting scheduler loop as requested number of runs has been reached")
+                span.add_event("Exiting scheduler loop as requested number of runs has been reached")
                 break
 
     def _do_scheduling(self, session: Session) -> int:
@@ -1946,102 +1768,107 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         )
 
         for dag_model in dag_models:
-            if dag_model.exceeds_max_non_backfill:
-                self.log.warning(
-                    "Dag run cannot be created; max active runs exceeded.",
-                    dag_id=dag_model.dag_id,
-                    max_active_runs=dag_model.max_active_runs,
-                    active_runs=active_runs_of_dags.get(dag_model.dag_id),
-                )
-                continue
-            if dag_model.next_dagrun is None:
-                self.log.error(
-                    "dag_model.next_dagrun is None; expected datetime",
-                    dag_id=dag_model.dag_id,
-                )
-                continue
-            if dag_model.next_dagrun_create_after is None:
-                self.log.error(
-                    "dag_model.next_dagrun_create_after is None; expected datetime",
-                    dag_id=dag_model.dag_id,
-                )
-                continue
+            tracer = Trace.get_tracer("dagrun")
+            with tracer.start_as_current_span("create_dagrun") as span:
+                span.set_attribute("dag_id", dag_model.dag_id)
+                span.set_attribute("component", "scheduler")
+                if dag_model.exceeds_max_non_backfill:
+                    self.log.warning(
+                        "Dag run cannot be created; max active runs exceeded.",
+                        dag_id=dag_model.dag_id,
+                        max_active_runs=dag_model.max_active_runs,
+                        active_runs=active_runs_of_dags.get(dag_model.dag_id),
+                    )
+                    continue
+                if dag_model.next_dagrun is None:
+                    self.log.error(
+                        "dag_model.next_dagrun is None; expected datetime",
+                        dag_id=dag_model.dag_id,
+                    )
+                    continue
+                if dag_model.next_dagrun_create_after is None:
+                    self.log.error(
+                        "dag_model.next_dagrun_create_after is None; expected datetime",
+                        dag_id=dag_model.dag_id,
+                    )
+                    continue
 
-            serdag = self._get_current_dag(dag_id=dag_model.dag_id, session=session)
-            if not serdag:
-                self.log.error("Dag not found in serialized_dag table", dag_id=dag_model.dag_id)
-                continue
+                serdag = self._get_current_dag(dag_id=dag_model.dag_id, session=session)
+                if not serdag:
+                    self.log.error("Dag not found in serialized_dag table", dag_id=dag_model.dag_id)
+                    continue
 
-            # Explicitly check if the DagRun already exists. This is an edge case
-            # where a Dag Run is created but `DagModel.next_dagrun` and `DagModel.next_dagrun_create_after`
-            # are not updated.
-            # We opted to check DagRun existence instead
-            # of catching an Integrity error and rolling back the session i.e
-            if dr := existing_dagruns.get((dag_model.dag_id, dag_model.next_dagrun)):
-                self.log.warning(
-                    "run already exists; skipping dagrun creation",
-                    dag_id=dag_model.dag_id,
-                    logical_date=dag_model.next_dagrun,
-                )
-                dag_model.calculate_dagrun_date_fields(dag=serdag, last_automated_run=dr)
-                continue
+                # Explicitly check if the DagRun already exists. This is an edge case
+                # where a Dag Run is created but `DagModel.next_dagrun` and `DagModel.next_dagrun_create_after`
+                # are not updated.
+                # We opted to check DagRun existence instead
+                # of catching an Integrity error and rolling back the session i.e
+                if dr := existing_dagruns.get((dag_model.dag_id, dag_model.next_dagrun)):
+                    self.log.warning(
+                        "run already exists; skipping dagrun creation",
+                        dag_id=dag_model.dag_id,
+                        logical_date=dag_model.next_dagrun,
+                    )
+                    dag_model.calculate_dagrun_date_fields(dag=serdag, last_automated_run=dr)
+                    continue
 
-            if (
-                dag_model.allowed_run_types is not None
-                and DagRunType.SCHEDULED not in dag_model.allowed_run_types
-            ):
-                self.log.warning(
-                    "Dag does not allow scheduled runs; skipping",
-                    dag_id=dag_model.dag_id,
-                )
-                continue
+                if (
+                    dag_model.allowed_run_types is not None
+                    and DagRunType.SCHEDULED not in dag_model.allowed_run_types
+                ):
+                    self.log.warning(
+                        "Dag does not allow scheduled runs; skipping",
+                        dag_id=dag_model.dag_id,
+                    )
+                    continue
 
-            try:
-                next_info = serdag.timetable.next_run_info_from_dag_model(dag_model=dag_model)
-                data_interval = next_info.data_interval
-                logical_date = next_info.logical_date
-                partition_key = next_info.partition_key
-                run_after = next_info.run_after
-                # todo: AIP-76 partition date is not passed to dag run
-                #  See https://github.com/apache/airflow/issues/61167.
-                created_run = serdag.create_dagrun(
-                    run_id=serdag.timetable.generate_run_id(
-                        run_type=DagRunType.SCHEDULED,
-                        run_after=run_after,
+                try:
+                    next_info = serdag.timetable.next_run_info_from_dag_model(dag_model=dag_model)
+                    data_interval = next_info.data_interval
+                    logical_date = next_info.logical_date
+                    partition_key = next_info.partition_key
+                    run_after = next_info.run_after
+                    # todo: AIP-76 partition date is not passed to dag run
+                    #  See https://github.com/apache/airflow/issues/61167.
+
+                    created_run = serdag.create_dagrun(
+                        run_id=serdag.timetable.generate_run_id(
+                            run_type=DagRunType.SCHEDULED,
+                            run_after=run_after,
+                            data_interval=data_interval,
+                            partition_key=partition_key,
+                        ),
+                        logical_date=logical_date,
                         data_interval=data_interval,
+                        run_after=run_after,
+                        run_type=DagRunType.SCHEDULED,
+                        triggered_by=DagRunTriggeredByType.TIMETABLE,
+                        state=DagRunState.QUEUED,
+                        creating_job_id=self.job.id,
+                        session=session,
                         partition_key=partition_key,
-                    ),
-                    logical_date=logical_date,
-                    data_interval=data_interval,
-                    run_after=run_after,
-                    run_type=DagRunType.SCHEDULED,
-                    triggered_by=DagRunTriggeredByType.TIMETABLE,
-                    state=DagRunState.QUEUED,
-                    creating_job_id=self.job.id,
-                    session=session,
-                    partition_key=partition_key,
-                )
-                active_runs_of_dags[dag_model.dag_id] += 1
-                dag_model.calculate_dagrun_date_fields(dag=serdag, last_automated_run=created_run)
-                self._set_exceeds_max_active_runs(
-                    dag_model=dag_model,
-                    session=session,
-                    active_non_backfill_runs=active_runs_of_dags[dag_model.dag_id],
-                )
+                    )
+                    active_runs_of_dags[dag_model.dag_id] += 1
+                    dag_model.calculate_dagrun_date_fields(dag=serdag, last_automated_run=created_run)
+                    self._set_exceeds_max_active_runs(
+                        dag_model=dag_model,
+                        session=session,
+                        active_non_backfill_runs=active_runs_of_dags[dag_model.dag_id],
+                    )
 
-            # Exceptions like ValueError, ParamValidationError, etc. are raised by
-            # DagModel.create_dagrun() when dag is misconfigured. The scheduler should not
-            # crash due to misconfigured dags. We should log any exception encountered
-            # and continue to the next serdag.
-            except Exception:
-                self.log.exception("Failed creating DagRun", dag_id=dag_model.dag_id)
-                # todo: if you get a database error here, continuing does not work because
-                #  session needs rollback. you need either to make smaller transactions and
-                #  commit after every dag run or use savepoints.
-                #  https://github.com/apache/airflow/issues/59120
+                # Exceptions like ValueError, ParamValidationError, etc. are raised by
+                # DagModel.create_dagrun() when dag is misconfigured. The scheduler should not
+                # crash due to misconfigured dags. We should log any exception encountered
+                # and continue to the next serdag.
+                except Exception:
+                    self.log.exception("Failed creating DagRun", dag_id=dag_model.dag_id)
+                    # todo: if you get a database error here, continuing does not work because
+                    #  session needs rollback. you need either to make smaller transactions and
+                    #  commit after every dag run or use savepoints.
+                    #  https://github.com/apache/airflow/issues/59120
 
-            # TODO[HA]: Should we do a session.flush() so we don't have to keep lots of state/object in
-            #  memory for larger dags? or expunge_all()
+                # TODO[HA]: Should we do a session.flush() so we don't have to keep lots of state/object in
+                #  memory for larger dags? or expunge_all()
 
     def _create_dag_runs_asset_triggered(
         self,
@@ -2192,19 +2019,18 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     tags={},
                     extra_tags={"dag_id": dag.dag_id},
                 )
-                if span.is_recording():
-                    span.add_event(
-                        name="schedule_delay",
-                        attributes={"dag_id": dag.dag_id, "schedule_delay": str(schedule_delay)},
-                    )
+                span.add_event(
+                    name="schedule_delay",
+                    attributes={"dag_id": dag.dag_id, "schedule_delay": str(schedule_delay)},
+                )
 
         # cache saves time during scheduling of many dag_runs for same dag
         cached_get_dag: Callable[[DagRun], SerializedDAG | None] = lru_cache()(
             partial(self.scheduler_dag_bag.get_dag_for_run, session=session)
         )
 
-        span = Trace.get_current_span()
         for dag_run in dag_runs:
+            span = Trace.get_current_span()
             dag_id = dag_run.dag_id
             run_id = dag_run.run_id
             backfill_id = dag_run.backfill_id
@@ -2243,15 +2069,13 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                         dag_run.run_id,
                     )
                     continue
-            if span.is_recording():
-                span.add_event(
-                    name="dag_run",
-                    attributes={
-                        "run_id": dag_run.run_id,
-                        "dag_id": dag_run.dag_id,
-                        "conf": str(dag_run.conf),
-                    },
-                )
+            span.add_event(
+                name="dag_run.set_running",
+                attributes={
+                    "run_id": dag_run.run_id,
+                    "dag_id": dag_run.dag_id,
+                },
+            )
             active_runs_of_dags[(dag_run.dag_id, backfill_id)] += 1
             _update_state(dag, dag_run)
             dag_run.notify_dagrun_state_changed(msg="started")
@@ -2268,6 +2092,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         guard.commit()
         return callback_tuples
 
+    @add_span
     def _schedule_dag_run(
         self,
         dag_run: DagRun,
@@ -2363,14 +2188,13 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                         extra_tags={"dag_id": dag_run.dag_id},
                     )
                 span.set_attribute("error", True)
-                if span.is_recording():
-                    span.add_event(
-                        name="error",
-                        attributes={
-                            "message": f"Run {dag_run.run_id} of {dag_run.dag_id} has timed-out",
-                            "duration": str(duration),
-                        },
-                    )
+                span.add_event(
+                    name="error",
+                    attributes={
+                        "message": f"Run {dag_run.run_id} of {dag_run.dag_id} has timed-out",
+                        "duration": str(duration),
+                    },
+                )
                 return callback_to_execute
 
             if dag_run.logical_date and dag_run.logical_date > timezone.utcnow():
@@ -2384,17 +2208,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     "The DAG disappeared before verifying integrity: %s. Skipping.", dag_run.dag_id
                 )
                 return callback
-
-            if (
-                self._is_tracing_enabled()
-                and dag_run.scheduled_by_job_id is not None
-                and dag_run.scheduled_by_job_id != self.job.id
-                and self.active_spans.get("dr:" + str(dag_run.id)) is None
-            ):
-                # If the dag_run has been previously scheduled by another job and there is no active span,
-                # then check if the job is still healthy.
-                # If it's not healthy, then recreate the spans.
-                self._recreate_unhealthy_scheduler_spans_if_needed(dag_run, session)
 
             dag_run.scheduled_by_job_id = self.job.id
 
@@ -2412,14 +2225,13 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             # query to update all the TIs across all the logical dates and dag
             # IDs in a single query, but it turns out that can be _very very slow_
             # see #11147/commit ee90807ac for more details
-            if span.is_recording():
-                span.add_event(
-                    name="schedule_tis",
-                    attributes={
-                        "message": "dag_run scheduling its tis",
-                        "schedulable_tis": [_ti.task_id for _ti in schedulable_tis],
-                    },
-                )
+            span.add_event(
+                name="schedule_tis",
+                attributes={
+                    "message": "dag_run scheduling its tis",
+                    "schedulable_tis": [_ti.task_id for _ti in schedulable_tis],
+                },
+            )
             dag_run.schedule_tis(schedulable_tis, session, max_tis_per_query=self.job.max_tis_per_query)
 
             return callback_to_run

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -27,7 +27,7 @@ import sys
 import time
 from collections import Counter, defaultdict, deque
 from collections.abc import Callable, Collection, Iterable, Iterator
-from contextlib import ExitStack
+from contextlib import ExitStack, nullcontext
 from datetime import date, datetime, timedelta
 from functools import lru_cache, partial, wraps
 from itertools import groupby
@@ -1784,107 +1784,102 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         )
 
         for dag_model in dag_models:
-            tracer = Trace.get_tracer("dagrun")
-            with tracer.start_as_current_span("create_dagrun") as span:
-                span.set_attribute("dag_id", dag_model.dag_id)
-                span.set_attribute("component", "scheduler")
-                if dag_model.exceeds_max_non_backfill:
-                    self.log.warning(
-                        "Dag run cannot be created; max active runs exceeded.",
-                        dag_id=dag_model.dag_id,
-                        max_active_runs=dag_model.max_active_runs,
-                        active_runs=active_runs_of_dags.get(dag_model.dag_id),
-                    )
-                    continue
-                if dag_model.next_dagrun is None:
-                    self.log.error(
-                        "dag_model.next_dagrun is None; expected datetime",
-                        dag_id=dag_model.dag_id,
-                    )
-                    continue
-                if dag_model.next_dagrun_create_after is None:
-                    self.log.error(
-                        "dag_model.next_dagrun_create_after is None; expected datetime",
-                        dag_id=dag_model.dag_id,
-                    )
-                    continue
+            if dag_model.exceeds_max_non_backfill:
+                self.log.warning(
+                    "Dag run cannot be created; max active runs exceeded.",
+                    dag_id=dag_model.dag_id,
+                    max_active_runs=dag_model.max_active_runs,
+                    active_runs=active_runs_of_dags.get(dag_model.dag_id),
+                )
+                continue
+            if dag_model.next_dagrun is None:
+                self.log.error(
+                    "dag_model.next_dagrun is None; expected datetime",
+                    dag_id=dag_model.dag_id,
+                )
+                continue
+            if dag_model.next_dagrun_create_after is None:
+                self.log.error(
+                    "dag_model.next_dagrun_create_after is None; expected datetime",
+                    dag_id=dag_model.dag_id,
+                )
+                continue
 
-                serdag = self._get_current_dag(dag_id=dag_model.dag_id, session=session)
-                if not serdag:
-                    self.log.error("Dag not found in serialized_dag table", dag_id=dag_model.dag_id)
-                    continue
+            serdag = self._get_current_dag(dag_id=dag_model.dag_id, session=session)
+            if not serdag:
+                self.log.error("Dag not found in serialized_dag table", dag_id=dag_model.dag_id)
+                continue
 
-                # Explicitly check if the DagRun already exists. This is an edge case
-                # where a Dag Run is created but `DagModel.next_dagrun` and `DagModel.next_dagrun_create_after`
-                # are not updated.
-                # We opted to check DagRun existence instead
-                # of catching an Integrity error and rolling back the session i.e
-                if dr := existing_dagruns.get((dag_model.dag_id, dag_model.next_dagrun)):
-                    self.log.warning(
-                        "run already exists; skipping dagrun creation",
-                        dag_id=dag_model.dag_id,
-                        logical_date=dag_model.next_dagrun,
-                    )
-                    dag_model.calculate_dagrun_date_fields(dag=serdag, last_automated_run=dr)
-                    continue
+            # Explicitly check if the DagRun already exists. This is an edge case
+            # where a Dag Run is created but `DagModel.next_dagrun` and `DagModel.next_dagrun_create_after`
+            # are not updated.
+            # We opted to check DagRun existence instead
+            # of catching an Integrity error and rolling back the session i.e
+            if dr := existing_dagruns.get((dag_model.dag_id, dag_model.next_dagrun)):
+                self.log.warning(
+                    "run already exists; skipping dagrun creation",
+                    dag_id=dag_model.dag_id,
+                    logical_date=dag_model.next_dagrun,
+                )
+                dag_model.calculate_dagrun_date_fields(dag=serdag, last_automated_run=dr)
+                continue
 
-                if (
-                    dag_model.allowed_run_types is not None
-                    and DagRunType.SCHEDULED not in dag_model.allowed_run_types
-                ):
-                    self.log.warning(
-                        "Dag does not allow scheduled runs; skipping",
-                        dag_id=dag_model.dag_id,
-                    )
-                    continue
+            if (
+                dag_model.allowed_run_types is not None
+                and DagRunType.SCHEDULED not in dag_model.allowed_run_types
+            ):
+                self.log.warning(
+                    "Dag does not allow scheduled runs; skipping",
+                    dag_id=dag_model.dag_id,
+                )
+                continue
+            try:
+                next_info = serdag.timetable.next_run_info_from_dag_model(dag_model=dag_model)
+                data_interval = next_info.data_interval
+                logical_date = next_info.logical_date
+                partition_key = next_info.partition_key
+                run_after = next_info.run_after
+                # todo: AIP-76 partition date is not passed to dag run
+                #  See https://github.com/apache/airflow/issues/61167.
 
-                try:
-                    next_info = serdag.timetable.next_run_info_from_dag_model(dag_model=dag_model)
-                    data_interval = next_info.data_interval
-                    logical_date = next_info.logical_date
-                    partition_key = next_info.partition_key
-                    run_after = next_info.run_after
-                    # todo: AIP-76 partition date is not passed to dag run
-                    #  See https://github.com/apache/airflow/issues/61167.
-
-                    created_run = serdag.create_dagrun(
-                        run_id=serdag.timetable.generate_run_id(
-                            run_type=DagRunType.SCHEDULED,
-                            run_after=run_after,
-                            data_interval=data_interval,
-                            partition_key=partition_key,
-                        ),
-                        logical_date=logical_date,
-                        data_interval=data_interval,
-                        run_after=run_after,
+                created_run = serdag.create_dagrun(
+                    run_id=serdag.timetable.generate_run_id(
                         run_type=DagRunType.SCHEDULED,
-                        triggered_by=DagRunTriggeredByType.TIMETABLE,
-                        state=DagRunState.QUEUED,
-                        creating_job_id=self.job.id,
-                        session=session,
+                        run_after=run_after,
+                        data_interval=data_interval,
                         partition_key=partition_key,
-                    )
-                    active_runs_of_dags[dag_model.dag_id] += 1
-                    dag_model.calculate_dagrun_date_fields(dag=serdag, last_automated_run=created_run)
-                    self._set_exceeds_max_active_runs(
-                        dag_model=dag_model,
-                        session=session,
-                        active_non_backfill_runs=active_runs_of_dags[dag_model.dag_id],
-                    )
+                    ),
+                    logical_date=logical_date,
+                    data_interval=data_interval,
+                    run_after=run_after,
+                    run_type=DagRunType.SCHEDULED,
+                    triggered_by=DagRunTriggeredByType.TIMETABLE,
+                    state=DagRunState.QUEUED,
+                    creating_job_id=self.job.id,
+                    session=session,
+                    partition_key=partition_key,
+                )
+                active_runs_of_dags[dag_model.dag_id] += 1
+                dag_model.calculate_dagrun_date_fields(dag=serdag, last_automated_run=created_run)
+                self._set_exceeds_max_active_runs(
+                    dag_model=dag_model,
+                    session=session,
+                    active_non_backfill_runs=active_runs_of_dags[dag_model.dag_id],
+                )
 
-                # Exceptions like ValueError, ParamValidationError, etc. are raised by
-                # DagModel.create_dagrun() when dag is misconfigured. The scheduler should not
-                # crash due to misconfigured dags. We should log any exception encountered
-                # and continue to the next serdag.
-                except Exception:
-                    self.log.exception("Failed creating DagRun", dag_id=dag_model.dag_id)
-                    # todo: if you get a database error here, continuing does not work because
-                    #  session needs rollback. you need either to make smaller transactions and
-                    #  commit after every dag run or use savepoints.
-                    #  https://github.com/apache/airflow/issues/59120
+            # Exceptions like ValueError, ParamValidationError, etc. are raised by
+            # DagModel.create_dagrun() when dag is misconfigured. The scheduler should not
+            # crash due to misconfigured dags. We should log any exception encountered
+            # and continue to the next serdag.
+            except Exception:
+                self.log.exception("Failed creating DagRun", dag_id=dag_model.dag_id)
+                # todo: if you get a database error here, continuing does not work because
+                #  session needs rollback. you need either to make smaller transactions and
+                #  commit after every dag run or use savepoints.
+                #  https://github.com/apache/airflow/issues/59120
 
-                # TODO[HA]: Should we do a session.flush() so we don't have to keep lots of state/object in
-                #  memory for larger dags? or expunge_all()
+            # TODO[HA]: Should we do a session.flush() so we don't have to keep lots of state/object in
+            #  memory for larger dags? or expunge_all()
 
     def _create_dag_runs_asset_triggered(
         self,

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -23,7 +23,8 @@ import re
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar, cast, overload
+from functools import wraps
+from typing import TYPE_CHECKING, Any, NamedTuple, ParamSpec, TypeVar, cast, overload
 from uuid import UUID
 
 import structlog
@@ -77,7 +78,6 @@ from airflow.serialization.definitions.deadline import SerializedReferenceModels
 from airflow.serialization.definitions.notset import NOTSET, ArgNotSet, is_arg_set
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.dependencies_states import SCHEDULEABLE_STATES
-from airflow.utils.dates import datetime_to_nano
 from airflow.utils.helpers import chunks, is_container, prune_dict
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.retries import retry_db_transaction
@@ -92,19 +92,16 @@ from airflow.utils.sqlalchemy import (
 )
 from airflow.utils.state import DagRunState, State, TaskInstanceState
 from airflow.utils.strings import get_random_string
-from airflow.utils.thread_safe_dict import ThreadSafeDict
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 if TYPE_CHECKING:
     from typing import Literal, TypeAlias
 
-    from opentelemetry.sdk.trace import Span
     from pydantic import NonNegativeInt
     from sqlalchemy.engine import ScalarResult
     from sqlalchemy.orm import Session
     from sqlalchemy.sql.elements import Case, ColumnElement
 
-    from airflow._shared.observability.traces.base_tracer import EmptySpan
     from airflow.models.dag_version import DagVersion
     from airflow.models.taskinstancekey import TaskInstanceKey
     from airflow.sdk import DAG as SDKDAG
@@ -119,6 +116,23 @@ if TYPE_CHECKING:
 RUN_ID_REGEX = r"^(?:manual|scheduled|asset_triggered)__(?:\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+00:00)$"
 
 log = structlog.get_logger(__name__)
+
+
+PS = ParamSpec("PS")
+RT = TypeVar("RT")
+
+
+def add_span(func: Callable[PS, RT]) -> Callable[PS, RT]:
+    @wraps(func)
+    def wrapper(self, *args, **kwargs) -> RT:
+        if self.context_carrier:
+            context = Trace.extract(self.context_carrier)
+            tracer = Trace.get_tracer("dagrun")
+            with tracer.start_as_current_span(func.__name__, context=context):
+                return func(self, *args, **kwargs)
+        return func(self, *args, **kwargs)
+
+    return wrapper
 
 
 class TISchedulingDecision(NamedTuple):
@@ -152,8 +166,6 @@ class DagRun(Base, LoggingMixin):
     A DAG run can be created by the scheduler (i.e. scheduled runs), or by an
     external trigger (i.e. manual runs).
     """
-
-    active_spans = ThreadSafeDict()
 
     __tablename__ = "dag_run"
 
@@ -365,7 +377,11 @@ class DagRun(Base, LoggingMixin):
         self.triggered_by = triggered_by
         self.triggering_user_name = triggering_user_name
         self.scheduled_by_job_id = None
-        self.context_carrier = {}
+        context_carrier = Trace.inject()
+        self.context_carrier = context_carrier
+        span = Trace.get_current_span()
+        span.set_attribute("dag_id", self.dag_id)
+        span.set_attribute("run_id", self.run_id)
         if not isinstance(partition_key, str | None):
             raise ValueError(
                 f"Expected partition_key to be a `str` or `None` but got `{partition_key.__class__.__name__}`"
@@ -457,10 +473,6 @@ class DagRun(Base, LoggingMixin):
     def stats_tags(self) -> dict[str, str]:
         return prune_dict({"dag_id": self.dag_id, "run_type": self.run_type})
 
-    @classmethod
-    def set_active_spans(cls, active_spans: ThreadSafeDict):
-        cls.active_spans = active_spans
-
     def get_state(self):
         return self._state
 
@@ -534,9 +546,6 @@ class DagRun(Base, LoggingMixin):
                 if state in State.finished_dr_states:
                     self.end_date = timezone.utcnow()
             self._state = state
-        else:
-            if state == DagRunState.QUEUED:
-                self.queued_at = timezone.utcnow()
 
     @declared_attr
     def state(self):
@@ -1015,132 +1024,6 @@ class DagRun(Base, LoggingMixin):
         leaf_tis = {ti for ti in tis if ti.task_id in leaf_task_ids if ti.state != TaskInstanceState.REMOVED}
         return leaf_tis
 
-    def set_dagrun_span_attrs(self, span: Span | EmptySpan):
-        if self._state == DagRunState.FAILED:
-            span.set_attribute("airflow.dag_run.error", True)
-
-        # Explicitly set the value type to Union[...] to avoid a mypy error.
-        attributes: dict[str, AttributeValueType] = {
-            "airflow.category": "DAG runs",
-            "airflow.dag_run.dag_id": str(self.dag_id),
-            "airflow.dag_run.logical_date": str(self.logical_date),
-            "airflow.dag_run.run_id": str(self.run_id),
-            "airflow.dag_run.queued_at": str(self.queued_at),
-            "airflow.dag_run.run_start_date": str(self.start_date),
-            "airflow.dag_run.run_end_date": str(self.end_date),
-            "airflow.dag_run.run_duration": str(
-                (self.end_date - self.start_date).total_seconds() if self.start_date and self.end_date else 0
-            ),
-            "airflow.dag_run.state": str(self._state),
-            "airflow.dag_run.run_type": str(self.run_type),
-            "airflow.dag_run.data_interval_start": str(self.data_interval_start),
-            "airflow.dag_run.data_interval_end": str(self.data_interval_end),
-            "airflow.dag_run.conf": str(self.conf),
-        }
-        if span.is_recording():
-            span.add_event(name="airflow.dag_run.queued", timestamp=datetime_to_nano(self.queued_at))
-            span.add_event(name="airflow.dag_run.started", timestamp=datetime_to_nano(self.start_date))
-            span.add_event(name="airflow.dag_run.ended", timestamp=datetime_to_nano(self.end_date))
-        span.set_attributes(attributes)
-
-    def start_dr_spans_if_needed(self, tis: list[TI]):
-        # If there is no value in active_spans, then the span hasn't already been started.
-        if self.active_spans is not None and self.active_spans.get("dr:" + str(self.id)) is None:
-            if self.span_status == SpanStatus.NOT_STARTED or self.span_status == SpanStatus.NEEDS_CONTINUANCE:
-                dr_span = None
-                continue_ti_spans = False
-                if self.span_status == SpanStatus.NOT_STARTED:
-                    dr_span = Trace.start_root_span(
-                        span_name=f"{self.dag_id}",
-                        component="dag",
-                        start_time=self.queued_at,  # This is later converted to nano.
-                        start_as_current=False,
-                    )
-                elif self.span_status == SpanStatus.NEEDS_CONTINUANCE:
-                    # Use the existing context_carrier to set the initial dag_run span as the parent.
-                    parent_context = Trace.extract(self.context_carrier)
-                    with Trace.start_child_span(
-                        span_name="new_scheduler", parent_context=parent_context
-                    ) as s:
-                        s.set_attribute("trace_status", "continued")
-
-                    dr_span = Trace.start_child_span(
-                        span_name=f"{self.dag_id}_continued",
-                        parent_context=parent_context,
-                        component="dag",
-                        # No start time
-                        start_as_current=False,
-                    )
-                    # After this span is started, the context_carrier will be replaced by the new one.
-                    # New task span will use this span as the parent.
-                    continue_ti_spans = True
-                carrier = Trace.inject()
-                self.context_carrier = carrier
-                self.span_status = SpanStatus.ACTIVE
-                # Set the span in a synchronized dictionary, so that the variable can be used to end the span.
-                self.active_spans.set("dr:" + str(self.id), dr_span)
-                self.log.debug(
-                    "DagRun span has been started and the injected context_carrier is: %s",
-                    self.context_carrier,
-                )
-                # Start TI spans that also need continuance.
-                if continue_ti_spans:
-                    new_dagrun_context = Trace.extract(self.context_carrier)
-                    for ti in tis:
-                        if ti.span_status == SpanStatus.NEEDS_CONTINUANCE:
-                            ti_span = Trace.start_child_span(
-                                span_name=f"{ti.task_id}_continued",
-                                parent_context=new_dagrun_context,
-                                start_as_current=False,
-                            )
-                            ti_carrier = Trace.inject()
-                            ti.context_carrier = ti_carrier
-                            ti.span_status = SpanStatus.ACTIVE
-                            self.active_spans.set(f"ti:{ti.id}", ti_span)
-            else:
-                self.log.debug(
-                    "Found span_status '%s', while updating state for dag_run '%s'",
-                    self.span_status,
-                    self.run_id,
-                )
-
-    def end_dr_span_if_needed(self):
-        if self.active_spans is not None:
-            active_span = self.active_spans.get("dr:" + str(self.id))
-            if active_span is not None:
-                self.log.debug(
-                    "Found active span with span_id: %s, for dag_id: %s, run_id: %s, state: %s",
-                    active_span.get_span_context().span_id,
-                    self.dag_id,
-                    self.run_id,
-                    self.state,
-                )
-
-                self.set_dagrun_span_attrs(span=active_span)
-                active_span.end(end_time=datetime_to_nano(self.end_date))
-                # Remove the span from the dict.
-                self.active_spans.delete("dr:" + str(self.id))
-                self.span_status = SpanStatus.ENDED
-            else:
-                if self.span_status == SpanStatus.ACTIVE:
-                    # Another scheduler has started the span.
-                    # Update the DB SpanStatus to notify the owner to end it.
-                    self.span_status = SpanStatus.SHOULD_END
-                elif self.span_status == SpanStatus.NEEDS_CONTINUANCE:
-                    # This is a corner case where the scheduler exited gracefully
-                    # while the dag_run was almost done.
-                    # Since it reached this point, the dag has finished but there has been no time
-                    # to create a new span for the current scheduler.
-                    # There is no need for more spans, update the status on the db.
-                    self.span_status = SpanStatus.ENDED
-                else:
-                    self.log.debug(
-                        "No active span has been found for dag_id: %s, run_id: %s, state: %s",
-                        self.dag_id,
-                        self.run_id,
-                        self.state,
-                    )
-
     @provide_session
     def update_state(
         self, session: Session = NEW_SESSION, execute_callbacks: bool = True
@@ -1305,11 +1188,6 @@ class DagRun(Base, LoggingMixin):
                 )
 
         # finally, if the leaves aren't done, the dag is still running
-        else:
-            # It might need to start TI spans as well.
-            self.start_dr_spans_if_needed(tis=tis)
-
-            self.set_state(DagRunState.RUNNING)
 
         if self._state == DagRunState.FAILED or self._state == DagRunState.SUCCESS:
             msg = (
@@ -1335,8 +1213,6 @@ class DagRun(Base, LoggingMixin):
                 self.data_interval_start,
                 self.data_interval_end,
             )
-
-            self.end_dr_span_if_needed()
 
             session.flush()
 

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -22,6 +22,7 @@ import os
 import re
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator, Sequence
+from contextlib import contextmanager
 from datetime import datetime
 from functools import wraps
 from typing import TYPE_CHECKING, Any, NamedTuple, ParamSpec, TypeVar, cast, overload
@@ -29,6 +30,11 @@ from uuid import UUID
 
 import structlog
 from natsort import natsorted
+from opentelemetry import context, trace
+from opentelemetry.sdk.trace import RandomIdGenerator, TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.trace import SpanContext, StatusCode, TraceFlags
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from sqlalchemy import (
     JSON,
     Enum,
@@ -58,11 +64,14 @@ from sqlalchemy.orm import Mapped, declared_attr, joinedload, mapped_column, rel
 from sqlalchemy.sql.expression import false, select
 from sqlalchemy.sql.functions import coalesce
 
+from airflow._shared.observability.common import get_otel_data_exporter
 from airflow._shared.observability.metrics.dual_stats_manager import DualStatsManager
 from airflow._shared.observability.metrics.stats import Stats
+from airflow._shared.observability.otel_env_config import load_traces_env_config
+from airflow._shared.observability.traces.otel_tracer import OVERRIDE_SPAN_ID_KEY, OVERRIDE_TRACE_ID_KEY
 from airflow._shared.timezones import timezone
 from airflow.callbacks.callback_requests import DagCallbackRequest, DagRunContext
-from airflow.configuration import conf as airflow_conf
+from airflow.configuration import conf, conf as airflow_conf
 from airflow.exceptions import AirflowException, NotMapped, TaskNotFound
 from airflow.listeners.listener import get_listener_manager
 from airflow.models import Deadline, Log
@@ -122,6 +131,35 @@ PS = ParamSpec("PS")
 RT = TypeVar("RT")
 
 
+class OverrideableRandomIdGenerator(RandomIdGenerator):
+    """Lets you override the span id."""
+
+    def generate_span_id(self):
+        override = context.get_value(OVERRIDE_SPAN_ID_KEY)
+        if override is not None:
+            context.attach(context.set_value(OVERRIDE_SPAN_ID_KEY, None))
+            return override
+        return super().generate_span_id()
+
+    def generate_trace_id(self):
+        override = context.get_value(OVERRIDE_TRACE_ID_KEY)
+        if override is not None:
+            context.attach(context.set_value(OVERRIDE_TRACE_ID_KEY, None))
+            return override
+        return super().generate_trace_id()
+
+
+@contextmanager
+def override_ids(trace_id, span_id, ctx=None):
+    ctx = context.set_value(OVERRIDE_TRACE_ID_KEY, trace_id, context=ctx)
+    ctx = context.set_value(OVERRIDE_SPAN_ID_KEY, span_id, context=ctx)
+    token = context.attach(ctx)
+    try:
+        yield
+    finally:
+        context.detach(token)
+
+
 def add_span(func: Callable[PS, RT]) -> Callable[PS, RT]:
     @wraps(func)
     def wrapper(self, *args, **kwargs) -> RT:
@@ -157,6 +195,42 @@ def _creator_note(val):
     if isinstance(val, dict):
         return DagRunNote(**val)
     return DagRunNote(*val)
+
+
+@contextmanager
+def use_root_context():
+    dummy_span_context = SpanContext(
+        trace_id=0x00000000000000000000000000000000,
+        span_id=0x0000000000000000,
+        is_remote=False,
+        trace_flags=TraceFlags(TraceFlags.SAMPLED),
+    )
+    ctx = trace.set_span_in_context(trace.NonRecordingSpan(dummy_span_context))
+    token = context.attach(ctx)
+    try:
+        yield
+    finally:
+        context.detach(token)
+
+
+@contextmanager
+def start_root_span():
+    generator = RandomIdGenerator()
+    trace_id = generator.generate_trace_id()
+    span_id = generator.generate_span_id()
+    with use_root_context():
+        span_context = SpanContext(
+            trace_id=trace_id,
+            span_id=span_id,
+            is_remote=True,
+            trace_flags=TraceFlags(TraceFlags.SAMPLED),
+        )
+        ctx = trace.set_span_in_context(trace.NonRecordingSpan(span_context))
+        token = context.attach(ctx)
+        try:
+            yield
+        finally:
+            context.detach(token)
 
 
 class DagRun(Base, LoggingMixin):
@@ -377,11 +451,10 @@ class DagRun(Base, LoggingMixin):
         self.triggered_by = triggered_by
         self.triggering_user_name = triggering_user_name
         self.scheduled_by_job_id = None
-        context_carrier = Trace.inject()
+
+        with start_root_span():
+            context_carrier = Trace.inject()
         self.context_carrier = context_carrier
-        span = Trace.get_current_span()
-        span.set_attribute("dag_id", self.dag_id)
-        span.set_attribute("run_id", self.run_id)
         if not isinstance(partition_key, str | None):
             raise ValueError(
                 f"Expected partition_key to be a `str` or `None` but got `{partition_key.__class__.__name__}`"
@@ -1024,6 +1097,41 @@ class DagRun(Base, LoggingMixin):
         leaf_tis = {ti for ti in tis if ti.task_id in leaf_task_ids if ti.state != TaskInstanceState.REMOVED}
         return leaf_tis
 
+    def _emit_dagrun_span(self):
+        # resource = Resource.create(
+        #     attributes={
+        #         SERVICE_NAME: "syntheticemitter",
+        #     }
+        # )
+        otel_env_config = load_traces_env_config()
+        host = conf.get("traces", "otel_host", fallback=None)
+        port = conf.getint("traces", "otel_port")
+        ssl_active = conf.getboolean("traces", "otel_ssl_active", fallback=False)
+        exporter = get_otel_data_exporter(
+            otel_env_config=otel_env_config,
+            host=host,
+            port=port,
+            ssl_active=ssl_active,
+        )
+        tracer_provider = TracerProvider(id_generator=OverrideableRandomIdGenerator())
+        processor = BatchSpanProcessor(exporter)
+        tracer_provider.add_span_processor(processor)
+        trace.set_tracer_provider(tracer_provider)
+        ctx = TraceContextTextMapPropagator().extract(self.context_carrier)
+        span = trace.get_current_span(context=ctx)
+        span_context = span.get_span_context()
+        tracer = trace.get_tracer(__name__)
+        log.warning("setting id overrides", trace_id=span_context.trace_id, span_id=span_context.span_id)
+        with override_ids(span_context.trace_id, span_context.span_id):
+            span = tracer.start_span(
+                "my-dag-run",
+                start_time=int(self.start_date.timestamp() * 1e9),
+                attributes={"airflow.dag.id": "my_dag"},
+                context=context.Context(),
+            )
+            span.set_status(StatusCode.OK)
+            span.end()
+
     @provide_session
     def update_state(
         self, session: Session = NEW_SESSION, execute_callbacks: bool = True
@@ -1215,7 +1323,7 @@ class DagRun(Base, LoggingMixin):
             )
 
             session.flush()
-
+            self._emit_dagrun_span()
         self._emit_true_scheduling_delay_stats_for_finished_state(finished_tis)
         self._emit_duration_stats_for_finished_state()
 

--- a/airflow-core/src/airflow/serialization/definitions/dag.py
+++ b/airflow-core/src/airflow/serialization/definitions/dag.py
@@ -40,6 +40,7 @@ from airflow.models.deadline import Deadline
 from airflow.models.deadline_alert import DeadlineAlert as DeadlineAlertModel
 from airflow.models.taskinstancekey import TaskInstanceKey
 from airflow.models.tasklog import LogTemplate
+from airflow.observability.trace import Trace
 from airflow.sdk._shared.observability.metrics.stats import Stats
 from airflow.serialization.decoders import decode_deadline_alert
 from airflow.serialization.definitions.deadline import DeadlineAlertFields, SerializedReferenceModels
@@ -68,6 +69,18 @@ if TYPE_CHECKING:
     from airflow.utils.types import DagRunTriggeredByType
 
 log = structlog.get_logger(__name__)
+
+
+def add_dagrun_span(func):
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+        tracer = Trace.get_tracer("dagrun")
+        with tracer.start_as_current_span("create_dagrun") as span:
+            span.set_attribute("dag_id", self.dag_id)
+            span.set_attribute("component", "scheduler")
+            return func(self, *args, **kwargs)
+
+    return wrapper
 
 
 # TODO (GH-52141): Share definition with SDK?
@@ -486,6 +499,7 @@ class SerializedDAG:
         return total_tasks >= self.max_active_tasks
 
     @provide_session
+    @add_dagrun_span
     def create_dagrun(
         self,
         *,

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -3277,65 +3277,6 @@ class TestSchedulerJob:
         assert self.job_runner.active_spans.get("dr:" + str(dr.id)) is None
         assert self.job_runner.active_spans.get(f"ti:{ti.id}") is None
 
-    @pytest.mark.parametrize(
-        ("state", "final_span_status"),
-        [
-            pytest.param(State.SUCCESS, SpanStatus.ENDED, id="dr_ended_successfully"),
-            pytest.param(State.RUNNING, SpanStatus.NEEDS_CONTINUANCE, id="dr_still_running"),
-        ],
-    )
-    def test_end_active_spans(self, state, final_span_status, dag_maker):
-        with dag_maker(
-            dag_id="test_end_active_spans",
-            start_date=DEFAULT_DATE,
-            max_active_runs=1,
-            dagrun_timeout=datetime.timedelta(seconds=60),
-        ):
-            EmptyOperator(task_id="dummy")
-
-        session = settings.Session()
-
-        job = Job()
-        job.job_type = SchedulerJobRunner.job_type
-
-        self.job_runner = SchedulerJobRunner(job=job)
-        self.job_runner.active_spans = ThreadSafeDict()
-        assert len(self.job_runner.active_spans.get_all()) == 0
-
-        dr = dag_maker.create_dagrun()
-        dr.state = state
-        dr.span_status = SpanStatus.ACTIVE
-
-        ti = dr.get_task_instances(session=session)[0]
-        ti.state = state
-        ti.span_status = SpanStatus.ACTIVE
-        ti.context_carrier = {}
-        session.merge(ti)
-        session.merge(dr)
-        session.commit()
-
-        dr_span = Trace.start_root_span(span_name="dag_run_span", start_as_current=False)
-        ti_span = Trace.start_child_span(span_name="ti_span", start_as_current=False)
-
-        self.job_runner.active_spans.set("dr:" + str(dr.id), dr_span)
-        self.job_runner.active_spans.set(f"ti:{ti.id}", ti_span)
-
-        assert dr.span_status == SpanStatus.ACTIVE
-        assert ti.span_status == SpanStatus.ACTIVE
-
-        assert self.job_runner.active_spans.get("dr:" + str(dr.id)) is not None
-        assert self.job_runner.active_spans.get(f"ti:{ti.id}") is not None
-        assert len(self.job_runner.active_spans.get_all()) == 2
-
-        self.job_runner._end_active_spans(session)
-
-        assert dr.span_status == final_span_status
-        assert ti.span_status == final_span_status
-
-        assert self.job_runner.active_spans.get("dr:" + str(dr.id)) is None
-        assert self.job_runner.active_spans.get(f"ti:{ti.id}") is None
-        assert len(self.job_runner.active_spans.get_all()) == 0
-
     def test_dagrun_timeout_verify_max_active_runs(self, dag_maker, session):
         """
         Test if a dagrun will not be scheduled if max_dag_runs

--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
@@ -51,6 +51,7 @@ from airflow.providers.openlineage.utils.utils import (
     is_selective_lineage_enabled,
     print_warning,
 )
+from airflow.sdk.observability.trace import Trace
 from airflow.settings import configure_orm
 from airflow.utils.state import TaskInstanceState
 
@@ -243,6 +244,7 @@ class OpenLineageListener:
     if AIRFLOW_V_3_0_PLUS:
 
         @hookimpl
+        @Trace.start_span("openlineage.success")
         def on_task_instance_success(
             self, previous_state: TaskInstanceState, task_instance: RuntimeTaskInstance | TaskInstance
         ) -> None:

--- a/shared/observability/src/airflow_shared/observability/traces/base_tracer.py
+++ b/shared/observability/src/airflow_shared/observability/traces/base_tracer.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Protocol
 
 import structlog
@@ -177,6 +178,10 @@ class EmptyTrace:
     ):
         """Get a tracer using provided node id and trace id."""
         return cls
+
+    @contextmanager
+    def start_as_current_span(self):
+        yield EMPTY_SPAN
 
     @classmethod
     def start_span(

--- a/shared/observability/src/airflow_shared/observability/traces/otel_tracer.py
+++ b/shared/observability/src/airflow_shared/observability/traces/otel_tracer.py
@@ -23,7 +23,7 @@ from contextlib import AbstractContextManager
 from typing import TYPE_CHECKING
 
 import pendulum
-from opentelemetry import trace
+from opentelemetry import context, trace
 from opentelemetry.context import attach, create_key
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import Span, SpanProcessor, Tracer as OpenTelemetryTracer, TracerProvider
@@ -33,7 +33,7 @@ from opentelemetry.sdk.trace.export import (
     SimpleSpanProcessor,
     SpanExporter,
 )
-from opentelemetry.sdk.trace.id_generator import IdGenerator
+from opentelemetry.sdk.trace.id_generator import IdGenerator, RandomIdGenerator
 from opentelemetry.trace import Link, NonRecordingSpan, SpanContext, TraceFlags, Tracer
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from opentelemetry.trace.span import INVALID_SPAN_ID, INVALID_TRACE_ID
@@ -52,6 +52,28 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 _NEXT_ID = create_key("next_id")
+
+
+OVERRIDE_SPAN_ID_KEY = context.create_key("override_span_id")
+OVERRIDE_TRACE_ID_KEY = context.create_key("override_trace_id")
+
+
+class OverrideableRandomIdGenerator(RandomIdGenerator):
+    """Lets you override the span id."""
+
+    def generate_span_id(self):
+        override = context.get_value(OVERRIDE_SPAN_ID_KEY)
+        if override is not None:
+            context.attach(context.set_value(OVERRIDE_SPAN_ID_KEY, None))
+            return override
+        return super().generate_span_id()
+
+    def generate_trace_id(self):
+        override = context.get_value(OVERRIDE_TRACE_ID_KEY)
+        if override is not None:
+            context.attach(context.set_value(OVERRIDE_TRACE_ID_KEY, None))
+            return override
+        return super().generate_trace_id()
 
 
 class OtelTrace:
@@ -100,7 +122,7 @@ class OtelTrace:
             # in case where trace_id or span_id was given
             tracer_provider = TracerProvider(
                 resource=self.resource,
-                id_generator=AirflowOtelIdGenerator(span_id=span_id, trace_id=trace_id),
+                id_generator=OverrideableRandomIdGenerator(),
             )
         else:
             tracer_provider = TracerProvider(resource=self.resource)

--- a/shared/observability/src/airflow_shared/observability/traces/otel_tracer.py
+++ b/shared/observability/src/airflow_shared/observability/traces/otel_tracer.py
@@ -38,6 +38,8 @@ from opentelemetry.trace import Link, NonRecordingSpan, SpanContext, TraceFlags,
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from opentelemetry.trace.span import INVALID_SPAN_ID, INVALID_TRACE_ID
 
+from airflow.configuration import conf
+
 from ..common import get_otel_data_exporter
 from ..otel_env_config import load_traces_env_config
 from .utils import (
@@ -74,6 +76,36 @@ class OverrideableRandomIdGenerator(RandomIdGenerator):
             context.attach(context.set_value(OVERRIDE_TRACE_ID_KEY, None))
             return override
         return super().generate_trace_id()
+
+
+port = conf.getint("traces", "otel_port", fallback=None)
+host = conf.get("traces", "otel_host", fallback=None)
+ssl_active = conf.getboolean("traces", "otel_ssl_active", fallback=False)
+otel_service = conf.get("traces", "otel_service", fallback=None)
+debug = conf.getboolean("traces", "otel_debugging_on", fallback=False)
+resource = Resource.create(attributes={SERVICE_NAME: otel_service})
+
+otel_env_config = load_traces_env_config()
+
+exporter = get_otel_data_exporter(
+    otel_env_config=otel_env_config,
+    host=host,
+    port=port,
+    ssl_active=ssl_active,
+)
+
+if self.debug is True:
+    log.info("[ConsoleSpanExporter] is being used")
+    if self.use_simple_processor:
+        log.info("[SimpleSpanProcessor] is being used")
+        span_processor_for_tracer_prov: SpanProcessor = SimpleSpanProcessor(ConsoleSpanExporter())
+    else:
+        log.info("[BatchSpanProcessor] is being used")
+        span_processor_for_tracer_prov = BatchSpanProcessor(ConsoleSpanExporter())
+else:
+    span_processor_for_tracer_prov = self.span_processor
+
+tracer_provider.add_span_processor(span_processor_for_tracer_prov)
 
 
 class OtelTrace:
@@ -370,13 +402,6 @@ def get_otel_tracer(
     otel_env_config = load_traces_env_config()
 
     tag_string = cls.get_constant_tags()
-
-    exporter = get_otel_data_exporter(
-        otel_env_config=otel_env_config,
-        host=host,
-        port=port,
-        ssl_active=ssl_active,
-    )
 
     otel_service = otel_env_config.service_name or otel_service
 

--- a/task-sdk/src/airflow/sdk/definitions/dag.py
+++ b/task-sdk/src/airflow/sdk/definitions/dag.py
@@ -1324,10 +1324,6 @@ class DAG:
                 triggered_by=DagRunTriggeredByType.TEST,
                 triggering_user_name="dag_test",
             )
-            # Start a mock span so that one is present and not started downstream. We
-            # don't care about otel in dag.test and starting the span during dagrun update
-            # is not functioning properly in this context anyway.
-            dr.start_dr_spans_if_needed(tis=[])
 
             log.debug("starting dagrun")
             # Instead of starting a scheduler, we run the minimal loop possible to check

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -41,6 +41,7 @@ from pydantic import AwareDatetime, ConfigDict, Field, JsonValue, TypeAdapter
 from airflow.dag_processing.bundles.base import BaseDagBundle, BundleVersionLock
 from airflow.dag_processing.bundles.manager import DagBundlesManager
 from airflow.sdk._shared.observability.metrics.stats import Stats
+from airflow.sdk._shared.observability.traces.base_tracer import EMPTY_SPAN
 from airflow.sdk.api.client import get_hostname, getuser
 from airflow.sdk.api.datamodels._generated import (
     AssetProfile,
@@ -732,21 +733,24 @@ def parse(what: StartupDetails, log: Logger) -> RuntimeTaskInstance:
     from airflow.dag_processing.dagbag import BundleDagBag
 
     bundle_info = what.bundle_info
-    bundle_instance = DagBundlesManager().get_bundle(
-        name=bundle_info.name,
-        version=bundle_info.version,
-    )
-    bundle_instance.initialize()
+    with Trace.start_span("get_bundle"):
+        bundle_instance = DagBundlesManager().get_bundle(
+            name=bundle_info.name,
+            version=bundle_info.version,
+        )
+    with Trace.start_span("initialize"):
+        bundle_instance.initialize()
     _verify_bundle_access(bundle_instance, log)
 
     dag_absolute_path = os.fspath(Path(bundle_instance.path, what.dag_rel_path))
-    bag = BundleDagBag(
-        dag_folder=dag_absolute_path,
-        safe_mode=False,
-        load_op_links=False,
-        bundle_path=bundle_instance.path,
-        bundle_name=bundle_info.name,
-    )
+    with Trace.start_span("bundle_init"):
+        bag = BundleDagBag(
+            dag_folder=dag_absolute_path,
+            safe_mode=False,
+            load_op_links=False,
+            bundle_path=bundle_instance.path,
+            bundle_name=bundle_info.name,
+        )
     if TYPE_CHECKING:
         assert what.ti.dag_id
 
@@ -810,6 +814,7 @@ SUPERVISOR_COMMS: CommsDecoder[ToTask, ToSupervisor]
 # 3. Shutdown and report status
 
 
+@Trace.start_span("_verify_bundle_access")
 def _verify_bundle_access(bundle_instance: BaseDagBundle, log: Logger) -> None:
     """
     Verify bundle is accessible by the current user.
@@ -848,6 +853,9 @@ def _verify_bundle_access(bundle_instance: BaseDagBundle, log: Logger) -> None:
 
 @contextmanager
 def _set_span(ti, parent_context, name):
+    if not ti or not parent_context:
+        yield EMPTY_SPAN
+        return
     with Trace.start_child_span(
         span_name=name,
         parent_context=parent_context,
@@ -1767,69 +1775,84 @@ def finalize(
 
     task = ti.task
     # Pushing xcom for each operator extra links defined on the operator only.
-    for oe in task.operator_extra_links:
-        try:
-            link, xcom_key = oe.get_link(operator=task, ti_key=ti), oe.xcom_key  # type: ignore[arg-type]
-            log.debug("Setting xcom for operator extra link", link=link, xcom_key=xcom_key)
-            _xcom_push_to_db(ti, key=xcom_key, value=link)
-        except Exception:
-            log.exception(
-                "Failed to push an xcom for task operator extra link",
-                link_name=oe.name,
-                xcom_key=oe.xcom_key,
-                ti=ti,
-            )
+    with Trace.start_span("handle_extra_links"):
+        for oe in task.operator_extra_links:
+            try:
+                link, xcom_key = oe.get_link(operator=task, ti_key=ti), oe.xcom_key  # type: ignore[arg-type]
+                log.debug("Setting xcom for operator extra link", link=link, xcom_key=xcom_key)
+                _xcom_push_to_db(ti, key=xcom_key, value=link)
+            except Exception:
+                log.exception(
+                    "Failed to push an xcom for task operator extra link",
+                    link_name=oe.name,
+                    xcom_key=oe.xcom_key,
+                    ti=ti,
+                )
 
     if getattr(ti.task, "overwrite_rtif_after_execution", False):
-        log.debug("Overwriting Rendered template fields.")
-        if ti.task.template_fields:
-            try:
-                SUPERVISOR_COMMS.send(SetRenderedFields(rendered_fields=_serialize_rendered_fields(ti.task)))
-            except Exception:
-                log.exception("Failed to set rendered fields during finalization", ti=ti, task=ti.task)
+        with Trace.start_span("overwrite_rtif"):
+            log.debug("Overwriting Rendered template fields.")
+            if ti.task.template_fields:
+                try:
+                    SUPERVISOR_COMMS.send(
+                        SetRenderedFields(rendered_fields=_serialize_rendered_fields(ti.task))
+                    )
+                except Exception:
+                    log.exception("Failed to set rendered fields during finalization", ti=ti, task=ti.task)
 
     log.debug("Running finalizers", ti=ti)
     if state == TaskInstanceState.SUCCESS:
-        _run_task_state_change_callbacks(task, "on_success_callback", context, log)
-        try:
-            get_listener_manager().hook.on_task_instance_success(
-                previous_state=TaskInstanceState.RUNNING, task_instance=ti
-            )
-        except Exception:
-            log.exception("error calling listener")
+        with Trace.start_span("success_callback"):
+            _run_task_state_change_callbacks(task, "on_success_callback", context, log)
+        with Trace.start_span("listener.success_callback"):
+            try:
+                get_listener_manager().hook.on_task_instance_success(
+                    previous_state=TaskInstanceState.RUNNING, task_instance=ti
+                )
+            except Exception:
+                log.exception("error calling listener")
     elif state == TaskInstanceState.SKIPPED:
-        _run_task_state_change_callbacks(task, "on_skipped_callback", context, log)
-        try:
-            get_listener_manager().hook.on_task_instance_skipped(
-                previous_state=TaskInstanceState.RUNNING, task_instance=ti
-            )
-        except Exception:
-            log.exception("error calling listener")
+        with Trace.start_span("skipped_callback"):
+            _run_task_state_change_callbacks(task, "on_skipped_callback", context, log)
+        with Trace.start_span("listener.success_callback"):
+            try:
+                get_listener_manager().hook.on_task_instance_skipped(
+                    previous_state=TaskInstanceState.RUNNING, task_instance=ti
+                )
+            except Exception:
+                log.exception("error calling listener")
     elif state == TaskInstanceState.UP_FOR_RETRY:
-        _run_task_state_change_callbacks(task, "on_retry_callback", context, log)
-        try:
-            get_listener_manager().hook.on_task_instance_failed(
-                previous_state=TaskInstanceState.RUNNING, task_instance=ti, error=error
-            )
-        except Exception:
-            log.exception("error calling listener")
+        with Trace.start_span("retry_callback"):
+            _run_task_state_change_callbacks(task, "on_retry_callback", context, log)
+        with Trace.start_span("listener.retry_callback"):
+            try:
+                get_listener_manager().hook.on_task_instance_failed(
+                    previous_state=TaskInstanceState.RUNNING, task_instance=ti, error=error
+                )
+            except Exception:
+                log.exception("error calling listener")
         if error and task.email_on_retry and task.email:
-            _send_error_email_notification(task, ti, context, error, log)
+            with Trace.start_span("email_notif"):
+                _send_error_email_notification(task, ti, context, error, log)
     elif state == TaskInstanceState.FAILED:
-        _run_task_state_change_callbacks(task, "on_failure_callback", context, log)
+        with Trace.start_span("failure_callback"):
+            _run_task_state_change_callbacks(task, "on_failure_callback", context, log)
+        with Trace.start_span("listener.failure_callback"):
+            try:
+                get_listener_manager().hook.on_task_instance_failed(
+                    previous_state=TaskInstanceState.RUNNING, task_instance=ti, error=error
+                )
+            except Exception:
+                log.exception("error calling listener")
+        if error and task.email_on_failure and task.email:
+            with Trace.start_span("send_error_email"):
+                _send_error_email_notification(task, ti, context, error, log)
+
+    with Trace.start_span("listener.before_stopping"):
         try:
-            get_listener_manager().hook.on_task_instance_failed(
-                previous_state=TaskInstanceState.RUNNING, task_instance=ti, error=error
-            )
+            get_listener_manager().hook.before_stopping(component=TaskRunnerMarker())
         except Exception:
             log.exception("error calling listener")
-        if error and task.email_on_failure and task.email:
-            _send_error_email_notification(task, ti, context, error, log)
-
-    try:
-        get_listener_manager().hook.before_stopping(component=TaskRunnerMarker())
-    except Exception:
-        log.exception("error calling listener")
 
 
 def main():
@@ -1840,7 +1863,8 @@ def main():
 
     stats_factory = stats_utils.get_stats_factory(Stats)
     Stats.initialize(factory=stats_factory)
-
+    ti = None
+    parent_context = None
     try:
         try:
             ti, context, log = startup()
@@ -1873,9 +1897,10 @@ def main():
     finally:
         # Ensure the request socket is closed on the child side in all circumstances
         # before the process fully terminates.
-        if SUPERVISOR_COMMS and SUPERVISOR_COMMS.socket:
-            with suppress(Exception):
-                SUPERVISOR_COMMS.socket.close()
+        with _set_span(ti, parent_context, "close_socket"):
+            if SUPERVISOR_COMMS and SUPERVISOR_COMMS.socket:
+                with suppress(Exception):
+                    SUPERVISOR_COMMS.socket.close()
 
 
 def reinit_supervisor_comms() -> None:

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -26,7 +26,7 @@ import os
 import sys
 import time
 from collections.abc import Callable, Iterable, Iterator, Mapping
-from contextlib import suppress
+from contextlib import contextmanager, suppress
 from datetime import datetime, timedelta, timezone
 from itertools import product
 from pathlib import Path
@@ -181,6 +181,7 @@ class RuntimeTaskInstance(TaskInstance):
 
     __rich_repr__.angular = True  # type: ignore[attr-defined]
 
+    @Trace.start_span("get_template_context")
     def get_template_context(self) -> Context:
         # TODO: Move this to `airflow.sdk.execution_time.context`
         #   once we port the entire context logic from airflow/utils/context.py ?
@@ -724,6 +725,7 @@ def _maybe_reschedule_startup_failure(
     )
 
 
+@Trace.start_span("parse")
 def parse(what: StartupDetails, log: Logger) -> RuntimeTaskInstance:
     # TODO: Task-SDK:
     # Using BundleDagBag here is about 98% wrong, but it'll do for now
@@ -844,9 +846,6 @@ def _verify_bundle_access(bundle_instance: BaseDagBundle, log: Logger) -> None:
         )
 
 
-from contextlib import contextmanager
-
-
 @contextmanager
 def _set_span(ti, parent_context, name):
     with Trace.start_child_span(
@@ -890,58 +889,58 @@ def startup() -> tuple[RuntimeTaskInstance, Context, Logger]:
 
         if not isinstance(msg, StartupDetails):
             raise RuntimeError(f"Unhandled startup message {type(msg)} {msg}")
-    ti = msg.ti
-    parent_context = Trace.extract(ti.context_carrier) if ti.context_carrier else None
-    # setproctitle causes issue on Mac OS: https://github.com/benoitc/gunicorn/issues/3021
-    os_type = sys.platform
-    if os_type == "darwin":
-        log.debug("Mac OS detected, skipping setproctitle")
-    else:
-        from setproctitle import setproctitle
 
-        setproctitle(f"airflow worker -- {msg.ti.id}")
-    with _set_span(ti, parent_context, "hook.on_starting"):
-        try:
-            get_listener_manager().hook.on_starting(component=TaskRunnerMarker())
-        except Exception:
-            log.exception("error calling listener")
+    parent_context = Trace.extract(msg.ti.context_carrier) if msg.ti.context_carrier else None
+    with _set_span(msg.ti, parent_context, "startup"):
+        # setproctitle causes issue on Mac OS: https://github.com/benoitc/gunicorn/issues/3021
+        os_type = sys.platform
+        if os_type == "darwin":
+            log.debug("Mac OS detected, skipping setproctitle")
+        else:
+            from setproctitle import setproctitle
 
-    with _set_span(ti, parent_context, "parse"):
+            setproctitle(f"airflow worker -- {msg.ti.id}")
+
+        with Trace.start_span("hook.on_starting"):
+            try:
+                get_listener_manager().hook.on_starting(component=TaskRunnerMarker())
+            except Exception:
+                log.exception("error calling listener")
+
         with _airflow_parsing_context_manager(dag_id=msg.ti.dag_id, task_id=msg.ti.task_id):
             ti = parse(msg, log)
         log.debug("Dag file parsed", file=msg.dag_rel_path)
 
-    run_as_user = getattr(ti.task, "run_as_user", None) or conf.get(
-        "core", "default_impersonation", fallback=None
-    )
-
-    if os.environ.get("_AIRFLOW__REEXECUTED_PROCESS") != "1" and run_as_user and run_as_user != getuser():
-        # enters here for re-exec process
-        os.environ["_AIRFLOW__REEXECUTED_PROCESS"] = "1"
-        # store startup message in environment for re-exec process
-        os.environ["_AIRFLOW__STARTUP_MSG"] = msg.model_dump_json()
-        os.set_inheritable(SUPERVISOR_COMMS.socket.fileno(), True)
-
-        # Import main directly from the module instead of re-executing the file.
-        # This ensures that when other parts modules import
-        # airflow.sdk.execution_time.task_runner, they get the same module instance
-        # with the properly initialized SUPERVISOR_COMMS global variable.
-        # If we re-executed the module with `python -m`, it would load as __main__ and future
-        # imports would get a fresh copy without the initialized globals.
-        rexec_python_code = "from airflow.sdk.execution_time.task_runner import main; main()"
-        cmd = ["sudo", "-E", "-H", "-u", run_as_user, sys.executable, "-c", rexec_python_code]
-        log.info(
-            "Running command",
-            command=cmd,
+        run_as_user = getattr(ti.task, "run_as_user", None) or conf.get(
+            "core", "default_impersonation", fallback=None
         )
-        os.execvp("sudo", cmd)
 
-        # ideally, we should never reach here, but if we do, we should return None, None, None
-        return None, None, None
+        if os.environ.get("_AIRFLOW__REEXECUTED_PROCESS") != "1" and run_as_user and run_as_user != getuser():
+            # enters here for re-exec process
+            os.environ["_AIRFLOW__REEXECUTED_PROCESS"] = "1"
+            # store startup message in environment for re-exec process
+            os.environ["_AIRFLOW__STARTUP_MSG"] = msg.model_dump_json()
+            os.set_inheritable(SUPERVISOR_COMMS.socket.fileno(), True)
 
-    with _set_span(ti, parent_context, "get_template_context"):
+            # Import main directly from the module instead of re-executing the file.
+            # This ensures that when other parts modules import
+            # airflow.sdk.execution_time.task_runner, they get the same module instance
+            # with the properly initialized SUPERVISOR_COMMS global variable.
+            # If we re-executed the module with `python -m`, it would load as __main__ and future
+            # imports would get a fresh copy without the initialized globals.
+            rexec_python_code = "from airflow.sdk.execution_time.task_runner import main; main()"
+            cmd = ["sudo", "-E", "-H", "-u", run_as_user, sys.executable, "-c", rexec_python_code]
+            log.info(
+                "Running command",
+                command=cmd,
+            )
+            os.execvp("sudo", cmd)
+
+            # ideally, we should never reach here, but if we do, we should return None, None, None
+            return None, None, None
+
         template_context = ti.get_template_context()
-    return ti, template_context, log
+        return ti, template_context, log
 
 
 def _serialize_template_field(template_field: Any, name: str) -> str | dict | list | int | float:
@@ -1195,7 +1194,6 @@ def run(
     ti: RuntimeTaskInstance,
     context: Context,
     log: Logger,
-    span,
 ) -> tuple[TaskInstanceState, ToSupervisor | None, BaseException | None]:
     """Run the task in this process."""
     import signal
@@ -1260,8 +1258,7 @@ def run(
                 return state, msg, error
 
             try:
-                with Trace.start_span("execute"):
-                    result = _execute_task(context=context, ti=ti, log=log, span=span)
+                result = _execute_task(context=context, ti=ti, log=log)
             except Exception:
                 import jinja2
 
@@ -1625,7 +1622,8 @@ def _send_error_email_notification(
         log.exception("Failed to send email notification")
 
 
-def _execute_task(context: Context, ti: RuntimeTaskInstance, log: Logger, span):
+@Trace.start_span("_execute_task")
+def _execute_task(context: Context, ti: RuntimeTaskInstance, log: Logger):
     """Execute Task (optionally with a Timeout) and push Xcom results."""
     task = ti.task
     execute = task.execute
@@ -1666,29 +1664,25 @@ def _execute_task(context: Context, ti: RuntimeTaskInstance, log: Logger, span):
     with Trace.start_span("on_execute_callback"):
         _run_task_state_change_callbacks(task, "on_execute_callback", context, log)
 
-    if task.execution_timeout:
-        from airflow.sdk.execution_time.timeout import timeout
+    with Trace.start_span("execute") as span:
+        if task.execution_timeout:
+            from airflow.sdk.execution_time.timeout import timeout
 
-        # TODO: handle timeout in case of deferral
-        timeout_seconds = task.execution_timeout.total_seconds()
-        try:
-            # It's possible we're already timed out, so fast-fail if true
-            if timeout_seconds <= 0:
-                raise AirflowTaskTimeout()
-            # Run task in timeout wrapper
-            with timeout(timeout_seconds), Trace.start_span("execute"):
-                span.add_event("task.execute.start")
-                result = ctx.run(execute, context=context)
-                span.add_event("task.execute.end")
-        except AirflowTaskTimeout:
-            span.add_event("task.execute.timeout")
-            task.on_kill()
-            raise
-    else:
-        with Trace.start_span("execute"):
-            span.add_event("task.execute.start")
+            # TODO: handle timeout in case of deferral
+            timeout_seconds = task.execution_timeout.total_seconds()
+            try:
+                # It's possible we're already timed out, so fast-fail if true
+                if timeout_seconds <= 0:
+                    raise AirflowTaskTimeout()
+                # Run task in timeout wrapper
+                with timeout(timeout_seconds):
+                    result = ctx.run(execute, context=context)
+            except AirflowTaskTimeout:
+                span.add_event("task.execute.timeout")
+                task.on_kill()
+                raise
+        else:
             result = ctx.run(execute, context=context)
-            span.add_event("task.execute.finish")
 
     with Trace.start_span("post_execute_hook"):
         if (post_execute_hook := task._post_execute_hook) is not None:
@@ -1755,6 +1749,7 @@ def _push_xcom_if_needed(result: Any, ti: RuntimeTaskInstance, log: Logger):
     _xcom_push(ti, BaseXCom.XCOM_RETURN_KEY, result, mapped_length=mapped_length)
 
 
+@Trace.start_span("finalize")
 def finalize(
     ti: RuntimeTaskInstance,
     state: TaskInstanceState,
@@ -1865,10 +1860,9 @@ def main():
             bundle_version=ti.bundle_instance.version,
         ):
             with _set_span(ti, parent_context, "run") as span:
-                state, _, error = run(ti, context, log, span=span)
+                state, _, error = run(ti, context, log)
                 context["exception"] = error
                 span.set_attribute("state", state.value if state else "unknown")
-            with _set_span(ti, parent_context, "finalize"):
                 finalize(ti, state, context, log, error)
     except KeyboardInterrupt:
         log.exception("Ctrl-c hit")

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -855,14 +855,17 @@ def _verify_bundle_access(bundle_instance: BaseDagBundle, log: Logger) -> None:
 
 @contextmanager
 def _set_span(msg: StartupDetails):
+    log = structlog.get_logger()
     parent_context = Trace.extract(msg.ti.context_carrier) if msg.ti.context_carrier else None
     ti = msg.ti
     span_name = f"task_run.{ti.task_id}"
     if ti.map_index > 0:
         span_name += f"_{ti.map_index}"
+    if not parent_context:
+        log.warning("no context carrier", carrier=msg.ti.context_carrier)
     with Trace.start_child_span(
         span_name=span_name,
-        parent_context=parent_context,
+        parent_context=parent_context or {},
         component="task",
     ) as span:
         span.set_attributes(

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -36,12 +36,13 @@ from urllib.parse import quote
 import attrs
 import lazy_object_proxy
 import structlog
+from opentelemetry.trace import Status, StatusCode
 from pydantic import AwareDatetime, ConfigDict, Field, JsonValue, TypeAdapter
 
 from airflow.dag_processing.bundles.base import BaseDagBundle, BundleVersionLock
 from airflow.dag_processing.bundles.manager import DagBundlesManager
 from airflow.sdk._shared.observability.metrics.stats import Stats
-from airflow.sdk._shared.observability.traces.base_tracer import EMPTY_SPAN
+from airflow.sdk._shared.observability.traces.base_tracer import EmptySpan
 from airflow.sdk.api.client import get_hostname, getuser
 from airflow.sdk.api.datamodels._generated import (
     AssetProfile,
@@ -127,6 +128,7 @@ from airflow.sdk.timezone import coerce_datetime
 
 if TYPE_CHECKING:
     import jinja2
+    from opentelemetry.sdk.trace import Span
     from pendulum.datetime import DateTime
     from structlog.typing import FilteringBoundLogger as Logger
 
@@ -852,12 +854,14 @@ def _verify_bundle_access(bundle_instance: BaseDagBundle, log: Logger) -> None:
 
 
 @contextmanager
-def _set_span(ti, parent_context, name):
-    if not ti or not parent_context:
-        yield EMPTY_SPAN
-        return
+def _set_span(msg: StartupDetails):
+    parent_context = Trace.extract(msg.ti.context_carrier) if msg.ti.context_carrier else None
+    ti = msg.ti
+    span_name = f"task_run.{ti.task_id}"
+    if ti.map_index > 0:
+        span_name += f"_{ti.map_index}"
     with Trace.start_child_span(
-        span_name=name,
+        span_name=span_name,
         parent_context=parent_context,
         component="task",
     ) as span:
@@ -873,82 +877,58 @@ def _set_span(ti, parent_context, name):
         yield span
 
 
-def startup() -> tuple[RuntimeTaskInstance, Context, Logger]:
-    # The parent sends us a StartupDetails message un-prompted. After this, every single message is only sent
-    # in response to us sending a request.
-    log = structlog.get_logger(logger_name="task")
-
-    if os.environ.get("_AIRFLOW__REEXECUTED_PROCESS") == "1" and (
-        msgjson := os.environ.get("_AIRFLOW__STARTUP_MSG")
-    ):
-        # Clear any Kerberos replace cache if there is one, so new process can't reuse it.
-        os.environ.pop("KRB5CCNAME", None)
-        # entrypoint of re-exec process
-
-        msg: StartupDetails = TypeAdapter(StartupDetails).validate_json(msgjson)
-        reinit_supervisor_comms()
-
-        # We delay this message until _after_ we've got the logging re-configured, otherwise it will show up
-        # on stdout
-        log.debug("Using serialized startup message from environment", msg=msg)
+@Trace.start_span("startup")
+def startup(msg: StartupDetails) -> tuple[RuntimeTaskInstance, Context]:
+    log = structlog.get_logger("task")
+    # setproctitle causes issue on Mac OS: https://github.com/benoitc/gunicorn/issues/3021
+    os_type = sys.platform
+    if os_type == "darwin":
+        log.debug("Mac OS detected, skipping setproctitle")
     else:
-        # normal entry point
-        msg = SUPERVISOR_COMMS._get_response()  # type: ignore[assignment]
+        from setproctitle import setproctitle
 
-        if not isinstance(msg, StartupDetails):
-            raise RuntimeError(f"Unhandled startup message {type(msg)} {msg}")
+        setproctitle(f"airflow worker -- {msg.ti.id}")
 
-    parent_context = Trace.extract(msg.ti.context_carrier) if msg.ti.context_carrier else None
-    with _set_span(msg.ti, parent_context, "startup"):
-        # setproctitle causes issue on Mac OS: https://github.com/benoitc/gunicorn/issues/3021
-        os_type = sys.platform
-        if os_type == "darwin":
-            log.debug("Mac OS detected, skipping setproctitle")
-        else:
-            from setproctitle import setproctitle
+    with Trace.start_span("hook.on_starting"):
+        try:
+            get_listener_manager().hook.on_starting(component=TaskRunnerMarker())
+        except Exception:
+            log.exception("error calling listener")
 
-            setproctitle(f"airflow worker -- {msg.ti.id}")
+    with _airflow_parsing_context_manager(dag_id=msg.ti.dag_id, task_id=msg.ti.task_id):
+        ti = parse(msg, log)
+    log.debug("Dag file parsed", file=msg.dag_rel_path)
 
-        with Trace.start_span("hook.on_starting"):
-            try:
-                get_listener_manager().hook.on_starting(component=TaskRunnerMarker())
-            except Exception:
-                log.exception("error calling listener")
+    run_as_user = getattr(ti.task, "run_as_user", None) or conf.get(
+        "core", "default_impersonation", fallback=None
+    )
 
-        with _airflow_parsing_context_manager(dag_id=msg.ti.dag_id, task_id=msg.ti.task_id):
-            ti = parse(msg, log)
-        log.debug("Dag file parsed", file=msg.dag_rel_path)
+    if os.environ.get("_AIRFLOW__REEXECUTED_PROCESS") != "1" and run_as_user and run_as_user != getuser():
+        # enters here for re-exec process
+        os.environ["_AIRFLOW__REEXECUTED_PROCESS"] = "1"
+        # store startup message in environment for re-exec process
+        os.environ["_AIRFLOW__STARTUP_MSG"] = msg.model_dump_json()
+        os.set_inheritable(SUPERVISOR_COMMS.socket.fileno(), True)
 
-        run_as_user = getattr(ti.task, "run_as_user", None) or conf.get(
-            "core", "default_impersonation", fallback=None
+        # Import main directly from the module instead of re-executing the file.
+        # This ensures that when other parts modules import
+        # airflow.sdk.execution_time.task_runner, they get the same module instance
+        # with the properly initialized SUPERVISOR_COMMS global variable.
+        # If we re-executed the module with `python -m`, it would load as __main__ and future
+        # imports would get a fresh copy without the initialized globals.
+        rexec_python_code = "from airflow.sdk.execution_time.task_runner import main; main()"
+        cmd = ["sudo", "-E", "-H", "-u", run_as_user, sys.executable, "-c", rexec_python_code]
+        log.info(
+            "Running command",
+            command=cmd,
         )
+        os.execvp("sudo", cmd)
 
-        if os.environ.get("_AIRFLOW__REEXECUTED_PROCESS") != "1" and run_as_user and run_as_user != getuser():
-            # enters here for re-exec process
-            os.environ["_AIRFLOW__REEXECUTED_PROCESS"] = "1"
-            # store startup message in environment for re-exec process
-            os.environ["_AIRFLOW__STARTUP_MSG"] = msg.model_dump_json()
-            os.set_inheritable(SUPERVISOR_COMMS.socket.fileno(), True)
+        # ideally, we should never reach here, but if we do, we should return None, None, None
+        return None, None, None
 
-            # Import main directly from the module instead of re-executing the file.
-            # This ensures that when other parts modules import
-            # airflow.sdk.execution_time.task_runner, they get the same module instance
-            # with the properly initialized SUPERVISOR_COMMS global variable.
-            # If we re-executed the module with `python -m`, it would load as __main__ and future
-            # imports would get a fresh copy without the initialized globals.
-            rexec_python_code = "from airflow.sdk.execution_time.task_runner import main; main()"
-            cmd = ["sudo", "-E", "-H", "-u", run_as_user, sys.executable, "-c", rexec_python_code]
-            log.info(
-                "Running command",
-                command=cmd,
-            )
-            os.execvp("sudo", cmd)
-
-            # ideally, we should never reach here, but if we do, we should return None, None, None
-            return None, None, None
-
-        template_context = ti.get_template_context()
-        return ti, template_context, log
+    template_context = ti.get_template_context()
+    return ti, template_context
 
 
 def _serialize_template_field(template_field: Any, name: str) -> str | dict | list | int | float:
@@ -1855,6 +1835,33 @@ def finalize(
             log.exception("error calling listener")
 
 
+def get_startup_details() -> StartupDetails:
+    # The parent sends us a StartupDetails message un-prompted. After this, every single message is only sent
+    # in response to us sending a request.
+    log = structlog.get_logger(logger_name="task")
+
+    if os.environ.get("_AIRFLOW__REEXECUTED_PROCESS") == "1" and (
+        msgjson := os.environ.get("_AIRFLOW__STARTUP_MSG")
+    ):
+        # Clear any Kerberos replace cache if there is one, so new process can't reuse it.
+        os.environ.pop("KRB5CCNAME", None)
+        # entrypoint of re-exec process
+
+        msg: StartupDetails = TypeAdapter(StartupDetails).validate_json(msgjson)
+        reinit_supervisor_comms()
+
+        # We delay this message until _after_ we've got the logging re-configured, otherwise it will show up
+        # on stdout
+        log.debug("Using serialized startup message from environment", msg=msg)
+    else:
+        # normal entry point
+        msg = SUPERVISOR_COMMS._get_response()  # type: ignore[assignment]
+
+        if not isinstance(msg, StartupDetails):
+            raise RuntimeError(f"Unhandled startup message {type(msg)} {msg}")
+    return msg
+
+
 def main():
     log = structlog.get_logger(logger_name="task")
 
@@ -1864,43 +1871,60 @@ def main():
     stats_factory = stats_utils.get_stats_factory(Stats)
     Stats.initialize(factory=stats_factory)
     ti = None
-    parent_context = None
-    try:
-        try:
-            ti, context, log = startup()
-        except AirflowRescheduleException as reschedule:
-            log.warning("Rescheduling task during startup, marking task as UP_FOR_RESCHEDULE")
-            SUPERVISOR_COMMS.send(
-                msg=RescheduleTask(
-                    reschedule_date=reschedule.reschedule_date,
-                    end_date=datetime.now(tz=timezone.utc),
-                )
-            )
-            sys.exit(0)
+    from contextlib import ExitStack
 
-        parent_context = Trace.extract(ti.context_carrier) if ti.context_carrier else None
-        with BundleVersionLock(
-            bundle_name=ti.bundle_instance.name,
-            bundle_version=ti.bundle_instance.version,
-        ):
-            with _set_span(ti, parent_context, "run") as span:
-                state, _, error = run(ti, context, log)
-                context["exception"] = error
-                span.set_attribute("state", state.value if state else "unknown")
-                finalize(ti, state, context, log, error)
-    except KeyboardInterrupt:
-        log.exception("Ctrl-c hit")
-        sys.exit(2)
-    except Exception:
-        log.exception("Top level error")
-        sys.exit(1)
-    finally:
-        # Ensure the request socket is closed on the child side in all circumstances
-        # before the process fully terminates.
-        with _set_span(ti, parent_context, "close_socket"):
-            if SUPERVISOR_COMMS and SUPERVISOR_COMMS.socket:
-                with suppress(Exception):
-                    SUPERVISOR_COMMS.socket.close()
+    span = EmptySpan()
+    stack = ExitStack()
+    with stack:
+        try:
+            try:
+                startup_details = get_startup_details()
+                span: Span = _set_span(msg=startup_details)
+                stack.enter_context(span)
+                ti, context = startup(msg=startup_details)
+            except AirflowRescheduleException as e:
+                log.warning("Rescheduling task during startup, marking task as UP_FOR_RESCHEDULE")
+                SUPERVISOR_COMMS.send(
+                    msg=RescheduleTask(
+                        reschedule_date=e.reschedule_date,
+                        end_date=datetime.now(tz=timezone.utc),
+                    )
+                )
+                span.record_exception(e)
+                span.set_status(Status(StatusCode.ERROR, description=f"Exception: {type(e).__name__}"))
+                sys.exit(0)
+
+            with Trace.start_span("run") as span:
+                with BundleVersionLock(
+                    bundle_name=ti.bundle_instance.name,
+                    bundle_version=ti.bundle_instance.version,
+                ):
+                    state, _, error = run(ti, context, log)
+                    if error:
+                        span.record_exception(error)
+                        span.set_status(
+                            Status(StatusCode.ERROR, description=f"Exception: {type(error).__name__}")
+                        )
+                    context["exception"] = error
+                    span.set_attribute("state", state.value if state else "unknown")
+                    finalize(ti, state, context, log, error)
+        except KeyboardInterrupt as e:
+            log.exception("Ctrl-c hit")
+            span.record_exception(e)
+            span.set_status(Status(StatusCode.ERROR, description=f"Exception: {type(e).__name__}"))
+            sys.exit(2)
+        except Exception as e:
+            log.exception("Top level error")
+            span.record_exception(e)
+            span.set_status(Status(StatusCode.ERROR, description=f"Exception: {type(e).__name__}"))
+            sys.exit(1)
+        finally:
+            # Ensure the request socket is closed on the child side in all circumstances
+            # before the process fully terminates.
+            with Trace.start_span("close_socket"):
+                if SUPERVISOR_COMMS and SUPERVISOR_COMMS.socket:
+                    with suppress(Exception):
+                        SUPERVISOR_COMMS.socket.close()
 
 
 def reinit_supervisor_comms() -> None:

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -121,6 +121,7 @@ from airflow.sdk.execution_time.sentry import Sentry
 from airflow.sdk.execution_time.xcom import XCom
 from airflow.sdk.listener import get_listener_manager
 from airflow.sdk.observability.metrics import stats_utils
+from airflow.sdk.observability.trace import Trace
 from airflow.sdk.timezone import coerce_datetime
 
 if TYPE_CHECKING:
@@ -843,6 +844,28 @@ def _verify_bundle_access(bundle_instance: BaseDagBundle, log: Logger) -> None:
         )
 
 
+from contextlib import contextmanager
+
+
+@contextmanager
+def _set_span(ti, parent_context, name):
+    with Trace.start_child_span(
+        span_name=name,
+        parent_context=parent_context,
+        component="task",
+    ) as span:
+        span.set_attributes(
+            {
+                "dag_id": ti.dag_id,
+                "task_id": ti.task_id,
+                "run_id": ti.run_id,
+                "try_number": ti.try_number,
+                "map_index": ti.map_index if ti.map_index is not None else -1,
+            }
+        )
+        yield span
+
+
 def startup() -> tuple[RuntimeTaskInstance, Context, Logger]:
     # The parent sends us a StartupDetails message un-prompted. After this, every single message is only sent
     # in response to us sending a request.
@@ -867,7 +890,8 @@ def startup() -> tuple[RuntimeTaskInstance, Context, Logger]:
 
         if not isinstance(msg, StartupDetails):
             raise RuntimeError(f"Unhandled startup message {type(msg)} {msg}")
-
+    ti = msg.ti
+    parent_context = Trace.extract(ti.context_carrier) if ti.context_carrier else None
     # setproctitle causes issue on Mac OS: https://github.com/benoitc/gunicorn/issues/3021
     os_type = sys.platform
     if os_type == "darwin":
@@ -876,15 +900,16 @@ def startup() -> tuple[RuntimeTaskInstance, Context, Logger]:
         from setproctitle import setproctitle
 
         setproctitle(f"airflow worker -- {msg.ti.id}")
+    with _set_span(ti, parent_context, "hook.on_starting"):
+        try:
+            get_listener_manager().hook.on_starting(component=TaskRunnerMarker())
+        except Exception:
+            log.exception("error calling listener")
 
-    try:
-        get_listener_manager().hook.on_starting(component=TaskRunnerMarker())
-    except Exception:
-        log.exception("error calling listener")
-
-    with _airflow_parsing_context_manager(dag_id=msg.ti.dag_id, task_id=msg.ti.task_id):
-        ti = parse(msg, log)
-    log.debug("Dag file parsed", file=msg.dag_rel_path)
+    with _set_span(ti, parent_context, "parse"):
+        with _airflow_parsing_context_manager(dag_id=msg.ti.dag_id, task_id=msg.ti.task_id):
+            ti = parse(msg, log)
+        log.debug("Dag file parsed", file=msg.dag_rel_path)
 
     run_as_user = getattr(ti.task, "run_as_user", None) or conf.get(
         "core", "default_impersonation", fallback=None
@@ -914,7 +939,9 @@ def startup() -> tuple[RuntimeTaskInstance, Context, Logger]:
         # ideally, we should never reach here, but if we do, we should return None, None, None
         return None, None, None
 
-    return ti, ti.get_template_context(), log
+    with _set_span(ti, parent_context, "get_template_context"):
+        template_context = ti.get_template_context()
+    return ti, template_context, log
 
 
 def _serialize_template_field(template_field: Any, name: str) -> str | dict | list | int | float:
@@ -1168,6 +1195,7 @@ def run(
     ti: RuntimeTaskInstance,
     context: Context,
     log: Logger,
+    span,
 ) -> tuple[TaskInstanceState, ToSupervisor | None, BaseException | None]:
     """Run the task in this process."""
     import signal
@@ -1209,16 +1237,19 @@ def run(
 
     try:
         # First, clear the xcom data sent from server
-        if ti._ti_context_from_server and (keys_to_delete := ti._ti_context_from_server.xcom_keys_to_clear):
-            for x in keys_to_delete:
-                log.debug("Clearing XCom with key", key=x)
-                XCom.delete(
-                    key=x,
-                    dag_id=ti.dag_id,
-                    task_id=ti.task_id,
-                    run_id=ti.run_id,
-                    map_index=ti.map_index,
-                )
+        with Trace.start_span("delete xcom"):
+            if ti._ti_context_from_server and (
+                keys_to_delete := ti._ti_context_from_server.xcom_keys_to_clear
+            ):
+                for x in keys_to_delete:
+                    log.debug("Clearing XCom with key", key=x)
+                    XCom.delete(
+                        key=x,
+                        dag_id=ti.dag_id,
+                        task_id=ti.task_id,
+                        run_id=ti.run_id,
+                        map_index=ti.map_index,
+                    )
 
         with set_current_context(context):
             # This is the earliest that we can render templates -- as if it excepts for any reason we need to
@@ -1229,7 +1260,8 @@ def run(
                 return state, msg, error
 
             try:
-                result = _execute_task(context=context, ti=ti, log=log)
+                with Trace.start_span("execute"):
+                    result = _execute_task(context=context, ti=ti, log=log, span=span)
             except Exception:
                 import jinja2
 
@@ -1244,15 +1276,19 @@ def run(
                         )
                 raise
             else:  # If the task succeeded, render normally to let rendering error bubble up.
-                previous_rendered_map_index = ti.rendered_map_index
-                ti.rendered_map_index = _render_map_index(context, ti=ti, log=log)
-                # Send update only if value changed (e.g., user set context variables during execution)
-                if ti.rendered_map_index and ti.rendered_map_index != previous_rendered_map_index:
-                    SUPERVISOR_COMMS.send(msg=SetRenderedMapIndex(rendered_map_index=ti.rendered_map_index))
+                with Trace.start_span("render_map_index"):
+                    previous_rendered_map_index = ti.rendered_map_index
+                    ti.rendered_map_index = _render_map_index(context, ti=ti, log=log)
+                    # Send update only if value changed (e.g., user set context variables during execution)
+                    if ti.rendered_map_index and ti.rendered_map_index != previous_rendered_map_index:
+                        SUPERVISOR_COMMS.send(
+                            msg=SetRenderedMapIndex(rendered_map_index=ti.rendered_map_index)
+                        )
 
-        _push_xcom_if_needed(result, ti, log)
-
-        msg, state = _handle_current_task_success(context, ti)
+        with Trace.start_span("push xcom"):
+            _push_xcom_if_needed(result, ti, log)
+        with Trace.start_span("handle success"):
+            msg, state = _handle_current_task_success(context, ti)
     except DownstreamTasksSkipped as skip:
         log.info("Skipping downstream tasks.")
         tasks_to_skip = skip.tasks if isinstance(skip.tasks, list) else [skip.tasks]
@@ -1589,7 +1625,7 @@ def _send_error_email_notification(
         log.exception("Failed to send email notification")
 
 
-def _execute_task(context: Context, ti: RuntimeTaskInstance, log: Logger):
+def _execute_task(context: Context, ti: RuntimeTaskInstance, log: Logger, span):
     """Execute Task (optionally with a Timeout) and push Xcom results."""
     task = ti.task
     execute = task.execute
@@ -1621,12 +1657,14 @@ def _execute_task(context: Context, ti: RuntimeTaskInstance, log: Logger):
 
     outlet_events = context_get_outlet_events(context)
 
-    if (pre_execute_hook := task._pre_execute_hook) is not None:
-        create_executable_runner(pre_execute_hook, outlet_events, logger=log).run(context)
-    if getattr(pre_execute_hook := task.pre_execute, "__func__", None) is not BaseOperator.pre_execute:
-        create_executable_runner(pre_execute_hook, outlet_events, logger=log).run(context)
+    with Trace.start_span("pre-execute"):
+        if (pre_execute_hook := task._pre_execute_hook) is not None:
+            create_executable_runner(pre_execute_hook, outlet_events, logger=log).run(context)
+        if getattr(pre_execute_hook := task.pre_execute, "__func__", None) is not BaseOperator.pre_execute:
+            create_executable_runner(pre_execute_hook, outlet_events, logger=log).run(context)
 
-    _run_task_state_change_callbacks(task, "on_execute_callback", context, log)
+    with Trace.start_span("on_execute_callback"):
+        _run_task_state_change_callbacks(task, "on_execute_callback", context, log)
 
     if task.execution_timeout:
         from airflow.sdk.execution_time.timeout import timeout
@@ -1638,18 +1676,25 @@ def _execute_task(context: Context, ti: RuntimeTaskInstance, log: Logger):
             if timeout_seconds <= 0:
                 raise AirflowTaskTimeout()
             # Run task in timeout wrapper
-            with timeout(timeout_seconds):
+            with timeout(timeout_seconds), Trace.start_span("execute"):
+                span.add_event("task.execute.start")
                 result = ctx.run(execute, context=context)
+                span.add_event("task.execute.end")
         except AirflowTaskTimeout:
+            span.add_event("task.execute.timeout")
             task.on_kill()
             raise
     else:
-        result = ctx.run(execute, context=context)
+        with Trace.start_span("execute"):
+            span.add_event("task.execute.start")
+            result = ctx.run(execute, context=context)
+            span.add_event("task.execute.finish")
 
-    if (post_execute_hook := task._post_execute_hook) is not None:
-        create_executable_runner(post_execute_hook, outlet_events, logger=log).run(context, result)
-    if getattr(post_execute_hook := task.post_execute, "__func__", None) is not BaseOperator.post_execute:
-        create_executable_runner(post_execute_hook, outlet_events, logger=log).run(context)
+    with Trace.start_span("post_execute_hook"):
+        if (post_execute_hook := task._post_execute_hook) is not None:
+            create_executable_runner(post_execute_hook, outlet_events, logger=log).run(context, result)
+        if getattr(post_execute_hook := task.post_execute, "__func__", None) is not BaseOperator.post_execute:
+            create_executable_runner(post_execute_hook, outlet_events, logger=log).run(context)
 
     return result
 
@@ -1813,13 +1858,18 @@ def main():
                 )
             )
             sys.exit(0)
+
+        parent_context = Trace.extract(ti.context_carrier) if ti.context_carrier else None
         with BundleVersionLock(
             bundle_name=ti.bundle_instance.name,
             bundle_version=ti.bundle_instance.version,
         ):
-            state, _, error = run(ti, context, log)
-            context["exception"] = error
-            finalize(ti, state, context, log, error)
+            with _set_span(ti, parent_context, "run") as span:
+                state, _, error = run(ti, context, log, span=span)
+                context["exception"] = error
+                span.set_attribute("state", state.value if state else "unknown")
+            with _set_span(ti, parent_context, "finalize"):
+                finalize(ti, state, context, log, error)
     except KeyboardInterrupt:
         log.exception("Ctrl-c hit")
         sys.exit(2)


### PR DESCRIPTION
The old way of doing spans was problematic because it went through a ton of trouble to manufacture long running spans, which start and end with the dag run or task. 

It was hugely complicated cus it had to deal with scheduler restarts, and the fact that many schedules could touch the dag run or task. And it didn't give us information we didn't already have with the dag run and task metadata. 

What I do here is get rid of all that logic and only add spans in a context manager for a specific action. 

We still see the lifecycle of a dag run and with even greater precision. 

You can see when the dag run is created, scheduled, etc. 

We can see from the moment an api call triggers a dag run to the moment the dag run finishes.

Still work in progress. 

The spans before are like this:
<img width="2700" height="394" alt="image" src="https://github.com/user-attachments/assets/02d5cf40-b4e2-4520-9cbb-553afe3d7bce" />



One for the dag run start to end
One for task, start to end

It doesn't really give us more information than we get from start and end dates.

Here I explore adding more granularity, for different parts of the execution path, as well as scheduler touchpoints.

<img width="1346" height="488" alt="image" src="https://github.com/user-attachments/assets/3a4ded07-b801-422c-8966-8e2bc1b458f6" />

What's gone is a long artificial span for the dag run and task.

But we could still emit a span with information like "dag run success" when the dag run completes etc.
