### PR TITLE
Fix Azure WasbTaskHandler to support full URLs in remote_base_log_folder

### DIFF
--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/log/wasb_task_handler.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/log/wasb_task_handler.py
@@ -49,15 +49,40 @@ class WasbRemoteLogIO(LoggingMixin):  # noqa: D101
 
     processors = ()
 
+    def _get_blob_path(self, relative_path: str | os.PathLike) -> str:
+        from urllib.parse import urlparse
+
+        if isinstance(relative_path, os.PathLike):
+            relative_path = str(relative_path)
+
+        if "://" in self.remote_base:
+            if self.remote_base.endswith("/"):
+                base = self.remote_base
+            else:
+                base = self.remote_base + "/"
+            full_path = base + relative_path
+            parsed = urlparse(full_path)
+            if parsed.scheme in ("wasb", "wasbs"):
+                return parsed.path.lstrip("/")
+            if parsed.scheme in ("http", "https"):
+                path = parsed.path.lstrip("/")
+                if path.startswith(f"{self.wasb_container}/"):
+                    return path[len(self.wasb_container) + 1 :]
+                return path
+
+        return os.path.join(self.remote_base, relative_path)
+
     def upload(self, path: str | os.PathLike, ti: RuntimeTI):
         """Upload the given log path to the remote storage."""
         path = Path(path)
         if path.is_absolute():
             local_loc = path
-            remote_loc = os.path.join(self.remote_base, path.relative_to(self.base_log_folder))
+            relative_path = path.relative_to(self.base_log_folder)
         else:
             local_loc = self.base_log_folder.joinpath(path)
-            remote_loc = os.path.join(self.remote_base, path)
+            relative_path = path
+
+        remote_loc = self._get_blob_path(relative_path)
 
         if local_loc.is_file():
             # read log and remove old logs to get just the latest additions
@@ -87,10 +112,7 @@ class WasbRemoteLogIO(LoggingMixin):  # noqa: D101
     def read(self, relative_path, ti: RuntimeTI) -> tuple[LogSourceInfo, LogMessages | None]:
         messages = []
         logs = []
-        # TODO: fix this - "relative path" i.e currently REMOTE_BASE_LOG_FOLDER should start with "wasb"
-        # unlike others with shceme in URL itself to identify the correct handler.
-        # This puts limitations on ways users can name the base_path.
-        prefix = os.path.join(self.remote_base, relative_path)
+        prefix = self._get_blob_path(relative_path)
         blob_names = []
         try:
             blob_names = self.hook.get_blobs_list(container_name=self.wasb_container, prefix=prefix)

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/log/test_wasb_task_handler.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/log/test_wasb_task_handler.py
@@ -232,3 +232,41 @@ class TestWasbTaskHandler:
             delete_local_copy=True,
             filename_template=None,
         )
+
+    @pytest.mark.parametrize(
+        ("remote_base", "relative_path", "expected_path"),
+        [
+            (
+                "wasb://container/remote/log/location",
+                "dag_id/task_id/run_id/1.log",
+                "remote/log/location/dag_id/task_id/run_id/1.log",
+            ),
+            (
+                "wasbs://container/remote/log/location",
+                "dag_id/task_id/run_id/1.log",
+                "remote/log/location/dag_id/task_id/run_id/1.log",
+            ),
+            (
+                "https://account.blob.core.windows.net/container/remote/log/location",
+                "dag_id/task_id/run_id/1.log",
+                "remote/log/location/dag_id/task_id/run_id/1.log",
+            ),
+            (
+                "remote/log/location",
+                "dag_id/task_id/run_id/1.log",
+                "remote/log/location/dag_id/task_id/run_id/1.log",
+            ),
+            (
+                "https://account.blob.core.windows.net/other-container/remote/log/location",
+                "dag_id/task_id/run_id/1.log",
+                "other-container/remote/log/location/dag_id/task_id/run_id/1.log",
+            ),
+        ],
+    )
+    def test_get_blob_path(self, remote_base, relative_path, expected_path):
+        handler = WasbTaskHandler(
+            base_log_folder=self.local_log_location,
+            wasb_log_folder=remote_base,
+            wasb_container="container",
+        )
+        assert handler.io._get_blob_path(relative_path) == expected_path


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->
This PR addresses a limitation in WasbTaskHandler where the remote_base_log_folder configuration was strictly expected to start with "wasb" and treated as a simple string prefix. This prevented users from configuring full URIs (e.g., https://... or wasb://... ) or other valid naming schemes for their Azure Blob Storage log paths.
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
