### PR TITLE
KubernetesHook: add AWS exec-auth botocore guardrails for EKS token flow (#60943)

### DIFF
--- a/providers/cncf/kubernetes/docs/connections/kubernetes.rst
+++ b/providers/cncf/kubernetes/docs/connections/kubernetes.rst
@@ -67,6 +67,16 @@ Disable TCP keepalive
   TCP keepalive is a feature (enabled by default) that tries to keep long-running connections
   alive. Set this parameter to True to disable this feature.
 
+AWS exec auth version check mode
+  Controls runtime validation for ``aws eks get-token`` exec authentication in kubeconfig.
+  Supported values are:
+
+  * ``warn`` (default): log warnings when botocore is below ``1.40.2`` or cannot be detected.
+  * ``fail``: raise an error for vulnerable or undetectable botocore versions.
+  * ``ignore``: skip the validation entirely.
+
+  This helps prevent the known ``~/.aws/cli/cache`` race condition in older botocore versions.
+
 Xcom sidecar image
   Define the ``image`` used by the ``PodDefaults.SIDECAR_CONTAINER`` (defaults to ``"alpine"``) to allow private
   repositories, as well as custom image overrides.
@@ -75,10 +85,10 @@ Example storing connection in env var using URI format:
 
 .. code-block:: bash
 
-    AIRFLOW_CONN_KUBERNETES_DEFAULT='kubernetes://?in_cluster=True&kube_config_path=~%2F.kube%2Fconfig&kube_config=kubeconfig+json&namespace=namespace'
+    AIRFLOW_CONN_KUBERNETES_DEFAULT='kubernetes://?in_cluster=True&kube_config_path=~%2F.kube%2Fconfig&kube_config=kubeconfig+json&namespace=namespace&exec_auth_aws_cli_version_check_mode=warn'
 
 And using JSON format:
 
 .. code-block:: bash
 
-    AIRFLOW_CONN_KUBERNETES_DEFAULT='{"conn_type": "kubernetes", "extra": {"in_cluster": true, "kube_config_path": "~/.kube/config", "namespace": "my-namespace"}}'
+    AIRFLOW_CONN_KUBERNETES_DEFAULT='{"conn_type": "kubernetes", "extra": {"in_cluster": true, "kube_config_path": "~/.kube/config", "namespace": "my-namespace", "exec_auth_aws_cli_version_check_mode": "warn"}}'

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -19,9 +19,13 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import os
+import re
+import shlex
+import subprocess
 import tempfile
 from collections.abc import AsyncGenerator
-from functools import cached_property
+from functools import cached_property, lru_cache
 from time import sleep
 from typing import TYPE_CHECKING, Any, Protocol
 
@@ -56,6 +60,11 @@ if TYPE_CHECKING:
     from kubernetes.client.models import CoreV1Event, CoreV1EventList, V1Job, V1Pod
 
 LOADING_KUBE_CONFIG_FILE_RESOURCE = "Loading Kubernetes configuration file kube_config from {}..."
+_AWS_EXEC_AUTH_VERSION_CHECK_MODE_FIELD = "exec_auth_aws_cli_version_check_mode"
+_AWS_EXEC_AUTH_VERSION_CHECK_MODES = {"warn", "fail", "ignore"}
+_AWS_EXEC_AUTH_AWS_BINARY_NAMES = {"aws", "aws.exe", "aws2", "aws2.exe"}
+_AWS_EXEC_AUTH_FIXED_BOTOCORE_VERSION = (1, 40, 2)
+_BOTOCORE_VERSION_PATTERN = re.compile(r"botocore/(?P<version>\d+(?:\.\d+){1,2})")
 
 JOB_FINAL_STATUS_CONDITION_TYPES = {
     "Complete",
@@ -63,6 +72,149 @@ JOB_FINAL_STATUS_CONDITION_TYPES = {
 }
 
 JOB_STATUS_CONDITION_TYPES = JOB_FINAL_STATUS_CONDITION_TYPES | {"Suspended"}
+
+
+def _parse_version_to_tuple(version: str) -> tuple[int, int, int] | None:
+    """Parse a version string to a fixed-length integer tuple."""
+    parts = version.strip().split(".")
+    if not 2 <= len(parts) <= 3:
+        return None
+    if not all(part.isdigit() for part in parts):
+        return None
+    normalized = [int(part) for part in parts]
+    while len(normalized) < 3:
+        normalized.append(0)
+    return normalized[0], normalized[1], normalized[2]
+
+
+def _extract_exec_command_binary(exec_command: str) -> str | None:
+    """Extract the executable binary from a kubeconfig exec command."""
+    if not exec_command:
+        return None
+    try:
+        split_command = shlex.split(exec_command)
+    except ValueError:
+        split_command = exec_command.split()
+    if not split_command:
+        return None
+    return split_command[0]
+
+
+def _tokenize_exec_args(exec_args: Any) -> list[str]:
+    """Tokenize kubeconfig exec args robustly."""
+    if not isinstance(exec_args, list):
+        return []
+    tokens: list[str] = []
+    for arg in exec_args:
+        arg_string = str(arg)
+        try:
+            tokens.extend(shlex.split(arg_string))
+        except ValueError:
+            tokens.extend(arg_string.split())
+    return tokens
+
+
+def _extract_aws_eks_exec_binary(kubeconfig: dict, cluster_context: str | None) -> str | None:
+    """
+    Return exec binary when selected context uses ``aws eks get-token`` auth.
+
+    We validate the selected context's user ``exec`` stanza and only return a
+    binary path when the command is AWS CLI and args include ``eks get-token``.
+    """
+    contexts = kubeconfig.get("contexts")
+    users = kubeconfig.get("users")
+    if not isinstance(contexts, list) or not isinstance(users, list):
+        return None
+
+    selected_context = cluster_context or kubeconfig.get("current-context")
+    if not isinstance(selected_context, str) or not selected_context:
+        return None
+
+    context_entry = next(
+        (
+            entry
+            for entry in contexts
+            if isinstance(entry, dict) and entry.get("name") == selected_context and isinstance(entry.get("context"), dict)
+        ),
+        None,
+    )
+    if context_entry is None:
+        return None
+
+    user_name = context_entry["context"].get("user")
+    if not isinstance(user_name, str) or not user_name:
+        return None
+
+    user_entry = next(
+        (
+            entry
+            for entry in users
+            if isinstance(entry, dict) and entry.get("name") == user_name and isinstance(entry.get("user"), dict)
+        ),
+        None,
+    )
+    if user_entry is None:
+        return None
+
+    exec_auth = user_entry["user"].get("exec")
+    if not isinstance(exec_auth, dict):
+        return None
+
+    exec_command = exec_auth.get("command")
+    if not isinstance(exec_command, str):
+        return None
+    exec_binary = _extract_exec_command_binary(exec_command)
+    if exec_binary is None:
+        return None
+    exec_binary_name = os.path.basename(exec_binary).lower()
+    if exec_binary_name not in _AWS_EXEC_AUTH_AWS_BINARY_NAMES:
+        return None
+
+    exec_args = _tokenize_exec_args(exec_auth.get("args", []))
+    if "eks" not in exec_args or "get-token" not in exec_args:
+        return None
+    if exec_args.index("eks") > exec_args.index("get-token"):
+        return None
+
+    return exec_binary
+
+
+@lru_cache(maxsize=8)
+def _get_aws_cli_botocore_version(exec_binary: str) -> tuple[tuple[int, int, int] | None, str | None]:
+    """
+    Get botocore version exposed by a given AWS CLI binary.
+
+    Returns a tuple ``(version_tuple, error_message)`` where only one value is
+    expected to be non-null.
+    """
+    try:
+        result = subprocess.run([exec_binary, "--version"], capture_output=True, text=True, check=False)
+    except OSError as e:
+        return None, f"Unable to execute '{exec_binary} --version': {e}"
+
+    output = " ".join(filter(None, [result.stdout, result.stderr])).strip()
+    if not output:
+        return None, f"No output from '{exec_binary} --version' (exit code {result.returncode})"
+
+    match = _BOTOCORE_VERSION_PATTERN.search(output)
+    if not match:
+        return None, f"Unable to parse botocore version from '{exec_binary} --version' output: {output!r}"
+
+    parsed_version = _parse_version_to_tuple(match.group("version"))
+    if parsed_version is None:
+        return None, f"Unsupported botocore version format in output: {match.group('version')!r}"
+
+    return parsed_version, None
+
+
+def _parse_kubeconfig_content(kubeconfig_content: str | dict) -> dict | None:
+    """Parse kubeconfig from string or dictionary input."""
+    if isinstance(kubeconfig_content, dict):
+        return kubeconfig_content
+    parsed = yaml.safe_load(kubeconfig_content)
+    if isinstance(parsed, dict):
+        return parsed
+    return None
 
 
 def _load_body_to_dict(body: str) -> dict:
@@ -178,6 +330,11 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
             "kube_config": PasswordField(
                 lazy_gettext("Kube config (JSON format)"), widget=BS3PasswordFieldWidget()
             ),
+            "exec_auth_aws_cli_version_check_mode": StringField(
+                lazy_gettext("AWS exec auth version check mode"),
+                widget=BS3TextFieldWidget(),
+                default="warn",
+            ),
             "namespace": StringField(lazy_gettext("Namespace"), widget=BS3TextFieldWidget()),
             "cluster_context": StringField(lazy_gettext("Cluster context"), widget=BS3TextFieldWidget()),
             "disable_verify_ssl": BooleanField(lazy_gettext("Disable SSL")),
@@ -269,6 +426,113 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
         prefixed_name = f"extra__kubernetes__{field_name}"
         return self.conn_extras.get(prefixed_name) or None
 
+    def _get_exec_auth_aws_cli_version_check_mode(self) -> str:
+        raw_mode = self._get_field(_AWS_EXEC_AUTH_VERSION_CHECK_MODE_FIELD)
+        if raw_mode is None:
+            return "warn"
+        mode = str(raw_mode).strip().lower()
+        if mode in _AWS_EXEC_AUTH_VERSION_CHECK_MODES:
+            return mode
+        self.log.warning(
+            "Invalid value for %s=%r. Expected one of %s. Falling back to 'warn'.",
+            _AWS_EXEC_AUTH_VERSION_CHECK_MODE_FIELD,
+            raw_mode,
+            sorted(_AWS_EXEC_AUTH_VERSION_CHECK_MODES),
+        )
+        return "warn"
+
+    def _load_kubeconfig_from_path(self, kubeconfig_path: str) -> dict | None:
+        resolved_path = os.path.expanduser(kubeconfig_path)
+        try:
+            with open(resolved_path, encoding="utf-8") as stream:
+                parsed = yaml.safe_load(stream)
+        except (OSError, yaml.YAMLError) as e:
+            self.log.debug("Skipping AWS exec auth runtime check; cannot parse kubeconfig at %s: %s", resolved_path, e)
+            return None
+        if not isinstance(parsed, dict):
+            self.log.debug(
+                "Skipping AWS exec auth runtime check; kubeconfig at %s did not parse to a dictionary.",
+                resolved_path,
+            )
+            return None
+        return parsed
+
+    def _check_exec_auth_aws_cli_botocore_version(
+        self,
+        *,
+        cluster_context: str | None,
+        kubeconfig_path: str | None = None,
+        kubeconfig_content: str | dict | None = None,
+        config_dict: dict | None = None,
+    ) -> None:
+        """
+        Validate AWS CLI botocore version for exec-based auth.
+
+        Only applies when kubeconfig auth for selected context uses
+        ``aws eks get-token``.
+        """
+        mode = self._get_exec_auth_aws_cli_version_check_mode()
+        if mode == "ignore":
+            return
+
+        kubeconfig: dict | None = None
+        if config_dict is not None:
+            kubeconfig = config_dict
+        elif kubeconfig_content is not None:
+            try:
+                kubeconfig = _parse_kubeconfig_content(kubeconfig_content)
+            except yaml.YAMLError as e:
+                self.log.debug(
+                    "Skipping AWS exec auth runtime check; cannot parse kubeconfig content from connection: %s",
+                    e,
+                )
+        elif kubeconfig_path:
+            kubeconfig = self._load_kubeconfig_from_path(kubeconfig_path)
+
+        if not kubeconfig:
+            return
+
+        exec_binary = _extract_aws_eks_exec_binary(kubeconfig, cluster_context)
+        if exec_binary is None:
+            return
+
+        botocore_version, version_error = _get_aws_cli_botocore_version(exec_binary)
+        if version_error:
+            message = (
+                "Unable to determine botocore version for Kubernetes exec auth command "
+                f"{exec_binary!r}: {version_error}. "
+                f"Set '{_AWS_EXEC_AUTH_VERSION_CHECK_MODE_FIELD}=ignore' to skip this validation."
+            )
+            if mode == "fail":
+                raise AirflowException(message)
+            self.log.warning(message)
+            return
+
+        if botocore_version is None:
+            return
+
+        if botocore_version < _AWS_EXEC_AUTH_FIXED_BOTOCORE_VERSION:
+            detected_version = ".".join(str(v) for v in botocore_version)
+            minimum_version = ".".join(str(v) for v in _AWS_EXEC_AUTH_FIXED_BOTOCORE_VERSION)
+            message = (
+                "Detected vulnerable botocore version "
+                f"{detected_version} for Kubernetes exec auth command {exec_binary!r}. "
+                f"Please upgrade to botocore >= {minimum_version} (or AWS CLI version that bundles it) "
+                f"to avoid the ~/.aws/cli/cache race condition, or set "
+                f"'{_AWS_EXEC_AUTH_VERSION_CHECK_MODE_FIELD}=ignore' to bypass this check."
+            )
+            if mode == "fail":
+                raise AirflowException(message)
+            self.log.warning(message)
+            return
+
+        self.log.debug(
+            "Detected botocore version %s for Kubernetes exec auth command %r; minimum required is %s.",
+            ".".join(str(v) for v in botocore_version),
+            exec_binary,
+            ".".join(str(v) for v in _AWS_EXEC_AUTH_FIXED_BOTOCORE_VERSION),
+        )
+
     def get_conn(self) -> client.ApiClient:
         """Return kubernetes api session for use with requests."""
         in_cluster = self._coalesce_param(self.in_cluster, self._get_field("in_cluster"))
@@ -307,6 +571,10 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
         if kubeconfig_path is not None:
             self.log.debug("loading kube_config from: %s", kubeconfig_path)
             self._is_in_cluster = False
+            self._check_exec_auth_aws_cli_botocore_version(
+                cluster_context=cluster_context,
+                kubeconfig_path=kubeconfig_path,
+            )
             config.load_kube_config(
                 config_file=kubeconfig_path,
                 client_configuration=self.client_configuration,
@@ -315,6 +583,10 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
             return _TimeoutK8sApiClient()
 
         if kubeconfig is not None:
+            self._check_exec_auth_aws_cli_botocore_version(
+                cluster_context=cluster_context,
+                kubeconfig_content=kubeconfig,
+            )
             with tempfile.NamedTemporaryFile() as temp_config:
                 self.log.debug("loading kube_config from: connection kube_config")
                 if isinstance(kubeconfig, dict):
@@ -332,6 +604,10 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
         if self.config_dict:
             self.log.debug(LOADING_KUBE_CONFIG_FILE_RESOURCE.format("config dictionary"))
             self._is_in_cluster = False
+            self._check_exec_auth_aws_cli_botocore_version(
+                cluster_context=cluster_context,
+                config_dict=self.config_dict,
+            )
             config.load_kube_config_from_dict(
                 config_dict=self.config_dict,
                 client_configuration=self.client_configuration,
@@ -352,6 +628,10 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
         except ConfigException:
             self.log.debug("loading kube_config from: default file")
             self._is_in_cluster = False
+            self._check_exec_auth_aws_cli_botocore_version(
+                cluster_context=cluster_context,
+                kubeconfig_path=config.kube_config.KUBE_CONFIG_DEFAULT_LOCATION,
+            )
             config.load_kube_config(
                 client_configuration=self.client_configuration,
                 context=cluster_context,

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -134,7 +134,9 @@ def _extract_aws_eks_exec_binary(kubeconfig: dict, cluster_context: str | None) 
         (
             entry
             for entry in contexts
-            if isinstance(entry, dict) and entry.get("name") == selected_context and isinstance(entry.get("context"), dict)
+            if isinstance(entry, dict)
+            and entry.get("name") == selected_context
+            and isinstance(entry.get("context"), dict)
         ),
         None,
     )
@@ -149,7 +151,9 @@ def _extract_aws_eks_exec_binary(kubeconfig: dict, cluster_context: str | None) 
         (
             entry
             for entry in users
-            if isinstance(entry, dict) and entry.get("name") == user_name and isinstance(entry.get("user"), dict)
+            if isinstance(entry, dict)
+            and entry.get("name") == user_name
+            and isinstance(entry.get("user"), dict)
         ),
         None,
     )
@@ -447,7 +451,9 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
             with open(resolved_path, encoding="utf-8") as stream:
                 parsed = yaml.safe_load(stream)
         except (OSError, yaml.YAMLError) as e:
-            self.log.debug("Skipping AWS exec auth runtime check; cannot parse kubeconfig at %s: %s", resolved_path, e)
+            self.log.debug(
+                "Skipping AWS exec auth runtime check; cannot parse kubeconfig at %s: %s", resolved_path, e
+            )
             return None
         if not isinstance(parsed, dict):
             self.log.debug(

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/hooks/test_kubernetes.py
@@ -38,6 +38,8 @@ from airflow.models import Connection
 from airflow.providers.cncf.kubernetes.hooks.kubernetes import (
     AsyncKubernetesHook,
     KubernetesHook,
+    _extract_aws_eks_exec_binary,
+    _get_aws_cli_botocore_version,
     _TimeoutAsyncK8sApiClient,
     _TimeoutK8sApiClient,
 )
@@ -181,6 +183,9 @@ class TestKubernetesHook:
         connections = [
             ("in_cluster", {"in_cluster": True}),
             ("in_cluster_empty", {"in_cluster": ""}),
+            ("exec_auth_aws_check_fail", {"exec_auth_aws_cli_version_check_mode": "fail"}),
+            ("exec_auth_aws_check_ignore", {"exec_auth_aws_cli_version_check_mode": "ignore"}),
+            ("exec_auth_aws_check_invalid", {"exec_auth_aws_cli_version_check_mode": "invalid"}),
             ("kube_config", {"kube_config": '{"test": "kube"}'}),
             ("kube_config_dict", {"kube_config": {"test": "kube"}}),
             ("kube_config_path", {"kube_config_path": "path/to/file"}),
@@ -892,6 +897,152 @@ class TestKubernetesHook:
         assert hook._is_in_cluster is False
         kube_config_loader.assert_called_once()
         assert isinstance(api_conn, kubernetes.client.api_client.ApiClient)
+
+    @staticmethod
+    def _aws_exec_kubeconfig(command: str = "aws", args: list[str] | None = None) -> dict:
+        if args is None:
+            args = ["eks", "get-token", "--cluster-name", "example-cluster"]
+        return {
+            "current-context": "example-context",
+            "contexts": [{"name": "example-context", "context": {"cluster": "example", "user": "example-user"}}],
+            "users": [{"name": "example-user", "user": {"exec": {"command": command, "args": args}}}],
+        }
+
+    def test_extract_aws_eks_exec_binary(self):
+        kubeconfig = self._aws_exec_kubeconfig(command="/usr/local/bin/aws")
+        assert _extract_aws_eks_exec_binary(kubeconfig, cluster_context=None) == "/usr/local/bin/aws"
+
+    def test_extract_aws_eks_exec_binary_returns_none_for_non_aws_exec(self):
+        kubeconfig = self._aws_exec_kubeconfig(command="python")
+        assert _extract_aws_eks_exec_binary(kubeconfig, cluster_context=None) is None
+
+    @patch(f"{HOOK_MODULE}.subprocess.run")
+    def test_get_aws_cli_botocore_version(self, mock_subprocess_run):
+        _get_aws_cli_botocore_version.cache_clear()
+        mock_subprocess_run.return_value = mock.Mock(
+            stdout="",
+            stderr="aws-cli/2.22.0 Python/3.12.0 Linux botocore/2.10.1",
+            returncode=0,
+        )
+
+        version, error = _get_aws_cli_botocore_version("aws")
+
+        assert version == (2, 10, 1)
+        assert error is None
+
+    @patch(f"{HOOK_MODULE}._extract_aws_eks_exec_binary")
+    @patch(f"{HOOK_MODULE}._get_aws_cli_botocore_version")
+    def test_exec_auth_runtime_check_warn_mode_logs_for_vulnerable_botocore(
+        self,
+        mock_get_botocore_version,
+        mock_extract_exec_binary,
+        caplog,
+    ):
+        hook = KubernetesHook(conn_id="default_kube_config")
+        mock_extract_exec_binary.return_value = "aws"
+        mock_get_botocore_version.return_value = ((1, 40, 1), None)
+
+        hook._check_exec_auth_aws_cli_botocore_version(
+            cluster_context=None,
+            config_dict=self._aws_exec_kubeconfig(),
+        )
+
+        assert "Detected vulnerable botocore version 1.40.1" in caplog.text
+
+    @patch(f"{HOOK_MODULE}._extract_aws_eks_exec_binary")
+    @patch(f"{HOOK_MODULE}._get_aws_cli_botocore_version")
+    def test_exec_auth_runtime_check_fail_mode_raises_for_vulnerable_botocore(
+        self,
+        mock_get_botocore_version,
+        mock_extract_exec_binary,
+    ):
+        hook = KubernetesHook(conn_id="exec_auth_aws_check_fail")
+        mock_extract_exec_binary.return_value = "aws"
+        mock_get_botocore_version.return_value = ((1, 39, 9), None)
+
+        with pytest.raises(AirflowException, match="Detected vulnerable botocore version 1.39.9"):
+            hook._check_exec_auth_aws_cli_botocore_version(
+                cluster_context=None,
+                config_dict=self._aws_exec_kubeconfig(),
+            )
+
+    @patch(f"{HOOK_MODULE}._extract_aws_eks_exec_binary")
+    @patch(f"{HOOK_MODULE}._get_aws_cli_botocore_version")
+    def test_exec_auth_runtime_check_fail_mode_raises_for_unknown_version(
+        self,
+        mock_get_botocore_version,
+        mock_extract_exec_binary,
+    ):
+        hook = KubernetesHook(conn_id="exec_auth_aws_check_fail")
+        mock_extract_exec_binary.return_value = "aws"
+        mock_get_botocore_version.return_value = (None, "Unable to parse version")
+
+        with pytest.raises(AirflowException, match="Unable to determine botocore version"):
+            hook._check_exec_auth_aws_cli_botocore_version(
+                cluster_context=None,
+                config_dict=self._aws_exec_kubeconfig(),
+            )
+
+    @patch.object(KubernetesHook, "_load_kubeconfig_from_path")
+    @patch(f"{HOOK_MODULE}._extract_aws_eks_exec_binary")
+    @patch(f"{HOOK_MODULE}._get_aws_cli_botocore_version")
+    def test_exec_auth_runtime_check_ignore_mode_skips_version_check(
+        self,
+        mock_get_botocore_version,
+        mock_extract_exec_binary,
+        mock_load_kubeconfig_from_path,
+    ):
+        hook = KubernetesHook(conn_id="exec_auth_aws_check_ignore")
+        mock_load_kubeconfig_from_path.return_value = self._aws_exec_kubeconfig()
+
+        hook._check_exec_auth_aws_cli_botocore_version(
+            cluster_context=None,
+            kubeconfig_path="/tmp/kubeconfig",
+        )
+
+        mock_load_kubeconfig_from_path.assert_not_called()
+        mock_extract_exec_binary.assert_not_called()
+        mock_get_botocore_version.assert_not_called()
+
+    def test_exec_auth_runtime_check_invalid_mode_falls_back_to_warn(self, caplog):
+        hook = KubernetesHook(conn_id="exec_auth_aws_check_invalid")
+        mode = hook._get_exec_auth_aws_cli_version_check_mode()
+        assert mode == "warn"
+        assert "Invalid value for exec_auth_aws_cli_version_check_mode='invalid'" in caplog.text
+
+    @patch("kubernetes.config.kube_config.KubeConfigLoader")
+    @patch("kubernetes.config.kube_config.KubeConfigMerger")
+    @patch.object(KubernetesHook, "_check_exec_auth_aws_cli_botocore_version")
+    def test_get_conn_runs_exec_auth_version_check_for_kubeconfig_path(
+        self,
+        mock_exec_auth_check,
+        mock_kube_config_merger,
+        mock_kube_config_loader,
+    ):
+        hook = KubernetesHook(conn_id="kube_config_path")
+        hook.get_conn()
+
+        mock_exec_auth_check.assert_called_once_with(cluster_context=None, kubeconfig_path="path/to/file")
+
+    @patch("kubernetes.config.load_kube_config")
+    @patch("kubernetes.config.load_incluster_config")
+    @patch.object(KubernetesHook, "_check_exec_auth_aws_cli_botocore_version")
+    def test_get_default_client_runs_exec_auth_version_check(
+        self,
+        mock_exec_auth_check,
+        mock_load_incluster_config,
+        mock_load_kube_config,
+    ):
+        mock_load_incluster_config.side_effect = ConfigException("not in cluster")
+        hook = KubernetesHook()
+
+        hook._get_default_client(cluster_context="ctx")
+
+        mock_exec_auth_check.assert_called_once_with(
+            cluster_context="ctx",
+            kubeconfig_path=kubernetes.config.kube_config.KUBE_CONFIG_DEFAULT_LOCATION,
+        )
+        mock_load_kube_config.assert_called_once_with(client_configuration=None, context="ctx")
 
 
 class TestKubernetesHookIncorrectConfiguration:

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/hooks/test_kubernetes.py
@@ -904,7 +904,9 @@ class TestKubernetesHook:
             args = ["eks", "get-token", "--cluster-name", "example-cluster"]
         return {
             "current-context": "example-context",
-            "contexts": [{"name": "example-context", "context": {"cluster": "example", "user": "example-user"}}],
+            "contexts": [
+                {"name": "example-context", "context": {"cluster": "example", "user": "example-user"}}
+            ],
             "users": [{"name": "example-user", "user": {"exec": {"command": command, "args": args}}}],
         }
 


### PR DESCRIPTION
## Why this change

Issue #60943 reports intermittent KubernetesPodOperator task failures on Celery workers when multiple tasks start together and kubeconfig uses `aws eks get-token` exec auth.

The failure mode is subtle:
- the auth subprocess (`aws eks get-token`) can fail due to older botocore race behavior around `~/.aws/cli/cache`
- Kubernetes client then proceeds with invalid/empty auth and surfaces a generic `403 Forbidden`
- this looks identical to real RBAC failures, so operators often lose time debugging the wrong problem

This PR adds **explicit runtime guardrails** for that path so operators get a clear signal before task execution fails in a misleading way.

## Impact of the change

This adds a policy-driven runtime check only when kubeconfig exec auth actually uses `aws eks get-token`:

- `warn` (default): emits an actionable warning if botocore is vulnerable (`< 1.40.2`) or version cannot be detected
- `fail`: hard-fails early with a clear error to enforce platform policy
- `ignore`: bypasses the check when users intentionally manage this externally

Operational impact:
- **Improves diagnosability** of a production issue that often appears as ambiguous `403`
- **Reduces MTTR** by surfacing root-cause guidance at connection/auth setup time
- **Adds governance controls** for teams that need strict enforcement (`fail`) without forcing everyone into that mode
- **Keeps backwards compatibility** with default `warn`

## Scope and non-goals

- Scope is intentionally limited to the AWS EKS exec-auth path (`aws eks get-token`) because this is the concrete failing path in #60943.
- This PR does **not** change Kubernetes retry semantics for `403` responses, and does not change auth flow for non-AWS exec plugins.

## Configuration

New Kubernetes connection extra:
- `exec_auth_aws_cli_version_check_mode`: `warn` (default) | `fail` | `ignore`

## Validation

- Added unit coverage for:
  - kubeconfig exec-auth detection (`aws eks get-token`)
  - botocore version parsing from `aws --version`
  - mode behavior (`warn`, `fail`, `ignore`, invalid fallback)
  - integration points in `get_conn` and default kubeconfig client path
- Test command used:
  - `AIRFLOW_HOME=/tmp/airflow-60943 uv run --python 3.12 -m pytest providers/cncf/kubernetes/tests/unit/cncf/kubernetes/hooks/test_kubernetes.py -q`

closes #60943
