### PR TITLE
Add icon support for theme customization

### DIFF
--- a/airflow-core/docs/howto/customize-ui.rst
+++ b/airflow-core/docs/howto/customize-ui.rst
@@ -70,7 +70,7 @@ We can provide a JSON configuration to customize the UI.
 
 .. important::
 
-  - Currently only the ``brand`` color palette and ``globalCss`` can be customized.
+  - You can customize the ``brand`` color palette, ``globalCss`` and the navigation icon via ``icon`` (and ``icon_dark_mode``).
   - You must supply ``50``-``950`` OKLCH color values for ``brand`` color.
   - OKLCH colors must have next format ``oklch(l c h)`` For more info see :ref:`config:api__theme`
   - There is also the ability to provide custom global CSS for a fine grained theme control.
@@ -179,6 +179,45 @@ Dark Mode
       }
     }
   }'
+
+Icon (SVG-only)
+^^^^^^^^^^^^^^^
+
+You can replace the default Airflow icon in the navigation bar by providing an ``icon`` key (and optionally
+``icon_dark_mode`` for dark color mode) in the ``theme`` configuration. The value must be either an absolute
+``http(s)`` URL or an app-relative path starting with ``/``, and must point to an ``.svg`` file.
+
+.. code-block::
+
+  [api]
+
+  theme = {
+      "tokens": {
+        "colors": {
+          "brand": {
+            "50": { "value": "oklch(0.971 0.013 17.38)" },
+            "100": { "value": "oklch(0.936 0.032 17.717)" },
+            "200": { "value": "oklch(0.885 0.062 18.334)" },
+            "300": { "value": "oklch(0.808 0.114 19.571)" },
+            "400": { "value": "oklch(0.704 0.191 22.216)" },
+            "500": { "value": "oklch(0.637 0.237 25.331)" },
+            "600": { "value": "oklch(0.577 0.245 27.325)" },
+            "700": { "value": "oklch(0.505 0.213 27.518)" },
+            "800": { "value": "oklch(0.444 0.177 26.899)" },
+            "900": { "value": "oklch(0.396 0.141 25.723)" },
+            "950": { "value": "oklch(0.258 0.092 26.042)" }
+          }
+        }
+      },
+      "icon": "/static/company-icon.svg",
+      "icon_dark_mode": "/static/company-icon-dark.svg"
+    }
+
+.. note::
+
+  - Only SVG icons are supported.
+  - If the icon fails to load, Airflow falls back to its default icon.
+  - Icon sizing is controlled by the UI and cannot be configured via the theme.
 
 |
 

--- a/airflow-core/src/airflow/api_fastapi/common/types.py
+++ b/airflow-core/src/airflow/api_fastapi/common/types.py
@@ -71,6 +71,28 @@ class TimeDelta(BaseModel):
 TimeDeltaWithValidation = Annotated[TimeDelta, BeforeValidator(_validate_timedelta_field)]
 
 
+# Common validator for theme icon fields (SVG-only, http(s) or app-relative path).
+def _validate_theme_icon(value: str | None) -> str | None:
+    if value is None:
+        return value
+    from urllib.parse import urlparse
+
+    parsed = urlparse(value)
+    if parsed.scheme in ("http", "https"):
+        path = parsed.path or ""
+    elif parsed.scheme == "" and value.startswith("/"):
+        path = value
+    else:
+        raise ValueError("theme.icon must be http(s) URL or app-relative path starting with '/'")
+    if not path.lower().endswith(".svg"):
+        raise ValueError("theme.icon must point to an SVG file (*.svg)")
+    return value
+
+
+# Alias type for theme icon fields with shared validation
+ThemeIconType = Annotated[str | None, BeforeValidator(_validate_theme_icon)]
+
+
 class Mimetype(str, Enum):
     """Mimetype for the `Content-Type` header."""
 
@@ -180,3 +202,5 @@ class Theme(BaseModel):
         ],
     ]
     globalCss: dict[str, dict] | None = None
+    icon: ThemeIconType = None
+    icon_dark_mode: ThemeIconType = None

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -3242,6 +3242,16 @@ components:
             type: object
           - type: 'null'
           title: Globalcss
+        icon:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Icon
+        icon_dark_mode:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Icon Dark Mode
       type: object
       required:
       - tokens

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1480,7 +1480,9 @@ api:
     theme:
       description: |
         JSON config to customize the Chakra UI theme.
