### PR TITLE
Fix td_format zero duration behavior for 0 values

### DIFF
--- a/shared/timezones/src/airflow_shared/timezones/timezone.py
+++ b/shared/timezones/src/airflow_shared/timezones/timezone.py
@@ -228,7 +228,7 @@ def td_format(td_object: None | dt.timedelta | float | int) -> str | None:
     For example timedelta(seconds=3752) would become `1h:2M:32s`.
     If the time is less than a second, the return will be `<1s`.
     """
-    if not td_object:
+    if td_object is None:
         return None
     if isinstance(td_object, dt.timedelta):
         delta = relativedelta() + td_object

--- a/shared/timezones/tests/timezones/test_timezone.py
+++ b/shared/timezones/tests/timezones/test_timezone.py
@@ -82,6 +82,12 @@ class TestTimezone:
         assert timezone.td_format(td) == "53M:20s"
         td = 3200
         assert timezone.td_format(td) == "53M:20s"
+        td = datetime.timedelta(0)
+        assert timezone.td_format(td) == "<1s"
+        td = 0.0
+        assert timezone.td_format(td) == "<1s"
+        td = 0
+        assert timezone.td_format(td) == "<1s"
         td = 0.123
         assert timezone.td_format(td) == "<1s"
         td = None


### PR DESCRIPTION
## What
Fix `td_format()` to treat zero durations as under one second (`<1s`) instead of returning `None`.\n\n## Why\nThe function docs state values below one second should return `<1s>`, but `0`, `0.0`, and `timedelta(0)` were treated as falsy and returned `None`.\n\n## How\n- Change the early-return guard from `if not td_object` to `if td_object is None`\n- Add regression tests for `timedelta(0)`, `0.0`, and `0`\n\n## Verification\n`PYTHONPATH=shared/timezones/src python3 -m pytest -q shared/timezones/tests`\n- 30 passed