### PR TITLE
Fix webserver.defaultUser.enabled=false not honored

### DIFF
--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -114,14 +114,10 @@ Flower Dashboard:      kubectl port-forward svc/{{ include "airflow.fullname" . 
 {{- end }}
 
 
-{{- if and .Values.webserver.defaultUser .Values.webserver.defaultUser.enabled}}
+{{- if eq (include "createUserJob.isEnabled" .) "true" }}
 Default user (Airflow UI) Login credentials:
-    username: {{ .Values.createUserJob.defaultUser.username }}
-    password: {{ .Values.createUserJob.defaultUser.password }}
-{{- else if .Values.createUserJob.enabled}}
-Default user (Airflow UI) Login credentials:
-    username: {{ .Values.createUserJob.defaultUser.username }}
-    password: {{ .Values.createUserJob.defaultUser.password }}
+    username: {{ if .Values.webserver.defaultUser }}{{ .Values.webserver.defaultUser.username }}{{ else }}{{ .Values.createUserJob.defaultUser.username }}{{ end }}
+    password: {{ if .Values.webserver.defaultUser }}{{ .Values.webserver.defaultUser.password }}{{ else }}{{ .Values.createUserJob.defaultUser.password }}{{ end }}
 {{- end }}
 
 {{- if .Values.postgresql.enabled }}

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -1169,6 +1169,19 @@ Usage:
 {{- end -}}
 
 {{/*
+Determine if the create-user job should be enabled.
+When webserver.defaultUser is set (deprecated), it takes precedence to preserve
+backwards compatibility. Otherwise, fall back to createUserJob.enabled.
+*/}}
+{{- define "createUserJob.isEnabled" -}}
+  {{- if .Values.webserver.defaultUser -}}
+    {{- .Values.webserver.defaultUser.enabled -}}
+  {{- else -}}
+    {{- .Values.createUserJob.enabled -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Convert dagBundleConfigList YAML list to JSON string for dag_bundle_config_list.
 This helper function converts the structured YAML format to the JSON string
 format required by Airflow's dag_bundle_config_list configuration.

--- a/chart/templates/jobs/create-user-job.yaml
+++ b/chart/templates/jobs/create-user-job.yaml
@@ -20,7 +20,7 @@
 ##########################
 ## Airflow Create User Job
 ##########################
-{{- if or (and .Values.webserver.defaultUser .Values.webserver.defaultUser.enabled) .Values.createUserJob.enabled }}
+{{- if eq (include "createUserJob.isEnabled" .) "true" }}
 {{- $nodeSelector := or .Values.createUserJob.nodeSelector .Values.nodeSelector }}
 {{- $affinity := or .Values.createUserJob.affinity .Values.affinity }}
 {{- $tolerations := or .Values.createUserJob.tolerations .Values.tolerations }}

--- a/chart/templates/rbac/security-context-constraint-rolebinding.yaml
+++ b/chart/templates/rbac/security-context-constraint-rolebinding.yaml
@@ -88,7 +88,7 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "migrateDatabaseJob.serviceAccountName" . }}
     namespace: "{{ .Release.Namespace }}"
-  {{- if or (and .Values.webserver.defaultUser .Values.webserver.defaultUser.enabled) .Values.createUserJob.enabled }}
+  {{- if eq (include "createUserJob.isEnabled" .) "true" }}
   - kind: ServiceAccount
     name: {{ include "createUserJob.serviceAccountName" . }}
     namespace: "{{ .Release.Namespace }}"

--- a/helm-tests/tests/helm_tests/airflow_aux/test_create_user_job.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_create_user_job.py
@@ -486,6 +486,69 @@ class TestCreateUserJob:
         assert len(docs) == 1
         assert docs[0]["kind"] == "Job"
 
+    def test_should_not_create_job_when_deprecated_default_user_disabled(self):
+        """Setting webserver.defaultUser.enabled=false must suppress job even with createUserJob.enabled default."""
+        docs = render_chart(
+            values={
+                "webserver": {
+                    "defaultUser": {
+                        "enabled": False,
+                        "role": "Admin",
+                        "username": "admin",
+                        "email": "admin@example.com",
+                        "firstName": "admin",
+                        "lastName": "user",
+                        "password": "admin",
+                    }
+                }
+            },
+            show_only=["templates/jobs/create-user-job.yaml"],
+        )
+        assert len(docs) == 0
+
+    def test_should_create_job_when_deprecated_default_user_enabled(self):
+        """Setting webserver.defaultUser.enabled=true should create the job."""
+        docs = render_chart(
+            values={
+                "webserver": {
+                    "defaultUser": {
+                        "enabled": True,
+                        "role": "Admin",
+                        "username": "admin",
+                        "email": "admin@example.com",
+                        "firstName": "admin",
+                        "lastName": "user",
+                        "password": "admin",
+                    }
+                }
+            },
+            show_only=["templates/jobs/create-user-job.yaml"],
+        )
+        assert len(docs) == 1
+        assert docs[0]["kind"] == "Job"
+
+    def test_deprecated_default_user_enabled_overrides_createuserjob_disabled(self):
+        """webserver.defaultUser.enabled=true takes precedence over createUserJob.enabled=false."""
+        docs = render_chart(
+            values={
+                "createUserJob": {"enabled": False},
+                "webserver": {
+                    "defaultUser": {
+                        "enabled": True,
+                        "role": "Admin",
+                        "username": "admin",
+                        "email": "admin@example.com",
+                        "firstName": "admin",
+                        "lastName": "user",
+                        "password": "admin",
+                    }
+                },
+            },
+            show_only=["templates/jobs/create-user-job.yaml"],
+        )
+        assert len(docs) == 1
+        assert docs[0]["kind"] == "Job"
+
 
 class TestCreateUserJobServiceAccount:
     """Tests create user job service account."""


### PR DESCRIPTION
When webserver.defaultUser.enabled was set to false, the create-user job still ran because createUserJob.enabled defaults to true and the OR condition let it through. This adds a helper template that gives the deprecated webserver.defaultUser precedence when present, only falling back to createUserJob.enabled otherwise. Also fixes NOTES.txt to display credentials from the correct source.


## `helm template` Test Results

  All scenarios tested against 3 templates: create-user-job.yaml, NOTES.txt, and security-context-constraint-rolebinding.yaml.

   | # | `webserver.defaultUser`  | `createUserJob.enabled` | Job Created? | NOTES Creds?    | SCC Subject? | Status           |
  |---|--------------------------|-------------------------|--------------|-----------------|--------------|------------------|
  | 1 | *(not set)*              | `true` (default)        | Yes          | `admin/admin`   | Yes          | PASS             |
  | 2 | *(not set)*              | `false`                 | No           | Hidden          | No           | PASS             |
  | 3 | `enabled: false`         | `true` (default)        | **No**       | Hidden          | No           | PASS (bug fix)   |
  | 4 | `enabled: true`          | `true` (default)        | Yes          | `depuser/deppass`| Yes          | PASS             |
  | 5 | `enabled: true`          | `false`                 | **Yes**      | `depuser/deppass`| Yes          | PASS (precedence)|
  | 6 | `enabled: false`         | `true`                  | **No**       | Hidden          | No           | PASS (precedence)|


  ## Key Behaviors Verified

  • Scenario 3 is the core bug fix: webserver.defaultUser.enabled=false now correctly suppresses the job. Before the fix, the old or condition would
    still evaluate createUserJob.enabled (default true) and create the job anyway.
  • Scenarios 5 & 6 confirm that when the deprecated webserver.defaultUser is set, it always takes precedence over createUserJob.enabled, regardless of
    conflict.
  • NOTES.txt correctly uses webserver.defaultUser credentials when that section is present, falling back to createUserJob.defaultUser otherwise.
  • SCC rolebinding consistently includes/excludes the create-user-job service account in lockstep with whether the job itself is created.

Fixed a missed compat scenario left from #61337.

---

##### Was generative AI tooling used to co-author this PR?


- [x] Yes (please specify the tool below)

Generated-by: Cursor CLI (Clause Opus 4.6)
