### PR TITLE
AIP-76: Add ProductMapper for multi-dimensional partition keys

### DIFF
--- a/airflow-core/src/airflow/example_dags/example_asset_partition.py
+++ b/airflow-core/src/airflow/example_dags/example_asset_partition.py
@@ -163,7 +163,7 @@ with DAG(
     dag_id="aggregate_regional_sales",
     schedule=PartitionedAssetTimetable(
         assets=regional_sales,
-        default_partition_mapper=ProductMapper([IdentityMapper(), DailyMapper()]),
+        default_partition_mapper=ProductMapper(IdentityMapper(), DailyMapper()),
     ),
     catchup=False,
     tags=["sales", "aggregation"],

--- a/airflow-core/src/airflow/example_dags/example_asset_partition.py
+++ b/airflow-core/src/airflow/example_dags/example_asset_partition.py
@@ -23,8 +23,11 @@ from airflow.sdk import (
     DAG,
     Asset,
     CronPartitionTimetable,
+    DailyMapper,
     HourlyMapper,
+    IdentityMapper,
     PartitionedAssetTimetable,
+    ProductMapper,
     YearlyMapper,
     asset,
     task,
@@ -137,3 +140,47 @@ with DAG(
         pass
 
     check_partition_alignment()
+
+
+regional_sales = Asset(uri="file://incoming/sales/regional.csv", name="regional_sales")
+
+with DAG(
+    dag_id="ingest_regional_sales",
+    schedule=CronPartitionTimetable("0 * * * *", timezone="UTC"),
+    tags=["sales", "ingestion"],
+):
+    """Produce hourly regional sales data with composite partition keys."""
+
+    @task(outlets=[regional_sales])
+    def ingest_sales():
+        """Ingest regional sales data partitioned by region and time."""
+        pass
+
+    ingest_sales()
+
+
+with DAG(
+    dag_id="aggregate_regional_sales",
+    schedule=PartitionedAssetTimetable(
+        assets=regional_sales,
+        default_partition_mapper=ProductMapper([IdentityMapper(), DailyMapper()]),
+    ),
+    catchup=False,
+    tags=["sales", "aggregation"],
+):
+    """
+    Aggregate regional sales using ProductMapper.
+
+    The ProductMapper splits the composite key "region|timestamp" and applies
+    IdentityMapper to the region segment and DailyMapper to the timestamp segment,
+    aligning hourly partitions to daily granularity per region.
+    """
+
+    @task
+    def aggregate_sales(dag_run=None):
+        """Aggregate sales data for the matched region-day partition."""
+        if TYPE_CHECKING:
+            assert dag_run
+        print(dag_run.partition_key)
+
+    aggregate_sales()

--- a/airflow-core/src/airflow/partition_mappers/product.py
+++ b/airflow-core/src/airflow/partition_mappers/product.py
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from typing import Any
+
+from airflow.partition_mappers.base import PartitionMapper
+
+
+class ProductMapper(PartitionMapper):
+    """Partition mapper that combines multiple mappers into a multi-dimensional key."""
+
+    DELIMITER = "|"
+
+    def __init__(self, mappers: list[PartitionMapper]) -> None:
+        if len(mappers) < 2:
+            raise ValueError("ProductMapper requires at least 2 child mappers")
+        self.mappers = mappers
+
+    def to_downstream(self, key: str) -> str:
+        segments = key.split(self.DELIMITER)
+        if len(segments) != len(self.mappers):
+            raise ValueError(f"Expected {len(self.mappers)} segments in key, got {len(segments)}")
+        return self.DELIMITER.join(
+            mapper.to_downstream(segment) for mapper, segment in zip(self.mappers, segments)
+        )
+
+    def serialize(self) -> dict[str, Any]:
+        from airflow.serialization.encoders import encode_partition_mapper
+
+        return {"mappers": [encode_partition_mapper(m) for m in self.mappers]}
+
+    @classmethod
+    def deserialize(cls, data: dict[str, Any]) -> PartitionMapper:
+        from airflow.serialization.decoders import decode_partition_mapper
+
+        return cls(mappers=[decode_partition_mapper(m) for m in data["mappers"]])

--- a/airflow-core/src/airflow/partition_mappers/product.py
+++ b/airflow-core/src/airflow/partition_mappers/product.py
@@ -25,15 +25,14 @@ from airflow.partition_mappers.base import PartitionMapper
 class ProductMapper(PartitionMapper):
     """Partition mapper that combines multiple mappers into a multi-dimensional key."""
 
-    DELIMITER = "|"
-
-    def __init__(self, mappers: list[PartitionMapper]) -> None:
+    def __init__(self, mappers: list[PartitionMapper], delimiter: str = "|") -> None:
         if len(mappers) < 2:
             raise ValueError("ProductMapper requires at least 2 child mappers")
         self.mappers = mappers
+        self.delimiter = delimiter
 
     def to_downstream(self, key: str) -> str:
-        segments = key.split(self.DELIMITER)
+        segments = key.split(self.delimiter)
         if len(segments) != len(self.mappers):
             raise ValueError(f"Expected {len(self.mappers)} segments in key, got {len(segments)}")
         results: list[str] = []
@@ -45,15 +44,21 @@ class ProductMapper(PartitionMapper):
                     f"but {type(mapper).__name__} returned multiple keys"
                 )
             results.append(result)
-        return self.DELIMITER.join(results)
+        return self.delimiter.join(results)
 
     def serialize(self) -> dict[str, Any]:
         from airflow.serialization.encoders import encode_partition_mapper
 
-        return {"mappers": [encode_partition_mapper(m) for m in self.mappers]}
+        return {
+            "delimiter": self.delimiter,
+            "mappers": [encode_partition_mapper(m) for m in self.mappers],
+        }
 
     @classmethod
     def deserialize(cls, data: dict[str, Any]) -> PartitionMapper:
         from airflow.serialization.decoders import decode_partition_mapper
 
-        return cls(mappers=[decode_partition_mapper(m) for m in data["mappers"]])
+        return cls(
+            mappers=[decode_partition_mapper(m) for m in data["mappers"]],
+            delimiter=data.get("delimiter", "|"),
+        )

--- a/airflow-core/src/airflow/partition_mappers/product.py
+++ b/airflow-core/src/airflow/partition_mappers/product.py
@@ -25,10 +25,15 @@ from airflow.partition_mappers.base import PartitionMapper
 class ProductMapper(PartitionMapper):
     """Partition mapper that combines multiple mappers into a multi-dimensional key."""
 
-    def __init__(self, mappers: list[PartitionMapper], delimiter: str = "|") -> None:
-        if len(mappers) < 2:
-            raise ValueError("ProductMapper requires at least 2 child mappers")
-        self.mappers = mappers
+    def __init__(
+        self,
+        mapper0: PartitionMapper,
+        mapper1: PartitionMapper,
+        /,
+        *mappers: PartitionMapper,
+        delimiter: str = "|",
+    ) -> None:
+        self.mappers = [mapper0, mapper1, *mappers]
         self.delimiter = delimiter
 
     def to_downstream(self, key: str) -> str:
@@ -58,7 +63,5 @@ class ProductMapper(PartitionMapper):
     def deserialize(cls, data: dict[str, Any]) -> PartitionMapper:
         from airflow.serialization.decoders import decode_partition_mapper
 
-        return cls(
-            mappers=[decode_partition_mapper(m) for m in data["mappers"]],
-            delimiter=data.get("delimiter", "|"),
-        )
+        mappers = [decode_partition_mapper(m) for m in data["mappers"]]
+        return cls(*mappers, delimiter=data.get("delimiter", "|"))

--- a/airflow-core/src/airflow/partition_mappers/product.py
+++ b/airflow-core/src/airflow/partition_mappers/product.py
@@ -36,9 +36,16 @@ class ProductMapper(PartitionMapper):
         segments = key.split(self.DELIMITER)
         if len(segments) != len(self.mappers):
             raise ValueError(f"Expected {len(self.mappers)} segments in key, got {len(segments)}")
-        return self.DELIMITER.join(
-            mapper.to_downstream(segment) for mapper, segment in zip(self.mappers, segments)
-        )
+        results: list[str] = []
+        for mapper, segment in zip(self.mappers, segments):
+            result = mapper.to_downstream(segment)
+            if not isinstance(result, str):
+                raise TypeError(
+                    f"ProductMapper child mappers must return a single key, "
+                    f"but {type(mapper).__name__} returned multiple keys"
+                )
+            results.append(result)
+        return self.DELIMITER.join(results)
 
     def serialize(self) -> dict[str, Any]:
         from airflow.serialization.encoders import encode_partition_mapper

--- a/airflow-core/src/airflow/serialization/encoders.py
+++ b/airflow-core/src/airflow/serialization/encoders.py
@@ -43,6 +43,7 @@ from airflow.sdk import (
     MonthlyMapper,
     MultipleCronTriggerTimetable,
     PartitionMapper,
+    ProductMapper,
     QuarterlyMapper,
     WeeklyMapper,
     YearlyMapper,
@@ -373,6 +374,7 @@ class _Serializer:
         MonthlyMapper: "airflow.partition_mappers.temporal.MonthlyMapper",
         QuarterlyMapper: "airflow.partition_mappers.temporal.QuarterlyMapper",
         YearlyMapper: "airflow.partition_mappers.temporal.YearlyMapper",
+        ProductMapper: "airflow.partition_mappers.product.ProductMapper",
     }
 
     @functools.singledispatchmethod
@@ -406,6 +408,10 @@ class _Serializer:
             "input_format": partition_mapper.input_format,
             "output_format": partition_mapper.output_format,
         }
+
+    @serialize_partition_mapper.register
+    def _(self, partition_mapper: ProductMapper) -> dict[str, Any]:
+        return {"mappers": [encode_partition_mapper(m) for m in partition_mapper.mappers]}
 
 
 _serializer = _Serializer()

--- a/airflow-core/src/airflow/serialization/encoders.py
+++ b/airflow-core/src/airflow/serialization/encoders.py
@@ -411,7 +411,10 @@ class _Serializer:
 
     @serialize_partition_mapper.register
     def _(self, partition_mapper: ProductMapper) -> dict[str, Any]:
-        return {"mappers": [encode_partition_mapper(m) for m in partition_mapper.mappers]}
+        return {
+            "delimiter": partition_mapper.delimiter,
+            "mappers": [encode_partition_mapper(m) for m in partition_mapper.mappers],
+        }
 
 
 _serializer = _Serializer()

--- a/airflow-core/tests/unit/partition_mappers/test_product.py
+++ b/airflow-core/tests/unit/partition_mappers/test_product.py
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import pytest
+
+from airflow.partition_mappers.identity import IdentityMapper
+from airflow.partition_mappers.product import ProductMapper
+
+
+class TestProductMapper:
+    def test_to_downstream(self):
+        pm = ProductMapper([IdentityMapper(), IdentityMapper()])
+        assert pm.to_downstream("a|b") == "a|b"
+
+    def test_to_downstream_wrong_segment_count(self):
+        pm = ProductMapper([IdentityMapper(), IdentityMapper()])
+        with pytest.raises(ValueError, match="Expected 2 segments"):
+            pm.to_downstream("a|b|c")
+
+    def test_to_downstream_single_segment_for_two_mappers(self):
+        pm = ProductMapper([IdentityMapper(), IdentityMapper()])
+        with pytest.raises(ValueError, match="Expected 2 segments"):
+            pm.to_downstream("a")
+
+    def test_requires_at_least_two_mappers(self):
+        with pytest.raises(ValueError, match="at least 2"):
+            ProductMapper([IdentityMapper()])
+
+    def test_requires_at_least_two_mappers_empty(self):
+        with pytest.raises(ValueError, match="at least 2"):
+            ProductMapper([])
+
+    def test_serialize(self):
+        from airflow.serialization.encoders import encode_partition_mapper
+
+        pm = ProductMapper([IdentityMapper(), IdentityMapper()])
+        result = pm.serialize()
+        assert result == {
+            "mappers": [
+                encode_partition_mapper(IdentityMapper()),
+                encode_partition_mapper(IdentityMapper()),
+            ]
+        }
+
+    def test_deserialize(self):
+        pm = ProductMapper([IdentityMapper(), IdentityMapper()])
+        serialized = pm.serialize()
+        restored = ProductMapper.deserialize(serialized)
+        assert isinstance(restored, ProductMapper)
+        assert len(restored.mappers) == 2
+        assert restored.to_downstream("x|y") == "x|y"
+
+    def test_three_mappers(self):
+        pm = ProductMapper([IdentityMapper(), IdentityMapper(), IdentityMapper()])
+        assert pm.to_downstream("a|b|c") == "a|b|c"

--- a/airflow-core/tests/unit/partition_mappers/test_product.py
+++ b/airflow-core/tests/unit/partition_mappers/test_product.py
@@ -26,40 +26,32 @@ from airflow.partition_mappers.temporal import DailyMapper, HourlyMapper
 
 class TestProductMapper:
     def test_to_downstream(self):
-        pm = ProductMapper([HourlyMapper(), DailyMapper()])
+        pm = ProductMapper(HourlyMapper(), DailyMapper())
         assert pm.to_downstream("2024-01-15T10:30:00|2024-01-15T10:30:00") == "2024-01-15T10|2024-01-15"
 
     def test_to_downstream_wrong_segment_count(self):
-        pm = ProductMapper([HourlyMapper(), DailyMapper()])
+        pm = ProductMapper(HourlyMapper(), DailyMapper())
         with pytest.raises(ValueError, match="Expected 2 segments"):
             pm.to_downstream("2024-01-15T10:30:00|2024-01-15T10:30:00|extra")
 
     def test_to_downstream_single_segment_for_two_mappers(self):
-        pm = ProductMapper([HourlyMapper(), DailyMapper()])
+        pm = ProductMapper(HourlyMapper(), DailyMapper())
         with pytest.raises(ValueError, match="Expected 2 segments"):
             pm.to_downstream("2024-01-15T10:30:00")
 
-    def test_requires_at_least_two_mappers(self):
-        with pytest.raises(ValueError, match="at least 2"):
-            ProductMapper([HourlyMapper()])
-
-    def test_requires_at_least_two_mappers_empty(self):
-        with pytest.raises(ValueError, match="at least 2"):
-            ProductMapper([])
-
     def test_custom_delimiter(self):
-        pm = ProductMapper([HourlyMapper(), DailyMapper()], delimiter="::")
+        pm = ProductMapper(HourlyMapper(), DailyMapper(), delimiter="::")
         assert pm.to_downstream("2024-01-15T10:30:00::2024-01-15T10:30:00") == "2024-01-15T10::2024-01-15"
 
     def test_custom_delimiter_wrong_segment_count(self):
-        pm = ProductMapper([HourlyMapper(), DailyMapper()], delimiter="::")
+        pm = ProductMapper(HourlyMapper(), DailyMapper(), delimiter="::")
         with pytest.raises(ValueError, match="Expected 2 segments"):
             pm.to_downstream("2024-01-15T10:30:00::2024-01-15T10:30:00::extra")
 
     def test_serialize(self):
         from airflow.serialization.encoders import encode_partition_mapper
 
-        pm = ProductMapper([HourlyMapper(), DailyMapper()])
+        pm = ProductMapper(HourlyMapper(), DailyMapper())
         result = pm.serialize()
         assert result == {
             "delimiter": "|",
@@ -72,7 +64,7 @@ class TestProductMapper:
     def test_serialize_custom_delimiter(self):
         from airflow.serialization.encoders import encode_partition_mapper
 
-        pm = ProductMapper([HourlyMapper(), DailyMapper()], delimiter="::")
+        pm = ProductMapper(HourlyMapper(), DailyMapper(), delimiter="::")
         result = pm.serialize()
         assert result == {
             "delimiter": "::",
@@ -83,7 +75,7 @@ class TestProductMapper:
         }
 
     def test_deserialize(self):
-        pm = ProductMapper([HourlyMapper(), DailyMapper()])
+        pm = ProductMapper(HourlyMapper(), DailyMapper())
         serialized = pm.serialize()
         restored = ProductMapper.deserialize(serialized)
         assert isinstance(restored, ProductMapper)
@@ -92,7 +84,7 @@ class TestProductMapper:
         assert restored.to_downstream("2024-01-15T10:30:00|2024-01-15T10:30:00") == "2024-01-15T10|2024-01-15"
 
     def test_deserialize_custom_delimiter(self):
-        pm = ProductMapper([HourlyMapper(), DailyMapper()], delimiter="::")
+        pm = ProductMapper(HourlyMapper(), DailyMapper(), delimiter="::")
         serialized = pm.serialize()
         restored = ProductMapper.deserialize(serialized)
         assert isinstance(restored, ProductMapper)
@@ -115,7 +107,7 @@ class TestProductMapper:
         assert restored.delimiter == "|"
 
     def test_three_mappers(self):
-        pm = ProductMapper([HourlyMapper(), DailyMapper(), IdentityMapper()])
+        pm = ProductMapper(HourlyMapper(), DailyMapper(), IdentityMapper())
         assert (
             pm.to_downstream("2024-01-15T10:30:00|2024-01-15T10:30:00|raw") == "2024-01-15T10|2024-01-15|raw"
         )

--- a/airflow-core/tests/unit/partition_mappers/test_product.py
+++ b/airflow-core/tests/unit/partition_mappers/test_product.py
@@ -46,16 +46,39 @@ class TestProductMapper:
         with pytest.raises(ValueError, match="at least 2"):
             ProductMapper([])
 
+    def test_custom_delimiter(self):
+        pm = ProductMapper([IdentityMapper(), IdentityMapper()], delimiter="::")
+        assert pm.to_downstream("a::b") == "a::b"
+
+    def test_custom_delimiter_wrong_segment_count(self):
+        pm = ProductMapper([IdentityMapper(), IdentityMapper()], delimiter="::")
+        with pytest.raises(ValueError, match="Expected 2 segments"):
+            pm.to_downstream("a::b::c")
+
     def test_serialize(self):
         from airflow.serialization.encoders import encode_partition_mapper
 
         pm = ProductMapper([IdentityMapper(), IdentityMapper()])
         result = pm.serialize()
         assert result == {
+            "delimiter": "|",
             "mappers": [
                 encode_partition_mapper(IdentityMapper()),
                 encode_partition_mapper(IdentityMapper()),
-            ]
+            ],
+        }
+
+    def test_serialize_custom_delimiter(self):
+        from airflow.serialization.encoders import encode_partition_mapper
+
+        pm = ProductMapper([IdentityMapper(), IdentityMapper()], delimiter="::")
+        result = pm.serialize()
+        assert result == {
+            "delimiter": "::",
+            "mappers": [
+                encode_partition_mapper(IdentityMapper()),
+                encode_partition_mapper(IdentityMapper()),
+            ],
         }
 
     def test_deserialize(self):
@@ -64,7 +87,29 @@ class TestProductMapper:
         restored = ProductMapper.deserialize(serialized)
         assert isinstance(restored, ProductMapper)
         assert len(restored.mappers) == 2
+        assert restored.delimiter == "|"
         assert restored.to_downstream("x|y") == "x|y"
+
+    def test_deserialize_custom_delimiter(self):
+        pm = ProductMapper([IdentityMapper(), IdentityMapper()], delimiter="::")
+        serialized = pm.serialize()
+        restored = ProductMapper.deserialize(serialized)
+        assert isinstance(restored, ProductMapper)
+        assert restored.delimiter == "::"
+        assert restored.to_downstream("x::y") == "x::y"
+
+    def test_deserialize_backward_compat(self):
+        """Deserializing data without delimiter field defaults to '|'."""
+        from airflow.serialization.encoders import encode_partition_mapper
+
+        data = {
+            "mappers": [
+                encode_partition_mapper(IdentityMapper()),
+                encode_partition_mapper(IdentityMapper()),
+            ],
+        }
+        restored = ProductMapper.deserialize(data)
+        assert restored.delimiter == "|"
 
     def test_three_mappers(self):
         pm = ProductMapper([IdentityMapper(), IdentityMapper(), IdentityMapper()])

--- a/airflow-core/tests/unit/partition_mappers/test_product.py
+++ b/airflow-core/tests/unit/partition_mappers/test_product.py
@@ -21,82 +21,85 @@ import pytest
 
 from airflow.partition_mappers.identity import IdentityMapper
 from airflow.partition_mappers.product import ProductMapper
+from airflow.partition_mappers.temporal import DailyMapper, HourlyMapper
 
 
 class TestProductMapper:
     def test_to_downstream(self):
-        pm = ProductMapper([IdentityMapper(), IdentityMapper()])
-        assert pm.to_downstream("a|b") == "a|b"
+        pm = ProductMapper([HourlyMapper(), DailyMapper()])
+        assert pm.to_downstream("2024-01-15T10:30:00|2024-01-15T10:30:00") == "2024-01-15T10|2024-01-15"
 
     def test_to_downstream_wrong_segment_count(self):
-        pm = ProductMapper([IdentityMapper(), IdentityMapper()])
+        pm = ProductMapper([HourlyMapper(), DailyMapper()])
         with pytest.raises(ValueError, match="Expected 2 segments"):
-            pm.to_downstream("a|b|c")
+            pm.to_downstream("2024-01-15T10:30:00|2024-01-15T10:30:00|extra")
 
     def test_to_downstream_single_segment_for_two_mappers(self):
-        pm = ProductMapper([IdentityMapper(), IdentityMapper()])
+        pm = ProductMapper([HourlyMapper(), DailyMapper()])
         with pytest.raises(ValueError, match="Expected 2 segments"):
-            pm.to_downstream("a")
+            pm.to_downstream("2024-01-15T10:30:00")
 
     def test_requires_at_least_two_mappers(self):
         with pytest.raises(ValueError, match="at least 2"):
-            ProductMapper([IdentityMapper()])
+            ProductMapper([HourlyMapper()])
 
     def test_requires_at_least_two_mappers_empty(self):
         with pytest.raises(ValueError, match="at least 2"):
             ProductMapper([])
 
     def test_custom_delimiter(self):
-        pm = ProductMapper([IdentityMapper(), IdentityMapper()], delimiter="::")
-        assert pm.to_downstream("a::b") == "a::b"
+        pm = ProductMapper([HourlyMapper(), DailyMapper()], delimiter="::")
+        assert pm.to_downstream("2024-01-15T10:30:00::2024-01-15T10:30:00") == "2024-01-15T10::2024-01-15"
 
     def test_custom_delimiter_wrong_segment_count(self):
-        pm = ProductMapper([IdentityMapper(), IdentityMapper()], delimiter="::")
+        pm = ProductMapper([HourlyMapper(), DailyMapper()], delimiter="::")
         with pytest.raises(ValueError, match="Expected 2 segments"):
-            pm.to_downstream("a::b::c")
+            pm.to_downstream("2024-01-15T10:30:00::2024-01-15T10:30:00::extra")
 
     def test_serialize(self):
         from airflow.serialization.encoders import encode_partition_mapper
 
-        pm = ProductMapper([IdentityMapper(), IdentityMapper()])
+        pm = ProductMapper([HourlyMapper(), DailyMapper()])
         result = pm.serialize()
         assert result == {
             "delimiter": "|",
             "mappers": [
-                encode_partition_mapper(IdentityMapper()),
-                encode_partition_mapper(IdentityMapper()),
+                encode_partition_mapper(HourlyMapper()),
+                encode_partition_mapper(DailyMapper()),
             ],
         }
 
     def test_serialize_custom_delimiter(self):
         from airflow.serialization.encoders import encode_partition_mapper
 
-        pm = ProductMapper([IdentityMapper(), IdentityMapper()], delimiter="::")
+        pm = ProductMapper([HourlyMapper(), DailyMapper()], delimiter="::")
         result = pm.serialize()
         assert result == {
             "delimiter": "::",
             "mappers": [
-                encode_partition_mapper(IdentityMapper()),
-                encode_partition_mapper(IdentityMapper()),
+                encode_partition_mapper(HourlyMapper()),
+                encode_partition_mapper(DailyMapper()),
             ],
         }
 
     def test_deserialize(self):
-        pm = ProductMapper([IdentityMapper(), IdentityMapper()])
+        pm = ProductMapper([HourlyMapper(), DailyMapper()])
         serialized = pm.serialize()
         restored = ProductMapper.deserialize(serialized)
         assert isinstance(restored, ProductMapper)
         assert len(restored.mappers) == 2
         assert restored.delimiter == "|"
-        assert restored.to_downstream("x|y") == "x|y"
+        assert restored.to_downstream("2024-01-15T10:30:00|2024-01-15T10:30:00") == "2024-01-15T10|2024-01-15"
 
     def test_deserialize_custom_delimiter(self):
-        pm = ProductMapper([IdentityMapper(), IdentityMapper()], delimiter="::")
+        pm = ProductMapper([HourlyMapper(), DailyMapper()], delimiter="::")
         serialized = pm.serialize()
         restored = ProductMapper.deserialize(serialized)
         assert isinstance(restored, ProductMapper)
         assert restored.delimiter == "::"
-        assert restored.to_downstream("x::y") == "x::y"
+        assert (
+            restored.to_downstream("2024-01-15T10:30:00::2024-01-15T10:30:00") == "2024-01-15T10::2024-01-15"
+        )
 
     def test_deserialize_backward_compat(self):
         """Deserializing data without delimiter field defaults to '|'."""
@@ -104,13 +107,15 @@ class TestProductMapper:
 
         data = {
             "mappers": [
-                encode_partition_mapper(IdentityMapper()),
-                encode_partition_mapper(IdentityMapper()),
+                encode_partition_mapper(HourlyMapper()),
+                encode_partition_mapper(DailyMapper()),
             ],
         }
         restored = ProductMapper.deserialize(data)
         assert restored.delimiter == "|"
 
     def test_three_mappers(self):
-        pm = ProductMapper([IdentityMapper(), IdentityMapper(), IdentityMapper()])
-        assert pm.to_downstream("a|b|c") == "a|b|c"
+        pm = ProductMapper([HourlyMapper(), DailyMapper(), IdentityMapper()])
+        assert (
+            pm.to_downstream("2024-01-15T10:30:00|2024-01-15T10:30:00|raw") == "2024-01-15T10|2024-01-15|raw"
+        )

--- a/airflow-core/tests/unit/serialization/test_serialized_objects.py
+++ b/airflow-core/tests/unit/serialization/test_serialized_objects.py
@@ -838,7 +838,7 @@ def test_encode_product_mapper():
     from airflow.sdk import HourlyMapper, IdentityMapper, ProductMapper
     from airflow.serialization.encoders import encode_partition_mapper
 
-    partition_mapper = ProductMapper([IdentityMapper(), HourlyMapper()])
+    partition_mapper = ProductMapper(IdentityMapper(), HourlyMapper())
     assert encode_partition_mapper(partition_mapper) == {
         Encoding.TYPE: "airflow.partition_mappers.product.ProductMapper",
         Encoding.VAR: {
@@ -866,7 +866,7 @@ def test_decode_product_mapper():
     from airflow.serialization.decoders import decode_partition_mapper
     from airflow.serialization.encoders import encode_partition_mapper
 
-    partition_mapper = ProductMapper([HourlyMapper(), DailyMapper()])
+    partition_mapper = ProductMapper(HourlyMapper(), DailyMapper())
     encoded_pm = encode_partition_mapper(partition_mapper)
 
     core_pm = decode_partition_mapper(encoded_pm)

--- a/airflow-core/tests/unit/serialization/test_serialized_objects.py
+++ b/airflow-core/tests/unit/serialization/test_serialized_objects.py
@@ -835,41 +835,49 @@ def test_decode_partition_mapper_not_exists():
 
 
 def test_encode_product_mapper():
-    from airflow.sdk import IdentityMapper, ProductMapper
+    from airflow.sdk import HourlyMapper, ProductMapper
     from airflow.serialization.encoders import encode_partition_mapper
 
-    partition_mapper = ProductMapper([IdentityMapper(), IdentityMapper()])
+    partition_mapper = ProductMapper([HourlyMapper(), HourlyMapper()])
     assert encode_partition_mapper(partition_mapper) == {
         Encoding.TYPE: "airflow.partition_mappers.product.ProductMapper",
         Encoding.VAR: {
+            "delimiter": "|",
             "mappers": [
                 {
-                    Encoding.TYPE: "airflow.partition_mappers.identity.IdentityMapper",
-                    Encoding.VAR: {},
+                    Encoding.TYPE: "airflow.partition_mappers.temporal.HourlyMapper",
+                    Encoding.VAR: {
+                        "input_format": "%Y-%m-%dT%H:%M:%S",
+                        "output_format": "%Y-%m-%dT%H",
+                    },
                 },
                 {
-                    Encoding.TYPE: "airflow.partition_mappers.identity.IdentityMapper",
-                    Encoding.VAR: {},
+                    Encoding.TYPE: "airflow.partition_mappers.temporal.HourlyMapper",
+                    Encoding.VAR: {
+                        "input_format": "%Y-%m-%dT%H:%M:%S",
+                        "output_format": "%Y-%m-%dT%H",
+                    },
                 },
-            ]
+            ],
         },
     }
 
 
 def test_decode_product_mapper():
     from airflow.partition_mappers.product import ProductMapper as CoreProductMapper
-    from airflow.sdk import IdentityMapper, ProductMapper
+    from airflow.sdk import DailyMapper, HourlyMapper, ProductMapper
     from airflow.serialization.decoders import decode_partition_mapper
     from airflow.serialization.encoders import encode_partition_mapper
 
-    partition_mapper = ProductMapper([IdentityMapper(), IdentityMapper()])
+    partition_mapper = ProductMapper([HourlyMapper(), DailyMapper()])
     encoded_pm = encode_partition_mapper(partition_mapper)
 
     core_pm = decode_partition_mapper(encoded_pm)
 
     assert isinstance(core_pm, CoreProductMapper)
     assert len(core_pm.mappers) == 2
-    assert core_pm.to_downstream("a|b") == "a|b"
+    assert core_pm.delimiter == "|"
+    assert core_pm.to_downstream("2024-06-15T10:30:00|2024-06-15T10:30:00") == "2024-06-15T10|2024-06-15"
 
 
 class TestSerializedBaseOperator:

--- a/airflow-core/tests/unit/serialization/test_serialized_objects.py
+++ b/airflow-core/tests/unit/serialization/test_serialized_objects.py
@@ -835,21 +835,18 @@ def test_decode_partition_mapper_not_exists():
 
 
 def test_encode_product_mapper():
-    from airflow.sdk import HourlyMapper, ProductMapper
+    from airflow.sdk import HourlyMapper, IdentityMapper, ProductMapper
     from airflow.serialization.encoders import encode_partition_mapper
 
-    partition_mapper = ProductMapper([HourlyMapper(), HourlyMapper()])
+    partition_mapper = ProductMapper([IdentityMapper(), HourlyMapper()])
     assert encode_partition_mapper(partition_mapper) == {
         Encoding.TYPE: "airflow.partition_mappers.product.ProductMapper",
         Encoding.VAR: {
             "delimiter": "|",
             "mappers": [
                 {
-                    Encoding.TYPE: "airflow.partition_mappers.temporal.HourlyMapper",
-                    Encoding.VAR: {
-                        "input_format": "%Y-%m-%dT%H:%M:%S",
-                        "output_format": "%Y-%m-%dT%H",
-                    },
+                    Encoding.TYPE: "airflow.partition_mappers.identity.IdentityMapper",
+                    Encoding.VAR: {},
                 },
                 {
                     Encoding.TYPE: "airflow.partition_mappers.temporal.HourlyMapper",

--- a/task-sdk/docs/api.rst
+++ b/task-sdk/docs/api.rst
@@ -215,6 +215,8 @@ Partition Mapper
 
 .. autoapiclass:: airflow.sdk.YearlyMapper
 
+.. autoapiclass:: airflow.sdk.ProductMapper
+
 I/O Helpers
 -----------
 .. autoapiclass:: airflow.sdk.ObjectStoragePath

--- a/task-sdk/src/airflow/sdk/__init__.py
+++ b/task-sdk/src/airflow/sdk/__init__.py
@@ -61,6 +61,7 @@ __all__ = [
     "PartitionedAssetTimetable",
     "PartitionMapper",
     "PokeReturnValue",
+    "ProductMapper",
     "QuarterlyMapper",
     "SkipMixin",
     "SyncCallback",
@@ -122,6 +123,7 @@ if TYPE_CHECKING:
     from airflow.sdk.definitions.param import Param, ParamsDict
     from airflow.sdk.definitions.partition_mappers.base import PartitionMapper
     from airflow.sdk.definitions.partition_mappers.identity import IdentityMapper
+    from airflow.sdk.definitions.partition_mappers.product import ProductMapper
     from airflow.sdk.definitions.partition_mappers.temporal import (
         DailyMapper,
         HourlyMapper,
@@ -198,6 +200,7 @@ __lazy_imports: dict[str, str] = {
     "PartitionedAssetTimetable": ".definitions.timetables.assets",
     "PartitionMapper": ".definitions.partition_mappers.base",
     "PokeReturnValue": ".bases.sensor",
+    "ProductMapper": ".definitions.partition_mappers.product",
     "QuarterlyMapper": ".definitions.partition_mappers.temporal",
     "SecretCache": ".execution_time.cache",
     "SkipMixin": ".bases.skipmixin",

--- a/task-sdk/src/airflow/sdk/__init__.pyi
+++ b/task-sdk/src/airflow/sdk/__init__.pyi
@@ -63,6 +63,7 @@ from airflow.sdk.definitions.edges import EdgeModifier as EdgeModifier, Label as
 from airflow.sdk.definitions.param import Param as Param
 from airflow.sdk.definitions.partition_mappers.base import PartitionMapper
 from airflow.sdk.definitions.partition_mappers.identity import IdentityMapper
+from airflow.sdk.definitions.partition_mappers.product import ProductMapper
 from airflow.sdk.definitions.partition_mappers.temporal import (
     DailyMapper,
     HourlyMapper,
@@ -135,6 +136,7 @@ __all__ = [
     "PokeReturnValue",
     "PartitionedAssetTimetable",
     "PartitionMapper",
+    "ProductMapper",
     "QuarterlyMapper",
     "SecretCache",
     "SkipMixin",

--- a/task-sdk/src/airflow/sdk/definitions/partition_mappers/product.py
+++ b/task-sdk/src/airflow/sdk/definitions/partition_mappers/product.py
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from airflow.sdk.definitions.partition_mappers.base import PartitionMapper
+
+
+class ProductMapper(PartitionMapper):
+    """Partition mapper that combines multiple mappers into a multi-dimensional key."""
+
+    def __init__(self, mappers: list[PartitionMapper]) -> None:
+        if len(mappers) < 2:
+            raise ValueError("ProductMapper requires at least 2 child mappers")
+        self.mappers = mappers

--- a/task-sdk/src/airflow/sdk/definitions/partition_mappers/product.py
+++ b/task-sdk/src/airflow/sdk/definitions/partition_mappers/product.py
@@ -22,7 +22,8 @@ from airflow.sdk.definitions.partition_mappers.base import PartitionMapper
 class ProductMapper(PartitionMapper):
     """Partition mapper that combines multiple mappers into a multi-dimensional key."""
 
-    def __init__(self, mappers: list[PartitionMapper]) -> None:
+    def __init__(self, mappers: list[PartitionMapper], delimiter: str = "|") -> None:
         if len(mappers) < 2:
             raise ValueError("ProductMapper requires at least 2 child mappers")
         self.mappers = mappers
+        self.delimiter = delimiter

--- a/task-sdk/src/airflow/sdk/definitions/partition_mappers/product.py
+++ b/task-sdk/src/airflow/sdk/definitions/partition_mappers/product.py
@@ -22,8 +22,13 @@ from airflow.sdk.definitions.partition_mappers.base import PartitionMapper
 class ProductMapper(PartitionMapper):
     """Partition mapper that combines multiple mappers into a multi-dimensional key."""
 
-    def __init__(self, mappers: list[PartitionMapper], delimiter: str = "|") -> None:
-        if len(mappers) < 2:
-            raise ValueError("ProductMapper requires at least 2 child mappers")
-        self.mappers = mappers
+    def __init__(
+        self,
+        mapper0: PartitionMapper,
+        mapper1: PartitionMapper,
+        /,
+        *mappers: PartitionMapper,
+        delimiter: str = "|",
+    ) -> None:
+        self.mappers = [mapper0, mapper1, *mappers]
         self.delimiter = delimiter


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->
## Summary                                                                                         
 
- Implements `ProductMapper` for AIP-76 (Asset Partitions), which combines multiple partition  mappers into a Cartesian product using pipe-delimited composite keys (e.g.`"2024-01-01|warehouse-a"`)                                                                        
- Adds core implementation with `to_downstream()`, `serialize()`/`deserialize()`, and SDK stub following the established `IdentityMapper` pattern                                                 
- Fixes a pre-existing bug in `encode_partition_mapper` that was missing the  `is_core_partition_mapper_import_path` check (the timetable equivalent  `_get_serialized_timetable_import_path` already had this), which prevented re-serialization of deserialized core mapper instances                                     
 

closes: #44145 (ProductMapper portion)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
