### PR TITLE
fix: LatestOnlyOperator not working if just before a Dynamic Task M...

### DIFF
--- a/airflow-core/src/airflow/ti_deps/deps/not_previously_skipped_dep.py
+++ b/airflow-core/src/airflow/ti_deps/deps/not_previously_skipped_dep.py
@@ -63,7 +63,10 @@ class NotPreviouslySkippedDep(BaseTIDep):
                 # query with -1 instead of the child's map_index.
                 xcom_map_index = ti.map_index if parent.is_mapped else -1
                 prev_result = ti.xcom_pull(
-                    task_ids=parent.task_id, key=XCOM_SKIPMIXIN_KEY, session=session, map_indexes=xcom_map_index
+                    task_ids=parent.task_id,
+                    key=XCOM_SKIPMIXIN_KEY,
+                    session=session,
+                    map_indexes=xcom_map_index,
                 )
 
                 if prev_result is None:

--- a/airflow-core/src/airflow/ti_deps/deps/not_previously_skipped_dep.py
+++ b/airflow-core/src/airflow/ti_deps/deps/not_previously_skipped_dep.py
@@ -58,8 +58,12 @@ class NotPreviouslySkippedDep(BaseTIDep):
                     # This can happen if the parent task has not yet run.
                     continue
 
+                # Use the parent's map context to look up the XCom. An unmapped parent
+                # (e.g. LatestOnlyOperator) writes XCom with map_index=-1, so we must
+                # query with -1 instead of the child's map_index.
+                xcom_map_index = ti.map_index if parent.is_mapped else -1
                 prev_result = ti.xcom_pull(
-                    task_ids=parent.task_id, key=XCOM_SKIPMIXIN_KEY, session=session, map_indexes=ti.map_index
+                    task_ids=parent.task_id, key=XCOM_SKIPMIXIN_KEY, session=session, map_indexes=xcom_map_index
                 )
 
                 if prev_result is None:

--- a/airflow-core/tests/unit/ti_deps/deps/test_not_previously_skipped_dep.py
+++ b/airflow-core/tests/unit/ti_deps/deps/test_not_previously_skipped_dep.py
@@ -25,7 +25,12 @@ from airflow.models import DagRun, TaskInstance
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.standard.operators.python import BranchPythonOperator
 from airflow.ti_deps.dep_context import DepContext
-from airflow.ti_deps.deps.not_previously_skipped_dep import NotPreviouslySkippedDep
+from airflow.models.xcom import XComModel
+from airflow.ti_deps.deps.not_previously_skipped_dep import (
+    XCOM_SKIPMIXIN_FOLLOWED,
+    XCOM_SKIPMIXIN_KEY,
+    NotPreviouslySkippedDep,
+)
 from airflow.utils.state import State
 from airflow.utils.types import DagRunType
 
@@ -161,3 +166,51 @@ def test_parent_not_executed(session, dag_maker):
     assert len(list(dep.get_dep_statuses(ti2, session, DepContext()))) == 0
     assert dep.is_met(ti2, session)
     assert ti2.state == State.NONE
+
+
+def test_unmapped_parent_skip_mapped_downstream(session, dag_maker):
+    """
+    When an unmapped SkipMixin parent writes XCom with map_index=-1,
+    mapped downstream TIs (map_index >= 0) should still be skipped
+    by NotPreviouslySkippedDep.
+
+    Regression test for https://github.com/apache/airflow/issues/62118
+    """
+    start_date = pendulum.datetime(2020, 1, 1)
+    with dag_maker(
+        "test_unmapped_skip_mapped_dag",
+        schedule=None,
+        start_date=start_date,
+        session=session,
+    ):
+        op1 = BranchPythonOperator(task_id="op1", python_callable=lambda: "op3")
+        op2 = EmptyOperator(task_id="op2")
+        op3 = EmptyOperator(task_id="op3")
+        op1 >> [op2, op3]
+
+    dr = dag_maker.create_dagrun(run_type=DagRunType.MANUAL, state=State.RUNNING)
+    tis = {ti.task_id: ti for ti in dr.task_instances}
+
+    # Simulate the unmapped branch operator having run: set it to SUCCESS
+    # and store XCom with map_index=-1 (as SkipMixin does for unmapped tasks).
+    tis["op1"].state = State.SUCCESS
+    session.merge(tis["op1"])
+    XComModel.set(
+        key=XCOM_SKIPMIXIN_KEY,
+        value={XCOM_SKIPMIXIN_FOLLOWED: ["op3"]},
+        dag_id=dr.dag_id,
+        task_id="op1",
+        run_id=dr.run_id,
+        map_index=-1,
+        session=session,
+    )
+
+    # Simulate a mapped downstream TI by changing map_index to 0.
+    tis["op2"].map_index = 0
+    session.merge(tis["op2"])
+    session.flush()
+
+    dep = NotPreviouslySkippedDep()
+    assert len(list(dep.get_dep_statuses(tis["op2"], session, DepContext()))) == 1
+    assert not dep.is_met(tis["op2"], session)
+    assert tis["op2"].state == State.SKIPPED

--- a/airflow-core/tests/unit/ti_deps/deps/test_not_previously_skipped_dep.py
+++ b/airflow-core/tests/unit/ti_deps/deps/test_not_previously_skipped_dep.py
@@ -22,10 +22,10 @@ import pytest
 from sqlalchemy import delete
 
 from airflow.models import DagRun, TaskInstance
+from airflow.models.xcom import XComModel
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.standard.operators.python import BranchPythonOperator
 from airflow.ti_deps.dep_context import DepContext
-from airflow.models.xcom import XComModel
 from airflow.ti_deps.deps.not_previously_skipped_dep import (
     XCOM_SKIPMIXIN_FOLLOWED,
     XCOM_SKIPMIXIN_KEY,


### PR DESCRIPTION
## Summary

Fixes `NotPreviouslySkippedDep` to correctly skip mapped downstream tasks when the parent is an unmapped `SkipMixin` operator (e.g., `LatestOnlyOperator`, `BranchPythonOperator`). The dependency check now queries XCom using the parent's map context instead of the child's.

## Issue

Fixes #62118

## Changes

- Fixed `NotPreviouslySkippedDep._get_dep_statuses()` to use the parent's map context when pulling XCom data
- Unmapped parents write XCom with `map_index=-1`, so we now query with `-1` instead of the child's `map_index` for unmapped parents
- Added regression test `test_unmapped_parent_skip_mapped_downstream` that verifies mapped TIs are correctly skipped by an unmapped `SkipMixin` parent

## Testing

- Added new unit test `test_unmapped_parent_skip_mapped_downstream` that simulates an unmapped `BranchPythonOperator` writing skip XCom with `map_index=-1` and verifies that a mapped downstream TI (with `map_index=0`) is correctly skipped
- Verified the test passes with the fix and fails without it