### PR TITLE
Examples: add measurement correction storyline example Dags

### DIFF
--- a/providers/standard/src/airflow/providers/standard/example_dags/example_measurement_correction_decorator.py
+++ b/providers/standard/src/airflow/providers/standard/example_dags/example_measurement_correction_decorator.py
@@ -1,0 +1,73 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Example Dag demonstrating a simple measurement correction workflow"""
+
+from __future__ import annotations
+
+from airflow.sdk import dag, task
+from airflow.utils.dates import days_ago
+
+
+# [START example_measurement_correction_decorator]
+@dag(
+    dag_id="example_measurement_correction_decorator",
+    start_date=days_ago(1),
+    schedule=None,
+    catchup=False,
+    tags=["example"],
+)
+def measurement_correction_decorator():
+    """
+    A tutorial Dag showing how to:
+    1. Read a raw measurement
+    2. Validate the measurement
+    3. Apply a correction factor
+    4. Log the corrected result
+    """
+
+    # Task 1: Read a raw measurement
+    @task
+    def read_measurement() -> int:
+        return 100
+
+    # Task 2: Validate the measurement
+    @task
+    def validate_measurement(value: int) -> int:
+        if value < 0:
+            raise ValueError("Measurement must be positive")
+        return value
+
+    # Task 3: Apply a correction factor
+    @task
+    def apply_correction(value: int) -> float:
+        correction_factor = 1.1
+        return value * correction_factor
+
+    # Task 4: Log the final corrected result
+    @task
+    def store_result(value: float) -> None:
+        print(f"Corrected measurement: {value}")
+
+    raw_value = read_measurement()
+    validated_value = validate_measurement(raw_value)
+    corrected_value = apply_correction(validated_value)
+    store_result(corrected_value)
+
+
+measurement_correction_decorator()
+# [END example_measurement_correction_decorator]

--- a/providers/standard/src/airflow/providers/standard/example_dags/example_measurement_correction_decorator.py
+++ b/providers/standard/src/airflow/providers/standard/example_dags/example_measurement_correction_decorator.py
@@ -20,13 +20,13 @@
 from __future__ import annotations
 
 from airflow.sdk import dag, task
-from airflow.utils.dates import days_ago
+import pendulum
 
 
 # [START example_measurement_correction_decorator]
 @dag(
     dag_id="example_measurement_correction_decorator",
-    start_date=days_ago(1),
+    start_date=pendulum.datetime(2024, 1, 1, tz="UTC"),
     schedule=None,
     catchup=False,
     tags=["example"],

--- a/providers/standard/src/airflow/providers/standard/example_dags/example_measurement_correction_operator.py
+++ b/providers/standard/src/airflow/providers/standard/example_dags/example_measurement_correction_operator.py
@@ -1,0 +1,85 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Example Dag demonstrating a simple measurement correction workflow
+using operator PythonOperator tasks.
+"""
+
+from __future__ import annotations
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from airflow.utils.dates import days_ago
+
+
+# Task 1: Return a raw measurement value
+def read_measurement(**context):
+    return 100
+
+
+# Task 2: Validate the measurement value
+def validate_measurement(**context):
+    value = context["ti"].xcom_pull(task_ids="read_measurement")
+    if value < 0:
+        raise ValueError("Measurement must be positive")
+    return value
+
+
+# Task 3: Apply correction factor
+def apply_correction(**context):
+    value = context["ti"].xcom_pull(task_ids="validate_measurement")
+    return value * 1.1
+
+
+# Task 4: Log the corrected result
+def store_result(**context):
+    value = context["ti"].xcom_pull(task_ids="apply_correction")
+    print(f"Corrected measurement: {value}")
+
+
+# [START example_measurement_correction_operator]
+with DAG(
+    dag_id="example_measurement_correction_operator",
+    start_date=days_ago(1),
+    schedule=None,
+    catchup=False,
+    tags=["example"],
+) as dag:
+
+    read = PythonOperator(
+        task_id="read_measurement",
+        python_callable=read_measurement,
+    )
+
+    validate = PythonOperator(
+        task_id="validate_measurement",
+        python_callable=validate_measurement,
+    )
+
+    correct = PythonOperator(
+        task_id="apply_correction",
+        python_callable=apply_correction,
+    )
+
+    store = PythonOperator(
+        task_id="store_result",
+        python_callable=store_result,
+    )
+
+    # Define execution order
+    read >> validate >> correct >> store
+# [END example_measurement_correction_operator]

--- a/providers/standard/src/airflow/providers/standard/example_dags/example_measurement_correction_operator.py
+++ b/providers/standard/src/airflow/providers/standard/example_dags/example_measurement_correction_operator.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 from airflow import DAG
 from airflow.operators.python import PythonOperator
-from airflow.utils.dates import days_ago
+import pendulum
 
 
 # Task 1: Return a raw measurement value
@@ -54,7 +54,7 @@ def store_result(**context):
 # [START example_measurement_correction_operator]
 with DAG(
     dag_id="example_measurement_correction_operator",
-    start_date=days_ago(1),
+    start_date=pendulum.datetime(2024, 1, 1, tz="UTC"),
     schedule=None,
     catchup=False,
     tags=["example"],


### PR DESCRIPTION
Adds new "Measurement Correction" storyline example Dags implemented using both
decorator-based (TaskFlow-style) and classic operator-based approaches.

These examples follow the example Dag review checklist and serve as tutorial-style reference examples.

Related to: #52482
