### PR TITLE
Add simple extra links support for TaskFlow tasks

### DIFF
--- a/airflow-core/docs/templates-ref.rst
+++ b/airflow-core/docs/templates-ref.rst
@@ -102,6 +102,7 @@ Variable                                    Type                  Description
 ``{{ expanded_ti_count }}``                 int | ``None``        | Number of task instances that a mapped task was expanded into. If
                                                                   | the current task is not mapped, this should be ``None``.
                                                                   | Added in version 2.5.
+``{{ extra_links }}``                       ExtraLinksAccessor    Accessor for operator extra links defined on the task. Added in version 3.2.
 ``{{ triggering_asset_events }}``           dict[str,             | If in an Asset Scheduled Dag, a map of Asset URI to a list of triggering :class:`~airflow.models.asset.AssetEvent`
                                             list[AssetEvent]]     | (there may be more than one, if there are multiple Assets with different frequencies).
                                                                   | Read more here :doc:`Assets <authoring-and-scheduling/asset-scheduling>`.

--- a/airflow-core/newsfragments/62079.feature.rst
+++ b/airflow-core/newsfragments/62079.feature.rst
@@ -1,0 +1,1 @@
+Add ``extra_links`` parameter to ``@task`` decorator for declaring operator extra links and setting their URLs at runtime.

--- a/providers/standard/src/airflow/providers/standard/operators/python.py
+++ b/providers/standard/src/airflow/providers/standard/operators/python.py
@@ -66,7 +66,11 @@ from airflow.providers.standard.utils.python_virtualenv import (
     prepare_virtualenv,
     write_python_script,
 )
-from airflow.providers.standard.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_2_PLUS
+from airflow.providers.standard.version_compat import (
+    AIRFLOW_V_3_0_PLUS,
+    AIRFLOW_V_3_2_PLUS,
+    AIRFLOW_V_3_3_PLUS,
+)
 from airflow.utils import hashlib_wrapper
 from airflow.utils.file import get_unique_dag_module_name
 
@@ -476,6 +480,8 @@ class _BasePythonVirtualenvOperator(PythonOperator, metaclass=ABCMeta):
         # The following should be removed when Airflow 2 support is dropped.
         "triggering_dataset_events",
     }
