### PR TITLE
Add overridable metadata engine creation hooks in `settings.py`

### DIFF
--- a/airflow-core/docs/administration-and-deployment/cluster-policies.rst
+++ b/airflow-core/docs/administration-and-deployment/cluster-policies.rst
@@ -185,3 +185,47 @@ Here's an example of re-routing tasks that are on their second (or greater) retr
         :end-before: [END example_task_mutation_hook]
 
 Note that since priority weight is determined dynamically using weight rules, you cannot alter the ``priority_weight`` of a task instance within the mutation hook.
+
+
+Metadata Engine Hooks
+---------------------
+
+In addition to cluster policies, ``airflow_local_settings.py`` can override how Airflow creates its metadata
+database engines. This is useful when you need per-connection logic that cannot be expressed through static
+configuration — for example, injecting short-lived JWT tokens or IAM credentials via a SQLAlchemy
+``do_connect`` event handler.
+
+Two functions can be overridden:
+
+* ``create_metadata_engine(sql_alchemy_conn, *, engine_args, connect_args) -> Engine`` — called by
+  ``configure_orm()`` to create the synchronous metadata engine.
+* ``create_async_metadata_engine(sql_alchemy_conn_async, *, connect_args) -> AsyncEngine`` — called by
+  ``_configure_async_session()`` to create the asynchronous metadata engine.
+
+The default implementations call ``sqlalchemy.create_engine`` / ``sqlalchemy.ext.asyncio.create_async_engine``
+with the same arguments Airflow has always used, so there is **no behavioral change** unless you provide an
+override.
+
+Example: registering a ``do_connect`` handler that refreshes a JWT token before every new physical connection:
+
+.. code-block:: python
+
+    # airflow_local_settings.py
+    from sqlalchemy import create_engine, event
+
+
+    def _refresh_jwt(dbapi_connection, connection_record):
+        """Called before every physical connection (including after pool recycle)."""
+        token = my_token_provider.get_token()
+        dbapi_connection.execute(f"SET SESSION AUTHORIZATION '{token}'")
+
+
+    def create_metadata_engine(sql_alchemy_conn, *, engine_args, connect_args):
+        engine = create_engine(
+            sql_alchemy_conn,
+            connect_args=connect_args,
+            **engine_args,
+            future=True,
+        )
+        event.listen(engine, "do_connect", _refresh_jwt)
+        return engine

--- a/airflow-core/src/airflow/settings.py
+++ b/airflow-core/src/airflow/settings.py
@@ -349,6 +349,44 @@ def _get_connect_args(mode: Literal["sync", "async"]) -> Any:
     return {}
 
 
