### PR TITLE
Add identifier validation to DatabricksCopyIntoOperator to prevent SQL structure mutation

### DIFF
--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks_sql.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks_sql.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import csv
 import json
 import os
+import re
 from collections.abc import Sequence
 from functools import cached_property
 from tempfile import NamedTemporaryFile
@@ -40,6 +41,9 @@ from airflow.providers.databricks.hooks.databricks_sql import DatabricksSqlHook
 
 if TYPE_CHECKING:
     from airflow.providers.common.compat.sdk import Context
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_DISALLOWED_SQL_TOKENS = (";", "--", "/*", "*/")
 
 
 class DatabricksSqlOperator(SQLExecuteQueryOperator):
@@ -447,7 +451,25 @@ class DatabricksCopyIntoOperator(BaseOperator):
 
         return formatted_opts
 
+    def _validate_sql_fragments(self) -> None:
+        # Validate table_name segments (supports table, schema.table, catalog.schema.table).
+        parts = self.table_name.split(".")
+        for part in parts:
+            if not part or not _IDENTIFIER_RE.match(part):
+                raise ValueError(
+                    f"Invalid table identifier segment '{part}' in '{self.table_name}'. "
+                    "Only alphanumeric characters and underscores are allowed."
+                )
+
+        # Prevent multi-statement injection via expression_list.
+        if self._expression_list:
+            for token in _DISALLOWED_SQL_TOKENS:
+                if token in self._expression_list:
+                    raise ValueError("expression_list must not contain statement separators or comments.")
+
     def _create_sql_query(self) -> str:
+
+        self._validate_sql_fragments()
         escaper = ParamEscaper()
         maybe_with = ""
         if self._encryption is not None or self._credential is not None:
@@ -484,7 +506,7 @@ class DatabricksCopyIntoOperator(BaseOperator):
                 validation = f"VALIDATE {self._validate} ROWS\n"
             else:
                 raise AirflowException(f"Incorrect data type for validate parameter: {type(self._validate)}")
-        # TODO: think on how to make sure that table_name and expression_list aren't used for SQL injection
+
         sql = f"""COPY INTO {self.table_name}{storage_cred}
 FROM {location}
 FILEFORMAT = {self._file_format}

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks_copy.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks_copy.py
@@ -240,6 +240,97 @@ def test_incorrect_params_wrong_format():
         )
 
 
+@pytest.mark.parametrize(
+    "table_name",
+    [
+        "safe; DROP TABLE x",
+        "safe table",
+        "safe-table",
+        "safe()",
+        "safe--comment",
+        "1invalid",
+        ".table",
+        "schema.",
+    ],
+)
+def test_invalid_table_identifier_rejected(table_name):
+    op = DatabricksCopyIntoOperator(
+        file_location=COPY_FILE_LOCATION,
+        file_format="JSON",
+        table_name=table_name,
+        task_id=TASK_ID,
+    )
+
+    with pytest.raises(ValueError, match="Invalid table identifier"):
+        op._create_sql_query()
+
+
+@pytest.mark.parametrize(
+    "table_name",
+    [
+        "table",
+        "schema.table",
+        "catalog.schema.table",
+        "_table",
+        "table_123",
+    ],
+)
+def test_valid_table_identifier_allowed(table_name):
+    op = DatabricksCopyIntoOperator(
+        file_location=COPY_FILE_LOCATION,
+        file_format="JSON",
+        table_name=table_name,
+        task_id=TASK_ID,
+    )
+
+    sql = op._create_sql_query()
+    assert f"COPY INTO {table_name}" in sql
+
+
+@pytest.mark.parametrize(
+    "expression_list",
+    [
+        "col1; DROP TABLE x",
+        "col1 -- comment",
+        "col1 /* comment */",
+    ],
+)
+def test_expression_list_rejects_multi_statement(expression_list):
+    op = DatabricksCopyIntoOperator(
+        file_location=COPY_FILE_LOCATION,
+        file_format="JSON",
+        table_name="test",
+        task_id=TASK_ID,
+        expression_list=expression_list,
+    )
+
+    with pytest.raises(ValueError, match="expression_list"):
+        op._create_sql_query()
+
+
+@pytest.mark.parametrize(
+    "expression_list",
+    [
+        "*",
+        "col1",
+        "col1, col2",
+        "upper(col1) as col1",
+        "cast(_c0 as int) as id",
+    ],
+)
+def test_valid_expression_list_allowed(expression_list):
+    op = DatabricksCopyIntoOperator(
+        file_location=COPY_FILE_LOCATION,
+        file_format="JSON",
+        table_name="test",
+        task_id=TASK_ID,
+        expression_list=expression_list,
+    )
+
+    sql = op._create_sql_query()
+    assert f"SELECT {expression_list}" in sql
+
+
 @pytest.mark.db_test
 def test_templating(create_task_instance_of_operator, session):
     ti = create_task_instance_of_operator(


### PR DESCRIPTION
**Description**

This change adds validation to `DatabricksCopyIntoOperator` to ensure that `table_name` is a valid SQL identifier and cannot alter the structure of the generated COPY INTO statement. Previously, table_name was directly interpolated into the SQL without validation, allowing malformed or multi-statement fragments to mutate the intended statement. A new helper method, `_validate_sql_fragments`, is introduced and invoked during SQL construction to enforce these constraints. It validates that each dot-separated segment of table_name contains only alphanumeric characters and underscores and conforms to standard identifier rules. If validation fails, an exception is raised before the SQL is executed.

**Rationale**

`DatabricksCopyIntoOperator` is a structured abstraction over the `COPY INTO` statement and is not intended to function as a general-purpose SQL executor. Allowing identifier fields such as `table_name` to mutate the generated SQL into multi-statement or destructive operations breaks that abstraction and undermines the operator’s intended semantics. The existing `#TODO` in `_create_sql_query()` acknowledges the need to consider how `table_name` and `expression_list` should be protected from SQL injection, and this change implements a concrete validation approach for `table_name` consistent with that intent.

While Airflow assumes trusted DAG authors, it is possible for non-DAG authors to trigger DAGs via the REST API and supply templated runtime input. Even if such scenarios fall outside Airflow’s strict security model, preventing structured SQL from being mutated through identifier fields improves robustness and reduces unintended destructive behavior arising from malformed configuration.

**Tests**

Added unit tests that verify that:

* invalid identifiers and multi-statement fragments in `table_name` or `expression_list` raise an exception during SQL construction.
* valid identifiers and valid projection expressions continue to generate correct `COPY INTO` SQL statements.

**Backwards Compatibility**

This change introduces validation on `table_name`. Valid identifiers continue to function as before and existing structured `COPY INTO` behavior remains unchanged. No public APIs have been modified.

Behavior changes only for previously accepted values that contained invalid identifier segments or multi-statement fragments. In particular, values that inject additional SQL statements via `table_name` will no longer result in mutated multi-statement SQL being constructed and executed. Instead, the operator will raise an exception during SQL construction.

Closes: #62498 