### PR TITLE
fix(breeze): use prek from breeze bin instead of PATH

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@
 # under the License.
 ---
 default_stages: [pre-commit, pre-push]
-minimum_prek_version: '0.3.2'
+minimum_prek_version: '0.3.4'
 default_language_version:
   python: python3
   node: 22.19.0

--- a/dev/breeze/src/airflow_breeze/utils/run_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_utils.py
@@ -212,16 +212,6 @@ def get_environments_to_print(env: Mapping[str, str] | None):
     return env_to_print
 
 
-def get_prek_executable() -> str:
-    """Return path to prek executable in same env as breeze (bin/prek)."""
-    prek_bin = shutil.which("prek", path=str(Path(sys.executable).parent))
-    if prek_bin is not None:
-        return prek_bin
-    # Fallback when prek is not found via which (e.g. Windows .exe resolution)
-    prek_in_bin = Path(sys.executable).parent / ("prek.exe" if sys.platform == "win32" else "prek")
-    return os.fspath(prek_in_bin)
-
-
 def assert_prek_installed():
     """
     Check if prek is installed in the right version.
@@ -235,17 +225,16 @@ def assert_prek_installed():
     prek_config = yaml.safe_load((AIRFLOW_ROOT_PATH / ".pre-commit-config.yaml").read_text())
     min_prek_version = prek_config["minimum_prek_version"]
 
-    prek_executable = get_prek_executable()
-    get_console().print("[info]Checking prek installed[/]")
+    get_console().print(f"[info]Checking prek installed for {sys.executable}[/]")
     need_to_reinstall_prek = False
     try:
         command_result = run_command(
-            [prek_executable, "--version"],
+            [sys.executable, "-m", "prek", "--version"],
             capture_output=True,
             text=True,
             check=False,
         )
-        if command_result and command_result.returncode == 0:
+        if command_result.returncode == 0:
             if command_result.stdout:
                 prek_version = command_result.stdout.split(" ")[1].strip()
                 if Version(prek_version) >= Version(min_prek_version):
@@ -256,10 +245,7 @@ def assert_prek_installed():
                 else:
                     get_console().print(
                         f"\n[error]Package name prek version is wrong. It should be "
-                        f"at least {min_prek_version} and is {prek_version}.[/]\n"
-                    )
-                    get_console().print(
-                        "[info]Reinstall breeze: 'uv tool install -e ./dev/breeze --force'[/]\n"
+                        f"at least {min_prek_version} and is {prek_version}.[/]\n\n"
                     )
                     sys.exit(1)
             else:
@@ -269,8 +255,7 @@ def assert_prek_installed():
         else:
             need_to_reinstall_prek = True
             get_console().print("\n[error]Error checking for prek-installation:[/]\n")
-            if command_result and command_result.stderr:
-                get_console().print(command_result.stderr)
+            get_console().print(command_result.stderr)
     except FileNotFoundError as e:
         need_to_reinstall_prek = True
         get_console().print(f"\n[error]Error checking for prek installation: [/]\n{e}\n")
@@ -548,7 +533,9 @@ def run_compile_ui_assets(
             "[info]However, it requires you to have local pnpm installation.\n"
         )
     command_to_execute = [
-        get_prek_executable(),
+        sys.executable,
+        "-m",
+        "prek",
         "run",
         "--hook-stage",
         "manual",

--- a/dev/breeze/src/airflow_breeze/utils/run_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_utils.py
@@ -212,6 +212,12 @@ def get_environments_to_print(env: Mapping[str, str] | None):
     return env_to_print
 
 
+def get_prek_executable() -> str:
+    """Return path to prek executable in same env as breeze (bin/prek)."""
+    prek_in_bin = Path(sys.executable).parent / ("prek.exe" if sys.platform == "win32" else "prek")
+    return os.fspath(prek_in_bin)
+
+
 def assert_prek_installed():
     """
     Check if prek is installed in the right version.
@@ -225,17 +231,17 @@ def assert_prek_installed():
     prek_config = yaml.safe_load((AIRFLOW_ROOT_PATH / ".pre-commit-config.yaml").read_text())
     min_prek_version = prek_config["minimum_prek_version"]
 
-    python_executable = sys.executable
-    get_console().print(f"[info]Checking prek installed for {python_executable}[/]")
+    prek_executable = get_prek_executable()
+    get_console().print("[info]Checking prek installed[/]")
     need_to_reinstall_prek = False
     try:
         command_result = run_command(
-            ["prek", "--version"],
+            [prek_executable, "--version"],
             capture_output=True,
             text=True,
             check=False,
         )
