### PR TITLE
feat: Make Hook Level Lineage limits configurable

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1929,6 +1929,23 @@ lineage:
       type: string
       example: ~
       default: ""
+    max_assets_per_collector:
+      description: |
+        Maximum number of asset inputs or outputs that can be collected by a single hook lineage collector
+        instance. Input assets and output assets are counted separately. Once the maximum is reached, any
+        additional assets will be dropped.
+      version_added: 3.2.0
+      type: integer
+      example: ~
+      default: "100"
+    max_extras_per_collector:
+      description: |
+        Maximum number of extra metadata entries that can be collected by a single hook lineage collector
+        instance. Once the maximum is reached, any additional extra metadata will be dropped.
+      version_added: 3.2.0
+      type: integer
+      example: ~
+      default: "200"
 operators:
   description: ~
   options:

--- a/task-sdk/src/airflow/sdk/lineage.py
+++ b/task-sdk/src/airflow/sdk/lineage.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING, Any, TypeAlias
 import attr
 import structlog
 
+from airflow.sdk.configuration import conf
 from airflow.sdk.definitions._internal.logging_mixin import LoggingMixin
 from airflow.sdk.definitions.asset import Asset
 from airflow.sdk.providers_manager_runtime import ProvidersManagerTaskRuntime
@@ -44,10 +45,10 @@ log = structlog.getLogger(__name__)
 
 # Maximum number of assets input or output that can be collected in a single hook execution.
 # Input assets and output assets are collected separately.
-MAX_COLLECTED_ASSETS = 100
+MAX_COLLECTED_ASSETS: int = conf.getint("lineage", "max_assets_per_collector", fallback=100)
 
 # Maximum number of extra metadata that can be collected in a single hook execution.
-MAX_COLLECTED_EXTRA = 200
+MAX_COLLECTED_EXTRA: int = conf.getint("lineage", "max_extras_per_collector", fallback=200)
 
 
 @attr.define


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

Currently `MAX_COLLECTED_ASSETS` and `MAX_COLLECTED_EXTRA` are hardcoded limits for hook lineage collectors. This PR makes them configurable with Airflow configuration. Users that want more detailed lineage can increase those limits and users that do not want any hook lineage can disable it by setting those limits to 0.

---

##### Was generative AI tooling used to co-author this PR?
No
<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->
<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
