### PR TITLE
Run hatch always in a clean env

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_candidate_command.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_candidate_command.py
@@ -362,11 +362,10 @@ def create_artifacts_with_hatch(source_date_epoch: int):
     console_print("[info]Creating artifacts with hatch")
     shutil.rmtree(AIRFLOW_DIST_PATH, ignore_errors=True)
     AIRFLOW_DIST_PATH.mkdir(exist_ok=True)
-    env_copy = os.environ.copy()
-    env_copy["SOURCE_DATE_EPOCH"] = str(source_date_epoch)
+    hatch_env = {"SOURCE_DATE_EPOCH": str(source_date_epoch)}
     # Build Airflow packages
     run_command(
-        ["hatch", "build", "-c", "-t", "custom", "-t", "sdist", "-t", "wheel"], check=True, env=env_copy
+        ["hatch", "build", "-c", "-t", "custom", "-t", "sdist", "-t", "wheel"], check=True, env=hatch_env
     )
     # Build Task SDK packages
     run_command(

--- a/dev/breeze/src/airflow_breeze/commands/release_candidate_command.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_candidate_command.py
@@ -362,7 +362,7 @@ def create_artifacts_with_hatch(source_date_epoch: int):
     console_print("[info]Creating artifacts with hatch")
     shutil.rmtree(AIRFLOW_DIST_PATH, ignore_errors=True)
     AIRFLOW_DIST_PATH.mkdir(exist_ok=True)
-    hatch_env = {"SOURCE_DATE_EPOCH": str(source_date_epoch)}
+    hatch_env = {"SOURCE_DATE_EPOCH": str(source_date_epoch), "PATH": os.environ["PATH"]}
     # Build Airflow packages
     run_command(
         ["hatch", "build", "-c", "-t", "custom", "-t", "sdist", "-t", "wheel"], check=True, env=hatch_env

--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -445,8 +445,7 @@ def apply_distribution_format_to_hatch_command(build_command: list[str], distrib
 
 
 def _build_airflow_packages_with_hatch(distribution_format: str, source_date_epoch: int, version_suffix: str):
-    env_copy = os.environ.copy()
-    env_copy["SOURCE_DATE_EPOCH"] = str(source_date_epoch)
+    hatch_env = {"SOURCE_DATE_EPOCH": str(source_date_epoch)}
     build_airflow_core_command = ["hatch", "build", "-c", "-t", "custom"]
     apply_distribution_format_to_hatch_command(build_airflow_core_command, distribution_format)
     get_console().print(f"[bright_blue]Building apache-airflow-core distributions: {distribution_format}\n")
@@ -459,7 +458,7 @@ def _build_airflow_packages_with_hatch(distribution_format: str, source_date_epo
         run_command(
             build_airflow_core_command,
             check=True,
-            env=env_copy,
+            env=hatch_env,
             cwd=AIRFLOW_CORE_ROOT_PATH,
         )
     get_console().print(f"[bright_blue]Building apache-airflow distributions: {distribution_format}\n")
@@ -474,7 +473,7 @@ def _build_airflow_packages_with_hatch(distribution_format: str, source_date_epo
         run_command(
             build_airflow_command,
             check=True,
-            env=env_copy,
+            env=hatch_env,
             cwd=AIRFLOW_ROOT_PATH,
         )
     for distribution_path in (AIRFLOW_CORE_ROOT_PATH / "dist").glob("apache_airflow_core*"):
@@ -613,12 +612,11 @@ def _prepare_non_core_distributions(
             command += ["-t", "sdist"]
         if build_distribution_format == "wheel" or build_distribution_format == "both":
             command += ["-t", "wheel"]
-        env_copy = os.environ.copy()
-        env_copy["SOURCE_DATE_EPOCH"] = str(source_date_epoch)
+        hatch_env = {"SOURCE_DATE_EPOCH": str(source_date_epoch)}
         run_command(
             cmd=command,
             cwd=root_path,
-            env=env_copy,
+            env=hatch_env,
             check=True,
         )
         shutil.copytree(distribution_path, AIRFLOW_DIST_PATH, dirs_exist_ok=True)
@@ -3451,12 +3449,11 @@ def _build_client_packages_with_hatch(source_date_epoch: int, distribution_forma
         command += ["-t", "sdist"]
     if distribution_format == "wheel" or distribution_format == "both":
         command += ["-t", "wheel"]
-    env_copy = os.environ.copy()
-    env_copy["SOURCE_DATE_EPOCH"] = str(source_date_epoch)
+    hatch_env = {"SOURCE_DATE_EPOCH": str(source_date_epoch)}
     run_command(
         cmd=command,
         cwd=PYTHON_CLIENT_DIR_PATH,
-        env=env_copy,
+        env=hatch_env,
         check=True,
     )
     shutil.copytree(PYTHON_CLIENT_DIST_DIR_PATH, AIRFLOW_DIST_PATH, dirs_exist_ok=True)

--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -445,7 +445,7 @@ def apply_distribution_format_to_hatch_command(build_command: list[str], distrib
 
 
 def _build_airflow_packages_with_hatch(distribution_format: str, source_date_epoch: int, version_suffix: str):
-    hatch_env = {"SOURCE_DATE_EPOCH": str(source_date_epoch)}
+    hatch_env = {"SOURCE_DATE_EPOCH": str(source_date_epoch), "PATH": os.environ["PATH"]}
     build_airflow_core_command = ["hatch", "build", "-c", "-t", "custom"]
     apply_distribution_format_to_hatch_command(build_airflow_core_command, distribution_format)
     get_console().print(f"[bright_blue]Building apache-airflow-core distributions: {distribution_format}\n")
@@ -612,7 +612,7 @@ def _prepare_non_core_distributions(
             command += ["-t", "sdist"]
         if build_distribution_format == "wheel" or build_distribution_format == "both":
             command += ["-t", "wheel"]
-        hatch_env = {"SOURCE_DATE_EPOCH": str(source_date_epoch)}
+        hatch_env = {"SOURCE_DATE_EPOCH": str(source_date_epoch), "PATH": os.environ["PATH"]}
         run_command(
             cmd=command,
             cwd=root_path,
@@ -3449,7 +3449,7 @@ def _build_client_packages_with_hatch(source_date_epoch: int, distribution_forma
         command += ["-t", "sdist"]
     if distribution_format == "wheel" or distribution_format == "both":
         command += ["-t", "wheel"]
-    hatch_env = {"SOURCE_DATE_EPOCH": str(source_date_epoch)}
+    hatch_env = {"SOURCE_DATE_EPOCH": str(source_date_epoch), "PATH": os.environ["PATH"]}
     run_command(
         cmd=command,
         cwd=PYTHON_CLIENT_DIR_PATH,

--- a/dev/breeze/src/airflow_breeze/prepare_providers/provider_distributions.py
+++ b/dev/breeze/src/airflow_breeze/prepare_providers/provider_distributions.py
@@ -103,6 +103,7 @@ def build_provider_distribution(
     if not provider_info:
         raise RuntimeError(f"The provider {provider_id} has no provider.yaml defined.")
     build_backend = provider_info.get("build-system", "flit_core")
+    build_env = {"SOURCE_DATE_EPOCH": str(get_provider_details(provider_id).source_date_epoch)}
     if build_backend == "flit_core":
         command: list[str] = [sys.executable, "-m", "flit", "build", "--no-setup-py", "--use-vcs"]
         get_console().print(
@@ -121,9 +122,7 @@ def build_provider_distribution(
                 command,
                 check=True,
                 cwd=target_provider_root_sources_path,
-                env={
-                    "SOURCE_DATE_EPOCH": str(get_provider_details(provider_id).source_date_epoch),
-                },
+                env=build_env,
             )
         except subprocess.CalledProcessError as ex:
             get_console().print(f"[error]The command returned an error {ex}")
@@ -145,9 +144,7 @@ def build_provider_distribution(
             run_command(
                 cmd=command,
                 cwd=target_provider_root_sources_path,
-                env={
-                    "SOURCE_DATE_EPOCH": str(get_provider_details(provider_id).source_date_epoch),
-                },
+                env=build_env,
                 check=True,
             )
         except subprocess.CalledProcessError as ex:

--- a/scripts/in_container/run_prepare_airflow_distributions.py
+++ b/scripts/in_container/run_prepare_airflow_distributions.py
@@ -86,8 +86,7 @@ def apply_distribution_format_to_hatch_command(build_command: list[str], distrib
 
 def build_airflow_packages(distribution_format: str):
     reproducible_date = yaml.safe_load(REPRODUCIBLE_BUILD_YAML_PATH.read_text())["source-date-epoch"]
-    envcopy = os.environ.copy()
-    envcopy["SOURCE_DATE_EPOCH"] = str(reproducible_date)
+    hatch_env = {"SOURCE_DATE_EPOCH": str(reproducible_date)}
     airflow_core_build_command = [sys.executable, "-m", "hatch", "build", "-t", "custom"]
     apply_distribution_format_to_hatch_command(airflow_core_build_command, distribution_format)
     console.print(f"[bright_blue]Building apache-airflow-core distributions: {distribution_format}\n")
@@ -96,7 +95,7 @@ def build_airflow_packages(distribution_format: str):
         check=False,
         capture_output=False,
         cwd=AIRFLOW_CORE_ROOT_PATH,
-        env=envcopy,
+        env=hatch_env,
     )
     if build_process.returncode != 0:
         console.print("[red]Error building Airflow packages")
@@ -109,7 +108,7 @@ def build_airflow_packages(distribution_format: str):
         check=False,
         capture_output=False,
         cwd=AIRFLOW_ROOT_PATH,
-        env=envcopy,
+        env=hatch_env,
     )
     if build_process.returncode != 0:
         console.print("[red]Error building Airflow packages")

--- a/scripts/in_container/run_prepare_airflow_distributions.py
+++ b/scripts/in_container/run_prepare_airflow_distributions.py
@@ -86,7 +86,7 @@ def apply_distribution_format_to_hatch_command(build_command: list[str], distrib
 
 def build_airflow_packages(distribution_format: str):
     reproducible_date = yaml.safe_load(REPRODUCIBLE_BUILD_YAML_PATH.read_text())["source-date-epoch"]
-    hatch_env = {"SOURCE_DATE_EPOCH": str(reproducible_date)}
+    hatch_env = {"SOURCE_DATE_EPOCH": str(reproducible_date), "PATH": os.environ["PATH"]}
     airflow_core_build_command = [sys.executable, "-m", "hatch", "build", "-t", "custom"]
     apply_distribution_format_to_hatch_command(airflow_core_build_command, distribution_format)
     console.print(f"[bright_blue]Building apache-airflow-core distributions: {distribution_format}\n")


### PR DESCRIPTION
In PR https://github.com/apache/airflow/pull/56456 @dheerajturaga detected that hatch was always executed in a env as copy... and changed to a clean env - now as consistency this PR changes the calls to "hatch" in all other cases in the repo.

Note that the `PATH` also needs to be added to be able that hatch can find prek.

Made a run with main and diffoscope of same changes of this PR. Only diff I was was packaged GIT hash and resulting diffs in CRC and ZIP structures.

---

##### Was generative AI tooling used to co-author this PR?

- [ ] No (please specify the tool below)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
