### PR TITLE
Fix qualname() handling for functools.partial with exclude_module

### DIFF
--- a/shared/module_loading/src/airflow_shared/module_loading/__init__.py
+++ b/shared/module_loading/src/airflow_shared/module_loading/__init__.py
@@ -71,15 +71,15 @@ def qualname(o: object | Callable, use_qualname: bool = False, exclude_module: b
     With exclude_module=True, returns only the qualified name without module prefix,
     useful for stable identification across deployments where module paths may vary.
     """
+    if exclude_module and isinstance(o, functools.partial):
+        return qualname(o.func, exclude_module=True)
+
     if callable(o) and hasattr(o, "__module__"):
         if exclude_module:
             if hasattr(o, "__qualname__"):
                 return o.__qualname__
             if hasattr(o, "__name__"):
                 return o.__name__
-            # Handle functools.partial objects specifically (not just any object with 'func' attr)
-            if isinstance(o, functools.partial):
-                return qualname(o.func, exclude_module=True)
             return type(o).__qualname__
         if use_qualname and hasattr(o, "__qualname__"):
             return f"{o.__module__}.{o.__qualname__}"


### PR DESCRIPTION
## What
Fix `qualname(..., exclude_module=True)` so `functools.partial` returns the wrapped callable's qualified name instead of `partial`.\n\n## Why\nThe shared module loading tests currently fail because partial callables can resolve to the type name (`partial`) instead of the wrapped function's qualname.\n\n## How\n- Add an early `functools.partial` guard in `qualname()` before module/name checks\n- Reuse existing wrapped callable resolution path\n\n## Verification\n`PYTHONPATH=shared/module_loading/src python3 -m pytest -q shared/module_loading/tests`\n- 23 passed