### PR TITLE
docs: add Spanish (es) translation agent skill and locale guidelines

### DIFF
--- a/.github/skills/airflow-translations/locales/es.md
+++ b/.github/skills/airflow-translations/locales/es.md
@@ -1,35 +1,5 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one
- or more contributor license agreements.  See the NOTICE file
- distributed with this work for additional information
- regarding copyright ownership.  The ASF licenses this file
- to you under the Apache License, Version 2.0 (the
- "License"); you may not use this file except in compliance
- with the License.  You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing,
- software distributed under the License is distributed on an
- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- KIND, either express or implied.  See the License for the
- specific language governing permissions and limitations
- under the License.
- -->
-
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
-
-- [Spanish Translation Agent Skill](#spanish-translation-agent-skill)
-  - [Tone and Style](#tone-and-style)
-  - [Keep in English](#keep-in-english)
-  - [Preferred Translations](#preferred-translations)
-  - [Translation Principles](#translation-principles)
-  - [Agent Instructions (DO / DON'T)](#agent-instructions-do--dont)
-  - [Notes](#notes)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
 
 # Spanish Translation Agent Skill
 

--- a/.github/skills/airflow-translations/locales/es.md
+++ b/.github/skills/airflow-translations/locales/es.md
@@ -1,0 +1,175 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Spanish Translation Agent Skill](#spanish-translation-agent-skill)
+  - [Tone and Style](#tone-and-style)
+  - [Keep in English](#keep-in-english)
+  - [Preferred Translations](#preferred-translations)
+  - [Translation Principles](#translation-principles)
+  - [Agent Instructions (DO / DON'T)](#agent-instructions-do--dont)
+  - [Notes](#notes)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# Spanish Translation Agent Skill
+
+**Locale code:** `es`
+
+This file defines terminology, tone, and translation preferences
+for Spanish (es) translations of Apache Airflow.
+
+It is derived from the existing Spanish locale files at:
+
+`airflow-core/src/airflow/ui/public/i18n/locales/es/*.json`
+
+## Tone and Style
+
+- Use **neutral, formal Spanish** suitable for professional software documentation.
+- Avoid region-specific idioms; prefer standard/international Spanish understood across Latin America and Spain.
+- Address the user implicitly (impersonal constructions) rather than "tú" or "usted" when possible — this is the pattern already established in the existing translations (e.g., "Presiona {{hotkey}} para..." instead of "Presione usted...").
+- Use polite, clear, and concise language.
+
+## Keep in English
+
+The following terms must remain untranslated:
+
+- **Dag / Dags** — Airflow's core concept; always "Dag" (never "DAG")
+- **Asset / Assets** — kept as-is in the existing translations
+- **Backfill / Backfills** — Airflow-specific concept
+- **XCom / XComs** — cross-communication mechanism
+- **Pool / Pools** — resource pool concept
+- **Plugins** — kept as-is
+- **ID** — universal technical identifier
+- **Log levels** (CRITICAL, ERROR, WARNING, INFO, DEBUG) — match log output
+- **Upstream / Downstream** — when referring to task dependencies (used as "Fallido en Upstream")
+- **Executor** — Airflow component name
+- **Trigger / Triggerer** — Airflow component names (but the verb "trigger" is translated as "Activar")
+- **Bundle** — Airflow bundle concept
+
+## Preferred Translations
+
+| English Term | Spanish | Notes |
+|---|---|---|
+| Dag Run | Ejecución del Dag | |
+| Task | Tarea | |
+| Task Instance | Instancia de Tarea | |
+| Operator | Operador | |
+| Connections | Conexiones | |
+| Variables | Variables | |
+| Providers | Proveedores | |
+| Configuration | Configuración | |
+| Schedule / Scheduled | Programación / Programado | |
+| Running | En Ejecución | |
+| Queued | En Cola | |
+| Failed | Fallido | |
+| Success / Successful | Exitoso | |
+| Deferred | Diferido | |
+| Skipped | Omitido | |
+| Removed | Removido | |
+| Restarting | Reiniciando | |
+| Planned | Planificado | |
+| Tags | Etiquetas | |
+| Owner | Propietario | |
+| Description | Descripción | |
+| Duration | Duración | |
+| Delete | Eliminar | |
+| Cancel | Cancelar | |
+| Confirm | Confirmar | |
+| Filter | Filtro | |
+| Reset | Restablecer | |
+| Download | Descargar | |
+| Expand / Collapse | Expandir / Colapsar | |
+| Logout | Cerrar Sesión | |
+| Browse | Navegar | |
+| Admin | Administración | |
+| Security | Seguridad | |
+| Users | Usuarios | |
+| Roles | Roles | |
+| Permissions | Permisos | |
+| Actions | Acciones | |
+| Resources | Recursos | |
+| Documentation | Documentación | |
+| Home | Inicio | |
+| Trigger (verb) | Activar | "Activado por" for "Triggered by" |
+| Trigger Rule | Regla de Activación | |
+| Catchup | Catchup | Kept in English |
+| Try Number | Intento Número | |
+| Map Index | Mapa de Índice | |
+| Timezone | Zona Horaria | |
+| Dark Mode | Modo Oscuro | |
+| Light Mode | Modo Claro | |
+| Audit Log | Auditar Log | |
+
+## Translation Principles
+
+1. **Neutral Spanish**
+   - Use international/neutral Spanish that works across all Spanish-speaking regions.
+   - Avoid regionalisms (e.g., prefer "Computadora" over "Ordenador" when relevant).
+
+2. **Airflow terms stay in English**
+   - Core Airflow concepts (Dag, Asset, XCom, Pool, Backfill) are kept in English.
+   - This ensures consistency with code, logs, and documentation.
+
+3. **Natural capitalization**
+   - Use title case for UI headers, buttons, and navigation items (e.g., "Todas las Ejecuciones").
+   - Use sentence case for descriptions and messages (e.g., "No se encontraron resultados").
+
+4. **Preserve placeholders and formatting**
+   - All `{{variable}}` placeholders must be preserved exactly.
+   - Adjust surrounding grammar to fit Spanish word order around placeholders.
+
+5. **Plural forms**
+   - Follow i18next plural keys: `_one`, `_many`, `_other`.
+   - Spanish uses `_one` for singular and `_other` for plural (same form as `_many`).
+
+6. **Gender agreement**
+   - Maintain correct grammatical gender (e.g., "Ejecución" is feminine → "Última Ejecución").
+   - "Dag" is treated as masculine in Spanish (e.g., "Ejecución del Dag").
+
+## Agent Instructions (DO / DON'T)
+
+**DO:**
+- Match tone, style, gender, and casing from existing `es/*.json` files
+- Use clear, professional Spanish readable across all Spanish-speaking regions
+- Preserve all placeholders: `{{count}}`, `{{dagName}}`, `{{hotkey}}`, etc.
+- For plurals: provide all needed suffixes (`_one`, `_many`, `_other`)
+- Check existing translations before adding new ones to maintain consistency
+
+**DON'T:**
+- Translate core Airflow terms listed in the "Keep in English" section
+- Use "DAG" — always use "Dag"
+- Use informal language or slang
+- Invent new vocabulary when an equivalent already exists in the JSON files
+- Translate hotkeys, code references, variable names, or file paths
+- Use region-specific expressions that could confuse speakers from other regions
+
+## Notes
+
+- `states.none` and `states.no_status` are both translated as **"Sin Estado"** in the existing files.
+- The verb "parsear" (from English "parse") is used as an accepted technical loanword (e.g., "Duración del parseo", "Último Parseado").
+- "Wrap" is translated as **"Envolver"** and "Unwrap" as **"Desenvolver"**.
+- Asset-related terms keep "Asset" in English (e.g., "Evento de Asset", "Eventos de Asset Fuente").
+
+---
+
+**Version:** 1.0 — based directly on current `es/` JSON files (Feb 2026)

--- a/airflow-core/src/airflow/ui/public/i18n/locales/es/README.md
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/es/README.md
@@ -1,21 +1,5 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one
- or more contributor license agreements.  See the NOTICE file
- distributed with this work for additional information
- regarding copyright ownership.  The ASF licenses this file
- to you under the Apache License, Version 2.0 (the
- "License"); you may not use this file except in compliance
- with the License.  You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing,
- software distributed under the License is distributed on an
- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- KIND, either express or implied.  See the License for the
- specific language governing permissions and limitations
- under the License.
- -->
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
 
 # Traducción al Español de la UI de Apache Airflow
 

--- a/airflow-core/src/airflow/ui/public/i18n/locales/es/README.md
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/es/README.md
@@ -1,0 +1,117 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# Traducción al Español de la UI de Apache Airflow
+
+Este documento describe los principios de traducción elegidos para el idioma español.
+Su propósito es documentar las decisiones de traducción y garantizar la consistencia
+en futuras iteraciones.
+
+## Tono y registro
+
+Se utiliza un español neutro y formal, adecuado para software profesional.
+Se evita el uso directo de "tú" o "usted", prefiriendo construcciones impersonales
+cuando es posible (por ejemplo: "Presiona {{hotkey}} para descargar los registros").
+Esto permite que la interfaz sea accesible para usuarios de cualquier región hispanohablante.
+
+## Términos que se mantienen en inglés
+
+Los siguientes términos no se traducen, ya que son conceptos centrales de Airflow
+que aparecen de forma consistente en el código, logs y documentación:
+
+- `Dag` / `Dags`: Concepto central de Airflow. Siempre "Dag", nunca "DAG".
+  Se trata como sustantivo masculino en español (por ejemplo: "Ejecución del Dag").
+- `Asset` / `Assets`: Concepto introducido en Airflow 3. Se mantiene en inglés
+  (por ejemplo: "Evento de Asset", "Eventos de Asset Fuente").
+- `Backfill` / `Backfills`: Concepto específico de Airflow para rellenar ejecuciones pasadas.
+- `XCom` / `XComs`: Mecanismo de comunicación entre tareas.
+- `Pool` / `Pools`: Concepto de pool de recursos. Una traducción precisa como
+  "grupo de recursos" sería innecesariamente larga.
+- `Plugins`: Término técnico ampliamente comprendido en español.
+- `Executor`: Nombre del componente de Airflow.
+- `Triggerer`: Nombre del componente de Airflow.
+- `Bundle`: Concepto de bundle en Airflow.
+- `Catchup`: Concepto específico de Airflow.
+- `ID`: Identificador técnico universal.
+- Niveles de log (`CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG`):
+  Se mantienen en inglés ya que coinciden con la salida de los logs.
+
+## Definiciones de traducciones de términos específicos de Airflow
+
+Para la traducción al español se han adoptado las siguientes convenciones
+(en orden alfabético):
+
+- `Actions` → `Acciones`: Traducción directa.
+- `Admin` → `Administración`: Se prefiere la forma completa sobre "Admin".
+- `Asset Event` → `Evento de Asset`: Se mantiene "Asset" en inglés por consistencia.
+- `Browse` → `Navegar`: Traducción directa para la navegación de la UI.
+- `Configuration` → `Configuración`: Traducción directa.
+- `Connections` → `Conexiones`: Aunque es un término técnico en Airflow,
+  la traducción directa es clara y comprensible.
+- `Dag Run` → `Ejecución del Dag`: Se usa "del" (contracción de "de el")
+  ya que "Dag" se trata como masculino.
+- `Deferred` (estado) → `Diferido`: El término más cercano al significado original,
+  ya que una tarea es delegada al componente Triggerer.
+- `Delete` → `Eliminar`: Traducción estándar para acciones destructivas.
+- `Documentation` → `Documentación`: Traducción directa.
+- `Duration` → `Duración`: Traducción directa.
+- `Failed` → `Fallido`: Estado de fallo de una ejecución o tarea.
+- `Filter` → `Filtro`: Traducción directa.
+- `Home` → `Inicio`: Traducción estándar para la página principal.
+- `Logout` → `Cerrar Sesión`: Expresión natural en español.
+- `Map Index` → `Mapa de Índice`: Traducción descriptiva para el índice
+  de tareas mapeadas.
+- `Operator` → `Operador`: Término técnico que coincide en ambos idiomas.
+- `Owner` → `Propietario`: Traducción directa.
+- `Permissions` → `Permisos`: Traducción directa.
+- `Planned` → `Planificado`: Estado planificado de una tarea.
+- `Providers` → `Proveedores`: Traducción directa.
+- `Queued` → `En Cola`: Estado de espera en la cola de ejecución.
+- `Removed` → `Removido`: Estado de tarea removida.
+- `Reset` → `Restablecer`: Traducción estándar para acciones de restablecimiento.
+- `Restarting` → `Reiniciando`: Estado de reinicio.
+- `Roles` → `Roles`: Término idéntico en ambos idiomas.
+- `Running` → `En Ejecución`: Estado de ejecución activa.
+- `Scheduled` → `Programado`: Se refiere a ejecuciones cíclicas planificadas.
+- `Security` → `Seguridad`: Traducción directa.
+- `Skipped` → `Omitido`: Estado de tarea omitida.
+- `Success` → `Exitoso`: Estado de ejecución exitosa.
+- `Tags` → `Etiquetas`: Marcadores para organizar Dags.
+- `Task` → `Tarea`: Traducción directa del concepto de tarea.
+- `Task Instance` → `Instancia de Tarea`: Traducción directa.
+- `Timezone` → `Zona Horaria`: Traducción estándar.
+- `Trigger` (verbo) → `Activar`: Se usa "Activar" para la acción de iniciar
+  una ejecución (por ejemplo: "Activado por").
+- `Trigger Rule` → `Regla de Activación`: Consistente con la traducción del verbo.
+- `Try Number` → `Intento Número`: Traducción directa.
+- `Users` → `Usuarios`: Traducción directa.
+- `Variables` → `Variables`: Término idéntico en ambos idiomas.
+- `Wrap` / `Unwrap` → `Envolver` / `Desenvolver`: Traducción directa para
+  la función de ajuste de texto.
+
+## Notas especiales
+
+- El verbo "parsear" (del inglés "parse") se usa como préstamo lingüístico
+  aceptado en el contexto técnico (por ejemplo: "Duración del parseo",
+  "Último Parseado").
+- `states.none` y `states.no_status` se traducen ambos como **"Sin Estado"**.
+- Se usa capitalización tipo título para encabezados, botones y elementos
+  de navegación (por ejemplo: "Todas las Ejecuciones").
+- Se usa capitalización tipo oración para descripciones y mensajes
+  (por ejemplo: "No se encontraron resultados").


### PR DESCRIPTION
Closes #61991

## Summary

Adds Spanish (es) translation agent skill and locale guidelines for Airflow's i18n effort:

### Files added:
- `.github/skills/airflow-translations/locales/es.md` — Agent skill file with translation rules for AI translation agents
- `airflow-core/src/airflow/ui/public/i18n/locales/es/README.md` — Locale-specific guidelines documenting translation decisions

### Contents:
- **Tone and style**: Neutral, formal Spanish with impersonal constructions (no tú/usted)
- **Terms kept in English**: Dag, Asset, XCom, Pool, Backfill, Executor, Triggerer, etc.
- **Preferred translations**: Complete glossary derived from existing `es/*.json` files
- **Translation principles**: Neutral Spanish, gender agreement, plural forms, capitalization rules
- **Agent instructions**: DO/DON'T guidelines for AI-assisted translation

All guidelines are derived directly from the existing Spanish locale JSON files to ensure consistency.

I'm a native Spanish speaker from Chile. Happy to iterate based on community feedback!