### PR TITLE
fix(timetable): fix failing to manually trigger a Dag with CronPartitionedTimetable

### DIFF
--- a/airflow-core/src/airflow/timetables/trigger.py
+++ b/airflow-core/src/airflow/timetables/trigger.py
@@ -516,12 +516,11 @@ class CronPartitionTimetable(CronTriggerTimetable):
         data_interval: DataInterval | None,
         **extra,
     ) -> str:
-        components = [
-            run_after.isoformat(),
-            extra.get("partition_key"),
-            get_random_string(),
-        ]
-        return run_type.generate_run_id(suffix="__".join(components))
+        suffix = run_after.isoformat()
+        if partition_key := extra.get("partition_key"):
+            suffix = f"{suffix}__{partition_key}"
+        suffix = f"{suffix}__{get_random_string()}"
+        return run_type.generate_run_id(suffix=suffix)
 
     def next_run_info_from_dag_model(self, *, dag_model: DagModel) -> DagRunInfo:
         run_after = timezone.coerce_datetime(dag_model.next_dagrun_create_after)


### PR DESCRIPTION
## Why
Closes: https://github.com/apache/airflow/issues/62337

When manually triggering a Dag with `schedule=CronPartitionedTimetable` (or via the cli), it throws an error because the partition key is missing.

## What
Do not include partition_key in run_id if not provided


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
