### PR TITLE
fix: Transient error state caused by rate limits from the container registry in `KubernetesPodOperator`

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -188,19 +188,47 @@ def detect_pod_terminate_early_issues(pod: V1Pod) -> str | None:
     """
     Identify issues that justify terminating the pod early.
 
+    This method distinguishes between permanent failures (e.g., invalid image names)
+    and transient errors (e.g., rate limits) that should be retried by Kubernetes.
+
     :param pod: The pod object to check.
     :return: An error message if an issue is detected; otherwise, None.
     """
+    # Indicators in error messages that suggest transient issues
+    TRANSIENT_ERROR_PATTERNS = [
+        "pull qps exceeded",
+        "rate limit",
+        "too many requests",
+        "quota exceeded",
+        "temporarily unavailable",
+        "timeout",
+        "account limit",
+    ]
+
+    FATAL_STATES = ["InvalidImageName", "ErrImageNeverPull"]
+    TRANSIENT_STATES = ["ErrImagePull", "ImagePullBackOff"]
+
     pod_status = pod.status
     if pod_status.container_statuses:
         for container_status in pod_status.container_statuses:
             container_state: V1ContainerState = container_status.state
             container_waiting: V1ContainerStateWaiting | None = container_state.waiting
-            if container_waiting:
-                if container_waiting.reason in ["ErrImagePull", "ImagePullBackOff", "InvalidImageName"]:
+            if not container_waiting:
+                continue
+
+            if container_waiting.reason in FATAL_STATES:
+                return (
+                    f"Image cannot be pulled, unable to start: {container_waiting.reason}"
+                    f"\n{container_waiting.message or ''}"
+                )
+
+            if container_waiting.reason in TRANSIENT_STATES:
+                message_lower = (container_waiting.message or "").lower()
+                is_transient = any(pattern in message_lower for pattern in TRANSIENT_ERROR_PATTERNS)
+                if not is_transient:
                     return (
-                        f"Pod docker image cannot be pulled, unable to start: {container_waiting.reason}"
-                        f"\n{container_waiting.message}"
+                        f"Image cannot be pulled, unable to start: {container_waiting.reason}"
+                        f"\n{container_waiting.message or ''}"
                     )
     return None
 

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -209,27 +209,29 @@ def detect_pod_terminate_early_issues(pod: V1Pod) -> str | None:
     TRANSIENT_STATES = ["ErrImagePull", "ImagePullBackOff"]
 
     pod_status = pod.status
-    if pod_status.container_statuses:
-        for container_status in pod_status.container_statuses:
-            container_state: V1ContainerState = container_status.state
-            container_waiting: V1ContainerStateWaiting | None = container_state.waiting
-            if not container_waiting:
-                continue
+    if not pod_status.container_statuses:
+        return None
 
-            if container_waiting.reason in FATAL_STATES:
+    for container_status in pod_status.container_statuses:
+        container_state: V1ContainerState = container_status.state
+        container_waiting: V1ContainerStateWaiting | None = container_state.waiting
+        if not container_waiting:
+            continue
+
+        if container_waiting.reason in FATAL_STATES:
+            return (
+                f"Image cannot be pulled, unable to start: {container_waiting.reason}"
+                f"\n{container_waiting.message or ''}"
+            )
+
+        if container_waiting.reason in TRANSIENT_STATES:
+            message_lower = (container_waiting.message or "").lower()
+            is_transient = any(pattern in message_lower for pattern in TRANSIENT_ERROR_PATTERNS)
+            if not is_transient:
                 return (
                     f"Image cannot be pulled, unable to start: {container_waiting.reason}"
                     f"\n{container_waiting.message or ''}"
                 )
-
-            if container_waiting.reason in TRANSIENT_STATES:
-                message_lower = (container_waiting.message or "").lower()
-                is_transient = any(pattern in message_lower for pattern in TRANSIENT_ERROR_PATTERNS)
-                if not is_transient:
-                    return (
-                        f"Image cannot be pulled, unable to start: {container_waiting.reason}"
-                        f"\n{container_waiting.message or ''}"
-                    )
     return None
 
 

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -220,13 +220,17 @@ def detect_pod_terminate_early_issues(pod: V1Pod) -> str | None:
             continue
 
         if container_waiting.reason in FATAL_STATES:
