### PR TITLE
Add display_filename parameter to SlackAPIFileOperator

### DIFF
--- a/providers/slack/src/airflow/providers/slack/operators/slack.py
+++ b/providers/slack/src/airflow/providers/slack/operators/slack.py
@@ -183,7 +183,7 @@ class SlackAPIFileOperator(SlackAPIOperator):
             filetype="txt",
         )
 
-        # Send file content
+        # Send file content with a custom display name
         slack_operator_file_content = SlackAPIFileOperator(
             task_id="slack_file_upload_2",
             dag=dag,
@@ -191,6 +191,17 @@ class SlackAPIFileOperator(SlackAPIOperator):
             channels="#general",
             initial_comment="Hello World!",
             content="file content in txt",
+            display_filename="test.txt",
+        )
+
+        # Upload a file with a custom display name
+        slack_operator_file_display = SlackAPIFileOperator(
+            task_id="slack_file_upload_3",
+            dag=dag,
+            slack_conn_id="slack",
+            channels="#general",
+            filename="/files/dags/test.txt",
+            display_filename="custom_test.txt",
         )
 
     :param channels: Comma-separated list of channel names or IDs where the file will be shared.
@@ -200,6 +211,8 @@ class SlackAPIFileOperator(SlackAPIOperator):
     :param filetype: slack filetype. (templated) See: https://api.slack.com/types/file#file_types
     :param content: file content. (templated)
     :param title: title of file. (templated)
