### PR TITLE
add overwrite_file flag and unique attachment saving

### DIFF
--- a/providers/imap/src/airflow/providers/imap/hooks/imap.py
+++ b/providers/imap/src/airflow/providers/imap/hooks/imap.py
@@ -209,6 +209,7 @@ class ImapHook(BaseHook):
         :param overwrite_file: Specify what should happen if file already exists on disk.
             If set to True - file is overwritten.
             If set to False - new file with suffix _1, _2, etc. is created.
+            Suffix is inserted before the last extension, so files with multiple extensions, like .tar.gz, will be transformed into .tar_1.gz.
             Defaults to True to preserve existing behavior.
         :param not_found_mode: Specify what should happen if no attachment has been found.
             Supported values are 'raise', 'warn' and 'ignore'.
@@ -320,9 +321,12 @@ class ImapHook(BaseHook):
     def _create_file(
         self, name: str, payload: Any, local_output_directory: str, overwrite_file: bool
     ) -> None:
-        filename, extensions = name.split(".", 1)
-        counter = 1
-        method = "wb" if overwrite_file else "xb"
+        if overwrite_file:
+            method = "wb"
+        else:
+            method = "xb"
+            filename, extension = os.path.splitext(name)
+            counter = 1
         while True:
             file_path = self._correct_path(name, local_output_directory)
             try:
@@ -330,7 +334,7 @@ class ImapHook(BaseHook):
                     file.write(payload)
                 break
             except FileExistsError:
-                name = f"{filename}_{counter}.{extensions}"
+                name = f"{filename}_{counter}{extension}"
                 counter += 1
 
 

--- a/providers/imap/src/airflow/providers/imap/hooks/imap.py
+++ b/providers/imap/src/airflow/providers/imap/hooks/imap.py
@@ -320,18 +320,17 @@ class ImapHook(BaseHook):
     def _create_file(
         self, name: str, payload: Any, local_output_directory: str, overwrite_file: bool
     ) -> None:
-        current_name = name
+        filename, extensions = name.split(".", 1)
         counter = 1
         method = "wb" if overwrite_file else "xb"
         while True:
-            file_path = self._correct_path(current_name, local_output_directory)
+            file_path = self._correct_path(name, local_output_directory)
             try:
                 with open(file_path, method) as file:
                     file.write(payload)
                 break
             except FileExistsError:
-                filename, extensions = name.split(".", 1)
-                current_name = f"{filename}_{counter}.{extensions}"
+                name = f"{filename}_{counter}.{extensions}"
                 counter += 1
 
 

--- a/providers/imap/tests/unit/imap/hooks/test_imap.py
+++ b/providers/imap/tests/unit/imap/hooks/test_imap.py
@@ -489,6 +489,40 @@ class TestImapHook:
         assert len(list(tmp_path.iterdir())) == 1
 
     @patch(imaplib_string)
