### PR TITLE
fix: allow production image to run with arbitrary UIDs on Podman

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2029,8 +2029,8 @@ RUN bash /scripts/docker/install_mysql.sh prod \
     && mkdir -pv "${AIRFLOW_HOME}" \
     && mkdir -pv "${AIRFLOW_HOME}/dags" \
     && mkdir -pv "${AIRFLOW_HOME}/logs" \
-    && chown -R airflow:0 "${AIRFLOW_USER_HOME_DIR}" "${AIRFLOW_HOME}" \
-    && chmod -R g+rw "${AIRFLOW_USER_HOME_DIR}" "${AIRFLOW_HOME}" \
+    && chgrp -R 0 "${AIRFLOW_USER_HOME_DIR}" "${AIRFLOW_HOME}" \
+    && chmod -R g=u "${AIRFLOW_USER_HOME_DIR}" "${AIRFLOW_HOME}" \
     && find "${AIRFLOW_HOME}" -executable ! -type l -print0 | xargs --null chmod g+x \
     && find "${AIRFLOW_USER_HOME_DIR}" -executable ! -type l -print0 | xargs --null chmod g+x
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1469,6 +1469,24 @@ function create_www_user() {
     fi
 }
 
+function set_pythonpath_for_arbitrary_user() {
+    # Airflow is installed as a local user application in /home/airflow/.local
+    # When the container is run with an arbitrary UID, we need to ensure that
+    # these directories are in PYTHONPATH and PATH even if $HOME is not set
+    # to /home/airflow.
+    local python_major_minor
+    python_major_minor=$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+    local airflow_local_site_packages="${AIRFLOW_USER_HOME_DIR}/.local/lib/python${python_major_minor}/site-packages"
+    local airflow_local_bin="${AIRFLOW_USER_HOME_DIR}/.local/bin"
+
+    if [[ ! "${PYTHONPATH:-}" =~ ${airflow_local_site_packages} ]]; then
+        export PYTHONPATH="${airflow_local_site_packages}:${PYTHONPATH:-}"
+    fi
+    if [[ ! "${PATH:-}" =~ ${airflow_local_bin} ]]; then
+        export PATH="${airflow_local_bin}:${PATH}"
+    fi
+}
+
 function create_system_user_if_missing() {
     # This is needed in case of OpenShift-compatible container execution. In case of OpenShift random
     # User id is used when starting the image, however group 0 is kept as the user group. Our production
@@ -1484,6 +1502,7 @@ function create_system_user_if_missing() {
       fi
       export HOME="${AIRFLOW_USER_HOME_DIR}"
     fi
+    set_pythonpath_for_arbitrary_user
 }
 
 function set_pythonpath_for_root_user() {


### PR DESCRIPTION
### Description

This PR fixes a regression in the Airflow 3.1.x production image where running the container with an arbitrary UID (e.g., via Podman or OpenShift) results in a `ModuleNotFoundError: No module named 'airflow'`.

Previously, running `podman run --user=$(id -u):0 docker.io/apache/airflow:3.1.7 airflow version` would fail because the Python environment could not properly locate the packages installed in `/home/airflow/.local`. 

**Changes made:**
* Ensured that the Python environment paths are correctly mapped and accessible when the container is executed by a non-default user with GID 0.
* Restored compatibility for rootless container environments without compromising the image's security posture.

closes: #62300

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (for understanding)

---