### PR TITLE
Triggered DAG button visible during queued/running state

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1386,7 +1386,7 @@ def _handle_trigger_dag_run(
     # Store the run id from the dag run (either created or found above) to
     # be used when creating the extra link on the webserver.
     ti.xcom_push(key="trigger_run_id", value=drte.dag_run_id)
-    
+
     # Push TriggerDagRunOperator's serialized extra link immediately so it is available
     # while the parent task is still running/deferred.
     _push_operator_extra_links_to_xcom(ti, log, link_class_names={"TriggerDagRunLink"})
@@ -1686,7 +1686,9 @@ def _push_operator_extra_links_to_xcom(
             continue
         try:
             link = operator_extra_link.get_link(operator=task, ti_key=ti)  # type: ignore[arg-type]
-            log.debug("Setting xcom for operator extra link", link=link, xcom_key=operator_extra_link.xcom_key)
+            log.debug(
+                "Setting xcom for operator extra link", link=link, xcom_key=operator_extra_link.xcom_key
+            )
             _xcom_push_to_db(ti, key=operator_extra_link.xcom_key, value=link)
         except Exception:
             log.exception(

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1386,6 +1386,10 @@ def _handle_trigger_dag_run(
     # Store the run id from the dag run (either created or found above) to
     # be used when creating the extra link on the webserver.
     ti.xcom_push(key="trigger_run_id", value=drte.dag_run_id)
+    
+    # Push TriggerDagRunOperator's serialized extra link immediately so it is available
+    # while the parent task is still running/deferred.
+    _push_operator_extra_links_to_xcom(ti, log, link_class_names={"TriggerDagRunLink"})
 
     if drte.wait_for_completion:
         if drte.deferrable:
@@ -1668,6 +1672,31 @@ def _push_xcom_if_needed(result: Any, ti: RuntimeTaskInstance, log: Logger):
     _xcom_push(ti, BaseXCom.XCOM_RETURN_KEY, result, mapped_length=mapped_length)
 
 
+def _push_operator_extra_links_to_xcom(
+    ti: RuntimeTaskInstance,
+    log: Logger,
+    *,
+    link_class_names: set[str] | None = None,
+) -> None:
+    task = ti.task
+    # Push link values to DB XCom for serialized operators. This allows webserver lookups
+    # through XComOperatorLink without requiring the task module to be imported.
+    for operator_extra_link in task.operator_extra_links:
+        if link_class_names and type(operator_extra_link).__name__ not in link_class_names:
+            continue
+        try:
+            link = operator_extra_link.get_link(operator=task, ti_key=ti)  # type: ignore[arg-type]
+            log.debug("Setting xcom for operator extra link", link=link, xcom_key=operator_extra_link.xcom_key)
+            _xcom_push_to_db(ti, key=operator_extra_link.xcom_key, value=link)
+        except Exception:
+            log.exception(
+                "Failed to push an xcom for task operator extra link",
+                link_name=operator_extra_link.name,
+                xcom_key=operator_extra_link.xcom_key,
+                ti=ti,
+            )
+
+
 def finalize(
     ti: RuntimeTaskInstance,
     state: TaskInstanceState,
@@ -1684,19 +1713,7 @@ def finalize(
         Stats.timing("task.duration", duration_ms, tags=stats_tags)
 
     task = ti.task
-    # Pushing xcom for each operator extra links defined on the operator only.
-    for oe in task.operator_extra_links:
-        try:
-            link, xcom_key = oe.get_link(operator=task, ti_key=ti), oe.xcom_key  # type: ignore[arg-type]
-            log.debug("Setting xcom for operator extra link", link=link, xcom_key=xcom_key)
-            _xcom_push_to_db(ti, key=xcom_key, value=link)
-        except Exception:
-            log.exception(
-                "Failed to push an xcom for task operator extra link",
-                link_name=oe.name,
-                xcom_key=oe.xcom_key,
-                ti=ti,
-            )
+    _push_operator_extra_links_to_xcom(ti, log)
 
     if getattr(ti.task, "overwrite_rtif_after_execution", False):
         log.debug("Overwriting Rendered template fields.")

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -4106,22 +4106,18 @@ class TestTriggerDagRunOperator:
                     map_index=-1,
                 ),
             ),
+            mock.call.send(
+                msg=SetXCom(
+                    key="_link_TriggerDagRunLink",
+                    value=mock.ANY,
+                    dag_id="test_handle_trigger_dag_run",
+                    task_id="test_task",
+                    run_id="test_run",
+                    map_index=-1,
+                ),
+            ),
         ]
         mock_supervisor_comms.assert_has_calls(expected_calls)
-        trigger_link_xcom_calls = [
-            call
-            for call in mock_supervisor_comms.send.call_args_list
-            if isinstance(call.kwargs.get("msg"), SetXCom)
-            and call.kwargs["msg"].key == "_link_TriggerDagRunLink"
-        ]
-        assert len(trigger_link_xcom_calls) == 1
-        trigger_link_xcom = trigger_link_xcom_calls[0].kwargs["msg"]
-        assert trigger_link_xcom.dag_id == "test_handle_trigger_dag_run"
-        assert trigger_link_xcom.task_id == "test_task"
-        assert trigger_link_xcom.run_id == "test_run"
-        assert trigger_link_xcom.map_index == -1
-        assert isinstance(trigger_link_xcom.value, str)
-        assert "dags/test_dag/runs/test_run_id" in trigger_link_xcom.value
 
     @pytest.mark.parametrize(
         ("skip_when_already_exists", "expected_state"),
@@ -4246,6 +4242,16 @@ class TestTriggerDagRunOperator:
                 ),
             ),
             mock.call.send(
+                msg=SetXCom(
+                    key="_link_TriggerDagRunLink",
+                    value=mock.ANY,
+                    dag_id="test_handle_trigger_dag_run_wait_for_completion",
+                    task_id="test_task",
+                    run_id="test_run",
+                    map_index=-1,
+                ),
+            ),
+            mock.call.send(
                 msg=GetDagRunState(
                     dag_id="test_dag",
                     run_id="test_run_id",
@@ -4259,20 +4265,6 @@ class TestTriggerDagRunOperator:
             ),
         ]
         mock_supervisor_comms.assert_has_calls(expected_calls)
-        trigger_link_xcom_calls = [
-            call
-            for call in mock_supervisor_comms.send.call_args_list
-            if isinstance(call.kwargs.get("msg"), SetXCom)
-            and call.kwargs["msg"].key == "_link_TriggerDagRunLink"
-        ]
-        assert len(trigger_link_xcom_calls) == 1
-        trigger_link_xcom = trigger_link_xcom_calls[0].kwargs["msg"]
-        assert trigger_link_xcom.dag_id == "test_handle_trigger_dag_run_wait_for_completion"
-        assert trigger_link_xcom.task_id == "test_task"
-        assert trigger_link_xcom.run_id == "test_run"
-        assert trigger_link_xcom.map_index == -1
-        assert isinstance(trigger_link_xcom.value, str)
-        assert "dags/test_dag/runs/test_run_id" in trigger_link_xcom.value
 
     @pytest.mark.parametrize(
         ("allowed_states", "failed_states", "intermediate_state"),

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -4106,18 +4106,22 @@ class TestTriggerDagRunOperator:
                     map_index=-1,
                 ),
             ),
-            mock.call.send(
-                msg=SetXCom(
-                    key="_link_TriggerDagRunLink",
-                    value=mock.ANY,
-                    dag_id="test_handle_trigger_dag_run",
-                    task_id="test_task",
-                    run_id="test_run",
-                    map_index=-1,
-                ),
-            ),
         ]
         mock_supervisor_comms.assert_has_calls(expected_calls)