+    def test_download_mail_attachments_with_overwrite_no_extension(self, mock_imaplib, tmp_path):
+        _create_fake_imap(mock_imaplib, with_mail=True, attachment_name="README")
+
+        with ImapHook() as imap_hook:
+            imap_hook.download_mail_attachments("README", str(tmp_path), overwrite_file=True)
+            imap_hook.download_mail_attachments("README", str(tmp_path), overwrite_file=True)
+            imap_hook.download_mail_attachments("README", str(tmp_path), overwrite_file=True)
+
+        assert (tmp_path / "README").exists()
+        assert not (tmp_path / "README_1").exists()
+        assert not (tmp_path / "README_2").exists()
+
+        payload = b"SWQsTmFtZQoxLEZlbGl4"
+        assert (tmp_path / "README").read_bytes() == payload
+        assert len(list(tmp_path.iterdir())) == 1
+
+    @patch(imaplib_string)
+    def test_download_mail_attachments_with_overwrite_multi_extension(self, mock_imaplib, tmp_path):
+        _create_fake_imap(mock_imaplib, with_mail=True, attachment_name="test.tar.gz")
+
+        with ImapHook() as imap_hook:
+            imap_hook.download_mail_attachments("test.tar.gz", str(tmp_path), overwrite_file=True)
+            imap_hook.download_mail_attachments("test.tar.gz", str(tmp_path), overwrite_file=True)
+            imap_hook.download_mail_attachments("test.tar.gz", str(tmp_path), overwrite_file=True)
+
+        assert (tmp_path / "test.tar.gz").exists()
+        assert not (tmp_path / "test.tar_1.gz").exists()
+        assert not (tmp_path / "test.tar_2.gz").exists()
+
+        payload = b"SWQsTmFtZQoxLEZlbGl4"
+        assert (tmp_path / "test.tar.gz").read_bytes() == payload
+        assert len(list(tmp_path.iterdir())) == 1
+
+    @patch(imaplib_string)
     def test_download_mail_attachments_without_overwrite_creates_copy(self, mock_imaplib, tmp_path):
         _create_fake_imap(mock_imaplib, with_mail=True)
 
@@ -505,3 +539,39 @@ class TestImapHook:
         assert (tmp_path / "test1.csv").read_bytes() == payload
         assert (tmp_path / "test1_1.csv").read_bytes() == payload
         assert (tmp_path / "test1_2.csv").read_bytes() == payload
+
+    @patch(imaplib_string)
+    def test_download_mail_attachments_without_overwrite_no_extension(self, mock_imaplib, tmp_path):
+        _create_fake_imap(mock_imaplib, with_mail=True, attachment_name="README")
+
+        with ImapHook() as imap_hook:
+            imap_hook.download_mail_attachments("README", str(tmp_path), overwrite_file=False)
+            imap_hook.download_mail_attachments("README", str(tmp_path), overwrite_file=False)
+            imap_hook.download_mail_attachments("README", str(tmp_path), overwrite_file=False)
+
+        assert (tmp_path / "README").exists()
+        assert (tmp_path / "README_1").exists()
+        assert (tmp_path / "README_2").exists()
+
+        payload = b"SWQsTmFtZQoxLEZlbGl4"
+        assert (tmp_path / "README").read_bytes() == payload
+        assert (tmp_path / "README_1").read_bytes() == payload
+        assert (tmp_path / "README_2").read_bytes() == payload
+
+    @patch(imaplib_string)
+    def test_download_mail_attachments_without_overwrite_multi_extension(self, mock_imaplib, tmp_path):
+        _create_fake_imap(mock_imaplib, with_mail=True, attachment_name="test.tar.gz")
+
+        with ImapHook() as imap_hook:
+            imap_hook.download_mail_attachments("test.tar.gz", str(tmp_path), overwrite_file=False)
+            imap_hook.download_mail_attachments("test.tar.gz", str(tmp_path), overwrite_file=False)
+            imap_hook.download_mail_attachments("test.tar.gz", str(tmp_path), overwrite_file=False)
+
+        assert (tmp_path / "test.tar.gz").exists()
+        assert (tmp_path / "test.tar_1.gz").exists()
+        assert (tmp_path / "test.tar_2.gz").exists()
+
+        payload = b"SWQsTmFtZQoxLEZlbGl4"
+        assert (tmp_path / "test.tar.gz").read_bytes() == payload
+        assert (tmp_path / "test.tar_1.gz").read_bytes() == payload
+        assert (tmp_path / "test.tar_2.gz").read_bytes() == payload

--- a/providers/imap/tests/unit/imap/hooks/test_imap.py
+++ b/providers/imap/tests/unit/imap/hooks/test_imap.py
@@ -33,7 +33,9 @@ imaplib_string = "airflow.providers.imap.hooks.imap.imaplib"
 open_string = "airflow.providers.imap.hooks.imap.open"
 
 
