### PR TITLE
Fix 2.11.1 dependencies for fab provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,15 +170,15 @@ them to the appropriate format and workflow that your tool requires.
 
 
 ```bash
-pip install 'apache-airflow==2.11.0' \
- --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.11.0/constraints-3.9.txt"
+pip install 'apache-airflow==2.11.1' \
+ --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.11.1/constraints-3.10.txt"
 ```
 
 2. Installing with extras (i.e., postgres, google)
 
 ```bash
-pip install 'apache-airflow[postgres,google]==2.8.3' \
- --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.11.0/constraints-3.9.txt"
+pip install 'apache-airflow[postgres,google]==2.11.1' \
+ --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.11.1/constraints-3.10.txt"
 ```
 
 For information on installing provider packages, check

--- a/generated/PYPI_README.md
+++ b/generated/PYPI_README.md
@@ -123,15 +123,15 @@ them to the appropriate format and workflow that your tool requires.
 
 
 ```bash
-pip install 'apache-airflow==2.11.0' \
- --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.11.0/constraints-3.9.txt"
+pip install 'apache-airflow==2.11.1' \
+ --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.11.1/constraints-3.10.txt"
 ```
 
 2. Installing with extras (i.e., postgres, google)
 
 ```bash
-pip install 'apache-airflow[postgres,google]==2.8.3' \
- --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.11.0/constraints-3.9.txt"
+pip install 'apache-airflow[postgres,google]==2.11.1' \
+ --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.11.1/constraints-3.10.txt"
 ```
 
 For information on installing provider packages, check

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -43,7 +43,7 @@ PRE_INSTALLED_PROVIDERS = [
     "common.compat",
     "common.io",
     "common.sql",
-    "fab>=1.5.4,<2.0",
+    "fab>=1.5.4rc0,<2.0",
     "ftp",
     "http",
     "imap",
@@ -576,13 +576,15 @@ def get_provider_requirement(provider_spec: str) -> str:
 
         current_airflow_version = Version(airflow_version_match.group(1))
         provider_id, min_version = provider_spec.split(">=")
-        min_version = min_version.split(",")[0]
+        version_split = min_version.split(",")
+        min_version = version_split[0]
         provider_version = Version(min_version)
         if provider_version.is_prerelease and not current_airflow_version.is_prerelease:
             # strip pre-release version from the pre-installed provider's version when we are preparing
             # the official package
             min_version = str(provider_version.base_version)
-        return f"apache-airflow-providers-{provider_id.replace('.', '-')}>={min_version}"
+        extra_version = "" if len(version_split) == 1 else "," + ",".join(version_split[1:])
+        return f"apache-airflow-providers-{provider_id.replace('.', '-')}>={min_version}{extra_version}"
     else:
         return f"apache-airflow-providers-{provider_spec.replace('.', '-')}"
 


### PR DESCRIPTION
The rc1 does not install because it had bad fab provider version specification (missing rc and missing upper-binding).

This was because in 2.11 we removed suffix for final version rather than added it as we do in Airflow 3 and we never had upper-binding in preinstalled providers.

This PR fixes both issues and will make it ready for rc2 of 2.11.1

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