-            return ERROR_MESSAGE.format(reason=container_waiting.reason, message=container_waiting.message or '')
+            return ERROR_MESSAGE.format(
+                reason=container_waiting.reason, message=container_waiting.message or ""
+            )
 
         if container_waiting.reason in TRANSIENT_STATES:
             message_lower = (container_waiting.message or "").lower()
             is_transient = any(pattern in message_lower for pattern in TRANSIENT_ERROR_PATTERNS)
             if not is_transient:
-                return ERROR_MESSAGE.format(reason=container_waiting.reason, message=container_waiting.message or '')
+                return ERROR_MESSAGE.format(
+                    reason=container_waiting.reason, message=container_waiting.message or ""
+                )
     return None
 
 

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -207,6 +207,7 @@ def detect_pod_terminate_early_issues(pod: V1Pod) -> str | None:
 
     FATAL_STATES = ["InvalidImageName", "ErrImageNeverPull"]
     TRANSIENT_STATES = ["ErrImagePull", "ImagePullBackOff"]
+    ERROR_MESSAGE = "Image cannot be pulled, unable to start: {reason}\n{message}"
 
     pod_status = pod.status
     if not pod_status.container_statuses:
@@ -219,19 +220,13 @@ def detect_pod_terminate_early_issues(pod: V1Pod) -> str | None:
             continue
 
         if container_waiting.reason in FATAL_STATES:
-            return (
-                f"Image cannot be pulled, unable to start: {container_waiting.reason}"
-                f"\n{container_waiting.message or ''}"
-            )
+            return ERROR_MESSAGE.format(reason=container_waiting.reason, message=container_waiting.message or '')
 
         if container_waiting.reason in TRANSIENT_STATES:
             message_lower = (container_waiting.message or "").lower()
             is_transient = any(pattern in message_lower for pattern in TRANSIENT_ERROR_PATTERNS)
             if not is_transient:
-                return (
-                    f"Image cannot be pulled, unable to start: {container_waiting.reason}"
-                    f"\n{container_waiting.message or ''}"
-                )
+                return ERROR_MESSAGE.format(reason=container_waiting.reason, message=container_waiting.message or '')
     return None
 
 

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_pod_manager.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_pod_manager.py
@@ -715,7 +715,9 @@ class TestPodManager:
         pod_response.status.container_statuses = [container_statuse]
 
         self.mock_kube_client.read_namespaced_pod.return_value = pod_response
-        expected_msg = f"Pod docker image cannot be pulled, unable to start: {waiting_state.reason}\n{waiting_state.message}"
+        expected_msg = (
+            f"Image cannot be pulled, unable to start: {waiting_state.reason}\n{waiting_state.message}"
+        )
         mock_pod = MagicMock()
         with pytest.raises(AirflowException, match=expected_msg):
             await self.pod_manager.await_pod_start(
@@ -1262,7 +1264,9 @@ class TestAsyncPodManager:
         container_status.state.waiting = waiting_state
         pod_response.status.container_statuses = [container_status]
         self.mock_async_hook.get_pod.return_value = pod_response
-        expected_msg = f"Pod docker image cannot be pulled, unable to start: {waiting_state.reason}\n{waiting_state.message}"
+        expected_msg = (
+            f"Image cannot be pulled, unable to start: {waiting_state.reason}\n{waiting_state.message}"
+        )
         mock_pod = mock.MagicMock()
         with pytest.raises(AirflowException, match=expected_msg):
             await self.async_pod_manager.await_pod_start(


### PR DESCRIPTION
* related: #61775 

Split from https://github.com/apache/airflow/pull/61778.

When facing a transient error state caused by rate limits from the container registry, kubernetes automatically retries.  As these states can change quickly, we don't want to have an early termination.