### PR TITLE
Display User ID of the current user to use in HITL assigned_users.

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Nav/UserSettingsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/UserSettingsButton.tsx
@@ -97,7 +97,7 @@ export const UserSettingsButton = ({ externalViews }: { readonly externalViews: 
                   {translate("signedInAs")}
                 </Box>
                 <Box fontSize="md" fontWeight="semibold">
-                  {currentUser.username}
+                  {`${currentUser.username} (id: ${currentUser.id})`}
                 </Box>
               </Box>
               <Menu.Separator />


### PR DESCRIPTION
Since `id` key is used in assigned_users it's not translated.



<img width="1848" height="994" alt="gh61817" src="https://github.com/user-attachments/assets/7382f576-18aa-4bcd-bbe9-d07b792d011b" />

closes: #61817 

##### Was generative AI tooling used to co-author this PR?

No