### PR TITLE
Read Python version from static www/ftp information

### DIFF
--- a/scripts/ci/prek/upgrade_important_versions.py
+++ b/scripts/ci/prek/upgrade_important_versions.py
@@ -117,27 +117,42 @@ def get_latest_pypi_version(package_name: str, should_upgrade: bool) -> str:
 
 
 def get_all_python_versions() -> list[Version]:
+    """
+    Fetch all released Python versions by parsing the Python FTP directory listing.
+    This provides static information about all available Python releases.
+    """
     if VERBOSE:
-        console.print("[bright_blue]Fetching all released Python versions from python.org")
-    url = "https://www.python.org/api/v2/downloads/release/?is_published=true"
+        console.print("[bright_blue]Fetching all released Python versions from python.org FTP")
+    url = "https://www.python.org/ftp/python/"
     headers = {"User-Agent": "Python requests"}
     response = requests.get(url, headers=headers)
     response.raise_for_status()
-    data = response.json()
+
+    # Parse the HTML directory listing to extract version numbers
+    # The FTP directory listing has links like: <a href="3.12.1/">3.12.1/</a>
     versions = []
-    matcher = re.compile(r"^Python ([\d.]+$)")
-    for release in data:
-        release_name = release["name"]
-        match = matcher.match(release_name)
-        if match:
-            versions.append(Version(match.group(1)))
+    # Match version patterns like "3.12.1/" in href attributes
+    version_pattern = re.compile(r'href="(\d+\.\d+\.\d+)/"')
+
+    for match in version_pattern.finditer(response.text):
+        version_str = match.group(1)
+        try:
+            # Parse as version to validate it's a proper version number
+            version_obj = Version(version_str)
+            # Only include Python 3.x versions
+            if version_obj.major == 3:
+                versions.append(version_obj)
+        except Exception:
+            # Skip invalid version strings
+            continue
+
     return versions
 
 
 def get_latest_python_version(python_major_minor: str, all_versions: list[Version]) -> str:
     """
-    Fetch the latest released Python version for a given major.minor (e.g. '3.12') using python.org API.
-    Much faster than paginating through all GitHub tags.
+    Fetch the latest released Python version for a given major.minor (e.g. '3.12') from FTP directory listing.
+    Uses static directory information rather than API calls.
     """
     # Only consider releases matching the major.minor.patch pattern
     matching = [


### PR DESCRIPTION
Release version check for Python started to fail with rate limit, this PR changes Python version retrieval to use static information hosted on ftp site of Python (which is behind CDN and can handle much bigger traffic and is read-only so there are no rate limits involved.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)


Generated-by: Copilot with Claude Sonnet 4.5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
