### PR TITLE
Add ingress deprecation warnings for apiServer, statsd, and pgbouncer

### DIFF
--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -113,6 +113,41 @@ Flower Dashboard:      kubectl port-forward svc/{{ include "airflow.fullname" . 
 {{- end }}
 {{- end }}
 
+{{- if or .Values.ingress.apiServer.enabled .Values.ingress.enabled }}
+
+{{- if .Values.ingress.apiServer.host }}
+
+DEPRECATION WARNING:
+   `ingress.apiServer.host` has been renamed to `ingress.apiServer.hosts` and is now an array.
+   Please change your values as support for the old name will be dropped in a future release.
+
+{{- end }}
+
+{{- if .Values.ingress.apiServer.tls.enabled }}
+
+DEPRECATION WARNING:
+   `ingress.apiServer.tls` has been renamed to `ingress.apiServer.hosts[*].tls` and can be set per host.
+   Please change your values as support for the old name will be dropped in a future release.
+
+{{- end }}
+
+{{- end }}
+
+{{- if and .Values.ingress.statsd.enabled .Values.ingress.statsd.host }}
+
+DEPRECATION WARNING:
+   `ingress.statsd.host` has been renamed to `ingress.statsd.hosts` and is now an array.
+   Please change your values as support for the old name will be dropped in a future release.
+
+{{- end }}
+
+{{- if and .Values.ingress.pgbouncer.enabled .Values.ingress.pgbouncer.host }}
+
+DEPRECATION WARNING:
+   `ingress.pgbouncer.host` has been renamed to `ingress.pgbouncer.hosts` and is now an array.
+   Please change your values as support for the old name will be dropped in a future release.
+
+{{- end }}
 
 {{- if eq (include "createUserJob.isEnabled" .) "true" }}
 Default user (Airflow UI) Login credentials:


### PR DESCRIPTION
Add deprecation warnings in Helm chart NOTES.txt for renamed ingress fields: apiServer.host, apiServer.tls, statsd.host, and pgbouncer.host. All warnings are guarded behind their respective ingress enabled flags to avoid false positives on default installs.

| Test Case | Values Set | Result |
  |---|---|---|
  | apiServer host | `ingress.apiServer.enabled=true, ingress.apiServer.host=example.com` | Shows `apiServer.host` warning |
  | apiServer tls | `ingress.apiServer.enabled=true, ingress.apiServer.tls.enabled=true` | Shows `apiServer.tls` warning |
  | statsd host | `statsd.enabled=true, ingress.statsd.enabled=true, ingress.statsd.host=statsd.example.com` | Shows `statsd.host` warning |
  | pgbouncer host | `pgbouncer.enabled=true, ingress.pgbouncer.enabled=true, ingress.pgbouncer.host=pgbouncer.example.com` | Shows `pgbouncer.host`  warning |
  | legacy `ingress.enabled` | `ingress.enabled=true, ingress.apiServer.host=api.example.com, ingress.apiServer.tls.enabled=true` | Shows both apiServer warnings (plus existing web/flower warnings) |
  | No deprecated fields (defaults only) | *(none)* | No warnings |
  | apiServer enabled, no deprecated fields | `ingress.apiServer.enabled=true` | No warnings |
  | statsd enabled, no deprecated fields | `statsd.enabled=true, ingress.statsd.enabled=true` | No warnings |



---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: Cursor CLI