+def create_metadata_engine(
+    sql_alchemy_conn: str,
+    *,
+    engine_args: dict[str, Any],
+    connect_args: dict[str, Any],
+) -> Engine:
+    """
+    Create the SQLAlchemy Engine for the Airflow metadata database.
+
+    Override in ``airflow_local_settings.py`` to customize engine creation,
+    e.g. to register ``do_connect`` event handlers for token-based authentication.
+    """
+    return create_engine(
+        sql_alchemy_conn,
+        connect_args=connect_args,
+        **engine_args,
+        future=True,
+    )
+
+
+def create_async_metadata_engine(
+    sql_alchemy_conn_async: str,
+    *,
+    connect_args: dict[str, Any],
+) -> AsyncEngine:
+    """
+    Create the async SQLAlchemy Engine for the Airflow metadata database.
+
+    Override in ``airflow_local_settings.py`` to customize async engine creation.
+    For ``do_connect`` handlers, register on ``engine.sync_engine``.
+    """
+    return create_async_engine(
+        sql_alchemy_conn_async,
+        connect_args=connect_args,
+        future=True,
+    )
+
+
 def _configure_async_session() -> None:
     """
     Configure async SQLAlchemy session.
@@ -364,10 +402,9 @@ def _configure_async_session() -> None:
         AsyncSession = None
         return
 
-    async_engine = create_async_engine(
+    async_engine = create_async_metadata_engine(
         SQL_ALCHEMY_CONN_ASYNC,
         connect_args=_get_connect_args("async"),
-        future=True,
     )
     AsyncSession = async_sessionmaker(
         bind=async_engine,
@@ -408,11 +445,10 @@ def configure_orm(disable_connection_pool=False, pool_class=None):
         # to so the `test` thread and the tested endpoints can use common objects.
         connect_args["check_same_thread"] = False
 
-    engine = create_engine(
+    engine = create_metadata_engine(
         SQL_ALCHEMY_CONN,
+        engine_args=engine_args,
         connect_args=connect_args,
-        **engine_args,
-        future=True,
     )
     _configure_async_session()
     mask_secret(engine.url.password)

--- a/airflow-core/tests/unit/core/test_settings.py
+++ b/airflow-core/tests/unit/core/test_settings.py
@@ -248,8 +248,8 @@ class TestMetadataEngineHooks:
         ):
             settings.configure_orm()
 
-        mock_create_engine.assert_called_once()
-        mock_async_session.assert_called_once()
+        assert len(mock_create_engine.mock_calls) == 1
+        assert mock_async_session.mock_calls == [call()]
         call_kwargs = mock_create_engine.call_args
         assert call_kwargs[0][0] == "sqlite://"
         assert "engine_args" in call_kwargs[1]
@@ -280,7 +280,7 @@ class TestMetadataEngineHooks:
         with patch("airflow.settings.SQL_ALCHEMY_CONN_ASYNC", ""):
             settings._configure_async_session()
 
-        mock_create_async_engine.assert_not_called()
+        assert mock_create_async_engine.mock_calls == []
 
     @patch("airflow.settings.create_engine")
     def test_default_create_metadata_engine_forwards_args(self, mock_sa_create_engine):
@@ -293,13 +293,15 @@ class TestMetadataEngineHooks:
 
         settings.create_metadata_engine("sqlite://", engine_args=engine_args, connect_args=connect_args)
 
-        mock_sa_create_engine.assert_called_once_with(
-            "sqlite://",
-            connect_args={"timeout": 30},
-            pool_size=5,
-            pool_recycle=1800,
-            future=True,
-        )
+        assert mock_sa_create_engine.mock_calls == [
+            call(
+                "sqlite://",
+                connect_args={"timeout": 30},
+                pool_size=5,
+                pool_recycle=1800,
+                future=True,
+            )
+        ]
 
     @patch("airflow.settings.create_async_engine")
     def test_default_create_async_metadata_engine_forwards_args(self, mock_sa_create_async):

--- a/airflow-core/tests/unit/core/test_settings.py
+++ b/airflow-core/tests/unit/core/test_settings.py
@@ -216,16 +216,22 @@ class TestMetadataEngineHooks:
 
     def setup_method(self):
         self.old_modules = dict(sys.modules)
+        from airflow import settings
+
+        self._orig_create_metadata_engine = settings.create_metadata_engine
+        self._orig_create_async_metadata_engine = settings.create_async_metadata_engine
 
     def teardown_method(self):
+        from airflow import settings
+
+        settings.create_metadata_engine = self._orig_create_metadata_engine
+        settings.create_async_metadata_engine = self._orig_create_async_metadata_engine
         for mod in [m for m in sys.modules if m not in self.old_modules]:
             del sys.modules[mod]
 
     @patch("airflow.settings.create_metadata_engine")
     @patch("airflow.settings._configure_async_session")
-    def test_configure_orm_delegates_to_create_metadata_engine(
-        self, mock_async_session, mock_create_engine
-    ):
+    def test_configure_orm_delegates_to_create_metadata_engine(self, mock_async_session, mock_create_engine):
         """configure_orm() must call create_metadata_engine, not create_engine directly."""
         from airflow import settings
 
@@ -285,9 +291,7 @@ class TestMetadataEngineHooks:
         engine_args = {"pool_size": 5, "pool_recycle": 1800}
         connect_args = {"timeout": 30}
 
-        settings.create_metadata_engine(
-            "sqlite://", engine_args=engine_args, connect_args=connect_args
-        )
+        settings.create_metadata_engine("sqlite://", engine_args=engine_args, connect_args=connect_args)
 
         mock_sa_create_engine.assert_called_once_with(
             "sqlite://",
@@ -305,9 +309,7 @@ class TestMetadataEngineHooks:
         mock_sa_create_async.return_value = MagicMock()
         connect_args = {"timeout": 30}
 
-        settings.create_async_metadata_engine(
-            "sqlite+aiosqlite://", connect_args=connect_args
-        )
+        settings.create_async_metadata_engine("sqlite+aiosqlite://", connect_args=connect_args)
 
         mock_sa_create_async.assert_called_once_with(
             "sqlite+aiosqlite://",
@@ -329,9 +331,7 @@ class TestMetadataEngineHooks:
             assert not airflow_local_settings._engine_created
 
             # Actually call the override and verify it runs the custom code
-            engine = settings.create_metadata_engine(
-                "sqlite://", engine_args={}, connect_args={}
-            )
+            engine = settings.create_metadata_engine("sqlite://", engine_args={}, connect_args={})
             assert airflow_local_settings._engine_created
             assert engine is not None
 

--- a/airflow-core/tests/unit/core/test_settings.py
+++ b/airflow-core/tests/unit/core/test_settings.py
@@ -28,6 +28,21 @@ import pytest
 
 from airflow.exceptions import AirflowClusterPolicyViolation, AirflowConfigException
 
+SETTINGS_FILE_CUSTOM_ENGINE = """
+from sqlalchemy import create_engine, event
+
+_engine_created = False
+
+def create_metadata_engine(sql_alchemy_conn, *, engine_args, connect_args):
+    global _engine_created
+    _engine_created = True
+    engine = create_engine(
+        sql_alchemy_conn, connect_args=connect_args, **engine_args, future=True,
+    )
+    event.listen(engine, "do_connect", lambda *a, **kw: None)
+    return engine
+"""
+
 SETTINGS_FILE_POLICY = """
 def test_policy(task_instance):
     task_instance.run_as_user = "myself"