-def _create_fake_imap(mock_imaplib, with_mail=False, attachment_name="test1.csv", use_ssl=True):
+def _create_fake_imap(
+    mock_imaplib, with_mail=False, attachment_name="test1.csv", use_ssl=True, payload="SWQsTmFtZQoxLEZlbGl4"
+):
     if use_ssl:
         mock_conn = Mock(spec=imaplib.IMAP4_SSL)
         mock_imaplib.IMAP4_SSL.return_value = mock_conn
@@ -51,7 +53,7 @@ def _create_fake_imap(mock_imaplib, with_mail=False, attachment_name="test1.csv"
             f"boundary=123\r\n--123\r\n"
             f"Content-Disposition: attachment; "
             f'filename="{attachment_name}";'
-            f"Content-Transfer-Encoding: base64\r\nSWQsTmFtZQoxLEZlbGl4\r\n--123--"
+            f"Content-Transfer-Encoding: base64\r\n{payload}\r\n--123--"
         )
         mock_conn.fetch.return_value = ("OK", [(b"", mail_string.encode("utf-8"))])
         mock_conn.close.return_value = ("OK", [])
@@ -470,108 +472,50 @@ class TestImapHook:
         mock_open_method.assert_called_once_with("test_directory/test1.csv", "xb")
         mock_open_method.return_value.write.assert_called_once_with(b"SWQsTmFtZQoxLEZlbGl4")
 
+    @pytest.mark.parametrize(
+        ("attachment_name", "unexpected_copies"),
+        [
+            ("test1.csv", ["test1_1.csv", "test1_2.csv"]),
+            ("README", ["README_1", "README_2"]),
+            ("test.tar.gz", ["test.tar_1.gz", "test.tar_2.gz"]),
+        ],
+    )
     @patch(imaplib_string)
-    def test_download_mail_attachments_with_overwrite(self, mock_imaplib, tmp_path):
-        _create_fake_imap(mock_imaplib, with_mail=True)
+    def test_download_mail_attachments_with_overwrite(
+        self, mock_imaplib, tmp_path, attachment_name, unexpected_copies
+    ):
+        payloads = ["test1", "test2", "test3"]
+        for payload in payloads:
+            _create_fake_imap(mock_imaplib, with_mail=True, attachment_name=attachment_name, payload=payload)
+            with ImapHook() as imap_hook:
+                imap_hook.download_mail_attachments(attachment_name, str(tmp_path), overwrite_file=True)
 
-        with ImapHook() as imap_hook:
-            imap_hook.download_mail_attachments("test1.csv", str(tmp_path), overwrite_file=True)
-            imap_hook.download_mail_attachments("test1.csv", str(tmp_path), overwrite_file=True)
-            imap_hook.download_mail_attachments("test1.csv", str(tmp_path), overwrite_file=True)
-
-        assert (tmp_path / "test1.csv").exists()
-        assert not (tmp_path / "test1_1.csv").exists()
-        assert not (tmp_path / "test1_2.csv").exists()
-
-        payload = b"SWQsTmFtZQoxLEZlbGl4"
-        assert (tmp_path / "test1.csv").read_bytes() == payload
-
+        assert (tmp_path / attachment_name).exists()
+        for copy_name in unexpected_copies:
+            assert not (tmp_path / copy_name).exists()
+        assert (tmp_path / attachment_name).read_bytes() == b"test3"
         assert len(list(tmp_path.iterdir())) == 1
 
+    @pytest.mark.parametrize(
+        ("attachment_name", "expected_copies"),
+        [
+            ("test1.csv", ["test1.csv", "test1_1.csv", "test1_2.csv"]),
+            ("README", ["README", "README_1", "README_2"]),
+            ("test.tar.gz", ["test.tar.gz", "test.tar_1.gz", "test.tar_2.gz"]),
+        ],
+    )
     @patch(imaplib_string)
