### PR TITLE
Add RAG failure analysis guide and example DAG

### DIFF
--- a/airflow-core/docs/howto/index.rst
+++ b/airflow-core/docs/howto/index.rst
@@ -58,3 +58,4 @@ configuring an Airflow environment.
     run-with-self-signed-certificate
     performance
     memory-profiling
+    rag-failure-analysis

--- a/airflow-core/docs/howto/rag-failure-analysis.rst
+++ b/airflow-core/docs/howto/rag-failure-analysis.rst
@@ -20,10 +20,10 @@ RAG Failure Analysis Guide
 
 As Retrieval-Augmented Generation (RAG) and Large Language Model (LLM) pipelines become more complex, debugging them requires moving beyond simple prompt tuning. When a RAG system fails, the issue often originates in earlier stages of the pipeline orchestrated by Airflow.
 
-This guide introduces a structured approach to RAG failure analysis using the **WFGY 16-problem ProblemMap**, a checklist of typical failure modes tailored for Airflow orchestrators.
+This guide introduces a structured approach to RAG failure analysis using the `WFGY ProblemMap <https://github.com/onestardao/WFGY>`_, an MIT-licensed open-source checklist of common RAG/LLM failure modes, adapted here for Airflow-orchestrated pipelines.
 
-The 16-Problem Framework
-------------------------
+RAG Failure Categories
+----------------------
 
 The WFGY ProblemMap categorizes RAG failures into several key areas. Understanding where your DAG fits into these categories helps localize issues quickly.
 
@@ -49,7 +49,7 @@ The WFGY ProblemMap categorizes RAG failures into several key areas. Understandi
 Debugging Patterns in Airflow
 -----------------------------
 
-Airflow provides several mechanisms to detect and log these 16 failure modes during DAG execution.
+Airflow provides several mechanisms to detect and log these failure modes during DAG execution.
 
 Attaching Sensors and Health Checks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -58,12 +58,17 @@ Instead of treating your RAG pipeline as a "black box," you can insert diagnosti
 
 .. code-block:: python
 
+    # pseudo-code
+
+
     @task
-    def semantic_firewall(answer, context):
+    def output_faithfulness_check(answer, context):
         """
-        A diagnostic task that validates the final output against context.
+        A diagnostic task that validates the final answer against retrieved context.
+        Checks hallucination and context mismatch.
         """
         # Perform faithfulness and relevance checks
+        # is_faithful() represents a custom validation function or call to an LLM evaluator
         if not is_faithful(answer, context):
             raise AirflowFailException("Faithfulness check failed: Hallucination detected.")
 
@@ -84,15 +89,17 @@ Use Airflow's task logging to capture specific failure metadata. This makes it e
 
 .. code-block:: python
 
+    # pseudo-code
+
     logger.info("FAILURE DETECTED: Retriever Bias. Query: '%s' returned Doc ID: %s", query, top_doc_id)
 
 Example DAG
 -----------
 
-For a full demonstration, see the :ref:`example_rag_dag` provided in the Airflow example dags.
+For a full demonstration, see the `example_rag_dag.py <https://github.com/apache/airflow/blob/main/airflow-core/src/airflow/example_dags/example_rag_dag.py>`_ provided in the Airflow source tree.
 
 Further Reading
 ---------------
 
-- `WFGY 16-problem ProblemMap <https://github.com/onestardao/WFGY>`_
+- `WFGY ProblemMap (MIT-licensed) <https://github.com/onestardao/WFGY>`_
 - `RAG Debugging Best Practices <https://airflow.apache.org/docs/apache-airflow/stable/best-practices.html>`_

