### PR TITLE
Support Python 3.13 in apache beam provider

### DIFF
--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -1318,7 +1318,7 @@ def test_excluded_providers():
         {
             "excluded-providers-as-string": json.dumps(
                 {
-                    "3.13": ["apache.beam", "fab"],
+                    "3.13": ["fab"],
                 }
             ),
         },

--- a/providers/apache/beam/docs/index.rst
+++ b/providers/apache/beam/docs/index.rst
@@ -100,11 +100,11 @@ PIP package                                 Version required
 ==========================================  ==================================================================
 ``apache-airflow``                          ``>=2.11.0``
 ``apache-airflow-providers-common-compat``  ``>=1.12.0``
-``apache-beam``                             ``>=2.60.0; python_version < "3.13"``
-``pyarrow``                                 ``>=16.1.0; python_version < "3.13"``
+``apache-beam``                             ``>=2.69.0``
+``pyarrow``                                 ``>=16.1.0``
 ``numpy``                                   ``>=1.22.4; python_version < "3.11"``
 ``numpy``                                   ``>=1.23.2; python_version < "3.12" and python_version >= "3.11"``
-``numpy``                                   ``>=1.26.0; python_version >= "3.12" and python_version < "3.13"``
+``numpy``                                   ``>=1.26.0; python_version >= "3.12"``
 ==========================================  ==================================================================
 
 Cross provider package dependencies

--- a/providers/apache/beam/provider.yaml
+++ b/providers/apache/beam/provider.yaml
@@ -80,9 +80,6 @@ versions:
   - 1.0.1
   - 1.0.0
 
-excluded-python-versions:
-  - "3.13"
-
 integrations:
   - integration-name: Apache Beam
     external-doc-url: https://beam.apache.org/

--- a/providers/apache/beam/pyproject.toml
+++ b/providers/apache/beam/pyproject.toml
@@ -48,9 +48,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: System :: Monitoring",
 ]
-requires-python = ">=3.10,!=3.13"
+requires-python = ">=3.10"
 
 # The dependencies should be modified in place in the generated file.
 # Any change in the dependencies is preserved when the file is regenerated
@@ -59,18 +60,18 @@ requires-python = ">=3.10,!=3.13"
 dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.12.0",
-    'apache-beam>=2.60.0; python_version < "3.13"',
-    "pyarrow>=16.1.0; python_version < '3.13'",
+    "apache-beam>=2.69.0",
+    "pyarrow>=16.1.0",
     "numpy>=1.22.4; python_version<'3.11'",
     "numpy>=1.23.2; python_version<'3.12' and python_version>='3.11'",
-    "numpy>=1.26.0; python_version>='3.12' and python_version < '3.13'",
+    "numpy>=1.26.0; python_version>='3.12'",
 ]
 
 # The optional dependencies should be modified in place in the generated file
 # Any change in the dependencies is preserved when the file is regenerated
 [project.optional-dependencies]
 "google" = [
-    'apache-beam[gcp]>=2.60.0; python_version < "3.13"',
+    "apache-beam[gcp]>=2.69.0",
 ]
 
 [dependency-groups]

--- a/providers/google/pyproject.toml
+++ b/providers/google/pyproject.toml
@@ -150,7 +150,7 @@ dependencies = [
 [project.optional-dependencies]
 "apache.beam" = [
     'apache-beam[gcp]>=2.53.0; python_version < "3.12"',
-    'apache-beam[gcp]>=2.57.0; python_version >= "3.12" and python_version < "3.13"',
+    'apache-beam[gcp]>=2.57.0; python_version >= "3.12"',
 ]
 "cncf.kubernetes" = [
     "apache-airflow-providers-cncf-kubernetes>=10.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ packages = []
     "apache-airflow-providers-amazon>=9.0.0"
 ]
 "apache.beam" = [
-    "apache-airflow-providers-apache-beam>=5.8.1; python_version !=\"3.13\""
+    "apache-airflow-providers-apache-beam>=5.8.1"
 ]
 "apache.cassandra" = [
     "apache-airflow-providers-apache-cassandra>=3.7.0"
@@ -399,7 +399,7 @@ packages = []
     "apache-airflow-providers-airbyte>=5.0.0",
     "apache-airflow-providers-alibaba>=3.0.0",
     "apache-airflow-providers-amazon>=9.0.0",
-    "apache-airflow-providers-apache-beam>=5.8.1; python_version !=\"3.13\"",
+    "apache-airflow-providers-apache-beam>=5.8.1",
     "apache-airflow-providers-apache-cassandra>=3.7.0",
     "apache-airflow-providers-apache-drill>=2.8.1",
     "apache-airflow-providers-apache-druid>=3.12.0",


### PR DESCRIPTION
Apache Beam supports Python 3.13 since v2.69.0. 
This removes the 3.13 exclusion from the beam provider, bumps the minimum apache-beam version to 2.69.0, and updates related config. 

Similar to #61434. Closes #61730.