### PR TITLE
Fix task-level audit logs missing success/running events in Airflow 3.1.x

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -30,7 +30,7 @@ import structlog
 from cadwyn import VersionedAPIRouter
 from fastapi import Body, HTTPException, Query, status
 from pydantic import JsonValue
-from sqlalchemy import func, or_, tuple_, update
+from sqlalchemy import and_, func, or_, tuple_, update
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import NoResultFound, SQLAlchemyError
 from sqlalchemy.orm import joinedload
@@ -137,10 +137,14 @@ def ti_run(
             # This selects the raw JSON value, by-passing the deserialization -- we want that to happen on the
             # client
             column("next_kwargs", JSON),
+            DR.logical_date,
+            DagModel.owners,
         )
         .select_from(TI)
+        .join(DR, and_(TI.dag_id == DR.dag_id, TI.run_id == DR.run_id))
+        .join(DagModel, TI.dag_id == DagModel.dag_id)
         .where(TI.id == task_instance_id)
-        .with_for_update()
+        .with_for_update(of=TI)
     )
     try:
         ti = session.execute(old).one()
@@ -204,6 +208,9 @@ def ti_run(
                 run_id=ti.run_id,
                 map_index=ti.map_index,
                 try_number=ti.try_number,
+                logical_date=ti.logical_date,
+                owner=ti.owners,
+                extra=json.dumps({"host_name": ti_run_payload.hostname}) if ti_run_payload.hostname else None,
             )
         )
     # Ensure there is no end date set.