--- a/airflow-core/docs/howto/rag-failure-analysis.rst
+++ b/airflow-core/docs/howto/rag-failure-analysis.rst
@@ -1,0 +1,98 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+..   http://www.apache.org/licenses/LICENSE-2.0
+
+.. Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+
+RAG Failure Analysis Guide
+==========================
+
+As Retrieval-Augmented Generation (RAG) and Large Language Model (LLM) pipelines become more complex, debugging them requires moving beyond simple prompt tuning. When a RAG system fails, the issue often originates in earlier stages of the pipeline orchestrated by Airflow.
+
+This guide introduces a structured approach to RAG failure analysis using the **WFGY 16-problem ProblemMap**, a checklist of typical failure modes tailored for Airflow orchestrators.
+
+The 16-Problem Framework
+------------------------
+
+The WFGY ProblemMap categorizes RAG failures into several key areas. Understanding where your DAG fits into these categories helps localize issues quickly.
+
+1. **Ingestion & Chunking Problems**
+   - *Small Chunk Sensitivity*: Chunks are too small to retain context.
+   - *Chunk Boundary Clipping*: Semantic meaning is lost at arbitrary cut-off points.
+   - *Table/Image Neglect*: Critical data in non-textual formats is skipped.
+
+2. **Retrieval & Embedding Failures**
+   - *Retriever Bias*: The search algorithm consistently misses specific topics.
+   - *Embedding Distance Mismatch*: High cosine similarity but low semantic relevance.
+   - *Top-K Dilution*: Including too many non-relevant chunks confuses the LLM.
+
+3. **Vector Store Integrity**
+   - *Index Skew*: Part of the vector store is out of date compared to the source.
+   - *Empty Index*: Startup failures where queries are run against an uninitialized store.
+
+4. **Reasoning & Generation Issues**
+   - *Hallucination*: The LLM generates plausible but factually incorrect information not present in the context.
+   - *Question Drift*: In multi-turn conversations, the original intent is lost.
+   - *Prompt Injection / Guardrail Breaches*.
+
+Debugging Patterns in Airflow
+-----------------------------
+
+Airflow provides several mechanisms to detect and log these 16 failure modes during DAG execution.
+
+Attaching Sensors and Health Checks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Instead of treating your RAG pipeline as a "black box," you can insert diagnostic tasks or sensors to validate each step.
+
+.. code-block:: python
+
+    @task
+    def semantic_firewall(answer, context):
+        """
+        A diagnostic task that validates the final output against context.
+        """
+        # Perform faithfulness and relevance checks
+        if not is_faithful(answer, context):
+            raise AirflowFailException("Faithfulness check failed: Hallucination detected.")
+
+
+    @task
+    def chunk_integrity_check(chunks):
+        """
+        Detects 'Small Chunk Sensitivity' failure mode.
+        """
+        avg_size = sum(len(c) for c in chunks) / len(chunks)
+        if avg_size < 150:
+            logger.warning("Potential failure: Average chunk size is too small.")
+
+Enhanced Logging
+~~~~~~~~~~~~~~~~
+
+Use Airflow's task logging to capture specific failure metadata. This makes it easier to use Airflow's UI to see exactly where a retrieval went wrong.
+
+.. code-block:: python
+
+    logger.info("FAILURE DETECTED: Retriever Bias. Query: '%s' returned Doc ID: %s", query, top_doc_id)
+
+Example DAG
+-----------
+
+For a full demonstration, see the :ref:`example_rag_dag` provided in the Airflow example dags.
+
+Further Reading
+---------------
+
+- `WFGY 16-problem ProblemMap <https://github.com/onestardao/WFGY>`_
+- `RAG Debugging Best Practices <https://airflow.apache.org/docs/apache-airflow/stable/best-practices.html>`_

