### PR TITLE
fix(amazon): Filter kwargs in AthenaSQLHook to prevent TypeError

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/athena_sql.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/athena_sql.py
@@ -33,6 +33,7 @@ from airflow.providers.common.compat.sdk import AirflowException, AirflowNotFoun
 from airflow.providers.common.sql.hooks.sql import DbApiHook
 
 if TYPE_CHECKING:
+    from botocore.config import Config
     from pyathena.connection import Connection as AthenaConnection
 
 
@@ -69,21 +70,30 @@ class AthenaSQLHook(AwsBaseHook, DbApiHook):
     hook_name = "Amazon Athena"
     supports_autocommit = True
 
-    def __init__(self, athena_conn_id: str = default_conn_name, *args, **kwargs) -> None:
-        # AwsGenericHook.__init__() only accepts these kwargs. Connection extras
-        # like s3_staging_dir and work_group are not constructor params — they are
-        # read later from the connection in get_conn(). BaseSQLOperator.get_hook()
-        # passes all connection extras as kwargs, so we must filter them out here.
-        _aws_generic_hook_kwargs = {
-            "aws_conn_id",
-            "verify",
-            "region_name",
-            "client_type",
-            "resource_type",
-            "config",
-        }
-        filtered_kwargs = {k: v for k, v in kwargs.items() if k in _aws_generic_hook_kwargs}
-        super().__init__(*args, **filtered_kwargs)
+    def __init__(
+        self,
+        athena_conn_id: str = default_conn_name,
+        aws_conn_id: str | None = AwsBaseHook.default_conn_name,
+        verify: bool | str | None = None,
+        region_name: str | None = None,
+        client_type: str | None = None,
+        resource_type: str | None = None,
+        config: Config | dict[str, Any] | None = None,
+        **kwargs,
+    ) -> None:
+        # AwsGenericHook.__init__() only accepts the params declared above.
+        # Connection extras like s3_staging_dir and work_group are not
+        # constructor params — they are read later from the connection in
+        # get_conn(). BaseSQLOperator.get_hook() passes all connection extras
+        # as kwargs, so we absorb them here via **kwargs and discard them.
+        super().__init__(
+            aws_conn_id=aws_conn_id,
+            verify=verify,
+            region_name=region_name,
+            client_type=client_type,
+            resource_type=resource_type,
+            config=config,
+        )
         self.athena_conn_id = athena_conn_id
 
     @classmethod

--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/athena_sql.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/athena_sql.py
@@ -74,7 +74,14 @@ class AthenaSQLHook(AwsBaseHook, DbApiHook):
         # like s3_staging_dir and work_group are not constructor params — they are
         # read later from the connection in get_conn(). BaseSQLOperator.get_hook()
         # passes all connection extras as kwargs, so we must filter them out here.
-        _aws_generic_hook_kwargs = {"aws_conn_id", "verify", "region_name", "client_type", "resource_type", "config"}
+        _aws_generic_hook_kwargs = {
+            "aws_conn_id",
+            "verify",
+            "region_name",
+            "client_type",
+            "resource_type",
+            "config",
+        }
         filtered_kwargs = {k: v for k, v in kwargs.items() if k in _aws_generic_hook_kwargs}
         super().__init__(*args, **filtered_kwargs)
         self.athena_conn_id = athena_conn_id

--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/athena_sql.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/athena_sql.py
@@ -70,7 +70,13 @@ class AthenaSQLHook(AwsBaseHook, DbApiHook):
     supports_autocommit = True
 
     def __init__(self, athena_conn_id: str = default_conn_name, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+        # AwsGenericHook.__init__() only accepts these kwargs. Connection extras
+        # like s3_staging_dir and work_group are not constructor params — they are
+        # read later from the connection in get_conn(). BaseSQLOperator.get_hook()
+        # passes all connection extras as kwargs, so we must filter them out here.
+        _aws_generic_hook_kwargs = {"aws_conn_id", "verify", "region_name", "client_type", "resource_type", "config"}
+        filtered_kwargs = {k: v for k, v in kwargs.items() if k in _aws_generic_hook_kwargs}
+        super().__init__(*args, **filtered_kwargs)
         self.athena_conn_id = athena_conn_id
 
     @classmethod

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_athena_sql.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_athena_sql.py
@@ -179,4 +179,3 @@ class TestAthenaSQLHookConn:
         assert hook.aws_conn_id == "custom_aws"
         assert hook._verify is False
         assert hook._region_name == "us-west-2"
-

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_athena_sql.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_athena_sql.py
@@ -174,8 +174,10 @@ class TestAthenaSQLHookConn:
             aws_conn_id="custom_aws",
             verify=False,
             region_name="us-west-2",
+            config={"retries": {"max_attempts": 5}},
         )
         assert hook.athena_conn_id == "athena_conn"
         assert hook.aws_conn_id == "custom_aws"
         assert hook._verify is False
         assert hook._region_name == "us-west-2"
