### PR TITLE
FastAPI: optimize DagRun list eager loading and avoid N+1 dag_versions

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/common/db/dag_runs.py
+++ b/airflow-core/src/airflow/api_fastapi/common/db/dag_runs.py
@@ -52,3 +52,18 @@ def eager_load_dag_run_for_validation() -> tuple[LoaderOption, ...]:
         .joinedload(DagVersion.bundle),
         joinedload(DagRun.dag_run_note),
     )
+
+
+def eager_load_dag_run_for_list() -> tuple[LoaderOption, ...]:
+    """
+    Eager loading options for listing DagRuns.
+
+    IMPORTANT: Do NOT load task instances / histories here.
+    Those collections can be huge and will cause extra queries and/or row explosion,
+    which makes list endpoints slow on large installations.
+    """
+    return (
+        joinedload(DagRun.dag_model),
+        joinedload(DagRun.dag_run_note),
+        joinedload(DagRun.created_dag_version).joinedload(DagVersion.bundle),
+    )

--- a/airflow-core/src/airflow/api_fastapi/common/db/dag_runs.py
+++ b/airflow-core/src/airflow/api_fastapi/common/db/dag_runs.py
@@ -55,15 +55,11 @@ def eager_load_dag_run_for_validation() -> tuple[LoaderOption, ...]:
 
 
 def eager_load_dag_run_for_list() -> tuple[LoaderOption, ...]:
-    """
-    Eager loading options for listing DagRuns.
-
-    IMPORTANT: Do NOT load task instances / histories here.
-    Those collections can be huge and will cause extra queries and/or row explosion,
-    which makes list endpoints slow on large installations.
-    """
     return (
         joinedload(DagRun.dag_model),
         joinedload(DagRun.dag_run_note),
-        joinedload(DagRun.created_dag_version).joinedload(DagVersion.bundle),
+        joinedload(DagRun.created_dag_version)
+        .joinedload(DagVersion.bundle),
+        joinedload(DagRun.created_dag_version)
+        .joinedload(DagVersion.dag_model),
     )

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
@@ -22,7 +22,7 @@ from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING
 
-from pydantic import AliasPath, AwareDatetime, Field, NonNegativeInt, model_validator
+from pydantic import AliasPath, AwareDatetime, Field, computed_field, NonNegativeInt, model_validator
 
 from airflow._shared.timezones import timezone
 from airflow.api_fastapi.core_api.base import BaseModel, StrictBaseModel
@@ -81,10 +81,22 @@ class DAGRunResponse(BaseModel):
     triggering_user_name: str | None
     conf: dict | None
     note: str | None
-    dag_versions: list[DagVersionResponse]
     bundle_version: str | None
     dag_display_name: str = Field(validation_alias=AliasPath("dag_model", "dag_display_name"))
     partition_key: str | None
+    # Internal helper field: populated from the ORM relationship
+    # Must be excluded from output, and MUST NOT trigger DagRun.dag_versions property
+    created_dag_version_obj: DagVersionResponse | None = Field(
+        default=None,
+        validation_alias="created_dag_version",
+        exclude=True,
+    )
+
+    @computed_field(return_type=list[DagVersionResponse])
+    def dag_versions(self) -> list[DagVersionResponse]:
+        # Derive from already-eager-loaded relationship.
+        # Do NOT touch run.dag_versions (ORM property).
+        return [self.created_dag_version_obj] if self.created_dag_version_obj else []
 
 
 class DAGRunCollectionResponse(BaseModel):

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
@@ -22,7 +22,7 @@ from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING
 
-from pydantic import AliasPath, AwareDatetime, Field, computed_field, NonNegativeInt, model_validator
+from pydantic import AliasPath, AwareDatetime, Field, NonNegativeInt, computed_field, model_validator
 
 from airflow._shared.timezones import timezone
 from airflow.api_fastapi.core_api.base import BaseModel, StrictBaseModel
@@ -81,11 +81,36 @@ class DAGRunResponse(BaseModel):
     triggering_user_name: str | None
     conf: dict | None
     note: str | None
+    dag_versions: list[DagVersionResponse]
     bundle_version: str | None
     dag_display_name: str = Field(validation_alias=AliasPath("dag_model", "dag_display_name"))
     partition_key: str | None
