### PR TITLE
Refactor: extract bundle lifecycle helpers and refresh predicate

### DIFF
--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -256,6 +256,14 @@ class DagFileProcessorManager(LoggingMixin):
         self.log.debug("Finished terminating DAG processors.")
         sys.exit(os.EX_OK)
 
+    def sync_bundles(self) -> None:
+        """Sync configured DAG bundles to the metadata database."""
+        DagBundlesManager().sync_bundles_to_db()
+
+    def get_all_bundles(self) -> list[BaseDagBundle]:
+        """Return configured DAG bundles filtered by ``bundle_names_to_parse`` if provided."""
+        return list(DagBundlesManager().get_all_dag_bundles())
+
     def run(self):
         """
         Use multiple processes to parse and generate tasks for the DAGs in parallel.
@@ -281,9 +289,8 @@ class DagFileProcessorManager(LoggingMixin):
         self.log.info("Processing files using up to %s processes at a time ", self._parallelism)
         self.log.info("Process each file at most once every %s seconds", self._file_process_interval)
 
-        DagBundlesManager().sync_bundles_to_db()
-
-        dag_bundles = list(DagBundlesManager().get_all_dag_bundles())
+        self.sync_bundles()
+        dag_bundles = self.get_all_bundles()
         if self.bundle_names_to_parse:
             dag_bundles = [b for b in dag_bundles if b.name in self.bundle_names_to_parse]
         self._dag_bundles = dag_bundles
@@ -321,11 +328,15 @@ class DagFileProcessorManager(LoggingMixin):
         if elapsed_time_since_cleanup < self.stale_bundle_cleanup_interval:
             return
         try:
-            BundleUsageTrackingManager().remove_stale_bundle_versions()
+            self.cleanup_stale_bundle_versions()
         except Exception:
             self.log.exception("Error removing stale bundle versions")
         finally:
             self._last_stale_bundle_cleanup_time = now
+
+    def cleanup_stale_bundle_versions(self) -> None:
+        """Clean up stale DAG bundle version usage records."""
+        BundleUsageTrackingManager().remove_stale_bundle_versions()
 
     @provide_session
     def deactivate_stale_dags(
@@ -458,6 +469,22 @@ class DagFileProcessorManager(LoggingMixin):
         if self._force_refresh_bundles:
             self.log.info("Bundles being force refreshed: %s", ", ".join(self._force_refresh_bundles))
 
+    def should_refresh_bundle(
+        self,
+        *,
+        bundle: BaseDagBundle,
+        elapsed_time_since_refresh: float,
+        current_version_matches_db: bool,
+        previously_seen: bool,
+    ) -> bool:
+        """Return ``True`` when a DAG bundle should be refreshed."""
+        return not (
+            elapsed_time_since_refresh < bundle.refresh_interval
+            and current_version_matches_db
+            and previously_seen
+            and bundle.name not in self._force_refresh_bundles
+        )
+
     @provide_session
     def _get_priority_files(self, session: Session = NEW_SESSION) -> list[DagFileInfo]:
         files: list[DagFileInfo] = []
@@ -587,11 +614,11 @@ class DagFileProcessorManager(LoggingMixin):
                     current_version_matches_db = True
 
                 previously_seen = bundle.name in self._bundle_versions
-                if (
-                    elapsed_time_since_refresh < bundle.refresh_interval
-                    and current_version_matches_db
-                    and previously_seen
-                    and bundle.name not in self._force_refresh_bundles
+                if not self.should_refresh_bundle(
+                    bundle=bundle,
+                    elapsed_time_since_refresh=elapsed_time_since_refresh,
+                    current_version_matches_db=current_version_matches_db,
+                    previously_seen=previously_seen,
                 ):
                     self.log.info("Not time to refresh bundle %s", bundle.name)
                     continue

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -469,7 +469,7 @@ class DagFileProcessorManager(LoggingMixin):
         if self._force_refresh_bundles:
             self.log.info("Bundles being force refreshed: %s", ", ".join(self._force_refresh_bundles))
 
-    def should_refresh_bundle(
+    def should_skip_refresh(
         self,
         *,
         bundle: BaseDagBundle,
@@ -477,8 +477,8 @@ class DagFileProcessorManager(LoggingMixin):
         current_version_matches_db: bool,
         previously_seen: bool,
     ) -> bool:
-        """Return ``True`` when a DAG bundle should be refreshed."""
-        return not (
+        """Return ``True`` when a Dag bundle refresh should be skipped."""
+        return (
             elapsed_time_since_refresh < bundle.refresh_interval
             and current_version_matches_db
             and previously_seen
@@ -614,7 +614,7 @@ class DagFileProcessorManager(LoggingMixin):
                     current_version_matches_db = True
 
                 previously_seen = bundle.name in self._bundle_versions
-                if not self.should_refresh_bundle(
+                if self.should_skip_refresh(
                     bundle=bundle,
                     elapsed_time_since_refresh=elapsed_time_since_refresh,
                     current_version_matches_db=current_version_matches_db,

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -643,6 +643,12 @@ class TestDagFileProcessorManager:
         manager._cleanup_stale_bundle_versions()
         mock_bundle_manager.return_value.remove_stale_bundle_versions.assert_not_called()
 
+    @mock.patch("airflow.dag_processing.manager.BundleUsageTrackingManager")
+    def test_cleanup_stale_bundle_versions(self, mock_bundle_manager):
+        manager = DagFileProcessorManager(max_runs=1)
+        manager.cleanup_stale_bundle_versions()
+        mock_bundle_manager.return_value.remove_stale_bundle_versions.assert_called_once_with()
+
     def test_kill_timed_out_processors_kill(self):
         manager = DagFileProcessorManager(max_runs=1, processor_timeout=5)
         # Set start_time to ensure timeout occurs: start_time = current_time - (timeout + 1) = always (timeout + 1) seconds
@@ -1356,6 +1362,47 @@ class TestDagFileProcessorManager:
             assert bundleone.refresh.call_count == 1
             manager._refresh_dag_bundles({})
             assert bundleone.refresh.call_count == 1  # didn't fresh the second time
+
+    @pytest.mark.parametrize(
+        (
+            "elapsed_time_since_refresh",
+            "current_version_matches_db",
+            "previously_seen",
+            "force_refresh",
+            "expected",
+        ),
+        [
+            (10, True, True, False, False),
+            (400, True, True, False, True),
+            (10, False, True, False, True),
+            (10, True, False, False, True),
+            (10, True, True, True, True),
+        ],
+    )
+    def test_should_refresh_bundle(
+        self,
+        elapsed_time_since_refresh,
+        current_version_matches_db,
+        previously_seen,
+        force_refresh,
+        expected,
+    ):
+        manager = DagFileProcessorManager(max_runs=1)
+        bundle = MagicMock()
+        bundle.name = "bundleone"
+        bundle.refresh_interval = 300
+
+        if force_refresh:
+            manager._force_refresh_bundles = {"bundleone"}
+
+        should_refresh = manager.should_refresh_bundle(
+            bundle=bundle,
+            elapsed_time_since_refresh=elapsed_time_since_refresh,
+            current_version_matches_db=current_version_matches_db,
+            previously_seen=previously_seen,
+        )
+
+        assert should_refresh is expected
 
     def test_bundle_force_refresh(self):
         """Ensure the dag processor honors force refreshing a bundle."""

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -1372,14 +1372,14 @@ class TestDagFileProcessorManager:
             "expected",
         ),
         [
-            (10, True, True, False, False),
-            (400, True, True, False, True),
-            (10, False, True, False, True),
-            (10, True, False, False, True),
-            (10, True, True, True, True),
+            (10, True, True, False, True),
+            (400, True, True, False, False),
+            (10, False, True, False, False),
+            (10, True, False, False, False),
+            (10, True, True, True, False),
         ],
     )
-    def test_should_refresh_bundle(
+    def test_should_skip_bundle_refresh(
         self,
         elapsed_time_since_refresh,
         current_version_matches_db,
@@ -1395,14 +1395,14 @@ class TestDagFileProcessorManager:
         if force_refresh:
             manager._force_refresh_bundles = {"bundleone"}
 
-        should_refresh = manager.should_refresh_bundle(
+        should_skip_refresh = manager.should_skip_refresh(
             bundle=bundle,
             elapsed_time_since_refresh=elapsed_time_since_refresh,
             current_version_matches_db=current_version_matches_db,
             previously_seen=previously_seen,
         )
 
-        assert should_refresh is expected
+        assert should_skip_refresh is expected
 
     def test_bundle_force_refresh(self):
         """Ensure the dag processor honors force refreshing a bundle."""


### PR DESCRIPTION
- Move bundle sync and bundle discovery/filtering into dedicated manager
  methods (sync_bundles, get_all_bundles) and keep run() focused on orchestration.
- Route stale bundle version cleanup through cleanup_stale_bundle_versions()
  instead of inline side effects.
- extract the should_refresh_bundle method from _refresh_dag_bundles to make
  it possible to override the refresh condition without overriding _refresh_dag_bundles
- Add/adjust unit tests to verify delegation paths and preserve existing behavior.

 
##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

gpt-5.3-codex for tests

