### PR TITLE
Symlink CLAUDE.md to AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Follow-up to #62440.

`AGENTS.md` is now the canonical agent instructions file. This adds a symlink so [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) reads the same instructions without maintaining a separate copy.

##### Was generative AI tooling used to co-author this PR?
- [x] Yes — Cursor