### PR TITLE
Add missing ti.start and ti.finish metrics in Airflow 3

### DIFF
--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -4333,3 +4333,91 @@ class TestTriggerDagRunOperator:
 
         # Also verify it was sent to supervisor
         mock_supervisor_comms.send.assert_any_call(msg)
+
+
+class TestTaskInstanceMetrics:
+    def test_ti_start_metric_emitted(self, create_runtime_ti, mock_supervisor_comms):
+        """Test that ti.start metric is emitted at the beginning of task."""
+        task = PythonOperator(task_id="test", python_callable=lambda: "success")
+        ti = create_runtime_ti(task=task)
+
+        with mock.patch("airflow.sdk.execution_time.task_runner.Stats") as mock_stats:
+            run(ti, context=ti.get_template_context(), log=mock.MagicMock())
+
+            # verify ti.start was called in legacy format
+            mock_stats.incr.assert_any_call(
+                f"ti.start.{ti.dag_id}.{ti.task_id}",
+                tags={"dag_id": ti.dag_id, "task_id": ti.task_id},
+            )
+            # verify ti.start was called in tagged format
+            mock_stats.incr.assert_any_call(
+                "ti.start",
+                tags={"dag_id": ti.dag_id, "task_id": ti.task_id},
+            )
+
+    @pytest.mark.parametrize(
+        ("task_callable", "expected_state")[
+            pytest.param(lambda: "success", "success", id="success"),
+            pytest.param(lambda: (_ for _ in ()).throw(AirflowSkipException()), "skipped", id="skipped"),
+            pytest.param(lambda: (_ for _ in ()).throw(AirflowFailException("fail")), "failed", id="failed"),
+            pytest.param(lambda: 1 / 0, "failed", id="zero_division"),
+        ],
+    )
+    def test_ti_finish_metric_emitted_for_terminal_states(
+        self, task_callable, expected_state, create_runtime_ti, mock_supervisor_comms
+    ):
+        """Test that ti.finish metric is emitted for all terminal states."""
+        task = PythonOperator(task_id="test", python_callable=task_callable)
+        ti = create_runtime_ti(task=task)
+
+        with mock.patch("airflow.sdk.execution_time.task_runner.Stats") as mock_stats:
+            run(ti, context=ti.get_template_context(), log=mock.MagicMock())
+
+            # verify ti.finish was called in legacy format
+            mock_stats.incr.assert_any_call(
+                f"ti.finish.{ti.dag_id}.{ti.task_id}.{expected_state}",
+                tags={"dag_id": ti.dag_id, "task_id": ti.task_id},
+            )
+            # verify ti.finish was called in tagged format
+            mock_stats.incr.assert_any_call(
+                "ti.finish",
+                tags={"dag_id": ti.dag_id, "task_id": ti.task_id, "state": expected_state},
+            )
+
+    def test_operator_successes_metrics_emitted(self, create_runtime_ti, mock_supervisor_comms):
+        """Test that operator_successes and ti_successes metrics are emitted on task success."""
+        task = PythonOperator(task_id="test", python_callable=lambda: "success")
+        ti = create_runtime_ti(task=task)
+
+        with mock.patch("airflow.sdk.execution_time.task_runner.Stats") as mock_stats:
+            run(ti, context=ti.get_template_context(), log=mock.MagicMock())
+
+            stats_tags = {"dag_id": ti.dag_id, "task_id": ti.task_id}
+
+            # verify operator_successes in legacy format
+            mock_stats.incr.assert_any_call("operator_successes_PythonOperator", tags=stats_tags)
+            # verify operator_successes in tagged format
+            mock_stats.incr.assert_any_call(
+                "operator_successes",
+                tags={**stats_tags, "operator": "PythonOperator"},
+            )
+            mock_stats.incr.assert_any_call("ti_successes", tags=stats_tags)
+
+    def test_operator_failures_metrics_emitted(self, create_runtime_ti, mock_supervisor_comms):
+        """Test that operator_failures and ti_failures metrics are emitted on task failure."""
+        task = PythonOperator(task_id="test", python_callable=lambda: 1 / 0)
+        ti = create_runtime_ti(task=task)
+
+        with mock.patch("airflow.sdk.execution_time.task_runner.Stats") as mock_stats:
+            run(ti, context=ti.get_template_context(), log=mock.MagicMock())
+
+            stats_tags = {"dag_id": ti.dag_id, "task_id": ti.task_id}
+
+            # verify operator_failures in legacy format
+            mock_stats.incr.assert_any_call("operator_failures_PythonOperator", tags=stats_tags)
+            # verify operator_failures in tagged format
+            mock_stats.incr.assert_any_call(
+                "operator_failures",
+                tags={**stats_tags, "operator": "PythonOperator"},
+            )
+            mock_stats.incr.assert_any_call("ti_failures", tags=stats_tags)

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -4356,7 +4356,8 @@ class TestTaskInstanceMetrics:
             )
 
     @pytest.mark.parametrize(
-        ("task_callable", "expected_state")[
+        ("task_callable", "expected_state"),
+        [
             pytest.param(lambda: "success", "success", id="success"),
             pytest.param(lambda: (_ for _ in ()).throw(AirflowSkipException()), "skipped", id="skipped"),
             pytest.param(lambda: (_ for _ in ()).throw(AirflowFailException("fail")), "failed", id="failed"),


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] No

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

closes: https://github.com/apache/airflow/issues/62015


Some metrics like `ti.start` and `ti.finish` were not ported over to Airflow 3. 

This PR intends to add those to Airflow 3 and emit it from task execution.


### Testing

Deployed Airflow with breeze with `--integration statsd` 

#### Earlier:

<img width="2560" height="564" alt="image (67)" src="https://github.com/user-attachments/assets/9814cd22-cc87-45dc-b16c-acaa9d1fcd6b" />

<img width="2560" height="564" alt="image (68)" src="https://github.com/user-attachments/assets/c23b7e50-e4d0-4183-b1a7-a29221afe1a8" />

#### After:

##### Prometheus

<img width="2560" height="564" alt="image" src="https://github.com/user-attachments/assets/4e73c549-9b46-4aec-88ce-231de4e3a86d" />

<img width="2560" height="564" alt="image" src="https://github.com/user-attachments/assets/c3cce2e7-4de5-4062-9a8b-059f221d1041" />


##### Statsd

Finish:

```shell
➜  ~ curl -s http://localhost:29102/metrics | grep -i "finish"

# HELP airflow_ti_finish Metric autogenerated by statsd_exporter.
# TYPE airflow_ti_finish counter
airflow_ti_finish 2
# HELP airflow_ti_finish_sleeping_sleep_success Metric autogenerated by statsd_exporter.
# TYPE airflow_ti_finish_sleeping_sleep_success counter
airflow_ti_finish_sleeping_sleep_success 2
```

Start:

```shell
➜  ~ curl -s http://localhost:29102/metrics | grep -i "start"
# HELP airflow_job_start Metric autogenerated by statsd_exporter.
# TYPE airflow_job_start counter
airflow_job_start 2
# HELP airflow_ti_start Metric autogenerated by statsd_exporter.
# TYPE airflow_ti_start counter
airflow_ti_start 4
# HELP airflow_ti_start_sleeping_sleep Metric autogenerated by statsd_exporter.
# TYPE airflow_ti_start_sleeping_sleep counter
airflow_ti_start_sleeping_sleep 4
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.77124692275e+09
```




---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
