### PR TITLE
Decouple core exceptions from SDK and fix TaskDeferred serialization

### DIFF
--- a/airflow-core/src/airflow/__init__.py
+++ b/airflow-core/src/airflow/__init__.py
@@ -31,7 +31,7 @@ __version__ = "3.2.0"
 import os
 import sys
 import warnings
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 from airflow.utils.deprecation_tools import DeprecatedImportWarning
 
@@ -98,7 +98,10 @@ if TYPE_CHECKING:
     # These objects are imported by PEP-562, however, static analyzers and IDE's
     # have no idea about typing of these objects.
     # Add it under TYPE_CHECKING block should help with it.
-    from airflow.sdk import DAG, Asset, Asset as Dataset, XComArg
+    DAG: TypeAlias = Any
+    Asset: TypeAlias = Any
+    Dataset: TypeAlias = Any
+    XComArg: TypeAlias = Any
 
 
 def __getattr__(name: str):

--- a/airflow-core/src/airflow/exceptions.py
+++ b/airflow-core/src/airflow/exceptions.py
@@ -21,8 +21,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Collection
 from http import HTTPStatus
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 if TYPE_CHECKING:
     from airflow.models import DagRun
@@ -30,47 +31,49 @@ if TYPE_CHECKING:
 # Re exporting AirflowConfigException from shared configuration
 from airflow._shared.configuration.exceptions import AirflowConfigException as AirflowConfigException
 
-try:
-    from airflow.sdk.exceptions import (
-        AirflowException,
-        AirflowNotFoundException,
-        AirflowOptionalProviderFeatureException as AirflowOptionalProviderFeatureException,
-        AirflowRescheduleException as AirflowRescheduleException,
-        AirflowTimetableInvalid as AirflowTimetableInvalid,
-        TaskNotFound as TaskNotFound,
-    )
-except ModuleNotFoundError:
-    # When _AIRFLOW__AS_LIBRARY is set, airflow.sdk may not be installed.
-    # In that case, we define fallback exception classes that mirror the SDK ones.
-    class AirflowException(Exception):  # type: ignore[no-redef]
-        """Base exception for Airflow errors."""
 
-    class AirflowNotFoundException(AirflowException):  # type: ignore[no-redef]
-        """Raise when a requested object is not found."""
+class AirflowException(Exception):
+    """Base exception for Airflow errors."""
 
-    class AirflowTimetableInvalid(AirflowException):  # type: ignore[no-redef]
-        """Raise when a DAG has an invalid timetable."""
+    status_code = HTTPStatus.INTERNAL_SERVER_ERROR
 
-    class TaskNotFound(AirflowException):  # type: ignore[no-redef]
-        """Raise when a Task is not available in the system."""
+    def serialize(self):
+        cls = self.__class__
+        return f"{cls.__module__}.{cls.__name__}", (str(self),), {}
 
-    class AirflowRescheduleException(AirflowException):  # type: ignore[no-redef]
-        """
-        Raise when the task should be re-scheduled at a later time.
 
-        :param reschedule_date: The date when the task should be rescheduled
-        """
+class AirflowNotFoundException(AirflowException):
+    """Raise when a requested object is not found."""
 
-        def __init__(self, reschedule_date):
-            super().__init__()
-            self.reschedule_date = reschedule_date
+    status_code = HTTPStatus.NOT_FOUND
 
-        def serialize(self):
-            cls = self.__class__
-            return f"{cls.__module__}.{cls.__name__}", (), {"reschedule_date": self.reschedule_date}
 