-        if command_result.returncode == 0:
+        if command_result and command_result.returncode == 0:
             if command_result.stdout:
                 prek_version = command_result.stdout.split(" ")[1].strip()
                 if Version(prek_version) >= Version(min_prek_version):
@@ -246,7 +252,10 @@ def assert_prek_installed():
                 else:
                     get_console().print(
                         f"\n[error]Package name prek version is wrong. It should be "
-                        f"at least {min_prek_version} and is {prek_version}.[/]\n\n"
+                        f"at least {min_prek_version} and is {prek_version}.[/]\n"
+                    )
+                    get_console().print(
+                        "[info]Reinstall breeze: 'uv tool install -e ./dev/breeze --force'[/]\n"
                     )
                     sys.exit(1)
             else:
@@ -256,15 +265,13 @@ def assert_prek_installed():
         else:
             need_to_reinstall_prek = True
             get_console().print("\n[error]Error checking for prek-installation:[/]\n")
-            get_console().print(command_result.stderr)
+            if command_result and command_result.stderr:
+                get_console().print(command_result.stderr)
     except FileNotFoundError as e:
         need_to_reinstall_prek = True
         get_console().print(f"\n[error]Error checking for prek installation: [/]\n{e}\n")
     if need_to_reinstall_prek:
-        get_console().print("[info]Make sure to install prek. For example by running:\n")
-        get_console().print("   uv tool install prek\n")
-        get_console().print("Or if you prefer pipx:\n")
-        get_console().print("   pipx install prek")
+        get_console().print("[info]Reinstall breeze: 'uv tool install -e ./dev/breeze --force'[/]")
         sys.exit(1)
 
 
@@ -537,7 +544,7 @@ def run_compile_ui_assets(
             "[info]However, it requires you to have local pnpm installation.\n"
         )
     command_to_execute = [
-        "prek",
+        get_prek_executable(),
         "run",
         "--hook-stage",
         "manual",

--- a/dev/breeze/src/airflow_breeze/utils/run_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_utils.py
@@ -214,6 +214,10 @@ def get_environments_to_print(env: Mapping[str, str] | None):
 
 def get_prek_executable() -> str:
     """Return path to prek executable in same env as breeze (bin/prek)."""
+    prek_bin = shutil.which("prek", path=str(Path(sys.executable).parent))
+    if prek_bin is not None:
+        return prek_bin
+    # Fallback when prek is not found via which (e.g. Windows .exe resolution)
     prek_in_bin = Path(sys.executable).parent / ("prek.exe" if sys.platform == "win32" else "prek")
     return os.fspath(prek_in_bin)
 


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

## Related PR
- https://github.com/apache/airflow/issues/62272
## Problem

When running `breeze start-airflow` or asset compilation, users could encounter:

1. **Version check failure**: "Package name prek version is wrong. It should be at least 0.3.2 and is 0.2.25" — even when prek 0.3.3 was installed in the breeze Python environment
2. **Asset compilation failure**: "Required minimum prek version `0.3.2` is greater than current version `0.2.25`"

This occurred because breeze was checking and invoking prek from `PATH`, which could point to an older standalone installation (e.g. `uv tool install prek` at 0.2.25), while breeze's own environment had the correct version (0.3.3) in its bin directory.
<img width="960" height="325" alt="image" src="https://github.com/user-attachments/assets/4a4fde12-9868-46dc-9a89-1bc47ae71f3a" />
<img width="1191" height="142" alt="image" src="https://github.com/user-attachments/assets/eef6dc75-7648-43f5-b871-d71430e55654" />

## Solution

- **`get_prek_executable()`**: New helper that returns the path to prek in the same bin directory as breeze's Python (`sys.executable`'s parent)
- **`assert_prek_installed()`**: Uses `get_prek_executable()` instead of `"prek"` from PATH, so the version check uses breeze's prek
- **`run_compile_ui_assets()`**: Uses `get_prek_executable()` instead of `"prek"`, so asset compilation invokes the correct prek version

## Error message improvements

- When prek version is insufficient: suggests `uv tool install -e ./dev/breeze --force` to reinstall breeze with updated dependencies
- When prek is not found: same reinstall suggestion (breeze includes prek as a dependency)
---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
cursor

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
