### PR TITLE
Fix stale doc link in `check_system_tests.py`

### DIFF
--- a/scripts/ci/prek/check_system_tests.py
+++ b/scripts/ci/prek/check_system_tests.py
@@ -46,7 +46,7 @@ WATCHER_APPEND_INSTRUCTION_SHORT = " >> watcher()"
 PYTEST_FUNCTION = """
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)
 """
 PYTEST_FUNCTION_PATTERN = re.compile(


### PR DESCRIPTION
Hi folks,

While working on another issue, I noticed a stale link in `scripts/ci/prek/check_system_tests.py`.

It referenced `tests/system/README.md#run_via_pytest` which no longer exists after Airflow 3. The system test documentation has been moved to `contributing-docs/testing/system_tests.rst`.

This PR updates the link to the correct location.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] No (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
