### PR TITLE
Revert "Use prek from Breeze Python instead of system PATH"

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/run_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_utils.py
@@ -230,7 +230,7 @@ def assert_prek_installed():
     need_to_reinstall_prek = False
     try:
         command_result = run_command(
-            [python_executable, "-m", "prek", "--version"],
+            ["prek", "--version"],
             capture_output=True,
             text=True,
             check=False,


### PR DESCRIPTION
Reverts apache/airflow#62309

See discussion in PR after merging.

The change broke workflows like `breeze start-airflow` with the error: 

```
Checking prek installed for /home/jscheffl/Workspace/airflow/.venv/bin/python3

Error checking for prek-installation:

/home/jscheffl/Workspace/airflow/.venv/bin/python3: No module named prek

Make sure to install prek. For example by running:

   uv tool install prek

Or if you prefer pipx:

   pipx install prek
```

Interesting though that it did not break CI.