-    def test_download_mail_attachments_with_overwrite_no_extension(self, mock_imaplib, tmp_path):
-        _create_fake_imap(mock_imaplib, with_mail=True, attachment_name="README")
+    def test_download_mail_attachments_without_overwrite_creates_copy(
+        self, mock_imaplib, tmp_path, attachment_name, expected_copies
+    ):
+        _create_fake_imap(mock_imaplib, with_mail=True, attachment_name=attachment_name)
+        payload = b"SWQsTmFtZQoxLEZlbGl4"
 
         with ImapHook() as imap_hook:
-            imap_hook.download_mail_attachments("README", str(tmp_path), overwrite_file=True)
-            imap_hook.download_mail_attachments("README", str(tmp_path), overwrite_file=True)
-            imap_hook.download_mail_attachments("README", str(tmp_path), overwrite_file=True)
+            for _ in range(3):
+                imap_hook.download_mail_attachments(attachment_name, str(tmp_path), overwrite_file=False)
 
-        assert (tmp_path / "README").exists()
-        assert not (tmp_path / "README_1").exists()
-        assert not (tmp_path / "README_2").exists()
-
-        payload = b"SWQsTmFtZQoxLEZlbGl4"
-        assert (tmp_path / "README").read_bytes() == payload
-        assert len(list(tmp_path.iterdir())) == 1
-
-    @patch(imaplib_string)
-    def test_download_mail_attachments_with_overwrite_multi_extension(self, mock_imaplib, tmp_path):
-        _create_fake_imap(mock_imaplib, with_mail=True, attachment_name="test.tar.gz")
-
-        with ImapHook() as imap_hook:
-            imap_hook.download_mail_attachments("test.tar.gz", str(tmp_path), overwrite_file=True)
-            imap_hook.download_mail_attachments("test.tar.gz", str(tmp_path), overwrite_file=True)
-            imap_hook.download_mail_attachments("test.tar.gz", str(tmp_path), overwrite_file=True)
-
-        assert (tmp_path / "test.tar.gz").exists()
-        assert not (tmp_path / "test.tar_1.gz").exists()
-        assert not (tmp_path / "test.tar_2.gz").exists()
-
-        payload = b"SWQsTmFtZQoxLEZlbGl4"
-        assert (tmp_path / "test.tar.gz").read_bytes() == payload
-        assert len(list(tmp_path.iterdir())) == 1
-
-    @patch(imaplib_string)
-    def test_download_mail_attachments_without_overwrite_creates_copy(self, mock_imaplib, tmp_path):
-        _create_fake_imap(mock_imaplib, with_mail=True)
-
-        with ImapHook() as imap_hook:
-            imap_hook.download_mail_attachments("test1.csv", str(tmp_path), overwrite_file=False)
-            imap_hook.download_mail_attachments("test1.csv", str(tmp_path), overwrite_file=False)
-            imap_hook.download_mail_attachments("test1.csv", str(tmp_path), overwrite_file=False)
-
-        assert (tmp_path / "test1.csv").exists()
-        assert (tmp_path / "test1_1.csv").exists()
-        assert (tmp_path / "test1_2.csv").exists()
-
-        payload = b"SWQsTmFtZQoxLEZlbGl4"
-        assert (tmp_path / "test1.csv").read_bytes() == payload
-        assert (tmp_path / "test1_1.csv").read_bytes() == payload
-        assert (tmp_path / "test1_2.csv").read_bytes() == payload
-
-    @patch(imaplib_string)
-    def test_download_mail_attachments_without_overwrite_no_extension(self, mock_imaplib, tmp_path):
-        _create_fake_imap(mock_imaplib, with_mail=True, attachment_name="README")
-
-        with ImapHook() as imap_hook:
-            imap_hook.download_mail_attachments("README", str(tmp_path), overwrite_file=False)
-            imap_hook.download_mail_attachments("README", str(tmp_path), overwrite_file=False)
-            imap_hook.download_mail_attachments("README", str(tmp_path), overwrite_file=False)
-
-        assert (tmp_path / "README").exists()
-        assert (tmp_path / "README_1").exists()
-        assert (tmp_path / "README_2").exists()
-
-        payload = b"SWQsTmFtZQoxLEZlbGl4"
-        assert (tmp_path / "README").read_bytes() == payload
-        assert (tmp_path / "README_1").read_bytes() == payload
-        assert (tmp_path / "README_2").read_bytes() == payload
-
-    @patch(imaplib_string)
-    def test_download_mail_attachments_without_overwrite_multi_extension(self, mock_imaplib, tmp_path):
-        _create_fake_imap(mock_imaplib, with_mail=True, attachment_name="test.tar.gz")
-
-        with ImapHook() as imap_hook:
-            imap_hook.download_mail_attachments("test.tar.gz", str(tmp_path), overwrite_file=False)
-            imap_hook.download_mail_attachments("test.tar.gz", str(tmp_path), overwrite_file=False)
-            imap_hook.download_mail_attachments("test.tar.gz", str(tmp_path), overwrite_file=False)
-
-        assert (tmp_path / "test.tar.gz").exists()
-        assert (tmp_path / "test.tar_1.gz").exists()
-        assert (tmp_path / "test.tar_2.gz").exists()
-
-        payload = b"SWQsTmFtZQoxLEZlbGl4"
-        assert (tmp_path / "test.tar.gz").read_bytes() == payload
-        assert (tmp_path / "test.tar_1.gz").read_bytes() == payload
-        assert (tmp_path / "test.tar_2.gz").read_bytes() == payload
+        for copy_name in expected_copies:
+            assert (tmp_path / copy_name).exists()
+            assert (tmp_path / copy_name).read_bytes() == payload
+        assert len(list(tmp_path.iterdir())) == 3