+    if AIRFLOW_V_3_3_PLUS:
+        AIRFLOW_SERIALIZABLE_CONTEXT_KEYS.add("extra_links")
 
     def __init__(
         self,

--- a/providers/standard/src/airflow/providers/standard/version_compat.py
+++ b/providers/standard/src/airflow/providers/standard/version_compat.py
@@ -36,6 +36,7 @@ AIRFLOW_V_3_0_PLUS: bool = get_base_airflow_version_tuple() >= (3, 0, 0)
 AIRFLOW_V_3_1_PLUS: bool = get_base_airflow_version_tuple() >= (3, 1, 0)
 AIRFLOW_V_3_1_3_PLUS: bool = get_base_airflow_version_tuple() >= (3, 1, 3)
 AIRFLOW_V_3_2_PLUS: bool = get_base_airflow_version_tuple() >= (3, 2, 0)
+AIRFLOW_V_3_3_PLUS: bool = get_base_airflow_version_tuple() >= (3, 3, 0)
 
 # BaseOperator: Use 3.1+ due to xcom_push method missing in SDK BaseOperator 3.0.x
 # This is needed for DecoratedOperator compatibility
@@ -50,6 +51,7 @@ __all__ = [
     "AIRFLOW_V_3_0_PLUS",
     "AIRFLOW_V_3_1_PLUS",
     "AIRFLOW_V_3_2_PLUS",
+    "AIRFLOW_V_3_3_PLUS",
     "ArgNotSet",
     "BaseOperator",
 ]

--- a/task-sdk/src/airflow/sdk/bases/decorator.py
+++ b/task-sdk/src/airflow/sdk/bases/decorator.py
@@ -20,6 +20,7 @@ import inspect
 import itertools
 import re
 import textwrap
+import warnings
 from collections.abc import Callable, Collection, Iterator, Mapping, Sequence
 from contextlib import suppress
 from functools import cached_property, partial, update_wrapper
@@ -37,6 +38,7 @@ from airflow.sdk.bases.operator import (
     get_merged_defaults,
     parse_retries,
 )
+from airflow.sdk.bases.operatorlink import TaskFlowExtraLink
 from airflow.sdk.definitions._internal.contextmanager import DagContext, TaskGroupContext
 from airflow.sdk.definitions._internal.decorators import remove_task_decorator
 from airflow.sdk.definitions._internal.expandinput import (
@@ -56,6 +58,7 @@ from airflow.sdk.definitions.mappedoperator import (
 from airflow.sdk.definitions.xcom_arg import XComArg
 
 if TYPE_CHECKING:
+    from airflow.sdk.bases.operatorlink import BaseOperatorLink
     from airflow.sdk.definitions._internal.expandinput import (
         ExpandInput,
         OperatorExpandArgument,
@@ -251,6 +254,24 @@ def determine_kwargs(
     :return: A dictionary which contains the keyword arguments that are compatible with the callable.
     """
     return KeywordParameters.determine(func, args, kwargs).unpacking()
+
+
+def _build_extra_links(
+    extra_links: list[str] | None,
+    existing_links: Collection[BaseOperatorLink] | None,
+) -> tuple[BaseOperatorLink, ...]:
+    links_by_name: dict[str, BaseOperatorLink] = {link.name: link for link in existing_links or ()}
+    for name in extra_links or ():
+        taskflow_link = TaskFlowExtraLink(name)
+        if name in links_by_name:
+            warnings.warn(
+                f"TaskFlow extra link '{name}' is overriding an existing operator extra link "
+                f"with the same name. The TaskFlow link will take precedence.",
+                UserWarning,
+                stacklevel=2,
+            )
+        links_by_name[name] = taskflow_link
+    return tuple(links_by_name.values())
 
 
 class DecoratedOperator(BaseOperator):
@@ -509,18 +530,28 @@ class _TaskDecorator(ExpandableFactory, Generic[FParams, FReturn, OperatorSubcla
         update_wrapper(self, self.function)
 
     def __call__(self, *args: FParams.args, **kwargs: FParams.kwargs) -> XComArg:
+        task_kwargs = self.kwargs.copy()
         if self.is_teardown:
-            if "trigger_rule" in self.kwargs:
+            if "trigger_rule" in task_kwargs:
                 raise ValueError("Trigger rule not configurable for teardown tasks.")
-            self.kwargs.update(trigger_rule=TriggerRule.ALL_DONE_SETUP_SUCCESS)
-        on_failure_fail_dagrun = self.kwargs.pop("on_failure_fail_dagrun", self.on_failure_fail_dagrun)
+            task_kwargs.update(trigger_rule=TriggerRule.ALL_DONE_SETUP_SUCCESS)
+        on_failure_fail_dagrun = task_kwargs.pop("on_failure_fail_dagrun", self.on_failure_fail_dagrun)
+
+        extra_links = task_kwargs.pop("extra_links", [])
+
         op = self.operator_class(
             python_callable=self.function,
             op_args=args,
             op_kwargs=kwargs,
             multiple_outputs=self.multiple_outputs,
-            **self.kwargs,
+            **task_kwargs,
         )
+
+        op.operator_extra_links = _build_extra_links(
+            extra_links,
+            op.operator_extra_links,
+        )
+
         op.is_setup = self.is_setup
         op.is_teardown = self.is_teardown
         op.on_failure_fail_dagrun = on_failure_fail_dagrun
@@ -589,6 +620,7 @@ class _TaskDecorator(ExpandableFactory, Generic[FParams, FReturn, OperatorSubcla
         ensure_xcomarg_return_value(expand_input.value)
 
         task_kwargs = self.kwargs.copy()
+        extra_links = task_kwargs.pop("extra_links", [])
         dag = task_kwargs.pop("dag", None) or DagContext.get_current()
         task_group = task_kwargs.pop("task_group", None) or TaskGroupContext.get_current(dag)
 
@@ -659,7 +691,10 @@ class _TaskDecorator(ExpandableFactory, Generic[FParams, FReturn, OperatorSubcla
             partial_kwargs=partial_kwargs,
             task_id=task_id,
             params=partial_params,
-            operator_extra_links=self.operator_class.operator_extra_links,
+            operator_extra_links=_build_extra_links(
+                extra_links,
+                self.operator_class.operator_extra_links,
+            ),
             template_ext=self.operator_class.template_ext,
             template_fields=self.operator_class.template_fields,
             template_fields_renderers=self.operator_class.template_fields_renderers,

--- a/task-sdk/src/airflow/sdk/bases/operatorlink.py
+++ b/task-sdk/src/airflow/sdk/bases/operatorlink.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
 class BaseOperatorLink(metaclass=ABCMeta):
     """Abstract base class that defines how we get an operator link."""
 
+    push_link_on_finalize: ClassVar[bool] = True
     operators: ClassVar[list[type[BaseOperator]]] = []
     """
     This property will be used by Airflow Plugins to find the Operators to which you want
@@ -64,3 +65,50 @@ class BaseOperatorLink(metaclass=ABCMeta):
         :param ti_key: TaskInstance ID to return link for.
         :return: link to external system
         """
+
+
+@attrs.define()
+class TaskFlowExtraLink(BaseOperatorLink):
+    """
+    Operator link for ``@task``-decorated tasks whose URL is set at runtime.
+
+    Exists to enable easy serialization.
+
+    Unlike provider links, which compute URLs in ``get_link()`` from XCom
+    data these URLs are pushed directly to XCom via SUPERVISOR_COMMS the
+    moment they are assigned in ``ExtraLinksAccessor``.  ``finalize()``
+    skips these links since the push already happened.
+    """
+
+    push_link_on_finalize: ClassVar[bool] = False
+
+    _link_name: str
+    _url: str | None = attrs.field(default=None)
+
+    XCOM_KEY_PREFIX = "_taskflow_extra_link_"
+
+    @property
+    def name(self) -> str:
+        return self._link_name
+
+    @property
+    def url(self) -> str:
+        return self._url or ""
+
+    @url.setter
+    def url(self, value: str) -> None:
+        self._url = value
+
+    @property
+    def xcom_key(self) -> str:
+        return f"{self.XCOM_KEY_PREFIX}{self.name}"
+
+    def get_link(self, operator: BaseOperator, *, ti_key: TaskInstanceKey) -> str:
+        """
+        Not called at runtime, exists only to satisfy the abstract method.
+
+        URLs are pushed directly to XCom via SUPERVISOR_COMMS in
+        ``ExtraLinksAccessor``, and ``finalize()`` skips these links.
+        The webserver reads URLs from XCom via ``XComOperatorLink``.
+        """
+        raise RuntimeError("TaskFlowExtraLink URLs are pushed via SUPERVISOR_COMMS, not get_link()")

--- a/task-sdk/src/airflow/sdk/definitions/context.py
+++ b/task-sdk/src/airflow/sdk/definitions/context.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 
     from airflow.sdk.bases.operator import BaseOperator
     from airflow.sdk.definitions.dag import DAG
-    from airflow.sdk.execution_time.context import InletEventsAccessors
+    from airflow.sdk.execution_time.context import ExtraLinksAccessor, InletEventsAccessors
     from airflow.sdk.types import (
         DagRunProtocol,
         Operator,
@@ -82,6 +82,7 @@ class Context(TypedDict, total=False):
     ts_nodash: str
     ts_nodash_with_tz: str
     var: Any
+    extra_links: ExtraLinksAccessor
 
 
 KNOWN_CONTEXT_KEYS: set[str] = set(Context.__annotations__.keys())

--- a/task-sdk/src/airflow/sdk/definitions/mappedoperator.py
+++ b/task-sdk/src/airflow/sdk/definitions/mappedoperator.py
@@ -781,6 +781,8 @@ class MappedOperator(AbstractOperator):
         op.on_failure_fail_dagrun = on_failure_fail_dagrun
         op.downstream_task_ids = self.downstream_task_ids
         op.upstream_task_ids = self.upstream_task_ids
+        if self.operator_extra_links:
+            op.operator_extra_links = self.operator_extra_links
         return op
 
     def _get_specified_expand_input(self) -> ExpandInput:

--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -20,7 +20,7 @@ import collections
 import contextlib
 import functools
 import inspect
-from collections.abc import Generator, Iterable, Iterator, Mapping, Sequence
+from collections.abc import Generator, Iterable, Iterator, Mapping, MutableMapping, Sequence
 from datetime import datetime
 from functools import cache
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, overload
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Any, Generic, TypeVar, overload
 import attrs
 import structlog
 
+from airflow.sdk.bases.operatorlink import TaskFlowExtraLink
 from airflow.sdk.definitions._internal.contextmanager import _CURRENT_CONTEXT
 from airflow.sdk.definitions._internal.types import NOTSET
 from airflow.sdk.definitions.asset import (
@@ -52,6 +53,7 @@ if TYPE_CHECKING:
 
     from airflow.sdk import Variable
     from airflow.sdk.bases.operator import BaseOperator
+    from airflow.sdk.bases.operatorlink import BaseOperatorLink
     from airflow.sdk.definitions.connection import Connection
     from airflow.sdk.definitions.context import Context
     from airflow.sdk.execution_time.comms import (
@@ -339,6 +341,87 @@ def _delete_variable(key: str) -> None:
 
     # Invalidate cache after deleting the variable
     SecretCache.invalidate_variable(key)
+
+
+class ExtraLinksAccessor(MutableMapping[str, str]):
+    """Wrapper over ``TaskFlowExtraLink`` instances that pushes URLs via supervisor comms."""
+
+    def __init__(
+        self,
+        links: Iterable[TaskFlowExtraLink] | None = None,
+        *,
+        dag_id: str = "",
+        task_id: str = "",
+        run_id: str = "",
+        map_index: int | None = -1,
+    ) -> None:
+        self._links: dict[str, TaskFlowExtraLink] = {}
+        for link in links or ():
+            self._links[link.name] = link
+        self._dag_id = dag_id
+        self._task_id = task_id
+        self._run_id = run_id
+        self._map_index = map_index
+
+    @classmethod
+    def from_operator_links(
+        cls,
+        operator_links: Iterable[BaseOperatorLink] | None,
+        *,
+        dag_id: str = "",
+        task_id: str = "",
+        run_id: str = "",
+        map_index: int | None = -1,
+    ) -> ExtraLinksAccessor:
+        return cls(
+            (link for link in operator_links or () if isinstance(link, TaskFlowExtraLink)),
+            dag_id=dag_id,
+            task_id=task_id,
+            run_id=run_id,
+            map_index=map_index,
+        )
+
+    def _push_to_xcom(self, link: TaskFlowExtraLink, url: str) -> None:
+        from airflow.sdk.execution_time.comms import SetXCom
+        from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
+
+        SUPERVISOR_COMMS.send(
+            SetXCom(
+                key=link.xcom_key,
+                value=url,
+                dag_id=self._dag_id,
+                task_id=self._task_id,
+                run_id=self._run_id,
+                map_index=self._map_index,
+            )
+        )
+
+    def __setitem__(self, link_name: str, link_url: str) -> None:
+        if link_name not in self._links:
+            raise KeyError(
+                f"Extra link '{link_name}' is not declared in the task's extra_links parameter. "
+                f"Declared links: {list(self._links)}"
+            )
+        link = self._links[link_name]
+        link.url = link_url
+        self._push_to_xcom(link, link_url)
+
+    def __delitem__(self, link_name: str) -> None:
+        link = self._links[link_name]
+        link.url = ""
+        self._push_to_xcom(link, "")
+
+    def __getitem__(self, link_name: str) -> str:
+        return self._links[link_name].url
+
+    def __iter__(self):
+        return iter(self._links)
+
+    def __len__(self):
+        return len(self._links)
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({dict(self)})"
 
 
 class ConnectionAccessor:

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -112,6 +112,7 @@ from airflow.sdk.execution_time.comms import (
 )
 from airflow.sdk.execution_time.context import (
     ConnectionAccessor,
+    ExtraLinksAccessor,
     InletEventsAccessors,
     MacrosAccessor,
     OutletEventAccessors,
@@ -248,6 +249,13 @@ class RuntimeTaskInstance(TaskInstance):
                     "value": VariableAccessor(deserialize_json=False),
                 },
                 "conn": ConnectionAccessor(),
+                "extra_links": ExtraLinksAccessor.from_operator_links(
+                    self.task.operator_extra_links,
+                    dag_id=self.dag_id,
+                    task_id=self.task_id,
+                    run_id=self.run_id,
+                    map_index=self.map_index,
+                ),
             }
         if TYPE_CHECKING:
             assert self._cached_template_context is not None
@@ -1779,6 +1787,8 @@ def finalize(
     task = ti.task
     # Pushing xcom for each operator extra links defined on the operator only.
     for oe in task.operator_extra_links:
+        if not oe.push_link_on_finalize:
+            continue
         try:
             link, xcom_key = oe.get_link(operator=task, ti_key=ti), oe.xcom_key  # type: ignore[arg-type]
             log.debug("Setting xcom for operator extra link", link=link, xcom_key=xcom_key)

--- a/task-sdk/tests/task_sdk/bases/test_operator.py
+++ b/task-sdk/tests/task_sdk/bases/test_operator.py
@@ -39,6 +39,7 @@ from airflow.sdk.bases.operator import (
     chain_linear,
     cross_downstream,
 )
+from airflow.sdk.bases.operatorlink import BaseOperatorLink, TaskFlowExtraLink
 from airflow.sdk.definitions.param import ParamsDict
 from airflow.sdk.definitions.template import literal
 from airflow.triggers.base import StartTriggerArgs
@@ -1137,3 +1138,95 @@ def test_partial_default_args():
     assert op.arg2 == "b"
     assert op.arg3 == 3
     assert op.queue == "THIS"
+
+
+class MockExistingLink(BaseOperatorLink):
+    """Mock existing operator link for testing."""
+
+    def __init__(self, name: str):
+        self._name = name
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def get_link(self, operator: BaseOperator, *, ti_key):
+        return f"https://existing.com/{self._name}"
+
+
+class TestTaskDecoratorExtraLinks:
+    """Test taskflow extra_links functionality."""
+
+    @pytest.mark.parametrize(
+        "extra_link_names",
+        [
+            (["link1", "link2"]),
+            ([]),
+            (None),
+        ],
+    )
+    def test_basic_extra_links_functionality(self, extra_link_names):
+        """Test that extra_links parameter creates TaskFlowExtraLink instances."""
+
+        @task_decorator(extra_links=extra_link_names)
+        def dummy_task():
+            return "test"
+
+        with DAG("test_dag", schedule=None, start_date=DEFAULT_DATE):
+            t = dummy_task()
+
+        expected_count = len(extra_link_names) if extra_link_names else 0
+        assert len(t.operator.operator_extra_links) == expected_count
+        if t.operator.operator_extra_links:
+            for link, link_name in zip(t.operator.operator_extra_links, extra_link_names):
+                assert isinstance(link, TaskFlowExtraLink)
+                assert link.name == link_name
+                assert link.xcom_key == f"{TaskFlowExtraLink.XCOM_KEY_PREFIX}{link_name}"
+
+    def test_taskflow_links_take_precedence_on_name_conflict(self):
+        """Test that TaskFlow extra links override existing operator links with the same name."""
+        from airflow.sdk.bases.decorator import DecoratedOperator, task_decorator_factory
+
+        class OperatorWithExistingLinks(DecoratedOperator):
+            operator_extra_links = (
+                MockExistingLink("existing_link"),
+                MockExistingLink("conflicting_link"),
+            )
+
+        test_decorator = task_decorator_factory(
+            decorated_operator_class=OperatorWithExistingLinks,
+            multiple_outputs=False,
+            extra_links=["conflicting_link", "new_link"],
+        )
+
+        @test_decorator
+        def conflicting_link_task():
+            return "test"
+
+        with DAG("warning_test_dag", schedule=None, start_date=DEFAULT_DATE):
+            with pytest.warns(UserWarning, match="TaskFlow extra link 'conflicting_link' is overriding"):
+                result = conflicting_link_task()
+
+        op = result.operator
+        links_by_name = {link.name: link for link in op.operator_extra_links}
+
+        assert len(links_by_name) == 3
+        assert isinstance(links_by_name["conflicting_link"], TaskFlowExtraLink)
+        assert isinstance(links_by_name["existing_link"], MockExistingLink)
+        assert isinstance(links_by_name["new_link"], TaskFlowExtraLink)
+
+    def test_extra_links_with_mapped(self):
+        """Extra links function correctly on mapped operators."""
+
+        @task_decorator(extra_links=["link1", "link2"])
+        def mapped_task(x):
+            return x
+
+        with DAG("test_dag", schedule=None, start_date=DEFAULT_DATE):
+            result = mapped_task.expand(x=[1, 2, 3])
+
+        mapped_op = result.operator
+        assert [link.name for link in mapped_op.operator_extra_links] == ["link1", "link2"]
+
+        unmapped_op = mapped_op.unmap({"op_kwargs": {"x": 1}})
+        assert [link.name for link in unmapped_op.operator_extra_links] == ["link1", "link2"]

--- a/task-sdk/tests/task_sdk/execution_time/test_context.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_context.py
@@ -24,6 +24,7 @@ import pytest
 
 from airflow.sdk import BaseOperator, get_current_context, timezone
 from airflow.sdk.api.datamodels._generated import AssetEventResponse, AssetResponse, DagRun
+from airflow.sdk.bases.operatorlink import TaskFlowExtraLink
 from airflow.sdk.bases.xcom import BaseXCom
 from airflow.sdk.definitions.asset import (
     Asset,
@@ -54,6 +55,7 @@ from airflow.sdk.execution_time.comms import (
 )
 from airflow.sdk.execution_time.context import (
     ConnectionAccessor,
+    ExtraLinksAccessor,
     InletEventsAccessors,
     OutletEventAccessor,
     OutletEventAccessors,
@@ -1018,3 +1020,79 @@ class TestSecretsBackend:
 
             with pytest.raises(AirflowNotFoundException, match="isn't defined"):
                 _get_connection("nonexistent_conn")
+
+
+class TestExtraLinksAccessor:
+    """Test that the ExtraLinksAccessor provides dict-like access to TaskFlowExtraLink instances."""
+
+    def test_setitem_stores_value_and_sends_xcom(self):
+        from airflow.sdk.execution_time.comms import SetXCom
+
+        link = TaskFlowExtraLink("My Link")
+        accessor = ExtraLinksAccessor(
+            [link], dag_id="test_dag", task_id="test_task", run_id="test_run", map_index=-1
+        )
+
+        with mock.patch("airflow.sdk.execution_time.task_runner.SUPERVISOR_COMMS", create=True) as mock_comms:
+            accessor["My Link"] = "https://example.com"
+
+        assert accessor["My Link"] == "https://example.com"
+        mock_comms.send.assert_called_once_with(
+            SetXCom(
+                key=link.xcom_key,
+                value="https://example.com",
+                dag_id="test_dag",
+                task_id="test_task",
+                run_id="test_run",
+                map_index=-1,
+            )
+        )
+
+    def test_link_url_defaults_to_empty(self):
+        link = TaskFlowExtraLink("My Link")
+        assert link.url == ""
+
+    def test_accessor_leaves_link_urls_empty(self):
+        link = TaskFlowExtraLink("My Link")
+        ExtraLinksAccessor([link])
+        assert link.url == ""
+
+    def test_setitem_undeclared_link_raises(self):
+        accessor = ExtraLinksAccessor([TaskFlowExtraLink("Declared")])
+
+        with pytest.raises(KeyError, match="Extra link 'Bogus' is not declared"):
+            accessor["Bogus"] = "https://bogus.com"
+
+    def test_delitem_resets_to_empty_string_and_sends_xcom(self):
+        from airflow.sdk.execution_time.comms import SetXCom
+
+        link = TaskFlowExtraLink("run_log")
+        accessor = ExtraLinksAccessor(
+            [link], dag_id="test_dag", task_id="test_task", run_id="test_run", map_index=-1
+        )
+
+        with mock.patch("airflow.sdk.execution_time.task_runner.SUPERVISOR_COMMS", create=True) as mock_comms:
+            accessor["run_log"] = "https://logs.example.com"
+            del accessor["run_log"]
+
+        assert accessor["run_log"] == ""
+        assert mock_comms.send.call_count == 2
+        mock_comms.send.assert_called_with(
+            SetXCom(
+                key=link.xcom_key,
+                value="",
+                dag_id="test_dag",
+                task_id="test_task",
+                run_id="test_run",
+                map_index=-1,
+            )
+        )
+
+    def test_unset_links_default_to_empty_string(self):
+        accessor = ExtraLinksAccessor([TaskFlowExtraLink("run_log"), TaskFlowExtraLink("dashboard")])
+
+        with mock.patch("airflow.sdk.execution_time.task_runner.SUPERVISOR_COMMS", create=True):
+            accessor["run_log"] = "https://logs.example.com"
+
+        assert accessor["run_log"] == "https://logs.example.com"
+        assert accessor["dashboard"] == ""

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -64,6 +64,7 @@ from airflow.sdk.api.datamodels._generated import (
     TaskInstanceState,
     TIRunContext,
 )
+from airflow.sdk.bases.operatorlink import TaskFlowExtraLink
 from airflow.sdk.bases.xcom import BaseXCom
 from airflow.sdk.definitions._internal.types import NOTSET, SET_DURING_EXECUTION, is_arg_set
 from airflow.sdk.definitions.asset import Asset, AssetAlias, AssetUniqueKey, Dataset, Model
@@ -125,6 +126,7 @@ from airflow.sdk.execution_time.comms import (
 )
 from airflow.sdk.execution_time.context import (
     ConnectionAccessor,
+    ExtraLinksAccessor,
     InletEventsAccessors,
     MacrosAccessor,
     OutletEventAccessors,
@@ -1655,6 +1657,7 @@ class TestRuntimeTaskInstance:
             },
             "conn": ConnectionAccessor(),
             "dag": runtime_ti.task.dag,
+            "extra_links": ExtraLinksAccessor(),
             "inlets": task.inlets,
             "inlet_events": InletEventsAccessors(inlets=[]),
             "macros": MacrosAccessor(),
@@ -1696,6 +1699,7 @@ class TestRuntimeTaskInstance:
             },
             "conn": ConnectionAccessor(),
             "dag": runtime_ti.task.dag,
+            "extra_links": ExtraLinksAccessor(),
             "inlets": task.inlets,
             "inlet_events": InletEventsAccessors(inlets=[]),
             "macros": MacrosAccessor(),
@@ -4741,3 +4745,43 @@ def test_dag_add_result(create_runtime_ti, mock_supervisor_comms):
             dag_result=True,
         )
     )
+
+
+class TestTaskFlowExtraLinksIntegration:
+    def test_finalize_skips_taskflow_extra_links(self, mock_supervisor_comms):
+        """TaskFlowExtraLinks are pushed via SUPERVISOR_COMMS on assignment, so finalize skips them."""
+        task = BaseOperator(task_id="test")
+        task.operator_extra_links = (TaskFlowExtraLink("run_log"), AirflowLink())
+
+        ti = mock.Mock(
+            task=task, start_date=None, dag_id="test_dag", task_id="test", run_id="test_run", map_index=-1
+        )
+        mock_supervisor_comms.send.reset_mock()
+        finalize(ti, "success", {}, mock.Mock())
+
+        xcom_calls = [
+            call.args[0]
+            for call in mock_supervisor_comms.send.call_args_list
+            if isinstance(call.args[0], SetXCom)
+        ]
+        assert xcom_calls == [
+            SetXCom(
+                key="_link_AirflowLink",
+                value="https://airflow.apache.org",
+                dag_id="test_dag",
+                task_id="test",
+                run_id="test_run",
+                map_index=-1,
+            )
+        ]
+
+    def test_context_extra_links_accessor_reflects_operator_links(self, create_runtime_ti):
+        task = BaseOperator(task_id="test_task")
+        task.operator_extra_links = (TaskFlowExtraLink("run_log"),)
+        ti = create_runtime_ti(task=task)
+
+        context = ti.get_template_context()
+
+        accessor = context["extra_links"]
+        assert isinstance(accessor, ExtraLinksAccessor)
+        assert list(accessor) == ["run_log"]


### PR DESCRIPTION
Previously, adding extra links to a TaskFlow task required creating
a custom BaseOperator subclass with operator_extra_links and a
companion BaseOperatorLink class. This is heavyweight for what is
often just a URL set at runtime.

This change lets @task authors declare link names in the decorator
and set URLs directly during execution:

```python
@task(extra_links=["Docs"])
def my_task(extra_links):
    extra_links["Docs"] = "https://example.com"
```

**What's included:**

- `TaskFlowExtraLink` — a concrete `BaseOperatorLink` that stores
  URLs via in-memory, created at parse time from declared link names
- `_build_extra_links()` merges TaskFlow links with existing
  class-level links, warning on name conflicts
- `ExtraLinksAccessor` — dict-like context object injected as
  `context["extra_links"]` for setting URLs during execution
- Mapped operators retain extra links through `unmap()`
- Serialization/deserialization works via existing `operator_extra_links`
  machinery (no new XCom keys or API changes needed)

closes: #54527

Simple DAGs used to verify this solution:
```
from airflow.decorators import dag, task


@dag
def taskflow_extra_links():
    """
    Vanilla test.
    """
    @task(extra_links=["Docs", "Home"])
    def process_data(extra_links):
        extra_links["Docs"] = "https://airflow.apache.org/docs/"
        extra_links["Home"] = "https://airflow.apache.org/"

    process_data()


taskflow_extra_links()


@dag
def taskflow_extra_links_mapped():
    """
    Task expansion test.
    """
    @task(extra_links=["Map"])
    def process_data(num, extra_links, ti):
        extra_links["Map"] = f"https://example.com/{ti.map_index}/"

    process_data.expand(num=[1,2,3])


taskflow_extra_links_mapped()


@dag
def taskflow_extra_links_undeclared():
    """
    This should blow up.
    """
    @task
    def process_data(extra_links):
        extra_links["Home"] = "invalid"

    process_data()


taskflow_extra_links_undeclared()


@dag
def taskflow_extra_links_virtualenv():
    @task.virtualenv(extra_links=["Venv"])
    def process_data(extra_links):
        extra_links["Venv"] = "https://example.com/virtualenv/"

    process_data()


taskflow_extra_links_virtualenv()
```

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
