### PR TITLE
Fix FAB auth_manager load_user causing PendingRollbackError and Inter…

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -1415,6 +1415,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
             log.error("Error loading user: %s", e)
             self.session.rollback()
             return None
+        return None
 
     def get_user_by_id(self, pk) -> User | None:
         return self.session.get(self.user_model, pk)

--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -1407,10 +1407,14 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
             raise FabException(const.LOGMSG_ERR_SEC_ADD_USER) from e
 
     def load_user(self, pk: int) -> User | None:
-        user = self.get_user_by_id(int(pk))
-        if user and user.is_active:
-            return user
-        return None
+        try:
+            user = self.get_user_by_id(int(pk))
+            if user and user.is_active:
+                return user
+        except Exception as e:
+            log.error("Error loading user: %s", e)
+            self.session.rollback()
+            return None
 
     def get_user_by_id(self, pk) -> User | None:
         return self.session.get(self.user_model, pk)


### PR DESCRIPTION

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

### Summary

This PR makes `FabAirflowSecurityManagerOverride.load_user` more robust by:

- Safely handling cases where the user does not exist or is inactive.
- Catching database exceptions (including `PendingRollbackError`), rolling back the session, and returning `None` instead of letting the exception bubble up.

The goal is to prevent `sqlalchemy.exc.PendingRollbackError` from causing `500 Internal Server Error` responses on the web UI when loading the current user.



---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
