### PR TITLE
Pass credentials object to GCSFileSystem for automatic token refresh

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/fs/gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/fs/gcs.py
@@ -51,7 +51,7 @@ def get_fs(conn_id: str | None, storage_options: dict[str, str] | None = None) -
     options = {
         "project": g.project_id,
         "access": g.extras.get(GCS_ACCESS, "full_control"),
-        "token": g._get_access_token(),
+        "token": g.get_credentials(),
         "consistency": g.extras.get(GCS_CONSISTENCY, "none"),
         "cache_timeout": g.extras.get(GCS_CACHE_TIMEOUT),
         "requester_pays": g.extras.get(GCS_REQUESTER_PAYS, False),

--- a/providers/google/tests/unit/google/cloud/fs/__init__.py
+++ b/providers/google/tests/unit/google/cloud/fs/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/google/tests/unit/google/cloud/fs/test_gcs.py
+++ b/providers/google/tests/unit/google/cloud/fs/test_gcs.py
@@ -1,0 +1,82 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("gcsfs")
+
+TEST_CONN = "google_cloud_test_conn"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _setup_connections():
+    with pytest.MonkeyPatch.context() as mp_ctx:
+        mp_ctx.setenv(f"AIRFLOW_CONN_{TEST_CONN}".upper(), "google-cloud-platform://")
+        yield
+
+
+class TestGCSFilesystem:
+    @patch("airflow.providers.google.cloud.fs.gcs.GoogleBaseHook")
+    @patch("gcsfs.GCSFileSystem")
+    def test_get_fs_passes_credentials_object(self, mock_gcsfs, mock_hook):
+        """Test that get_fs passes a Credentials object to GCSFileSystem."""
+        from airflow.providers.google.cloud.fs.gcs import get_fs
+
+        mock_credentials = MagicMock()
+        mock_hook_instance = MagicMock()
+        mock_hook_instance.get_credentials.return_value = mock_credentials
+        mock_hook_instance.project_id = "test-project"
+        mock_hook_instance.extras = {}
+        mock_hook.return_value = mock_hook_instance
+
+        get_fs(conn_id=TEST_CONN)
+
+        mock_hook_instance.get_credentials.assert_called_once()
+        call_kwargs = mock_gcsfs.call_args.kwargs
+        assert call_kwargs["token"] is mock_credentials
+
+    @patch("gcsfs.GCSFileSystem")
+    def test_get_fs_no_conn_id(self, mock_gcsfs):
+        """Test that get_fs works without conn_id."""
+        from airflow.providers.google.cloud.fs.gcs import get_fs
+
+        get_fs(conn_id=None)
+
+        mock_gcsfs.assert_called_once_with()
+
+    @patch("airflow.providers.google.cloud.fs.gcs.GoogleBaseHook")
+    @patch("gcsfs.GCSFileSystem")
+    def test_get_fs_with_anonymous_credentials(self, mock_gcsfs, mock_hook):
+        """Test that get_fs works with anonymous credentials."""
+        from google.auth.credentials import AnonymousCredentials
+
+        from airflow.providers.google.cloud.fs.gcs import get_fs
+
+        anonymous_creds = AnonymousCredentials()
+        mock_hook_instance = MagicMock()
+        mock_hook_instance.get_credentials.return_value = anonymous_creds
+        mock_hook_instance.project_id = None
+        mock_hook_instance.extras = {}
+        mock_hook.return_value = mock_hook_instance
+
+        get_fs(conn_id=TEST_CONN)
+
+        call_kwargs = mock_gcsfs.call_args.kwargs
+        assert isinstance(call_kwargs["token"], AnonymousCredentials)


### PR DESCRIPTION
Previously, `get_fs()` extracted a static access token string via `_get_access_token()` and passed it to `GCSFileSystem`. This token expires after ~1 hour with no way to refresh, causing 401 errors in long-running tasks.

By passing the `Credentials` object directly, `gcsfs` can automatically refresh the token before each request via its built-in `maybe_refresh()` mechanism.

This was introduced in #38102 to fix #37834 where `credentials.token` was `None` before manual refresh.

discussed on Slack few weeks ago with @shahar1 @potiuk 

---

I have added some mocked basic tests, but not sure how much value they brings. I have tested using following DAG locally also. Before it fails - after it refresh tokens and continue.

```python
import datetime

from airflow.decorators import dag, task
from airflow.io.path import ObjectStoragePath

GCS_CONN_ID = "gcs_test"
# Change this to your bucket
BUCKET = "gs://example-bucket"

base = ObjectStoragePath(BUCKET, conn_id=GCS_CONN_ID)


@dag(
    schedule=None,
    start_date=datetime.datetime(2024, 1, 1),
    catchup=False,
    tags=["test", "gcs"],
)
def test_gcs_token_refresh():
    @task
    def write_and_mangle_and_write_again():
        import datetime as dt

        path1 = base / "token_test_1.txt"
        path2 = base / "token_test_2.txt"

        # First write - should work with fresh token
        print("1. Writing first file...")
        with path1.open("w") as f:
            f.write("first write - fresh token")
        print(f"   OK: {path1}")

        # Mangle the token to simulate expiry
        # Access the underlying gcsfs filesystem and its credentials
        fs = path1.fs
        creds = fs.credentials.credentials
        print(f"\n2. Mangling token to simulate expiry...")
        print(f"   Token before: {creds.token[:30]}...")
        creds.token = "expired_garbage_token"
        creds.expiry = dt.datetime.utcnow() - dt.timedelta(hours=1)
        print(f"   Token after:  {creds.token}")
        print(f"   Expired:      {creds.expired}")

        # Second write - with our fix, gcsfs should auto-refresh
        # With the old code (_get_access_token), this would fail with 401
        print(f"\n3. Writing second file (should auto-refresh)...")
        with path2.open("w") as f:
            f.write("second write - after token refresh")
        print(f"   OK: {path2}")
        print(f"   Token now: {creds.token[:30]}...")

        # Cleanup
        path1.unlink()
        path2.unlink()
        print("\n4. Cleanup done. Token refresh works!")

    write_and_mangle_and_write_again()


test_gcs_token_refresh()

```