### PR TITLE
Warn when EdgeDBManager is missing from external_db_managers in config

### DIFF
--- a/providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py
+++ b/providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py
@@ -29,7 +29,7 @@ from airflow.executors import workloads
 from airflow.executors.base_executor import BaseExecutor
 from airflow.models.taskinstance import TaskInstance
 from airflow.providers.common.compat.sdk import Stats, timezone
-from airflow.providers.edge3.models.db import EdgeDBManager
+from airflow.providers.edge3.models.db import EdgeDBManager, check_db_manager_config
 from airflow.providers.edge3.models.edge_job import EdgeJobModel
 from airflow.providers.edge3.models.edge_logs import EdgeLogsModel
 from airflow.providers.edge3.models.edge_worker import EdgeWorkerModel, EdgeWorkerState, reset_metrics
@@ -62,6 +62,7 @@ class EdgeExecutor(BaseExecutor):
     @provide_session
     def start(self, session: Session = NEW_SESSION):
         """If EdgeExecutor provider is loaded first time, ensure table exists."""
+        check_db_manager_config()
         edge_db_manager = EdgeDBManager(session)
         if edge_db_manager.check_migration():
             return

--- a/providers/edge3/src/airflow/providers/edge3/models/db.py
+++ b/providers/edge3/src/airflow/providers/edge3/models/db.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 
 from sqlalchemy import inspect
@@ -26,11 +27,35 @@ from airflow.providers.edge3.models.edge_logs import EdgeLogsModel
 from airflow.providers.edge3.models.edge_worker import EdgeWorkerModel
 from airflow.utils.db_manager import BaseDBManager
 
+EDGE_DB_MANAGER_FQDN = "airflow.providers.edge3.models.db.EdgeDBManager"
+
 PACKAGE_DIR = Path(__file__).parents[1]
 
 _REVISION_HEADS_MAP: dict[str, str] = {
     "3.0.0": "9d34dfc2de06",
 }
+
+
+def check_db_manager_config() -> None:
+    """
+    Warn if EdgeDBManager is not registered in the external_db_managers config.
+
+    Should be called whenever the edge3 provider is active so operators are alerted
+    early if the required database configuration is missing.
+    """
+    from airflow.configuration import conf
+
+    configured = conf.get("database", "external_db_managers", fallback="")
+    registered = [m.strip() for m in configured.split(",") if m.strip()]
+    if EDGE_DB_MANAGER_FQDN not in registered:
+        warnings.warn(
+            f"EdgeDBManager is not configured. Add '{EDGE_DB_MANAGER_FQDN}' to "
+            f"AIRFLOW__DATABASE__EXTERNAL_DB_MANAGERS (the 'external_db_managers' option "
+            f"in the [database] section). Without this, edge3 database tables will not be "
+            f"managed through the standard Airflow migration process.",
+            UserWarning,
+            stacklevel=2,
+        )
 
 
 class EdgeDBManager(BaseDBManager):

--- a/providers/edge3/src/airflow/providers/edge3/models/db.py
+++ b/providers/edge3/src/airflow/providers/edge3/models/db.py
@@ -27,35 +27,11 @@ from airflow.providers.edge3.models.edge_logs import EdgeLogsModel
 from airflow.providers.edge3.models.edge_worker import EdgeWorkerModel
 from airflow.utils.db_manager import BaseDBManager
 
-EDGE_DB_MANAGER_FQDN = "airflow.providers.edge3.models.db.EdgeDBManager"
-
 PACKAGE_DIR = Path(__file__).parents[1]
 
 _REVISION_HEADS_MAP: dict[str, str] = {
     "3.0.0": "9d34dfc2de06",
 }
-
-
-def check_db_manager_config() -> None:
-    """
-    Warn if EdgeDBManager is not registered in the external_db_managers config.
-
-    Should be called whenever the edge3 provider is active so operators are alerted
-    early if the required database configuration is missing.
-    """
-    from airflow.configuration import conf
-
-    configured = conf.get("database", "external_db_managers", fallback="")
-    registered = [m.strip() for m in configured.split(",") if m.strip()]
-    if EDGE_DB_MANAGER_FQDN not in registered:
-        warnings.warn(
-            f"EdgeDBManager is not configured. Add '{EDGE_DB_MANAGER_FQDN}' to "
-            f"AIRFLOW__DATABASE__EXTERNAL_DB_MANAGERS (the 'external_db_managers' option "
-            f"in the [database] section). Without this, edge3 database tables will not be "
-            f"managed through the standard Airflow migration process.",
-            UserWarning,
-            stacklevel=2,
-        )
 
 
 class EdgeDBManager(BaseDBManager):
@@ -91,3 +67,26 @@ class EdgeDBManager(BaseDBManager):
         if inspector.has_table(version.name):
             self.log.info("Dropping version table %s", version.name)
             version.drop(connection)