-    class AirflowOptionalProviderFeatureException(AirflowException):  # type: ignore[no-redef]
-        """Raise by providers when imports are missing for optional provider features."""
+class AirflowOptionalProviderFeatureException(AirflowException):
+    """Raise by providers when imports are missing for optional provider features."""
+
+
+class AirflowTimetableInvalid(AirflowException):
+    """Raise when a DAG has an invalid timetable."""
+
+
+class TaskNotFound(AirflowException):
+    """Raise when a Task is not available in the system."""
+
+
+class AirflowRescheduleException(AirflowException):
+    """
+    Raise when the task should be re-scheduled at a later time.
+
+    :param reschedule_date: The date when the task should be rescheduled
+    """
+
+    def __init__(self, reschedule_date):
+        super().__init__()
+        self.reschedule_date = reschedule_date
+
+    def serialize(self):
+        cls = self.__class__
+        return f"{cls.__module__}.{cls.__name__}", (), {"reschedule_date": self.reschedule_date}
 
 
 class AirflowBadRequest(AirflowException):
@@ -170,6 +173,218 @@ class NotMapped(Exception):
 
 class PoolNotFound(AirflowNotFoundException):
     """Raise when a Pool is not available in the system."""
+
+
+class AirflowDagCycleException(AirflowException):
+    """Raise when there is a cycle in Dag definition."""
+
+
+class AirflowFailException(AirflowException):
+    """Raise when the task should be failed without retrying."""
+
+
+class _AirflowExecuteWithInactiveAssetExecption(AirflowFailException):
+    main_message: str
+
+    def __init__(self, inactive_asset_keys: Collection[Any]) -> None:
+        self.inactive_asset_keys = inactive_asset_keys
+
+    @staticmethod
+    def _render_asset_key(key: Any) -> str:
+        return repr(key)
+
+    def __str__(self) -> str:
+        return f"{self.main_message}: {self.inactive_assets_message}"
+
+    @property
+    def inactive_assets_message(self) -> str:
+        return ", ".join(self._render_asset_key(key) for key in self.inactive_asset_keys)
+
+
+class AirflowInactiveAssetInInletOrOutletException(_AirflowExecuteWithInactiveAssetExecption):
+    """Raise when the task is executed with inactive assets in its inlet or outlet."""
+
+    main_message = "Task has the following inactive assets in its inlets or outlets"
+
+
+class AirflowSensorTimeout(AirflowException):
+    """Raise when there is a timeout on sensor polling."""
+
+
+class AirflowSkipException(AirflowException):
+    """Raise when the task should be skipped."""
+
+
+class AirflowTaskTerminated(BaseException):
+    """Raise when the task execution is terminated."""
+
+
+class AirflowTaskTimeout(BaseException):
+    """Raise when the task execution times-out."""
+
+
+class TaskDeferred(BaseException):
+    """
+    Signal an operator moving to deferred state.
+
+    Special exception raised to signal that the operator it was raised from
+    wishes to defer until a trigger fires.
+    """
+
+    def __init__(
+        self,
+        *,
+        trigger,
+        method_name: str,
+        kwargs: dict[str, Any] | None = None,
+        timeout=None,
+    ):
+        super().__init__()
+        self.trigger = trigger
+        self.method_name = method_name
+        self.kwargs = kwargs
+        self.timeout = timeout
+
+    def serialize(self):
+        cls = self.__class__
+        return (
+            f"{cls.__module__}.{cls.__name__}",
+            (),
+            {
+                "trigger": self.trigger,
+                "method_name": self.method_name,
+                "kwargs": self.kwargs,
+                "timeout": self.timeout,
+            },
+        )
+
+    def __repr__(self) -> str:
+        return f"<TaskDeferred trigger={self.trigger} method={self.method_name}>"
+
+
+class TaskDeferralError(AirflowException):
+    """Raised when a task failed during deferral for some reason."""
+
+
+class TaskDeferralTimeout(AirflowException):
+    """Raise when there is a timeout on the deferral."""
+
+
+class DagRunTriggerException(AirflowException):
+    """
+    Signal by an operator to trigger a specific Dag Run of a dag.
+    """
+
+    def __init__(
+        self,
+        *,
+        trigger_dag_id: str,
+        dag_run_id: str,
+        conf: dict | None,
+        logical_date=None,
+        reset_dag_run: bool,
+        skip_when_already_exists: bool,
+        wait_for_completion: bool,
+        allowed_states: list[str],
+        failed_states: list[str],
+        poke_interval: int,
+        deferrable: bool,
+        note: str | None = None,
+    ):
+        super().__init__()
+        self.trigger_dag_id = trigger_dag_id
+        self.dag_run_id = dag_run_id
+        self.conf = conf
+        self.logical_date = logical_date
+        self.reset_dag_run = reset_dag_run
+        self.skip_when_already_exists = skip_when_already_exists
+        self.wait_for_completion = wait_for_completion
+        self.allowed_states = allowed_states
+        self.failed_states = failed_states
+        self.poke_interval = poke_interval
+        self.deferrable = deferrable
+        self.note = note
+
+
+class DownstreamTasksSkipped(AirflowException):
+    """
+    Signal by an operator to skip its downstream tasks.
+
+    :param tasks: List of task_ids to skip or a list of tuples with task_id and map_index to skip.
+    """
+
+    def __init__(self, *, tasks):
+        super().__init__()
+        self.tasks = tasks
+
+
+class XComNotFound(AirflowException):
+    """Raise when an XCom reference is being resolved against a non-existent XCom."""
+
+    def __init__(self, dag_id: str, task_id: str, key: str) -> None:
+        super().__init__()
+        self.dag_id = dag_id
+        self.task_id = task_id
+        self.key = key
+
+    def __str__(self) -> str:
+        return f'XComArg result from {self.task_id} at {self.dag_id} with key="{self.key}" is not found!'
+
+    def serialize(self):
+        cls = self.__class__
+        return (
+            f"{cls.__module__}.{cls.__name__}",
+            (),
+            {"dag_id": self.dag_id, "task_id": self.task_id, "key": self.key},
+        )
+
+
+class ParamValidationError(AirflowException):
+    """Raise when DAG params is invalid."""
+
+
+class DuplicateTaskIdFound(AirflowException):
+    """Raise when a Task with duplicate task_id is defined in the same DAG."""
+
+
+class TaskAlreadyInTaskGroup(AirflowException):
+    """Raise when a Task cannot be added to a TaskGroup since it already belongs to another TaskGroup."""
+
+    def __init__(self, task_id: str, existing_group_id: str | None, new_group_id: str):
+        super().__init__(task_id, new_group_id)
+        self.task_id = task_id
+        self.existing_group_id = existing_group_id
+        self.new_group_id = new_group_id
+
+    def __str__(self) -> str:
+        if self.existing_group_id is None:
+            existing_group = "the DAG's root group"
+        else:
+            existing_group = f"group {self.existing_group_id!r}"
+        return f"cannot add {self.task_id!r} to {self.new_group_id!r} (already in {existing_group})"
+
+
+class FailFastDagInvalidTriggerRule(AirflowException):
+    """Raise when a dag has 'fail_fast' enabled yet has a non-default trigger rule."""
+
+    @classmethod
+    def check(cls, *, fail_fast: bool, trigger_rule):
+        """
+        Check that fail_fast dag tasks have allowable trigger rules.
+
+        :meta private:
+        """
+        if not fail_fast:
+            return
+        from airflow.task.trigger_rule import TriggerRule
+
+        if trigger_rule not in (TriggerRule.ALL_SUCCESS, TriggerRule.ALL_DONE_SETUP_SUCCESS):
+            raise cls()
+
+    def __str__(self) -> str:
+        from airflow.task.trigger_rule import TriggerRule
+
+        return f"A 'fail_fast' dag can only have {TriggerRule.ALL_SUCCESS} trigger rule"
 
 
 class FileSyntaxError(NamedTuple):
