### PR TITLE
Add REST API to refresh DAG bundle without restart

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/__init__.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/__init__.py
@@ -26,6 +26,7 @@ from airflow.api_fastapi.core_api.routes.public.auth import auth_router
 from airflow.api_fastapi.core_api.routes.public.backfills import backfills_router
 from airflow.api_fastapi.core_api.routes.public.config import config_router
 from airflow.api_fastapi.core_api.routes.public.connections import connections_router
+from airflow.api_fastapi.core_api.routes.public.dag_bundles import dag_bundles_router
 from airflow.api_fastapi.core_api.routes.public.dag_parsing import dag_parsing_router
 from airflow.api_fastapi.core_api.routes.public.dag_run import dag_run_router
 from airflow.api_fastapi.core_api.routes.public.dag_sources import dag_sources_router
@@ -79,6 +80,7 @@ authenticated_router.include_router(task_instances_router)
 authenticated_router.include_router(tasks_router)
 authenticated_router.include_router(variables_router)
 authenticated_router.include_router(task_instances_log_router)
+authenticated_router.include_router(dag_bundles_router)
 authenticated_router.include_router(dag_parsing_router)
 authenticated_router.include_router(dag_tags_router)
 authenticated_router.include_router(dag_versions_router)

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_bundles.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_bundles.py
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from fastapi import Depends, HTTPException, status
+
+from airflow._shared.timezones import timezone
+from airflow.api_fastapi.common.db.common import SessionDep
+from airflow.api_fastapi.common.router import AirflowRouter
+from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
+from airflow.api_fastapi.logging.decorators import action_logging
+from airflow.models.dagbundle import DagBundleModel, DagBundleRefreshRequest
+
+dag_bundles_router = AirflowRouter(tags=["DAG Bundle"], prefix="/dagBundles")
+
+
+@dag_bundles_router.post(
+    "/{bundle_name}/refresh",
+    responses=create_openapi_http_exception_doc(
+        [status.HTTP_404_NOT_FOUND, status.HTTP_409_CONFLICT]
+    ),
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(action_logging())],
+)
+def refresh_dag_bundle(
+    bundle_name: str,
+    session: SessionDep,
+) -> None:
+    """Request a DAG bundle to be refreshed."""
+    bundle_model = session.get(DagBundleModel, bundle_name)
+    if bundle_model is None or not bundle_model.active:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            f"Bundle {bundle_name!r} not found or inactive",
+        )
+
+    existing = session.get(DagBundleRefreshRequest, bundle_name)
+    if existing is not None:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            f"A refresh request for bundle {bundle_name!r} is already pending",
+        )
+
+    refresh_request = DagBundleRefreshRequest(
+        bundle_name=bundle_name,
+        created_at=timezone.utcnow(),
+    )
+    session.add(refresh_request)

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -57,7 +57,7 @@ from airflow.exceptions import AirflowException
 from airflow.models.asset import remove_references_to_deleted_dags
 from airflow.models.dag import DagModel
 from airflow.models.dagbag import DagPriorityParsingRequest
-from airflow.models.dagbundle import DagBundleModel
+from airflow.models.dagbundle import DagBundleModel, DagBundleRefreshRequest
 from airflow.models.dagwarning import DagWarning
 from airflow.models.db_callback_request import DbCallbackRequest
 from airflow.models.errors import ParseImportError
@@ -388,6 +388,8 @@ class DagFileProcessorManager(LoggingMixin):
 
             self._kill_timed_out_processors()
 
+            self._queue_requested_bundle_refreshes()
+
             self._queue_requested_files_for_parsing()
 
             self._refresh_dag_bundles(known_files=known_files)
@@ -451,6 +453,24 @@ class DagFileProcessorManager(LoggingMixin):
                 sock: socket = key.fileobj  # type: ignore[assignment]
                 on_close(sock)
                 sock.close()
