### PR TITLE
Revert "Fix race condition in auth manager initialization"

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/app.py
+++ b/airflow-core/src/airflow/api_fastapi/app.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import logging
-import threading
 from contextlib import AsyncExitStack, asynccontextmanager
 from functools import cache
 from typing import TYPE_CHECKING
@@ -58,7 +57,6 @@ log = logging.getLogger(__name__)
 
 class _AuthManagerState:
     instance: BaseAuthManager | None = None
-    _lock = threading.Lock()
 
 
 @asynccontextmanager
@@ -139,12 +137,8 @@ def get_auth_manager_cls() -> type[BaseAuthManager]:
 
 def create_auth_manager() -> BaseAuthManager:
     """Create the auth manager."""
-    if _AuthManagerState.instance is not None:
-        return _AuthManagerState.instance
-    with _AuthManagerState._lock:
-        if _AuthManagerState.instance is None:
-            auth_manager_cls = get_auth_manager_cls()
-            _AuthManagerState.instance = auth_manager_cls()
+    auth_manager_cls = get_auth_manager_cls()
+    _AuthManagerState.instance = auth_manager_cls()
     return _AuthManagerState.instance
 
 

--- a/airflow-core/tests/unit/utils/test_db.py
+++ b/airflow-core/tests/unit/utils/test_db.py
@@ -250,9 +250,6 @@ class TestDb:
 
         mock_upgrade = mocker.patch("alembic.command.upgrade")
 
-        from airflow.api_fastapi.app import purge_cached_app
-
-        purge_cached_app()
         with conf_vars(auth):
             upgradedb()
 

--- a/providers/fab/src/airflow/providers/fab/auth_manager/cli_commands/utils.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/cli_commands/utils.py
@@ -29,7 +29,6 @@ from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.engine import make_url
 
 import airflow
-from airflow.api_fastapi.app import purge_cached_app
 from airflow.configuration import conf
 from airflow.exceptions import AirflowConfigException
 from airflow.providers.fab.www.extensions.init_appbuilder import init_appbuilder
@@ -51,8 +50,6 @@ def _return_appbuilder(app: Flask, db) -> AirflowAppBuilder:
 
 @contextmanager
 def get_application_builder() -> Generator[AirflowAppBuilder, None, None]:
-    _return_appbuilder.cache_clear()
-    purge_cached_app()
     static_folder = os.path.join(os.path.dirname(airflow.__file__), "www", "static")
     flask_app = Flask(__name__, static_folder=static_folder)
     webserver_config = conf.get_mandatory_value("fab", "config_file")

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/conftest.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/conftest.py
@@ -22,14 +22,12 @@ from contextlib import contextmanager
 import pytest
 from fastapi.testclient import TestClient
 
-from airflow.api_fastapi.app import purge_cached_app
 from airflow.api_fastapi.core_api.security import get_user as get_user_dep
 from airflow.providers.fab.auth_manager.fab_auth_manager import FabAuthManager
 
 
 @pytest.fixture(scope="module")
 def fab_auth_manager():
-    purge_cached_app()
     return FabAuthManager()
 
 

--- a/providers/fab/tests/unit/fab/auth_manager/conftest.py
+++ b/providers/fab/tests/unit/fab/auth_manager/conftest.py
@@ -22,9 +22,7 @@ from pathlib import Path
 
 import pytest
 
-from airflow.api_fastapi.app import purge_cached_app
 from airflow.providers.fab.www import app
-from airflow.providers.fab.www.app import purge_cached_app as purge_fab_cached_app
 
 from tests_common.test_utils.config import conf_vars
 from unit.fab.decorators import dont_initialize_flask_app_submodules
@@ -32,9 +30,6 @@ from unit.fab.decorators import dont_initialize_flask_app_submodules
 
 @pytest.fixture(scope="session")
 def minimal_app_for_auth_api():