--- a/airflow-core/src/airflow/example_dags/example_rag_dag.py
+++ b/airflow-core/src/airflow/example_dags/example_rag_dag.py
@@ -1,0 +1,164 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Example DAG demonstrating RAG (Retrieval-Augmented Generation) failure analysis.
+
+This DAG simulates a typical RAG pipeline and shows how to use Airflow to detect
+and diagnose common failure modes from the WFGY 16-problem ProblemMap, such as
+chunking errors, retriever bias, and hallucination risks.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+from datetime import datetime
+
+from airflow.decorators import dag, task, task_group
+from airflow.exceptions import AirflowFailException
+
+logger = logging.getLogger(__name__)
+
+
+@dag(
+    schedule=None,
+    start_date=datetime(2025, 1, 1),
+    catchup=False,
+    tags=["example", "rag", "llm", "monitoring"],
+)
+def example_rag_failure_analysis():
+    """
+    ### RAG Failure Analysis Pipeline
+    This DAG illustrates a RAG pipeline with built-in health checks for each stage.
+    """
+
+    @task_group(group_id="ingestion_and_chunking")
+    def ingestion():
+        """Simulates ingestion and chunking with failure detection."""
+
+        @task
+        def fetch_documents():
+            """Simulates fetching documents from a source."""
+            logger.info("Fetching documents from source...")
+            return ["doc1", "doc2", "doc3"]
+
+        @task
+        def chunk_documents(docs):
+            """
+            Simulates chunking with a check for 'Small Chunk Sensitivity'.
+            Failure mode: Too small chunks lose context.
+            """
+            logger.info("Chunking documents...")
+            chunks = []
+            for doc in docs:
+                # Simulating a failure mode: Chunk size analysis
+                chunk_size = random.randint(50, 500)
+                if chunk_size < 100:
+                    logger.warning(
+                        "FAILURE DETECTED: Small Chunk Sensitivity. "
+                        "Chunk for %s is only %d characters. Context might be lost.",
+                        doc,
+                        chunk_size,
+                    )
+                chunks.append(f"chunk_{doc}_{chunk_size}")
+            return chunks
+
+        chunk_documents(fetch_documents())
+
+    @task_group(group_id="vector_store_maintenance")
+    def vector_store():
+        """Simulates vector store updates and index health checks."""
+
+        @task
+        def embed_and_index(chunks):
+            """
+            Simulates embedding and indexing.
+            Failure mode: Index Skew / Partially rebuilt stores.
+            """
+            logger.info("Embedding %d chunks...", len(chunks))
+            # Simulate an indexing lag or partial update
+            if random.random() < 0.1:
+                logger.error("FAILURE DETECTED: Index Skew. Some chunks failed to index.")
+                raise AirflowFailException("Index integrity check failed.")
+            logger.info("Indexing complete.")
+
+        embed_and_index(ingestion())
+
+    @task_group(group_id="retrieval_and_generation")
+    def retrieval_gen():
+        """Simulates retrieval and LLM generation with semantic checks."""
+
+        @task
+        def retrieve_context(query="What is Airflow?"):
+            """
+            Simulates retrieval.
+            Failure mode: Retriever Bias / Distance Mismatch.
+            """
+            logger.info("Retrieving context for query: %s", query)
+            # Simulate a 16-problem Failure: Retriever Bias
+            # (e.g., retrieving shipping policy instead of warranty)
+            retrieved_docs = ["Airflow Guide", "Shipping Policy"]
+
+            if "Shipping Policy" in retrieved_docs:
+                logger.warning(
+                    "FAILURE DETECTED: Retriever Bias. Non-relevant document retrieved for query: %s", query
+                )
+            return retrieved_docs
+
+        @task
+        def generate_answer(context):
+            """
+            Simulates LLM generation.
+            Failure mode: Hallucination / Prompt Drift.
+            """
+            logger.info("Generating answer using context...")
+            # Simulate a semantic check on the output
+            answer = "Airflow is a platform to programmatically author, schedule and monitor workflows."
+
+            # Simple simulation of a guardrail check
+            if "platform" not in answer:
+                logger.error("FAILURE DETECTED: Hallucination. Answer lacks core definition.")
+
+            return answer
+
+        @task
+        def semantic_firewall(answer, context):
+            """
+            A diagnostic task that validates the final output against context.
+            This corresponds to the 'Semantic Firewall' concept in the WFGY framework.
+            """
+            logger.info("Running Semantic Firewall check...")
+            # Perform automated checks (e.g., faithfulness, relevance)
+            faithfulness_score = random.uniform(0.7, 1.0)
+            if faithfulness_score < 0.8:
+                logger.warning(
+                    "FAILURE DETECTED: Context Mismatch. LLM answer faithfulness score: %.2f",
+                    faithfulness_score,
+                )
+            else:
+                logger.info("Semantic Firewall check passed.")
+
+        context = retrieve_context()
+        answer = generate_answer(context)
+        semantic_firewall(answer, context)
+
+    # Define high-level dependencies
+    ingestion() >> vector_store() >> retrieval_gen()
+
+
+example_rag_failure_analysis()

