### PR TITLE
Fix unreachable branch and broken regex in PR-of-the-month script

### DIFF
--- a/dev/stats/get_important_pr_candidates.py
+++ b/dev/stats/get_important_pr_candidates.py
@@ -285,7 +285,7 @@ class PRFetcher:
         if not pr_body:
             return {"issue_comments": 0, "issue_reactions": 0, "issue_users": set()}
 
-        regex = r"(?<=closes: #|elated: #)\d{5}"
+        regex = r"(?:closes|related): #(\d+)"
         issue_nums = re.findall(regex, pr_body)
 
         total_issue_comments = 0
@@ -831,10 +831,10 @@ class SuperFastPRFinder:
             body_len = len(pr.get("body", ""))
             if body_len > 2000:
                 score *= 1.4
-            elif body_len < 1000:
-                score *= 0.8
             elif body_len < 20:
                 score *= 0.4
+            elif body_len < 1000:
+                score *= 0.8
 
             comments = pr.get("comments_count", 0)
             if comments > 30:


### PR DESCRIPTION
## Summary

- **Unreachable branch**: In `quick_score_prs`, the `elif body_len < 20` branch was dead code because `body_len < 1000` (checked first) is always true when `body_len < 20`. PRs with tiny/empty bodies got a 0.8x penalty instead of the intended 0.4x. Reordered to check `< 20` before `< 1000`.

- **Broken linked-issue regex**: The lookbehind `(?<=closes: #|elated: #)` matched literal `elated: #` instead of `related: #` (the `r` was consumed by the alternation boundary). Also required exactly 5 digits, missing issue numbers of other lengths. Replaced with `(?:closes|related): #(\d+)`.