### PR TITLE
fix S3RemoteLogIO using incorrect transfer config

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/log/s3_task_handler.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/log/s3_task_handler.py
@@ -68,7 +68,7 @@ class S3RemoteLogIO(LoggingMixin):  # noqa: D101
         """Returns S3Hook."""
         return S3Hook(
             aws_conn_id=conf.get("logging", "REMOTE_LOG_CONN_ID"),
-            transfer_config_args={"use_threads": False},
+            transfer_config_args={"use_threads": False, "preferred_transfer_client": "classic"},
         )
 
     def s3_log_exists(self, remote_log_location: str) -> bool:


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

The `S3RemoteLogIO` class was setting `use_threads=False` in the transfer config arguments, but this argument is ignored if using the (now default) `CRTTransferManager` instead of the `S3TransferManager`. Setting `preferred_transfer_client="classic"` will use the `S3TransferManager` instead.

https://docs.aws.amazon.com/boto3/latest/reference/customizations/s3.html#s3-transfers
> use_threads – If True, threads will be used when performing S3 transfers. If False, no threads will be used in performing transfers; all logic will be run in the current thread. Note: This value is ignored when resolved transfer manager type is CRTTransferManager. 

We noticed this because some of our tasks which had very large log files (a few GB each) were causing the worker pods in kubernetes to go OOMKilled when they were uploaded to S3.

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)
- [X] No

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---
