### PR TITLE
Use start_date and end_date to calculate duration when duration is null for running taskinstance.

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
@@ -30,7 +30,7 @@ import { HeaderCard } from "src/components/HeaderCard";
 import { MarkTaskInstanceAsButton } from "src/components/MarkAs";
 import Time from "src/components/Time";
 import { usePatchTaskInstance } from "src/queries/usePatchTaskInstance";
-import { renderDuration } from "src/utils";
+import { getDuration, renderDuration } from "src/utils";
 
 export const Header = ({ taskInstance }: { readonly taskInstance: TaskInstanceResponse }) => {
   const { t: translate } = useTranslation();
@@ -46,7 +46,14 @@ export const Header = ({ taskInstance }: { readonly taskInstance: TaskInstanceRe
     { label: translate("startDate"), value: <Time datetime={taskInstance.start_date} /> },
     { label: translate("endDate"), value: <Time datetime={taskInstance.end_date} /> },
     ...(Boolean(taskInstance.start_date)
-      ? [{ label: translate("duration"), value: renderDuration(taskInstance.duration) }]
+      ? [
+          {
+            label: translate("duration"),
+            value: Boolean(taskInstance.duration)
+              ? renderDuration(taskInstance.duration)
+              : getDuration(taskInstance.start_date, taskInstance.end_date),
+          },
+        ]
       : []),
     {
       label: translate("taskInstance.dagVersion"),


### PR DESCRIPTION
When the task instance is in running state the duration value is null in the database and response. For task instances in running state use start_date and current time since end_date is null for duration calculation.

* closes: #61887 

##### Was generative AI tooling used to co-author this PR?

No