### PR DESCRIPTION
Hello!

While testing new feature max_mails, that was released in #60963, I noticed unexpected behavior in `imap_hook.download_mail_attachments` method . It overwrites existing files if multiple attachments have the same filename.
For example, if 3 attachments returned by `mail_filter` share the same name, the `retrieve_mail_attachments` method correctly processes all of them. However, `download_mail_attachments` overwrites the files, resulting in only one file being saved instead of three.
Logs:
```
[2026-02-13, 22:43:03 UTC] {imap.py:336} INFO - Found attachment: test.xlsx
[2026-02-13, 22:43:03 UTC] {imap.py:336} INFO - Found attachment: test.xlsx
[2026-02-13, 22:43:03 UTC] {imap.py:336} INFO - Found attachment: test.xlsx
[2026-02-13, 22:43:03 UTC] {logging_mixin.py:190} INFO - downloaded attachments without max_mails: 1
```
<img width="391" height="194" alt="image" src="https://github.com/user-attachments/assets/74d86d34-23bf-45f8-a895-6ae10c60b201" />

This PR introduces a new flag `overwrite_file`, which defaults to `True` to preserve the existing behavior.
- If `overwrite_file=True`, files are overwritten as before.
- If `overwrite_file=False`, new files with incremental suffixes are created instead of overwriting existing ones.

<img width="158" height="90" alt="image" src="https://github.com/user-attachments/assets/dfd83d17-8ce5-49e5-b24e-8f23a0fe36e5" />

To achieve this behavior, I modified the internal `_create_file` method as follows:
1. Deciding wich write method to use. 'wb' to ovewrite file, 'xb' to create new file.
2. 'xb' method automaticly raises FileExistsError if file already exists.
3. So, if file exists -> generate new name using counter. Repeat until free filename is generated.

The following unit tests were added and are passing:

- Test overwrite behavior when `overwrite_file=True`
- Test unique file creation when `overwrite_file=False`
- Test multiple attachments with identical names
- Test incremental suffix creation (`_1`, `_2`, etc.)

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)
Generated-by: [GPT-5] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)



