### PR TITLE
Fix log horizontal overflow UI

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
@@ -141,6 +141,7 @@ export const TaskLogContent = ({ error, isLoading, logError, parsedLogs, wrap }:
           }}
           data-testid="virtualized-list"
           display="block"
+          overflowX="auto"
           textWrap={wrap ? "pre" : "nowrap"}
           width="100%"
         >


### PR DESCRIPTION
Follow up of https://github.com/apache/airflow/pull/62410. I realized big logs overflowing on X were missing the 'code' style.

### Before 
<img width="1883" height="928" alt="Screenshot 2026-02-25 at 16 28 00" src="https://github.com/user-attachments/assets/09ed4092-5b3e-401c-b234-5d8e8b4f6933" />

### After
<img width="1865" height="956" alt="Screenshot 2026-02-25 at 16 27 42" src="https://github.com/user-attachments/assets/30412ec1-c285-4f24-ac1f-aa0691005c92" />
