### PR TITLE
fix(CI breeze): Fix "Unsupported package" error for non-versioned docs in publish-docs

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -1862,6 +1862,10 @@ def get_package_version_possibly_from_stable_txt(package_name: str) -> str:
             return provider["versions"][0]
         raise SystemExit(f"Could not determine version for provider: {package_name}")
 
+    # Non-versioned packages (DocsPublisher.is_versioned=False)
+    if package_name in ("apache-airflow-providers", "docker-stack"):
+        return "non-versioned"
+
     raise SystemExit(f"Unsupported package: {package_name}")
 
 


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
# Fix "Unsupported package" error for non-versioned docs in publish-docs

## Related
Related PR: https://github.com/apache/airflow/pull/62277

## Problem
- https://github.com/apache/airflow/actions/runs/22253151122/job/64381296101?pr=62277
- https://github.com/apache/airflow/actions/runs/22254912012/job/64385629395#step:9:23

The CI job "Publish documentation and validate versions" fails with:
```
Unsupported package: docker-stack
# or
Unsupported package: apache-airflow-providers
Publishing docs for 104 package(s)
 - apache-airflow-providers-amazon: 9.22.0
 ...
Error: Process completed with exit code 1.
```

## Background: Non-versioned packages in DocsPublisher

In `docs_publisher.py`, `apache-airflow-providers` and `docker-stack` are defined as **non-versioned** packages:
https://github.com/apache/airflow/blob/b6bb1552e55fbf5761d45605dc65e27d434a53b2/dev/breeze/src/airflow_breeze/utils/docs_publisher.py#L42-L47

These packages are published to `docs-archive/{package}` without a version subdirectory (e.g. `docs-archive/docker-stack`), unlike versioned packages that go to `docs-archive/{package}/{version}`.

## Root cause

`get_package_version_possibly_from_stable_txt()` in `release_management_commands.py` is called for **every** package in a pre-publish loop to print versions. It had handlers for `apache-airflow`, `helm-chart`, `task-sdk`, `apache-airflow-providers-*` (individual providers), etc., but **no handler** for the aggregate non-versioned packages: `apache-airflow-providers` and `docker-stack`.

This caused `SystemExit("Unsupported package: ...")` before the actual publish step.

## Solution

Align `get_package_version_possibly_from_stable_txt()` with `DocsPublisher.is_versioned`: return `"non-versioned"` for `apache-airflow-providers` and `docker-stack` instead of raising.

## Changes

- `dev/breeze/src/airflow_breeze/commands/release_management_commands.py`: Add handling for non-versioned packages in `get_package_version_possibly_from_stable_txt()`


---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)
Cursor
<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
