### PR TITLE
fix(Breeze): Ensure parent directory exists before writing UI asset dev mode file

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/run_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_utils.py
@@ -458,6 +458,7 @@ def _run_compile_internally(
     if dev:
         # Clean up stale lock file
         compile_lock.unlink(missing_ok=True)
+        UI_ASSET_OUT_DEV_MODE_FILE.parent.mkdir(parents=True, exist_ok=True)
         with open(UI_ASSET_OUT_DEV_MODE_FILE, "w") as output_file:
             return run_command(
                 command_to_execute,


### PR DESCRIPTION
## summary
* Ensure the parent directory of `UI_ASSET_OUT_DEV_MODE_FILE` is created before opening it for writing in dev mode.

## Why
This issue became visible after running **`breeze doctor`**, which removes the .build/ui directory. Since the dev path did not recreate the parent directory, attempting to write the file could raise a FileNotFoundError.
### Before
<img width="1009" height="1009" alt="Screenshot 2026-02-22 at 4 02 28 PM" src="https://github.com/user-attachments/assets/de90dd58-a41b-4432-b4b9-f2bec9a62ab4" />

<img width="652" height="222" alt="image" src="https://github.com/user-attachments/assets/f1946c3e-8ef5-4fed-83bf-dee2f9b387ed" />


### After
<img width="1002" height="824" alt="Screenshot 2026-02-22 at 4 03 50 PM" src="https://github.com/user-attachments/assets/53bacea3-9fbc-497c-a24b-276b2d854b65" />
<img width="672" height="233" alt="image" src="https://github.com/user-attachments/assets/a52ece36-3856-4be3-beb4-915964421875" />


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
