### PR TITLE
Fix typo in config key: `missing_dag_retires` -> `missing_dag_retries`

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1835,7 +1835,7 @@ workers:
       type: float
       example: ~
       default: "60.0"
-    missing_dag_retires:
+    missing_dag_retries:
       description: |
         Maximum number of times a task will be rescheduled if the worker fails to
         load the Dag or task definition during startup.

--- a/shared/configuration/src/airflow_shared/configuration/parser.py
+++ b/shared/configuration/src/airflow_shared/configuration/parser.py
@@ -194,6 +194,7 @@ class AirflowConfigParser(ConfigParser):
         ("api", "log_config"): ("api", "access_logfile", "3.1.0"),
         ("scheduler", "ti_metrics_interval"): ("scheduler", "running_metrics_interval", "3.2.0"),
         ("api", "fallback_page_limit"): ("api", "page_size", "3.2.0"),
+        ("workers", "missing_dag_retries"): ("workers", "missing_dag_retires", "3.1.8"),
     }
 
     # A mapping of new section -> (old section, since_version).

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -706,11 +706,11 @@ def _maybe_reschedule_startup_failure(
     This does not count as a retry. If the reschedule limit is exceeded, this function
     returns and the caller should fail the task.
     """
-    missing_dag_retires = conf.getint("workers", "missing_dag_retires", fallback=3)
+    missing_dag_retries = conf.getint("workers", "missing_dag_retries", fallback=3)
     missing_dag_retry_delay = conf.getint("workers", "missing_dag_retry_delay", fallback=60)
 
     reschedule_count = int(getattr(ti_context, "task_reschedule_count", 0) or 0)
-    if missing_dag_retires > 0 and reschedule_count < missing_dag_retires:
+    if missing_dag_retries > 0 and reschedule_count < missing_dag_retries:
         raise AirflowRescheduleException(
             reschedule_date=datetime.now(tz=timezone.utc) + timedelta(seconds=missing_dag_retry_delay)
         )
@@ -718,7 +718,7 @@ def _maybe_reschedule_startup_failure(
     log.error(
         "Startup reschedule limit exceeded",
         reschedule_count=reschedule_count,
-        max_reschedules=missing_dag_retires,
+        max_reschedules=missing_dag_retries,
     )
 
 

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -337,7 +337,7 @@ def test_parse_not_found_does_not_reschedule_when_max_attempts_reached(test_dags
     with (
         conf_vars(
             {
-                ("workers", "missing_dag_retires"): "3",
+                ("workers", "missing_dag_retries"): "3",
                 ("workers", "missing_dag_retry_delay"): "60",
             }
         ),


### PR DESCRIPTION
The `[workers] missing_dag_retires` config option introduced in 3.1.7 (via [this PR](https://github.com/apache/airflow/pull/59604/changes)) has a typo ("retires" instead of "retries"). Rename it to `missing_dag_retries` and add a deprecated_options entry so existing users who set the old key name are not broken.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
