### PR TITLE
Fix race condition in AWS CLI cache creation during parallel KubernetesPodOperator auth (#60943)

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import os
 import tempfile
 from collections.abc import AsyncGenerator
 from functools import cached_property
@@ -57,12 +58,39 @@ if TYPE_CHECKING:
 
 LOADING_KUBE_CONFIG_FILE_RESOURCE = "Loading Kubernetes configuration file kube_config from {}..."
 
+# AWS CLI cache directory that can trigger a race condition (FileExistsError)
+# when multiple processes attempt to create it concurrently during exec-based
+# authentication (e.g. ``aws eks get-token``).  Pre-creating it avoids the race.
+# See: https://github.com/apache/airflow/issues/60943
+#      https://github.com/boto/botocore/commit/f1c1bc90
+_AWS_CLI_CACHE_DIR = os.path.join(os.path.expanduser("~"), ".aws", "cli", "cache")
+
 JOB_FINAL_STATUS_CONDITION_TYPES = {
     "Complete",
     "Failed",
 }
 
 JOB_STATUS_CONDITION_TYPES = JOB_FINAL_STATUS_CONDITION_TYPES | {"Suspended"}
+
+
+def _ensure_exec_plugin_cache_dirs() -> None:
+    """Pre-create cache directories used by exec-based authentication plugins.
+
+    When multiple KubernetesPodOperator tasks run concurrently on the same
+    worker, each invokes the exec-based credential plugin (e.g.
+    ``aws eks get-token``) in parallel.  Older versions of the AWS CLI /
+    botocore call ``os.makedirs()`` **without** ``exist_ok=True`` to create
+    ``~/.aws/cli/cache``, which causes a ``FileExistsError`` race condition
+    when two processes attempt the creation simultaneously.
+
+    This function defensively pre-creates the directory so that it already
+    exists by the time any exec plugin runs, eliminating the race regardless
+    of the installed botocore version.
+
+    .. seealso:: https://github.com/apache/airflow/issues/60943
+    .. seealso:: https://github.com/boto/botocore/commit/f1c1bc90
+    """
+    os.makedirs(_AWS_CLI_CACHE_DIR, exist_ok=True)
 
 
 def _load_body_to_dict(body: str) -> dict:
@@ -297,6 +325,11 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
             _disable_verify_ssl()
         if disable_tcp_keepalive is not True:
             _enable_tcp_keepalive()
+
+        # Pre-create cache directories used by exec-based auth plugins (e.g. AWS
+        # EKS) to avoid a race condition when multiple tasks authenticate in
+        # parallel on the same worker.  See https://github.com/apache/airflow/issues/60943
+        _ensure_exec_plugin_cache_dirs()
 
         if in_cluster:
             self.log.debug("loading kube_config from: in_cluster configuration")

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/hooks/test_kubernetes.py
@@ -40,6 +40,7 @@ from airflow.providers.cncf.kubernetes.hooks.kubernetes import (
     KubernetesHook,
     _TimeoutAsyncK8sApiClient,
     _TimeoutK8sApiClient,
+    _ensure_exec_plugin_cache_dirs,
 )
 from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import (
     API_TIMEOUT,
@@ -1708,3 +1709,36 @@ class TestAsyncKubernetesHook:
             ]
         )
         mock_sleep.assert_awaited_once_with(10)
+
+
+class TestEnsureExecPluginCacheDirs:
+    """Tests for _ensure_exec_plugin_cache_dirs (issue #60943)."""
+
+    def test_creates_aws_cli_cache_dir(self, tmp_path):
+        """Verify the AWS CLI cache directory is created when it does not exist."""
+        expected_dir = tmp_path / ".aws" / "cli" / "cache"
+        assert not expected_dir.exists()
+
+        with patch(f"{HOOK_MODULE}._AWS_CLI_CACHE_DIR", str(expected_dir)):
+            _ensure_exec_plugin_cache_dirs()
+
+        assert expected_dir.is_dir()
+
+    def test_no_error_when_dir_already_exists(self, tmp_path):
+        """Verify no error is raised when the cache directory already exists."""
+        expected_dir = tmp_path / ".aws" / "cli" / "cache"
+        expected_dir.mkdir(parents=True)
+
+        with patch(f"{HOOK_MODULE}._AWS_CLI_CACHE_DIR", str(expected_dir)):
+            # Should not raise
+            _ensure_exec_plugin_cache_dirs()
+
+        assert expected_dir.is_dir()
+
+    @patch("kubernetes.config.incluster_config.InClusterConfigLoader", new=MagicMock())
+    @patch(f"{HOOK_MODULE}._ensure_exec_plugin_cache_dirs")
+    def test_get_conn_calls_ensure_cache_dirs(self, mock_ensure_dirs):
+        """Verify that get_conn() calls _ensure_exec_plugin_cache_dirs before loading config."""
+        hook = KubernetesHook(in_cluster=True)
+        hook.get_conn()
+        mock_ensure_dirs.assert_called_once()


