### PR TITLE
Added API server startup instructions for /execution

### DIFF
--- a/providers/edge3/docs/deployment.rst
+++ b/providers/edge3/docs/deployment.rst
@@ -66,6 +66,8 @@ Minimum Airflow configuration settings for the Edge Worker to make it running is
   - ``api_url``: Must be set to the URL which exposes the api endpoint as it is reachable from the
     worker. Typically this looks like ``https://your-hostname-and-port/edge_worker/v1/rpcapi``.
 
+Your API server (within the central Airflow deployment) needs to be started with all apps (i.e., `airflow api-server --apps all`) in order to expose the `/execution` endpoint.
+
 To kick off a worker, you need to setup Airflow and kick off the worker
 subcommand
 


### PR DESCRIPTION
I've added note about starting the API server with all apps, otherwise the /execution endpoint will not be available and the edge worker deployment fails on 404 errors.