--- a/airflow-core/src/airflow/example_dags/example_rag_dag.py
+++ b/airflow-core/src/airflow/example_dags/example_rag_dag.py
@@ -19,8 +19,9 @@
 Example DAG demonstrating RAG (Retrieval-Augmented Generation) failure analysis.
 
 This DAG simulates a typical RAG pipeline and shows how to use Airflow to detect
-and diagnose common failure modes from the WFGY 16-problem ProblemMap, such as
-chunking errors, retriever bias, and hallucination risks.
+and diagnose common failure modes, such as chunking errors, retriever bias, and
+hallucination risks. The failure taxonomy follows the WFGY ProblemMap
+(https://github.com/onestardao/WFGY).
 """
 
 from __future__ import annotations
@@ -29,8 +30,8 @@ import logging
 import random
 from datetime import datetime
 
-from airflow.decorators import dag, task, task_group
-from airflow.exceptions import AirflowFailException
+from airflow.sdk import dag, task, task_group
+from airflow.sdk.exceptions import AirflowFailException
 
 logger = logging.getLogger(__name__)
 
@@ -52,13 +53,13 @@ def example_rag_failure_analysis():
         """Simulates ingestion and chunking with failure detection."""
 
         @task
-        def fetch_documents():
+        def fetch_documents() -> list[str]:
             """Simulates fetching documents from a source."""
             logger.info("Fetching documents from source...")
             return ["doc1", "doc2", "doc3"]
 
         @task
-        def chunk_documents(docs):
+        def chunk_documents(docs: list[str]) -> list[str]:
             """
             Simulates chunking with a check for 'Small Chunk Sensitivity'.
             Failure mode: Too small chunks lose context.
@@ -78,14 +79,14 @@ def example_rag_failure_analysis():
                 chunks.append(f"chunk_{doc}_{chunk_size}")
             return chunks
 
-        chunk_documents(fetch_documents())
+        return chunk_documents(fetch_documents())
 
     @task_group(group_id="vector_store_maintenance")
-    def vector_store():
+    def vector_store(chunks):
         """Simulates vector store updates and index health checks."""
 
         @task
-        def embed_and_index(chunks):
+        def embed_and_index(chunks: list[str]) -> None:
             """
             Simulates embedding and indexing.
             Failure mode: Index Skew / Partially rebuilt stores.
@@ -97,20 +98,20 @@ def example_rag_failure_analysis():
                 raise AirflowFailException("Index integrity check failed.")
             logger.info("Indexing complete.")
 
-        embed_and_index(ingestion())
+        return embed_and_index(chunks)
 
     @task_group(group_id="retrieval_and_generation")
     def retrieval_gen():
         """Simulates retrieval and LLM generation with semantic checks."""
 
         @task
-        def retrieve_context(query="What is Airflow?"):
+        def retrieve_context(query: str = "What is Airflow?") -> list[str]:
             """
             Simulates retrieval.
             Failure mode: Retriever Bias / Distance Mismatch.
             """
             logger.info("Retrieving context for query: %s", query)
-            # Simulate a 16-problem Failure: Retriever Bias
+            # Simulate a Retriever Bias failure mode
             # (e.g., retrieving shipping policy instead of warranty)
             retrieved_docs = ["Airflow Guide", "Shipping Policy"]
 
@@ -121,7 +122,7 @@ def example_rag_failure_analysis():
             return retrieved_docs
 
         @task
-        def generate_answer(context):
+        def generate_answer(context: list[str]) -> str:
             """
             Simulates LLM generation.
             Failure mode: Hallucination / Prompt Drift.
@@ -137,12 +138,14 @@ def example_rag_failure_analysis():
             return answer
 
         @task
-        def semantic_firewall(answer, context):
+        def output_faithfulness_check(answer: str, context: list[str]) -> None:
             """
-            A diagnostic task that validates the final output against context.
-            This corresponds to the 'Semantic Firewall' concept in the WFGY framework.
+            A diagnostic task that validates the final answer against retrieved context.
+
+            Checks for hallucination and context mismatch by scoring how well the
+            generated answer is grounded in the retrieved documents.
             """
-            logger.info("Running Semantic Firewall check...")
+            logger.info("Running output faithfulness check...")
             # Perform automated checks (e.g., faithfulness, relevance)
             faithfulness_score = random.uniform(0.7, 1.0)
             if faithfulness_score < 0.8:
@@ -151,14 +154,18 @@ def example_rag_failure_analysis():
                     faithfulness_score,
                 )
             else:
