### PR TITLE
Variables table handle long words break when values are expanded

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Variables/Variables.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/Variables.tsx
@@ -91,22 +91,26 @@ const getColumns = ({
     {
       accessorKey: "value",
       cell: ({ row }) => (
-        <TrimText
-          charLimit={open ? row.original.value.length : undefined}
-          showTooltip
-          text={row.original.value}
-        />
+        <Box minWidth={0} overflowWrap="anywhere" wordBreak="break-word">
+          <TrimText
+            charLimit={open ? row.original.value.length : undefined}
+            showTooltip
+            text={row.original.value}
+          />
+        </Box>
       ),
       header: translate("columns.value"),
     },
     {
       accessorKey: "description",
       cell: ({ row }) => (
-        <TrimText
-          charLimit={open ? row.original.description?.length : undefined}
-          showTooltip
-          text={row.original.description}
-        />
+        <Box minWidth={0} overflowWrap="anywhere" wordBreak="break-word">
+          <TrimText
+            charLimit={open ? row.original.description?.length : undefined}
+            showTooltip
+            text={row.original.description}
+          />
+        </Box>
       ),
       header: translate("columns.description"),
     },


### PR DESCRIPTION
When values are expanded, it should properly break on 'long words' (when there is no space or word break tokens).

### Before
<img width="1923" height="755" alt="Screenshot 2026-02-24 at 17 33 19" src="https://github.com/user-attachments/assets/080c34fb-e9b9-4bdd-82b0-2c884a82da1d" />


### After 
<img width="1918" height="729" alt="Screenshot 2026-02-24 at 17 32 53" src="https://github.com/user-attachments/assets/378b3f59-aeb9-4008-a378-5f714da53438" />
