### PR TITLE
Bump minimum prek version to 0.3.2 in edge3 provider

### DIFF
--- a/providers/edge3/.pre-commit-config.yaml
+++ b/providers/edge3/.pre-commit-config.yaml
@@ -16,7 +16,7 @@
 # under the License.
 ---
 default_stages: [pre-commit, pre-push]
-minimum_prek_version: '0.2.0'
+minimum_prek_version: '0.3.2'
 default_language_version:
   python: python3
   node: 22.19.0


### PR DESCRIPTION
 prek version in edge needs a bump 