### PR TITLE
Fix HiveServer2Hook password handling for PLAIN auth (#62338)

### DIFF
--- a/providers/apache/hive/src/airflow/providers/apache/hive/hooks/hive.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/hooks/hive.py
@@ -877,8 +877,8 @@ class HiveServer2Hook(DbApiHook):
             auth_mechanism = db.extra_dejson.get("auth_mechanism", "KERBEROS")
             kerberos_service_name = db.extra_dejson.get("kerberos_service_name", "hive")
 
-        # Password should be set if and only if in LDAP or CUSTOM mode
-        if auth_mechanism in ("LDAP", "CUSTOM"):
+        # Password should be set if in LDAP, CUSTOM or PLAIN mode
+        if auth_mechanism in ("LDAP", "CUSTOM", "PLAIN"):
             password = db.password
 
         from pyhive.hive import connect

--- a/providers/apache/hive/tests/unit/apache/hive/hooks/test_hive.py
+++ b/providers/apache/hive/tests/unit/apache/hive/hooks/test_hive.py
@@ -677,6 +677,26 @@ class TestHiveServer2Hook:
                 database="default",
             )
 
+    @mock.patch("pyhive.hive.connect")
+    def test_get_conn_with_password_plain(self, mock_connect):
+        conn_id = "conn_plain_with_password"
+        conn_env = CONN_ENV_PREFIX + conn_id.upper()
+
+        with mock.patch.dict(
+            "os.environ",
+            {conn_env: "jdbc+hive2://login:password@localhost:10000/default?auth_mechanism=PLAIN"},
+        ):
+            HiveServer2Hook(hiveserver2_conn_id=conn_id).get_conn()
+            mock_connect.assert_called_once_with(
+                host="localhost",
+                port=10000,
+                auth="PLAIN",
+                kerberos_service_name=None,
+                username="login",
+                password="password",
+                database="default",
+            )
+
     @pytest.mark.parametrize(
         ("host", "port", "schema", "message"),
         [


### PR DESCRIPTION
When creating a Hive Server 2 Thrift connection using the PLAIN authentication mechanism (the default), Airflow was failing to pass the provided password to the underlying pyhive library. This caused authentication failures even when correct credentials were provided.

This PR adds PLAIN to the list of mechanisms that correctly retrieve and pass the password in HiveServer2Hook.get_conn.

Related Issue: Fixes #62338

Tests: Added a new unit test 
test_get_conn_with_password_plain
 in 
tests/unit/apache/hive/hooks/test_hive.py
 to verify the fix.
