### PR TITLE
 Fix team-scoped auth check for POST variables, connections, and pools in multi-team mode

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/security.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/security.py
@@ -353,7 +353,7 @@ def requires_access_pool(method: ResourceMethod) -> Callable[[Request, BaseUser]
         pool_name = request.path_params.get("pool_name")
         for team_name in await _collect_teams_to_check(method, request, pool_name, Pool.get_team_name):
             _requires_access(
-                is_authorized_callback=lambda team_name=team_name: get_auth_manager().is_authorized_pool(
+                is_authorized_callback=lambda team_name=team_name: get_auth_manager().is_authorized_pool(  # type: ignore[misc]
                     method=method, details=PoolDetails(name=pool_name, team_name=team_name), user=user
                 ),
             )
@@ -450,7 +450,7 @@ def requires_access_connection(
             method, request, connection_id, Connection.get_team_name
         ):
             _requires_access(
-                is_authorized_callback=lambda team_name=team_name: (
+                is_authorized_callback=lambda team_name=team_name: (  # type: ignore[misc]
                     get_auth_manager().is_authorized_connection(
                         method=method,
                         details=ConnectionDetails(conn_id=connection_id, team_name=team_name),
@@ -594,7 +594,7 @@ def requires_access_variable(
         variable_key: str | None = request.path_params.get("variable_key")
         for team_name in await _collect_teams_to_check(method, request, variable_key, Variable.get_team_name):
             _requires_access(
-                is_authorized_callback=lambda team_name=team_name: get_auth_manager().is_authorized_variable(
+                is_authorized_callback=lambda team_name=team_name: get_auth_manager().is_authorized_variable(  # type: ignore[misc]
                     method=method, details=VariableDetails(key=variable_key, team_name=team_name), user=user
                 ),
             )

--- a/airflow-core/src/airflow/api_fastapi/core_api/security.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/security.py
@@ -345,13 +345,17 @@ def permitted_pool_filter_factory(
 ReadablePoolsFilterDep = Annotated[PermittedPoolFilter, Depends(permitted_pool_filter_factory("GET"))]
 
 
-def requires_access_pool(method: ResourceMethod) -> Callable[[Request, BaseUser], None]:
-    def inner(
+def requires_access_pool(method: ResourceMethod) -> Callable[[Request, BaseUser], Coroutine[Any, Any, None]]:
+    async def inner(
         request: Request,
         user: GetUserDep,
     ) -> None:
         pool_name = request.path_params.get("pool_name")
-        team_name = Pool.get_team_name(pool_name) if pool_name else None
+        raw_team_name = Pool.get_team_name(pool_name) if pool_name else None
+        if raw_team_name is None:
+            with suppress(JSONDecodeError):
+                raw_team_name = (await request.json()).get("team_name")
+        team_name = Team.get_name_if_exists(raw_team_name) if raw_team_name else None
 
         _requires_access(
             is_authorized_callback=lambda: get_auth_manager().is_authorized_pool(
@@ -439,13 +443,19 @@ ReadableConnectionsFilterDep = Annotated[
 ]
 
 
-def requires_access_connection(method: ResourceMethod) -> Callable[[Request, BaseUser], None]:
-    def inner(
+def requires_access_connection(
+    method: ResourceMethod,
+) -> Callable[[Request, BaseUser], Coroutine[Any, Any, None]]:
+    async def inner(
         request: Request,
         user: GetUserDep,
     ) -> None:
         connection_id = request.path_params.get("connection_id")
-        team_name = Connection.get_team_name(connection_id) if connection_id else None
+        raw_team_name = Connection.get_team_name(connection_id) if connection_id else None
+        if raw_team_name is None:
+            with suppress(JSONDecodeError):
+                raw_team_name = (await request.json()).get("team_name")
+        team_name = Team.get_name_if_exists(raw_team_name) if raw_team_name else None
 
         _requires_access(
             is_authorized_callback=lambda: get_auth_manager().is_authorized_connection(
@@ -580,13 +590,19 @@ ReadableVariablesFilterDep = Annotated[
 ]
 
 
-def requires_access_variable(method: ResourceMethod) -> Callable[[Request, BaseUser], None]:
-    def inner(
+def requires_access_variable(
+    method: ResourceMethod,
+) -> Callable[[Request, BaseUser], Coroutine[Any, Any, None]]:
+    async def inner(
         request: Request,
         user: GetUserDep,
     ) -> None:
         variable_key: str | None = request.path_params.get("variable_key")
-        team_name = Variable.get_team_name(variable_key) if variable_key else None
+        raw_team_name = Variable.get_team_name(variable_key) if variable_key else None
+        if raw_team_name is None:
+            with suppress(JSONDecodeError):
+                raw_team_name = (await request.json()).get("team_name")
+        team_name = Team.get_name_if_exists(raw_team_name) if raw_team_name else None
 
         _requires_access(
             is_authorized_callback=lambda: get_auth_manager().is_authorized_variable(

--- a/airflow-core/src/airflow/api_fastapi/core_api/security.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/security.py
@@ -352,11 +352,13 @@ def requires_access_pool(method: ResourceMethod) -> Callable[[Request, BaseUser]
     ) -> None:
         pool_name = request.path_params.get("pool_name")
         for team_name in await _collect_teams_to_check(method, request, pool_name, Pool.get_team_name):
-            _requires_access(
-                is_authorized_callback=lambda team_name=team_name: get_auth_manager().is_authorized_pool(  # type: ignore[misc]
-                    method=method, details=PoolDetails(name=pool_name, team_name=team_name), user=user
-                ),
-            )
+
+            def _callback(tn: str | None = team_name) -> bool:
+                return get_auth_manager().is_authorized_pool(
+                    method=method, details=PoolDetails(name=pool_name, team_name=tn), user=user
+                )
+
+            _requires_access(is_authorized_callback=_callback)
 
     return inner
 
@@ -449,15 +451,15 @@ def requires_access_connection(
         for team_name in await _collect_teams_to_check(
             method, request, connection_id, Connection.get_team_name
         ):
-            _requires_access(
-                is_authorized_callback=lambda team_name=team_name: (  # type: ignore[misc]
-                    get_auth_manager().is_authorized_connection(
-                        method=method,
-                        details=ConnectionDetails(conn_id=connection_id, team_name=team_name),
-                        user=user,
-                    )
-                ),
-            )
+
+            def _callback(tn: str | None = team_name) -> bool:
+                return get_auth_manager().is_authorized_connection(
+                    method=method,
+                    details=ConnectionDetails(conn_id=connection_id, team_name=tn),
+                    user=user,
+                )
+
+            _requires_access(is_authorized_callback=_callback)
 
     return inner
 
@@ -593,11 +595,13 @@ def requires_access_variable(
     ) -> None:
         variable_key: str | None = request.path_params.get("variable_key")
         for team_name in await _collect_teams_to_check(method, request, variable_key, Variable.get_team_name):
-            _requires_access(
-                is_authorized_callback=lambda team_name=team_name: get_auth_manager().is_authorized_variable(  # type: ignore[misc]
-                    method=method, details=VariableDetails(key=variable_key, team_name=team_name), user=user
-                ),
-            )
+
+            def _callback(tn: str | None = team_name) -> bool:
+                return get_auth_manager().is_authorized_variable(
+                    method=method, details=VariableDetails(key=variable_key, team_name=tn), user=user
+                )
+
+            _requires_access(is_authorized_callback=_callback)
 
     return inner
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/security.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/security.py
@@ -351,17 +351,12 @@ def requires_access_pool(method: ResourceMethod) -> Callable[[Request, BaseUser]
         user: GetUserDep,
     ) -> None:
         pool_name = request.path_params.get("pool_name")
-        raw_team_name = Pool.get_team_name(pool_name) if pool_name else None
-        if raw_team_name is None:
-            with suppress(JSONDecodeError):
-                raw_team_name = (await request.json()).get("team_name")
-        team_name = Team.get_name_if_exists(raw_team_name) if raw_team_name else None
-
-        _requires_access(
-            is_authorized_callback=lambda: get_auth_manager().is_authorized_pool(
-                method=method, details=PoolDetails(name=pool_name, team_name=team_name), user=user
+        for team_name in await _collect_teams_to_check(method, request, pool_name, Pool.get_team_name):
+            _requires_access(
+                is_authorized_callback=lambda team_name=team_name: get_auth_manager().is_authorized_pool(
+                    method=method, details=PoolDetails(name=pool_name, team_name=team_name), user=user
+                ),
             )
-        )
 
     return inner
 
@@ -451,19 +446,18 @@ def requires_access_connection(
         user: GetUserDep,
     ) -> None:
         connection_id = request.path_params.get("connection_id")
-        raw_team_name = Connection.get_team_name(connection_id) if connection_id else None
-        if raw_team_name is None:
-            with suppress(JSONDecodeError):
-                raw_team_name = (await request.json()).get("team_name")
-        team_name = Team.get_name_if_exists(raw_team_name) if raw_team_name else None
-
-        _requires_access(
-            is_authorized_callback=lambda: get_auth_manager().is_authorized_connection(
-                method=method,
-                details=ConnectionDetails(conn_id=connection_id, team_name=team_name),
-                user=user,
+        for team_name in await _collect_teams_to_check(
+            method, request, connection_id, Connection.get_team_name
+        ):
+            _requires_access(
+                is_authorized_callback=lambda team_name=team_name: (
+                    get_auth_manager().is_authorized_connection(
+                        method=method,
+                        details=ConnectionDetails(conn_id=connection_id, team_name=team_name),
+                        user=user,
+                    )
+                ),
             )
-        )
 
     return inner
 
@@ -598,17 +592,12 @@ def requires_access_variable(
         user: GetUserDep,
     ) -> None:
         variable_key: str | None = request.path_params.get("variable_key")
-        raw_team_name = Variable.get_team_name(variable_key) if variable_key else None
-        if raw_team_name is None:
-            with suppress(JSONDecodeError):
-                raw_team_name = (await request.json()).get("team_name")
-        team_name = Team.get_name_if_exists(raw_team_name) if raw_team_name else None
-
-        _requires_access(
-            is_authorized_callback=lambda: get_auth_manager().is_authorized_variable(
-                method=method, details=VariableDetails(key=variable_key, team_name=team_name), user=user
-            ),
-        )
+        for team_name in await _collect_teams_to_check(method, request, variable_key, Variable.get_team_name):
+            _requires_access(
+                is_authorized_callback=lambda team_name=team_name: get_auth_manager().is_authorized_variable(
+                    method=method, details=VariableDetails(key=variable_key, team_name=team_name), user=user
+                ),
+            )
 
     return inner
 
@@ -717,6 +706,30 @@ def requires_authenticated() -> Callable:
         pass
 
     return inner
+
+
+async def _collect_teams_to_check(
+    method: ResourceMethod,
+    request: Request,
+    resource_id: str | None,
+    get_existing_team: Callable[[str], str | None],
+) -> set[str | None]:
+    """Collect validated team names from existing resource (DB) and/or request body."""
+    if not conf.getboolean("core", "multi_team"):
+        return {None}
+    teams: set[str | None] = set()
+    if method != "POST":
+        teams.add(get_existing_team(resource_id) if resource_id else None)
+    if method in ("POST", "PUT"):
+        with suppress(JSONDecodeError):
+            raw = (await request.json()).get("team_name")
+            if raw and not Team.get_name_if_exists(raw):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Team {raw!r} does not exist",
+                )
+            teams.add(raw)
+    return teams
 
 
 def _requires_access(

--- a/airflow-core/src/airflow/models/team.py
+++ b/airflow-core/src/airflow/models/team.py
@@ -62,6 +62,12 @@ class Team(Base):
 
     @classmethod
     @provide_session
+    def get_name_if_exists(cls, name: str, *, session: Session = NEW_SESSION) -> str | None:
+        """Return name if a Team row with that name exists, otherwise None."""
+        return session.scalar(select(cls.name).where(cls.name == name))
+
+    @classmethod
+    @provide_session
     def get_all_team_names(cls, session: Session = NEW_SESSION) -> set[str]:
         """
         Return a set of all team names from the database.

--- a/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
@@ -54,7 +54,6 @@ from airflow.models.dag import DagModel
 from airflow.models.team import Team
 
 from tests_common.test_utils.config import conf_vars
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_2_PLUS
 
 
 @pytest.mark.asyncio
@@ -431,7 +430,6 @@ class TestFastApiSecurity:
         request.base_url = "https://requesting_server_base_url.com/prefix2"
         assert is_safe_url(url, request=request) == expected_is_safe
 
-    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Team not available before Airflow 3.2.0")
     @pytest.mark.db_test
     @pytest.mark.parametrize(
         "team_name",
@@ -463,7 +461,6 @@ class TestFastApiSecurity:
         )
         mock_get_team_name.assert_called_once_with("conn_id")
 
-    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Team not available before Airflow 3.2.0")
     @pytest.mark.db_test
     @patch.object(Team, "get_name_if_exists")
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
@@ -490,7 +487,6 @@ class TestFastApiSecurity:
         )
         mock_get_name_if_exists.assert_called_once_with("team1")
 
-    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Team not available before Airflow 3.2.0")
     @pytest.mark.db_test
     @patch.object(Team, "get_name_if_exists")
     @patch.object(Connection, "get_team_name")
@@ -524,7 +520,6 @@ class TestFastApiSecurity:
             user=user,
         )
 
-    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Team not available before Airflow 3.2.0")
     @pytest.mark.db_test
     @patch.object(Team, "get_name_if_exists")
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
@@ -608,7 +603,6 @@ class TestFastApiSecurity:
             user=user,
         )
 
-    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Team not available before Airflow 3.2.0")
     @pytest.mark.db_test
     @pytest.mark.parametrize(
         "team_name",
@@ -640,7 +634,6 @@ class TestFastApiSecurity:
         )
         mock_get_team_name.assert_called_once_with("var_key")
 
-    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Team not available before Airflow 3.2.0")
     @pytest.mark.db_test
     @patch.object(Team, "get_name_if_exists")
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
@@ -667,7 +660,6 @@ class TestFastApiSecurity:
         )
         mock_get_name_if_exists.assert_called_once_with("team1")
 
-    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Team not available before Airflow 3.2.0")
     @pytest.mark.db_test
     @patch.object(Team, "get_name_if_exists")
     @patch.object(Variable, "get_team_name")
@@ -701,7 +693,6 @@ class TestFastApiSecurity:
             user=user,
         )
 
-    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Team not available before Airflow 3.2.0")
     @pytest.mark.db_test
     @patch.object(Team, "get_name_if_exists")
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
@@ -782,7 +773,6 @@ class TestFastApiSecurity:
             user=user,
         )
 
-    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Team not available before Airflow 3.2.0")
     @pytest.mark.db_test
     @pytest.mark.parametrize(
         "team_name",
@@ -814,7 +804,6 @@ class TestFastApiSecurity:
         )
         mock_get_team_name.assert_called_once_with("pool")
 
-    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Team not available before Airflow 3.2.0")
     @pytest.mark.db_test
     @patch.object(Team, "get_name_if_exists")
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
@@ -839,7 +828,6 @@ class TestFastApiSecurity:
         )
         mock_get_name_if_exists.assert_called_once_with("team1")
 
-    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Team not available before Airflow 3.2.0")
     @pytest.mark.db_test
     @patch.object(Team, "get_name_if_exists")
     @patch.object(Pool, "get_team_name")
@@ -873,7 +861,6 @@ class TestFastApiSecurity:
             user=user,
         )
 
-    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Team not available before Airflow 3.2.0")
     @pytest.mark.db_test
     @patch.object(Team, "get_name_if_exists")
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")

--- a/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
@@ -54,6 +54,7 @@ from airflow.models.dag import DagModel
 from airflow.models.team import Team
 
 from tests_common.test_utils.config import conf_vars
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_2_PLUS
 
 
 @pytest.mark.asyncio
@@ -430,6 +431,7 @@ class TestFastApiSecurity:
         request.base_url = "https://requesting_server_base_url.com/prefix2"
         assert is_safe_url(url, request=request) == expected_is_safe
 
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Team not available before Airflow 3.2.0")
     @pytest.mark.db_test
     @pytest.mark.parametrize(
         "team_name",
@@ -451,7 +453,8 @@ class TestFastApiSecurity:
         fastapi_request.json = AsyncMock(return_value={})
         user = Mock()
 
-        await requires_access_connection("GET")(fastapi_request, user)
+        with conf_vars({("core", "multi_team"): "True"}):
+            await requires_access_connection("GET")(fastapi_request, user)
 
         auth_manager.is_authorized_connection.assert_called_once_with(
             method="GET",
@@ -460,6 +463,7 @@ class TestFastApiSecurity:
         )
         mock_get_team_name.assert_called_once_with("conn_id")
 
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Team not available before Airflow 3.2.0")
     @pytest.mark.db_test
     @patch.object(Team, "get_name_if_exists")
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
@@ -476,7 +480,8 @@ class TestFastApiSecurity:
         fastapi_request.json = AsyncMock(return_value={"team_name": "team1"})
         user = Mock()
 
-        await requires_access_connection("POST")(fastapi_request, user)
+        with conf_vars({("core", "multi_team"): "True"}):
+            await requires_access_connection("POST")(fastapi_request, user)
 
         auth_manager.is_authorized_connection.assert_called_once_with(
             method="POST",
@@ -484,6 +489,61 @@ class TestFastApiSecurity:
             user=user,
         )
         mock_get_name_if_exists.assert_called_once_with("team1")
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Team not available before Airflow 3.2.0")
+    @pytest.mark.db_test
+    @patch.object(Team, "get_name_if_exists")
+    @patch.object(Connection, "get_team_name")
+    @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
+    async def test_requires_access_connection_put_checks_both_teams(
+        self, mock_get_auth_manager, mock_get_team_name, mock_get_name_if_exists
+    ):
+        """PUT checks both existing team (from DB) and new team (from body)."""
+        auth_manager = Mock()
+        auth_manager.is_authorized_connection.return_value = True
+        mock_get_auth_manager.return_value = auth_manager
+        mock_get_team_name.return_value = "old-team"
+        mock_get_name_if_exists.side_effect = lambda name: name
+        fastapi_request = Mock()
+        fastapi_request.path_params = {"connection_id": "conn_id"}
+        fastapi_request.json = AsyncMock(return_value={"team_name": "new-team"})
+        user = Mock()
+
+        with conf_vars({("core", "multi_team"): "True"}):
+            await requires_access_connection("PUT")(fastapi_request, user)
+
+        assert auth_manager.is_authorized_connection.call_count == 2
+        auth_manager.is_authorized_connection.assert_any_call(
+            method="PUT",
+            details=ConnectionDetails(conn_id="conn_id", team_name="old-team"),
+            user=user,
+        )
+        auth_manager.is_authorized_connection.assert_any_call(
+            method="PUT",
+            details=ConnectionDetails(conn_id="conn_id", team_name="new-team"),
+            user=user,
+        )
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Team not available before Airflow 3.2.0")
+    @pytest.mark.db_test
+    @patch.object(Team, "get_name_if_exists")
+    @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
+    async def test_requires_access_connection_post_invalid_team_returns_400(
+        self, mock_get_auth_manager, mock_get_name_if_exists
+    ):
+        """POST with a team_name that doesn't exist raises 400."""
+        mock_get_name_if_exists.return_value = None
+        fastapi_request = Mock()
+        fastapi_request.path_params = {}
+        fastapi_request.json = AsyncMock(return_value={"team_name": "nonexistent"})
+        user = Mock()
+
+        with conf_vars({("core", "multi_team"): "True"}):
+            with pytest.raises(HTTPException) as exc_info:
+                await requires_access_connection("POST")(fastapi_request, user)
+
+        assert exc_info.value.status_code == 400
+        assert "nonexistent" in exc_info.value.detail
 
     @patch.object(Connection, "get_conn_id_to_team_name_mapping")
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
@@ -548,6 +608,7 @@ class TestFastApiSecurity:
             user=user,
         )
 
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Team not available before Airflow 3.2.0")
     @pytest.mark.db_test
     @pytest.mark.parametrize(
         "team_name",
@@ -569,7 +630,8 @@ class TestFastApiSecurity:
         fastapi_request.json = AsyncMock(return_value={})
         user = Mock()
 
-        await requires_access_variable("GET")(fastapi_request, user)
+        with conf_vars({("core", "multi_team"): "True"}):
+            await requires_access_variable("GET")(fastapi_request, user)
 
         auth_manager.is_authorized_variable.assert_called_once_with(
             method="GET",
@@ -578,6 +640,7 @@ class TestFastApiSecurity:
         )
         mock_get_team_name.assert_called_once_with("var_key")
 
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Team not available before Airflow 3.2.0")
     @pytest.mark.db_test
     @patch.object(Team, "get_name_if_exists")
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
@@ -594,7 +657,8 @@ class TestFastApiSecurity:
         fastapi_request.json = AsyncMock(return_value={"team_name": "team1"})
         user = Mock()
 
-        await requires_access_variable("POST")(fastapi_request, user)
+        with conf_vars({("core", "multi_team"): "True"}):
+            await requires_access_variable("POST")(fastapi_request, user)
 
         auth_manager.is_authorized_variable.assert_called_once_with(
             method="POST",
@@ -602,6 +666,61 @@ class TestFastApiSecurity:
             user=user,
         )
         mock_get_name_if_exists.assert_called_once_with("team1")
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Team not available before Airflow 3.2.0")
+    @pytest.mark.db_test
+    @patch.object(Team, "get_name_if_exists")
+    @patch.object(Variable, "get_team_name")
+    @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
+    async def test_requires_access_variable_put_checks_both_teams(
+        self, mock_get_auth_manager, mock_get_team_name, mock_get_name_if_exists
+    ):
+        """PUT checks both existing team (from DB) and new team (from body)."""
+        auth_manager = Mock()
+        auth_manager.is_authorized_variable.return_value = True
+        mock_get_auth_manager.return_value = auth_manager
+        mock_get_team_name.return_value = "old-team"
+        mock_get_name_if_exists.side_effect = lambda name: name
+        fastapi_request = Mock()
+        fastapi_request.path_params = {"variable_key": "var_key"}
+        fastapi_request.json = AsyncMock(return_value={"team_name": "new-team"})
+        user = Mock()
+
+        with conf_vars({("core", "multi_team"): "True"}):
+            await requires_access_variable("PUT")(fastapi_request, user)
+
+        assert auth_manager.is_authorized_variable.call_count == 2
+        auth_manager.is_authorized_variable.assert_any_call(
+            method="PUT",
+            details=VariableDetails(key="var_key", team_name="old-team"),
+            user=user,
+        )
+        auth_manager.is_authorized_variable.assert_any_call(
+            method="PUT",
+            details=VariableDetails(key="var_key", team_name="new-team"),
+            user=user,
+        )
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Team not available before Airflow 3.2.0")
+    @pytest.mark.db_test
+    @patch.object(Team, "get_name_if_exists")
+    @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
+    async def test_requires_access_variable_post_invalid_team_returns_400(
+        self, mock_get_auth_manager, mock_get_name_if_exists
+    ):
+        """POST with a team_name that doesn't exist raises 400."""
+        mock_get_name_if_exists.return_value = None
+        fastapi_request = Mock()
+        fastapi_request.path_params = {}
+        fastapi_request.json = AsyncMock(return_value={"team_name": "nonexistent"})
+        user = Mock()
+
+        with conf_vars({("core", "multi_team"): "True"}):
+            with pytest.raises(HTTPException) as exc_info:
+                await requires_access_variable("POST")(fastapi_request, user)
+
+        assert exc_info.value.status_code == 400
+        assert "nonexistent" in exc_info.value.detail
 
     @patch.object(Variable, "get_key_to_team_name_mapping")
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
@@ -663,6 +782,7 @@ class TestFastApiSecurity:
             user=user,
         )
 
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Team not available before Airflow 3.2.0")
     @pytest.mark.db_test
     @pytest.mark.parametrize(
         "team_name",
@@ -684,7 +804,8 @@ class TestFastApiSecurity:
         fastapi_request.json = AsyncMock(return_value={})
         user = Mock()
 
-        await requires_access_pool("GET")(fastapi_request, user)
+        with conf_vars({("core", "multi_team"): "True"}):
+            await requires_access_pool("GET")(fastapi_request, user)
 
         auth_manager.is_authorized_pool.assert_called_once_with(
             method="GET",
@@ -693,6 +814,7 @@ class TestFastApiSecurity:
         )
         mock_get_team_name.assert_called_once_with("pool")
 
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Team not available before Airflow 3.2.0")
     @pytest.mark.db_test
     @patch.object(Team, "get_name_if_exists")
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
@@ -707,7 +829,8 @@ class TestFastApiSecurity:
         fastapi_request.json = AsyncMock(return_value={"team_name": "team1"})
         user = Mock()
 
-        await requires_access_pool("POST")(fastapi_request, user)
+        with conf_vars({("core", "multi_team"): "True"}):
+            await requires_access_pool("POST")(fastapi_request, user)
 
         auth_manager.is_authorized_pool.assert_called_once_with(
             method="POST",
@@ -715,6 +838,61 @@ class TestFastApiSecurity:
             user=user,
         )
         mock_get_name_if_exists.assert_called_once_with("team1")
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Team not available before Airflow 3.2.0")
+    @pytest.mark.db_test
+    @patch.object(Team, "get_name_if_exists")
+    @patch.object(Pool, "get_team_name")
+    @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
+    async def test_requires_access_pool_put_checks_both_teams(
+        self, mock_get_auth_manager, mock_get_team_name, mock_get_name_if_exists
+    ):
+        """PUT checks both existing team (from DB) and new team (from body)."""
+        auth_manager = Mock()
+        auth_manager.is_authorized_pool.return_value = True
+        mock_get_auth_manager.return_value = auth_manager
+        mock_get_team_name.return_value = "old-team"
+        mock_get_name_if_exists.side_effect = lambda name: name
+        fastapi_request = Mock()
+        fastapi_request.path_params = {"pool_name": "pool"}
+        fastapi_request.json = AsyncMock(return_value={"team_name": "new-team"})
+        user = Mock()
+
+        with conf_vars({("core", "multi_team"): "True"}):
+            await requires_access_pool("PUT")(fastapi_request, user)
+
+        assert auth_manager.is_authorized_pool.call_count == 2
+        auth_manager.is_authorized_pool.assert_any_call(
+            method="PUT",
+            details=PoolDetails(name="pool", team_name="old-team"),
+            user=user,
+        )
+        auth_manager.is_authorized_pool.assert_any_call(
+            method="PUT",
+            details=PoolDetails(name="pool", team_name="new-team"),
+            user=user,
+        )
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Team not available before Airflow 3.2.0")
+    @pytest.mark.db_test
+    @patch.object(Team, "get_name_if_exists")
+    @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
+    async def test_requires_access_pool_post_invalid_team_returns_400(
+        self, mock_get_auth_manager, mock_get_name_if_exists
+    ):
+        """POST with a team_name that doesn't exist raises 400."""
+        mock_get_name_if_exists.return_value = None
+        fastapi_request = Mock()
+        fastapi_request.path_params = {}
+        fastapi_request.json = AsyncMock(return_value={"team_name": "nonexistent"})
+        user = Mock()
+
+        with conf_vars({("core", "multi_team"): "True"}):
+            with pytest.raises(HTTPException) as exc_info:
+                await requires_access_pool("POST")(fastapi_request, user)
+
+        assert exc_info.value.status_code == 400
+        assert "nonexistent" in exc_info.value.detail
 
     @patch.object(Pool, "get_name_to_team_name_mapping")
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")

--- a/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
@@ -51,6 +51,7 @@ from airflow.api_fastapi.core_api.security import (
 )
 from airflow.models import Connection, Pool, Variable
 from airflow.models.dag import DagModel
+from airflow.models.team import Team
 
 from tests_common.test_utils.config import conf_vars
 
@@ -434,18 +435,23 @@ class TestFastApiSecurity:
         "team_name",
         [None, "team1"],
     )
+    @patch.object(Team, "get_name_if_exists")
     @patch.object(Connection, "get_team_name")
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
-    def test_requires_access_connection(self, mock_get_auth_manager, mock_get_team_name, team_name):
+    async def test_requires_access_connection(
+        self, mock_get_auth_manager, mock_get_team_name, mock_get_name_if_exists, team_name
+    ):
         auth_manager = Mock()
         auth_manager.is_authorized_connection.return_value = True
         mock_get_auth_manager.return_value = auth_manager
+        mock_get_team_name.return_value = team_name
+        mock_get_name_if_exists.return_value = team_name
         fastapi_request = Mock()
         fastapi_request.path_params = {"connection_id": "conn_id"}
-        mock_get_team_name.return_value = team_name
+        fastapi_request.json = AsyncMock(return_value={})
         user = Mock()
 
-        requires_access_connection("GET")(fastapi_request, user)
+        await requires_access_connection("GET")(fastapi_request, user)
 
         auth_manager.is_authorized_connection.assert_called_once_with(
             method="GET",
@@ -453,6 +459,31 @@ class TestFastApiSecurity:
             user=user,
         )
         mock_get_team_name.assert_called_once_with("conn_id")
+
+    @pytest.mark.db_test
+    @patch.object(Team, "get_name_if_exists")
+    @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
+    async def test_requires_access_connection_team_from_body(
+        self, mock_get_auth_manager, mock_get_name_if_exists
+    ):
+        """When connection doesn't exist yet (POST), team_name is read from request body."""
+        auth_manager = Mock()
+        auth_manager.is_authorized_connection.return_value = True
+        mock_get_auth_manager.return_value = auth_manager
+        mock_get_name_if_exists.return_value = "team1"
+        fastapi_request = Mock()
+        fastapi_request.path_params = {}
+        fastapi_request.json = AsyncMock(return_value={"team_name": "team1"})
+        user = Mock()
+
+        await requires_access_connection("POST")(fastapi_request, user)
+
+        auth_manager.is_authorized_connection.assert_called_once_with(
+            method="POST",
+            details=ConnectionDetails(conn_id=None, team_name="team1"),
+            user=user,
+        )
+        mock_get_name_if_exists.assert_called_once_with("team1")
 
     @patch.object(Connection, "get_conn_id_to_team_name_mapping")
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
@@ -522,18 +553,23 @@ class TestFastApiSecurity:
         "team_name",
         [None, "team1"],
     )
+    @patch.object(Team, "get_name_if_exists")
     @patch.object(Variable, "get_team_name")
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
-    def test_requires_access_variable(self, mock_get_auth_manager, mock_get_team_name, team_name):
+    async def test_requires_access_variable(
+        self, mock_get_auth_manager, mock_get_team_name, mock_get_name_if_exists, team_name
+    ):
         auth_manager = Mock()
         auth_manager.is_authorized_variable.return_value = True
         mock_get_auth_manager.return_value = auth_manager
+        mock_get_team_name.return_value = team_name
+        mock_get_name_if_exists.return_value = team_name
         fastapi_request = Mock()
         fastapi_request.path_params = {"variable_key": "var_key"}
-        mock_get_team_name.return_value = team_name
+        fastapi_request.json = AsyncMock(return_value={})
         user = Mock()
 
-        requires_access_variable("GET")(fastapi_request, user)
+        await requires_access_variable("GET")(fastapi_request, user)
 
         auth_manager.is_authorized_variable.assert_called_once_with(
             method="GET",
@@ -541,6 +577,31 @@ class TestFastApiSecurity:
             user=user,
         )
         mock_get_team_name.assert_called_once_with("var_key")
+
+    @pytest.mark.db_test
+    @patch.object(Team, "get_name_if_exists")
+    @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
+    async def test_requires_access_variable_team_from_body(
+        self, mock_get_auth_manager, mock_get_name_if_exists
+    ):
+        """When variable doesn't exist yet (POST), team_name is read from request body."""
+        auth_manager = Mock()
+        auth_manager.is_authorized_variable.return_value = True
+        mock_get_auth_manager.return_value = auth_manager
+        mock_get_name_if_exists.return_value = "team1"
+        fastapi_request = Mock()
+        fastapi_request.path_params = {}
+        fastapi_request.json = AsyncMock(return_value={"team_name": "team1"})
+        user = Mock()
+
+        await requires_access_variable("POST")(fastapi_request, user)
+
+        auth_manager.is_authorized_variable.assert_called_once_with(
+            method="POST",
+            details=VariableDetails(key=None, team_name="team1"),
+            user=user,
+        )
+        mock_get_name_if_exists.assert_called_once_with("team1")
 
     @patch.object(Variable, "get_key_to_team_name_mapping")
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
@@ -607,18 +668,23 @@ class TestFastApiSecurity:
         "team_name",
         [None, "team1"],
     )
+    @patch.object(Team, "get_name_if_exists")
     @patch.object(Pool, "get_team_name")
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
-    def test_requires_access_pool(self, mock_get_auth_manager, mock_get_team_name, team_name):
+    async def test_requires_access_pool(
+        self, mock_get_auth_manager, mock_get_team_name, mock_get_name_if_exists, team_name
+    ):
         auth_manager = Mock()
         auth_manager.is_authorized_pool.return_value = True
         mock_get_auth_manager.return_value = auth_manager
+        mock_get_team_name.return_value = team_name
+        mock_get_name_if_exists.return_value = team_name
         fastapi_request = Mock()
         fastapi_request.path_params = {"pool_name": "pool"}
-        mock_get_team_name.return_value = team_name
+        fastapi_request.json = AsyncMock(return_value={})
         user = Mock()
 
-        requires_access_pool("GET")(fastapi_request, user)
+        await requires_access_pool("GET")(fastapi_request, user)
 
         auth_manager.is_authorized_pool.assert_called_once_with(
             method="GET",
@@ -626,6 +692,29 @@ class TestFastApiSecurity:
             user=user,
         )
         mock_get_team_name.assert_called_once_with("pool")
+
+    @pytest.mark.db_test
+    @patch.object(Team, "get_name_if_exists")
+    @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
+    async def test_requires_access_pool_team_from_body(self, mock_get_auth_manager, mock_get_name_if_exists):
+        """When pool doesn't exist yet (POST), team_name is read from request body."""
+        auth_manager = Mock()
+        auth_manager.is_authorized_pool.return_value = True
+        mock_get_auth_manager.return_value = auth_manager
+        mock_get_name_if_exists.return_value = "team1"
+        fastapi_request = Mock()
+        fastapi_request.path_params = {}
+        fastapi_request.json = AsyncMock(return_value={"team_name": "team1"})
+        user = Mock()
+
+        await requires_access_pool("POST")(fastapi_request, user)
+
+        auth_manager.is_authorized_pool.assert_called_once_with(
+            method="POST",
+            details=PoolDetails(name=None, team_name="team1"),
+            user=user,
+        )
+        mock_get_name_if_exists.assert_called_once_with("team1")
 
     @patch.object(Pool, "get_name_to_team_name_mapping")
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")

--- a/airflow-core/tests/unit/models/test_team.py
+++ b/airflow-core/tests/unit/models/test_team.py
@@ -25,6 +25,14 @@ class TestTeam:
     """Unit tests for Team model class methods."""
 
     @pytest.mark.db_test
+    def test_get_name_if_exists_returns_name(self, testing_team):
+        assert Team.get_name_if_exists("testing") == "testing"
+
+    @pytest.mark.db_test
+    def test_get_name_if_exists_returns_none(self):
+        assert Team.get_name_if_exists("nonexistent") is None
+
+    @pytest.mark.db_test
     def test_get_all_team_names_with_teams(self, testing_team):
         result = Team.get_all_team_names()
 


### PR DESCRIPTION
Description:

In multi-team mode, creating a variable, connection, or pool via POST was always rejected with 403, even for users with the correct team permissions.

The three security dependencies (`requires_access_variable`, `requires_access_connection`, `requires_access_pool`) resolved `team_name` exclusively from the existing DB row. For POST requests, the resource does not exist yet, so the lookup always returned None. The auth manager then evaluated the request with no team context and denied it per policy — regardless of the team_name provided in the request body.

This fix reads `team_name` from the request body when the DB lookup returns None (same pattern as requires_access_backfill), and validates the resolved value against the team table via a new Team.get_name_if_exists() method before passing it to the auth manager.

Tested end-to-end with the Keycloak auth manager in multi-team mode (variables, connections, pools — POST, GET, and team isolation between users).

Open questions (not addressed in this PR):

Global resources (no team) for superadmin — the UI shows team selection as optional, but there is currently no defined behavior for resources with team_name = NULL in multi-team mode. Should a superadmin be able to create resources visible across all teams?

<img width="1753" height="921" alt="image" src="https://github.com/user-attachments/assets/123d5f39-8d40-43ad-91e0-b4442da92929" />

Team re-assignment via PUT — team_name is currently mutable on PUT (unlike key). The auth check uses the current DB value, so a user with write access to team-a can move a resource to team-b without needing any team-b permission. Should team_name be immutable after creation (added to non_update_fields), or should the auth check validate both the source and target team?

Part of #62252

Note: This PR was developed with the assistance of Claude (AI). The logic and security reasoning were reviewed manually.