### PR TITLE
fix(helm): omit api-server replicas when HPA is enabled

### DIFF
--- a/chart/templates/api-server/api-server-deployment.yaml
+++ b/chart/templates/api-server/api-server-deployment.yaml
@@ -47,7 +47,9 @@ metadata:
   annotations: {{- toYaml .Values.apiServer.annotations | nindent 4 }}
   {{- end }}
 spec:
+  {{- if not .Values.apiServer.hpa.enabled }}
   replicas: {{ .Values.apiServer.replicas }}
+  {{- end }}
   {{- if ne $revisionHistoryLimit "" }}
   revisionHistoryLimit: {{ $revisionHistoryLimit }}
   {{- end }}

--- a/helm-tests/tests/helm_tests/apiserver/test_apiserver.py
+++ b/helm-tests/tests/helm_tests/apiserver/test_apiserver.py
@@ -76,6 +76,30 @@ class TestAPIServerDeployment:
             "readOnly": True,
         } in jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
 
+    def test_should_remove_replicas_field(self):
+        docs = render_chart(
+            values={
+                "airflowVersion": "3.0.0",
+                "apiServer": {
+                    "hpa": {"enabled": True},
+                },
+            },
+            show_only=["templates/api-server/api-server-deployment.yaml"],
+        )
+        assert "replicas" not in jmespath.search("spec", docs[0])
+
+    def test_should_not_remove_replicas_field(self):
+        docs = render_chart(
+            values={
+                "airflowVersion": "3.0.0",
+                "apiServer": {
+                    "hpa": {"enabled": False},
+                },
+            },
+            show_only=["templates/api-server/api-server-deployment.yaml"],
+        )
+        assert "replicas" in jmespath.search("spec", docs[0])
+
 
 class TestAPIServerJWTSecret:
     """Tests API Server JWT secret."""

--- a/helm-tests/tests/helm_tests/apiserver/test_apiserver.py
+++ b/helm-tests/tests/helm_tests/apiserver/test_apiserver.py
@@ -17,11 +17,17 @@
 from __future__ import annotations
 
 import jmespath
+import pytest
 from chart_utils.helm_template_generator import render_chart
 
 
 class TestAPIServerDeployment:
     """Tests API Server deployment."""
+
+    def _get_values_with_version(self, values, version):
+        if version != "default":
+            values["airflowVersion"] = version
+        return values
 
     def test_airflow_2(self):
         """
@@ -76,26 +82,24 @@ class TestAPIServerDeployment:
             "readOnly": True,
         } in jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
 
-    def test_should_remove_replicas_field(self):
+    @pytest.mark.parametrize("version", ["3.0.0", "default"])
+    def test_should_remove_replicas_field(self, version):
         docs = render_chart(
-            values={
-                "airflowVersion": "3.0.0",
-                "apiServer": {
-                    "hpa": {"enabled": True},
-                },
-            },
+            values=self._get_values_with_version(
+                values={"apiServer": {"hpa": {"enabled": True}}},
+                version=version,
+            ),
             show_only=["templates/api-server/api-server-deployment.yaml"],
         )
         assert "replicas" not in jmespath.search("spec", docs[0])
 
-    def test_should_not_remove_replicas_field(self):
+    @pytest.mark.parametrize("version", ["3.0.0", "default"])
+    def test_should_not_remove_replicas_field(self, version):
         docs = render_chart(
-            values={
-                "airflowVersion": "3.0.0",
-                "apiServer": {
-                    "hpa": {"enabled": False},
-                },
-            },
+            values=self._get_values_with_version(
+                values={"apiServer": {"hpa": {"enabled": False}}},
+                version=version,
+            ),
             show_only=["templates/api-server/api-server-deployment.yaml"],
         )
         assert "replicas" in jmespath.search("spec", docs[0])


### PR DESCRIPTION
When apiServer.hpa.enabled is true, the deployment must not set a replicas field so the HPA can manage replica count. Otherwise GitOps tools (e.g. ArgoCD) detect drift and continuously reconcile.
This affects the new hpa capabilities defined in `helm-chart/1.19.0rc3`

The fix follows the same pattern used previously by webserver and workers deployments.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
