### PR TITLE
Add PAT authentication support to SnowflakeSqlApiHook

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1427,6 +1427,7 @@ proc
 productionalize
 ProductSearchClient
 profiler
+Programmatic
 programmatically
 proj
 projectId

--- a/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake_sql_api.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake_sql_api.py
@@ -54,10 +54,15 @@ class SnowflakeSqlApiHook(SnowflakeHook):
     In combination with aiohttp, make post request to submit SQL statements for execution,
     poll to check the status of the execution of a statement. Fetch query results asynchronously.
 
-    This hook requires the snowflake_conn_id connection. This hooks mainly uses account, schema, database,
-    warehouse, and an authentication mechanism from one of below:
-    1. JWT Token generated from private_key_file or private_key_content. Other inputs can be defined in the connection or hook instantiation.
-    2. OAuth Token generated from the refresh_token, client_id and client_secret specified in the connection
+    This hook requires the snowflake_conn_id connection. This hook mainly uses account, schema, database,
+    warehouse, and an authentication mechanism from one of the following:
+
+    1. JWT Token generated from ``private_key_file`` or ``private_key_content``. Other inputs can be
+       defined in the connection or hook instantiation.
+    2. OAuth Token generated from the ``refresh_token``, ``client_id`` and ``client_secret`` specified
+       in the connection.
+    3. PAT (Programmatic Access Token): set ``authenticator`` to ``programmatic_access_token`` in the
+       connection extras and put the PAT value in the connection ``password`` field.
 
     :param snowflake_conn_id: Reference to
         :ref:`Snowflake connection id<howto/connection:snowflake>`
@@ -253,7 +258,7 @@ class SnowflakeSqlApiHook(SnowflakeHook):
         return self.query_ids
 
     def get_headers(self) -> dict[str, Any]:
-        """Form auth headers based on either OAuth token or JWT token from private key."""
+        """Form auth headers based on OAuth token, PAT, or JWT token from private key."""
         conn_config = self._get_conn_params()
 
         # Use OAuth if refresh_token and client_id and client_secret are provided
@@ -261,16 +266,31 @@ class SnowflakeSqlApiHook(SnowflakeHook):
             [conn_config.get("refresh_token"), conn_config.get("client_id"), conn_config.get("client_secret")]
         ):
             oauth_token = self.get_oauth_token(conn_config=conn_config)
-            headers = {
+            return {
                 "Content-Type": "application/json",
                 "Authorization": f"Bearer {oauth_token}",
                 "Accept": "application/json",
                 "User-Agent": "snowflakeSQLAPI/1.0",
                 "X-Snowflake-Authorization-Token-Type": "OAUTH",
             }
-            return headers
 
-        # Alternatively, get the JWT token from the connection details and the private key
+        # Use PAT (Programmatic Access Token) when authenticator is set to programmatic_access_token
+        if conn_config.get("authenticator") == "programmatic_access_token":
+            pat = conn_config.get("password")
+            if not pat:
+                raise AirflowException(
+                    "Programmatic Access Token (PAT) authentication requires the connection password "
+                    "field to contain the PAT token value."
+                )
+            return {
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {pat}",
+                "Accept": "application/json",
+                "User-Agent": "snowflakeSQLAPI/1.0",
+                "X-Snowflake-Authorization-Token-Type": "PROGRAMMATIC_ACCESS_TOKEN",
+            }
+
+        # Fall back to JWT token from the connection details and the private key
         if not self.private_key:
             self.get_private_key()
 
@@ -282,14 +302,13 @@ class SnowflakeSqlApiHook(SnowflakeHook):
             renewal_delay=self.token_renewal_delta,
         ).get_token()
 