-        Currently only supports ``brand`` color customization and ``globalCss``.
+        Supports ``brand`` color customization, ``globalCss``, and optional navigation icons ``icon``
+        (for light mode) and ``icon_dark_mode`` (for dark mode). Icons must be SVG files and can be
+        either absolute http(s) URLs or app-relative paths starting with ``/``.
 
         Must supply ``50``-``950`` OKLCH color values for ``brand`` color.
 

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -8921,6 +8921,28 @@ export const $Theme = {
                 }
             ],
             title: 'Globalcss'
+        },
+        icon: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Icon'
+        },
+        icon_dark_mode: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Icon Dark Mode'
         }
     },
     type: 'object',

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -2207,6 +2207,8 @@ export type Theme = {
         [key: string]: unknown;
     };
 } | null;
+    icon?: string | null;
+    icon_dark_mode?: string | null;
 };
 
 /**

--- a/airflow-core/src/airflow/ui/src/components/Logo.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Logo.tsx
@@ -1,0 +1,54 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import type { ComponentProps } from "react";
+import { useState } from "react";
+
+import { AirflowPin } from "src/assets/AirflowPin";
+import { useColorMode } from "src/context/colorMode";
+import { useConfig } from "src/queries/useConfig";
+
+type LogoProps = ComponentProps<typeof AirflowPin>;
+
+export const Logo = ({ height = "1.5em", width = "1.5em", ...rest }: LogoProps) => {
+  const theme = useConfig("theme") as unknown as { icon?: string; icon_dark_mode?: string } | undefined;
+  const { colorMode } = useColorMode();
+  const darkIcon = theme?.icon_dark_mode ?? undefined;
+  const lightIcon = theme?.icon ?? undefined;
+  const iconSrc = colorMode === "dark" && darkIcon !== undefined ? darkIcon : lightIcon;
+  const hasIconSrc = Boolean(iconSrc);
+  const [failedLoadingCustomIcon, setFailedLoadingCustomIcon] = useState({ dark: false, light: false });
+
+  if (hasIconSrc && colorMode && !failedLoadingCustomIcon[colorMode]) {
+    return (
+      // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
+      <img
+        alt="Logo"
+        onError={() => setFailedLoadingCustomIcon((prev) => ({ ...prev, [colorMode]: true }))}
+        src={iconSrc}
+        // Chakra allows object as 'height' and 'width' but 'img' tag only allows string or number, so we need to check the type before passing it to 'img'
+        style={{
+          height: typeof height === "string" || typeof height === "number" ? height : "1.5em",
+          width: typeof width === "string" || typeof width === "number" ? width : "1.5em",
+        }}
+      />
+    );
+  }
+
+  return <AirflowPin height={height} width={width} {...rest} />;
+};

--- a/airflow-core/src/airflow/ui/src/layouts/BaseLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/BaseLayout.tsx
@@ -32,6 +32,7 @@ export const BaseLayout = ({ children }: PropsWithChildren) => {
   const instanceName = useConfig("instance_name");
   const { i18n } = useTranslation();
   const { data: pluginData } = usePluginServiceGetPlugins();
+  const theme = useConfig("theme") as unknown as { icon?: string; icon_dark_mode?: string } | undefined;
 
   const baseReactPlugins =
     pluginData?.plugins
@@ -58,6 +59,47 @@ export const BaseLayout = ({ children }: PropsWithChildren) => {
       i18n.off("languageChanged", updateHtml);
     };
   }, [i18n]);
+
+  useEffect(() => {
+    const link = document.querySelector<HTMLLinkElement>("link[rel='icon']");
+
+    if (!link) {
+      return undefined;
+    }
+
+    const defaultFavicon = link.href;
+    const darkIcon = theme?.icon_dark_mode;
+    const lightIcon = theme?.icon;
+    // favicon color theme should follow system color scheme, not the one set in Airflow UI.
+    // (tab colors in browsers are based on system color scheme, not the one set in the website)
+    const darkModeQuery = globalThis.matchMedia("(prefers-color-scheme: dark)");
+
+    const updateFavicon = () => {
+      const customIcon =
+        darkModeQuery.matches && typeof darkIcon === "string" && darkIcon.length > 0 ? darkIcon : lightIcon;
+
+      if (typeof customIcon === "string" && customIcon.length > 0) {
+        link.href = customIcon;
+
+        const img = new Image();
+
+        img.addEventListener("error", () => {
+          link.href = defaultFavicon;
+        });
+        img.src = customIcon;
+      } else {
+        link.href = defaultFavicon;
+      }
+    };
+
+    updateFavicon();
+    darkModeQuery.addEventListener("change", updateFavicon);
+
+    return () => {
+      darkModeQuery.removeEventListener("change", updateFavicon);
+      link.href = defaultFavicon;
+    };
+  }, [theme?.icon, theme?.icon_dark_mode]);
 
   return (
     <LocaleProvider locale={i18n.language || "en"}>

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.tsx
@@ -104,12 +104,10 @@ export const Nav = () => {
   const tooltipLabel = getTimezoneTooltipLabel(selectedTimezone);
   const theme = useConfig("theme") as unknown as { icon?: string; icon_dark_mode?: string } | undefined;
   const { colorMode } = useColorMode();
-  // Determine icon sources explicitly to satisfy strict-boolean-expressions
-  const darkIcon: string | undefined =
-    theme && typeof theme.icon_dark_mode === "string" ? theme.icon_dark_mode : undefined;
-  const lightIcon: string | undefined = theme && typeof theme.icon === "string" ? theme.icon : undefined;
-  const iconSrc: string | undefined = colorMode === "dark" && darkIcon !== undefined ? darkIcon : lightIcon;
-  const hasIconSrc = iconSrc !== undefined && iconSrc !== "";
+  const darkIcon = theme?.icon_dark_mode ?? undefined;
+  const lightIcon = theme?.icon ?? undefined;
+  const iconSrc = colorMode === "dark" && darkIcon !== undefined ? darkIcon : lightIcon;
+  const hasIconSrc = Boolean(iconSrc);
 
   // Get both external views and react apps with nav destination
   const navItems: Array<NavItemResponse> =

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.tsx
@@ -17,7 +17,6 @@
  * under the License.
  */
 import { Box, Flex, VStack, useDisclosure } from "@chakra-ui/react";
