### PR TITLE
Correct compat shim routing for XCom models and introduce deprecation…

### DIFF
--- a/airflow-core/src/airflow/models/xcom.py
+++ b/airflow-core/src/airflow/models/xcom.py
@@ -411,9 +411,24 @@ __compat_imports = {
 
 
 def __getattr__(name: str):
+    import importlib
+    import warnings
+
+    from airflow.utils.deprecation_tools import DeprecatedImportWarning
+
     try:
         modpath = __compat_imports[name]
     except KeyError:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None
-    globals()[name] = value = getattr(__import__(modpath), name)
+
+    warnings.warn(
+        f"Importing {name} from 'airflow.models.xcom' is deprecated and will be removed in a future version. "
+        f"Please import from '{modpath}' instead.",
+        DeprecatedImportWarning,
+        stacklevel=2,
+    )
+
+    mod = importlib.import_module(modpath)
+    value = getattr(mod, name)
+    globals()[name] = value
     return value


### PR DESCRIPTION
… warning

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] No

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

Some recent refactor like: https://github.com/apache/airflow/pull/59491 ended up breaking the compat a bit for models/xcom.

Example:
```python
ImportError: cannot import name 'BaseXCom' from 'airflow.models.xcom'
```

Handling that through this PR and also issuing deprecation warning which was not done.

After the changes:

```python
from airflow.models.xcom import BaseXCom
2026-02-17T08:54:19.550476Z [info     ] setup plugin alembic.autogenerate.schemas [alembic.runtime.plugins] loc=plugins.py:37
2026-02-17T08:54:19.550584Z [info     ] setup plugin alembic.autogenerate.tables [alembic.runtime.plugins] loc=plugins.py:37
2026-02-17T08:54:19.550634Z [info     ] setup plugin alembic.autogenerate.types [alembic.runtime.plugins] loc=plugins.py:37
2026-02-17T08:54:19.550672Z [info     ] setup plugin alembic.autogenerate.constraints [alembic.runtime.plugins] loc=plugins.py:37
2026-02-17T08:54:19.550708Z [info     ] setup plugin alembic.autogenerate.defaults [alembic.runtime.plugins] loc=plugins.py:37
2026-02-17T08:54:19.550745Z [info     ] setup plugin alembic.autogenerate.comments [alembic.runtime.plugins] loc=plugins.py:37
<ipython-input-2-540b7f0284a4>:1 DeprecatedImportWarning: Importing BaseXCom from 'airflow.models.xcom' is deprecated and will be removed in a future version. Please import from 'airflow.sdk.bases.xcom' instead.
from airflow.models.xcom import XCom
<ipython-input-3-8031bdebcdc8>:1 DeprecatedImportWarning: Importing XCom from 'airflow.models.xcom' is deprecated and will be removed in a future version. Please import from 'airflow.sdk.execution_time.xcom' instead.
XCom
Out[4]: airflow.sdk.bases.xcom.BaseXCom
from airflow.models.xcom import XComArg
<ipython-input-5-e09fb99fd161>:1 DeprecatedImportWarning: Importing XComArg from 'airflow.models.xcom' is deprecated and will be removed in a future version. Please import from 'airflow.sdk' instead.
XComArg
Out[6]: airflow.sdk.definitions.xcom_arg.XComArg
```

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