-        headers = {
+        return {
             "Content-Type": "application/json",
             "Authorization": f"Bearer {token}",
             "Accept": "application/json",
             "User-Agent": "snowflakeSQLAPI/1.0",
             "X-Snowflake-Authorization-Token-Type": "KEYPAIR_JWT",
         }
-        return headers
 
     def get_oauth_token(
         self,

--- a/providers/snowflake/src/airflow/providers/snowflake/operators/snowflake.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/operators/snowflake.py
@@ -292,12 +292,17 @@ class SnowflakeSqlApiOperator(SQLExecuteQueryOperator):
     multiple SQL statements in a single request. It make post request to submit SQL
     statements for execution, poll to check the status of the execution of a statement. Fetch query results
     concurrently.
-    This Operator currently uses key pair authentication, so you need to provide private key raw content or
-    private key file path in the snowflake connection along with other details
+
+    The operator supports the following authentication methods via the Snowflake connection:
+
+    - **Key pair**: provide ``private_key_file`` or ``private_key_content`` in the connection extras.
+    - **OAuth**: provide ``refresh_token``, ``client_id``, and ``client_secret`` in the connection extras.
+    - **Programmatic Access Token (PAT)**: set ``authenticator`` to ``programmatic_access_token`` in
+      the connection extras and put the PAT value in the connection ``password`` field.
 
     .. seealso::
 
-        `Snowflake SQL API key pair Authentication <https://docs.snowflake.com/en/developer-guide/sql-api/authenticating.html#label-sql-api-authenticating-key-pair>`_
+        `Snowflake SQL API Authentication <https://docs.snowflake.com/en/developer-guide/sql-api/authenticating>`_
 
     Where can this operator fit in?
          - To execute multiple SQL statements in a single request

--- a/providers/snowflake/tests/unit/snowflake/hooks/test_snowflake_sql_api.py
+++ b/providers/snowflake/tests/unit/snowflake/hooks/test_snowflake_sql_api.py
@@ -91,6 +91,20 @@ CONN_PARAMS_OAUTH = {
     "warehouse": "af_wh",
 }
 
+CONN_PARAMS_PAT = {
+    "account": "airflow",
+    "application": "AIRFLOW",
+    "authenticator": "programmatic_access_token",
+    "database": "db",
+    "password": "my_pat_token_value",
+    "region": "af_region",
+    "role": "af_role",
+    "schema": "public",
+    "session_parameters": None,
+    "user": "user",
+    "warehouse": "af_wh",
+}
+
 HEADERS = {
     "Content-Type": "application/json",
     "Authorization": "Bearer newT0k3n",
@@ -105,6 +119,14 @@ HEADERS_OAUTH = {
     "Accept": "application/json",
     "User-Agent": "snowflakeSQLAPI/1.0",
     "X-Snowflake-Authorization-Token-Type": "OAUTH",
+}
+
+HEADERS_PAT = {
+    "Content-Type": "application/json",
+    "Authorization": "Bearer my_pat_token_value",
+    "Accept": "application/json",
+    "User-Agent": "snowflakeSQLAPI/1.0",
+    "X-Snowflake-Authorization-Token-Type": "PROGRAMMATIC_ACCESS_TOKEN",
 }
 
 
@@ -484,6 +506,23 @@ class TestSnowflakeSqlApiHook:
         hook = SnowflakeSqlApiHook(snowflake_conn_id="mock_conn_id")
         result = hook.get_headers()
         assert result == HEADERS_OAUTH
+
+    @mock.patch(f"{HOOK_PATH}._get_conn_params")
+    def test_get_headers_should_support_pat(self, mock_conn_param):
+        """Test get_headers returns PROGRAMMATIC_ACCESS_TOKEN headers when authenticator is PAT."""
+        mock_conn_param.return_value = CONN_PARAMS_PAT
+        hook = SnowflakeSqlApiHook(snowflake_conn_id="mock_conn_id")
+        result = hook.get_headers()
+        assert result == HEADERS_PAT
+
+    @mock.patch(f"{HOOK_PATH}._get_conn_params")
+    def test_get_headers_pat_raises_when_password_missing(self, mock_conn_param):
+        """Test get_headers raises AirflowException when PAT authenticator is set but password is empty."""
+        conn_params_pat_no_password = {**CONN_PARAMS_PAT, "password": ""}
+        mock_conn_param.return_value = conn_params_pat_no_password
+        hook = SnowflakeSqlApiHook(snowflake_conn_id="mock_conn_id")
+        with pytest.raises(AirflowException, match="Programmatic Access Token"):
+            hook.get_headers()
 
     @mock.patch("airflow.providers.snowflake.hooks.snowflake.HTTPBasicAuth")
     @mock.patch("requests.post")


### PR DESCRIPTION
## Problem

`SnowflakeSqlApiHook` (and by extension `SnowflakeSqlApiOperator`) had no
authentication path for Snowflake Programmatic Access Tokens (PATs).

This was reported in #62037, where users expected PAT auth to work
consistently across both `SnowflakeHook` (Python connector) and
`SnowflakeSqlApiHook` (REST API).

## Solution

Added a dedicated branch in `SnowflakeSqlApiHook.get_headers()` that:
- Detects `authenticator == "programmatic_access_token"` in the connection config
- Uses the connection `password` field as a `PROGRAMMATIC_ACCESS_TOKEN` bearer token
- Raises `AirflowException` with a clear message if the password field is empty

The auth priority order is preserved: OAuth → PAT → Key Pair JWT.

```
## Connection setup for PAT
conn_type : snowflake
login : <username>
password : <PAT value>
extra : {"account": "...", "authenticator": "programmatic_access_token", ...}
```

## Testing

- Added unit tests for the happy path and the missing-password error case
- Validated end-to-end against a live Snowflake account: both `SnowflakeHook`
  (Python connector, PAT as password) and `SnowflakeSqlApiHook` (SQL REST API,
  PAT bearer token) returned `state=success`

## Migration impact

No breaking changes. Existing Key Pair and OAuth connections are unaffected.

Fixes #62037

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)