### PR TITLE
Add workers.celery.hostAliases & workers.kubernetes.hostAliases

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -223,8 +223,8 @@ spec:
   runtimeClassName: {{ .Values.workers.runtimeClassName }}
   {{- end }}
   imagePullSecrets: {{- include "image_pull_secrets" . | nindent 4 }}
-  {{- if .Values.workers.hostAliases }}
-  hostAliases: {{- toYaml .Values.workers.hostAliases | nindent 4 }}
+  {{- if or .Values.workers.kubernetes.hostAliases .Values.workers.hostAliases }}
+  hostAliases: {{- toYaml (.Values.workers.kubernetes.hostAliases | default .Values.workers.hostAliases) | nindent 4 }}
   {{- end }}
   restartPolicy: Never
   securityContext: {{ $securityContext | nindent 4 }}

--- a/chart/newsfragments/61960.significant.rst
+++ b/chart/newsfragments/61960.significant.rst
@@ -1,0 +1,1 @@
+``workers.hostAliases`` section is now deprecated in favor of ``workers.celery.hostAliases`` and ``workers.kubernetes.hostAliases``. Please update your configuration accordingly.

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -645,6 +645,14 @@ DEPRECATION WARNING:
 
 {{- end }}
 
+{{- if not (empty .Values.workers.hostAliases) }}
+
+ DEPRECATION WARNING:
+    `workers.hostAliases` has been renamed to `workers.celery.hostAliases`/`workers.kubernetes.hostAliases`.
+    Please change your values as support for the old name will be dropped in a future release.
+
+{{- end }}
+
 {{- if not (empty .Values.webserver.defaultUser) }}
 
  DEPRECATION WARNING:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2381,7 +2381,7 @@
                     }
                 },
                 "hostAliases": {
-                    "description": "Specify HostAliases for Airflow Celery worker pods and pods created with pod-template-file.",
+                    "description": "Specify HostAliases for Airflow Celery worker pods and pods created with pod-template-file. Use `workers.celery.hostAliases` and/or `workers.kubernetes.hostAliases` to separate value between Celery workers and pod-template-file.",
                     "items": {
                         "$ref": "#/definitions/io.k8s.api.core.v1.HostAlias"
                     },
@@ -3309,6 +3309,28 @@
                             "additionalProperties": {
                                 "type": "string"
                             }
+                        },
+                        "hostAliases": {
+                            "description": "Specify HostAliases for Airflow Celery worker pods.",
+                            "items": {
+                                "$ref": "#/definitions/io.k8s.api.core.v1.HostAlias"
+                            },
+                            "type": "array",
+                            "default": [],
+                            "examples": [
+                                {
+                                    "ip": "127.0.0.2",
+                                    "hostnames": [
+                                        "test.hostname.one"
+                                    ]
+                                },
+                                {
+                                    "ip": "127.0.0.3",
+                                    "hostnames": [
+                                        "test.hostname.two"
+                                    ]
+                                }
+                            ]
                         }
                     }
                 },
@@ -3606,6 +3628,28 @@
                             "additionalProperties": {
                                 "type": "string"
                             }
