### PR TITLE
Add workers.celery.extraPorts

### DIFF
--- a/chart/newsfragments/61919.significant.rst
+++ b/chart/newsfragments/61919.significant.rst
@@ -1,0 +1,1 @@
+``workers.extraPorts`` section is now deprecated in favor of ``workers.celery.extraPorts``. Please update your configuration accordingly.

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -637,6 +637,14 @@ DEPRECATION WARNING:
 
 {{- end }}
 
+{{- if not (empty .Values.workers.extraPorts) }}
+
+ DEPRECATION WARNING:
+    `workers.extraPorts` has been renamed to `workers.celery.extraPorts`.
+    Please change your values as support for the old name will be dropped in a future release.
+
+{{- end }}
+
 {{- if not (empty .Values.webserver.defaultUser) }}
 
  DEPRECATION WARNING:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2309,7 +2309,7 @@
                     }
                 },
                 "extraPorts": {
-                    "description": "Expose additional ports of Airflow Celery worker container.",
+                    "description": "Expose additional ports of Airflow Celery worker container (deprecated, use `workers.celery.extraPorts` instead).",
                     "type": "array",
                     "default": [],
                     "items": {
@@ -3293,6 +3293,14 @@
                                 "null"
                             ],
                             "default": null
+                        },
+                        "extraPorts": {
+                            "description": "Expose additional ports of Airflow Celery worker container.",
+                            "type": "array",
+                            "default": [],
+                            "items": {
+                                "$ref": "#/definitions/io.k8s.api.core.v1.ContainerPort"
+                            }
                         },
                         "nodeSelector": {
                             "description": "Select certain nodes for Airflow Celery worker pods.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1055,6 +1055,7 @@ workers:
   #       readOnly: true
 
   # Expose additional ports of Airflow Celery workers. These can be used for additional metric collection.
+  # (deprecated, use workers.celery.extraPorts instead)
   extraPorts: []
 
   # Select certain nodes for Airflow Celery worker pods and pods created with pod-template-file
@@ -1382,6 +1383,9 @@ workers:
 
     # This setting tells kubernetes that its ok to evict when it wants to scale a node down
     safeToEvict: ~
+
+    # Expose additional ports of Airflow Celery workers. These can be used for additional metric collection.
+    extraPorts: []
 
     # Select certain nodes for Airflow Celery worker pods
     nodeSelector: {}

--- a/helm-tests/tests/helm_tests/airflow_core/test_worker.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_worker.py
@@ -1920,6 +1920,27 @@ class TestWorker:
 
         assert jmespath.search("spec.template.spec.terminationGracePeriodSeconds", docs[0]) == 5
 
+    @pytest.mark.parametrize(
+        "workers_values",
+        [
+            {"extraPorts": [{"name": "test-extra-port", "containerPort": 10}]},
+            {"celery": {"extraPorts": [{"name": "test-extra-port", "containerPort": 10}]}},
+            {
+                "extraPorts": [{"name": "test", "containerPort": 1}],
+                "celery": {"extraPorts": [{"name": "test-extra-port", "containerPort": 10}]},
+            },
+        ],
+    )
+    def test_overwrite_extra_ports(self, workers_values):
+        docs = render_chart(
+            values={"workers": workers_values},
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+
+        assert jmespath.search("spec.template.spec.containers[0].ports[:-1]", docs[0]) == [
+            {"name": "test-extra-port", "containerPort": 10}
+        ]
+
 
 class TestWorkerLogGroomer(LogGroomerTestBase):
     """Worker groomer."""

--- a/helm-tests/tests/helm_tests/airflow_core/test_worker_sets.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_worker_sets.py
@@ -2431,8 +2431,24 @@ class TestWorkerSets:
                 "celery": {"enableDefault": False, "sets": [{"name": "set1"}]},
             },
             {
+                "celery": {
+                    "extraPorts": [{"name": "test-extra-port", "containerPort": 10}],
+                    "enableDefault": False,
+                    "sets": [{"name": "set1"}],
+                },
+            },
+            {
                 "extraPorts": [{"name": "test", "containerPort": 1}],
                 "celery": {
+                    "enableDefault": False,
+                    "sets": [
+                        {"name": "set1", "extraPorts": [{"name": "test-extra-port", "containerPort": 10}]}
+                    ],
+                },
+            },
+            {
+                "celery": {
+                    "extraPorts": [{"name": "test", "containerPort": 1}],
                     "enableDefault": False,
                     "sets": [
                         {"name": "set1", "extraPorts": [{"name": "test-extra-port", "containerPort": 10}]}


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

related: https://github.com/apache/airflow/issues/28880

This PR introduces a new `workers.celery.extraPorts` section and deprecates the old `workers.extraPorts` section (as it was only applicable to Celery workers).

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
