### PR TITLE
Make provider dependency comment matching more flexible

### DIFF
--- a/dev/breeze/doc/09_release_management_tasks.rst
+++ b/dev/breeze/doc/09_release_management_tasks.rst
@@ -451,7 +451,8 @@ Updating provider next version
 """"""""""""""""""""""""""""""
 
 You can use Breeze to update references to other providers automatically to the
-next version of dependent providers, when they are commented with ``# use next version``.
+next version of dependent providers, when they are commented with ``# use next version``
+(or ``#use next version`` without space after ``#``).
 
 The below example perform the upgrade.
 

--- a/dev/breeze/src/airflow_breeze/utils/packages.py
+++ b/dev/breeze/src/airflow_breeze/utils/packages.py
@@ -1260,8 +1260,8 @@ def _update_dependency_line_with_new_version(
     new_constraint = f'"{provider_package_name}>={new_version}"'
     updated_line = line.replace(old_constraint, new_constraint)
 
-    # remove the comment starting with '# use next version' (and anything after it) and rstrip spaces
-    updated_line = re.sub(r"#\s*use next version.*$", "", updated_line).rstrip()
+    # remove the comment starting with '# use next version' or '#use next version' (and anything after it) and rstrip spaces
+    updated_line = re.sub(r"#\s*use next version.*$", "", updated_line, flags=re.IGNORECASE).rstrip()
 
     # Track the update
     provider_id_short = pyproject_file.parent.relative_to(AIRFLOW_PROVIDERS_ROOT_PATH)
@@ -1335,8 +1335,8 @@ def update_providers_with_next_version_comment() -> dict[str, dict[str, Any]]:
         file_modified = False
 
         for line in lines:
-            # Check if line contains "# use next version" comment (but not the dependencies declaration line)
-            if "# use next version" in line and "dependencies = [" not in line:
+            # Check if line contains "# use next version" or "#use next version" comment (but not the dependencies declaration line)
+            if re.search(r"#\s*use next version", line, re.IGNORECASE) and "dependencies = [" not in line:
                 processed_line, was_modified = _process_line_with_next_version_comment(
                     line, pyproject_file, updates_made
                 )

--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -1865,7 +1865,7 @@ class SelectiveChecks:
         # Check if dependency line contains both the package and the comment
         for line in result.stdout.splitlines():
             if "apache-airflow-providers-common-compat" in line.lower():
-                return "# use next version" in line.lower()
+                return bool(re.search(r"#\s*use next version", line, re.IGNORECASE))
         return True  # If dependency not found, don't flag as violation
 
     def _print_violations_and_exit_or_bypass(self, violations: list[str]) -> bool:


### PR DESCRIPTION
Allow both '# use next version' and '#use next version' formats when updating provider dependencies to next versions. 

The regex pattern now allows optional whitespace after the hash symbol and uses case-insensitive matching for more robust detection.

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: Copilot with Claude Sonnet 4.5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

