### PR TITLE
Raise ValueError instead of KeyError when cancel_previous_runs=True and no job identifier is provided

### DIFF
--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
@@ -921,8 +921,15 @@ class DatabricksRunNowOperator(BaseOperator):
             self.json["job_id"] = job_id
             del self.json["job_name"]
 
-        if self.cancel_previous_runs and self.json["job_id"] is not None:
-            hook.cancel_all_runs(self.json["job_id"])
+        if self.cancel_previous_runs:
+            job_id = self.json.get("job_id")
+
+            if job_id is None:
+                raise AirflowException(
+                    "cancel_previous_runs=True requires either job_id or job_name to be provided."
+                )
+
+            hook.cancel_all_runs(job_id)
 
         self.run_id = hook.run_now(self.json)
         if self.deferrable:

--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
@@ -922,9 +922,7 @@ class DatabricksRunNowOperator(BaseOperator):
             del self.json["job_name"]
 
         if self.cancel_previous_runs:
-            job_id = self.json.get("job_id")
-
-            if job_id is None:
+            if (job_id := self.json.get("job_id")) is None:
                 raise ValueError(
                     "cancel_previous_runs=True requires either job_id or job_name to be provided."
                 )

--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
@@ -925,7 +925,7 @@ class DatabricksRunNowOperator(BaseOperator):
             job_id = self.json.get("job_id")
 
             if job_id is None:
-                raise AirflowException(
+                raise ValueError(
                     "cancel_previous_runs=True requires either job_id or job_name to be provided."
                 )
 

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks.py
@@ -1656,16 +1656,17 @@ class TestDatabricksRunNowOperator:
         ):
             op.execute(None)
 
-        db_mock_class.assert_called_once_with(
-            DEFAULT_CONN_ID,
-            retry_limit=op.databricks_retry_limit,
-            retry_delay=op.databricks_retry_delay,
-            retry_args=None,
-            caller="DatabricksRunNowOperator",
-        )
-
-        db_mock.cancel_all_runs.assert_not_called()
-        db_mock.run_now.assert_not_called()
+        assert db_mock_class.mock_calls == [
+            call(
+                DEFAULT_CONN_ID,
+                retry_limit=op.databricks_retry_limit,
+                retry_delay=op.databricks_retry_delay,
+                retry_args=None,
+                caller="DatabricksRunNowOperator",
+            )
+        ]
+        assert db_mock.cancel_all_runs.mock_calls == []
+        assert db_mock.run_now.mock_calls == []
 
     @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
     def test_execute_task_deferred(self, db_mock_class):

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks.py
@@ -1635,6 +1635,39 @@ class TestDatabricksRunNowOperator:
         db_mock.get_run.assert_not_called()
 
     @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
+    def test_cancel_previous_runs_without_job_id_raises(self, db_mock_class):
+        run = {
+            "notebook_params": NOTEBOOK_PARAMS,
+            "notebook_task": NOTEBOOK_TASK,
+            "jar_params": JAR_PARAMS,
+        }
+
+        op = DatabricksRunNowOperator(
+            task_id=TASK_ID,
+            json=run,
+            cancel_previous_runs=True,
+        )
+
+        db_mock = db_mock_class.return_value
+
+        with pytest.raises(
+            AirflowException,
+            match="cancel_previous_runs=True requires either job_id or job_name",
+        ):
+            op.execute(None)
+
+        db_mock_class.assert_called_once_with(
+            DEFAULT_CONN_ID,
+            retry_limit=op.databricks_retry_limit,
+            retry_delay=op.databricks_retry_delay,
+            retry_args=None,
+            caller="DatabricksRunNowOperator",
+        )
+
+        db_mock.cancel_all_runs.assert_not_called()
+        db_mock.run_now.assert_not_called()
+
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
     def test_execute_task_deferred(self, db_mock_class):
         """
         Test the execute function in case where the run is successful.

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks.py
@@ -1651,7 +1651,7 @@ class TestDatabricksRunNowOperator:
         db_mock = db_mock_class.return_value
 
         with pytest.raises(
-            AirflowException,
+            ValueError,
             match="cancel_previous_runs=True requires either job_id or job_name",
         ):
             op.execute(None)

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks.py
@@ -21,7 +21,7 @@ import hashlib
 from datetime import datetime, timedelta
 from typing import Any
 from unittest import mock
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 


### PR DESCRIPTION
**Description**

This change ensures that `DatabricksRunNowOperator` raises a clear `ValueError` when `cancel_previous_runs=True` is set without specifying either `job_id` or `job_name`. Previously, the operator failed with a raw `KeyError` at execution time.

The behavior remains unchanged for valid configurations. This update aligns the operator with existing validation patterns by surfacing configuration errors as `ValueError` rather than internal Python errors.

**Rationale**

`DatabricksRunNowOperator` already performs validation for conflicting and missing parameters using `AirflowException`. In this specific branch, however, an invalid configuration surfaced as a raw `KeyError`, which exposes internal implementation details and produces inconsistent error semantics.

Raising an `ValueError` provides clearer feedback to DAG authors and keeps validation behavior consistent across the operator.

**Tests**

A unit test has been added to verify that a ValueError` is raised when `cancel_previous_runs=True` is used without a job identifier.

**Backwards Compatibility**

This change does not modify valid execution paths or operator semantics. It only replaces an unintended `KeyError` with a `ValueError`.

Closes: #62392 
