### PR TITLE
fix: prevent FK violation when cleaning dag_version table

### DIFF
--- a/airflow-core/src/airflow/utils/db_cleanup.py
+++ b/airflow-core/src/airflow/utils/db_cleanup.py
@@ -77,6 +77,7 @@ class _TableConfig:
         supply additional filters here (e.g. externally triggered dag runs)
     :param keep_last_group_by: if keeping the last record, can keep the last record for each group
     :param dependent_tables: list of tables which have FK relationship with this table
+    :param skip_if_referenced_by: dict mapping referencing table name to the FK column name.
     """
 
     table_name: str
@@ -90,6 +91,7 @@ class _TableConfig:
     # because the relationships are unlikely to change and the number of tables is small.
     # Relying on automation here would increase complexity and reduce maintainability.
     dependent_tables: list[str] | None = None
+    skip_if_referenced_by: dict[str, str] | None = None
 
     def __post_init__(self):
         self.recency_column = column(self.recency_column_name)
@@ -171,6 +173,7 @@ config_list: list[_TableConfig] = [
         dag_id_column_name="dag_id",
         keep_last=True,
         keep_last_group_by=["dag_id"],
+        skip_if_referenced_by={"task_instance": "dag_version_id", "dag_run": "created_dag_version_id"},
     ),
     _TableConfig(table_name="deadline", recency_column_name="deadline_time", dag_id_column_name="dag_id"),
     _TableConfig(table_name="revoked_token", recency_column_name="exp"),
@@ -329,6 +332,36 @@ def _compile_create_table_as__other(element, compiler, **kw):
     return f"CREATE TABLE {element.name} AS {compiler.process(element.query)}"
 
 
+def _build_skip_if_referenced_filter(
+    *,
+    skip_if_referenced_by: dict[str, str],
+) -> list:
+    """
+    Build filter conditions to exclude rows that are still referenced by other tables.
+
+    :param skip_if_referenced_by: Dict mapping referencing table name to FK column name.
+    :return: List of filter conditions to exclude referenced rows
+    """
+    conditions = []
+
+    for ref_table_name, ref_column_name in skip_if_referenced_by.items():
+        ref_table = table(ref_table_name, column(ref_column_name))
+
+        # Build a subquery to find all IDs that are still referenced
+        referenced_ids_subquery = (
+            select(column(ref_column_name))
+            .select_from(ref_table)
+            .where(column(ref_column_name).isnot(None))
+            .distinct()
+            .scalar_subquery()
+        )
+
+        # Exclude rows where the primary key is in the set of referenced IDs
+        conditions.append(column("id").notin_(referenced_ids_subquery))
+
+    return conditions
+
+
 def _build_query(
     *,
     orm_model,
@@ -337,6 +370,7 @@ def _build_query(
     keep_last_filters,
     keep_last_group_by,
     clean_before_timestamp: DateTime,
+    skip_if_referenced_by: dict[str, str] | None = None,
     session: Session,
     dag_id_column=None,
     dag_ids: list[str] | None = None,
@@ -375,6 +409,15 @@ def _build_query(
         )
         conditions.append(column(max_date_col_name).is_(None))
     query = query.where(and_(*conditions))
+
+    # Add conditions to skip rows that are still referenced by other tables
+    if skip_if_referenced_by:
+        skip_conditions = _build_skip_if_referenced_filter(
+            skip_if_referenced_by=skip_if_referenced_by,
+        )
+        conditions.extend(skip_conditions)
+
+    query = query.filter(and_(*conditions))
     return query
 
 
@@ -389,6 +432,7 @@ def _cleanup_table(
     dag_id_column=None,
     dag_ids=None,
     exclude_dag_ids=None,
+    skip_if_referenced_by: dict[str, str] | None = None,
     dry_run: bool = True,
     verbose: bool = False,
     skip_archive: bool = False,
@@ -409,6 +453,7 @@ def _cleanup_table(
         keep_last_filters=keep_last_filters,
         keep_last_group_by=keep_last_group_by,
         clean_before_timestamp=clean_before_timestamp,
+        skip_if_referenced_by=skip_if_referenced_by,
         session=session,
     )
     logger.debug("old rows query:\n%s", query.selectable.compile())


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->
When running airflow db clean with a timestamp, the command fails with a ForeignKeyViolation error when attempting to delete old dag_version records.

```
Checking table dag_version
Found 1 rows meeting deletion criteria.
Performing Delete...
Moving data to table _airflow_deleted__dag_version__20251011083345
Traceback (most recent call last):
  File "/usr/python/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1910, in _execute_context
    self.dialect.do_execute(
  File "/usr/python/lib/python3.12/site-packages/sqlalchemy/engine/default.py", line 736, in do_execute
    cursor.execute(statement, parameters)
psycopg2.errors.ForeignKeyViolation: update or delete on table "dag_version" violates foreign key constraint "task_instance_dag_version_id_fkey" on table "task_instance"
DETAIL:  Key (id)=(018c5e5e-7a8b-7000-8000-000000000001) is still referenced from table "task_instance".
```

Why this happened? Reference to https://github.com/apache/airflow/issues/56192#issuecomment-3393068953.

### Change

Add a skip_if_referenced_by parameter to _TableConfig to exclude records that are
still referenced by other tables during cleanup.
Added _build_skip_if_referenced_filter() function to generate exclusion conditions

* closes: #https://github.com/apache/airflow/issues/56192
It's continuation of https://github.com/apache/airflow/pull/56567 rebased with latest main. 


---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
