### PR TITLE
Fix `DepContext` mutation leak and restore `reschedule-mode` guard

### DIFF
--- a/airflow-core/tests/unit/ti_deps/deps/test_ready_to_reschedule_dep.py
+++ b/airflow-core/tests/unit/ti_deps/deps/test_ready_to_reschedule_dep.py
@@ -107,6 +107,14 @@ class TestNotInReschedulePeriodDep:
         ti = self._get_task_instance(State.UP_FOR_RETRY)
         assert ReadyToRescheduleDep().is_met(ti=ti)
 
+    def test_should_pass_without_db_query_for_non_reschedule_task_in_none_state(
+        self, not_expected_tr_db_call
+    ):
+        """Non-reschedule, non-mapped tasks in NONE state should short-circuit without a DB query."""
+        ti = self._get_task_instance(State.NONE)
+        ti.task.reschedule = False
+        assert ReadyToRescheduleDep().is_met(ti=ti)
+
     def test_should_pass_if_no_reschedule_record_exists(self):
         ti = self._get_task_instance(State.NONE)
         assert ReadyToRescheduleDep().is_met(ti=ti)


### PR DESCRIPTION
This PR fixes two scheduler dependency regressions introduced by #59604 in the `UP_FOR_RESCHEDULE` path:

- Prevents `DepContext` mutation leakage in `TaskInstance.are_dependencies_met()`.
- Restores the fast-exit guard in `ReadyToRescheduleDep` for non-reschedule tasks in `NONE` state.

Together, these changes keep `ReadyToRescheduleDep` behavior scoped to the intended task instances and avoid unnecessary `task_reschedule` lookups on hot scheduler paths.

## Why?

`DepContext` is shared across multiple task instances in scheduler loops. Mutating `dep_context.deps` in-place for one `UP_FOR_RESCHEDULE` TI leaked `ReadyToRescheduleDep` into subsequent unrelated TIs.

Separately, removing the `NONE`-state fast-exit for non-reschedule tasks caused broad DB query amplification against `task_reschedule` (the incident path we observed in production).


<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