+
+
+def check_db_manager_config() -> None:
+    """
+    Warn if EdgeDBManager is not registered in the external_db_managers config.
+
+    Should be called whenever the edge3 provider is active so operators are alerted
+    early if the required database configuration is missing.
+    """
+    from airflow.configuration import conf
+
+    fqcn = f"{EdgeDBManager.__module__}.{EdgeDBManager.__name__}"
+    configured = conf.get("database", "external_db_managers", fallback="")
+    registered = [m.strip() for m in configured.split(",") if m.strip()]
+    if fqcn not in registered:
+        warnings.warn(
+            f"EdgeDBManager is not configured. Add '{fqcn}' to "
+            f"AIRFLOW__DATABASE__EXTERNAL_DB_MANAGERS (the 'external_db_managers' option "
+            f"in the [database] section). Without this, edge3 database tables will not be "
+            f"managed through the standard Airflow migration process.",
+            UserWarning,
+            stacklevel=2,
+        )

--- a/providers/edge3/src/airflow/providers/edge3/plugins/edge_executor_plugin.py
+++ b/providers/edge3/src/airflow/providers/edge3/plugins/edge_executor_plugin.py
@@ -60,6 +60,11 @@ try:
 except AirflowConfigException:
     EDGE_EXECUTOR_ACTIVE = False
 
+if EDGE_EXECUTOR_ACTIVE:
+    from airflow.providers.edge3.models.db import check_db_manager_config
+
+    check_db_manager_config()
+
 # Load the API endpoint only on api-server
 # TODO(jscheffl): Remove this check when the discussion in
 #                 https://lists.apache.org/thread/w170czq6r7bslkqp1tk6bjjjo0789wgl

--- a/providers/edge3/tests/unit/edge3/models/test_db.py
+++ b/providers/edge3/tests/unit/edge3/models/test_db.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import warnings
 from unittest import mock
 
 import pytest
@@ -239,3 +240,53 @@ class TestEdgeDBManager:
                 # The drop method should not be called on any table
                 # We check this by ensuring has_table was called but drop was not
                 assert mock_inspector.has_table.called
+
+
+class TestCheckDbManagerConfig:
+    """Test check_db_manager_config warning helper."""
+
+    pytestmark = []  # no db_test needed — purely config-based
+
+    def test_warns_when_not_configured(self):
+        """Warning is emitted when EdgeDBManager is absent from external_db_managers."""
+        from airflow.providers.edge3.models.db import check_db_manager_config
+
+        with conf_vars({("database", "external_db_managers"): ""}):
+            with pytest.warns(UserWarning, match="EdgeDBManager is not configured"):
+                check_db_manager_config()
+
+    def test_warns_when_other_manager_configured(self):
+        """Warning is emitted when a different manager is configured but not EdgeDBManager."""
+        from airflow.providers.edge3.models.db import check_db_manager_config
+
+        with conf_vars({("database", "external_db_managers"): "some.other.DBManager"}):
+            with pytest.warns(UserWarning, match="EdgeDBManager is not configured"):
+                check_db_manager_config()
+
+    def test_no_warn_when_configured(self):
+        """No warning when EdgeDBManager is properly configured."""
+        from airflow.providers.edge3.models.db import check_db_manager_config
+
+        with conf_vars(
+            {
+                ("database", "external_db_managers"): "airflow.providers.edge3.models.db.EdgeDBManager",
+            }
+        ):
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                check_db_manager_config()  # must not raise
+
+    def test_no_warn_when_configured_among_multiple(self):
+        """No warning when EdgeDBManager appears alongside other managers."""
+        from airflow.providers.edge3.models.db import check_db_manager_config
+
+        with conf_vars(
+            {
+                ("database", "external_db_managers"): (
+                    "some.other.DBManager,airflow.providers.edge3.models.db.EdgeDBManager"
+                ),
+            }
+        ):
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                check_db_manager_config()  # must not raise

--- a/providers/edge3/tests/unit/edge3/models/test_db.py
+++ b/providers/edge3/tests/unit/edge3/models/test_db.py
@@ -245,7 +245,7 @@ class TestEdgeDBManager:
 class TestCheckDbManagerConfig:
     """Test check_db_manager_config warning helper."""
 
-    pytestmark = []  # no db_test needed — purely config-based
+    pytestmark: list = []  # no db_test needed — purely config-based
 
     def test_warns_when_not_configured(self):
         """Warning is emitted when EdgeDBManager is absent from external_db_managers."""


### PR DESCRIPTION
When the edge3 provider is active but AIRFLOW__DATABASE__EXTERNAL_DB_MANAGERS
is not configured with EdgeDBManager, database tables will not be managed
through the standard Airflow migration process. This adds an early UserWarning
at both startup paths (api-server via the plugin, scheduler via EdgeExecutor.start)
to surface this misconfiguration clearly 

<img width="2938" height="628" alt="image" src="https://github.com/user-attachments/assets/6df828e1-d6c1-4255-9b26-e62be5a07d91" />


