### PR TITLE
UI: Optimize grid view refresh pressure on the API

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/TaskInstancesColumn.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/TaskInstancesColumn.tsx
@@ -39,7 +39,13 @@ const ROW_HEIGHT = 20;
 
 export const TaskInstancesColumn = ({ nodes, onCellClick, run, virtualItems }: Props) => {
   const { dagId = "", runId } = useParams();
-  const { data: gridTISummaries } = useGridTiSummaries({ dagId, runId: run.run_id, state: run.state });
+  const isSelected = runId === run.run_id;
+  const { data: gridTISummaries } = useGridTiSummaries({
+    dagId,
+    isSelected,
+    runId: run.run_id,
+    state: run.state,
+  });
   const { hoveredRunId, setHoveredRunId } = useHover();
 
   const itemsToRender =
@@ -52,7 +58,6 @@ export const TaskInstancesColumn = ({ nodes, onCellClick, run, virtualItems }: P
     taskInstanceMap.set(ti.task_id, ti);
   }
 
-  const isSelected = runId === run.run_id;
   const isHovered = hoveredRunId === run.run_id;
 
   const handleMouseEnter = () => setHoveredRunId(run.run_id);

--- a/airflow-core/src/airflow/ui/src/queries/useGridTISummaries.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useGridTISummaries.ts
@@ -23,15 +23,22 @@ import { isStatePending, useAutoRefresh } from "src/utils";
 export const useGridTiSummaries = ({
   dagId,
   enabled,
+  isSelected,
   runId,
   state,
 }: {
   dagId: string;
   enabled?: boolean;
+  isSelected?: boolean;
   runId: string;
   state?: TaskInstanceState | null | undefined;
 }) => {
-  const refetchInterval = useAutoRefresh({ dagId });
+  const baseRefetchInterval = useAutoRefresh({ dagId });
+  const slowRefreshMultiplier = 5;
+  const refetchInterval =
+    typeof baseRefetchInterval === "number"
+      ? baseRefetchInterval * (isSelected ? 1 : slowRefreshMultiplier)
+      : baseRefetchInterval;
 
   const { data: gridTiSummaries, ...rest } = useGridServiceGetGridTiSummaries(
     {


### PR DESCRIPTION
### Summary

This PR adjust how the Grid view refreshes task summaries by slowing down refreshing pending tasks.

* closes #62033
* related #62020

### Detailed

1. adds `isSelected` parameter in `useGridTiSummaries` hook.
2. only keep the selected DAG run on the default `useAutoRefresh` interval. (3s)
3. slow down non-selected DAG run by a fixed multiplier. (**currently 5x -> 15s, we can discuss in the comments : D**)

### Benchmark results

| Visible DAG runs | Before (requests / 60s) | After (requests / 60s) | Reduction |
|------------------|-------------------------|------------------------|-----------|
| 5                | 100                     | 36                     | 64%       |
| 10               | 200                     | 56                     | 72%       |
| 25               | 500                     | 116                    | 76.8%     |
| 50               | 1000                    | 216                    | 78.4%     |

This result only calculates ideally, not in realistic situation. (bcz we need to consider about network etc.)

- The currently selected DAG run still refreshes at the original auto-refresh interval, so the behavior as before.
- Non-selected runs refresh less frequently, but still often enough to serve as an overview. (IMO)

No API contract changes are introduced; the change is limited to the Grid view’s client-side polling strategy.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