-                logger.info("Semantic Firewall check passed.")
+                logger.info("Output faithfulness check passed.")
 
         context = retrieve_context()
         answer = generate_answer(context)
-        semantic_firewall(answer, context)
+        return output_faithfulness_check(answer, context)
 
     # Define high-level dependencies
-    ingestion() >> vector_store() >> retrieval_gen()
+    chunks_out = ingestion()
+    vec_store_out = vector_store(chunks_out)
+    retrieval_out = retrieval_gen()
+
+    vec_store_out >> retrieval_out
 
 
 example_rag_failure_analysis()

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -226,6 +226,7 @@ checksums
 childs
 chmod
 chown
+chunking
 ci
 cid
 ciphertext
@@ -296,6 +297,7 @@ contrib
 copyable
 CoreV
 coroutine
+cosine
 cosmosdb
 cp
 cpu
@@ -711,12 +713,15 @@ Grpc
 gRPC
 grpc
 gsuite
+guardrail
 Gunicorn
 gunicorn
 gz
 Gzip
 gzipped
 hadoop
+hadoopcmd
+hallucination
 hardcode
 hardcoded
 hardcoding
@@ -948,6 +953,7 @@ LiteralValue
 Liveness
 liveness
 livy
+LLM
 llm
 loadBalancerIP
 localhost
@@ -1215,6 +1221,7 @@ presigned
 prestodb
 pretify
 prev
+ProblemMap
 Proc
 proc
 productionalize
@@ -1332,6 +1339,8 @@ resourceVersion
 reStructuredText
 resultset
 resumable
+retransmits
+retriever
 Reusability
 rfc
 rmse
@@ -1790,6 +1799,7 @@ webserver
 webservers
 Werkzeug
 werkzeug
+WFGY
 whitespace
 whl
 wildcarded


### PR DESCRIPTION
Adds a RAG/LLM pipeline failure analysis guide and example DAG to help Airflow users debug orchestrated RAG workflows using structured failure categories from the [WFGY ProblemMap](https://github.com/onestardao/WFGY) (MIT-licensed).

Changes:

rag-failure-analysis.rst — how-to guide covering ingestion, retrieval, vector store, and generation failure modes with Airflow logging/task patterns

example_rag_dag.py — runnable example DAG with built-in health checks (chunk_integrity_check, output_faithfulness_check) at each pipeline stage

howto/index.rst — adds guide to the official how-to section

closes: #62291

Was generative AI tooling used to co-author this PR?

 Yes — Antigravity (Google DeepMind)