@@ -194,6 +209,131 @@ class TestLocalSettings:
             task_instance.owner = "airflow"
             with pytest.raises(AirflowClusterPolicyViolation):
                 settings.task_must_have_owners(task_instance)
+
+
+class TestMetadataEngineHooks:
+    """Tests for the overridable create_metadata_engine / create_async_metadata_engine hooks."""
+
+    def setup_method(self):
+        self.old_modules = dict(sys.modules)
+
+    def teardown_method(self):
+        for mod in [m for m in sys.modules if m not in self.old_modules]:
+            del sys.modules[mod]
+
+    @patch("airflow.settings.create_metadata_engine")
+    @patch("airflow.settings._configure_async_session")
+    def test_configure_orm_delegates_to_create_metadata_engine(
+        self, mock_async_session, mock_create_engine
+    ):
+        """configure_orm() must call create_metadata_engine, not create_engine directly."""
+        from airflow import settings
+
+        mock_create_engine.return_value = MagicMock()
+
+        with (
+            patch("os.environ", {"_AIRFLOW_SKIP_DB_TESTS": "false"}),
+            patch("airflow.settings.SQL_ALCHEMY_CONN", "sqlite://"),
+            patch("airflow.settings.Session"),
+            patch("airflow.settings.engine"),
+            patch("airflow.settings.setup_event_handlers"),
+            patch("airflow.settings.mask_secret", create=True),
+            patch("airflow._shared.secrets_masker.mask_secret"),
+        ):
+            settings.configure_orm()
+
+        mock_create_engine.assert_called_once()
+        mock_async_session.assert_called_once()
+        call_kwargs = mock_create_engine.call_args
+        assert call_kwargs[0][0] == "sqlite://"
+        assert "engine_args" in call_kwargs[1]
+        assert "connect_args" in call_kwargs[1]
+
+    @patch("airflow.settings.create_async_metadata_engine")
+    def test_configure_async_session_delegates_to_create_async_metadata_engine(
+        self, mock_create_async_engine
+    ):
+        """_configure_async_session() must call create_async_metadata_engine."""
+        from airflow import settings
+
+        mock_create_async_engine.return_value = MagicMock()
+
+        with patch("airflow.settings.SQL_ALCHEMY_CONN_ASYNC", "sqlite+aiosqlite://"):
+            settings._configure_async_session()
+
+        mock_create_async_engine.assert_called_once()
+        call_kwargs = mock_create_async_engine.call_args
+        assert call_kwargs[0][0] == "sqlite+aiosqlite://"
+        assert "connect_args" in call_kwargs[1]
+
+    @patch("airflow.settings.create_async_metadata_engine")
+    def test_configure_async_session_skips_when_no_async_conn(self, mock_create_async_engine):
+        """_configure_async_session() must not call the hook when SQL_ALCHEMY_CONN_ASYNC is empty."""
+        from airflow import settings
+
+        with patch("airflow.settings.SQL_ALCHEMY_CONN_ASYNC", ""):
+            settings._configure_async_session()
+
+        mock_create_async_engine.assert_not_called()
+
+    @patch("airflow.settings.create_engine")
+    def test_default_create_metadata_engine_forwards_args(self, mock_sa_create_engine):
+        """Default create_metadata_engine must forward all args to sqlalchemy.create_engine."""
+        from airflow import settings
+
+        mock_sa_create_engine.return_value = MagicMock()
+        engine_args = {"pool_size": 5, "pool_recycle": 1800}
+        connect_args = {"timeout": 30}
+
+        settings.create_metadata_engine(
+            "sqlite://", engine_args=engine_args, connect_args=connect_args
+        )
+
+        mock_sa_create_engine.assert_called_once_with(
+            "sqlite://",
+            connect_args={"timeout": 30},
+            pool_size=5,
+            pool_recycle=1800,
+            future=True,
+        )
+
+    @patch("airflow.settings.create_async_engine")
+    def test_default_create_async_metadata_engine_forwards_args(self, mock_sa_create_async):
+        """Default create_async_metadata_engine must forward args to sqlalchemy.create_async_engine."""
+        from airflow import settings
+
+        mock_sa_create_async.return_value = MagicMock()
+        connect_args = {"timeout": 30}
+
+        settings.create_async_metadata_engine(
+            "sqlite+aiosqlite://", connect_args=connect_args
+        )
+
+        mock_sa_create_async.assert_called_once_with(
+            "sqlite+aiosqlite://",
+            connect_args={"timeout": 30},
+            future=True,
+        )
+
+    def test_override_via_local_settings(self):
+        """An override in airflow_local_settings.py replaces the default create_metadata_engine."""
+        with SettingsContext(SETTINGS_FILE_CUSTOM_ENGINE, "airflow_local_settings"):
+            from airflow import settings
+
+            settings.import_local_settings()
+
+            import airflow_local_settings
+
+            # Verify the override is wired in
+            assert settings.create_metadata_engine is airflow_local_settings.create_metadata_engine
+            assert not airflow_local_settings._engine_created
+
+            # Actually call the override and verify it runs the custom code
+            engine = settings.create_metadata_engine(
+                "sqlite://", engine_args={}, connect_args={}
+            )
+            assert airflow_local_settings._engine_created
+            assert engine is not None
 
 
 _local_db_path_error = pytest.raises(AirflowConfigException, match=r"Cannot use relative path:")


