### PR TITLE
Make backport responsibility clearer

### DIFF
--- a/dev/backport/update_backport_status.py
+++ b/dev/backport/update_backport_status.py
@@ -29,6 +29,7 @@ def get_success_comment(branch: str, pr_url: str, pr_number: str):
                 Note: As of [Merging PRs targeted for Airflow 3.X](https://github.com/apache/airflow/blob/main/dev/README_AIRFLOW3_DEV.md#merging-prs-targeted-for-airflow-3x)
                 the committer who merges the PR is responsible for backporting the PRs that are bug fixes (generally speaking) to the maintenance branches.
 
+                In matter of doubt please ask in [#release-management](https://apache-airflow.slack.com/archives/C03G9H97MM2) Slack channel.
 
                     <tr>
                     <th>Status</th>
@@ -50,6 +51,8 @@ def get_failure_comment(branch: str, commit_sha_url: str, commit_sha: str):
 
 Note: As of [Merging PRs targeted for Airflow 3.X](https://github.com/apache/airflow/blob/main/dev/README_AIRFLOW3_DEV.md#merging-prs-targeted-for-airflow-3x)
 the committer who merges the PR is responsible for backporting the PRs that are bug fixes (generally speaking) to the maintenance branches.
+
+In matter of doubt please ask in [#release-management](https://apache-airflow.slack.com/archives/C03G9H97MM2) Slack channel.
 
 <table>
     <tr>

--- a/dev/backport/update_backport_status.py
+++ b/dev/backport/update_backport_status.py
@@ -25,7 +25,12 @@ import requests
 def get_success_comment(branch: str, pr_url: str, pr_number: str):
     shield_url = f"https://img.shields.io/badge/PR-{pr_number}-blue"
     comment = f"""### Backport successfully created: {branch}\n\n<table>
-                <tr>
+
+                Note: As of [Merging PRs targeted for Airflow 3.X](https://github.com/apache/airflow/blob/main/dev/README_AIRFLOW3_DEV.md#merging-prs-targeted-for-airflow-3x)
+                the committer who merges the PR is responsible for backporting the PRs that are bug fixes (generally speaking) to the maintenance branches.
+
+
+                    <tr>
                     <th>Status</th>
                     <th>Branch</th>
                     <th>Result</th>
@@ -42,6 +47,10 @@ def get_success_comment(branch: str, pr_url: str, pr_number: str):
 def get_failure_comment(branch: str, commit_sha_url: str, commit_sha: str):
     commit_shield_url = f"https://img.shields.io/badge/Commit-{commit_sha[:7]}-red"
     comment = f"""### Backport failed to create: {branch}. View the failure log <a href='https://github.com/{os.getenv("REPOSITORY")}/actions/runs/{os.getenv("RUN_ID")}'> Run details </a>\n
+
+Note: As of [Merging PRs targeted for Airflow 3.X](https://github.com/apache/airflow/blob/main/dev/README_AIRFLOW3_DEV.md#merging-prs-targeted-for-airflow-3x)
+the committer who merges the PR is responsible for backporting the PRs that are bug fixes (generally speaking) to the maintenance branches.
+
 <table>
     <tr>
         <th>Status</th>


### PR DESCRIPTION
As not everybody ws committer at point where we defined the policy for backporting making the message a bit more clear with a pointer to the docs.

---

##### Was generative AI tooling used to co-author this PR?

- [ ] No (please specify the tool below)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