+        assert hook._config is not None

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_athena_sql.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_athena_sql.py
@@ -148,3 +148,35 @@ class TestAthenaSQLHookConn:
         hook = AthenaSQLHook(athena_conn_id=AWS_ATHENA_CONN_ID, aws_conn_id=AWS_CONN_ID)
         assert hook.athena_conn_id == AWS_ATHENA_CONN_ID
         assert hook.aws_conn_id == AWS_CONN_ID
+
+    def test_init_ignores_unexpected_kwargs(self):
+        """Verify that connection extras passed as kwargs don't crash the constructor.
+
+        BaseSQLOperator.get_hook() passes all connection extras as hook_params which
+        end up as constructor kwargs. Extras like s3_staging_dir and work_group are
+        not valid params for AwsGenericHook.__init__ and must be filtered out.
+        """
+        hook = AthenaSQLHook(
+            athena_conn_id="athena_conn",
+            s3_staging_dir="s3://mybucket/athena/",
+            work_group="primary",
+            region_name="eu-west-1",
+            driver="rest",
+        )
+        assert hook.athena_conn_id == "athena_conn"
+        # region_name is a valid AwsGenericHook param and should be passed through
+        assert hook._region_name == "eu-west-1"
+
+    def test_init_passes_valid_aws_kwargs(self):
+        """Verify that valid AwsGenericHook kwargs are still forwarded correctly."""
+        hook = AthenaSQLHook(
+            athena_conn_id="athena_conn",
+            aws_conn_id="custom_aws",
+            verify=False,
+            region_name="us-west-2",
+        )
+        assert hook.athena_conn_id == "athena_conn"
+        assert hook.aws_conn_id == "custom_aws"
+        assert hook._verify is False
+        assert hook._region_name == "us-west-2"
+

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_hooks_signature.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_hooks_signature.py
@@ -31,7 +31,15 @@ ALLOWED_THICK_HOOKS_PARAMETERS: dict[str, set[str]] = {
     # This list should only be reduced not extended with new parameters,
     # unless there is an exceptional reason.
     "AthenaHook": {"sleep_time", "log_query"},
-    "AthenaSQLHook": {"athena_conn_id"},
+    "AthenaSQLHook": {
+        "athena_conn_id",
+        "aws_conn_id",
+        "verify",
+        "region_name",
+        "client_type",
+        "resource_type",
+        "config",
+    },
     "BatchClientHook": {"status_retries", "max_retries"},
     "BatchWaitersHook": {"waiter_config"},
     "DataSyncHook": {"wait_interval_seconds"},


### PR DESCRIPTION
## What

Fix `TypeError` when SQL operators (e.g., `SQLValueCheckOperator`) instantiate
`AthenaSQLHook` with Athena-specific connection extras like `s3_staging_dir`
and `work_group`.

Closes: #55678

## Why

`BaseSQLOperator.get_hook()` copies all `connection.extra_dejson` fields into
`hook_params` and passes them as kwargs to the hook constructor.
`AwsGenericHook.__init__()` has a strict signature (no `**kwargs`) and rejects
unknown params, causing a `TypeError`.

These Athena-specific params aren't needed in `__init__` — they're already
read from `self.conn.extra_dejson` in `get_conn()`.

## How

Declare the six `AwsGenericHook.__init__()` params (`aws_conn_id`,
`verify`, `region_name`, `client_type`, `resource_type`, `config`) as
explicit named parameters in `AthenaSQLHook.__init__()` with matching
types. Unknown extras from `BaseSQLOperator.get_hook()` (like
`s3_staging_dir`, `work_group`, `driver`) are absorbed by `**kwargs`
and silently discarded — they're read later from `self.conn.extra_dejson`
in `get_conn()`.

Updated `ALLOWED_THICK_HOOKS_PARAMETERS` in `test_hooks_signature.py`
to permit the newly declared params, per reviewer guidance.

## Tests

Added unit tests verifying:
- Hook instantiation with Athena-specific kwargs doesn't raise TypeError
- Valid AWS kwargs (aws_conn_id, region_name, verify) are still forwarded correctly

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below): Kiro

Generated-by: Kiro following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
