### PR TITLE
add gc.freeze to minimize memory usage in celery worker

### DIFF
--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
@@ -23,6 +23,7 @@ Much of this code is expensive to import/load, be careful where this module is i
 from __future__ import annotations
 
 import contextlib
+import gc
 import logging
 import math
 import os
@@ -37,7 +38,7 @@ from typing import TYPE_CHECKING, Any
 from celery import Celery, states as celery_states
 from celery.backends.base import BaseKeyValueStoreBackend
 from celery.backends.database import DatabaseBackend, Task as TaskDb, retry, session_cleanup
-from celery.signals import import_modules as celery_import_modules
+from celery.signals import import_modules as celery_import_modules, worker_ready
 from sqlalchemy import select
 
 from airflow.configuration import AirflowConfigParser, conf
@@ -165,6 +166,15 @@ def on_celery_import_modules(*args, **kwargs):
 
     with contextlib.suppress(ImportError):
         import kubernetes.client  # noqa: F401
+
+    # To prevent memory increase by COW in celery's ForkPoolWorker.
+    gc.freeze()
+
+
+@worker_ready.connect
+def on_celery_worker_ready(*args, **kwargs):
+    # Unfreeze the objects from gc freeze when the ForkPoolWorker is all loaded.
+    gc.unfreeze()
 
 
 # Once Celery 5.5 is out of beta, we can pass `pydantic=True` to the decorator and it will handle the validation


### PR DESCRIPTION
discuss: https://lists.apache.org/thread/33hdp3hm705mzgrltv7o3468wvwbjsr3
related: https://github.com/apache/airflow/pull/60505, https://github.com/apache/airflow/pull/60505

### Body

In a Celery worker, the Celery Main Process runs by default, and 16 ForkPoolWorkers are created as sub-processes of that process (based on default settings).

It operates based on COW (Copy-On-Write), which is the default memory behavior of fork, and through this, heavy modules (numpy, k8s) are [pre-loaded](https://github.com/apache/airflow/blob/main/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py#L163). However, it was observed that as soon as ForkPoolWorkers are created, they have a higher PSS than the Main Process, confirming that memory increased due to COW.

As with other PRs, `gc.freeze` was applied, and it was confirmed that memory usage per process was reduced to less than half.

### Benchmark

This test is a memory snapshot of celery worker container taken after 10 hours have elapsed when 100 tasks per minute were executed every minute, deploying with Docker 

#### AS-IS (docker image 3.1.7)
<img width="350" height="250" alt="image" src="https://github.com/user-attachments/assets/b95ad62c-ac1d-4c9b-a55e-410c8355b998" />


#### TO-BE (apply with gc.freeze)
<img width="350" height="250" alt="image" src="https://github.com/user-attachments/assets/933f6614-01e7-49a0-b8f2-c638d88fe6f3" />



 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
