### PR TITLE
Centralize OAuth grant_type validation in SnowflakeHook

### DIFF
--- a/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake.py
@@ -51,6 +51,8 @@ from airflow.utils.strings import to_boolean
 
 OAUTH_REQUEST_TIMEOUT = 30  # seconds, avoid hanging tasks on token request
 OAUTH_EXPIRY_BUFFER = 30
+SUPPORTED_GRANT_TYPES = {"refresh_token", "client_credentials"}
+
 T = TypeVar("T")
 
 
@@ -222,6 +224,18 @@ class SnowflakeHook(DbApiHook):
             return extra_dict[field_name] or None
         return extra_dict.get(backcompat_key) or None
 
+    def _validate_grant_type(self, grant_type: str | None) -> str:
+        """Validate OAuth grant_type."""
+        if not grant_type:
+            raise ValueError("Grant type must be provided for OAuth authentication.")
+
+        if grant_type not in SUPPORTED_GRANT_TYPES:
+            supported = ", ".join(sorted(SUPPORTED_GRANT_TYPES))
+
+            raise ValueError(f"Unsupported grant_type '{grant_type}'. Supported values: {supported}")
+
+        return grant_type
+
     @property
     def account_identifier(self) -> str:
         """Get snowflake account identifier."""
@@ -296,9 +310,8 @@ class SnowflakeHook(DbApiHook):
             if azure_conn_id:
                 conn_config["token"] = self.get_azure_oauth_token(azure_conn_id)
             else:
-                grant_type = conn_config.get("grant_type")
-                if not grant_type:
-                    raise ValueError("Grant_type not provided")
+                grant_type = self._validate_grant_type(conn_config.get("grant_type"))
+
                 conn_config["token"] = self._get_valid_oauth_token(
                     conn_config=conn_config,
                     token_endpoint=conn_config.get("token_endpoint"),
@@ -494,14 +507,12 @@ class SnowflakeHook(DbApiHook):
         if scope:
             data["scope"] = scope
 
+        grant_type = self._validate_grant_type(grant_type)
+
         if grant_type == "refresh_token":
             data |= {
                 "refresh_token": conn_config["refresh_token"],
             }
-        elif grant_type == "client_credentials":
-            pass  # no setup necessary for client credentials grant.
-        else:
-            raise ValueError(f"Unknown grant_type: {grant_type}")
 
         response = requests.post(
             url,

--- a/providers/snowflake/tests/unit/snowflake/hooks/test_snowflake.py
+++ b/providers/snowflake/tests/unit/snowflake/hooks/test_snowflake.py
@@ -1076,6 +1076,24 @@ class TestPytestSnowflakeHook:
                 }
             )
 
+    @pytest.mark.parametrize(
+        ("grant_type", "expected", "match"),
+        [
+            ("refresh_token", "refresh_token", None),
+            ("client_credentials", "client_credentials", None),
+            ("invalid_grant", ValueError, r"Unsupported grant_type"),
+            (None, ValueError, r"Grant type must be provided"),
+        ],
+    )
+    def test_validate_grant_type(self, grant_type, expected, match):
+        hook = SnowflakeHook(snowflake_conn_id="test")
+
+        if expected is ValueError:
+            with pytest.raises(ValueError, match=match):
+                hook._validate_grant_type(grant_type)
+        else:
+            assert hook._validate_grant_type(grant_type) == expected
+
     @mock.patch("airflow.providers.snowflake.hooks.snowflake.HTTPBasicAuth")
     @mock.patch("requests.post")
     @mock.patch(


### PR DESCRIPTION
**Description**

This change centralizes OAuth `grant_type` validation in `SnowflakeHook` by introducing a `_validate_grant_type` method and a `SUPPORTED_GRANT_TYPES` constant.

Validation logic that was previously implemented inline in `_get_conn_params` and `_get_valid_oauth_token` now delegates to `_validate_grant_type`, providing a single validation entry point for supported OAuth grant types.

**Rationale**

`grant_type` validation was previously implemented in multiple locations within the hook. Consolidating this logic into a single validation method ensures consistent enforcement of supported values and reduces duplication across OAuth-related code paths. Validation is performed during OAuth resolution rather than during static connection parameter construction, preserving the separation between configuration parsing and authentication enforcement and avoiding impact on non-OAuth authentication flows such as Azure-based authentication. Error messages for invalid or missing `grant_type` values have been consolidated under the new validation method.

**Notes**

Removed the redundant inline `client_credentials `grant type check in `_get_valid_oauth_token`.

**Tests**

Added a parametrized unit test covering supported, unsupported, and missing `grant_type` values to ensure centralized validation behaves consistently across valid and invalid inputs.

**Backwards Compatibility**

Method signatures of public APIs have not been altered. No behavior changes have been introduced. Error messages for invalid or missing `grant_type` values have been standardized as part of the centralized validation.