### PR TITLE
Add thread_ts parameter to Slack operators for thread replies

### DIFF
--- a/providers/slack/src/airflow/providers/slack/hooks/slack.py
+++ b/providers/slack/src/airflow/providers/slack/hooks/slack.py
@@ -227,6 +227,7 @@ class SlackHook(BaseHook):
         channel_id: str | None = None,
         file_uploads: FileUploadTypeDef | list[FileUploadTypeDef],
         initial_comment: str | None = None,
+        thread_ts: str | None = None,
     ) -> SlackResponse:
         """
         Send one or more files to a Slack channel using the Slack SDK Client method `files_upload_v2`.
@@ -235,6 +236,8 @@ class SlackHook(BaseHook):
             If omitting this parameter, then file will send to workspace.
         :param file_uploads: The file(s) specification to upload.
         :param initial_comment: The message text introducing the file in specified ``channel``.
+        :param thread_ts: Provide another message's ``ts`` value to upload the file as a reply in a
+            thread. See https://api.slack.com/messaging#threading.
         """
         if channel_id and channel_id.startswith("#"):
             retried_channel_id = self.get_channel_id(channel_id[1:])
@@ -260,6 +263,7 @@ class SlackHook(BaseHook):
             # see: https://github.com/python/mypy/issues/4976
             file_uploads=file_uploads,  # type: ignore[arg-type]
             initial_comment=initial_comment,
+            thread_ts=thread_ts,
         )
 
     def send_file_v1_to_v2(
@@ -272,6 +276,7 @@ class SlackHook(BaseHook):
         initial_comment: str | None = None,
         title: str | None = None,
         snippet_type: str | None = None,
+        thread_ts: str | None = None,
     ) -> list[SlackResponse]:
         """
         Smooth transition between ``send_file`` and ``send_file_v2`` methods.
@@ -285,6 +290,8 @@ class SlackHook(BaseHook):
         :param initial_comment: The message text introducing the file in specified ``channels``.
         :param title: Title of the file.
         :param snippet_type: Syntax type for the content being uploaded.
+        :param thread_ts: Provide another message's ``ts`` value to upload the file as a reply in a
+            thread. See https://api.slack.com/messaging#threading.
         """
         if not exactly_one(file, content):
             raise ValueError("Either `file` or `content` must be provided, not both.")
@@ -307,7 +314,10 @@ class SlackHook(BaseHook):
         for channel in channels_to_share:
             responses.append(
                 self.send_file_v2(
-                    channel_id=channel, file_uploads=file_uploads, initial_comment=initial_comment
+                    channel_id=channel,
+                    file_uploads=file_uploads,
+                    initial_comment=initial_comment,
+                    thread_ts=thread_ts,
                 )
             )
         return responses

--- a/providers/slack/src/airflow/providers/slack/operators/slack.py
+++ b/providers/slack/src/airflow/providers/slack/operators/slack.py
@@ -126,9 +126,11 @@ class SlackAPIPostOperator(SlackAPIOperator):
         See https://api.slack.com/reference/block-kit/blocks
     :param attachments: (legacy) A list of attachments to send with the message. (templated)
         See https://api.slack.com/docs/attachments
+    :param thread_ts: Provide another message's ``ts`` value to make this message a reply in a
+        thread. See https://api.slack.com/messaging#threading (templated)
     """
 
-    template_fields: Sequence[str] = ("username", "text", "attachments", "blocks", "channel")
+    template_fields: Sequence[str] = ("username", "text", "attachments", "blocks", "channel", "thread_ts")
     ui_color = "#FFBA40"
 
     def __init__(
@@ -145,6 +147,7 @@ class SlackAPIPostOperator(SlackAPIOperator):
         ),
         blocks: list | None = None,
         attachments: list | None = None,
+        thread_ts: str | None = None,
         **kwargs,
     ) -> None:
         super().__init__(method="chat.postMessage", **kwargs)
@@ -154,6 +157,7 @@ class SlackAPIPostOperator(SlackAPIOperator):
         self.icon_url = icon_url
         self.attachments = attachments or []
         self.blocks = blocks or []
+        self.thread_ts = thread_ts
 
     def construct_api_call_params(self) -> Any:
         self.api_params = {
@@ -164,6 +168,8 @@ class SlackAPIPostOperator(SlackAPIOperator):
             "attachments": json.dumps(self.attachments),
             "blocks": json.dumps(self.blocks),
         }
+        if self.thread_ts is not None:
+            self.api_params["thread_ts"] = self.thread_ts
 
 
 class SlackAPIFileOperator(SlackAPIOperator):
@@ -215,6 +221,8 @@ class SlackAPIFileOperator(SlackAPIOperator):
         derived from ``filename``. (templated)
     :param snippet_type: Syntax type for the snippet being uploaded.(templated)
     :param method_version: The version of the method of Slack SDK Client to be used, either "v1" or "v2".
+    :param thread_ts: Provide another message's ``ts`` value to upload the file as a reply in a
+        thread. See https://api.slack.com/messaging#threading (templated)
     """
 
     template_fields: Sequence[str] = (
@@ -226,6 +234,7 @@ class SlackAPIFileOperator(SlackAPIOperator):
         "title",
         "display_filename",
         "snippet_type",
+        "thread_ts",
     )
     ui_color = "#44BEDF"
 
