### PR TITLE
Add template_fields to SalesforceBulkOperator

### DIFF
--- a/providers/salesforce/newsfragments/62539.bugfix.rst
+++ b/providers/salesforce/newsfragments/62539.bugfix.rst
@@ -1,0 +1,1 @@
+Add ``template_fields`` to ``SalesforceBulkOperator`` so Jinja templates are rendered for ``operation``, ``object_name``, ``payload``, and ``external_id_field``.

--- a/providers/salesforce/src/airflow/providers/salesforce/operators/bulk.py
+++ b/providers/salesforce/src/airflow/providers/salesforce/operators/bulk.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING, cast
 
 from airflow.providers.common.compat.sdk import BaseOperator
@@ -48,6 +48,13 @@ class SalesforceBulkOperator(BaseOperator):
     :param salesforce_conn_id: The :ref:`Salesforce Connection id <howto/connection:SalesforceHook>`.
     """
 
+    template_fields: Sequence[str] = (
+        "operation",
+        "object_name",
+        "payload",
+        "external_id_field",
+    )
+
     available_operations = ("insert", "update", "upsert", "delete", "hard_delete")
 
     def __init__(
@@ -70,7 +77,6 @@ class SalesforceBulkOperator(BaseOperator):
         self.batch_size = batch_size
         self.use_serial = use_serial
         self.salesforce_conn_id = salesforce_conn_id
-        self._validate_inputs()
 
     def _validate_inputs(self) -> None:
         if not self.object_name:
@@ -89,6 +95,7 @@ class SalesforceBulkOperator(BaseOperator):
         :param context: The task context during execution.
         :return: API response if do_xcom_push is True
         """
+        self._validate_inputs()
         sf_hook = SalesforceHook(salesforce_conn_id=self.salesforce_conn_id)
         conn = sf_hook.get_conn()
         bulk: SFBulkHandler = cast("SFBulkHandler", conn.__getattr__("bulk"))

--- a/providers/salesforce/tests/unit/salesforce/operators/test_bulk.py
+++ b/providers/salesforce/tests/unit/salesforce/operators/test_bulk.py
@@ -40,13 +40,18 @@ class TestSalesforceBulkOperator:
                 payload=[],
             )
 
+    def test_execute_invalid_operation(self):
+        """
+        Test execute with invalid operation value (validated at execute time).
+        """
+        operator = SalesforceBulkOperator(
+            task_id="missing_operation",
+            operation="operation",
+            object_name="Account",
+            payload=[],
+        )
         with pytest.raises(ValueError, match="Operation 'operation' not found!"):
-            SalesforceBulkOperator(
-                task_id="missing_operation",
-                operation="operation",
-                object_name="Account",
-                payload=[],
-            )
+            operator.execute(context={})
 
     def test_execute_missing_object_name(self):
         """
@@ -59,15 +64,20 @@ class TestSalesforceBulkOperator:
                 payload=[],
             )
 
+    def test_execute_empty_object_name(self):
+        """
+        Test execute with empty object_name value (validated at execute time).
+        """
+        operator = SalesforceBulkOperator(
+            task_id="missing_object_name",
+            operation="insert",
+            object_name="",
+            payload=[],
+        )
         with pytest.raises(
             ValueError, match="The required parameter 'object_name' cannot have an empty value."
         ):
-            SalesforceBulkOperator(
-                task_id="missing_object_name",
-                operation="insert",
-                object_name="",
-                payload=[],
-            )
+            operator.execute(context={})
 
     @patch("airflow.providers.salesforce.operators.bulk.SalesforceHook.get_conn")
     def test_execute_salesforce_bulk_insert(self, mock_get_conn):
@@ -236,3 +246,14 @@ class TestSalesforceBulkOperator:
             batch_size=batch_size,
             use_serial=use_serial,
         )
+
+    def test_template_fields(self):
+        """Test that all template_fields are valid instance attributes."""
+        operator = SalesforceBulkOperator(
+            task_id="test_template",
+            operation="insert",
+            object_name="Account",
+            payload=[{"Name": "test"}],
+        )
+        for field in SalesforceBulkOperator.template_fields:
+            assert hasattr(operator, field), f"template_field '{field}' is not an operator attribute"


### PR DESCRIPTION
## Summary
- Added `template_fields` to `SalesforceBulkOperator` so Jinja-templated values for `operation`, `object_name`, `payload`, and `external_id_field` are rendered before execution
- Moved input validation from `__init__` to `execute()` so it runs after template rendering, consistent with Airflow's coding standards
- Updated tests to reflect validation timing change and added `test_template_fields` to verify all declared template fields are valid instance attributes

Closes: #62375

## Test plan
- [x] All 10 unit tests pass (`uv run --project providers/salesforce pytest providers/salesforce/tests/unit/salesforce/operators/test_bulk.py -xvs`)
- [x] New `test_template_fields` test validates template field declarations
- [x] `validate_operators_init.py` prek check passes (verifies `self.field = field` pattern in `__init__`)
- [x] `prek run --from-ref apache/main --stage pre-commit` — all checks pass
- [x] `prek run ruff --from-ref apache/main` passes
- [x] `prek run ruff-format --from-ref apache/main` passes

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)