### PR TITLE
 Add map_index_template support for mapped task group  (#40799)

### DIFF
--- a/airflow-core/docs/authoring-and-scheduling/dynamic-task-mapping.rst
+++ b/airflow-core/docs/authoring-and-scheduling/dynamic-task-mapping.rst
@@ -217,6 +217,25 @@ Since the template is rendered after the main execution block, it is possible to
     # The task instances will be named "aaa" and "bbb".
     my_task.expand(my_value=["a", "b"])
 
+Named mapping for task groups
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When using mapped task groups, you can set ``map_index_template`` on the ``@task_group`` decorator. This makes the group's expansion arguments available in the rendering context for **all** child tasks in the group, not just the first one that receives the argument directly.
+
+.. code-block:: python
+
+    @task_group(map_index_template="{{ filename }}")
+    def file_transforms(filename):
+        extracted = extract(filename)
+        load(extracted)
+
+
+    file_transforms.expand(filename=["data1.json", "data2.json"])
+
+In this example, both ``extract`` and ``load`` task instances will be labeled "data1.json" or "data2.json" based on the group's expansion argument. Without the group-level template, only ``extract`` would have access to ``filename`` in its rendering context, while ``load`` would only see ``extracted``.
+
+If a child task also defines its own ``map_index_template``, the task-level template takes precedence over the group-level one.
+
 Mapping with non-TaskFlow operators
 ===================================
 

--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
@@ -393,6 +393,12 @@ class TIRunContext(BaseModel):
     always reflects when the task *first* started, not when it was rescheduled/resumed.
     """
 
+    task_group_map_index_template: str | None = None
+    """map_index_template from parent MappedTaskGroup, if any."""
+
+    task_group_expanded_args: dict[str, Any] | None = None
+    """Resolved expansion arguments from parent MappedTaskGroup for this specific map_index."""
+
 
 class PrevSuccessfulDagRunResponse(BaseModel):
     """Schema for response with previous successful DagRun information for Task Template Context."""

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -289,6 +289,12 @@ def ti_run(
             context.next_method = ti.next_method
             context.next_kwargs = ti.next_kwargs
             context.start_date = ti.start_date
+
+        if ti.map_index >= 0:
+            _populate_task_group_map_index_context(
+                context, ti.dag_id, ti.task_id, ti.map_index, ti.run_id, session, dag_bag
+            )
+
         return context
     except SQLAlchemyError:
         log.exception("Error marking Task Instance state as running")
@@ -1077,6 +1083,98 @@ def get_task_instance_breadcrumbs(dag_id: str, run_id: str, session: SessionDep)
             yield {str(k): v for k, v in row.items()}
 
     return TaskBreadcrumbsResponse(breadcrumbs=_iter_breadcrumbs())
+
+
+def _populate_task_group_map_index_context(
+    context: TIRunContext,
+    dag_id: str,
+    task_id: str,
+    map_index: int,
+    run_id: str,
+    session: SessionDep,
+    dag_bag: DagBagDep,
+) -> None:
+    """Populate task group map_index_template and expanded args on the TIRunContext."""
+    try:
+        dag = get_latest_version_of_dag(dag_bag, dag_id, session)
+    except HTTPException:
+        return
+
+    task = dag.task_dict.get(task_id)
+    if not task:
+        return
+
+    for mtg in task.iter_mapped_task_groups():
+        if not mtg.map_index_template:
+            continue
+
+        context.task_group_map_index_template = mtg.map_index_template
+        context.task_group_expanded_args = _resolve_task_group_expand_args(
+            mtg._expand_input, map_index, run_id, session
+        )
+        break
+
+
+def _resolve_task_group_expand_args(
+    expand_input: Any,
+    map_index: int,
+    run_id: str,
+    session: SessionDep,
+) -> dict[str, Any] | None:
+    """Resolve the expand_input for a specific map_index to get the expanded arguments."""
+    from airflow.models.expandinput import SchedulerDictOfListsExpandInput, SchedulerListOfDictsExpandInput
+    from airflow.serialization.definitions.xcom_arg import SchedulerXComArg
+
+    if isinstance(expand_input, SchedulerDictOfListsExpandInput):
+        resolved: dict[str, Any] = {}
+        for key, value in expand_input.value.items():
+            if isinstance(value, SchedulerXComArg):
+                xcom_result = _resolve_xcom_arg_value(value, run_id, session)
+                if isinstance(xcom_result, list) and map_index < len(xcom_result):
+                    resolved[key] = xcom_result[map_index]
+            elif isinstance(value, (list, tuple)):
+                if map_index < len(value):
+                    resolved[key] = value[map_index]
+        return resolved if resolved else None
+
+    if isinstance(expand_input, SchedulerListOfDictsExpandInput):
+        if isinstance(expand_input.value, (list, tuple)):
+            if map_index < len(expand_input.value):
+                item = expand_input.value[map_index]
+                if isinstance(item, dict):
+                    return item
+        elif isinstance(expand_input.value, SchedulerXComArg):
+            xcom_result = _resolve_xcom_arg_value(expand_input.value, run_id, session)
+            if isinstance(xcom_result, list) and map_index < len(xcom_result):
+                item = xcom_result[map_index]
+                if isinstance(item, dict):
+                    return item
+
+    return None
+
+
+def _resolve_xcom_arg_value(xcom_arg: Any, run_id: str, session: SessionDep) -> Any:
+    """Resolve a SchedulerXComArg to its actual value via XCom query."""
+    refs = list(xcom_arg.iter_references())
+    if not refs:
+        return None
+    operator, key = refs[0]
+
+    xcom_value = session.scalar(
+        select(XComModel.value).where(
+            XComModel.dag_id == operator.dag_id,
+            XComModel.task_id == operator.task_id,
+            XComModel.run_id == run_id,
+            XComModel.key == key,
+            XComModel.map_index == -1,
+        )
+    )
+    if xcom_value is None:
+        return None
+    try:
+        return json.loads(xcom_value)
+    except (json.JSONDecodeError, TypeError):
+        return None
 
 
 def _is_eligible_to_retry(state: str, try_number: int, max_tries: int) -> bool:

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -1104,6 +1104,7 @@ def _populate_task_group_map_index_context(
     if not task:
         return
 
+    # iter_mapped_task_groups walks from innermost to outermost; we use the first match.
     for mtg in task.iter_mapped_task_groups():
         if not mtg.map_index_template:
             continue
@@ -1125,30 +1126,30 @@ def _resolve_task_group_expand_args(
     from airflow.models.expandinput import SchedulerDictOfListsExpandInput, SchedulerListOfDictsExpandInput
     from airflow.serialization.definitions.xcom_arg import SchedulerXComArg
 
-    if isinstance(expand_input, SchedulerDictOfListsExpandInput):
-        resolved: dict[str, Any] = {}
-        for key, value in expand_input.value.items():
-            if isinstance(value, SchedulerXComArg):
-                xcom_result = _resolve_xcom_arg_value(value, run_id, session)
-                if isinstance(xcom_result, list) and map_index < len(xcom_result):
-                    resolved[key] = xcom_result[map_index]
-            elif isinstance(value, (list, tuple)):
-                if map_index < len(value):
-                    resolved[key] = value[map_index]
-        return resolved if resolved else None
+    def _resolve_at_index(value: Any) -> Any | None:
+        """Resolve a single value (list/tuple or XComArg) at the given map_index."""
+        match value:
+            case SchedulerXComArg():
+                value = _resolve_xcom_arg_value(value, run_id, session)
+            case list() | tuple():
+                pass
+            case _:
+                return None
+        if isinstance(value, (list, tuple)) and map_index < len(value):
+            return value[map_index]
+        return None
 
-    if isinstance(expand_input, SchedulerListOfDictsExpandInput):
-        if isinstance(expand_input.value, (list, tuple)):
-            if map_index < len(expand_input.value):
-                item = expand_input.value[map_index]
-                if isinstance(item, dict):
-                    return item
-        elif isinstance(expand_input.value, SchedulerXComArg):
-            xcom_result = _resolve_xcom_arg_value(expand_input.value, run_id, session)
-            if isinstance(xcom_result, list) and map_index < len(xcom_result):
-                item = xcom_result[map_index]
-                if isinstance(item, dict):
-                    return item
+    match expand_input:
+        case SchedulerDictOfListsExpandInput(value=mapping):
+            resolved = {}
+            for key, val in mapping.items():
+                if (item := _resolve_at_index(val)) is not None:
+                    resolved[key] = item
+            return resolved or None
+
+        case SchedulerListOfDictsExpandInput(value=val):
+            if isinstance(item := _resolve_at_index(val), dict):
+                return item
 
     return None
 
@@ -1174,6 +1175,7 @@ def _resolve_xcom_arg_value(xcom_arg: Any, run_id: str, session: SessionDep) -> 
     try:
         return json.loads(xcom_value)
     except (json.JSONDecodeError, TypeError):
+        log.debug("Failed to decode XCom value for task_group expand args", exc_info=True)
         return None
 
 

--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py
@@ -39,9 +39,11 @@ from airflow.api_fastapi.execution_api.versions.v2026_04_06 import (
     MovePreviousRunEndpoint,
     RemoveUpstreamMapIndexesField,
 )
+from airflow.api_fastapi.execution_api.versions.v2026_04_15 import AddTaskGroupMapIndexTemplateFields
 
 bundle = VersionBundle(
     HeadVersion(),
+    Version("2026-04-15", AddTaskGroupMapIndexTemplateFields),
     Version(
         "2026-04-06",
         AddPartitionKeyField,

--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_04_15.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_04_15.py
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from cadwyn import ResponseInfo, VersionChange, convert_response_to_previous_version_for, schema
+
+from airflow.api_fastapi.execution_api.datamodels.taskinstance import TIRunContext
+
+
+class AddTaskGroupMapIndexTemplateFields(VersionChange):
+    """Add task_group_map_index_template and task_group_expanded_args fields to TIRunContext."""
+
+    description = __doc__
+
+    instructions_to_migrate_to_previous_version = (
+        schema(TIRunContext).field("task_group_map_index_template").didnt_exist,
+        schema(TIRunContext).field("task_group_expanded_args").didnt_exist,
+    )
+
+    @convert_response_to_previous_version_for(TIRunContext)  # type: ignore[arg-type]
+    def remove_task_group_fields(response: ResponseInfo) -> None:  # type: ignore[misc]
+        """Remove task group map index fields for older API versions."""
+        response.body.pop("task_group_map_index_template", None)
+        response.body.pop("task_group_expanded_args", None)

--- a/airflow-core/src/airflow/serialization/definitions/taskgroup.py
+++ b/airflow-core/src/airflow/serialization/definitions/taskgroup.py
@@ -48,6 +48,7 @@ class SerializedTaskGroup(DAGNode):
     parent_group: SerializedTaskGroup | None = attrs.field()
     dag: SerializedDAG = attrs.field()
     tooltip: str = attrs.field()
+    map_index_template: str | None = attrs.field(default=None)
     default_args: dict[str, Any] = attrs.field(factory=dict)
 
     # TODO: Are these actually useful?

--- a/airflow-core/src/airflow/serialization/schema.json
+++ b/airflow-core/src/airflow/serialization/schema.json
@@ -377,7 +377,7 @@
         "tooltip": { "type": "string" },
         "ui_color": { "type": "string" },
         "ui_fgcolor": { "type": "string" },
-        "map_index_template": {"anyOf": [{"type": "null"}, { "type": "string" }]},
+        "map_index_template": { "type": ["null", "string"] },
         "upstream_group_ids": {
           "type": "array",
           "items": { "type": "string" }

--- a/airflow-core/src/airflow/serialization/schema.json
+++ b/airflow-core/src/airflow/serialization/schema.json
@@ -377,6 +377,7 @@
         "tooltip": { "type": "string" },
         "ui_color": { "type": "string" },
         "ui_fgcolor": { "type": "string" },
+        "map_index_template": {"anyOf": [{"type": "null"}, { "type": "string" }]},
         "upstream_group_ids": {
           "type": "array",
           "items": { "type": "string" }

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -2102,6 +2102,7 @@ class TaskGroupSerialization(BaseSerialization):
             "tooltip": task_group.tooltip,
             "ui_color": task_group.ui_color,
             "ui_fgcolor": task_group.ui_fgcolor,
+            "map_index_template": task_group.map_index_template,
             "children": {
                 label: child.serialize_for_task_group() for label, child in task_group.children.items()
             },
@@ -2132,6 +2133,7 @@ class TaskGroupSerialization(BaseSerialization):
             for key in ["prefix_group_id", "tooltip", "ui_color", "ui_fgcolor"]
         }
         kwargs["group_display_name"] = cls.deserialize(encoded_group.get("group_display_name", ""))
+        kwargs["map_index_template"] = cls.deserialize(encoded_group.get("map_index_template"))
 
         if not encoded_group.get("is_mapped"):
             group = SerializedTaskGroup(group_id=group_id, parent_group=parent_group, dag=dag, **kwargs)

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -430,6 +430,88 @@ class TestTIRunState:
         )
         assert response.status_code == 200
 
+    def test_ti_run_includes_task_group_map_index_template(
+        self, client: Client, dag_maker: DagMaker, session: Session
+    ):
+        """Test that ti_run includes task_group_map_index_template and expanded args for mapped task groups."""
+        with dag_maker("test_tg_map_index_template", serialized=True):
+
+            @task_group(map_index_template="{{ filename }}")
+            def tg(filename):
+                @task
+                def process(filename):
+                    return filename
+
+                process(filename)
+
+            tg.expand(filename=["a.json", "b.json"])
+
+        dr = dag_maker.create_dagrun()
+
+        # Set all task instances to queued for the mapped tasks
+        for ti in dr.get_task_instances():
+            if ti.map_index >= 0:
+                ti.set_state(State.QUEUED)
+        session.flush()
+
+        # Get the first mapped task instance
+        mapped_tis = [ti for ti in dr.get_task_instances() if ti.map_index >= 0]
+        assert len(mapped_tis) > 0
+
+        ti = mapped_tis[0]
+        response = client.patch(
+            f"/execution/task-instances/{ti.id}/run",
+            json={
+                "state": "running",
+                "hostname": "random-hostname",
+                "unixname": "random-unixname",
+                "pid": 100,
+                "start_date": "2024-09-30T12:00:00Z",
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data.get("task_group_map_index_template") == "{{ filename }}"
+        assert data.get("task_group_expanded_args") == {"filename": "a.json"}
+
+    def test_ti_run_no_task_group_fields_for_non_mapped(
+        self, client, session, create_task_instance, time_machine
+    ):
+        """Test that task_group fields are not set for non-mapped task instances."""
+        instant_str = "2024-09-30T12:00:00Z"
+        instant = timezone.parse(instant_str)
+        time_machine.move_to(instant, tick=False)
+
+        ti = create_task_instance(
+            task_id="test_non_mapped",
+            state=State.QUEUED,
+            dagrun_state=DagRunState.RUNNING,
+            session=session,
+            start_date=instant,
+            dag_id=str(uuid4()),
+        )
+        session.commit()
+
+        response = client.patch(
+            f"/execution/task-instances/{ti.id}/run",
+            json={
+                "state": "running",
+                "hostname": "random-hostname",
+                "unixname": "random-unixname",
+                "pid": 100,
+                "start_date": instant_str,
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Non-mapped tasks should not have task group fields
+        assert "task_group_map_index_template" not in data
+        assert "task_group_expanded_args" not in data
+
     def test_dynamic_task_mapping_with_all_success_trigger_rule(self, dag_maker: DagMaker, session: Session):
         """Test that with ALL_SUCCESS trigger rule and skipped upstream, downstream should not run."""
 

--- a/airflow-core/tests/unit/serialization/test_dag_serialization.py
+++ b/airflow-core/tests/unit/serialization/test_dag_serialization.py
@@ -212,6 +212,7 @@ serialized_simple_dag_ground_truth = {
             "tooltip": "",
             "ui_color": "CornflowerBlue",
             "ui_fgcolor": "#000",
+            "map_index_template": None,
             "upstream_group_ids": [],
             "downstream_group_ids": [],
             "upstream_task_ids": [],
@@ -1728,6 +1729,30 @@ class TestStringifiedDAGs:
 
         check_task_group(serialized_dag.task_group)
 
+    def test_task_group_map_index_template_serialization(self):
+        """Test that map_index_template on TaskGroup survives serialization round-trip."""
+        from airflow.providers.standard.operators.empty import EmptyOperator
+
+        with DAG("test_tg_map_index_template", schedule=None, start_date=datetime(2020, 1, 1)) as dag:
+            with TaskGroup("my_group", map_index_template="{{ filename }}"):
+                EmptyOperator(task_id="task1")
+
+        serialized_dag = DagSerialization.deserialize_dag(DagSerialization.serialize_dag(dag))
+        tg = serialized_dag.task_group.children["my_group"]
+        assert tg.map_index_template == "{{ filename }}"
+
+    def test_task_group_map_index_template_none_by_default(self):
+        """Test that map_index_template defaults to None when not set."""
+        from airflow.providers.standard.operators.empty import EmptyOperator
+
+        with DAG("test_tg_mit_default", schedule=None, start_date=datetime(2020, 1, 1)) as dag:
+            with TaskGroup("my_group"):
+                EmptyOperator(task_id="task1")
+
+        serialized_dag = DagSerialization.deserialize_dag(DagSerialization.serialize_dag(dag))
+        tg = serialized_dag.task_group.children["my_group"]
+        assert tg.map_index_template is None
+
     @staticmethod
     def assert_taskgroup_children(se_task_group, dag_task_group, expected_children):
         assert se_task_group.children.keys() == dag_task_group.children.keys() == expected_children
@@ -3114,6 +3139,7 @@ def test_mapped_task_group_serde():
             },
             "group_display_name": "",
             "is_mapped": True,
+            "map_index_template": None,
             "prefix_group_id": True,
             "tooltip": "",
             "ui_color": "CornflowerBlue",
@@ -3127,6 +3153,7 @@ def test_mapped_task_group_serde():
     serde_tg = serde_dag.task_group.children["tg"]
     assert isinstance(serde_tg, SerializedTaskGroup)
     assert serde_tg._expand_input == SchedulerDictOfListsExpandInput({"a": [".", ".."]})
+    assert serde_tg.map_index_template is None
 
 
 @pytest.mark.db_test

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -27,7 +27,7 @@ from uuid import UUID
 
 from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, JsonValue, RootModel
 
-API_VERSION: Final[str] = "2026-04-06"
+API_VERSION: Final[str] = "2026-04-15"
 
 
 class AssetAliasReferenceAssetEventDagRun(BaseModel):
@@ -664,3 +664,5 @@ class TIRunContext(BaseModel):
     xcom_keys_to_clear: Annotated[list[str] | None, Field(title="Xcom Keys To Clear")] = None
     should_retry: Annotated[bool | None, Field(title="Should Retry")] = False
     start_date: Annotated[AwareDatetime | None, Field(title="Start Date")] = None
+    task_group_map_index_template: Annotated[str | None, Field(title="Task Group Map Index Template")] = None
+    task_group_expanded_args: Annotated[dict[str, Any] | None, Field(title="Task Group Expanded Args")] = None

--- a/task-sdk/src/airflow/sdk/definitions/decorators/task_group.py
+++ b/task-sdk/src/airflow/sdk/definitions/decorators/task_group.py
@@ -196,6 +196,7 @@ def task_group(
     tooltip: str = "",
     ui_color: str = "CornflowerBlue",
     ui_fgcolor: str = "#000",
+    map_index_template: str | None = None,
     add_suffix_on_collision: bool = False,
     group_display_name: str = "",
 ) -> Callable[[Callable[FParams, FReturn]], _TaskGroupFactory[FParams, FReturn]]: ...

--- a/task-sdk/src/airflow/sdk/definitions/taskgroup.py
+++ b/task-sdk/src/airflow/sdk/definitions/taskgroup.py
@@ -105,6 +105,10 @@ class TaskGroup(DAGNode):
     :param add_suffix_on_collision: If this task group name already exists,
         automatically add `__1` etc suffixes
     :param group_display_name: If set, this will be the display name for the TaskGroup node in the UI.
+    :param map_index_template: A Jinja2 template string used to render a meaningful label for each
+        mapped instance of this task group. The template has access to the group's expanded arguments.
+        For example, ``"{{ filename }}"`` when the group is expanded with ``filename=["a.json", "b.json"]``
+        will label the mapped instances as ``"a.json"`` and ``"b.json"`` for ALL child tasks.
     """
 
     _group_id: str | None = attrs.field(
@@ -133,6 +137,8 @@ class TaskGroup(DAGNode):
 
     ui_color: str = attrs.field(default="CornflowerBlue", validator=attrs.validators.instance_of(str))
     ui_fgcolor: str = attrs.field(default="#000", validator=attrs.validators.instance_of(str))
+
+    map_index_template: str | None = attrs.field(default=None)
 
     add_suffix_on_collision: bool = False
 

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -307,6 +307,17 @@ class RuntimeTaskInstance(TaskInstance):
             if upstream_map_indexes is not None:
                 setattr(self, "_upstream_map_indexes", upstream_map_indexes)
 
+            # Kept separate from the main context to avoid conflicts with op_kwargs
+            # in PythonOperator.determine_kwargs — only used during _render_map_index.
+            task_group_expanded_args = getattr(from_server, "task_group_expanded_args", None)
+            if task_group_expanded_args:
+                self._task_group_expanded_args = task_group_expanded_args
+
+            if not self.task.map_index_template:
+                task_group_template = getattr(from_server, "task_group_map_index_template", None)
+                if task_group_template:
+                    self._cached_template_context["map_index_template"] = task_group_template
+
         return self._cached_template_context
 
     def render_templates(
@@ -1711,7 +1722,11 @@ def _render_map_index(context: Context, ti: RuntimeTaskInstance, log: Logger) ->
         return None
     log.debug("Rendering map_index_template", template_length=len(template))
     jinja_env = ti.task.dag.get_template_env()
-    rendered_map_index = jinja_env.from_string(template).render(context)
+    render_context: dict[str, Any] = dict(context)
+    task_group_args = getattr(ti, "_task_group_expanded_args", None)
+    if task_group_args:
+        render_context.update(task_group_args)
+    rendered_map_index = jinja_env.from_string(template).render(render_context)
     log.debug("Map index rendered", length=len(rendered_map_index))
     return rendered_map_index
 

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -1616,6 +1616,58 @@ def test_rendered_map_index_updates_sent_progressively(create_runtime_ti, mock_s
     assert ti.rendered_map_index == "Label: test_task"
 
 
+def test_task_group_map_index_template_injected_into_context(create_runtime_ti, mock_supervisor_comms):
+    """Test that task_group_map_index_template from server is used when task has no map_index_template."""
+
+    task = BaseOperator(task_id="test_task")
+
+    ti = create_runtime_ti(task=task, dag_id="dag_with_tg_map_index_template")
+
+    ti._ti_context_from_server.task_group_map_index_template = "{{ filename }}"
+    ti._ti_context_from_server.task_group_expanded_args = {"filename": "data1.json"}
+    ti._cached_template_context = None
+
+    context = ti.get_template_context()
+
+    # Expanded args are kept out of the main context to avoid conflicts with op_kwargs
+    assert "filename" not in context
+    assert ti._task_group_expanded_args == {"filename": "data1.json"}
+    assert context["map_index_template"] == "{{ filename }}"
+
+
+def test_task_level_map_index_template_takes_precedence(create_runtime_ti, mock_supervisor_comms):
+    """Test that task-level map_index_template takes precedence over group-level."""
+
+    task = BaseOperator(task_id="test_task", map_index_template="Task: {{ task.task_id }}")
+
+    ti = create_runtime_ti(task=task, dag_id="dag_with_both_templates")
+
+    ti._ti_context_from_server.task_group_map_index_template = "{{ filename }}"
+    ti._ti_context_from_server.task_group_expanded_args = {"filename": "data1.json"}
+    ti._cached_template_context = None
+
+    context = ti.get_template_context()
+
+    assert ti._task_group_expanded_args == {"filename": "data1.json"}
+    assert context["map_index_template"] == "Task: {{ task.task_id }}"
+
+
+def test_task_group_expanded_args_used_in_map_index_rendering(create_runtime_ti, mock_supervisor_comms):
+    """Test that group expanded args are available during map_index_template rendering."""
+
+    task = BaseOperator(task_id="test_task")
+
+    ti = create_runtime_ti(task=task, dag_id="dag_with_tg_rendering")
+
+    ti._ti_context_from_server.task_group_map_index_template = "{{ filename }}"
+    ti._ti_context_from_server.task_group_expanded_args = {"filename": "data1.json"}
+    ti._cached_template_context = None
+
+    run(ti, ti.get_template_context(), log=mock.MagicMock())
+
+    assert ti.rendered_map_index == "data1.json"
+
+
 class TestRuntimeTaskInstance:
     def test_get_context_without_ti_context_from_server(self, mocked_parse, make_ti_context):
         """Test get_template_context without ti_context_from_server."""


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

## Summary
This adds `map_index_template` support to `@task_group`, so all child tasks in a mapped task group show meaningful labels instead of numeric indexes.  

    
<img width="1085" height="1009" alt="image" src="https://github.com/user-attachments/assets/ec8f16f9-2dce-45fd-aee3-a2b8cd2f1384" />
                                                                                               
                                                                                                                                                                                                                                                                    
```python                                                                                                                       
  @task_group(map_index_template="{{ filename }}")
  def file_transforms(filename):
      extracted = extract(filename)
      load(extracted)
```
## Testing

 - Unit tests across all layers (decorator, serialization, API, task runner)
 - Manual E2E in breeze with three scenarios: basic chained tasks, task-level precedence, and partial() + expand()

closes #40799.
---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