### PR DESCRIPTION
## Summary
- Pre-create `~/.aws/cli/cache` directory in `KubernetesHook.get_conn()` to prevent a `FileExistsError` race condition when multiple KPO tasks authenticate via `aws eks get-token` concurrently on the same Celery worker
- Older botocore versions (<1.40.2) call `os.makedirs()` without `exist_ok=True`, causing intermittent task failures before pod creation

## Root Cause
When parallel KubernetesPodOperator tasks invoke exec-based EKS authentication on the same worker, the AWS CLI races to create `~/.aws/cli/cache`. The losing process gets `FileExistsError` (errno 17), which surfaces as a **403 Forbidden** from the Kubernetes API — the task fails before the pod is even created.

Fixed upstream in [botocore 1.40.2](https://github.com/boto/botocore/commit/f1c1bc90aa292b42195edecf4cf35ae348e6cc37), but this defensive fix protects users on older versions.

## Why this approach (and not something else)

We considered several alternatives before landing on defensive directory pre-creation:

| Approach | Why we rejected it |
|----------|-------------------|
| **Retry on 403 in `generic_api_retry`** | 403 is normally a permanent permissions error. Adding it to `TRANSIENT_STATUS_CODES` would mask real auth failures and add retry latency to every legitimate 403. Distinguishing transient exec-auth 403s from real permission denials is not reliably possible — the Kubernetes client's ExecProvider silently swallows the subprocess error and proceeds with a bad token, so the 403 looks identical to a genuine RBAC denial. |
| **`threading.Lock` around config loading** | The exec plugin (`aws eks get-token`) runs *lazily* during the first API call, not during `config.load_kube_config()`. A lock around config loading wouldn't prevent the race. Locking around every API call would serialize all K8s operations — unacceptable for performance. |
| **Parse kubeconfig to detect exec-based auth** | Over-engineered for a one-line fix. Would add complexity, fragile YAML parsing, and still need per-tool knowledge of which cache dirs to create. |
| **Pin `botocore >= 1.40.2` as a dependency** | The Kubernetes provider has no direct dependency on botocore and shouldn't. AWS is just one of many possible exec-based auth backends. |
| **Documentation-only (recommend botocore upgrade)** | Doesn't help users who can't control their botocore version (e.g., managed Airflow platforms like Astronomer). |

**Why pre-creation wins:**
- It's a single `os.makedirs(..., exist_ok=True)` call — the exact same fix botocore 1.40.2 applied, just done earlier in the call chain
- `exist_ok=True` is inherently safe for concurrent invocations — no race between our pre-creation and the AWS CLI
- Zero performance overhead (one syscall, idempotent)
- Zero risk of masking real errors — we don't change retry behavior or error handling
- Protects all users regardless of their botocore version

### Changes
- **`hooks/kubernetes.py`**: Added `_ensure_exec_plugin_cache_dirs()` function called from `get_conn()` before any kube config loading. Uses `os.makedirs(..., exist_ok=True)` to pre-create the cache directory.
- **`test_kubernetes.py`**: 3 new test cases verifying directory creation, idempotency, and integration with `get_conn()`.

closes: #60943

## Test plan
- [x] New unit tests verify directory creation, idempotency, and integration
- [ ] Manual: Run parallel KPO tasks on same Celery worker with EKS auth and botocore < 1.40.2

> **Note to users**: Upgrading to `botocore >= 1.40.2` also resolves this at the source. This fix provides a safety net for environments that cannot upgrade immediately.