### PR TITLE
Fix race condition in auth manager initialization

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/app.py
+++ b/airflow-core/src/airflow/api_fastapi/app.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 from contextlib import AsyncExitStack, asynccontextmanager
 from functools import cache
 from typing import TYPE_CHECKING
@@ -57,6 +58,7 @@ log = logging.getLogger(__name__)
 
 class _AuthManagerState:
     instance: BaseAuthManager | None = None
+    _lock = threading.Lock()
 
 
 @asynccontextmanager
@@ -137,8 +139,11 @@ def get_auth_manager_cls() -> type[BaseAuthManager]:
 
 def create_auth_manager() -> BaseAuthManager:
     """Create the auth manager."""
-    auth_manager_cls = get_auth_manager_cls()
-    _AuthManagerState.instance = auth_manager_cls()
+    if _AuthManagerState.instance is None:
+        with _AuthManagerState._lock:
+            if _AuthManagerState.instance is None:
+                auth_manager_cls = get_auth_manager_cls()
+                _AuthManagerState.instance = auth_manager_cls()
     return _AuthManagerState.instance
 
 

--- a/airflow-core/tests/unit/api_fastapi/test_app.py
+++ b/airflow-core/tests/unit/api_fastapi/test_app.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import threading
 from unittest import mock
 
 import pytest
@@ -118,3 +119,31 @@ def test_plugin_with_invalid_url_prefix(caplog, fastapi_apps, expected_message, 
 
     assert any(expected_message in rec.message for rec in caplog.records)
     assert not any(r.path == invalid_path for r in app.routes)
+
+
+def test_create_auth_manager_thread_safety():
+    """Concurrent calls to create_auth_manager must return the same singleton instance."""
+    mock_instance = mock.MagicMock()
+    mock_cls = mock.MagicMock(return_value=mock_instance)
+
+    app_module.purge_cached_app()
+
+    results = []
+    barrier = threading.Barrier(10)
+
+    def call_create_auth_manager():
+        barrier.wait()
+        results.append(app_module.create_auth_manager())
+
+    with mock.patch.object(app_module, "get_auth_manager_cls", return_value=mock_cls):
+        threads = [threading.Thread(target=call_create_auth_manager) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+    assert len(results) == 10
+    assert all(r is mock_instance for r in results)
+    mock_cls.assert_called_once()
+
+    app_module.purge_cached_app()


### PR DESCRIPTION
Closes #61108

### Problem

When sending concurrent requests to `/auth/token`, intermittent 500 errors occur:

```
AttributeError: 'AirflowAppBuilder' object has no attribute 'sm'
```

`create_auth_manager()` creates a new instance on every call without checking for an existing one. Under concurrent requests, one thread can overwrite `_AuthManagerState.instance` while another thread's instance is still being initialized via `init()`, resulting in an uninitialized auth manager being served.

### Fix

Apply double-checked locking in `create_auth_manager()` so the auth manager is created exactly once:

```python
def create_auth_manager() -> BaseAuthManager:
    if _AuthManagerState.instance is None:
        with _AuthManagerState._lock:
            if _AuthManagerState.instance is None:
                auth_manager_cls = get_auth_manager_cls()
                _AuthManagerState.instance = auth_manager_cls()
    return _AuthManagerState.instance
```

The first check avoids lock overhead on subsequent calls. The second check (inside the lock) prevents duplicate creation when multiple threads pass the first check simultaneously.

### What's changed

- `airflow-core/src/airflow/api_fastapi/app.py`: Added `threading.Lock` to `_AuthManagerState` and guarded instance creation with double-checked locking
- `airflow-core/tests/unit/api_fastapi/test_app.py`: Added `test_create_auth_manager_thread_safety` — spawns 10 concurrent threads and verifies singleton behavior

### Testing

- All 9 tests in `test_app.py` pass locally (including the new one)
- `prek`, `ruff check`, `ruff format` all clean