### PR TITLE
Bugfix english translation keys

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
@@ -161,12 +161,12 @@
     "placeholder": "Add a note...",
     "taskInstance": "Task Instance Note"
   },
-  "partitionedDagRun": "Partitioned Dag Run",
+  "partitionedDagRun_one": "Partitioned Dag Run",
   "partitionedDagRun_other": "Partitioned Dag Runs",
   "partitionedDagRunDetail": {
     "receivedAssetEvents": "Received Asset Events"
   },
-  "pendingDagRun": "{{count}} Pending Dag Run",
+  "pendingDagRun_one": "{{count}} Pending Dag Run",
   "pendingDagRun_other": "{{count}} Pending Dag Runs",
   "reset": "Reset",
   "runId": "Run ID",


### PR DESCRIPTION
I just noticed that singular/plural translation keys are not correct after PR #61398

This is a corretcion before too many translations follow them

---

##### Was generative AI tooling used to co-author this PR?

- [ ] No (please specify the tool below)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