@@ -240,6 +249,7 @@ class SlackAPIFileOperator(SlackAPIOperator):
         display_filename: str | None = None,
         method_version: Literal["v1", "v2"] | None = None,
         snippet_type: str | None = None,
+        thread_ts: str | None = None,
         **kwargs,
     ) -> None:
         super().__init__(method="files.upload", **kwargs)
@@ -252,6 +262,7 @@ class SlackAPIFileOperator(SlackAPIOperator):
         self.display_filename = display_filename
         self.method_version = method_version
         self.snippet_type = snippet_type
+        self.thread_ts = thread_ts
 
         if self.filetype:
             warnings.warn(
@@ -277,4 +288,5 @@ class SlackAPIFileOperator(SlackAPIOperator):
             initial_comment=self.initial_comment,
             title=self.title,
             snippet_type=self.snippet_type,
+            thread_ts=self.thread_ts,
         )

--- a/providers/slack/tests/unit/slack/hooks/test_slack.py
+++ b/providers/slack/tests/unit/slack/hooks/test_slack.py
@@ -434,6 +434,21 @@ class TestSlackHook:
             channel="C00000000",
             file_uploads=[{"file": "/foo/bar/file.txt", "filename": "foo.txt"}],
             initial_comment=None,
+            thread_ts=None,
+        )
+
+    def test_send_file_v2_with_thread_ts(self, mocked_client):
+        """Test that thread_ts is passed to files_upload_v2 when provided."""
+        SlackHook(slack_conn_id=SLACK_API_DEFAULT_CONN_ID).send_file_v2(
+            channel_id="C00000000",
+            file_uploads={"file": "/foo/bar/file.txt", "filename": "foo.txt"},
+            thread_ts="1234567890.123456",
+        )
+        mocked_client.files_upload_v2.assert_called_once_with(
+            channel="C00000000",
+            file_uploads=[{"file": "/foo/bar/file.txt", "filename": "foo.txt"}],
+            initial_comment=None,
+            thread_ts="1234567890.123456",
         )
 
     def test_send_file_v2_multiple_files(self, mocked_client):
@@ -451,6 +466,7 @@ class TestSlackHook:
                 {"content": "Some Text", "filename": "foo.txt"},
             ],
             initial_comment="Awesome File",
+            thread_ts=None,
         )
 
     def test_send_file_v2_channel_name(self, mocked_client, caplog):
@@ -465,6 +481,7 @@ class TestSlackHook:
                 channel="C00",
                 file_uploads=mock.ANY,
                 initial_comment=mock.ANY,
+                thread_ts=None,
             )
 
     @pytest.mark.parametrize("initial_comment", [None, "test comment"])
@@ -492,6 +509,7 @@ class TestSlackHook:
                     "snippet_type": snippet_type,
                 },
                 initial_comment=initial_comment,
+                thread_ts=None,
             )
 
     @pytest.mark.parametrize("initial_comment", [None, "test comment"])
@@ -519,6 +537,7 @@ class TestSlackHook:
                     "snippet_type": snippet_type,
                 },
                 initial_comment=initial_comment,
+                thread_ts=None,
             )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

Adds `thread_ts` parameter to `SlackAPIPostOperator` and `SlackAPIFileOperator` so users can send messages and files as replies in a Slack thread. When `thread_ts` is set to another message's `ts` value, the message or file is posted as a reply in that thread.

## Screenshots

### SlackAPIPostOperator

<img width="300" height="328" alt="image" src="https://github.com/user-attachments/assets/cb207e87-2880-435c-bdd4-2763d21fc491" />


### SlackAPIFileOperator

<img width="300" height="683" alt="image" src="https://github.com/user-attachments/assets/3128d73d-f6e8-4ab2-a089-f4514977e271" />


---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
  - Cursor

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
