### PR TITLE
Fix Git bundle clone race condition with version-level locking (#61716)

### DIFF
--- a/airflow-core/src/airflow/dag_processing/bundles/base.py
+++ b/airflow-core/src/airflow/dag_processing/bundles/base.py
@@ -253,6 +253,7 @@ class BaseDagBundle(ABC):
     supports_versioning: bool = False
 
     _locked: bool = False
+    _version_locked: bool = False
 
     def __init__(
         self,
@@ -391,6 +392,68 @@ class BaseDagBundle(ABC):
 
     def __repr__(self):
         return f"{self.__class__.__name__}(name={self.name})"
+
+    @contextmanager
+    def version_lock(self):
+        """
+        Acquire a version-specific lock for this bundle.
+
+        Unlike ``lock()`` which serializes all operations on a bundle (regardless of version),
+        this method provides finer-grained locking scoped to a specific bundle version directory.
+        This allows different versions of the same bundle to be initialized concurrently while
+        preventing race conditions when multiple processes attempt to prepare the same version
+        directory simultaneously.
+
+        Race condition context:
+            Multiple concurrent DAG runs or task instances may attempt to clone/open the same
+            bundle version into the same directory. Without version-level locking, concurrent
+            clones can fail with "destination path already exists and is not empty", or leave
+            partial clones visible to other processes. This lock ensures that cleanup, clone,
+            and validation of a version directory happen atomically from the perspective of
+            other processes.
+
+        When no version is set (tracking mode), falls back to a tracking-specific lock file
+        to avoid deadlocks with ``lock()``.
+        """
+        if self._version_locked:
+            yield
+            return
+
+        lock_dir_path = get_bundle_storage_root_path() / "_locks"
+        lock_dir_path.mkdir(parents=True, exist_ok=True)
+
+        if self.version:
+            # Version-specific lock file allows parallel init of different versions
+            lock_file_path = lock_dir_path / f"{self.name}_version_{self.version}.lock"
+        else:
+            # Tracking-specific lock file (distinct from bundle lock to avoid deadlock)
+            lock_file_path = lock_dir_path / f"{self.name}_tracking.lock"
+
+        log.debug(
+            "Acquiring version lock: bundle=%s version=%s lock_path=%s",
+            self.name,
+            self.version,
+            lock_file_path,
+        )
+
+        with open(lock_file_path, "w") as lock_file:
+            fcntl.flock(lock_file, fcntl.LOCK_EX)
+            try:
+                log.debug(
+                    "Version lock acquired: bundle=%s version=%s",
+                    self.name,
+                    self.version,
+                )
+                self._version_locked = True
+                yield
+            finally:
+                fcntl.flock(lock_file, LOCK_UN)
+                self._version_locked = False
+                log.debug(
+                    "Version lock released: bundle=%s version=%s",
+                    self.name,
+                    self.version,
+                )
 
 
 class BundleVersionLock:

--- a/airflow-core/tests/unit/dag_processing/bundles/test_base.py
+++ b/airflow-core/tests/unit/dag_processing/bundles/test_base.py
@@ -137,6 +137,184 @@ def test_lock_exception_handling():
         assert acquired
 
 
+def test_version_lock_acquisition():
+    """Test that version_lock uses a version-specific lock file."""
+    bundle = BasicBundle(name="locktest", version="abc123")
+    lock_dir = get_bundle_storage_root_path() / "_locks"
+    lock_file = lock_dir / "locktest_version_abc123.lock"
+
+    assert not bundle._version_locked
+
+    with bundle.version_lock():
+        assert bundle._version_locked
+        assert lock_file.exists()
+
+        # Check lock file is now locked
+        with open(lock_file, "w") as f:
+            try:
+                fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                locked = False
+            except OSError:
+                locked = True
+            assert locked
+
+    assert bundle._version_locked is False
+    with open(lock_file, "w") as f:
+        try:
+            fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            unlocked = True
+            fcntl.flock(f, fcntl.LOCK_UN)
+        except OSError:
+            unlocked = False
+        assert unlocked
+
+
+def test_version_lock_tracking_uses_separate_lock_file():
+    """Test that version_lock without a version uses a tracking-specific lock (not the bundle lock)."""
+    bundle = BasicBundle(name="locktest")
+    lock_dir = get_bundle_storage_root_path() / "_locks"
+    tracking_lock = lock_dir / "locktest_tracking.lock"
+    bundle_lock = lock_dir / "locktest.lock"
+
+    with bundle.version_lock():
+        assert tracking_lock.exists()
+        # Bundle lock file should NOT be created by version_lock
+        assert not bundle_lock.exists()
+
+
+def test_version_lock_exception_handling():
+    """Test that exceptions within version_lock still release the lock."""
+    bundle = BasicBundle(name="locktest", version="abc123")
+    lock_dir = get_bundle_storage_root_path() / "_locks"
+    lock_file = lock_dir / "locktest_version_abc123.lock"
+
+    try:
+        with bundle.version_lock():
+            assert bundle._version_locked
+            raise Exception("simulated failure")
+    except Exception:
+        pass
+
+    assert not bundle._version_locked
+    with open(lock_file, "w") as f:
+        try:
+            fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            acquired = True
+            fcntl.flock(f, fcntl.LOCK_UN)
+        except OSError:
+            acquired = False
+        assert acquired
+
+
+def test_version_lock_reentrancy():
+    """Test that nested version_lock calls don't deadlock (reentrancy check)."""
+    bundle = BasicBundle(name="locktest", version="abc123")
+
+    with bundle.version_lock():
+        assert bundle._version_locked
+        # Nested call should pass through without deadlock
+        with bundle.version_lock():
+            assert bundle._version_locked
+        assert bundle._version_locked
+
+    assert not bundle._version_locked
+
+
+def test_different_versions_use_different_lock_files():
+    """Test that different versions of the same bundle use different lock files."""
+    bundle_v1 = BasicBundle(name="mybundle", version="v1")
+    lock_dir = get_bundle_storage_root_path() / "_locks"
+
+    with bundle_v1.version_lock():
+        # v1 lock should be held
+        lock_v1 = lock_dir / "mybundle_version_v1.lock"
+        with open(lock_v1, "w") as f:
+            try:
+                fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                v1_locked = False
+            except OSError:
+                v1_locked = True
+            assert v1_locked
+
+        # v2 lock should NOT be held — different versions don't block each other
+        lock_v2 = lock_dir / "mybundle_version_v2.lock"
+        lock_v2.parent.mkdir(parents=True, exist_ok=True)
+        lock_v2.touch()
+        with open(lock_v2, "w") as f:
+            try:
+                fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                v2_free = True
+                fcntl.flock(f, fcntl.LOCK_UN)
+            except OSError:
+                v2_free = False
+            assert v2_free
+
+
+def test_version_lock_different_versions_parallel():
+    """Test that two different versions of the same bundle can be locked simultaneously from different threads."""
+    bundle_v1 = BasicBundle(name="parallel_test", version="v1")
+    bundle_v2 = BasicBundle(name="parallel_test", version="v2")
+    results = {"v1_locked": False, "v2_locked": False, "v1_saw_v2": False, "v2_saw_v1": False}
+    barrier = threading.Barrier(2, timeout=5)
+
+    def lock_v1():
+        with bundle_v1.version_lock():
+            results["v1_locked"] = True
+            barrier.wait()  # Wait for both threads to hold their locks
+            results["v1_saw_v2"] = results["v2_locked"]
+
+    def lock_v2():
+        with bundle_v2.version_lock():
+            results["v2_locked"] = True
+            barrier.wait()  # Wait for both threads to hold their locks
+            results["v2_saw_v1"] = results["v1_locked"]
+
+    t1 = threading.Thread(target=lock_v1)
+    t2 = threading.Thread(target=lock_v2)
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    # Both should have been locked at the same time
+    assert results["v1_locked"]
+    assert results["v2_locked"]
+    assert results["v1_saw_v2"], "v1 should have seen v2 locked concurrently"
+    assert results["v2_saw_v1"], "v2 should have seen v1 locked concurrently"
+
+
+def test_version_lock_same_version_serializes():
+    """Test that two threads trying to lock the same version are serialized."""
+    bundle1 = BasicBundle(name="serial_test", version="same_v")
+    bundle2 = BasicBundle(name="serial_test", version="same_v")
+    order = []
+    lock_held = threading.Event()
+
+    def thread1():
+        with bundle1.version_lock():
+            order.append("t1_start")
+            lock_held.set()
+            time.sleep(0.3)
+            order.append("t1_end")
+
+    def thread2():
+        lock_held.wait(timeout=5)
+        time.sleep(0.05)  # Ensure t1 is well inside the lock
+        with bundle2.version_lock():
+            order.append("t2_start")
+            order.append("t2_end")
+
+    t1 = threading.Thread(target=thread1)
+    t2 = threading.Thread(target=thread2)
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    # t2 should start only after t1 has finished (serialized)
+    assert order == ["t1_start", "t1_end", "t2_start", "t2_end"]
+
+
 class LockTestHelper:
     def __init__(self, num, **kwargs):
         super().__init__(**kwargs)

--- a/providers/git/src/airflow/providers/git/bundles/git.py
+++ b/providers/git/src/airflow/providers/git/bundles/git.py
@@ -116,6 +116,7 @@ class GitDagBundle(BaseDagBundle):
             self._log.debug("repo_url updated from hook")
 
     def _initialize(self):
+        # Bundle-level lock protects the shared bare repository used by all versions.
         with self.lock():
             cm = self.hook.configure_hook_env() if self.hook else nullcontext()
             with cm:
@@ -128,6 +129,14 @@ class GitDagBundle(BaseDagBundle):
                 self._ensure_version_in_bare_repo()
             self.bare_repo.close()
 
+        # Version-level lock for version-specific directory operations.
+        # This prevents race conditions when multiple concurrent processes try to
+        # clone/prepare the same version directory simultaneously, which can fail
+        # with "destination path already exists and is not empty".
+        # Using version-level granularity allows different versions of the same
+        # bundle to be initialized in parallel without unnecessary blocking.
+        # For tracking mode (no version), this uses a tracking-specific lock.
+        with self.version_lock():
             try:
                 self._clone_repo_if_required()
             except GitCommandError as e:

--- a/providers/git/tests/unit/git/bundles/test_git.py
+++ b/providers/git/tests/unit/git/bundles/test_git.py
@@ -993,3 +993,157 @@ class TestGitDagBundle:
             bundle.initialize()
 
         mock_rmtree.assert_not_called()
+
+
+class TestGitDagBundleVersionLocking:
+    """Tests for version-level locking in GitDagBundle._initialize().
+
+    These tests verify that the split locking strategy (bundle-level lock for bare repo,
+    version-level lock for version directory) correctly prevents race conditions when
+    multiple concurrent processes attempt to clone/prepare the same version directory.
+    """
+
+    @mock.patch("airflow.providers.git.bundles.git.shutil.rmtree")
+    @mock.patch("airflow.providers.git.bundles.git.os.path.exists")
+    @mock.patch("airflow.providers.git.bundles.git.GitHook")
+    @mock.patch("airflow.providers.git.bundles.git.Repo")
+    def test_initialize_uses_version_lock_for_versioned_bundle(
+        self, mock_repo_class, mock_githook, mock_exists, mock_rmtree
+    ):
+        """Test that _initialize uses version_lock (not just bundle lock) for versioned bundles."""
+        mock_githook.return_value.repo_url = "git@github.com:apache/airflow.git"
+        mock_exists.return_value = True
+        mock_repo_instance = mock_repo_class.return_value
+        mock_repo_instance.commit.return_value = mock.MagicMock()
+
+        bundle = GitDagBundle(
+            name="test",
+            git_conn_id="git_default",
+            tracking_ref="main",
+            version="abc123",
+        )
+
+        with mock.patch.object(bundle, "lock") as mock_lock, mock.patch.object(
+            bundle, "version_lock"
+        ) as mock_version_lock:
+            mock_lock.return_value.__enter__ = mock.MagicMock()
+            mock_lock.return_value.__exit__ = mock.MagicMock(return_value=False)
+            mock_version_lock.return_value.__enter__ = mock.MagicMock()
+            mock_version_lock.return_value.__exit__ = mock.MagicMock(return_value=False)
+
+            bundle._initialize()
+
+            # Both lock() and version_lock() should be called
+            mock_lock.assert_called_once()
+            mock_version_lock.assert_called_once()
+
+    @mock.patch("airflow.providers.git.bundles.git.shutil.rmtree")
+    @mock.patch("airflow.providers.git.bundles.git.os.path.exists")
+    @mock.patch("airflow.providers.git.bundles.git.GitHook")
+    @mock.patch("airflow.providers.git.bundles.git.Repo")
+    def test_initialize_uses_version_lock_for_tracking_bundle(
+        self, mock_repo_class, mock_githook, mock_exists, mock_rmtree
+    ):
+        """Test that _initialize uses version_lock for tracking bundles (no version)."""
+        mock_githook.return_value.repo_url = "git@github.com:apache/airflow.git"
+        mock_exists.return_value = True
+
+        bundle = GitDagBundle(
+            name="test",
+            git_conn_id="git_default",
+            tracking_ref="main",
+        )
+
+        with mock.patch.object(bundle, "lock") as mock_lock, mock.patch.object(
+            bundle, "version_lock"
+        ) as mock_version_lock:
+            mock_lock.return_value.__enter__ = mock.MagicMock()
+            mock_lock.return_value.__exit__ = mock.MagicMock(return_value=False)
+            mock_version_lock.return_value.__enter__ = mock.MagicMock()
+            mock_version_lock.return_value.__exit__ = mock.MagicMock(return_value=False)
+
+            bundle._initialize()
+
+            # Both lock() (for bare repo) and version_lock() (for tracking repo) should be called.
+            # refresh() inside will additionally call lock() again.
+            assert mock_lock.call_count >= 1
+            mock_version_lock.assert_called_once()
+
+    @mock.patch("airflow.providers.git.bundles.git.shutil.rmtree")
+    @mock.patch("airflow.providers.git.bundles.git.os.path.exists")
+    @mock.patch("airflow.providers.git.bundles.git.GitHook")
+    @mock.patch("airflow.providers.git.bundles.git.Repo")
+    def test_version_lock_released_on_clone_exception(
+        self, mock_repo_class, mock_githook, mock_exists, mock_rmtree
+    ):
+        """Test that version_lock is released even when clone raises an exception."""
+        mock_githook.return_value.repo_url = "git@github.com:apache/airflow.git"
+        mock_exists.return_value = False
+
+        # Make clone fail permanently
+        mock_repo_class.clone_from.side_effect = GitCommandError("clone", "failed")
+
+        bundle = GitDagBundle(
+            name="test",
+            git_conn_id="git_default",
+            tracking_ref="main",
+            version="abc123",
+        )
+
+        assert not bundle._version_locked
+
+        with pytest.raises(RuntimeError, match="Error cloning repository"):
+            bundle.initialize()
+
+        # Lock must be released even after exception
+        assert not bundle._version_locked
+        assert not bundle._locked
+
+    @mock.patch("airflow.providers.git.bundles.git.shutil.rmtree")
+    @mock.patch("airflow.providers.git.bundles.git.os.path.exists")
+    @mock.patch("airflow.providers.git.bundles.git.GitHook")
+    @mock.patch("airflow.providers.git.bundles.git.Repo")
+    def test_partial_clone_cleanup_under_version_lock(
+        self, mock_repo_class, mock_githook, mock_exists, mock_rmtree
+    ):
+        """Test that a failed clone triggers cleanup and retry, all under the version lock."""
+        mock_githook.return_value.repo_url = "git@github.com:apache/airflow.git"
+        mock_githook.return_value.env = {}
+
+        # Simulate: directory doesn't exist first, then exists after failed clone
+        mock_exists.side_effect = [
+            True,  # bare repo exists (skip bare clone)
+            False,  # version repo doesn't exist (trigger clone)
+            True,  # cleanup check (exists for rmtree)
+            True,  # retry: version repo still doesn't exist after cleanup... wait
+        ]
+
+        repo_mock = mock.MagicMock()
+        repo_mock.commit.return_value = mock.MagicMock()
+
+        # First clone fails, retry succeeds
+        mock_repo_class.clone_from.side_effect = [
+            GitCommandError("clone", "partial failure"),
+            mock.MagicMock(),  # retry succeeds
+        ]
+        mock_repo_class.side_effect = [
+            mock.MagicMock(),  # bare repo open
+            InvalidGitRepositoryError("bad partial clone"),  # first Repo() call fails
+            repo_mock,  # retry Repo() works
+        ]
+
+        bundle = GitDagBundle(
+            name="test",
+            git_conn_id="git_default",
+            tracking_ref="main",
+            version="abc123",
+            prune_dotgit_folder=False,
+        )
+
+        bundle.initialize()
+
+        # Verify cleanup was triggered (rmtree called for the partial clone)
+        assert mock_rmtree.call_count >= 1
+        # Lock should be released after completion
+        assert not bundle._version_locked
+        assert not bundle._locked


### PR DESCRIPTION
Summary

This PR fixes Git bundle clone race condition by introducing version-level locking during clone, cleanup, and validation operations.

When multiple tasks attempt to clone or access the same bundle version concurrently, the destination directory may already exist or be partially populated, causing clone failures. This change ensures operations are atomic per bundle version and prevents inconsistent repository states.

Root Cause:

Concurrent clone attempts can lead to:

Partial directory creation
Failed cleanup before retry
Git clone failing due to non-empty destination

Solution:

Add version-level locking around bundle operations
Ensure clone + cleanup + validation run atomically
Prevent concurrent writes to same bundle version directory

Tests:

Added unit tests for concurrent clone scenarios
Verified cleanup and retry logic under lock conditions

Impact

Improves DAG bundle stability
Prevents repeated clone retries
Reduces log noise and transient failures

Issue:
closes: #61716