### PR TITLE
Adding description of restrictions on creation of a new team name

### DIFF
--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -1444,6 +1444,9 @@ TEAMS_COMMANDS = (
     ActionCommand(
         name="create",
         help="Create a team",
+        description=(
+            "Create a team. Team names must be 3-50 characters long and contain only alphanumeric characters, hyphens, and underscores.\n"
+        ),
         func=lazy_load_command("airflow.cli.commands.team_command.team_create"),
         args=(ARG_TEAM_NAME, ARG_VERBOSE),
     ),

--- a/airflow-core/src/airflow/cli/commands/team_command.py
+++ b/airflow-core/src/airflow/cli/commands/team_command.py
@@ -61,7 +61,7 @@ def _extract_team_name(args):
 @providers_configuration_loaded
 @provide_session
 def team_create(args, session=NEW_SESSION):
-    """Create a new team. Team name can contain uppercase or lowercase alphabets, digits from 0 through 9, underscore and hyphen sign. All other special characters are not allowed."""
+    """Create a new team. Team names must be 3-50 characters long and contain only alphanumeric characters, hyphens, and underscores."""
     team_name = _extract_team_name(args)
 
     # Check if team with this name already exists

--- a/airflow-core/src/airflow/cli/commands/team_command.py
+++ b/airflow-core/src/airflow/cli/commands/team_command.py
@@ -61,7 +61,7 @@ def _extract_team_name(args):
 @providers_configuration_loaded
 @provide_session
 def team_create(args, session=NEW_SESSION):
-    """Create a new team."""
+    """Create a new team. Team name can contain uppercase or lowercase alphabets, digits from 0 through 9, underscore and hyphen sign. All other special characters are not allowed."""
     team_name = _extract_team_name(args)
 
     # Check if team with this name already exists


### PR DESCRIPTION
This PR adds description of the requirements of a new team name when creating a new team.

Team name can contain uppercase or lowercase alphabets, digits from 0 through 9, underscore and hyphen sign. All other special characters are not allowed.

Having a prompt at onset of a new team creation will help users follow guidelines and avoid encountering errors in creation of a new team name.

##### Was generative AI tooling used to co-author this PR?

No