+        trigger_link_xcom_calls = [
+            call
+            for call in mock_supervisor_comms.send.call_args_list
+            if isinstance(call.kwargs.get("msg"), SetXCom)
+            and call.kwargs["msg"].key == "_link_TriggerDagRunLink"
+        ]
+        assert len(trigger_link_xcom_calls) == 1
+        trigger_link_xcom = trigger_link_xcom_calls[0].kwargs["msg"]
+        assert trigger_link_xcom.dag_id == "test_handle_trigger_dag_run"
+        assert trigger_link_xcom.task_id == "test_task"
+        assert trigger_link_xcom.run_id == "test_run"
+        assert trigger_link_xcom.map_index == -1
+        assert isinstance(trigger_link_xcom.value, str)
+        assert "dags/test_dag/runs/test_run_id" in trigger_link_xcom.value
 
     @pytest.mark.parametrize(
         ("skip_when_already_exists", "expected_state"),
@@ -4242,16 +4246,6 @@ class TestTriggerDagRunOperator:
                 ),
             ),
             mock.call.send(
-                msg=SetXCom(
-                    key="_link_TriggerDagRunLink",
-                    value=mock.ANY,
-                    dag_id="test_handle_trigger_dag_run_wait_for_completion",
-                    task_id="test_task",
-                    run_id="test_run",
-                    map_index=-1,
-                ),
-            ),
-            mock.call.send(
                 msg=GetDagRunState(
                     dag_id="test_dag",
                     run_id="test_run_id",
@@ -4265,6 +4259,20 @@ class TestTriggerDagRunOperator:
             ),
         ]
         mock_supervisor_comms.assert_has_calls(expected_calls)