@@ -308,9 +315,23 @@ def ti_update_state(
     log.debug("Updating task instance state", new_state=ti_patch_payload.state)
 
     old = (
-        select(TI.state, TI.try_number, TI.max_tries, TI.dag_id, TI.task_id, TI.run_id, TI.map_index)
+        select(
+            TI.state,
+            TI.try_number,
+            TI.max_tries,
+            TI.dag_id,
+            TI.task_id,
+            TI.run_id,
+            TI.map_index,
+            TI.hostname,
+            DR.logical_date,
+            DagModel.owners,
+        )
+        .select_from(TI)
+        .join(DR, and_(TI.dag_id == DR.dag_id, TI.run_id == DR.run_id))
+        .join(DagModel, TI.dag_id == DagModel.dag_id)
         .where(TI.id == task_instance_id)
-        .with_for_update()
+        .with_for_update(of=TI)
     )
     try:
         (
@@ -321,6 +342,9 @@ def ti_update_state(
             task_id,
             run_id,
             map_index,
+            hostname,
+            logical_date,
+            owners,
         ) = session.execute(old).one()
         log.debug(
             "Retrieved current task instance state",
@@ -395,6 +419,9 @@ def ti_update_state(
                 run_id=run_id,
                 map_index=map_index,
                 try_number=try_number,
+                logical_date=logical_date,
+                owner=owners,
+                extra=json.dumps({"host_name": hostname}) if hostname else None,
             )
         )
     except SQLAlchemyError as e:

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -64,6 +64,7 @@ from airflow.exceptions import TaskNotFound
 from airflow.models.asset import AssetActive
 from airflow.models.dag import DagModel
 from airflow.models.dagrun import DagRun as DR
+from airflow.models.log import Log
 from airflow.models.taskinstance import TaskInstance as TI, _stop_remaining_tasks
 from airflow.models.taskreschedule import TaskReschedule
 from airflow.models.trigger import Trigger
@@ -195,6 +196,16 @@ def ti_run(
         )
     else:
         log.info("Task started", previous_state=previous_state, hostname=ti_run_payload.hostname)
+        session.add(
+            Log(
+                event=TaskInstanceState.RUNNING.value,
+                task_id=ti.task_id,
+                dag_id=ti.dag_id,
+                run_id=ti.run_id,
+                map_index=ti.map_index,
+                try_number=ti.try_number,
+            )
+        )
     # Ensure there is no end date set.
     query = query.values(
         end_date=None,
@@ -297,7 +308,7 @@ def ti_update_state(
     log.debug("Updating task instance state", new_state=ti_patch_payload.state)
 
     old = (
-        select(TI.state, TI.try_number, TI.max_tries, TI.dag_id)
+        select(TI.state, TI.try_number, TI.max_tries, TI.dag_id, TI.task_id, TI.run_id, TI.map_index)
         .where(TI.id == task_instance_id)
         .with_for_update()
     )
@@ -307,6 +318,9 @@ def ti_update_state(
             try_number,
             max_tries,
             dag_id,
+            task_id,
+            run_id,
+            map_index,
         ) = session.execute(old).one()
         log.debug(
             "Retrieved current task instance state",
@@ -372,6 +386,16 @@ def ti_update_state(
             "Task instance state updated",
             new_state=updated_state,
             rows_affected=getattr(result, "rowcount", 0),
+        )
+        session.add(
+            Log(
+                event=updated_state.value,
+                task_id=task_id,
+                dag_id=dag_id,
+                run_id=run_id,
+                map_index=map_index,
+                try_number=try_number,
+            )
         )
     except SQLAlchemyError as e:
         log.error("Error updating Task Instance state", error=str(e))

--- a/airflow-core/src/airflow/ui/tests/e2e/specs/dag-audit-log.spec.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/specs/dag-audit-log.spec.ts
@@ -22,7 +22,6 @@ import { DagsPage } from "tests/e2e/pages/DagsPage";
 import { EventsPage } from "tests/e2e/pages/EventsPage";
 
 test.describe("DAG Audit Log", () => {
-  // Serial mode ensures all tests run on one worker, preventing parallel beforeAll conflicts
   test.describe.configure({ mode: "serial" });
 
   let eventsPage: EventsPage;

--- a/airflow-core/src/airflow/ui/tests/e2e/specs/dag-audit-log.spec.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/specs/dag-audit-log.spec.ts
@@ -25,7 +25,7 @@ test.describe("DAG Audit Log", () => {
   let eventsPage: EventsPage;
 
   const testDagId = testConfig.testDag.id;
-  const triggerCount = 2;
+  const triggerCount = 3;
   const expectedEventCount = triggerCount + 1;
 
   test.setTimeout(60_000);
@@ -38,9 +38,7 @@ test.describe("DAG Audit Log", () => {
     const setupEventsPage = new EventsPage(page);
 
     for (let i = 0; i < triggerCount; i++) {
-      const dagRunId = await setupDagsPage.triggerDag(testDagId);
-
-      await setupDagsPage.verifyDagRunStatus(testDagId, dagRunId);
+      await setupDagsPage.triggerDag(testDagId);
     }
 
     await setupEventsPage.navigateToAuditLog(testDagId);

--- a/airflow-core/src/airflow/ui/tests/e2e/specs/dag-audit-log.spec.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/specs/dag-audit-log.spec.ts
@@ -22,10 +22,13 @@ import { DagsPage } from "tests/e2e/pages/DagsPage";
 import { EventsPage } from "tests/e2e/pages/EventsPage";
 
 test.describe("DAG Audit Log", () => {
+  // Serial mode ensures all tests run on one worker, preventing parallel beforeAll conflicts
+  test.describe.configure({ mode: "serial" });
+
   let eventsPage: EventsPage;
 
   const testDagId = testConfig.testDag.id;
-  const triggerCount = 3;
+  const triggerCount = 2;
   const expectedEventCount = triggerCount + 1;
 
   test.setTimeout(60_000);
@@ -38,7 +41,9 @@ test.describe("DAG Audit Log", () => {
     const setupEventsPage = new EventsPage(page);
 
     for (let i = 0; i < triggerCount; i++) {
-      await setupDagsPage.triggerDag(testDagId);
+      const dagRunId = await setupDagsPage.triggerDag(testDagId);
+
+      await setupDagsPage.verifyDagRunStatus(testDagId, dagRunId);
     }
 
     await setupEventsPage.navigateToAuditLog(testDagId);

--- a/airflow-core/src/airflow/ui/tests/e2e/specs/dag-audit-log.spec.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/specs/dag-audit-log.spec.ts
@@ -22,8 +22,6 @@ import { DagsPage } from "tests/e2e/pages/DagsPage";
 import { EventsPage } from "tests/e2e/pages/EventsPage";
 
 test.describe("DAG Audit Log", () => {
-  test.describe.configure({ mode: "serial" });
-
   let eventsPage: EventsPage;
 
   const testDagId = testConfig.testDag.id;

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -252,13 +252,6 @@ class TestTIRunState:
         )
         assert response.status_code == 409
 
-        # Test that no audit log was created on the second request when resulting in conflict
-        logs = session.scalars(select(Log).where(Log.dag_id == ti.dag_id)).all()
-        assert len(logs) == 1
-        assert logs[0].event == TaskInstanceState.RUNNING.value
-        assert logs[0].task_id == ti.task_id
-        assert logs[0].run_id == ti.run_id
-
     def test_dynamic_task_mapping_with_parse_time_value(self, client, dag_maker):
         """Test that dynamic task mapping works correctly with parse-time values."""
         with dag_maker("test_dynamic_task_mapping_with_parse_time_value", serialized=True):
@@ -695,9 +688,6 @@ class TestTIRunState:
 
         assert session.scalar(select(TaskInstance.state).where(TaskInstance.id == ti.id)) == initial_ti_state
 
-        # Test that no audit log was created on conflict
-        assert session.scalars(select(Log)).all() == []
-
     def test_xcom_not_cleared_for_deferral(self, client, session, create_task_instance, time_machine):
         """
         Test that the xcoms are not cleared when the Task Instance state is re-running after deferral.
@@ -893,15 +883,54 @@ class TestTIUpdateState:
         assert ti.end_date == end_date
 
     @pytest.mark.parametrize(
-        ("state", "end_date"),
+        ("payload", "expected_event"),
         [
-            (State.SUCCESS, DEFAULT_END_DATE),
-            (State.FAILED, DEFAULT_END_DATE),
-            (State.SKIPPED, DEFAULT_END_DATE),
+            pytest.param(
+                {"state": State.SUCCESS, "end_date": DEFAULT_END_DATE.isoformat()},
+                State.SUCCESS,
+                id="success",
+            ),
+            pytest.param(
+                {"state": State.FAILED, "end_date": DEFAULT_END_DATE.isoformat()},
+                State.FAILED,
+                id="failed",
+            ),
+            pytest.param(
+                {"state": State.SKIPPED, "end_date": DEFAULT_END_DATE.isoformat()},
+                State.SKIPPED,
+                id="skipped",
+            ),
+            pytest.param(
+                {"state": State.UP_FOR_RETRY, "end_date": DEFAULT_END_DATE.isoformat()},
+                TaskInstanceState.UP_FOR_RETRY.value,
+                id="up_for_retry",
+            ),
+            pytest.param(
+                {
+                    "state": "deferred",
+                    "trigger_kwargs": {"key": "value", "moment": "2026-02-18T00:00:00Z"},
+                    "trigger_timeout": "P1D",
+                    "classpath": "my-classpath",
+                    "next_method": "execute_callback",
+                },
+                TaskInstanceState.DEFERRED.value,
+                id="deferred",
+            ),
+            pytest.param(
+                {
+                    "state": "up_for_reschedule",
+                    "reschedule_date": "2026-02-18T11:03:00+00:00",
+                    "end_date": DEFAULT_END_DATE.isoformat(),
+                },
+                TaskInstanceState.UP_FOR_RESCHEDULE.value,
+                id="up_for_reschedule",
+            ),
         ],
     )
-    def test_ti_update_state_creates_audit_log(self, client, session, create_task_instance, state, end_date):
-        """Test that transitioning to a terminal state creates an audit log record."""
+    def test_ti_update_state_creates_audit_log(
+        self, client, session, create_task_instance, payload, expected_event
+    ):
+        """Test that state transition creates an audit log record."""
         ti = create_task_instance(
             task_id="test_ti_update_state_creates_audit_log",
             start_date=DEFAULT_START_DATE,
@@ -911,107 +940,19 @@ class TestTIUpdateState:
 
         response = client.patch(
             f"/execution/task-instances/{ti.id}/state",
-            json={
-                "state": state,
-                "end_date": end_date.isoformat(),
-            },
+            json=payload,
         )
 
         assert response.status_code == 204
 
         logs = session.scalars(select(Log).where(Log.dag_id == ti.dag_id)).all()
         assert len(logs) == 1
-        assert logs[0].event == state
+        assert logs[0].event == expected_event
         assert logs[0].task_id == ti.task_id
         assert logs[0].dag_id == ti.dag_id
         assert logs[0].run_id == ti.run_id
         assert logs[0].map_index == ti.map_index
         assert logs[0].try_number == ti.try_number
-
-    def test_ti_update_state_to_deferred_creates_audit_log(
-        self, client, session, create_task_instance, time_machine
-    ):
-        """Test that transitioning to DEFERRED creates an audit log record."""
-        ti = create_task_instance(
-            task_id="test_ti_update_state_to_deferred_creates_audit_log",
-            state=State.RUNNING,
-            session=session,
-        )
-        session.commit()
-
-        instant = timezone.datetime(2024, 11, 22)
-        time_machine.move_to(instant, tick=False)
-
-        payload = {
-            "state": "deferred",
-            "trigger_kwargs": {"key": "value", "moment": "2024-12-18T00:00:00Z"},
-            "trigger_timeout": "P1D",
-            "classpath": "my-classpath",
-            "next_method": "execute_callback",
-        }
-
-        response = client.patch(f"/execution/task-instances/{ti.id}/state", json=payload)
-        assert response.status_code == 204
-
-        logs = session.scalars(select(Log).where(Log.dag_id == ti.dag_id)).all()
-        assert len(logs) == 1
-        assert logs[0].event == TaskInstanceState.DEFERRED.value
-        assert logs[0].task_id == ti.task_id
-        assert logs[0].dag_id == ti.dag_id
-
-    def test_ti_update_state_to_reschedule_creates_audit_log(
-        self, client, session, create_task_instance, time_machine
-    ):
-        """Test that transitioning to UP_FOR_RESCHEDULE creates an audit log record."""
-        instant = timezone.datetime(2024, 10, 30)
-        time_machine.move_to(instant, tick=False)
-
-        ti = create_task_instance(
-            task_id="test_ti_update_state_to_reschedule_creates_audit_log",
-            state=State.RUNNING,
-            session=session,
-        )
-        ti.start_date = instant
-        session.commit()
-
-        payload = {
-            "state": "up_for_reschedule",
-            "reschedule_date": "2024-10-31T11:03:00+00:00",
-            "end_date": DEFAULT_END_DATE.isoformat(),
-        }
-
-        response = client.patch(f"/execution/task-instances/{ti.id}/state", json=payload)
-        assert response.status_code == 204
-
-        logs = session.scalars(select(Log).where(Log.dag_id == ti.dag_id)).all()
-        assert len(logs) == 1
-        assert logs[0].event == TaskInstanceState.UP_FOR_RESCHEDULE.value
-        assert logs[0].task_id == ti.task_id
-        assert logs[0].dag_id == ti.dag_id
-
-    def test_ti_update_state_to_retry_creates_audit_log(self, client, session, create_task_instance):
-        """Test that transitioning to UP_FOR_RETRY creates an audit log record."""
-        ti = create_task_instance(
-            task_id="test_ti_update_state_to_retry_creates_audit_log",
-            state=State.RUNNING,
-        )
-        session.commit()
-
-        response = client.patch(
-            f"/execution/task-instances/{ti.id}/state",
-            json={
-                "state": State.UP_FOR_RETRY,
-                "end_date": DEFAULT_END_DATE.isoformat(),
-            },
-        )
-
-        assert response.status_code == 204
-
-        logs = session.scalars(select(Log).where(Log.dag_id == ti.dag_id)).all()
-        assert len(logs) == 1
-        assert logs[0].event == TaskInstanceState.UP_FOR_RETRY.value
-        assert logs[0].task_id == ti.task_id
-        assert logs[0].dag_id == ti.dag_id
 
     @pytest.mark.parametrize(
         ("state", "end_date", "expected_state", "rendered_map_index"),
@@ -1201,9 +1142,6 @@ class TestTIUpdateState:
             "message": "Task Instance not found",
         }
 
-        # Test that no audit log was created when TI not found
-        assert session.scalars(select(Log)).all() == []
-
     def test_ti_update_state_running_errors(self, client, session, create_task_instance, time_machine):
         """
         Test that a 422 error is returned when the Task Instance state is RUNNING in the payload.
@@ -1258,9 +1196,6 @@ class TestTIUpdateState:
             response = client.patch(f"/execution/task-instances/{ti.id}/state", json=payload)
             assert response.status_code == 500
             assert response.json()["detail"] == "Database error occurred"
-
-        # Test that no audit log was created when database error occurred
-        assert session.scalars(select(Log)).all() == []
 
     @pytest.mark.parametrize("queues_enabled", [False, True])
     def test_ti_update_state_to_deferred(
@@ -1580,9 +1515,6 @@ class TestTIUpdateState:
         # Verify the task instance state hasn't changed
         session.refresh(ti)
         assert ti.state == State.SUCCESS
-
-        # Test that no audit log was created when TI state is not RUNNING
-        assert session.scalars(select(Log)).all() == []
 
     def test_ti_update_state_to_failed_without_fail_fast(self, client, session, dag_maker):
         """Test that SerializedDAG is NOT loaded when fail_fast=False (default)."""

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -834,6 +834,9 @@ class TestTIRunState:
         assert logs[0].run_id == ti.run_id
         assert logs[0].map_index == ti.map_index
         assert logs[0].try_number == ti.try_number
+        assert logs[0].logical_date == instant
+        assert logs[0].owner == ti.task.owner
+        assert logs[0].extra == '{"host_name": "random-hostname"}'
 
 
 class TestTIUpdateState:
@@ -935,6 +938,7 @@ class TestTIUpdateState:
             task_id="test_ti_update_state_creates_audit_log",
             start_date=DEFAULT_START_DATE,
             state=State.RUNNING,
+            hostname="random-hostname",
         )
         session.commit()
 
@@ -953,6 +957,9 @@ class TestTIUpdateState:
         assert logs[0].run_id == ti.run_id
         assert logs[0].map_index == ti.map_index
         assert logs[0].try_number == ti.try_number
+        assert logs[0].logical_date == ti.dag_run.logical_date
+        assert logs[0].owner == ti.task.owner
+        assert logs[0].extra == '{"host_name": "random-hostname"}'
 
     @pytest.mark.parametrize(
         ("state", "end_date", "expected_state", "rendered_map_index"),
@@ -1180,10 +1187,32 @@ class TestTIUpdateState:
                 "airflow.api_fastapi.common.db.common.Session.execute",
                 side_effect=[
                     mock.Mock(
-                        one=lambda: ("running", 1, 0, "dag", "task", "run", -1)
+                        one=lambda: (
+                            "running",
+                            1,
+                            0,
+                            "dag",
+                            "task",
+                            "run",
+                            -1,
+                            "localhost",
+                            timezone.utcnow(),
+                            "test_owner",
+                        )
                     ),  # First call returns "queued"
                     mock.Mock(
-                        one=lambda: ("running", 1, 0, "dag", "task", "run", -1)
+                        one=lambda: (
+                            "running",
+                            1,
+                            0,
+                            "dag",
+                            "task",
+                            "run",
+                            -1,
+                            "localhost",
+                            timezone.utcnow(),
+                            "test_owner",
+                        )
                     ),  # Second call returns "queued"
                     SQLAlchemyError("Database error"),  # Last call raises an error
                 ],

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -34,6 +34,7 @@ from airflow.api_fastapi.execution_api.app import lifespan
 from airflow.exceptions import AirflowSkipException
 from airflow.models import RenderedTaskInstanceFields, TaskReschedule, Trigger
 from airflow.models.asset import AssetActive, AssetAliasModel, AssetEvent, AssetModel
+from airflow.models.log import Log
 from airflow.models.taskinstance import TaskInstance
 from airflow.models.taskinstancehistory import TaskInstanceHistory
 from airflow.providers.standard.operators.empty import EmptyOperator
@@ -44,6 +45,7 @@ from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import (
     clear_db_assets,
     clear_db_dags,
+    clear_db_logs,
     clear_db_runs,
     clear_db_serialized_dags,
     clear_rendered_ti_fields,
@@ -127,11 +129,13 @@ def test_id_matches_sub_claim(client, session, create_task_instance):
 
 class TestTIRunState:
     def setup_method(self):
+        clear_db_logs()
         clear_db_runs()
         clear_db_serialized_dags()
         clear_db_dags()
 
     def teardown_method(self):
+        clear_db_logs()
         clear_db_runs()
         clear_db_serialized_dags()
         clear_db_dags()
@@ -247,6 +251,13 @@ class TestTIRunState:
             },
         )
         assert response.status_code == 409
+
+        # Test that no audit log was created on the second request when resulting in conflict
+        logs = session.scalars(select(Log).where(Log.dag_id == ti.dag_id)).all()
+        assert len(logs) == 1
+        assert logs[0].event == TaskInstanceState.RUNNING.value
+        assert logs[0].task_id == ti.task_id
+        assert logs[0].run_id == ti.run_id
 
     def test_dynamic_task_mapping_with_parse_time_value(self, client, dag_maker):
         """Test that dynamic task mapping works correctly with parse-time values."""
@@ -684,6 +695,9 @@ class TestTIRunState:
 
         assert session.scalar(select(TaskInstance.state).where(TaskInstance.id == ti.id)) == initial_ti_state
 
+        # Test that no audit log was created on conflict
+        assert session.scalars(select(Log)).all() == []
+
     def test_xcom_not_cleared_for_deferral(self, client, session, create_task_instance, time_machine):
         """
         Test that the xcoms are not cleared when the Task Instance state is re-running after deferral.
@@ -793,14 +807,54 @@ class TestTIRunState:
         assert dag_run["run_id"] == "test"
         assert dag_run["state"] == "running"
 
+    def test_ti_run_creates_audit_log(self, client, session, create_task_instance, time_machine):
+        """Test that transitioning to RUNNING creates an audit log record."""
+        instant_str = "2024-09-30T12:00:00Z"
+        instant = timezone.parse(instant_str)
+        time_machine.move_to(instant, tick=False)
+
+        ti = create_task_instance(
+            task_id="test_ti_run_creates_audit_log",
+            state=State.QUEUED,
+            dagrun_state=DagRunState.RUNNING,
+            session=session,
+            start_date=instant,
+            dag_id=str(uuid4()),
+        )
+        session.commit()
+
+        response = client.patch(
+            f"/execution/task-instances/{ti.id}/run",
+            json={
+                "state": "running",
+                "hostname": "random-hostname",
+                "unixname": "random-unixname",
+                "pid": 100,
+                "start_date": instant_str,
+            },
+        )
+
+        assert response.status_code == 200
+
+        logs = session.scalars(select(Log).where(Log.dag_id == ti.dag_id)).all()
+        assert len(logs) == 1
+        assert logs[0].event == TaskInstanceState.RUNNING.value
+        assert logs[0].task_id == ti.task_id
+        assert logs[0].dag_id == ti.dag_id
+        assert logs[0].run_id == ti.run_id
+        assert logs[0].map_index == ti.map_index
+        assert logs[0].try_number == ti.try_number
+
 
 class TestTIUpdateState:
     def setup_method(self):
         clear_db_assets()
+        clear_db_logs()
         clear_db_runs()
 
     def teardown_method(self):
         clear_db_assets()
+        clear_db_logs()
         clear_db_runs()
 
     @pytest.mark.parametrize(
@@ -837,6 +891,127 @@ class TestTIUpdateState:
         ti = session.get(TaskInstance, ti.id)
         assert ti.state == expected_state
         assert ti.end_date == end_date
+
+    @pytest.mark.parametrize(
+        ("state", "end_date"),
+        [
+            (State.SUCCESS, DEFAULT_END_DATE),
+            (State.FAILED, DEFAULT_END_DATE),
+            (State.SKIPPED, DEFAULT_END_DATE),
+        ],
+    )
+    def test_ti_update_state_creates_audit_log(self, client, session, create_task_instance, state, end_date):
+        """Test that transitioning to a terminal state creates an audit log record."""
+        ti = create_task_instance(
+            task_id="test_ti_update_state_creates_audit_log",
+            start_date=DEFAULT_START_DATE,
+            state=State.RUNNING,
+        )
+        session.commit()
+
+        response = client.patch(
+            f"/execution/task-instances/{ti.id}/state",
+            json={
+                "state": state,
+                "end_date": end_date.isoformat(),
+            },
+        )
+
+        assert response.status_code == 204
+
+        logs = session.scalars(select(Log).where(Log.dag_id == ti.dag_id)).all()
+        assert len(logs) == 1
+        assert logs[0].event == state
+        assert logs[0].task_id == ti.task_id
+        assert logs[0].dag_id == ti.dag_id
+        assert logs[0].run_id == ti.run_id
+        assert logs[0].map_index == ti.map_index
+        assert logs[0].try_number == ti.try_number
+
+    def test_ti_update_state_to_deferred_creates_audit_log(
+        self, client, session, create_task_instance, time_machine
+    ):
+        """Test that transitioning to DEFERRED creates an audit log record."""
+        ti = create_task_instance(
+            task_id="test_ti_update_state_to_deferred_creates_audit_log",
+            state=State.RUNNING,
+            session=session,
+        )
+        session.commit()
+
+        instant = timezone.datetime(2024, 11, 22)
+        time_machine.move_to(instant, tick=False)
+
+        payload = {
+            "state": "deferred",
+            "trigger_kwargs": {"key": "value", "moment": "2024-12-18T00:00:00Z"},
+            "trigger_timeout": "P1D",
+            "classpath": "my-classpath",
+            "next_method": "execute_callback",
+        }
+
+        response = client.patch(f"/execution/task-instances/{ti.id}/state", json=payload)
+        assert response.status_code == 204
+
+        logs = session.scalars(select(Log).where(Log.dag_id == ti.dag_id)).all()
+        assert len(logs) == 1
+        assert logs[0].event == TaskInstanceState.DEFERRED.value
+        assert logs[0].task_id == ti.task_id
+        assert logs[0].dag_id == ti.dag_id
+
+    def test_ti_update_state_to_reschedule_creates_audit_log(
+        self, client, session, create_task_instance, time_machine
+    ):
+        """Test that transitioning to UP_FOR_RESCHEDULE creates an audit log record."""
+        instant = timezone.datetime(2024, 10, 30)
+        time_machine.move_to(instant, tick=False)
+
+        ti = create_task_instance(
+            task_id="test_ti_update_state_to_reschedule_creates_audit_log",
+            state=State.RUNNING,
+            session=session,
+        )
+        ti.start_date = instant
+        session.commit()
+
+        payload = {
+            "state": "up_for_reschedule",
+            "reschedule_date": "2024-10-31T11:03:00+00:00",
+            "end_date": DEFAULT_END_DATE.isoformat(),
+        }
+
+        response = client.patch(f"/execution/task-instances/{ti.id}/state", json=payload)
+        assert response.status_code == 204
+
+        logs = session.scalars(select(Log).where(Log.dag_id == ti.dag_id)).all()
+        assert len(logs) == 1
+        assert logs[0].event == TaskInstanceState.UP_FOR_RESCHEDULE.value
+        assert logs[0].task_id == ti.task_id
+        assert logs[0].dag_id == ti.dag_id
+
+    def test_ti_update_state_to_retry_creates_audit_log(self, client, session, create_task_instance):
+        """Test that transitioning to UP_FOR_RETRY creates an audit log record."""
+        ti = create_task_instance(
+            task_id="test_ti_update_state_to_retry_creates_audit_log",
+            state=State.RUNNING,
+        )
+        session.commit()
+
+        response = client.patch(
+            f"/execution/task-instances/{ti.id}/state",
+            json={
+                "state": State.UP_FOR_RETRY,
+                "end_date": DEFAULT_END_DATE.isoformat(),
+            },
+        )
+
+        assert response.status_code == 204
+
+        logs = session.scalars(select(Log).where(Log.dag_id == ti.dag_id)).all()
+        assert len(logs) == 1
+        assert logs[0].event == TaskInstanceState.UP_FOR_RETRY.value
+        assert logs[0].task_id == ti.task_id
+        assert logs[0].dag_id == ti.dag_id
 
     @pytest.mark.parametrize(
         ("state", "end_date", "expected_state", "rendered_map_index"),
@@ -1026,6 +1201,9 @@ class TestTIUpdateState:
             "message": "Task Instance not found",
         }
 
+        # Test that no audit log was created when TI not found
+        assert session.scalars(select(Log)).all() == []
+
     def test_ti_update_state_running_errors(self, client, session, create_task_instance, time_machine):
         """
         Test that a 422 error is returned when the Task Instance state is RUNNING in the payload.
@@ -1063,8 +1241,12 @@ class TestTIUpdateState:
             mock.patch(
                 "airflow.api_fastapi.common.db.common.Session.execute",
                 side_effect=[
-                    mock.Mock(one=lambda: ("running", 1, 0, "dag")),  # First call returns "queued"
-                    mock.Mock(one=lambda: ("running", 1, 0, "dag")),  # Second call returns "queued"
+                    mock.Mock(
+                        one=lambda: ("running", 1, 0, "dag", "task", "run", -1)
+                    ),  # First call returns "queued"
+                    mock.Mock(
+                        one=lambda: ("running", 1, 0, "dag", "task", "run", -1)
+                    ),  # Second call returns "queued"
                     SQLAlchemyError("Database error"),  # Last call raises an error
                 ],
             ),
@@ -1076,6 +1258,9 @@ class TestTIUpdateState:
             response = client.patch(f"/execution/task-instances/{ti.id}/state", json=payload)
             assert response.status_code == 500
             assert response.json()["detail"] == "Database error occurred"
+
+        # Test that no audit log was created when database error occurred
+        assert session.scalars(select(Log)).all() == []
 
     @pytest.mark.parametrize("queues_enabled", [False, True])
     def test_ti_update_state_to_deferred(
@@ -1395,6 +1580,9 @@ class TestTIUpdateState:
         # Verify the task instance state hasn't changed
         session.refresh(ti)
         assert ti.state == State.SUCCESS
+
+        # Test that no audit log was created when TI state is not RUNNING
+        assert session.scalars(select(Log)).all() == []
 
     def test_ti_update_state_to_failed_without_fail_fast(self, client, session, dag_maker):
         """Test that SerializedDAG is NOT loaded when fail_fast=False (default)."""


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #58381 
* related: #ISSUE
-->
closes: #58381 

### Issue

In Airflow 2, task instance state transition such as `RUNNING`, `SUCCESS`, `SKIPPED`, `FAILED` were logged into the `log` table through the `TaskInstance` model methods. In Airflow 3, the task state update/management is moved to the execution API endpoints `ti_run` and `ti_update_state`. However, the endpoints were not wired up to create `log` records, resulting in missing audit logs for task instance state transitions.

### Fix

Added `session.add(Log(...))` calls to both `ti_run` and `ti_update_state` when the task instance state is updated. The call will be executed in the same transaction as the state update in both endpoints.

In `ti_run`, the audit log is placed inside the `else` branch such that duplicated requests, or conflict request, due to network glitch, will not be logged.

In `ti_update_state`, the `TI` select query is updated to fetch `task_id`, `run_id`, and `map_index`.

<img width="1650" height="631" alt="Screenshot from 2026-02-14 19-13-44" src="https://github.com/user-attachments/assets/7c67e47f-4a63-4600-ae61-1d9bcda19b04" />


### Caveat

The following fields in the `log` table are missing. Require extra query/join to fetch the following information.
* `logical_date` (previously `execution_date`)
* `owner` (the value is `airflow` in Airflow 2)
* `owner_display_name` (this field is also empty for task state transition)
* `extra` (`full_command` will not be available as it is not run/update through CLI; `hostname` is not available in `ti_update_state`)

EmptyOperator or operators skipped by branch doesn't have audit log

<img width="1358" height="356" alt="Screenshot from 2026-02-14 22-24-31" src="https://github.com/user-attachments/assets/24470f14-3b3e-454e-a2a4-22b8a4b3a1af" />


---

### DAG Test Samples

<img width="443" height="612" alt="Screenshot from 2026-02-14 22-13-16" src="https://github.com/user-attachments/assets/3371b6b9-21d5-4094-a3fa-0deabc843400" />

### Edited on Feb 27, 2026

Gather data for `owner`, and `logical_date` from `DagModel` and `DagRun`, and fill `extra` with `host_name`.

<img width="1385" height="880" alt="Screenshot from 2026-02-27 00-34-48" src="https://github.com/user-attachments/assets/bff7b6aa-0fe1-48da-af2e-79936d35f913" />
<img width="1082" height="378" alt="Screenshot from 2026-02-27 00-37-19" src="https://github.com/user-attachments/assets/b300b91a-52e0-46dd-9747-29b1abf952a3" />


##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

Generated-by: [Antigravity] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

The tool is used to analyze the existing test cases to understand the expected behavior of both `ti_run` and `ti_update_state`. It is also used to generate new test cases.

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
