### PR TITLE
Check teams defined in auth managers exist in DB when spinning up API server

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
@@ -118,6 +118,7 @@ class SimpleAuthManager(BaseAuthManager[SimpleAuthManagerUser]):
             return SimpleAuthManager._get_passwords(file)
 
     def init(self) -> None:
+        super().init()
         is_simple_auth_manager_all_admins = conf.getboolean("core", "simple_auth_manager_all_admins")
         if is_simple_auth_manager_all_admins:
             return
@@ -359,6 +360,10 @@ class SimpleAuthManager(BaseAuthManager[SimpleAuthManagerUser]):
             )
 
         return app
+
+    def _get_teams(self) -> set[str]:
+        users = self.get_users()
+        return {team for user in users for team in user.teams}
 
     @staticmethod
     def _is_admin(user: SimpleAuthManagerUser) -> bool:

--- a/airflow-core/tests/unit/api_fastapi/auth/managers/simple/services/test_login.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/managers/simple/services/test_login.py
@@ -25,6 +25,7 @@ from fastapi import HTTPException
 
 from airflow.api_fastapi.auth.managers.simple.datamodels.login import LoginBody
 from airflow.api_fastapi.auth.managers.simple.services.login import SimpleAuthManagerLogin
+from airflow.models.team import Team
 
 from tests_common.test_utils.config import conf_vars
 
@@ -48,10 +49,12 @@ class TestLogin:
             (TEST_USER_3, TEST_ROLE_3, ["test", "marketing"]),
         ],
     )
+    @patch.object(Team, "get_all_team_names")
     @patch("airflow.api_fastapi.auth.managers.simple.services.login.get_auth_manager")
-    def test_create_token(self, get_auth_manager, auth_manager, user, role, teams):
+    def test_create_token(self, get_auth_manager, mock_get_all_team_names, auth_manager, user, role, teams):
         mock_am = Mock(wraps=auth_manager)
         get_auth_manager.return_value = mock_am
+        mock_get_all_team_names.return_value = {"test", "marketing"}
 
         with conf_vars(
             {

--- a/airflow-core/tests/unit/api_fastapi/auth/managers/simple/test_simple_auth_manager.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/managers/simple/test_simple_auth_manager.py
@@ -354,3 +354,16 @@ class TestSimpleAuthManager:
             user = SimpleAuthManagerUser(username=user_id, role="user")
             result = auth_manager.is_authorized_hitl_task(assigned_users=assigned_users, user=user)
             assert result == expected
+
+    @conf_vars(
+        {
+            ("core", "multi_team"): "true",
+            (
+                "core",
+                "simple_auth_manager_users",
+            ): "test1:viewer,test2:viewer:test,test3:viewer:test|marketing",
+        }
+    )
+    def test_get_teams(self, auth_manager):
+        teams = auth_manager._get_teams()
+        assert teams == {"test", "marketing"}

--- a/providers/amazon/src/airflow/providers/amazon/aws/auth_manager/aws_auth_manager.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/auth_manager/aws_auth_manager.py
@@ -71,6 +71,7 @@ class AwsAuthManager(BaseAuthManager[AwsAuthManagerUser]):
     """
 
     def init(self) -> None:
+        super().init()
         if not AIRFLOW_V_3_0_PLUS:
             raise AirflowOptionalProviderFeatureException(
                 "AWS auth manager is only compatible with Airflow versions >= 3.0.0"


### PR DESCRIPTION
It can be confusing and/or not obvious for users to define first their teams in the DB before actually running the environment. This change adds a check in auth managers, so that it checks that any teams defined in auth managers exist in the DB as well. That way, at least the API server will fail instead of being in a confusing situation.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
