### PR TITLE
fix: pod_override existing init_containers

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/pod_generator.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/pod_generator.py
@@ -271,10 +271,11 @@ class PodGenerator:
             client_spec.containers = PodGenerator.reconcile_containers(
                 base_spec.containers, client_spec.containers
             )
-            client_spec.init_containers = PodGenerator.reconcile_init_containers(
-                base_spec.init_containers, client_spec.init_containers
-            )
-            merged_spec = client_spec
+            merged_spec = extend_object_field(base_spec, client_spec, "init_containers")
+            if base_spec.init_containers and client_spec.init_containers:
+                merged_spec.init_containers = PodGenerator.reconcile_init_containers(
+                    base_spec.init_containers, client_spec.init_containers
+                )
             merged_spec = extend_object_field(base_spec, merged_spec, "volumes")
             return merge_objects(base_spec, merged_spec)
 

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/pod_generator.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/pod_generator.py
@@ -271,7 +271,10 @@ class PodGenerator:
             client_spec.containers = PodGenerator.reconcile_containers(
                 base_spec.containers, client_spec.containers
             )
-            merged_spec = extend_object_field(base_spec, client_spec, "init_containers")
+            client_spec.init_containers = PodGenerator.reconcile_init_containers(
+                base_spec.init_containers, client_spec.init_containers
+            )
+            merged_spec = client_spec
             merged_spec = extend_object_field(base_spec, merged_spec, "volumes")
             return merge_objects(base_spec, merged_spec)
 
@@ -309,6 +312,49 @@ class PodGenerator:
             client_container,
             *PodGenerator.reconcile_containers(base_containers[1:], client_containers[1:]),
         ]
+
+    @staticmethod
+    def reconcile_init_containers(
+        base_containers: list[k8s.V1Container] | None,
+        client_containers: list[k8s.V1Container] | None,
+    ) -> list[k8s.V1Container]:
+        """
+        Merge Kubernetes init containers by name.
+
+        Containers with the same name are merged; others are appended.
+
+        :param base_containers: base init containers
+        :param client_containers: client init containers that override base
+        :return: the merged init containers
+        """
+        if not base_containers:
+            return client_containers or []
+        if not client_containers:
+            return base_containers
+
+        client_map = {c.name: c for c in client_containers}
+        merged = []
+        matched_names = set()
+
+        for base_container in base_containers:
+            if base_container.name in client_map:
+                client_container = client_map[base_container.name]
+                client_container = extend_object_field(base_container, client_container, "volume_mounts")
+                client_container = extend_object_field(base_container, client_container, "env")
+                client_container = extend_object_field(base_container, client_container, "env_from")
+                client_container = extend_object_field(base_container, client_container, "ports")
+                client_container = extend_object_field(base_container, client_container, "volume_devices")
+                client_container = merge_objects(base_container, client_container)
+                merged.append(client_container)
+                matched_names.add(base_container.name)
+            else:
+                merged.append(base_container)
+
+        for client_container in client_containers:
+            if client_container.name not in matched_names:
+                merged.append(client_container)
+
+        return merged
 
     @classmethod
     def construct_pod(

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/test_pod_generator.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/test_pod_generator.py
@@ -668,6 +668,21 @@ class TestPodGenerator:
         res = PodGenerator.reconcile_specs(base_spec, client_spec)
         assert res.init_containers == base_spec.init_containers + client_spec.init_containers
 
+    def test_reconcile_specs_init_containers_same_name(self):
+        base_spec = k8s.V1PodSpec(
+            containers=[],
+            init_containers=[k8s.V1Container(name="init1", image="base_image", args=["base_arg"])],
+        )
+        client_spec = k8s.V1PodSpec(
+            containers=[],
+            init_containers=[k8s.V1Container(name="init1", image="client_image")],
+        )
+        res = PodGenerator.reconcile_specs(base_spec, client_spec)
+        assert len(res.init_containers) == 1
+        assert res.init_containers[0].name == "init1"
+        assert res.init_containers[0].image == "client_image"
+        assert res.init_containers[0].args == ["base_arg"]
+
     def test_deserialize_model_file(self, caplog, data_file):
         template_file = data_file("pods/template.yaml").as_posix()
         result = PodGenerator.deserialize_model_file(template_file)


### PR DESCRIPTION
## Summary

Fixes init container reconciliation in `PodGenerator.reconcile_specs()` to properly merge init containers by name instead of simply appending them. This aligns init container handling with the existing behavior for regular containers.

## Issue

Fixes #61074

## Changes

- Added `reconcile_init_containers()` method to merge init containers by name, matching the pattern used for regular containers
- Updated `reconcile_specs()` to use the new method instead of `extend_object_field()`
- For containers with matching names, lists like `volume_mounts`, `env`, `env_from`, `ports`, and `volume_devices` are extended; other properties are merged with client values taking precedence
- Added unit test for init container reconciliation with same-name containers

## Testing

- Added new test `test_reconcile_specs_init_containers_same_name` verifying that init containers with the same name are properly merged
- Test confirms that client image overrides base image while base args are preserved