+    :param display_filename: displayed filename in Slack. Overrides the default basename
+        derived from ``filename``. (templated)
     :param snippet_type: Syntax type for the snippet being uploaded.(templated)
     :param method_version: The version of the method of Slack SDK Client to be used, either "v1" or "v2".
     """
@@ -211,6 +224,7 @@ class SlackAPIFileOperator(SlackAPIOperator):
         "filetype",
         "content",
         "title",
+        "display_filename",
         "snippet_type",
     )
     ui_color = "#44BEDF"
@@ -223,6 +237,7 @@ class SlackAPIFileOperator(SlackAPIOperator):
         filetype: str | None = None,
         content: str | None = None,
         title: str | None = None,
+        display_filename: str | None = None,
         method_version: Literal["v1", "v2"] | None = None,
         snippet_type: str | None = None,
         **kwargs,
@@ -234,6 +249,7 @@ class SlackAPIFileOperator(SlackAPIOperator):
         self.filetype = filetype
         self.content = content
         self.title = title
+        self.display_filename = display_filename
         self.method_version = method_version
         self.snippet_type = snippet_type
 
@@ -257,6 +273,7 @@ class SlackAPIFileOperator(SlackAPIOperator):
             # For historical reason SlackAPIFileOperator use filename as reference to file
             file=self.filename,
             content=self.content,
+            filename=self.display_filename,
             initial_comment=self.initial_comment,
             title=self.title,
             snippet_type=self.snippet_type,

--- a/providers/slack/src/airflow/providers/slack/operators/slack.py
+++ b/providers/slack/src/airflow/providers/slack/operators/slack.py
@@ -211,7 +211,7 @@ class SlackAPIFileOperator(SlackAPIOperator):
     :param filetype: slack filetype. (templated) See: https://api.slack.com/types/file#file_types
     :param content: file content. (templated)
     :param title: title of file. (templated)
-    :param display_filename: displayed filename in Slack. Overrides the default basename
+    :param display_filename: displayed filename in Slack. Overrides the default name
         derived from ``filename``. (templated)
     :param snippet_type: Syntax type for the snippet being uploaded.(templated)
     :param method_version: The version of the method of Slack SDK Client to be used, either "v1" or "v2".

--- a/providers/slack/tests/unit/slack/operators/test_slack.py
+++ b/providers/slack/tests/unit/slack/operators/test_slack.py
@@ -234,6 +234,7 @@ class TestSlackAPIFileOperator:
                 channels="#test-channel",
                 content="test-content",
                 file=None,
+                filename=None,
                 initial_comment=initial_comment,
                 title=title,
                 snippet_type=snippet_type,
@@ -260,7 +261,56 @@ class TestSlackAPIFileOperator:
                 channels="C1234567890",
                 content=None,
                 file="/dev/null",
+                filename=None,
                 initial_comment=initial_comment,
                 title=title,
                 snippet_type=snippet_type,
+            )
+
+    def test_api_call_params_with_content_and_display_filename(self):
+        """Test that content upload uses display_filename as the displayed name."""
+        op = SlackAPIFileOperator(
+            task_id="slack",
+            slack_conn_id=SLACK_API_TEST_CONNECTION_ID,
+            channels="#test-channel",
+            content="test-content",
+            display_filename="test.txt",
+            initial_comment="test",
+        )
+        with mock.patch(
+            "airflow.providers.slack.operators.slack.SlackHook.send_file_v1_to_v2"
+        ) as mock_send_file:
+            op.execute({})
+            mock_send_file.assert_called_once_with(
+                channels="#test-channel",
+                content="test-content",
+                file=None,
+                filename="test.txt",
+                initial_comment="test",
+                title=None,
+                snippet_type=None,
+            )
+
+    def test_api_call_params_with_file_and_display_filename(self):
+        """Test that file upload uses display_filename as the displayed name."""
+        op = SlackAPIFileOperator(
+            task_id="slack",
+            slack_conn_id=SLACK_API_TEST_CONNECTION_ID,
+            channels="#test-channel",
+            filename="/path/to/file.txt",
+            display_filename="custom_test.txt",
+            initial_comment="test",
+        )
+        with mock.patch(
+            "airflow.providers.slack.operators.slack.SlackHook.send_file_v1_to_v2"
+        ) as mock_send_file:
+            op.execute({})
+            mock_send_file.assert_called_once_with(
+                channels="#test-channel",
+                content=None,
+                file="/path/to/file.txt",
+                filename="custom_test.txt",
+                initial_comment="test",
+                title=None,
+                snippet_type=None,
             )


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 https://www.apache.org/licenses/LICENSE-2.0 -->
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

Closes #61952

Add `display_filename` parameter to `SlackAPIFileOperator` so users can control the file name shown in Slack. Previously, content-only uploads always appeared as "Uploaded file" with no way to customize. This parameter addresses that limitation. Also, it does so without changing the existing file path behavior. This approach was taken because `filename` is already used as the file path (where to read the file), and reusing it for the display name would break backward compatibility.

## Before Screenshot
<img width="390" height="317" alt="image" src="https://github.com/user-attachments/assets/55344cbb-bf95-4aa8-9483-c86e9f54cff1" />


## After (4 cases)

| Case | Screenshot | Code |
|------|------------|------|
| 1. file only | <img width="200" height="282" alt="image" src="https://github.com/user-attachments/assets/50d5b18c-2f8e-4f03-a7c7-8dc47ccc887a" /> | SlackAPIFileOperator(<br>&nbsp;&nbsp;filename="data/airflow.png",<br>&nbsp;&nbsp;...<br>) |
| 2. file + display_filename | <img width="200" height="281" alt="image" src="https://github.com/user-attachments/assets/53511caa-04d9-4d41-b55d-3aaf6bfe41b6" /> | SlackAPIFileOperator(<br>&nbsp;&nbsp;filename="data/airflow.png",<br>&nbsp;&nbsp;display_filename="custom_airflow.png",<br>&nbsp;&nbsp;...<br>) |
| 3. content only | <img width="200" height="281" alt="image" src="https://github.com/user-attachments/assets/dbc08d53-4608-4650-8b9b-22c3df0459de" /> | SlackAPIFileOperator(<br>&nbsp;&nbsp;content=IMAGE_CONTENT,<br>&nbsp;&nbsp;...<br>) |
| 4. content + display_filename | <img width="200" height="279" alt="image" src="https://github.com/user-attachments/assets/dd3ea845-a7f4-49ec-9a30-65e8dfa6c961" /> | SlackAPIFileOperator(<br>&nbsp;&nbsp;content=IMAGE_CONTENT,<br>&nbsp;&nbsp;display_filename="custom_airflow.png",<br>&nbsp;&nbsp;...<br>) |

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
  - Cursor
<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
