### PR TITLE
Fix UTC guard in from_timestamp to skip redundant timezone conversion

### DIFF
--- a/shared/timezones/src/airflow_shared/timezones/timezone.py
+++ b/shared/timezones/src/airflow_shared/timezones/timezone.py
@@ -308,7 +308,7 @@ def from_timestamp(timestamp: int | float, tz: str | FixedTimezone | Timezone = 
     :meta private:
     """
     result = coerce_datetime(dt.datetime.fromtimestamp(timestamp, tz=utc))
-    if tz != utc or tz != "UTC":
+    if tz != utc and tz != "UTC":
         if isinstance(tz, str) and tz.lower() == "local":
             tz = local_timezone()
         result = result.in_timezone(tz)

--- a/shared/timezones/tests/timezones/test_timezone.py
+++ b/shared/timezones/tests/timezones/test_timezone.py
@@ -202,3 +202,27 @@ def test_from_timestamp_fixed_timezone(utc_offset):
     from_ts = timezone.from_timestamp(0, tz=FixedTimezone(utc_offset))
     assert from_ts == pendulum.DateTime(1970, 1, 1, tzinfo=timezone.utc)
     assert from_ts.utcoffset() == datetime.timedelta(seconds=utc_offset)
+
+
+@pytest.mark.parametrize(
+    "tz",
+    [
+        pytest.param(timezone.utc, id="utc-object"),
+        pytest.param("UTC", id="utc-literal"),
+    ],
+)
+def test_from_timestamp_utc_skips_timezone_conversion(tz, monkeypatch):
+    class DummyDateTime:
+        called = False
+
+        def in_timezone(self, _):
+            self.called = True
+            raise AssertionError("UTC inputs should not trigger timezone conversion")
+
+    dummy = DummyDateTime()
+    monkeypatch.setattr(timezone, "coerce_datetime", lambda _: dummy)
+
+    result = timezone.from_timestamp(0, tz=tz)
+
+    assert result is dummy
+    assert dummy.called is False


### PR DESCRIPTION
## What
Fix `from_timestamp()` UTC guard condition so UTC inputs do not perform an unnecessary `in_timezone()` call.\n\n## Why\nThe previous condition used `or`, which is always true for this check and forced conversion even when `tz` was already UTC.\n\n## How\n- Change `if tz != utc or tz != "UTC"` to `if tz != utc and tz != "UTC"`\n- Add regression tests to ensure UTC object and `"UTC"` string skip timezone conversion\n\n## Verification\n`PYTHONPATH=shared/timezones/src python3 -m pytest -q shared/timezones/tests`\n- 32 passed