### PR TITLE
Add documentation for using kerberos with HttpOperator

### DIFF
--- a/providers/http/docs/howto/index.rst
+++ b/providers/http/docs/howto/index.rst
@@ -1,0 +1,26 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Working with Auth Types
+=======================
+
+This section gives examples on how to work with different types of authentication
+objects in your HTTP request.
+
+.. toctree::
+    :maxdepth: 1
+    kerberos/example

--- a/providers/http/docs/howto/kerberos/example.rst
+++ b/providers/http/docs/howto/kerberos/example.rst
@@ -1,0 +1,20 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Kerberos Authentication
+=======================
+

--- a/providers/http/docs/howto/kerberos/example_dag.py
+++ b/providers/http/docs/howto/kerberos/example_dag.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import logging
+from typing import List
+import os
+import subprocess
+
+from requests_kerberos import HTTPKerberosAuth, OPTIONAL
+
+from airflow.security.kerberos import renew_from_kt
+
+from airflow.providers.common.compat.sdk import DAG
+from airflow.providers.http.operators.http import HttpOperator
+
+PRINCIPAL_DOMAIN = "{login}@EXAMPLE.COM"
+
+KEYTAB_PATH = "/tmp/{conn_id}.keytab"
+
+KTUTIL_CMD = 'echo -e "add_entry -password -p {principal} -k 1 -e aes256-cts\\n{password}\\nwkt {keytab_path}" | ktutil \\\n&& echo -e "read_kt {keytab_path}\nlist" | ktutil && echo -e ""'
+
+logger = logging.getLogger(__name__)
+
+def _kerberos_auth_type(principal: str):
+    """
+    Workaround to pass in parameters to HttpHook session auth
+    """
+    def _inner_auth_type(*args, **kwargs):
+        return HTTPKerberosAuth(principal=principal,mutual_authentication=OPTIONAL)
+    
+    return _inner_auth_type
+
+def make_keytab(context):
+    """
+    Create a keytab from a username and password using ktutil
+    
+    :param context: Airflow task context
+    """
+    conn_id = context["task"].http_conn_id
+    keytab = KEYTAB_PATH.format(conn_id=conn_id)
+
+    if not os.path.exists(keytab):
+        logger.info(f"Creating {keytab=}")
+        conn = getattr(context["conn"],conn_id)
+    
+        principal = PRINCIPAL_DOMAIN.format(login=conn.login)
+
+        ktutil_cmd = KTUTIL_CMD.format(principal=principal, password=conn.password, keytab_path=keytab)
+
+        ktutil = subprocess.run(["bash", "-c", ktutil_cmd], stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
+        return_code, stdout, stderr = ktutil.returncode, ktutil.stdout.decode(), ktutil.stderr.decode()
+        if return_code != 0:
+            raise RuntimeError(f"Failed to create keytab:\nstdout: {stdout}\nstderr: {stderr}")
+
+
+
+def reinit_kerberos(context):
+    """
+    Run kinit to setup Kerberos authentication
+
+    :param context: Airflow task context
+    """
+
+    task = context["task"]
+    conn_id = task.http_conn_id
+    keytab = KEYTAB_PATH.format(conn_id=conn_id)
+    conn = getattr(context["conn"],conn_id)
+    principal = PRINCIPAL_DOMAIN.format(login=conn.login)
+    renew_from_kt(principal,keytab)
+    task.auth_type = _kerberos_auth_type(principal)
+
+def make_http_kerberos_task(task_id:str,http_conn_id:str = "http_default", endpoint:str = "/", create_keytab=True, **kwargs):
+    """
+    Create a HttpOperator using kerberos authentication.
+
+    :param task_id: task id
+    :param http_conn_id: Http connection to use
+    :param endpoint: Operator endpoint
+    :param create_keytab: Enables creating a keytab from user credentials.
+    """
+    callbacks = kwargs.pop("on_execute_callback",[])
+    if not isinstance(callbacks,List):
+        callbacks = [callbacks]
+
+    if create_keytab:
+        callbacks.append(make_keytab)
+    callbacks.append(reinit_kerberos)
+
+    return HttpOperator(
+        task_id=task_id,
+        http_conn_id=http_conn_id,
+        endpoint=endpoint,
+        on_execute_callback=callbacks,
+        **kwargs,
+        )
+
+with DAG(dag_id="kerberos_http"):
+    http_task = make_http_kerberos_task(task_id="kerberos_request")


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)
- [x] No

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

adds an example of the HttpOperator using kerberos authentication to the provider docs
closes: #60991