+                        },
+                        "hostAliases": {
+                            "description": "Specify HostAliases for pods created with pod-template-file.",
+                            "items": {
+                                "$ref": "#/definitions/io.k8s.api.core.v1.HostAlias"
+                            },
+                            "type": "array",
+                            "default": [],
+                            "examples": [
+                                {
+                                    "ip": "127.0.0.2",
+                                    "hostnames": [
+                                        "test.hostname.one"
+                                    ]
+                                },
+                                {
+                                    "ip": "127.0.0.3",
+                                    "hostnames": [
+                                        "test.hostname.two"
+                                    ]
+                                }
+                            ]
                         }
                     }
                 }

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2381,7 +2381,7 @@
                     }
                 },
                 "hostAliases": {
-                    "description": "Specify HostAliases for Airflow Celery worker pods and pods created with pod-template-file. Use `workers.celery.hostAliases` and/or `workers.kubernetes.hostAliases` to separate value between Celery workers and pod-template-file.",
+                    "description": "Specify HostAliases for Airflow Celery worker pods and pods created with pod-template-file (deprecated, use ``workers.celery.hostAliases`` and/or ``workers.kubernetes.hostAliases`` instead).",
                     "items": {
                         "$ref": "#/definitions/io.k8s.api.core.v1.HostAlias"
                     },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1078,8 +1078,7 @@ workers:
   topologySpreadConstraints: []
 
   # hostAliases to use in Airflow Celery worker pods and pods created with pod-template-file
-  # Use workers.celery.hostAliases and/or workers.kubernetes.hostAliases to separate value
-  # between Celery workers and pod-template-file
+  # (deprecated, use workers.celery.nodeSelector and/or workers.kubernetes.nodeSelector instead)
   # See:
   # https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   hostAliases: []

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1076,7 +1076,10 @@ workers:
   #      weight: 100
   tolerations: []
   topologySpreadConstraints: []
+
   # hostAliases to use in Airflow Celery worker pods and pods created with pod-template-file
+  # Use workers.celery.hostAliases and/or workers.kubernetes.hostAliases to separate value
+  # between Celery workers and pod-template-file
   # See:
   # https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   hostAliases: []
@@ -1390,6 +1393,17 @@ workers:
     # Select certain nodes for Airflow Celery worker pods
     nodeSelector: {}
 
+    # hostAliases to use in Airflow Celery worker pods
+    # See:
+    # https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+    hostAliases: []
+    # - ip: "127.0.0.2"
+    #   hostnames:
+    #   - "test.hostname.one"
+    # - ip: "127.0.0.3"
+    #   hostnames:
+    #   - "test.hostname.two"
+
   kubernetes:
     # Command to use in pod-template-file (templated)
     command: ~
@@ -1462,6 +1476,17 @@ workers:
 
     # Select certain nodes for pods created with pod-template-file
     nodeSelector: {}
+
+    # hostAliases to use in pods created with pod-template-file
+    # See:
+    # https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+    hostAliases: []
+    # - ip: "127.0.0.2"
+    #   hostnames:
+    #   - "test.hostname.one"
+    # - ip: "127.0.0.3"
+    #   hostnames:
+    #   - "test.hostname.two"
 
 # Airflow scheduler settings
 scheduler:

--- a/helm-tests/tests/helm_tests/airflow_aux/test_pod_template_file.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_pod_template_file.py
@@ -1168,19 +1168,27 @@ class TestPodTemplateFile:
         )
         assert jmespath.search("spec.containers[0].resources", docs[0]) == {}
 
-    def test_workers_host_aliases(self):
-        docs = render_chart(
-            values={
-                "workers": {
-                    "hostAliases": [{"ip": "127.0.0.2", "hostnames": ["test.hostname"]}],
-                },
+    @pytest.mark.parametrize(
+        "workers_values",
+        [
+            {"hostAliases": [{"ip": "127.0.0.2", "hostnames": ["test.hostname"]}]},
+            {"kubernetes": {"hostAliases": [{"ip": "127.0.0.2", "hostnames": ["test.hostname"]}]}},
+            {
+                "hostAliases": [{"ip": "192.168.0.1", "hostnames": ["hostname"]}],
+                "kubernetes": {"hostAliases": [{"ip": "127.0.0.2", "hostnames": ["test.hostname"]}]},
             },
+        ],
+    )
+    def test_workers_host_aliases(self, workers_values):
+        docs = render_chart(
+            values={"workers": workers_values},
             show_only=["templates/pod-template-file.yaml"],
             chart_dir=self.temp_chart_dir,
         )
 
-        assert jmespath.search("spec.hostAliases[0].ip", docs[0]) == "127.0.0.2"
-        assert jmespath.search("spec.hostAliases[0].hostnames[0]", docs[0]) == "test.hostname"
+        assert jmespath.search("spec.hostAliases", docs[0]) == [
+            {"ip": "127.0.0.2", "hostnames": ["test.hostname"]}
+        ]
 
     def test_workers_priority_class_name(self):
         docs = render_chart(

--- a/helm-tests/tests/helm_tests/airflow_core/test_worker_sets.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_worker_sets.py
@@ -2755,6 +2755,15 @@ class TestWorkerSets:
                     ],
                 },
             },
+            {
+                "celery": {
+                    "hostAliases": [{"ip": "192.168.0.0", "hostnames": ["test"]}],
+                    "enableDefault": False,
+                    "sets": [
+                        {"name": "set1", "hostAliases": [{"ip": "127.0.0.2", "hostnames": ["test.hostname"]}]}
+                    ],
+                },
+            },
         ],
     )
     def test_overwrite_host_aliases(self, workers_values):


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

related: https://github.com/apache/airflow/issues/28880

This PR introduces two new fields: `workers.celery.hostAliases` and `workers.kubernetes.hostAliases`. The `workers.hostAliases` field is deprecated.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
