### PR TITLE
Fix Task Instances list view rendering raw HTML instead of links

### DIFF
--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -458,7 +458,8 @@ def task_instance_link(attr):
         execution_date=execution_date,
         tab="graph",
     )
-    return f"""
+    return Markup(
+        f"""
         <span style="white-space: nowrap;">
         <a href="{url}">{escape(task_id)}</a>
         <a href="{url_root}" title="Filter on this task">
@@ -467,6 +468,7 @@ def task_instance_link(attr):
         </a>
         </span>
         """
+    )
 
 
 def state_token(state):
@@ -537,7 +539,7 @@ def dag_link(attr):
     if not dag_id:
         return Markup("None")
     url = url_for("Airflow.grid", dag_id=dag_id, execution_date=execution_date)
-    return f'<a href="{url}">{escape(dag_id)}</a>'
+    return Markup(f'<a href="{url}">{escape(dag_id)}</a>')
 
 
 def dag_run_link(attr):
@@ -556,7 +558,7 @@ def dag_run_link(attr):
         dag_run_id=run_id,
         tab="graph",
     )
-    return f'<a href="{url}">{escape(run_id)}</a>'
+    return Markup(f'<a href="{url}">{escape(run_id)}</a>')
 
 
 def _get_run_ordering_expr(name: str) -> ColumnOperators:

--- a/newsfragments/62533.bugfix.rst
+++ b/newsfragments/62533.bugfix.rst
@@ -1,0 +1,1 @@
+Fix Task Instances list view rendering raw HTML instead of clickable links for Dag Id, Task Id, and Run Id columns.

--- a/tests/www/test_utils.py
+++ b/tests/www/test_utils.py
@@ -232,20 +232,25 @@ class TestUtils:
     @pytest.mark.skip_if_database_isolation_mode
     @pytest.mark.db_test
     def test_task_instance_link(self):
+        from markupsafe import Markup
+
         from airflow.www.app import cached_app
 
         with cached_app(testing=True).test_request_context():
-            html = str(
-                utils.task_instance_link(
-                    {"dag_id": "<a&1>", "task_id": "<b2>", "map_index": 1, "execution_date": datetime.now()}
-                )
+            result = utils.task_instance_link(
+                {"dag_id": "<a&1>", "task_id": "<b2>", "map_index": 1, "execution_date": datetime.now()}
             )
 
-            html_map_index_none = str(
-                utils.task_instance_link(
-                    {"dag_id": "<a&1>", "task_id": "<b2>", "map_index": -1, "execution_date": datetime.now()}
-                )
+            result_map_index_none = utils.task_instance_link(
+                {"dag_id": "<a&1>", "task_id": "<b2>", "map_index": -1, "execution_date": datetime.now()}
             )
+
+        html = str(result)
+        html_map_index_none = str(result_map_index_none)
+
+        # Return type must be Markup so Jinja2 renders HTML instead of escaping it
+        assert isinstance(result, Markup)
+        assert isinstance(result_map_index_none, Markup)
 
         assert "%3Ca&1%3E" in html
         assert "%3Cb2%3E" in html
@@ -262,11 +267,17 @@ class TestUtils:
     @pytest.mark.skip_if_database_isolation_mode
     @pytest.mark.db_test
     def test_dag_link(self):
+        from markupsafe import Markup
+
         from airflow.www.app import cached_app
 
         with cached_app(testing=True).test_request_context():
-            html = str(utils.dag_link({"dag_id": "<a&1>", "execution_date": datetime.now()}))
+            result = utils.dag_link({"dag_id": "<a&1>", "execution_date": datetime.now()})
 
+        html = str(result)
+
+        # Return type must be Markup so Jinja2 renders HTML instead of escaping it
+        assert isinstance(result, Markup)
         assert "%3Ca&1%3E" in html
         assert "<a&1>" not in html
 
@@ -285,13 +296,19 @@ class TestUtils:
     @pytest.mark.skip_if_database_isolation_mode
     @pytest.mark.db_test
     def test_dag_run_link(self):
+        from markupsafe import Markup
+
         from airflow.www.app import cached_app
 
         with cached_app(testing=True).test_request_context():
-            html = str(
-                utils.dag_run_link({"dag_id": "<a&1>", "run_id": "<b2>", "execution_date": datetime.now()})
+            result = utils.dag_run_link(
+                {"dag_id": "<a&1>", "run_id": "<b2>", "execution_date": datetime.now()}
             )
 
+        html = str(result)
+
+        # Return type must be Markup so Jinja2 renders HTML instead of escaping it
+        assert isinstance(result, Markup)
         assert "%3Ca&1%3E" in html
         assert "%3Cb2%3E" in html
         assert "<a&1>" not in html


### PR DESCRIPTION
Fix Task Instances list view rendering raw HTML instead of links

The connexion 2.15 migration (#51681) inadvertently removed the `Markup()` wrapper from `task_instance_link()`, `dag_link()`, and `dag_run_link()` in `airflow/www/utils.py`. Without `Markup`, Jinja2 auto-escapes the returned HTML strings, causing raw `<a href="...">` tags to display as plain text instead of clickable links in Browse > Task Instances.

This wraps the f-string returns back in `Markup()` while keeping the explicit `escape()` calls on user-provided values for XSS safety.

Before:

<img width="1162" height="500" alt="image" src="https://github.com/user-attachments/assets/fc9af3a7-7000-4d7f-983f-c3e9f1332aab" />

After:
<img width="732" height="388" alt="image" src="https://github.com/user-attachments/assets/3189a747-e8c5-4911-9b96-f91d2c7dedde" />


closes: #62371

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)
   Claude Code

<!--
Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).