### PR TITLE
Add initial Polish translation skill (#62000)

### DIFF
--- a/.github/skills/airflow-translations/locales/pl.md
+++ b/.github/skills/airflow-translations/locales/pl.md
@@ -1,6 +1,41 @@
- <!-- SPDX-License-Identifier: Apache-2.0 
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Polish (pl)](#polish-pl)
+  - [Plural Forms](#plural-forms)
+  - [Case Declension](#case-declension)
+  - [Gender Agreement](#gender-agreement)
+  - [Unchanged Terms](#unchanged-terms)
+  - [Verb Forms and User Address](#verb-forms-and-user-address)
+  - [Diacritics](#diacritics)
+  - [Variable and Placeholder Examples](#variable-and-placeholder-examples)
+  - [Terminology Reference](#terminology-reference)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+ <!-- SPDX-License-Identifier: Apache-2.0
       https://www.apache.org/licenses/LICENSE-2.0 -->
-      
+
 # Polish (pl)
 
 This document provides locale-specific instructions for translating English
@@ -82,6 +117,7 @@ Match noun gender (masculine/feminine/neuter) with verbs and adjectives:
 ## Unchanged Terms
 
 Keep these in English:
+
 - `XCom` — Airflow cross-communication term
 - `ID` — Technical identifier (always uppercase)
 - `Dag` / `Dags` → use `Dag` / `Dagi` (Polish plural adaptation)

--- a/.github/skills/airflow-translations/locales/pl.md
+++ b/.github/skills/airflow-translations/locales/pl.md
@@ -1,4 +1,6 @@
-<!-- SPDX-License-Identifier: Apache-2.0 https://www.apache.org/licenses/LICENSE-2.0 -->
+ <!-- SPDX-License-Identifier: Apache-2.0 
+      https://www.apache.org/licenses/LICENSE-2.0 -->
+      
 # Polish (pl)
 
 This document provides locale-specific instructions for translating English

--- a/.github/skills/airflow-translations/locales/pl.md
+++ b/.github/skills/airflow-translations/locales/pl.md
@@ -1,39 +1,4 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one
- or more contributor license agreements.  See the NOTICE file
- distributed with this work for additional information
- regarding copyright ownership.  The ASF licenses this file
- to you under the Apache License, Version 2.0 (the
- "License"); you may not use this file except in compliance
- with the License.  You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing,
- software distributed under the License is distributed on an
- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- KIND, either express or implied.  See the License for the
- specific language governing permissions and limitations
- under the License.
- -->
-
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
-
-- [Polish (pl)](#polish-pl)
-  - [Plural Forms](#plural-forms)
-  - [Case Declension](#case-declension)
-  - [Gender Agreement](#gender-agreement)
-  - [Unchanged Terms](#unchanged-terms)
-  - [Verb Forms and User Address](#verb-forms-and-user-address)
-  - [Diacritics](#diacritics)
-  - [Variable and Placeholder Examples](#variable-and-placeholder-examples)
-  - [Terminology Reference](#terminology-reference)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
- <!-- SPDX-License-Identifier: Apache-2.0
+<!-- SPDX-License-Identifier: Apache-2.0
       https://www.apache.org/licenses/LICENSE-2.0 -->
 
 # Polish (pl)

--- a/.github/skills/airflow-translations/locales/pl.md
+++ b/.github/skills/airflow-translations/locales/pl.md
@@ -1,0 +1,160 @@
+<!-- SPDX-License-Identifier: Apache-2.0 https://www.apache.org/licenses/LICENSE-2.0 -->
+# Polish (pl)
+
+This document provides locale-specific instructions for translating English
+Airflow UI strings into Polish. It inherits all global rules from
+the parent [SKILL.md](../SKILL.md).
+
+## Plural Forms
+
+Polish has **four plural forms** based on the count. Use the correct form for each suffix:
+
+- `_one`: 1 item (nominative singular)
+- `_few`: 2-4 items, 22-24, 32-34, etc. (nominative plural)
+- `_many`: 5+ items, 11-21, 25-31, etc. (genitive plural)
+- `_other`: fractions and general plural
+
+**English source:**
+
+```json
+"connection_one": "Connection",
+"connection_few": "Connections",
+"connection_many": "Connections",
+"connection_other": "Connections"
+```
+
+**Correct:**
+
+```json
+"connection_one": "Połączenie",
+"connection_few": "Połączenia",
+"connection_many": "Połączeń",
+"connection_other": "Połączenia"
+```
+
+**Incorrect:**
+
+```json
+"connection_few": "Połączeń",  // wrong case for 2-4
+"connection_many": "Połączenia" // wrong case for 5+
+```
+
+## Case Declension
+
+Polish nouns change form by grammatical case. Use the appropriate case for context:
+
+**Nominative** (subject):
+
+```json
+"title": "Wszystkie połączenia"  // All connections
+```
+
+**Genitive** (possession, "of"):
+
+```json
+"title": "Lista połączeń"  // List of connections
+```
+
+**Accusative** (direct object):
+
+```json
+"button": "Dodaj połączenie"  // Add connection
+```
+
+## Gender Agreement
+
+Match noun gender (masculine/feminine/neuter) with verbs and adjectives:
+
+**Correct:**
+
+```json
+"message": "Połączenie zostało usunięte"  // neuter noun + neuter verb
+```
+
+**Incorrect:**
+
+```json
+"message": "Połączenie został usunięty"  // neuter noun + masculine verb
+```
+
+## Unchanged Terms
+
+Keep these in English:
+- `XCom` — Airflow cross-communication term
+- `ID` — Technical identifier (always uppercase)
+- `Dag` / `Dags` → use `Dag` / `Dagi` (Polish plural adaptation)
+- Log levels: `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG`
+
+
+## Verb Forms and User Address
+
+- Use **infinitive** for commands: `"Dodaj połączenie"` (Add connection)
+- Use **indicative** for status: `"Połączenie zostało usunięte"` (Connection was deleted)
+- Use **informal "ty"** (lowercase) for questions: `"Czy chcesz kontynuować?"` (Do you want to continue?)
+
+**Correct:**
+
+```json
+"confirm": "Czy na pewno chcesz kontynuować?"
+```
+
+**Incorrect:**
+
+```json
+"confirm": "Czy na pewno Pan chce kontynuować?"  // overly formal
+```
+
+## Diacritics
+
+Polish uses diacritics that must be preserved:
+
+| Letter | Correct | Incorrect |
+|--------|---------|-----------|
+| ą | będą | bedą |
+| ć | połączenie | polaczenie |
+| ę | usunięte | usuniete |
+| ł | został | zostal |
+| ń | koń | kon |
+| ó | główna | glowna |
+| ś | więcej | wiecej |
+| ź | źródło | zrodlo |
+| ż | żaden | zaden |
+
+## Variable and Placeholder Examples
+
+Preserve all `{{variable}}` placeholders. Adjust word order for natural Polish:
+
+**English source:**
+
+```json
+"title": "Delete {{count}} connections"
+```
+
+**Correct:**
+
+```json
+"deleteConnection_one": "Usuń 1 połączenie",
+"deleteConnection_few": "Usuń {{count}} połączenia",
+"deleteConnection_many": "Usuń {{count}} połączeń"
+```
+
+**Incorrect:**
+
+```json
+"title": "Usuń {{liczba}} połączeń"  // variable name translated
+```
+
+## Terminology Reference
+
+The established Polish translations are defined in the existing locale files.
+Before translating, **read the existing pl JSON files** to learn the
+established terminology:
+
+```
+airflow-core/src/airflow/ui/public/i18n/locales/pl/
+```
+
+Use the translations found in these files as the authoritative glossary. When
+translating a term, check how it has been translated elsewhere in the locale
+to maintain consistency. If a term has not been translated yet, refer to the
+English source in `en/` and apply the rules in this document.


### PR DESCRIPTION
This PR adds locale-specific translation guidelines for Polish (pl) to support AI agents and translators working on the Airflow UI. The guidelines follow the template established in the parent issue and similar locale files like zh-CN.

<!-- SPDX-License-Identifier: Apache-2.0 https://www.apache.org/licenses/LICENSE-2.0 -->

* closes: #62000 
* related: #61984

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

Generated-by: [Claude Sonnet 4.5] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