+
+    @provide_session
+    def _queue_requested_bundle_refreshes(self, session: Session = NEW_SESSION) -> None:
+        """Check for API-requested bundle refreshes and add them to the force-refresh set."""
+        bundle_names = {b.name for b in self._dag_bundles}
+        requests = session.scalars(
+            select(DagBundleRefreshRequest).where(
+                DagBundleRefreshRequest.bundle_name.in_(bundle_names)
+            )
+        )
+        for request in requests:
+            self._force_refresh_bundles.add(request.bundle_name)
+            session.delete(request)
+        if self._force_refresh_bundles:
+            self.log.info(
+                "Bundles queued for forced refresh via API: %s",
+                ", ".join(self._force_refresh_bundles),
+            )
 
     def _queue_requested_files_for_parsing(self) -> None:
         """Queue any files requested for parsing as requested by users via UI/API."""

--- a/airflow-core/src/airflow/migrations/versions/0104_3_2_0_add_dag_bundle_refresh_request_table.py
+++ b/airflow-core/src/airflow/migrations/versions/0104_3_2_0_add_dag_bundle_refresh_request_table.py
@@ -1,0 +1,54 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Add dag_bundle_refresh_request table.
+
+Revision ID: a1b2c3d4e5f6
+Revises: f8c9d7e6b5a4
+Create Date: 2026-02-16 00:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+from airflow.utils.sqlalchemy import UtcDateTime
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f6"
+down_revision = "f8c9d7e6b5a4"
+branch_labels = None
+depends_on = None
+airflow_version = "3.2.0"
+
+
+def upgrade():
+    """Create dag_bundle_refresh_request table."""
+    op.create_table(
+        "dag_bundle_refresh_request",
+        sa.Column("bundle_name", sa.String(250), primary_key=True, nullable=False),
+        sa.Column("created_at", UtcDateTime(), nullable=False),
+    )
+
+
+def downgrade():
+    """Drop dag_bundle_refresh_request table."""
+    op.drop_table("dag_bundle_refresh_request")