### PR DESCRIPTION
## Summary

Add `create_metadata_engine()` and `create_async_metadata_engine()` as overridable module-level functions in `settings.py`, following the same pattern as `task_policy` / `dag_policy`.

`configure_orm()` and `_configure_async_session()` now call these hooks instead of `create_engine()` / `create_async_engine()` directly. Users can override them in `airflow_local_settings.py`.

## Motivation

Some deployments need to customize how Airflow creates its metadata database engine — for example, to register SQLAlchemy `do_connect` event handlers for per-connection authentication (JWT token injection, IAM auth, etc.).

Today there is no way to do this without patching `settings.py` at build time. Existing config options don't help:

| Option | Why it doesn't work |
|---|---|
| `sql_alchemy_conn_cmd` | Runs once at startup. Pool recycling reuses the same connection string, so short-lived tokens (e.g. 4h JWT) expire and new connections fail. |
| `sql_alchemy_connect_args` | Static dict passed to `create_engine()`. Not a per-connection callback. |

The SQLAlchemy `do_connect` event fires before every physical connection (including after pool recycle), which is the right hook point. But registering it requires access to the engine object during creation — hence the need for an overridable factory function.

## What changed

Two new functions in `settings.py`:

```python
def create_metadata_engine(sql_alchemy_conn, *, engine_args, connect_args) -> Engine
def create_async_metadata_engine(sql_alchemy_conn_async, *, connect_args) -> AsyncEngine
```

Default implementations call `create_engine()` / `create_async_engine()` with identical arguments as before — **zero behavioral change** when no override is provided.

### Example override in `airflow_local_settings.py`

```python
from sqlalchemy import create_engine, event

def create_metadata_engine(sql_alchemy_conn, *, engine_args, connect_args):
    engine = create_engine(
        sql_alchemy_conn, connect_args=connect_args, **engine_args, future=True,
    )
    event.listen(engine, "do_connect", my_jwt_injector)
    return engine
```

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
