### PR TITLE
fix: Add fastAPI test coverage for `upstream_map_indexes` in execut...

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -178,7 +178,8 @@ class TestTIRunState:
         )
 
         assert response.status_code == 200
-        assert response.json() == {
+        result = response.json()
+        assert result == {
             "dag_run": {
                 "dag_id": ti.dag_id,
                 "run_id": "test",
@@ -204,6 +205,8 @@ class TestTIRunState:
             "connections": [],
             "xcom_keys_to_clear": [],
         }
+        # upstream_map_indexes is now computed by Task SDK, not returned by the server in HEAD version
+        assert "upstream_map_indexes" not in result
 
         # Refresh the Task Instance from the database so that we can check the updated values
         session.refresh(ti)


### PR DESCRIPTION
## Summary

Adds test assertion to verify that `upstream_map_indexes` is not returned by the HEAD version of the execution API, as this field is now computed by the Task SDK rather than being returned by the server.

## Issue

Fixes #50541

## Changes

- Added assertion to verify `upstream_map_indexes` is not present in the HEAD version response of `GET /task_instances/{ti_key}/state`
- Refactored response check to store `response.json()` in a variable for reuse

## Testing

- Unit test passes, verifying the expected behavior of the HEAD version execution API endpoint