### PR TITLE
fix(ui): Graph View layout broken for non-LR orientations with TaskGroups

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/Graph/useGraphLayout.ts
+++ b/airflow-core/src/airflow/ui/src/components/Graph/useGraphLayout.ts
@@ -164,7 +164,7 @@ const generateElkGraph = ({
         label: node.label,
         layoutOptions: {
           "elk.padding": "[top=80,left=15,bottom=15,right=15]",
-          "elk.portConstraints": "FIXED_SIDE",
+          ...(direction === "RIGHT" ? { "elk.portConstraints": "FIXED_SIDE" } : {}),
         },
       };
     }
@@ -216,7 +216,7 @@ const generateElkGraph = ({
       isGroup: Boolean(node.children),
       isMapped: node.is_mapped === null ? undefined : node.is_mapped,
       label: node.label,
-      layoutOptions: { "elk.portConstraints": "FIXED_SIDE" },
+      layoutOptions: direction === "RIGHT" ? { "elk.portConstraints": "FIXED_SIDE" } : undefined,
       operator: node.operator,
       setupTeardownType: node.setup_teardown_type,
       type: node.type,


### PR DESCRIPTION
## Summary

- Fix Graph View layout regression where TB/RL/BT orientations break when TaskGroups are present
- The `elk.portConstraints: "FIXED_SIDE"` layout option is now conditionally applied only for RIGHT (LR) direction, as it causes ELK.js to incorrectly spread nodes horizontally for other orientations
- This restores the correct behavior from Airflow 3.0.6

## Root Cause

The `elk.portConstraints: "FIXED_SIDE"` option was applied unconditionally to both open TaskGroup nodes and individual task nodes. This constraint works correctly for LR layouts but breaks the ELK.js layout algorithm for TB, BT, and RL orientations when TaskGroups are present.

## Test plan

- [ ] Deploy a DAG with TaskGroups (see reproduction DAG in #61384)
- [ ] Verify Graph View renders correctly in all four orientations: LR, RL, TB, BT
- [ ] Verify LR orientation still benefits from the FIXED_SIDE port constraint
- [ ] Verify non-TaskGroup DAGs are unaffected

Closes #61384