--- a/airflow-core/src/airflow/models/dagbundle.py
+++ b/airflow-core/src/airflow/models/dagbundle.py
@@ -28,6 +28,23 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.sqlalchemy import UtcDateTime
 
 
+class DagBundleRefreshRequest(Base):
+    """Model to store bundle refresh requests triggered via API."""
+
+    __tablename__ = "dag_bundle_refresh_request"
+
+    bundle_name: Mapped[str] = mapped_column(StringID(length=250), primary_key=True, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(UtcDateTime, nullable=False)
+
+    def __init__(self, bundle_name: str, created_at: datetime) -> None:
+        super().__init__()
+        self.bundle_name = bundle_name
+        self.created_at = created_at
+
+    def __repr__(self) -> str:
+        return f"<DagBundleRefreshRequest: bundle_name={self.bundle_name}>"
+
+
 class DagBundleModel(Base, LoggingMixin):
     """
     A table for storing DAG bundle metadata.

--- a/airflow-core/src/airflow/utils/db.py
+++ b/airflow-core/src/airflow/utils/db.py
@@ -112,7 +112,7 @@ _REVISION_HEADS_MAP: dict[str, str] = {
     "3.0.0": "29ce7909c52b",
     "3.0.3": "fe199e1abd77",
     "3.1.0": "cc92b33c6709",
-    "3.2.0": "f8c9d7e6b5a4",
+    "3.2.0": "a1b2c3d4e5f6",
 }
 
 # Prefix used to identify tables holding data moved during migration.

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_bundles.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_bundles.py
@@ -1,0 +1,112 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+
+from airflow.models.dagbundle import DagBundleModel, DagBundleRefreshRequest
+
+pytestmark = pytest.mark.db_test
+
+TEST_BUNDLE_NAME = "test-bundle"
+
+
+class TestDagBundleRefreshEndpoint:
+    @pytest.fixture(autouse=True)
+    def setup(self, session) -> None:
+        # Clean up any existing test data
+        session.query(DagBundleRefreshRequest).delete()
+        session.query(DagBundleModel).filter(DagBundleModel.name == TEST_BUNDLE_NAME).delete()
+        session.commit()
+
+    @pytest.fixture
+    def create_test_bundle(self, session):
+        """Create a test bundle in the database."""
+        bundle = DagBundleModel(name=TEST_BUNDLE_NAME)
+        bundle.active = True
+        session.add(bundle)
+        session.commit()
+        return bundle
+
+    def test_refresh_existing_bundle(self, session, test_client, create_test_bundle):
+        response = test_client.post(
+            f"/dagBundles/{TEST_BUNDLE_NAME}/refresh",
+            headers={"Accept": "application/json"},
+        )
+        assert response.status_code == 201
+
+        refresh_requests = session.scalars(select(DagBundleRefreshRequest)).all()
+        assert len(refresh_requests) == 1
+        assert refresh_requests[0].bundle_name == TEST_BUNDLE_NAME
+
+    def test_refresh_nonexistent_bundle(self, session, test_client):
+        response = test_client.post(
+            "/dagBundles/nonexistent-bundle/refresh",
+            headers={"Accept": "application/json"},
+        )
+        assert response.status_code == 404
+
+        refresh_requests = session.scalars(select(DagBundleRefreshRequest)).all()
+        assert refresh_requests == []
+
+    def test_refresh_inactive_bundle(self, session, test_client):
+        bundle = DagBundleModel(name=TEST_BUNDLE_NAME)
+        bundle.active = False
+        session.add(bundle)
+        session.commit()
+
+        response = test_client.post(
+            f"/dagBundles/{TEST_BUNDLE_NAME}/refresh",
+            headers={"Accept": "application/json"},
+        )
+        assert response.status_code == 404
+
+        refresh_requests = session.scalars(select(DagBundleRefreshRequest)).all()
+        assert refresh_requests == []
+
+    def test_duplicate_refresh_request(self, session, test_client, create_test_bundle):
+        # First request should succeed
+        response = test_client.post(
+            f"/dagBundles/{TEST_BUNDLE_NAME}/refresh",
+            headers={"Accept": "application/json"},
+        )
+        assert response.status_code == 201
+
+        # Duplicate request should return 409
+        response = test_client.post(
+            f"/dagBundles/{TEST_BUNDLE_NAME}/refresh",
+            headers={"Accept": "application/json"},
+        )
+        assert response.status_code == 409
+
+        refresh_requests = session.scalars(select(DagBundleRefreshRequest)).all()
+        assert len(refresh_requests) == 1
+
+    def test_should_respond_401(self, unauthenticated_test_client):
+        response = unauthenticated_test_client.post(
+            f"/dagBundles/{TEST_BUNDLE_NAME}/refresh",
+            headers={"Accept": "application/json"},
+        )
+        assert response.status_code == 401
+
+    def test_should_respond_403(self, unauthorized_test_client):
+        response = unauthorized_test_client.post(
+            f"/dagBundles/{TEST_BUNDLE_NAME}/refresh",
+            headers={"Accept": "application/json"},
+        )
+        assert response.status_code == 403


### PR DESCRIPTION
Closes #60616

## Summary
- Adds `POST /api/v2/dagBundles/{bundle_name}/refresh` endpoint
- Adds `DagBundleRefreshRequest` model to signal the DAG processor
- DAG processor consumes requests and force-refreshs the bundle
- Adds Alembic migration and tests

## What it does
Allows authorized clients to force-refresh a DAG bundle immediately via API, without needing to restart the dag processor or wait for the polling interval. This allows CI/CD pipelines and external systems to programmatically refresh DAG bundles after deployment.

## Changes
- **`airflow-core/src/airflow/models/dagbundle.py`** - Added `DagBundleRefreshRequest` model
- **`airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_bundles.py`** - Added endpoint
- **`airflow-core/src/airflow/api_fastapi/core_api/routes/public/__init__.py`** - Router registration
- **`airflow-core/src/airflow