-    # Internal helper field: populated from the ORM relationship
-    # Must be excluded from output, and MUST NOT trigger DagRun.dag_versions property
+
+
+class DAGRunBaseResponse(BaseModel):
+    dag_run_id: str = Field(validation_alias="run_id")
+    dag_id: str
+    logical_date: datetime | None
+    queued_at: datetime | None
+    start_date: datetime | None
+    end_date: datetime | None
+    duration: float | None
+    data_interval_start: datetime | None
+    data_interval_end: datetime | None
+    run_after: datetime
+    last_scheduling_decision: datetime | None
+    run_type: DagRunType
+    state: DagRunState
+    triggered_by: DagRunTriggeredByType | None
+    triggering_user_name: str | None
+    conf: dict | None
+    note: str | None
+    bundle_version: str | None
+    dag_display_name: str = Field(validation_alias=AliasPath("dag_model", "dag_display_name"))
+    partition_key: str | None
+
+
+class DAGRunListResponse(DAGRunBaseResponse):
     created_dag_version_obj: DagVersionResponse | None = Field(
         default=None,
         validation_alias="created_dag_version",
@@ -94,9 +119,20 @@ class DAGRunResponse(BaseModel):
 
     @computed_field(return_type=list[DagVersionResponse])
     def dag_versions(self) -> list[DagVersionResponse]:
-        # Derive from already-eager-loaded relationship.
-        # Do NOT touch run.dag_versions (ORM property).
-        return [self.created_dag_version_obj] if self.created_dag_version_obj else []
+        dv = self.created_dag_version_obj
+        if not dv:
+            return []
+
+        # Non-versioned DAGs must not expose versions
+        if dv.bundle_name is None:
+            return []
+
+        return [dv]
+        
+
+class DAGRunListCollectionResponse(BaseModel):
+    dag_runs: Iterable[DAGRunListResponse]
+    total_entries: int
 
 
 class DAGRunCollectionResponse(BaseModel):

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -36,7 +36,7 @@ from airflow.api.common.mark_tasks import (
 from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity
 from airflow.api_fastapi.common.dagbag import DagBagDep, get_dag_for_run, get_latest_version_of_dag
 from airflow.api_fastapi.common.db.common import SessionDep, paginated_select
-from airflow.api_fastapi.common.db.dag_runs import eager_load_dag_run_for_validation
+from airflow.api_fastapi.common.db.dag_runs import eager_load_dag_run_for_list
 from airflow.api_fastapi.common.parameters import (
     FilterOptionEnum,
     FilterParam,
@@ -384,7 +384,7 @@ def get_dag_runs(
 
     This endpoint allows specifying `~` as the dag_id to retrieve Dag Runs for all DAGs.
     """
-    query = select(DagRun).options(*eager_load_dag_run_for_validation())
+    query = select(DagRun).options(*eager_load_dag_run_for_list())
 
     if dag_id != "~":
         get_latest_version_of_dag(dag_bag, dag_id, session)  # Check if the DAG exists.
@@ -625,7 +625,7 @@ def get_list_dag_runs_batch(
         {"dag_run_id": "run_id"},
     ).set_value([body.order_by] if body.order_by else None)
 
-    base_query = select(DagRun).options(*eager_load_dag_run_for_validation())
+    base_query = select(DagRun).options(*eager_load_dag_run_for_list())
 
     dag_runs_select, total_entries = paginated_select(
         statement=base_query,

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -63,6 +63,7 @@ from airflow.api_fastapi.core_api.datamodels.assets import AssetEventCollectionR
 from airflow.api_fastapi.core_api.datamodels.dag_run import (
     DAGRunClearBody,
     DAGRunCollectionResponse,
+    DAGRunListCollectionResponse,
     DAGRunPatchBody,
     DAGRunPatchStates,
     DAGRunResponse,
@@ -378,7 +379,7 @@ def get_dag_runs(
     ],
     dag_id_pattern: Annotated[_SearchParam, Depends(search_param_factory(DagRun.dag_id, "dag_id_pattern"))],
     partition_key_pattern: QueryDagRunPartitionKeySearch,
-) -> DAGRunCollectionResponse:
+) -> DAGRunListCollectionResponse:
     """
     Get all DAG Runs.
 
@@ -420,7 +421,7 @@ def get_dag_runs(
     )
     dag_runs = session.scalars(dag_run_select)
 
-    return DAGRunCollectionResponse(
+    return DAGRunListCollectionResponse(
         dag_runs=dag_runs,
         total_entries=total_entries,
     )
@@ -554,7 +555,7 @@ def get_list_dag_runs_batch(
     body: DAGRunsBatchBody,
     readable_dag_runs_filter: ReadableDagRunsFilterDep,
     session: SessionDep,
-) -> DAGRunCollectionResponse:
+) -> DAGRunListCollectionResponse:
     """Get a list of DAG Runs."""
     dag_ids = FilterParam(DagRun.dag_id, body.dag_ids, FilterOptionEnum.IN)  # type: ignore[arg-type]
     logical_date = RangeFilter(
@@ -648,7 +649,7 @@ def get_list_dag_runs_batch(
 
     dag_runs = session.scalars(dag_runs_select)
 
-    return DAGRunCollectionResponse(
+    return DAGRunListCollectionResponse(
         dag_runs=dag_runs,
         total_entries=total_entries,
     )

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run_list_perf.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run_list_perf.py
@@ -1,0 +1,130 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy import inspect as sa_inspect
+from sqlalchemy.orm.attributes import NO_VALUE
+
+from airflow.models.dagrun import DagRun
+from airflow.utils import timezone
+
+from tests_common.test_utils.asserts import assert_queries_count
+from tests_common.test_utils.db import (
+    clear_db_dag_bundles,
+    clear_db_dags,
+    clear_db_runs,
+    clear_db_serialized_dags,
+)
+
+pytestmark = pytest.mark.db_test
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_db():
+    # Keep this isolated/repeatable and aligned with other route tests.
+    clear_db_runs()
+    clear_db_dags()
+    clear_db_dag_bundles()
+    clear_db_serialized_dags()
+
+
+def _list_stmt(dag_id: str):
+    # Import here so test fails loudly if someone refactors paths.
+    from airflow.api_fastapi.common.db.dag_runs import eager_load_dag_run_for_list
+
+    return select(DagRun).where(DagRun.dag_id == dag_id).options(*eager_load_dag_run_for_list())
+
+
+@pytest.mark.usefixtures("configure_git_connection_for_dag_bundle")
+def test_dagrun_list_loader_does_not_eager_load_task_instances(dag_maker, session):
+    """
+    Regression for #62025:
+    List loader must not eager load task_instances or task_instances_histories.
+    """
+    dag_id = "perf_dagrun_list_no_ti"
+
+    # Create a serialized DAG + a bunch of runs with unique logical_date.
+    with dag_maker(dag_id=dag_id, schedule=None, start_date=timezone.utcnow(), serialized=True):
+        pass
+
+    base = timezone.utcnow()
+    for i in range(40):
+        dag_maker.create_dagrun(
+            run_id=f"run_{i}",
+            logical_date=base + timedelta(seconds=i),
+        )
+
+    dag_maker.sync_dagbag_to_db()
+    session.commit()
+
+    stmt = _list_stmt(dag_id).limit(100)
+
+    # 1 query to fetch dagruns + joined relationships in loader
+    with assert_queries_count(1):
+        runs = session.scalars(stmt).all()
+
+    # Confirm TI/TIH were NOT eager loaded (still NO_VALUE)
+    for dr in runs:
+        insp = sa_inspect(dr)
+        assert insp.attrs.task_instances.loaded_value is NO_VALUE
+        assert insp.attrs.task_instances_histories.loaded_value is NO_VALUE
+
+
+@pytest.mark.usefixtures("configure_git_connection_for_dag_bundle")
+def test_dagrun_list_loader_keeps_access_to_loaded_relationships_bounded(dag_maker, session):
+    """
+    Ensure list loader eager loads only the small relationships needed by response serialization:
+    - dag_model
+    - dag_run_note
+    - created_dag_version (+ bundle)
+    and accessing them does not trigger extra queries.
+    """
+    dag_id = "perf_dagrun_list_bounded"
+
+    with dag_maker(dag_id=dag_id, schedule=None, start_date=timezone.utcnow(), serialized=True):
+        pass
+
+    base = timezone.utcnow()
+    for i in range(40):
+        dag_maker.create_dagrun(
+            run_id=f"run_{i}",
+            logical_date=base + timedelta(seconds=i),
+        )
+
+    dag_maker.sync_dagbag_to_db()
+    session.commit()
+
+    stmt = _list_stmt(dag_id).limit(100)
+
+    with assert_queries_count(1):
+        runs = session.scalars(stmt).all()
+
+    # Accessing these must not emit additional queries.
+    with assert_queries_count(0):
+        for dr in runs:
+            _ = dr.dag_model
+            _ = dr.dag_run_note
+            # created_dag_version can be None depending on how the DagRun was created;
+            # the important bit: if present, bundle access must not query.
+            cdv = dr.created_dag_version
+            if cdv is not None:
+                _ = cdv.bundle


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 https://www.apache.org/licenses/LICENSE-2.0 -->
<!--
Thank you for contributing!

This PR fixes a performance regression in the FastAPI DagRun list endpoints reported in #62025 by avoiding unnecessary relationship loading and preventing N+1 queries during response serialization.

**What changed**
	•	Introduced `eager_load_dag_run_for_list()` to define the minimal, safe eager-loading strategy for listing DagRuns:
	         - eagerly loads dag_model, dag_run_note, and created_dag_version (plus its bundle)
	         - explicitly avoids loading task_instances / task_instances_histories
	•	Updated /dags/{dag_id}/dagRuns and /dags/~/dagRuns/list to use eager_load_dag_run_for_list().
	•	Updated DAGRunResponse serialization to derive dag_versions from the already eagerly-loaded created_dag_version instead of touching DagRun.dag_versions (which is a DB-querying property), eliminating N+1 queries.
	•	Added/updated performance-focused tests to assert bounded query count and ensure list endpoints do not eager load TaskInstance collections.

**Why**
DagRun.dag_versions is implemented as a property that triggers DB access. When listing many DagRuns, serializing dag_versions caused extra queries and degraded performance. This PR ensures list endpoints remain bounded and do not accidentally load large collections.

**Tests**
	•	pytest airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
	•	pytest airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run_list_perf.py

* closes: #62025 
* related: #62027
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
