### PR TITLE
Handle non-dictionary json payload during logging to avoid internal server error.

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/logging/decorators.py
+++ b/airflow-core/src/airflow/api_fastapi/logging/decorators.py
@@ -92,16 +92,16 @@ def action_logging(event: str | None = None):
             user_display = user.get_name()
 
         has_json_body = "application/json" in request.headers.get("content-type", "") and await request.body()
+        request_body = {}
+        masked_body_json = {}
 
         if has_json_body:
             request_body = await request.json()
-            masked_body_json = {k: secrets_masker.redact(v, k) for k, v in request_body.items()}
-        else:
-            request_body = {}
-            masked_body_json = {}
+            if isinstance(request_body, dict):
+                masked_body_json = {k: secrets_masker.redact(v, k) for k, v in request_body.items()}
 
-        if event_name in skip_dry_run_events and request_body.get("dry_run", True):
-            return
+                if event_name in skip_dry_run_events and request_body.get("dry_run", True):
+                    return
 
         fields_skip_logging = {
             "csrf_token",

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -1733,11 +1733,25 @@ class TestTriggerDagRun:
                     ]
                 },
             ),
+            (
+                [],
+                {
+                    "detail": [
+                        {
+                            "type": "model_attributes_type",
+                            "loc": ["body"],
+                            "msg": "Input should be a valid dictionary or object to extract fields from",
+                            "input": [],
+                        }
+                    ]
+                },
+            ),
         ],
     )
     def test_invalid_data(self, test_client, post_body, expected_detail):
-        now = timezone.utcnow().isoformat()
-        post_body["logical_date"] = now
+        if isinstance(post_body, dict):
+            now = timezone.utcnow().isoformat()
+            post_body["logical_date"] = now
         response = test_client.post(f"/dags/{DAG1_ID}/dagRuns", json=post_body)
         assert response.status_code == 422
         assert response.json() == expected_detail


### PR DESCRIPTION
`action_logging` logs the masked payload for endpoints accepting json payload. But a list is also a valid json and in this case iterating through with `items` causes `AttributeError` and internal server error. This change skips logging and lets FastAPI handle payload structure validation. After this PR 422 status code will be returned with proper error message instead of internal server error.

This still results in audit log entry like below though but validating for all payloads to be dictionary feels very restrictive and something that should be handled at FastAPI layer instead.

```
*************************** 289. row ***************************
                id: 289
              dttm: 2026-02-23 18:58:33.799714
            dag_id: example_complex
           task_id: NULL
         map_index: NULL
             event: trigger_dag_run
      logical_date: NULL
            run_id: NULL
             owner: admin
owner_display_name: admin
             extra: {"method": "POST"}
        try_number: NULL

```

closes: #62354

##### Was generative AI tooling used to co-author this PR?

No