### PR TITLE
Emit dag_processing.last_run.seconds_ago with dag_file as a tag

### DIFF
--- a/airflow-core/docs/administration-and-deployment/logging-monitoring/metric_tables.rst
+++ b/airflow-core/docs/administration-and-deployment/logging-monitoring/metric_tables.rst
@@ -75,7 +75,7 @@ Name                                                  Legacy Name               
 ``dag_processing.import_errors``                      ``-``                                             Number of errors from trying to parse Dag files
 ``dag_processing.total_parse_time``                   ``-``                                             Seconds taken to scan and import ``dag_processing.file_path_queue_size`` Dag files
 ``dag_processing.file_path_queue_size``               ``-``                                             Number of Dag files to be considered for the next scan
-``dag_processing.last_run.seconds_ago.{dag_file}``    ``-``                                             Seconds since ``{dag_file}`` was last processed
+``dag_processing.last_run.seconds_ago``                ``dag_processing.last_run.seconds_ago.{dag_file}``  Seconds since a DAG file was last processed. Uses ``dag_file`` as a tag.
 ``dag_processing.last_num_of_db_queries.{dag_file}``  ``-``                                             Number of queries to Airflow database during parsing per ``{dag_file}``
 ``scheduler.tasks.starving``                          ``-``                                             Number of tasks that cannot be scheduled because of no open slot in pool
 ``scheduler.tasks.executable``                        ``-``                                             Number of tasks that are ready for execution (set to queued) with respect to pool limits, Dag concurrency, executor state, and priority.

--- a/airflow-core/newsfragments/62487.significant.rst
+++ b/airflow-core/newsfragments/62487.significant.rst
@@ -1,0 +1,1 @@
+``dag_processing.last_run.seconds_ago.{dag_file}`` is now a legacy metric. The new metric ``dag_processing.last_run.seconds_ago`` is emitted with ``dag_file`` as a tag.

--- a/airflow-core/newsfragments/62487.significant.rst
+++ b/airflow-core/newsfragments/62487.significant.rst
@@ -1,0 +1,1 @@
+``dag_processing.last_run.seconds_ago.{dag_file}`` is now a legacy metric. The new metric ``dag_processing.last_run.seconds_ago`` is emitted with ``file_path``, ``bundle_name`` and ``file_name`` as tags, where ``file_path`` and ``bundle_name`` uniquely identify the DAG file. The legacy metric is still emitted by default and can be disabled via ``[metrics] legacy_names_on``.

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -776,6 +776,10 @@ class DagFileProcessorManager(LoggingMixin):
                 if last_run:
                     seconds_ago = (utcnow - last_run).total_seconds()
                     Stats.gauge(f"dag_processing.last_run.seconds_ago.{file_name}", seconds_ago)