-import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { FiDatabase, FiHome, FiClock } from "react-icons/fi";
 import { Link } from "react-router-dom";
@@ -28,11 +27,9 @@ import {
   usePluginServiceGetPlugins,
 } from "openapi/queries";
 import type { ExternalViewResponse } from "openapi/requests/types.gen";
-import { AirflowPin } from "src/assets/AirflowPin";
 import { DagIcon } from "src/assets/DagIcon";
-import { useColorMode } from "src/context/colorMode";
+import { Logo } from "src/components/Logo";
 import { useTimezone } from "src/context/timezone";
-import { useConfig } from "src/queries/useConfig";
 import { getTimezoneOffsetString, getTimezoneTooltipLabel } from "src/utils/datetimeUtils";
 import type { NavItemResponse } from "src/utils/types";
 
@@ -103,15 +100,6 @@ export const Nav = () => {
   const { selectedTimezone } = useTimezone();
   const offset = getTimezoneOffsetString(selectedTimezone);
   const tooltipLabel = getTimezoneTooltipLabel(selectedTimezone);
-  const theme = useConfig("theme") as unknown as { icon?: string; icon_dark_mode?: string } | undefined;
-
-  // Custom icons handling
-  const { colorMode } = useColorMode();
-  const darkIcon = theme?.icon_dark_mode ?? undefined;
-  const lightIcon = theme?.icon ?? undefined;
-  const iconSrc = colorMode === "dark" && darkIcon !== undefined ? darkIcon : lightIcon;
-  const hasIconSrc = Boolean(iconSrc);
-  const [failedLoadingCustomIcon, setFailedLoadingCustomIcon] = useState({ dark: false, light: false });
 
   // Get both external views and react apps with nav destination
   const navItems: Array<NavItemResponse> =
@@ -169,25 +157,15 @@ export const Nav = () => {
       <Flex alignItems="center" flexDir="column" gap={1} width="100%">
         <Box alignItems="center" asChild boxSize={14} display="flex" justifyContent="center">
           <Link title={translate("nav.home")} to="/">
-            {hasIconSrc && colorMode && !failedLoadingCustomIcon[colorMode] ? (
-              // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
-              <img
-                alt="Airflow"
-                onError={() => setFailedLoadingCustomIcon((prev) => ({ ...prev, [colorMode]: true }))}
-                src={iconSrc}
-                style={{ height: "2rem", width: "2rem" }}
-              />
-            ) : (
-              <AirflowPin
-                _motionSafe={{
-                  _hover: {
-                    transform: "rotate(360deg)",
-                    transition: "transform 0.8s ease-in-out",
-                  },
-                }}
-                boxSize={8}
-              />
-            )}
+            <Logo
+              _motionSafe={{
+                _hover: {
+                  transform: "rotate(360deg)",
+                  transition: "transform 0.8s ease-in-out",
+                },
+              }}
+              boxSize={8}
+            />
           </Link>
         </Box>
         <NavButton data-testid="nav-home-link" icon={FiHome} title={translate("nav.home")} to="/" />

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.tsx
@@ -29,7 +29,9 @@ import {
 import type { ExternalViewResponse } from "openapi/requests/types.gen";
 import { AirflowPin } from "src/assets/AirflowPin";
 import { DagIcon } from "src/assets/DagIcon";
+import { useColorMode } from "src/context/colorMode";
 import { useTimezone } from "src/context/timezone";
+import { useConfig } from "src/queries/useConfig";
 import { getTimezoneOffsetString, getTimezoneTooltipLabel } from "src/utils/datetimeUtils";
 import type { NavItemResponse } from "src/utils/types";
 
@@ -100,6 +102,14 @@ export const Nav = () => {
   const { selectedTimezone } = useTimezone();
   const offset = getTimezoneOffsetString(selectedTimezone);
   const tooltipLabel = getTimezoneTooltipLabel(selectedTimezone);
+  const theme = useConfig("theme") as unknown as { icon?: string; icon_dark_mode?: string } | undefined;
+  const { colorMode } = useColorMode();
+  // Determine icon sources explicitly to satisfy strict-boolean-expressions
+  const darkIcon: string | undefined =
+    theme && typeof theme.icon_dark_mode === "string" ? theme.icon_dark_mode : undefined;
+  const lightIcon: string | undefined = theme && typeof theme.icon === "string" ? theme.icon : undefined;
+  const iconSrc: string | undefined = colorMode === "dark" && darkIcon !== undefined ? darkIcon : lightIcon;
+  const hasIconSrc = iconSrc !== undefined && iconSrc !== "";
 
   // Get both external views and react apps with nav destination
   const navItems: Array<NavItemResponse> =
@@ -157,15 +167,19 @@ export const Nav = () => {
       <Flex alignItems="center" flexDir="column" gap={1} width="100%">
         <Box alignItems="center" asChild boxSize={14} display="flex" justifyContent="center">
           <Link title={translate("nav.home")} to="/">
-            <AirflowPin
-              _motionSafe={{
-                _hover: {
-                  transform: "rotate(360deg)",
-                  transition: "transform 0.8s ease-in-out",
-                },
-              }}
-              boxSize={8}
-            />
+            {hasIconSrc ? (
+              <img alt="Airflow" src={iconSrc} style={{ height: "2rem", width: "2rem" }} />
+            ) : (
+              <AirflowPin
+                _motionSafe={{
+                  _hover: {
+                    transform: "rotate(360deg)",
+                    transition: "transform 0.8s ease-in-out",
+                  },
+                }}
+                boxSize={8}
+              />
+            )}
           </Link>
         </Box>
         <NavButton data-testid="nav-home-link" icon={FiHome} title={translate("nav.home")} to="/" />

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { Box, Flex, VStack, useDisclosure } from "@chakra-ui/react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { FiDatabase, FiHome, FiClock } from "react-icons/fi";
 import { Link } from "react-router-dom";
@@ -103,11 +104,14 @@ export const Nav = () => {
   const offset = getTimezoneOffsetString(selectedTimezone);
   const tooltipLabel = getTimezoneTooltipLabel(selectedTimezone);
   const theme = useConfig("theme") as unknown as { icon?: string; icon_dark_mode?: string } | undefined;
+
+  // Custom icons handling
   const { colorMode } = useColorMode();
   const darkIcon = theme?.icon_dark_mode ?? undefined;
   const lightIcon = theme?.icon ?? undefined;
   const iconSrc = colorMode === "dark" && darkIcon !== undefined ? darkIcon : lightIcon;
   const hasIconSrc = Boolean(iconSrc);
+  const [failedLoadingCustomIcon, setFailedLoadingCustomIcon] = useState({ dark: false, light: false });
 
   // Get both external views and react apps with nav destination
   const navItems: Array<NavItemResponse> =
@@ -165,8 +169,14 @@ export const Nav = () => {
       <Flex alignItems="center" flexDir="column" gap={1} width="100%">
         <Box alignItems="center" asChild boxSize={14} display="flex" justifyContent="center">
           <Link title={translate("nav.home")} to="/">
-            {hasIconSrc ? (
-              <img alt="Airflow" src={iconSrc} style={{ height: "2rem", width: "2rem" }} />
+            {hasIconSrc && colorMode && !failedLoadingCustomIcon[colorMode] ? (
+              // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
+              <img
+                alt="Airflow"
+                onError={() => setFailedLoadingCustomIcon((prev) => ({ ...prev, [colorMode]: true }))}
+                src={iconSrc}
+                style={{ height: "2rem", width: "2rem" }}
+              />
             ) : (
               <AirflowPin
                 _motionSafe={{

--- a/airflow-core/src/airflow/ui/src/pages/Dag/DagNotFound.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/DagNotFound.tsx
@@ -20,7 +20,7 @@ import { Box, Button, Container, Heading, HStack, Text, VStack } from "@chakra-u
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
-import { AirflowPin } from "src/assets/AirflowPin";
+import { Logo } from "src/components/Logo";
 
 type DagNotFoundProps = {
   readonly dagId: string;
@@ -34,7 +34,7 @@ export const DagNotFound = ({ dagId }: DagNotFoundProps) => {
     <Box alignItems="center" display="flex" justifyContent="center" pt={36} px={4}>
       <Container maxW="lg">
         <VStack gap={8} textAlign="center">
-          <AirflowPin height="50px" width="50px" />
+          <Logo height="50px" width="50px" />
 
           <VStack gap={4}>
             <Heading>404</Heading>

--- a/airflow-core/src/airflow/ui/src/pages/Error.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Error.tsx
@@ -20,7 +20,7 @@ import { Box, VStack, Heading, Text, Button, Container, HStack, Code } from "@ch
 import { useTranslation } from "react-i18next";
 import { useNavigate, useRouteError, isRouteErrorResponse } from "react-router-dom";
 
-import { AirflowPin } from "src/assets/AirflowPin";
+import { Logo } from "src/components/Logo";
 
 export const ErrorPage = () => {
   const navigate = useNavigate();
@@ -51,7 +51,7 @@ export const ErrorPage = () => {
     <Box alignItems="center" display="flex" justifyContent="center" pt={36} px={4}>
       <Container maxW="lg">
         <VStack gap={8} textAlign="center">
-          <AirflowPin height="50px" width="50px" />
+          <Logo height="50px" width="50px" />
 
           <VStack gap={4}>
             <Heading>{statusCode || translate("error.title")}</Heading>

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_config.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_config.py
@@ -51,6 +51,8 @@ THEME = {
             "text-transform": "uppercase",
         },
     },
+    "icon": "/static/custom-logo.svg",
+    "icon_dark_mode": "/static/custom-logo-dark.svg",
 }
 
 expected_config_response = {

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_config.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_config.py
@@ -51,7 +51,7 @@ THEME = {
             "text-transform": "uppercase",
         },
     },
-    "icon": "/static/custom-logo.svg",
+    "icon": "https://somehost.com/static/custom-logo.svg",
     "icon_dark_mode": "/static/custom-logo-dark.svg",
 }
 


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/62088

Navbar icon customization is done through the custom "THEME" configuration targetted for 3.2.0. (not possible via plugins, otherwise multiple plugins can clash trying to set the navbar icon, and this is a core theme customization)

Failure to load one of the icon for a specific theme, will default to basic airflow logo for that theme. (Video below)

Examples with the astronomer logo

### Light theme
<img width="1892" height="681" alt="Screenshot 2026-02-19 at 15 15 04" src="https://github.com/user-attachments/assets/ea974f24-68f1-4817-b3c8-e8b7767a30ca" />

### Zoomed in
<img width="1761" height="822" alt="Screenshot 2026-02-19 at 15 15 20" src="https://github.com/user-attachments/assets/beaeab9c-bb84-4bde-9637-7a1d0d0eeb31" />

### Dark theme
<img width="1906" height="816" alt="Screenshot 2026-02-19 at 15 15 56" src="https://github.com/user-attachments/assets/332ac323-c68b-400a-9275-55b438b668f4" />

### Zoomed in 
<img width="1855" height="896" alt="Screenshot 2026-02-19 at 15 16 19" src="https://github.com/user-attachments/assets/c8d01ae2-9430-416f-87c9-20542d7b2e4f" />


### Failure to load dark icon

https://github.com/user-attachments/assets/b8b5e70f-cabd-44bc-ae39-880539b9afbc


