### PR TITLE
Fix race condition in auth manager initialization

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/app.py
+++ b/airflow-core/src/airflow/api_fastapi/app.py
@@ -153,9 +153,7 @@ def create_auth_manager() -> BaseAuthManager:
     if _AuthManagerState.instance is not None and isinstance(_AuthManagerState.instance, auth_manager_cls):
         return _AuthManagerState.instance
     with _AuthManagerState._lock:
-        if _AuthManagerState.instance is None or not isinstance(
-            _AuthManagerState.instance, auth_manager_cls
-        ):
+        if _AuthManagerState.instance is None or not isinstance(_AuthManagerState.instance, auth_manager_cls):
             _AuthManagerState.instance = auth_manager_cls()
     return _AuthManagerState.instance
 

--- a/airflow-core/src/airflow/api_fastapi/app.py
+++ b/airflow-core/src/airflow/api_fastapi/app.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 from contextlib import AsyncExitStack, asynccontextmanager
 from functools import cache
 from typing import TYPE_CHECKING
@@ -67,6 +68,7 @@ log = logging.getLogger(__name__)
 
 class _AuthManagerState:
     instance: BaseAuthManager | None = None
+    _lock = threading.Lock()
 
 
 @asynccontextmanager
@@ -146,9 +148,15 @@ def get_auth_manager_cls() -> type[BaseAuthManager]:
 
 
 def create_auth_manager() -> BaseAuthManager:
-    """Create the auth manager."""
+    """Create the auth manager, cached as a thread-safe singleton."""
     auth_manager_cls = get_auth_manager_cls()
-    _AuthManagerState.instance = auth_manager_cls()
+    if _AuthManagerState.instance is not None and isinstance(_AuthManagerState.instance, auth_manager_cls):
+        return _AuthManagerState.instance
+    with _AuthManagerState._lock:
+        if _AuthManagerState.instance is None or not isinstance(
+            _AuthManagerState.instance, auth_manager_cls
+        ):
+            _AuthManagerState.instance = auth_manager_cls()
     return _AuthManagerState.instance
 
 

--- a/airflow-core/tests/unit/api_fastapi/test_app.py
+++ b/airflow-core/tests/unit/api_fastapi/test_app.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import threading
 from unittest import mock
 
 import pytest
@@ -140,3 +141,37 @@ class TestGetCookiePath:
         """When base_url contains a nested subpath, get_cookie_path() should return it."""
         with mock.patch.object(app_module, "API_ROOT_PATH", "/org/team-a/airflow/"):
             assert app_module.get_cookie_path() == "/org/team-a/airflow/"
