### PR TITLE
Helm chart 1.19.0 released

### DIFF
--- a/.github/ISSUE_TEMPLATE/4-airflow_helmchart_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/4-airflow_helmchart_bug_report.yml
@@ -37,7 +37,8 @@ body:
         What Apache Airflow Helm Chart version are you using?
       multiple: false
       options:
-        - "1.18.0 (latest released)"
+        - "1.19.0 (latest released)"
+        - "1.18.0"
         - "1.17.0"
         - "1.16.0"
         - "1.15.0"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -19,7 +19,7 @@
 ---
 apiVersion: v2
 name: airflow
-version: 1.19.0
+version: 1.20.0-dev
 appVersion: 3.1.7
 description: The official Helm chart to deploy Apache Airflow, a platform to
   programmatically author, schedule, and monitor workflows
@@ -44,7 +44,7 @@ type: application
 annotations:
   artifacthub.io/links: |
     - name: Documentation
-      url: https://airflow.apache.org/docs/helm-chart/1.19.0/
+      url: https://airflow.apache.org/docs/helm-chart/1.20.0/
   artifacthub.io/screenshots: |
     - title: Home Page
       url: https://airflow.apache.org/docs/apache-airflow/3.1.7/_images/home_dark.png


### PR DESCRIPTION
Mark 1.19.0 as latest in the Helm chart bug report template and advance the chart metadata to 1.20.0-dev for continued development.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: Cursor CLI (GPT 5.3 Codex)
