### PR TITLE
Use prek from Breeze Python instead of system PATH

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/run_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_utils.py
@@ -230,7 +230,7 @@ def assert_prek_installed():
     need_to_reinstall_prek = False
     try:
         command_result = run_command(
-            ["prek", "--version"],
+            [python_executable, "-m", "prek", "--version"],
             capture_output=True,
             text=True,
             check=False,


### PR DESCRIPTION
What this PR does

Updates assert_prek_installed() to run:

python -m prek --version

instead of:

prek --version
Why

This ensures prek is executed from the Breeze Python environment rather than relying on a system-installed binary. It improves environment isolation and avoids false positives from globally installed versions.

Impact

More reliable prek detection

No functional changes beyond environment correctness

No unrelated files modified
