### PR TITLE
docs: Add external_db_managers configuration requirement

### DIFF
--- a/providers/edge3/docs/deployment.rst
+++ b/providers/edge3/docs/deployment.rst
@@ -66,6 +66,41 @@ Minimum Airflow configuration settings for the Edge Worker to make it running is
   - ``api_url``: Must be set to the URL which exposes the api endpoint as it is reachable from the
     worker. Typically this looks like ``https://your-hostname-and-port/edge_worker/v1/rpcapi``.
 
+The following setting is required on the **central Airflow instance** (not the edge worker node)
+so that edge3 database tables (``edge_worker``, ``edge_job``, ``edge_logs``) are created and
+migrated when running ``airflow db migrate``:
+
+- Section ``[database]``
+
+  - ``external_db_managers``: Must include ``airflow.providers.edge3.models.db.EdgeDBManager``.
+
+    .. code-block:: ini
+
+        [database]
+        external_db_managers = airflow.providers.edge3.models.db.EdgeDBManager
+
+    Or via environment variable:
+
+    .. code-block:: bash
+
+        export AIRFLOW__DATABASE__EXTERNAL_DB_MANAGERS="airflow.providers.edge3.models.db.EdgeDBManager"
+
+    .. note::
+
+        If you are also using ``FabAuthManager``, include both managers as a comma-separated list:
+
+        .. code-block:: ini
+
+            [database]
+            external_db_managers = airflow.providers.fab.auth_manager.models.db.FABDBManager,airflow.providers.edge3.models.db.EdgeDBManager
+
+After configuring ``external_db_managers``, run the following on the central Airflow instance
+to apply the edge3 schema migrations:
+
+.. code-block:: bash
+
+    airflow db migrate
+
 To kick off a worker, you need to setup Airflow and kick off the worker
 subcommand
 


### PR DESCRIPTION
Document that the central Airflow instance must register EdgeDBManager
via AIRFLOW__DATABASE__EXTERNAL_DB_MANAGERS so that edge3 tables are
created and migrated on airflow db migrate.
