### PR TITLE
Remove block_use_of_multi_team for 3.2

### DIFF
--- a/airflow-core/src/airflow/executors/executor_loader.py
+++ b/airflow-core/src/airflow/executors/executor_loader.py
@@ -18,7 +18,6 @@
 
 from __future__ import annotations
 
-import os
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
@@ -147,20 +146,6 @@ class ExecutorLoader:
         return executor_names
 
     @classmethod
-    def block_use_of_multi_team(cls):
-        """
-        Raise an exception if the user tries to use multiple team based executors.
-
-        Before the feature is complete we do not want users to accidentally configure this.
-        This can be overridden by setting the AIRFLOW__DEV__MULTI_TEAM_MODE environment
-        variable to "enabled"
-        This check is built into a method so that it can be easily mocked in unit tests.
-        """
-        team_dev_mode: str | None = os.environ.get("AIRFLOW__DEV__MULTI_TEAM_MODE")
-        if not team_dev_mode or team_dev_mode != "enabled":
-            raise AirflowConfigException("Configuring multiple team based executors is not yet supported!")
-
-    @classmethod
     def _validate_teams_exist_in_database(cls, team_names: set[str]) -> None:
         """
         Validate that all specified team names exist in the database.
@@ -218,7 +203,6 @@ class ExecutorLoader:
                 team_name = None
                 executor_names = team_executor_config.strip("=")
             else:
-                cls.block_use_of_multi_team()
                 if conf.getboolean("core", "multi_team", fallback=False):
                     team_name, executor_names = team_executor_config.split("=")
                 else:


### PR DESCRIPTION
We're going to do an experimental/partial release of multi-team for Airflow 3.2 and thus the feature blocker must be removed.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
