### PR TITLE
Allow null start_date in DagRun Pydantic model to fix rerun regression (#61381)

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
@@ -295,7 +295,7 @@ class DagRun(StrictBaseModel):
     data_interval_start: UtcDateTime | None
     data_interval_end: UtcDateTime | None
     run_after: UtcDateTime
-    start_date: UtcDateTime
+    start_date: UtcDateTime | None = None
     end_date: UtcDateTime | None
     clear_number: int = 0
     run_type: DagRunType
@@ -303,7 +303,7 @@ class DagRun(StrictBaseModel):
     conf: dict[str, Any] | None = None
     triggering_user_name: str | None = None
     consumed_asset_events: list[AssetEventDagRunReference]
-    partition_key: str | None
+    partition_key: str | None = None
 
 
 class TIRunContext(BaseModel):

--- a/airflow-core/tests/unit/api_fastapi/execution_api/datamodels/test_taskinstance.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/datamodels/test_taskinstance.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from airflow.api_fastapi.execution_api.datamodels.taskinstance import DagRun
+from airflow.callbacks.callback_requests import DagRunContext
+from airflow.sdk import timezone
+from airflow.utils.state import DagRunState
+from airflow.utils.types import DagRunType
+
+
+def test_dagrun_model_accepts_null_start_date():
+    """Ensure DagRun Pydantic model allows start_date=None."""
+    data = {
+        "dag_id": "test_dag",
+        "run_id": "test_run",
+        "logical_date": timezone.utcnow(),
+        "data_interval_start": None,
+        "data_interval_end": None,
+        "run_after": timezone.utcnow(),
+        "start_date": None,
+        "end_date": None,
+        "run_type": DagRunType.MANUAL,
+        "state": DagRunState.QUEUED,
+        "consumed_asset_events": [],
+    }
+
+    dr = DagRun.model_validate(data)
+    assert dr.start_date is None
+
+
+def test_dagrun_context_accepts_null_start_date():
+    """Ensure DagRunContext (used by scheduler) accepts DagRun with null start_date."""
+    data = {
+        "dag_id": "test_dag",
+        "run_id": "test_run",
+        "logical_date": timezone.utcnow(),
+        "data_interval_start": None,
+        "data_interval_end": None,
+        "run_after": timezone.utcnow(),
+        "start_date": None,
+        "end_date": None,
+        "run_type": DagRunType.MANUAL,
+        "state": DagRunState.QUEUED,
+        "consumed_asset_events": [],
+    }
+
+    dr = DagRun.model_validate(data)
+    ctx = DagRunContext(dag_run=dr)
+
+    assert ctx.dag_run.start_date is None


### PR DESCRIPTION

##  Fix Pydantic ValidationError when rerunning cleared DagRun

Closes #61381

---

### Problem

When rerunning or clearing DAG runs (especially those created in older Airflow versions), the scheduler may raise:

```
ValidationError: dag_run.start_date
Input should be a valid datetime
```

This occurs because the Pydantic `DagRun` model required `start_date` to be a non-null datetime, while cleared or queued DAG runs can legitimately have `start_date=None` in the database.

---

### Root Cause

The Pydantic `DagRun` model in:

```
airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
```

did not allow `start_date=None`, causing a `ValidationError` when constructing `DagRunContext` during scheduling.

---

### Changes Made

#### 1️⃣ Allow `start_date` to be nullable

```diff
- start_date: UtcDateTime
+ start_date: UtcDateTime | None = None
```

This aligns the Pydantic model with:

* ORM definition
* Database state
* Scheduler behavior

#### 2️⃣ Add default for `partition_key`

```diff
- partition_key: str | None
+ partition_key: str | None = None
```

Ensures consistent optional behavior.

---

### Tests Added

New test file:

```
airflow-core/tests/unit/api_fastapi/execution_api/datamodels/test_taskinstance.py
```

Includes:

* `test_dagrun_model_accepts_null_start_date`
* `test_dagrun_context_accepts_null_start_date`

These verify:

* The Pydantic `DagRun` model accepts `start_date=None`
* `DagRunContext` can be constructed without raising `ValidationError`

---

### Result

* Scheduler no longer crashes when rerunning cleared DAG runs
* Backward compatibility with existing DAG runs is restored
* Model validation now reflects actual database behavior

---

