### PR TITLE
Fix GenericTransfer reference not clickable in templates documentation (apache#62470)

### DIFF
--- a/airflow-core/docs/operators-and-hooks-ref.rst
+++ b/airflow-core/docs/operators-and-hooks-ref.rst
@@ -65,7 +65,7 @@ For details see: :doc:`apache-airflow-providers:operators-and-hooks-ref/index`.
    * - :mod:`airflow.providers.standard.operators.empty`
      -
 
-   * - :mod:`airflow.providers.common.sql.operators.generic_transfer.GenericTransfer`
+   * - :mod:`airflow.providers.common.sql.operators.generic_transfer`
      - :doc:`How to use <apache-airflow-providers-common-sql:operators>`
 
    * - :mod:`airflow.providers.standard.operators.latest_only`


### PR DESCRIPTION
Closes #62470
Problem
On the templates reference (and operators-and-hooks reference), the reference to airflow.providers.common.sql.operators.generic_transfer.GenericTransfer was not clickable, while other operators (e.g. BashOperator) were correctly linked. Users could not go from the docs to the GenericTransfer class.
Solution
Updated the documentation so the GenericTransfer reference is a proper Sphinx cross-reference and renders as a clickable link, consistent with other operators on the same page.
Changes
airflow-core/docs/operators-and-hooks-ref.rst: Adjusted the GenericTransfer entry so the reference resolves correctly during the docs build (e.g. using the appropriate ``:class:`` or ``:mod:`` role and/or ensuring the provider inventory is used).
Testing
1. Docs build completes successfully.
2.  Built docs: the GenericTransfer reference on the operators-and-hooks / templates reference page is clickable and points to the correct provider documentation.
