### PR TITLE
Fix: Preserve BACKFILL run_type and triggering_user_name for repeated backfills

### DIFF
--- a/airflow-core/src/airflow/models/backfill.py
+++ b/airflow-core/src/airflow/models/backfill.py
@@ -28,6 +28,7 @@ from collections.abc import Sequence
 from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING
+from airflow.models.dagrun import DagRun
 
 import sqlalchemy as sa
 from sqlalchemy import (
@@ -407,9 +408,6 @@ def _create_backfill_dag_run(
             )
             nested.rollback()
 
-            from airflow.models.dagrun import DagRun
-            from sqlalchemy import select
-
             existing = session.scalar(
                 select(DagRun)
                 .where(DagRun.dag_id == dag.dag_id)
@@ -421,7 +419,7 @@ def _create_backfill_dag_run(
                 existing.triggered_by = DagRunTriggeredByType.BACKFILL
                 existing.triggering_user_name = triggering_user_name
                 session.flush()
-
+                
                 session.add(
                     BackfillDagRun(
                         backfill_id=backfill_id,

--- a/airflow-core/src/airflow/models/backfill.py
+++ b/airflow-core/src/airflow/models/backfill.py
@@ -407,15 +407,29 @@ def _create_backfill_dag_run(
             )
             nested.rollback()
 
-            session.add(
-                BackfillDagRun(
-                    backfill_id=backfill_id,
-                    dag_run_id=None,
-                    logical_date=info.logical_date,
-                    exception_reason=BackfillDagRunExceptionReason.IN_FLIGHT,
-                    sort_ordinal=backfill_sort_ordinal,
-                )
+            from airflow.models.dagrun import DagRun
+            from sqlalchemy import select
+
+            existing = session.scalar(
+                select(DagRun)
+                .where(DagRun.dag_id == dag.dag_id)
+                .where(DagRun.logical_date == info.logical_date)
             )
+
+            if existing:
+                existing.run_type = DagRunType.BACKFILL_JOB
+                existing.triggered_by = DagRunTriggeredByType.BACKFILL
+                existing.triggering_user_name = triggering_user_name
+                session.flush()
+
+                session.add(
+                    BackfillDagRun(
+                        backfill_id=backfill_id,
+                        dag_run_id=existing.id,
+                        logical_date=info.logical_date,
+                        sort_ordinal=backfill_sort_ordinal,
+                    )
+                )
 
 
 def _get_info_list(


### PR DESCRIPTION
### What does this PR do?

Fixes an issue where repeated backfill runs for the same logical date
could result in incorrect DagRun metadata due to IntegrityError handling
that skipped updating existing DagRuns.

### Root Cause

When a DagRun already existed for a logical_date, backfill logic skipped
creation without ensuring the run_type and triggering_user_name remained
consistent with BACKFILL semantics.

### Fix

When IntegrityError occurs:
- Fetch the existing DagRun
- Ensure run_type is set to BACKFILL_JOB
- Preserve triggering_user_name
- Link BackfillDagRun correctly

### Additional Notes

No new dependencies are introduced. This ensures consistent metadata
for all backfill runs, first or subsequent.

Closes: #62126

