### PR TITLE
Add workers.celery.waitForMigrations section

### DIFF
--- a/chart/newsfragments/62054.significant.rst
+++ b/chart/newsfragments/62054.significant.rst
@@ -1,0 +1,1 @@
+``workers.waitForMigrations`` section is now deprecated in favor of ``workers.celery.waitForMigrations``. Please update your configuration accordingly.

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -685,6 +685,30 @@ DEPRECATION WARNING:
 
 {{- end }}
 
+{{- if not .Values.workers.waitForMigrations.enabled }}
+
+ DEPRECATION WARNING:
+    `workers.waitForMigrations.enabled` has been renamed to `workers.celery.waitForMigrations.enabled`.
+    Please change your values as support for the old name will be dropped in a future release.
+
+{{- end }}
+
+{{- if not (empty .Values.workers.waitForMigrations.env) }}
+
+ DEPRECATION WARNING:
+    `workers.waitForMigrations.env` has been renamed to `workers.celery.waitForMigrations.env`.
+    Please change your values as support for the old name will be dropped in a future release.
+
+{{- end }}
+
+{{- if not (empty .Values.workers.waitForMigrations.securityContexts.container) }}
+
+ DEPRECATION WARNING:
+    `workers.waitForMigrations.securityContexts.container` has been renamed to `workers.celery.waitForMigrations.securityContexts.container`.
+    Please change your values as support for the old name will be dropped in a future release.
+
+{{- end }}
+
 {{- if not (empty .Values.webserver.defaultUser) }}
 
  DEPRECATION WARNING:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2520,17 +2520,17 @@
                     }
                 },
                 "waitForMigrations": {
-                    "description": "Configuration of wait-for-airflow-migration init container for Airflow Celery workers.",
+                    "description": "Configuration of wait-for-airflow-migration init container for Airflow Celery workers (deprecated, use ``workers.celery.waitForMigrations`` instead).",
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
                         "enabled": {
-                            "description": "Enable wait-for-airflow-migrations init container.",
+                            "description": "Enable wait-for-airflow-migrations init container (deprecated, use ``workers.celery.waitForMigrations.enabled`` instead).",
                             "type": "boolean",
                             "default": true
                         },
                         "env": {
-                            "description": "Add additional env vars to wait-for-airflow-migrations init container.",
+                            "description": "Add additional env vars to wait-for-airflow-migrations init container (deprecated, use ``workers.celery.waitForMigrations.env`` instead).",
                             "type": "array",
                             "default": [],
                             "items": {
@@ -2551,12 +2551,12 @@
                             }
                         },
                         "securityContexts": {
-                            "description": "Security context definition for the wait-for-airflow-migrations container. If not set, the values from global `securityContexts` will be used.",
+                            "description": "Security context definition for the wait-for-airflow-migrations container (deprecated, use ``workers.celery.waitForMigrations.securityContexts`` instead). If not set, the values from global `securityContexts` will be used.",
                             "type": "object",
                             "x-docsSection": "Kubernetes",
                             "properties": {
                                 "container": {
-                                    "description": "Container security context definition for the wait-for-airflow-migrations container.",
+                                    "description": "Container security context definition for the wait-for-airflow-migrations container (deprecated, use ``workers.celery.waitForMigrations.securityContexts.container`` instead).",
                                     "type": "object",
                                     "$ref": "#/definitions/io.k8s.api.core.v1.SecurityContext",
                                     "default": {},
@@ -3347,6 +3347,66 @@
                                     ]
                                 }
                             ]
+                        },
+                        "waitForMigrations": {
+                            "description": "Configuration of wait-for-airflow-migration init container for Airflow Celery workers.",
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "enabled": {
+                                    "description": "Whether to create init container to wait for db migrations.",
+                                    "type": [
+                                        "boolean",
+                                        "null"
+                                    ],
+                                    "default": null
+                                },
+                                "env": {
+                                    "description": "Add additional env vars to wait-for-airflow-migrations init container.",
+                                    "type": "array",
+                                    "default": [],
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "value"
+                                        ],
+                                        "additionalProperties": false
+                                    }
+                                },
+                                "securityContexts": {
+                                    "description": "Security context definition for the wait-for-airflow-migrations container. If not set, the values from ``workers.waitForMigrations.securityContexts`` will be used.",
+                                    "type": "object",
+                                    "x-docsSection": "Kubernetes",
+                                    "properties": {
+                                        "container": {
+                                            "description": "Container security context definition for the wait-for-airflow-migrations container.",
+                                            "type": "object",
+                                            "$ref": "#/definitions/io.k8s.api.core.v1.SecurityContext",
+                                            "default": {},
+                                            "x-docsSection": "Kubernetes",
+                                            "examples": [
+                                                {
+                                                    "allowPrivilegeEscalation": false,
+                                                    "capabilities": {
+                                                        "drop": [
+                                                            "ALL"
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
                         },
                         "volumeClaimTemplates": {
                             "description": "Specify additional volume claim template for Airflow Celery workers.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1136,14 +1136,19 @@ workers:
     env: []
 
   # Configuration of wait-for-airflow-migration init container for Airflow Celery workers
+  # (deprecated, use `workers.celery.waitForMigrations` instead)
   waitForMigrations:
     # Whether to create init container to wait for db migrations
+    # (deprecated, use `workers.celery.waitForMigrations.enabled` instead)
     enabled: true
 
+    # (deprecated, use `workers.celery.waitForMigrations.env` instead)
     env: []
 
     # Detailed default security context for wait-for-airflow-migrations container
+    # (deprecated, use `workers.celery.waitForMigrations.securityContexts` instead)
     securityContexts:
+      # (deprecated, use `workers.celery.waitForMigrations.securityContexts.container` instead)
       container: {}
 
   # Additional env variable configuration for Airflow Celery workers and pods created with pod-template-file
@@ -1403,6 +1408,17 @@ workers:
     # - ip: "127.0.0.3"
     #   hostnames:
     #   - "test.hostname.two"
+
+    # Configuration of wait-for-airflow-migration init container for Airflow Celery workers
+    waitForMigrations:
+      # Whether to create init container to wait for db migrations
+      enabled: ~
+
+      env: []
+
+      # Detailed default security context for wait-for-airflow-migrations container
+      securityContexts:
+        container: {}
 
     # Additional volume claim templates for Airflow Celery workers.
     # Requires mounting of specified volumes under extraVolumeMounts.

--- a/helm-tests/tests/helm_tests/airflow_core/test_worker.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_worker.py
@@ -203,13 +203,16 @@ class TestWorker:
             "name": "release-name-test-container"
         }
 
-    def test_disable_wait_for_migration(self):
+    @pytest.mark.parametrize(
+        "workers_values",
+        [
+            {"waitForMigrations": {"enabled": False}},
+            {"celery": {"waitForMigrations": {"enabled": False}}},
+        ],
+    )
+    def test_disable_wait_for_migration(self, workers_values):
         docs = render_chart(
-            values={
-                "workers": {
-                    "waitForMigrations": {"enabled": False},
-                },
-            },
+            values={"workers": workers_values},
             show_only=["templates/workers/worker-deployment.yaml"],
         )
         actual = jmespath.search(
@@ -362,13 +365,20 @@ class TestWorker:
             "valueFrom": {"configMapKeyRef": {"name": "my-config-map", "key": "my-key"}},
         } in jmespath.search("spec.template.spec.containers[0].env", docs[0])
 
-    def test_should_add_extraEnvs_to_wait_for_migration_container(self):
-        docs = render_chart(
-            values={
-                "workers": {
-                    "waitForMigrations": {"env": [{"name": "TEST_ENV_1", "value": "test_env_1"}]},
-                },
+    @pytest.mark.parametrize(
+        "workers_values",
+        [
+            {"waitForMigrations": {"env": [{"name": "TEST_ENV_1", "value": "test_env_1"}]}},
+            {"celery": {"waitForMigrations": {"env": [{"name": "TEST_ENV_1", "value": "test_env_1"}]}}},
+            {
+                "waitForMigrations": {"env": [{"name": "TEST", "value": "test"}]},
+                "celery": {"waitForMigrations": {"env": [{"name": "TEST_ENV_1", "value": "test_env_1"}]}},
             },
+        ],
+    )
+    def test_should_add_extraEnvs_to_wait_for_migration_container(self, workers_values):
+        docs = render_chart(
+            values={"workers": workers_values},
             show_only=["templates/workers/worker-deployment.yaml"],
         )
 

--- a/helm-tests/tests/helm_tests/airflow_core/test_worker_sets.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_worker_sets.py
@@ -2866,16 +2866,27 @@ class TestWorkerSets:
         assert labels["test"] == "echo"
         assert labels.get("echo") is None
 
-    def test_overwrite_wait_for_migration_disable(self):
-        docs = render_chart(
-            values={
-                "workers": {
-                    "celery": {
-                        "enableDefault": False,
-                        "sets": [{"name": "set1", "waitForMigrations": {"enabled": False}}],
-                    },
-                },
+    @pytest.mark.parametrize(
+        "workers_values",
+        [
+            {
+                "celery": {
+                    "enableDefault": False,
+                    "sets": [{"name": "set1", "waitForMigrations": {"enabled": False}}],
+                }
             },
+            {
+                "celery": {
+                    "waitForMigrations": {"enabled": True},
+                    "enableDefault": False,
+                    "sets": [{"name": "set1", "waitForMigrations": {"enabled": False}}],
+                }
+            },
+        ],
+    )
+    def test_overwrite_wait_for_migration_disable(self, workers_values):
+        docs = render_chart(
+            values={"workers": workers_values},
             show_only=["templates/workers/worker-deployment.yaml"],
         )
         assert (
@@ -2885,17 +2896,28 @@ class TestWorkerSets:
             is None
         )
 
-    def test_overwrite_wait_for_migration_enable(self):
-        docs = render_chart(
-            values={
-                "workers": {
-                    "waitForMigrations": {"enabled": False},
-                    "celery": {
-                        "enableDefault": False,
-                        "sets": [{"name": "set1", "waitForMigrations": {"enabled": True}}],
-                    },
+    @pytest.mark.parametrize(
+        "workers_values",
+        [
+            {
+                "waitForMigrations": {"enabled": False},
+                "celery": {
+                    "enableDefault": False,
+                    "sets": [{"name": "set1", "waitForMigrations": {"enabled": True}}],
                 },
             },
+            {
+                "celery": {
+                    "waitForMigrations": {"enabled": False},
+                    "enableDefault": False,
+                    "sets": [{"name": "set1", "waitForMigrations": {"enabled": True}}],
+                }
+            },
+        ],
+    )
+    def test_overwrite_wait_for_migration_enable(self, workers_values):
+        docs = render_chart(
+            values={"workers": workers_values},
             show_only=["templates/workers/worker-deployment.yaml"],
         )
         assert (
@@ -2915,6 +2937,18 @@ class TestWorkerSets:
             {
                 "waitForMigrations": {"env": [{"name": "TEST", "value": "test"}]},
                 "celery": {
+                    "enableDefault": False,
+                    "sets": [
+                        {
+                            "name": "set1",
+                            "waitForMigrations": {"env": [{"name": "TEST_ENV_1", "value": "test_env_1"}]},
+                        }
+                    ],
+                },
+            },
+            {
+                "celery": {
+                    "waitForMigrations": {"env": [{"name": "TEST", "value": "test"}]},
                     "enableDefault": False,
                     "sets": [
                         {
@@ -2951,6 +2985,20 @@ class TestWorkerSets:
             {
                 "waitForMigrations": {"securityContexts": {"container": {"allowPrivilegeEscalation": False}}},
                 "celery": {
+                    "enableDefault": False,
+                    "sets": [
+                        {
+                            "name": "set1",
+                            "waitForMigrations": {"securityContexts": {"container": {"runAsUser": 10}}},
+                        }
+                    ],
+                },
+            },
+            {
+                "celery": {
+                    "waitForMigrations": {
+                        "securityContexts": {"container": {"allowPrivilegeEscalation": False}}
+                    },
                     "enableDefault": False,
                     "sets": [
                         {

--- a/helm-tests/tests/helm_tests/security/test_security_context.py
+++ b/helm-tests/tests/helm_tests/security/test_security_context.py
@@ -671,7 +671,28 @@ class TestSecurityContext:
         ) == {"runAsUser": 2000}
 
     # Test securityContexts for the wait-for-migrations init containers
-    def test_wait_for_migrations_init_container_setting_airflow_2(self):
+    @pytest.mark.parametrize(
+        "workers_values",
+        [
+            {"waitForMigrations": {"securityContexts": {"container": {"allowPrivilegeEscalation": False}}}},
+            {
+                "celery": {
+                    "waitForMigrations": {
+                        "securityContexts": {"container": {"allowPrivilegeEscalation": False}}
+                    }
+                }
+            },
+            {
+                "waitForMigrations": {"securityContexts": {"container": {"runAsUser": 0}}},
+                "celery": {
+                    "waitForMigrations": {
+                        "securityContexts": {"container": {"allowPrivilegeEscalation": False}}
+                    }
+                },
+            },
+        ],
+    )
+    def test_wait_for_migrations_init_container_setting_airflow_2(self, workers_values):
         ctx_value = {"allowPrivilegeEscalation": False}
         spec = {
             "waitForMigrations": {
@@ -684,7 +705,7 @@ class TestSecurityContext:
                 "scheduler": spec,
                 "webserver": spec,
                 "triggerer": spec,
-                "workers": {"waitForMigrations": {"securityContexts": {"container": ctx_value}}},
+                "workers": workers_values,
                 "airflowVersion": "2.11.0",
             },
             show_only=[
@@ -698,7 +719,28 @@ class TestSecurityContext:
         for doc in docs:
             assert ctx_value == jmespath.search("spec.template.spec.initContainers[0].securityContext", doc)
 
-    def test_wait_for_migrations_init_container_setting(self):
+    @pytest.mark.parametrize(
+        "workers_values",
+        [
+            {"waitForMigrations": {"securityContexts": {"container": {"allowPrivilegeEscalation": False}}}},
+            {
+                "celery": {
+                    "waitForMigrations": {
+                        "securityContexts": {"container": {"allowPrivilegeEscalation": False}}
+                    }
+                }
+            },
+            {
+                "waitForMigrations": {"securityContexts": {"container": {"runAsUser": 0}}},
+                "celery": {
+                    "waitForMigrations": {
+                        "securityContexts": {"container": {"allowPrivilegeEscalation": False}}
+                    }
+                },
+            },
+        ],
+    )
+    def test_wait_for_migrations_init_container_setting(self, workers_values):
         ctx_value = {"allowPrivilegeEscalation": False}
         spec = {
             "waitForMigrations": {
@@ -712,7 +754,7 @@ class TestSecurityContext:
                 "apiServer": spec,
                 "triggerer": spec,
                 "dagProcessor": spec,
-                "workers": {"waitForMigrations": {"securityContexts": {"container": ctx_value}}},
+                "workers": workers_values,
             },
             show_only=[
                 "templates/scheduler/scheduler-deployment.yaml",


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

related: https://github.com/apache/airflow/issues/28880

This PR introduces a new `workers.celery.waitForMigrations` section and deprecates the old `workers.waitForMigrations` section (as it was only applicable to Celery workers).

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
