### PR TITLE
UI Fix Logs truncated after 50 lines

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
@@ -129,6 +129,7 @@ export const TaskLogContent = ({ error, isLoading, logError, parsedLogs, wrap }:
         data-testid="virtual-scroll-container"
         flexGrow={1}
         minHeight={0}
+        overflow="auto"
         position="relative"
         py={3}
         ref={parentRef}
@@ -140,7 +141,6 @@ export const TaskLogContent = ({ error, isLoading, logError, parsedLogs, wrap }:
           }}
           data-testid="virtualized-list"
           display="block"
-          overflow="auto"
           textWrap={wrap ? "pre" : "nowrap"}
           width="100%"
         >


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/62341


Verified that 'copy to clipboard' 'jump to bottom' 'jump to top' 'wrapping' still work.

### Before
<img width="1898" height="959" alt="Screenshot 2026-02-24 at 15 15 50" src="https://github.com/user-attachments/assets/bf0e86bc-4089-4005-ae6d-bde163fa9cc5" />


### After
<img width="1914" height="964" alt="Screenshot 2026-02-24 at 15 15 24" src="https://github.com/user-attachments/assets/3179d7ce-cda7-4dd6-82df-cda5a71065bf" />
