### PR TITLE
Fix GitHub Actions workflow policy violations by adding max-parallel

### DIFF
--- a/.github/workflows/airflow-distributions-tests.yml
+++ b/.github/workflows/airflow-distributions-tests.yml
@@ -75,6 +75,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runners) }}
     strategy:
       fail-fast: false
+      max-parallel: 20
       matrix:
         python-version: "${{fromJSON(inputs.python-versions)}}"
     env:

--- a/.github/workflows/generate-constraints.yml
+++ b/.github/workflows/generate-constraints.yml
@@ -60,6 +60,8 @@ jobs:
     name: Generate constraints for ${{ matrix.python-version }} on ${{ inputs.platform }}
     runs-on: ${{ fromJSON(inputs.runners) }}
     strategy:
+      fail-fast: false
+      max-parallel: 20
       matrix:
         python-version: ${{ fromJson(inputs.python-versions) }}
     env:

--- a/.github/workflows/helm-tests.yml
+++ b/.github/workflows/helm-tests.yml
@@ -49,6 +49,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runners) }}
     strategy:
       fail-fast: false
+      max-parallel: 20
       matrix:
         helm-test-package: ${{ fromJSON(inputs.helm-test-packages) }}
     env:

--- a/.github/workflows/integration-system-tests.yml
+++ b/.github/workflows/integration-system-tests.yml
@@ -78,6 +78,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runners) }}
     strategy:
       fail-fast: false
+      max-parallel: 20
       matrix:
         integration: ${{ fromJSON(inputs.testable-core-integrations) }}
     env:
@@ -128,6 +129,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runners) }}
     strategy:
       fail-fast: false
+      max-parallel: 20
       matrix:
         integration: ${{ fromJSON(inputs.testable-providers-integrations) }}
     env:

--- a/.github/workflows/k8s-tests.yml
+++ b/.github/workflows/k8s-tests.yml
@@ -56,11 +56,12 @@ jobs:
     name: "K8S System:${{ matrix.executor }}-${{ matrix.kubernetes-combo }}-${{ matrix.use-standard-naming }}"
     runs-on: ${{ fromJSON(inputs.runners) }}
     strategy:
+      fail-fast: false
+      max-parallel: 20
       matrix:
         executor: [KubernetesExecutor, CeleryExecutor, LocalExecutor]
         use-standard-naming: [true, false]
         kubernetes-combo: ${{ fromJSON(inputs.kubernetes-combos) }}
-      fail-fast: false
     env:
       DEBUG_RESOURCES: ${{ inputs.debug-resources }}
       INCLUDE_SUCCESS_OUTPUTS: ${{ inputs.include-success-outputs }}

--- a/.github/workflows/push-image-cache.yml
+++ b/.github/workflows/push-image-cache.yml
@@ -85,6 +85,7 @@ jobs:
       packages: write
     strategy:
       fail-fast: false
+      max-parallel: 20
       matrix:
         python: ${{ fromJSON(inputs.python-versions) }}
     env:
@@ -154,6 +155,7 @@ jobs:
       packages: write
     strategy:
       fail-fast: false
+      max-parallel: 20
       matrix:
         python: ${{ fromJSON(inputs.python-versions) }}
     env:

--- a/.github/workflows/release_single_dockerhub_image.yml
+++ b/.github/workflows/release_single_dockerhub_image.yml
@@ -62,6 +62,7 @@ jobs:
     runs-on: ${{ (matrix.platform == 'linux/amd64') && fromJSON(inputs.amdRunners) || fromJSON(inputs.armRunners) }}
     strategy:
       fail-fast: false
+      max-parallel: 20
       matrix:
         platform: ${{ fromJSON(inputs.platformMatrix) }}
     env:

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -144,6 +144,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runners) }}
     strategy:
       fail-fast: false
+      max-parallel: 20
       matrix:
         python-version: "${{fromJSON(inputs.python-versions)}}"
         backend-version: "${{fromJSON(inputs.backend-versions)}}"


### PR DESCRIPTION
Fixes GitHub Actions workflow policy violations by adding `max-parallel: 20` to all job matrices as required by Apache Software Foundation infrastructure policy.
                                                                                                                                                                                
The repository was scanned and flagged for missing `max-parallel` configuration in GitHub Actions workflows. Per ASF policy, all job matrices must include `max-parallel: 20` to prevent resource exhaustion on shared runners.

References
- ASF GitHub Actions Policy: https://infra.apache.org/github-actions-policy.html
- Max Parallel Documentation: https://s.apache.org/max-parallel
