### PR TITLE
Handle race condition in DatabricksReposCreateOperator when concurrently creating the same repo path

### DIFF
--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks_repos.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks_repos.py
@@ -142,15 +142,40 @@ class DatabricksReposCreateOperator(BaseOperator):
                 )
             payload["path"] = self.repo_path
         existing_repo_id = None
+
         if self.repo_path is not None:
             existing_repo_id = self._hook.get_repo_by_path(self.repo_path)
             if existing_repo_id is not None and not self.ignore_existing_repo:
                 raise AirflowException(f"Repo with path '{self.repo_path}' already exists")
+
         if existing_repo_id is None:
-            result = self._hook.create_repo(payload)
-            repo_id = result["id"]
+            try:
+                result = self._hook.create_repo(payload)
+                repo_id = result["id"]
+            except Exception:
+                # If ignore_existing_repo is False, preserve existing behavior
+                # and propagate the original create failure.
+                if not self.ignore_existing_repo:
+                    raise
+
+                # When ignore_existing_repo=True, attempt to recover from a possible
+                # create-time conflict (e.g., repo created concurrently).
+                if self.repo_path is not None:
+                    repo_id = self._hook.get_repo_by_path(self.repo_path)
+
+                # Only treat this as success if the repo now exists.
+                # If it still does not exist, re-raise the original exception
+                # to avoid masking genuine create failures.
+                if repo_id is None:
+                    raise
+
+                self.log.info(
+                    "Repository at path '%s' already exists; continuing because ignore_existing_repo=True.",
+                    self.repo_path,
+                )
         else:
             repo_id = existing_repo_id
+
         # update repo if necessary
         if self.branch is not None:
             self._hook.update_repo(str(repo_id), {"branch": str(self.branch)})

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks_repos.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks_repos.py
@@ -210,6 +210,68 @@ class TestDatabricksReposCreateOperator:
         db_mock.get_repo_by_path.assert_called_once_with(repo_path)
         db_mock.update_repo.assert_called_once_with("123", {"branch": "releases"})
 
+    @mock.patch("airflow.providers.databricks.operators.databricks_repos.DatabricksHook")
+    def test_create_conflict_recovered_when_ignore_flag_set(self, db_mock_class):
+        """
+        Test that create-time conflict is recovered when ignore_existing_repo=True.
+        """
+        git_url = "https://github.com/test/test"
+        repo_path = "/Repos/Project1/test-repo"
+
+        op = DatabricksReposCreateOperator(
+            task_id=TASK_ID,
+            git_url=git_url,
+            repo_path=repo_path,
+            ignore_existing_repo=True,
+        )
+
+        db_mock = db_mock_class.return_value
+
+        # After first existence check, repo is not found.
+        # After second existence check, repo exists (created concurrently).
+        db_mock.get_repo_by_path.side_effect = [None, "123"]
+
+        db_mock.create_repo.side_effect = Exception("Conflict")
+
+        result = op.execute(None)
+
+        db_mock_class.assert_called_once_with(
+            DEFAULT_CONN_ID,
+            retry_limit=op.databricks_retry_limit,
+            retry_delay=op.databricks_retry_delay,
+            caller="DatabricksReposCreateOperator",
+        )
+
+        db_mock.create_repo.assert_called_once_with({"url": git_url, "provider": "gitHub", "path": repo_path})
+
+        assert result == "123"
+
+    @mock.patch("airflow.providers.databricks.operators.databricks_repos.DatabricksHook")
+    def test_create_conflict_not_recovered_when_repo_still_missing(self, db_mock_class):
+        """
+        Test that create failure is re-raised if repo does not exist after failure.
+        """
+        git_url = "https://github.com/test/test"
+        repo_path = "/Repos/Project1/test-repo"
+
+        op = DatabricksReposCreateOperator(
+            task_id=TASK_ID,
+            git_url=git_url,
+            repo_path=repo_path,
+            ignore_existing_repo=True,
+        )
+
+        db_mock = db_mock_class.return_value
+
+        # Repo not found before or after create failure.
+        db_mock.get_repo_by_path.side_effect = [None, None]
+        db_mock.create_repo.side_effect = Exception("Create failure")
+
+        with pytest.raises(Exception, match="Create failure"):
+            op.execute(None)
+
+        db_mock.create_repo.assert_called_once()
+
     def test_init_exception(self):
         """
         Tests handling of incorrect parameters passed to ``__init__``


### PR DESCRIPTION
**Description**

This change makes `DatabricksReposCreateOperator` resilient to a race condition when multiple tasks attempt to create a repository at the same `repo_path` concurrently.

Previously, the operator performed a `get_repo_by_path` check followed by `create_repo`. If two tasks ran at the same time, both could observe that the repository did not exist and both attempt creation. One task would succeed, while the other would fail with a 400 error from the Databricks API indicating that the repo already exists.

The operator now treats this as a recoverable condition. If `create_repo` fails because the repo already exists, the operator re-fetches the repo ID via `get_repo_by_path`. If the repo is found, execution proceeds normally and preserves the existing `ignore_existing_repo` semantics.

**Rationale**

The previous implementation relied on a non-atomic existence check followed by creation. In concurrent DAG runs, this leads to a classic time-of-check/time-of-use race condition. Two tasks can both pass the existence check and attempt creation, even though only one creation can succeed.

Since repository creation is an external side-effect managed by the Databricks API, the operator cannot assume exclusivity or single-writer behavior. It must defensively handle the possibility that another task or DAG run creates the resource between the check and the create call. Handling this explicitly makes the operator more robust under concurrency without changing its single-run behavior.

**Tests**

Add tests that verify that:

* the operator recovers when `create_repo` raises an “already exists” error by re-fetching the repo ID and proceeding successfully.
* a genuine creation failure (where the repo still cannot be found after the error) is propagated and not silently swallowed.