### PR TITLE
Do not dilute task failures with finalization errors during execution

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1701,7 +1701,10 @@ def finalize(
     if getattr(ti.task, "overwrite_rtif_after_execution", False):
         log.debug("Overwriting Rendered template fields.")
         if ti.task.template_fields:
-            SUPERVISOR_COMMS.send(SetRenderedFields(rendered_fields=_serialize_rendered_fields(ti.task)))
+            try:
+                SUPERVISOR_COMMS.send(SetRenderedFields(rendered_fields=_serialize_rendered_fields(ti.task)))
+            except Exception:
+                log.exception("Failed to set rendered fields during finalization", ti=ti, task=ti.task)
 
     log.debug("Running finalizers", ti=ti)
     if state == TaskInstanceState.SUCCESS:

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -2179,6 +2179,53 @@ class TestRuntimeTaskInstance:
             msg=SetRenderedFields(rendered_fields={"bash_command": rendered_cmd})
         )
 
+    def test_overwrite_rtif_after_execution_handles_errors_gracefully(
+        self, create_runtime_ti, mock_supervisor_comms
+    ):
+        """
+        Test that errors during SetRenderedFields in finalize() don't mask the original task error.
+        """
+        from airflow.sdk.exceptions import AirflowRuntimeError
+        from airflow.sdk.execution_time.comms import ErrorResponse, ErrorType
+
+        class TaskWithRTIF(BaseOperator):
+            overwrite_rtif_after_execution = True
+            template_fields = ["command"]
+
+            def __init__(self, command, *args, **kwargs):
+                self.command = command
+                super().__init__(*args, **kwargs)
+
+        task = TaskWithRTIF(task_id="test_task", command="test command")
+        runtime_ti = create_runtime_ti(task=task)
+        mock_log = mock.MagicMock()
+
+        # mock the SetRenderedFields call to fail with API_SERVER_ERROR
+        mock_supervisor_comms.send.side_effect = AirflowRuntimeError(
+            error=ErrorResponse(
+                error=ErrorType.API_SERVER_ERROR,
+                detail={
+                    "status_code": 404,
+                    "message": "Not Found",
+                    "detail": {"detail": "Not Found"},
+                },
+            )
+        )
+
+        finalize(
+            runtime_ti,
+            state=TaskInstanceState.FAILED,
+            context=runtime_ti.get_template_context(),
+            log=mock_log,
+            error=Exception("Task execution failed"),
+        )
+
+        mock_log.exception.assert_called_once_with(
+            "Failed to set rendered fields during finalization",
+            ti=runtime_ti,
+            task=task,
+        )
+
     @pytest.mark.parametrize(
         ("task_reschedule_count", "expected_date"),
         [

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -65,6 +65,7 @@ from airflow.sdk.exceptions import (
     AirflowException,
     AirflowFailException,
     AirflowRescheduleException,
+    AirflowRuntimeError,
     AirflowSensorTimeout,
     AirflowSkipException,
     AirflowTaskTerminated,
@@ -2185,8 +2186,6 @@ class TestRuntimeTaskInstance:
         """
         Test that errors during SetRenderedFields in finalize() don't mask the original task error.
         """
-        from airflow.sdk.exceptions import AirflowRuntimeError
-        from airflow.sdk.execution_time.comms import ErrorResponse, ErrorType
 
         class TaskWithRTIF(BaseOperator):
             overwrite_rtif_after_execution = True


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] no

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->


### Why and Fix

When a task with `overwrite_rtif_after_execution=True` fails, the finalize() function attempts to update RTIF via the execution API. If this API call fails (e.g., 404 Not Found due to timing issues or whatever reasons), the error propagates and masks the original task failure error.

This causes users to see "AirflowRuntimeError: API_SERVER_ERROR" instead of their actual task error , making it confusing to narrow down the issue while debugging.

The fix is to wrap the `SetRenderedFields` call in a error handling block, consistent with how operator extra links xcoms pushes are handled in the same function. Errors are now logged but don't prevent finalization from completing or
mask the original task error.

If you undo changes in the `task_runner` file, you can see the error like this:
```python
/Users/amoghdesai/Documents/OSS/repos/airflow/.venv/bin/python /Applications/PyCharm.app/Contents/plugins/python-ce/helpers/pycharm/_jb_pytest_runner.py --target task_sdk/execution_time/test_task_runner.py::TestRuntimeTaskInstance.test_overwrite_rtif_after_execution_handles_errors_gracefully 
Testing started at 4:28 pm ...
Launching pytest with arguments task_sdk/execution_time/test_task_runner.py::TestRuntimeTaskInstance::test_overwrite_rtif_after_execution_handles_errors_gracefully --no-header --no-summary -q in /Users/amoghdesai/Documents/OSS/repos/airflow/task-sdk/tests

============================= test session starts ==============================
collecting ... collected 1 item

task_sdk/execution_time/test_task_runner.py::TestRuntimeTaskInstance::test_overwrite_rtif_after_execution_handles_errors_gracefully 

========================= 1 failed, 1 warning in 4.61s =========================

========================= AIRFLOW ==========================
Home of the user: /Users/amoghdesai
Airflow home /Users/amoghdesai/airflow
2026-02-17T10:58:13.964423Z [warning  ] The airflow.security.permissions module is deprecated; please see https://airflow.apache.org/docs/apache-airflow/stable/security/deprecated_permissions.html [py.warnings] category=RemovedInAirflow4Warning filename=/Users/amoghdesai/Documents/OSS/repos/airflow/devel-common/src/tests_common/test_utils/db.py lineno=47
FAILED [100%]
tests/task_sdk/execution_time/test_task_runner.py:2181 (TestRuntimeTaskInstance.test_overwrite_rtif_after_execution_handles_errors_gracefully)
task_sdk/execution_time/test_task_runner.py:2215: in test_overwrite_rtif_after_execution_handles_errors_gracefully
    finalize(
../src/airflow/sdk/execution_time/task_runner.py:1705: in finalize
    SUPERVISOR_COMMS.send(SetRenderedFields(rendered_fields=_serialize_rendered_fields(ti.task)))
/opt/homebrew/Cellar/python@3.13/3.13.3_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py:1169: in __call__
    return self._mock_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/opt/homebrew/Cellar/python@3.13/3.13.3_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py:1173: in _mock_call
    return self._execute_mock_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/opt/homebrew/Cellar/python@3.13/3.13.3_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/unittest/mock.py:1228: in _execute_mock_call
    raise effect
E   airflow.sdk.exceptions.AirflowRuntimeError: API_SERVER_ERROR: {'status_code': 404, 'message': 'Not Found', 'detail': {'detail': 'Not Found'}}

Process finished with exit code 1

```

But that error doesn't show up with the fix which is TLDR of the PR.



---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