-    purge_cached_app()
-    purge_fab_cached_app()
-
     @dont_initialize_flask_app_submodules(
         skip_all_except=[
             "init_appbuilder",

--- a/providers/fab/tests/unit/fab/auth_manager/test_fab_auth_manager.py
+++ b/providers/fab/tests/unit/fab/auth_manager/test_fab_auth_manager.py
@@ -160,12 +160,6 @@ def auth_manager():
 
 @pytest.fixture
 def flask_app():
-    from airflow.api_fastapi.app import purge_cached_app
-
-    purge_cached_app()
-    from airflow.providers.fab.www.app import purge_cached_app as purge_fab_cached_app
-
-    purge_fab_cached_app()
     with conf_vars(
         {
             (

--- a/providers/fab/tests/unit/fab/auth_manager/test_security.py
+++ b/providers/fab/tests/unit/fab/auth_manager/test_security.py
@@ -211,9 +211,6 @@ def clear_db_before_test():
 
 @pytest.fixture(scope="module")
 def app():
-    from airflow.api_fastapi.app import purge_cached_app
-
-    purge_cached_app()
     with conf_vars(
         {
             (

--- a/providers/fab/tests/unit/fab/auth_manager/views/test_permissions.py
+++ b/providers/fab/tests/unit/fab/auth_manager/views/test_permissions.py
@@ -30,9 +30,6 @@ from unit.fab.utils import client_with_login
 
 @pytest.fixture(scope="module")
 def fab_app():
-    from airflow.api_fastapi.app import purge_cached_app
-
-    purge_cached_app()
     with conf_vars(
         {
             (

--- a/providers/fab/tests/unit/fab/auth_manager/views/test_roles_list.py
+++ b/providers/fab/tests/unit/fab/auth_manager/views/test_roles_list.py
@@ -30,9 +30,6 @@ from unit.fab.utils import client_with_login
 
 @pytest.fixture(scope="module")
 def fab_app():
-    from airflow.api_fastapi.app import purge_cached_app
-
-    purge_cached_app()
     with conf_vars(
         {
             (

--- a/providers/fab/tests/unit/fab/auth_manager/views/test_user.py
+++ b/providers/fab/tests/unit/fab/auth_manager/views/test_user.py
@@ -30,9 +30,6 @@ from unit.fab.utils import client_with_login
 
 @pytest.fixture(scope="module")
 def fab_app():
-    from airflow.api_fastapi.app import purge_cached_app
-
-    purge_cached_app()
     with conf_vars(
         {
             (

--- a/providers/fab/tests/unit/fab/auth_manager/views/test_user_edit.py
+++ b/providers/fab/tests/unit/fab/auth_manager/views/test_user_edit.py
@@ -30,9 +30,6 @@ from unit.fab.utils import client_with_login
 
 @pytest.fixture(scope="module")
 def fab_app():
-    from airflow.api_fastapi.app import purge_cached_app
-
-    purge_cached_app()
     with conf_vars(
         {
             (

--- a/providers/fab/tests/unit/fab/auth_manager/views/test_user_stats.py
+++ b/providers/fab/tests/unit/fab/auth_manager/views/test_user_stats.py
@@ -30,9 +30,6 @@ from unit.fab.utils import client_with_login
 
 @pytest.fixture(scope="module")
 def fab_app():
-    from airflow.api_fastapi.app import purge_cached_app
-
-    purge_cached_app()
     with conf_vars(
         {
             (

--- a/providers/fab/tests/unit/fab/www/test_auth.py
+++ b/providers/fab/tests/unit/fab/www/test_auth.py
@@ -33,9 +33,6 @@ mock_call = Mock()
 
 @pytest.fixture
 def app():
-    from airflow.api_fastapi.app import purge_cached_app
-
-    purge_cached_app()
     with conf_vars(
         {
             (

--- a/providers/fab/tests/unit/fab/www/views/test_views_custom_user_views.py
+++ b/providers/fab/tests/unit/fab/www/views/test_views_custom_user_views.py
@@ -69,9 +69,6 @@ def delete_roles(app):
 
 @pytest.fixture
 def app():
-    from airflow.api_fastapi.app import purge_cached_app
-
-    purge_cached_app()
     with conf_vars(
         {
             (

--- a/providers/google/tests/unit/google/common/auth_backend/test_google_openid.py
+++ b/providers/google/tests/unit/google/common/auth_backend/test_google_openid.py
@@ -34,8 +34,6 @@ if not AIRFLOW_V_3_0_PLUS:
         allow_module_level=True,
     )
 
-from airflow.api_fastapi.app import purge_cached_app
-
 from tests_common.test_utils.config import conf_vars
 
 
@@ -43,11 +41,6 @@ from tests_common.test_utils.config import conf_vars
 def google_openid_app():
     if importlib.util.find_spec("flask_session") is None:
         return None
-
-    purge_cached_app()
-    from airflow.providers.fab.www.app import purge_cached_app as purge_fab_cached_app
-
-    purge_fab_cached_app()
 
     def factory():
         with conf_vars(

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/routes/conftest.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/routes/conftest.py
@@ -23,7 +23,7 @@ import pytest
 import time_machine
 from fastapi.testclient import TestClient
 
-from airflow.api_fastapi.app import create_app, purge_cached_app
+from airflow.api_fastapi.app import create_app
 from airflow.providers.keycloak.auth_manager.constants import (
     CONF_CLIENT_ID_KEY,
     CONF_CLIENT_SECRET_KEY,
@@ -40,7 +40,6 @@ if TYPE_CHECKING:
 
 @pytest.fixture
 def client():
-    purge_cached_app()
     with conf_vars(
         {
             (


### PR DESCRIPTION
Reverts apache/airflow#62214

I'm having trouble starting breeze with the Fab auth manager because of this change. 

I believe this is creating a problem because `get_application_builder` is actually also called by the fastapi fab provider routes. (generating token, login / login, create users etc...).

So every time we call the fab provider fastapi API, we clear the global fastapi APP and the `_return_appbuilder`. 

Then calling a core api fastapi endpiont will try to re-init the APP, before the overrides are initialized.

```
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 999, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/opt/airflow/airflow-core/src/airflow/api_fastapi/main.py", line 46, in <module>
    app = cached_app(apps=os.environ.get("AIRFLOW_API_APPS", "all"))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/airflow/airflow-core/src/airflow/api_fastapi/app.py", line 115, in cached_app
    return create_app(apps=apps)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/airflow/airflow-core/src/airflow/utils/providers_configuration_loader.py", line 54, in wrapped_function
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/airflow/airflow-core/src/airflow/api_fastapi/app.py", line 102, in create_app
    init_flask_plugins(app)
  File "/opt/airflow/airflow-core/src/airflow/api_fastapi/core_api/app.py", line 145, in init_flask_plugins
    flask_app = create_app(enable_plugins=True)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/airflow/providers/fab/src/airflow/providers/fab/www/app.py", line 96, in create_app
    init_appbuilder(flask_app, enable_plugins=enable_plugins)
  File "/opt/airflow/providers/fab/src/airflow/providers/fab/www/extensions/init_appbuilder.py", line 599, in init_appbuilder
    return AirflowAppBuilder(
           ^^^^^^^^^^^^^^^^^^
  File "/opt/airflow/providers/fab/src/airflow/providers/fab/www/extensions/init_appbuilder.py", line 156, in __init__
    self.init_app(app, session)
  File "/opt/airflow/providers/fab/src/airflow/providers/fab/www/extensions/init_appbuilder.py", line 208, in init_app
    self._add_admin_views()
  File "/opt/airflow/providers/fab/src/airflow/providers/fab/www/extensions/init_appbuilder.py", line 304, in _add_admin_views
    auth_manager.register_views()
  File "/opt/airflow/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py", line 618, in register_views
    self.security_manager.register_views()
  File "/opt/airflow/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py", line 440, in register_views
    if self.auth_user_registration:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/airflow/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py", line 754, in auth_user_registration
    return current_app.config["AUTH_USER_REGISTRATION"]
           ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'AUTH_USER_REGISTRATION'
```