@@ -305,34 +520,36 @@ class AirflowClearRunningTaskException(AirflowException):
     """Raise when the user attempts to clear currently running tasks."""
 
 
-_DEPRECATED_EXCEPTIONS = {
-    "AirflowDagCycleException",
-    "AirflowFailException",
-    "AirflowInactiveAssetInInletOrOutletException",
-    "AirflowSensorTimeout",
-    "AirflowSkipException",
-    "AirflowTaskTerminated",
-    "AirflowTaskTimeout",
-    "DagRunTriggerException",
-    "DownstreamTasksSkipped",
-    "DuplicateTaskIdFound",
-    "FailFastDagInvalidTriggerRule",
-    "ParamValidationError",
-    "TaskAlreadyInTaskGroup",
-    "TaskDeferralError",
-    "TaskDeferralTimeout",
-    "TaskDeferred",
-    "XComNotFound",
+_DEPRECATED_EXCEPTION_CLASSES = {
+    "AirflowDagCycleException": AirflowDagCycleException,
+    "AirflowFailException": AirflowFailException,
+    "AirflowInactiveAssetInInletOrOutletException": AirflowInactiveAssetInInletOrOutletException,
+    "AirflowSensorTimeout": AirflowSensorTimeout,
+    "AirflowSkipException": AirflowSkipException,
+    "AirflowTaskTerminated": AirflowTaskTerminated,
+    "AirflowTaskTimeout": AirflowTaskTimeout,
+    "DagRunTriggerException": DagRunTriggerException,
+    "DownstreamTasksSkipped": DownstreamTasksSkipped,
+    "DuplicateTaskIdFound": DuplicateTaskIdFound,
+    "FailFastDagInvalidTriggerRule": FailFastDagInvalidTriggerRule,
+    "ParamValidationError": ParamValidationError,
+    "TaskAlreadyInTaskGroup": TaskAlreadyInTaskGroup,
+    "TaskDeferralError": TaskDeferralError,
+    "TaskDeferralTimeout": TaskDeferralTimeout,
+    "TaskDeferred": TaskDeferred,
+    "XComNotFound": XComNotFound,
 }
+
+for _name in _DEPRECATED_EXCEPTION_CLASSES:
+    globals().pop(_name, None)
 
 
 def __getattr__(name: str):
     """Provide backward compatibility for moved exceptions."""
-    if name in _DEPRECATED_EXCEPTIONS:
+    if name in _DEPRECATED_EXCEPTION_CLASSES:
         import warnings
 
         from airflow import DeprecatedImportWarning
-        from airflow._shared.module_loading import import_string
 
         target_path = f"airflow.sdk.exceptions.{name}"
         warnings.warn(
@@ -340,5 +557,5 @@ def __getattr__(name: str):
             DeprecatedImportWarning,
             stacklevel=2,
         )
-        return import_string(target_path)
+        return _DEPRECATED_EXCEPTION_CLASSES[name]
     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/airflow-core/src/airflow/models/__init__.py
+++ b/airflow-core/src/airflow/models/__init__.py
@@ -53,7 +53,7 @@ __all__ = [
     "clear_task_instances",
 ]
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 
 def import_all_models():
@@ -148,10 +148,13 @@ if TYPE_CHECKING:
     from airflow.models.taskreschedule import TaskReschedule
     from airflow.models.trigger import Trigger
     from airflow.models.variable import Variable
-    from airflow.sdk import DAG, BaseOperator, BaseOperatorLink, Param
-    from airflow.sdk.bases.xcom import BaseXCom
-    from airflow.sdk.definitions.mappedoperator import MappedOperator
-    from airflow.sdk.execution_time.xcom import XCom
+    DAG: TypeAlias = Any
+    BaseOperator: TypeAlias = Any
+    BaseOperatorLink: TypeAlias = Any
+    Param: TypeAlias = Any
+    BaseXCom: TypeAlias = Any
+    MappedOperator: TypeAlias = Any
+    XCom: TypeAlias = Any
 
 
 __deprecated_classes = {

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -472,7 +472,7 @@ class BaseSerialization:
         :meta private:
         """
         from airflow.sdk.definitions._internal.types import is_arg_set
-        from airflow.sdk.exceptions import TaskDeferred
+        from airflow.exceptions import TaskDeferred
 
         if not is_arg_set(var):
             return cls._encode(None, type_=DAT.ARG_NOT_SET)


### PR DESCRIPTION
Remove SDK imports from core init/models/exceptions.

Use core TaskDeferred in serialization to keep exception roundtrip working. 

related: #57315  (follow up)


---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