+                    # Same metric with tagging
+                    Stats.gauge(
+                        "dag_processing.last_run.seconds_ago", seconds_ago, tags={"dag_file": file_name}
+                    )
 
                 rows.append(
                     (

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -1023,7 +1023,19 @@ class DagFileProcessorManager(LoggingMixin):
                 last_run = stat.last_finish_time
                 if last_run:
                     seconds_ago = (utcnow - last_run).total_seconds()
-                    stats.gauge(f"dag_processing.last_run.seconds_ago.{file_name}", seconds_ago)
+                    # file_path and bundle_name uniquely identify a file (the same file name can
+                    # exist in different folders or bundles). file_name is kept as a tag to ease
+                    # migration from the legacy interpolated metric, which is emitted automatically
+                    # from the registry (controlled by the export_legacy_names config).
+                    stats.gauge(
+                        "dag_processing.last_run.seconds_ago",
+                        seconds_ago,
+                        tags={
+                            "file_path": file.normalized_file_path_for_stats,
+                            "bundle_name": normalize_name_for_stats(file.bundle_name),
+                            "file_name": file_name,
+                        },
+                    )
 
                 rows.append(
                     (

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -1459,8 +1459,10 @@ class TestDagFileProcessorManager:
             tags={"bundle_name": bundle_name, "file_name": dag_filename[:-3]},
         )
 
-    @mock.patch("airflow.dag_processing.manager.stats.gauge")
-    def test_log_file_processing_stats_normalizes_metric_name(self, statsd_gauge_mock):
+    @mock.patch("airflow.dag_processing.manager.stats._get_backend")
+    def test_log_file_processing_stats_normalizes_metric_name(self, mock_get_backend):
+        backend = mock.MagicMock()
+        mock_get_backend.return_value = backend
         manager = DagFileProcessorManager(max_runs=1)
         dag_file = DagFileInfo(
             bundle_name="testing",
@@ -1473,9 +1475,21 @@ class TestDagFileProcessorManager:
 
         manager._log_file_processing_stats({"testing": {dag_file}})
 
-        statsd_gauge_mock.assert_any_call(
+        # Legacy interpolated metric, kept for backward compatibility.
+        backend.gauge.assert_any_call(
             "dag_processing.last_run.seconds_ago.test_of_sprak_opertaor",
             mock.ANY,
+            tags={"file_path": "test_of_sprak_opertaor.py", "bundle_name": "testing"},
+        )
+        # New metric with file_path, bundle_name and file_name tagging.
+        backend.gauge.assert_any_call(
+            "dag_processing.last_run.seconds_ago",
+            mock.ANY,
+            tags={
+                "file_path": "test_of_sprak_opertaor.py",
+                "bundle_name": "testing",
+                "file_name": "test_of_sprak_opertaor",
+            },
         )
 
     @pytest.mark.usefixtures("testing_dag_bundle")

--- a/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
+++ b/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
@@ -289,10 +289,10 @@ metrics:
     legacy_name: "-"
     name_variables: []
 
-  - name: "dag_processing.last_run.seconds_ago.{dag_file}"
-    description: "Seconds since ``{dag_file}`` was last processed"
+  - name: "dag_processing.last_run.seconds_ago"
+    description: "Seconds since ``{dag_file}`` was last processed with dag_file tagging."
     type: "gauge"
-    legacy_name: "-"
+    legacy_name: "dag_processing.last_run.seconds_ago.{dag_file}"
     name_variables: ["dag_file"]
 
   - name: "dag_processing.last_num_of_db_queries.{dag_file}"

--- a/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
+++ b/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
@@ -376,11 +376,12 @@ metrics:
     legacy_name: "-"
     name_variables: []
 
-  - name: "dag_processing.last_run.seconds_ago.{dag_file}"
-    description: "Seconds since ``{dag_file}`` was last processed"
+  - name: "dag_processing.last_run.seconds_ago"
+    description: "Seconds since a DAG file was last processed.
+    Metric with file_path, bundle_name and file_name tagging."
     type: "gauge"
-    legacy_name: "-"
-    name_variables: ["dag_file"]
+    legacy_name: "dag_processing.last_run.seconds_ago.{file_name}"
+    name_variables: ["file_name"]
 
   - name: "dag_processing.last_num_of_db_queries.{dag_file}"
     description: "Number of queries to Airflow database during parsing per ``{dag_file}``"


### PR DESCRIPTION
Moves `dag_processing.last_run.seconds_ago.{dag_file}` to a tagged metric `dag_processing.last_run.seconds_ago`.

The new metric is emitted with three tags:
- `file_path`: the full (normalized) relative file path
- `bundle_name`: the (normalized) bundle name
- `file_name`: the (normalized) file name stem

`file_path` and `bundle_name` together uniquely identify a DAG file (the same file name can exist in different folders or bundles). `file_name` is kept as a tag to ease migration from the legacy interpolated metric.

The old interpolated name `dag_processing.last_run.seconds_ago.{dag_file}` is registered as the metric's `legacy_name`, so it is still emitted by default and can be disabled via `[metrics] legacy_names_on`, preserving backward compatibility.