+
+
+def test_create_auth_manager_thread_safety():
+    """Concurrent calls to create_auth_manager must return the same singleton instance."""
+    call_count = 0
+    singleton = None
+
+    class FakeAuthManager:
+        def __init__(self):
+            nonlocal call_count, singleton
+            call_count += 1
+            singleton = self
+
+    app_module.purge_cached_app()
+
+    results = []
+    barrier = threading.Barrier(10)
+
+    def call_create_auth_manager():
+        barrier.wait()
+        results.append(app_module.create_auth_manager())
+
+    with mock.patch.object(app_module, "get_auth_manager_cls", return_value=FakeAuthManager):
+        threads = [threading.Thread(target=call_create_auth_manager) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+    assert len(results) == 10
+    assert all(r is singleton for r in results)
+    assert call_count == 1
+
+    app_module.purge_cached_app()

--- a/providers/fab/src/airflow/providers/fab/www/extensions/init_appbuilder.py
+++ b/providers/fab/src/airflow/providers/fab/www/extensions/init_appbuilder.py
@@ -195,6 +195,9 @@ class AirflowAppBuilder:
         self.session = session
         auth_manager = create_auth_manager()
         auth_manager.appbuilder = self
+        # Invalidate cached security_manager so it binds to the current Flask app.
+        if "security_manager" in auth_manager.__dict__:
+            del auth_manager.__dict__["security_manager"]
         if hasattr(auth_manager, "init_flask_resources"):
             auth_manager.init_flask_resources()
         if hasattr(auth_manager, "security_manager"):

--- a/providers/fab/src/airflow/providers/fab/www/extensions/init_appbuilder.py
+++ b/providers/fab/src/airflow/providers/fab/www/extensions/init_appbuilder.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 from functools import reduce
 from typing import TYPE_CHECKING
 
@@ -57,6 +58,8 @@ if TYPE_CHECKING:
 # Copyright 2013, Daniel Vaz Gaspar
 # This module contains code imported from FlaskAppbuilder, so lets use _its_ logger name
 log = logging.getLogger("flask_appbuilder.base")
+
+_init_app_lock = threading.Lock()
 
 
 def dynamic_class_import(class_path):
@@ -194,22 +197,23 @@ class AirflowAppBuilder:
         self._addon_managers = app.config["ADDON_MANAGERS"]
         self.session = session
         auth_manager = create_auth_manager()
-        auth_manager.appbuilder = self
-        # Invalidate cached security_manager so it binds to the current Flask app.
-        if "security_manager" in auth_manager.__dict__:
-            del auth_manager.__dict__["security_manager"]
-        if hasattr(auth_manager, "init_flask_resources"):
-            auth_manager.init_flask_resources()
-        if hasattr(auth_manager, "security_manager"):
-            self.sm = auth_manager.security_manager
-        else:
-            self.sm = AirflowSecurityManagerV2(self)
-        self.bm = BabelManager(self)
-        self._add_global_static()
-        self._add_global_filters()
-        app.before_request(self.sm.before_request)
-        self._add_admin_views()
-        self._add_addon_views()
+        with _init_app_lock:
+            auth_manager.appbuilder = self
+            # Invalidate cached security_manager so it binds to the current Flask app.
+            if "security_manager" in auth_manager.__dict__:
+                del auth_manager.__dict__["security_manager"]
+            if hasattr(auth_manager, "init_flask_resources"):
+                auth_manager.init_flask_resources()
+            if hasattr(auth_manager, "security_manager"):
+                self.sm = auth_manager.security_manager
+            else:
+                self.sm = AirflowSecurityManagerV2(self)
+            self.bm = BabelManager(self)
+            self._add_global_static()
+            self._add_global_filters()
+            app.before_request(self.sm.before_request)
+            self._add_admin_views()
+            self._add_addon_views()
         self._init_extension(app)
         self._swap_url_filter()
 


### PR DESCRIPTION
Closes #61108

This is a follow-up to #62214 (reverted in #62404).

### Problem

Concurrent requests to `/auth/token` cause intermittent 500 errors:

```
AttributeError: 'AirflowAppBuilder' object has no attribute 'sm'
```

`create_auth_manager()` creates a new instance on every call. Under concurrent requests, one thread overwrites `_AuthManagerState.instance` while another's is still initializing.

### Previous approach (#62214) and why it was reverted

The previous fix added `purge_cached_app()` in `get_application_builder()`, but that function is called at runtime by FAB FastAPI routes (login, user/role management). Clearing the singleton on every call broke subsequent core API requests with `KeyError: 'AUTH_USER_REGISTRATION'`.

### This fix

1. **`create_auth_manager()`**: Double-checked locking with `isinstance` validation — creates the singleton once, replaces it only when the auth manager class changes (e.g. `SimpleAuthManager` → `FabAuthManager`).

2. **`init_appbuilder.py`**: Clears `security_manager` `@cached_property` when `init_app()` is called with a new Flask app, so `_init_config()` runs against the current app context.

No changes to `get_application_builder()` or test fixtures.

### Testing

Added `test_create_auth_manager_thread_safety` — verifies singleton behavior under 10 concurrent threads.