### PR TITLE
Refactor get_oauth_token for better error handling

### DIFF
--- a/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake.py
@@ -521,11 +521,7 @@ class SnowflakeHook(DbApiHook):
             data |= {
                 "refresh_token": conn_config["refresh_token"],
             }
-<<<<<<< HEAD
-=======
-        
 
->>>>>>> 631a55f2a0 (Refactor get_oauth_token for better error handling)
 
         response = self._request_oauth_token(
             url=url,

--- a/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake.py
@@ -266,11 +266,28 @@ class SnowflakeHook(DbApiHook):
         return account_identifier
 
     def get_oauth_token(
-        self,
-        conn_config: dict | None = None,
-        token_endpoint: str | None = None,
-        grant_type: str = "refresh_token",
-    ) -> str:
+    self,
+    conn_config: dict | None = None,
+    token_endpoint: str | None = None,
+    grant_type: str = "refresh_token",
+) -> str:
+    """
+    Generate temporary OAuth access token using refresh token in connection details.
+
+    Transient network and server-side errors are retried automatically.
+    """
+    if conn_config is None:
+        conn_config = self._get_static_conn_params  # FIXED
+
+    if token_endpoint is None:
+        token_endpoint = conn_config.get("token_endpoint")
+
+    return self._get_valid_oauth_token(
+        conn_config=conn_config,
+        token_endpoint=token_endpoint,
+        grant_type=grant_type,
+    )
+
         """
         Generate temporary OAuth access token using refresh token in connection details.
 
@@ -504,6 +521,11 @@ class SnowflakeHook(DbApiHook):
             data |= {
                 "refresh_token": conn_config["refresh_token"],
             }
+<<<<<<< HEAD
+=======
+        
+
+>>>>>>> 631a55f2a0 (Refactor get_oauth_token for better error handling)
 
         response = self._request_oauth_token(
             url=url,
@@ -512,8 +534,13 @@ class SnowflakeHook(DbApiHook):
             client_secret=conn_config["client_secret"],
         )
 
-        token = response.json()["access_token"]
-        expires_in = int(response.json()["expires_in"])
+        response_json = response.json()
+
+     if "access_token" not in response_json or "expires_in" not in response_json:
+                raise AirflowException("Invalid OAuth response: missing access_token or expires_in")
+
+     token = response_json["access_token"]
+     expires_in = int(response_json["expires_in"])
 
         # Capture issue timestamp after access token is retrieved.
         issued_at = timezone.utcnow()
@@ -770,7 +797,8 @@ class SnowflakeHook(DbApiHook):
         else:
             sql_list = sql
 
-        if sql_list:
+        if sql_list and any(stmt.strip() for stmt in sql_list):
+
             self.log.debug("Executing following statements against Snowflake DB: %s", sql_list)
         else:
             raise ValueError("List of SQL statements is empty")


### PR DESCRIPTION
refactor(snowflake): clean up connection parameter handling and improve OAuth flow

- Separated static and dynamic connection parameters
- Cached static connection parameters using cached_property
- Centralized OAuth token validation logic
- Improved readability and error handling in connection setup
- Minor logging and structure improvements

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
