### PR TITLE
fix(providers/fab): restore OAuth callback route exposure

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/views/auth_oauth.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/views/auth_oauth.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import logging
 
 from flask import session
+from flask_appbuilder import expose
 from flask_appbuilder.security.views import AuthOAuthView
 
 from airflow.configuration import conf
@@ -37,6 +38,7 @@ class CustomAuthOAuthView(AuthOAuthView):
     the Flask session is not yet committed when the redirect response is sent.
     """
 
+    @expose("/oauth-authorized/<provider>")
     def oauth_authorized(self, provider):
         """
         OAuth callback handler that explicitly commits session before redirect.

--- a/providers/fab/tests/unit/fab/auth_manager/views/test_auth_oauth.py
+++ b/providers/fab/tests/unit/fab/auth_manager/views/test_auth_oauth.py
@@ -28,6 +28,14 @@ from airflow.providers.fab.auth_manager.views.auth_oauth import CustomAuthOAuthV
 class TestCustomAuthOAuthView:
     """Test CustomAuthOAuthView."""
 
+    def test_oauth_authorized_keeps_callback_route_exposed(self):
+        """Test oauth callback route is exposed on the custom view."""
+        assert hasattr(CustomAuthOAuthView.oauth_authorized, "_urls")
+        assert any(
+            route == "/oauth-authorized/<provider>"
+            for route, _methods in CustomAuthOAuthView.oauth_authorized._urls
+        )
+
     @pytest.mark.parametrize("backend", ["database", "securecookie"])
     @mock.patch("airflow.providers.fab.auth_manager.views.auth_oauth.conf")
     def test_oauth_authorized_marks_session_modified(self, mock_conf, backend):


### PR DESCRIPTION
Restore OAuth callback route registration on `CustomAuthOAuthView`.

`CustomAuthOAuthView.oauth_authorized` overrides FAB's `AuthOAuthView.oauth_authorized`, but without re-applying the `@expose("/oauth-authorized/<provider>")` decorator the callback endpoint is not registered on the custom view. This breaks URL generation for `CustomAuthOAuthView.oauth_authorized` during OAuth login.

This PR re-adds the route decorator and includes a regression unit test asserting the callback route remains exposed.

Fixes #62028

## Testing
- `source .venv/bin/activate && ruff check providers/fab/src/airflow/providers/fab/auth_manager/views/auth_oauth.py providers/fab/tests/unit/fab/auth_manager/views/test_auth_oauth.py`
- `breeze run --python 3.12 --platform linux/amd64 --tty disabled --skip-image-upgrade-check -- python -m pytest providers/fab/tests/unit/fab/auth_manager/views/test_auth_oauth.py -q`

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Cursor (GPT-5.3) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).

Made with [Cursor](https://cursor.com)