### PR TITLE
[v3-1-test] Fix race condition in auth manager initialization (#62214)

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/app.py
+++ b/airflow-core/src/airflow/api_fastapi/app.py
@@ -119,9 +119,8 @@ def cached_app(config=None, testing=False, apps="all") -> FastAPI:
 
 def purge_cached_app() -> None:
     """Remove the cached version of the app and auth_manager in global state."""
-    global app, auth_manager
-    app = None
-    auth_manager = None
+    cached_app.cache_clear()
+    _AuthManagerState.instance = None
 
 
 def get_auth_manager_cls() -> type[BaseAuthManager]:
@@ -166,12 +165,12 @@ def init_auth_manager(app: FastAPI | None = None) -> BaseAuthManager:
 
 def get_auth_manager() -> BaseAuthManager:
     """Return the auth manager, provided it's been initialized before."""
-    if auth_manager is None:
+    if _AuthManagerState.instance is None:
         raise RuntimeError(
             "Auth Manager has not been initialized yet. "
             "The `init_auth_manager` method needs to be called first."
         )
-    return auth_manager
+    return _AuthManagerState.instance
 
 
 def init_plugins(app: FastAPI) -> None:

--- a/airflow-core/src/airflow/api_fastapi/app.py
+++ b/airflow-core/src/airflow/api_fastapi/app.py
@@ -17,7 +17,9 @@
 from __future__ import annotations
 
 import logging
+import threading
 from contextlib import AsyncExitStack, asynccontextmanager
+from functools import cache
 from typing import TYPE_CHECKING, cast
 from urllib.parse import urlsplit
 
@@ -54,8 +56,10 @@ RESERVED_URL_PREFIXES = ["/api/v2", "/ui", "/execution"]
 
 log = logging.getLogger(__name__)
 
-app: FastAPI | None = None
-auth_manager: BaseAuthManager | None = None
+
+class _AuthManagerState:
+    instance: BaseAuthManager | None = None
+    _lock = threading.Lock()
 
 
 @asynccontextmanager
@@ -107,12 +111,10 @@ def create_app(apps: str = "all") -> FastAPI:
     return app
 
 
+@cache
 def cached_app(config=None, testing=False, apps="all") -> FastAPI:
     """Return cached instance of Airflow API app."""
-    global app
-    if not app:
-        app = create_app(apps=apps)
-    return app
+    return create_app(apps=apps)
 
 
 def purge_cached_app() -> None:
@@ -140,10 +142,13 @@ def get_auth_manager_cls() -> type[BaseAuthManager]:
 
 def create_auth_manager() -> BaseAuthManager:
     """Create the auth manager."""
-    global auth_manager
-    auth_manager_cls = get_auth_manager_cls()
-    auth_manager = auth_manager_cls()
-    return auth_manager
+    if _AuthManagerState.instance is not None:
+        return _AuthManagerState.instance
+    with _AuthManagerState._lock:
+        if _AuthManagerState.instance is None:
+            auth_manager_cls = get_auth_manager_cls()
+            _AuthManagerState.instance = auth_manager_cls()
+    return _AuthManagerState.instance
 
 
 def init_auth_manager(app: FastAPI | None = None) -> BaseAuthManager:

--- a/airflow-core/tests/unit/api_fastapi/test_app.py
+++ b/airflow-core/tests/unit/api_fastapi/test_app.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import threading
 from unittest import mock
 
 import pytest
@@ -118,3 +119,37 @@ def test_plugin_with_invalid_url_prefix(caplog, fastapi_apps, expected_message, 
 
     assert any(expected_message in rec.message for rec in caplog.records)
     assert not any(r.path == invalid_path for r in app.routes)
+
+
+def test_create_auth_manager_thread_safety():
+    """Concurrent calls to create_auth_manager must return the same singleton instance."""
+    call_count = 0
+    singleton = None
+
+    class FakeAuthManager:
+        def __init__(self):
+            nonlocal call_count, singleton
+            call_count += 1
+            singleton = self
+
+    app_module.purge_cached_app()
+
+    results = []
+    barrier = threading.Barrier(10)
+
+    def call_create_auth_manager():
+        barrier.wait()
+        results.append(app_module.create_auth_manager())
+
+    with mock.patch.object(app_module, "get_auth_manager_cls", return_value=FakeAuthManager):
+        threads = [threading.Thread(target=call_create_auth_manager) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+    assert len(results) == 10
+    assert all(r is singleton for r in results)
+    assert call_count == 1
+
+    app_module.purge_cached_app()

--- a/airflow-core/tests/unit/utils/test_db.py
+++ b/airflow-core/tests/unit/utils/test_db.py
@@ -240,6 +240,9 @@ class TestDb:
 
         mock_upgrade = mocker.patch("alembic.command.upgrade")
 
+        from airflow.api_fastapi.app import purge_cached_app
+
+        purge_cached_app()
         with conf_vars(auth):
             upgradedb()
 

--- a/providers/fab/src/airflow/providers/fab/auth_manager/cli_commands/utils.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/cli_commands/utils.py
@@ -28,6 +28,7 @@ from flask import Flask
 from sqlalchemy.engine import make_url
 
 import airflow
+from airflow.api_fastapi.app import purge_cached_app
 from airflow.configuration import conf
 from airflow.exceptions import AirflowConfigException
 from airflow.providers.fab.www.extensions.init_appbuilder import init_appbuilder
@@ -49,6 +50,8 @@ def _return_appbuilder(app: Flask) -> AirflowAppBuilder:
 
 @contextmanager
 def get_application_builder() -> Generator[AirflowAppBuilder, None, None]:
+    _return_appbuilder.cache_clear()
+    purge_cached_app()
     static_folder = os.path.join(os.path.dirname(airflow.__file__), "www", "static")
     flask_app = Flask(__name__, static_folder=static_folder)
     webserver_config = conf.get_mandatory_value("fab", "config_file")

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/conftest.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/conftest.py
@@ -19,11 +19,13 @@ from __future__ import annotations
 import pytest
 from fastapi.testclient import TestClient
 
+from airflow.api_fastapi.app import purge_cached_app
 from airflow.providers.fab.auth_manager.fab_auth_manager import FabAuthManager
 
 
 @pytest.fixture(scope="module")
 def fab_auth_manager():
+    purge_cached_app()
     return FabAuthManager(None)
 
 

--- a/providers/fab/tests/unit/fab/auth_manager/conftest.py
+++ b/providers/fab/tests/unit/fab/auth_manager/conftest.py
@@ -22,7 +22,9 @@ from pathlib import Path
 
 import pytest
 
+from airflow.api_fastapi.app import purge_cached_app
 from airflow.providers.fab.www import app
+from airflow.providers.fab.www.app import purge_cached_app as purge_fab_cached_app
 
 from tests_common.test_utils.config import conf_vars
 from unit.fab.decorators import dont_initialize_flask_app_submodules
@@ -30,6 +32,9 @@ from unit.fab.decorators import dont_initialize_flask_app_submodules
 
 @pytest.fixture(scope="session")
 def minimal_app_for_auth_api():
+    purge_cached_app()
+    purge_fab_cached_app()
+
     @dont_initialize_flask_app_submodules(
         skip_all_except=[
             "init_appbuilder",

--- a/providers/fab/tests/unit/fab/auth_manager/test_fab_auth_manager.py
+++ b/providers/fab/tests/unit/fab/auth_manager/test_fab_auth_manager.py
@@ -159,6 +159,12 @@ def auth_manager():
 
 @pytest.fixture
 def flask_app():
+    from airflow.api_fastapi.app import purge_cached_app
+
+    purge_cached_app()
+    from airflow.providers.fab.www.app import purge_cached_app as purge_fab_cached_app
+
+    purge_fab_cached_app()
     with conf_vars(
         {
             (

--- a/providers/fab/tests/unit/fab/auth_manager/test_security.py
+++ b/providers/fab/tests/unit/fab/auth_manager/test_security.py
@@ -203,6 +203,9 @@ def clear_db_before_test():
 
 @pytest.fixture(scope="module")
 def app():
+    from airflow.api_fastapi.app import purge_cached_app
+
+    purge_cached_app()
     with conf_vars(
         {
             (

--- a/providers/fab/tests/unit/fab/auth_manager/views/test_permissions.py
+++ b/providers/fab/tests/unit/fab/auth_manager/views/test_permissions.py
@@ -30,6 +30,9 @@ from unit.fab.utils import client_with_login
 
 @pytest.fixture(scope="module")
 def fab_app():
+    from airflow.api_fastapi.app import purge_cached_app
+
+    purge_cached_app()
     with conf_vars(
         {
             (

--- a/providers/fab/tests/unit/fab/auth_manager/views/test_roles_list.py
+++ b/providers/fab/tests/unit/fab/auth_manager/views/test_roles_list.py
@@ -30,6 +30,9 @@ from unit.fab.utils import client_with_login
 
 @pytest.fixture(scope="module")
 def fab_app():
+    from airflow.api_fastapi.app import purge_cached_app
+
+    purge_cached_app()
     with conf_vars(
         {
             (

--- a/providers/fab/tests/unit/fab/auth_manager/views/test_user.py
+++ b/providers/fab/tests/unit/fab/auth_manager/views/test_user.py
@@ -30,6 +30,9 @@ from unit.fab.utils import client_with_login
 
 @pytest.fixture(scope="module")
 def fab_app():
+    from airflow.api_fastapi.app import purge_cached_app
+
+    purge_cached_app()
     with conf_vars(
         {
             (

--- a/providers/fab/tests/unit/fab/auth_manager/views/test_user_edit.py
+++ b/providers/fab/tests/unit/fab/auth_manager/views/test_user_edit.py
@@ -30,6 +30,9 @@ from unit.fab.utils import client_with_login
 
 @pytest.fixture(scope="module")
 def fab_app():
+    from airflow.api_fastapi.app import purge_cached_app
+
+    purge_cached_app()
     with conf_vars(
         {
             (

--- a/providers/fab/tests/unit/fab/auth_manager/views/test_user_stats.py
+++ b/providers/fab/tests/unit/fab/auth_manager/views/test_user_stats.py
@@ -30,6 +30,9 @@ from unit.fab.utils import client_with_login
 
 @pytest.fixture(scope="module")
 def fab_app():
+    from airflow.api_fastapi.app import purge_cached_app
+
+    purge_cached_app()
     with conf_vars(
         {
             (

--- a/providers/fab/tests/unit/fab/www/test_auth.py
+++ b/providers/fab/tests/unit/fab/www/test_auth.py
@@ -33,6 +33,9 @@ mock_call = Mock()
 
 @pytest.fixture
 def app():
+    from airflow.api_fastapi.app import purge_cached_app
+
+    purge_cached_app()
     with conf_vars(
         {
             (

--- a/providers/fab/tests/unit/fab/www/views/test_views_custom_user_views.py
+++ b/providers/fab/tests/unit/fab/www/views/test_views_custom_user_views.py
@@ -63,6 +63,34 @@ PERMISSIONS_TESTS_PARAMS = [
 ]
 
 
+def delete_roles(app):
+    for role_name in ["role_edit_one_dag"]:
+        delete_role(app, role_name)
+
+
+@pytest.fixture
+def app():
+    from airflow.api_fastapi.app import purge_cached_app
+
+    purge_cached_app()
+    with conf_vars(
+        {
+            (
+                "core",
+                "auth_manager",
+            ): "airflow.providers.fab.auth_manager.fab_auth_manager.FabAuthManager",
+        }
+    ):
+        app = application.create_app(enable_plugins=False)
+        app.config["WTF_CSRF_ENABLED"] = False
+        yield app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
 class TestSecurity:
     @classmethod
     def setup_class(cls):

--- a/providers/google/tests/unit/google/common/auth_backend/test_google_openid.py
+++ b/providers/google/tests/unit/google/common/auth_backend/test_google_openid.py
@@ -34,6 +34,8 @@ if not AIRFLOW_V_3_0_PLUS:
         allow_module_level=True,
     )
 
+from airflow.api_fastapi.app import purge_cached_app
+
 from tests_common.test_utils.config import conf_vars
 
 
@@ -41,6 +43,11 @@ from tests_common.test_utils.config import conf_vars
 def google_openid_app():
     if importlib.util.find_spec("flask_session") is None:
         return None
+
+    purge_cached_app()
+    from airflow.providers.fab.www.app import purge_cached_app as purge_fab_cached_app
+
+    purge_fab_cached_app()
 
     def factory():
         with conf_vars(

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/routes/conftest.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/routes/conftest.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import pytest
 from fastapi.testclient import TestClient
 
-from airflow.api_fastapi.app import create_app
+from airflow.api_fastapi.app import create_app, purge_cached_app
 from airflow.providers.keycloak.auth_manager.constants import (
     CONF_CLIENT_ID_KEY,
     CONF_CLIENT_SECRET_KEY,
@@ -32,6 +32,7 @@ from tests_common.test_utils.config import conf_vars
 
 @pytest.fixture
 def client():
+    purge_cached_app()
     with conf_vars(
         {
             (


### PR DESCRIPTION
* Fix race condition in auth manager initialization

Make create_auth_manager() thread-safe using double-checked locking to prevent concurrent requests from creating multiple auth manager instances. This fixes intermittent 500 errors on /auth/token when multiple requests arrive simultaneously.

Closes: #61108

* Handle auth manager class change in singleton cache

The singleton check now also verifies the cached instance matches the currently configured auth manager class. This prevents stale instances when the config changes (e.g. switching between SimpleAuthManager and FabAuthManager during db upgrade).

* Avoid calling get_auth_manager_cls on every create_auth_manager call

Move get_auth_manager_cls() inside the lock so the fast path is just a None check. Add purge_cached_app() in test_upgradedb to ensure clean state between parametrized cases with different auth manager configs.

* Reset auth manager singleton in get_application_builder

Since get_application_builder creates a fresh Flask app each time, the cached auth manager singleton from a previous app context must be cleared to avoid stale state (e.g. KeyError on AUTH_USER_REGISTRATION).

* Clear auth manager singleton in test fixtures using create_app

Test fixtures that call application.create_app() or get_application_builder() can receive a stale auth manager singleton from a previous test, causing AirflowSecurityManagerV2 to be used instead of FabAirflowSecurityManagerOverride.

Add purge_cached_app() calls to test fixtures across fab, google, and keycloak providers to ensure each test gets a fresh auth manager instance. (cherry picked from commit 5c9171af1a56b5b60bb121537159ceb9c4de9f73)

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