+        trigger_link_xcom_calls = [
+            call
+            for call in mock_supervisor_comms.send.call_args_list
+            if isinstance(call.kwargs.get("msg"), SetXCom)
+            and call.kwargs["msg"].key == "_link_TriggerDagRunLink"
+        ]
+        assert len(trigger_link_xcom_calls) == 1
+        trigger_link_xcom = trigger_link_xcom_calls[0].kwargs["msg"]
+        assert trigger_link_xcom.dag_id == "test_handle_trigger_dag_run_wait_for_completion"
+        assert trigger_link_xcom.task_id == "test_task"
+        assert trigger_link_xcom.run_id == "test_run"
+        assert trigger_link_xcom.map_index == -1
+        assert isinstance(trigger_link_xcom.value, str)
+        assert "dags/test_dag/runs/test_run_id" in trigger_link_xcom.value
 
     @pytest.mark.parametrize(
         ("allowed_states", "failed_states", "intermediate_state"),

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -4106,6 +4106,16 @@ class TestTriggerDagRunOperator:
                     map_index=-1,
                 ),
             ),
+            mock.call.send(
+                msg=SetXCom(
+                    key="_link_TriggerDagRunLink",
+                    value=mock.ANY,
+                    dag_id="test_handle_trigger_dag_run",
+                    task_id="test_task",
+                    run_id="test_run",
+                    map_index=-1,
+                ),
+            ),
         ]
         mock_supervisor_comms.assert_has_calls(expected_calls)
 
@@ -4198,6 +4208,8 @@ class TestTriggerDagRunOperator:
             OKResponse(ok=True),
             # Set XCOM,
             None,
+            # Set TriggerDagRunLink XCOM.
+            None,
             # Dag Run is still running
             DagRunStateResult(state=DagRunState.RUNNING),
             # Dag Run completes execution on the next poll
@@ -4223,6 +4235,16 @@ class TestTriggerDagRunOperator:
                 msg=SetXCom(
                     key="trigger_run_id",
                     value="test_run_id",
+                    dag_id="test_handle_trigger_dag_run_wait_for_completion",
+                    task_id="test_task",
+                    run_id="test_run",
+                    map_index=-1,
+                ),
+            ),
+            mock.call.send(
+                msg=SetXCom(
+                    key="_link_TriggerDagRunLink",
+                    value=mock.ANY,
                     dag_id="test_handle_trigger_dag_run_wait_for_completion",
                     task_id="test_task",
                     run_id="test_run",


### PR DESCRIPTION
closes: #60867

## Problem
The "Triggered DAG" button only appeared **after** the parent task completed execution. During RUNNING/QUEUED states, the button was completely hidden.

## Solution
This change makes the Triggered DAG button appear as soon as the child DAG run is created/queued, instead of only after the parent task finishes.

### Changes
* **Added a reusable helper** in task runner to push operator extra-link XComs:
  * `_push_operator_extra_links_to_xcom(...)`
* **In `_handle_trigger_dag_run(...)`**, after pushing `trigger_run_id`, we now immediately push the `TriggerDagRunLink` XCom:
  * `_link_TriggerDagRunLink`
* **Kept existing finalize behavior** by reusing the same helper in `finalize()`.

### Behavior After This Change
* While task is still running/deferred, once child DAG run is triggered, the "Triggered DAG" link is already available to the UI
* No behavior change for conflict path (`DAGRUN_ALREADY_EXISTS`)
* No change to task state transitions

## Testing
Updated task-sdk unit tests to expect immediate `_link_TriggerDagRunLink` XCom write:
* `test_handle_trigger_dag_run`
* `test_handle_trigger_dag_run_wait_for_completion`

<img width="1920" height="855" alt="Screenshot from 2026-02-14 10-04-54" src="https://github.com/user-attachments/assets/246c2a93-788a-463a-be6b-7c2231400277" />