### PR TITLE
Fix tpl rendering for TLS hosts in ingress templates #62358

### DIFF
--- a/chart/templates/api-server/api-server-ingress.yaml
+++ b/chart/templates/api-server/api-server-ingress.yaml
@@ -55,7 +55,7 @@ spec:
   {{- if .tls }}
   {{- if .tls.enabled }}
     - hosts:
-        - {{ .name | quote }}
+        - {{ tpl .name $ | quote }}
       secretName: {{ .tls.secretName }}
   {{- end }}
   {{- end }}
@@ -64,7 +64,9 @@ spec:
   {{- else if .Values.ingress.apiServer.tls.enabled }}
   tls:
     - hosts:
-        {{- .Values.ingress.apiServer.hosts | default (list .Values.ingress.apiServer.host) | toYaml | nindent 8 }}
+        {{- range .Values.ingress.apiServer.hosts | default (list .Values.ingress.apiServer.host) }}
+        - {{ tpl . $ | quote }}
+        {{- end }}
       secretName: {{ .Values.ingress.apiServer.tls.secretName }}
   {{- end }}
   rules:

--- a/chart/templates/flower/flower-ingress.yaml
+++ b/chart/templates/flower/flower-ingress.yaml
@@ -55,7 +55,7 @@ spec:
   {{- if .tls }}
   {{- if .tls.enabled }}
     - hosts:
-        - {{ .name | quote }}
+        - {{ tpl .name $ | quote }}
       secretName: {{ .tls.secretName }}
   {{- end }}
   {{- end }}
@@ -64,7 +64,9 @@ spec:
   {{- else if .Values.ingress.flower.tls.enabled }}
   tls:
     - hosts:
-        {{- .Values.ingress.flower.hosts | default (list .Values.ingress.flower.host) | toYaml | nindent 8 }}
+        {{- range .Values.ingress.flower.hosts | default (list .Values.ingress.flower.host) }}
+        - {{ tpl . $ | quote }}
+        {{- end }}
       secretName: {{ .Values.ingress.flower.tls.secretName }}
   {{- end }}
   rules:

--- a/chart/templates/pgbouncer/pgbouncer-ingress.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-ingress.yaml
@@ -54,7 +54,7 @@ spec:
   {{- if .tls }}
   {{- if .tls.enabled }}
     - hosts:
-        - {{ .name | quote }}
+        - {{ tpl .name $ | quote }}
       secretName: {{ .tls.secretName }}
   {{- end }}
   {{- end }}

--- a/chart/templates/statsd/statsd-ingress.yaml
+++ b/chart/templates/statsd/statsd-ingress.yaml
@@ -54,7 +54,7 @@ spec:
   {{- if .tls }}
   {{- if .tls.enabled }}
     - hosts:
-        - {{ .name | quote }}
+        - {{ tpl .name $ | quote }}
       secretName: {{ .tls.secretName }}
   {{- end }}
   {{- end }}

--- a/chart/templates/webserver/webserver-ingress.yaml
+++ b/chart/templates/webserver/webserver-ingress.yaml
@@ -55,7 +55,7 @@ spec:
   {{- if .tls }}
   {{- if .tls.enabled }}
     - hosts:
-        - {{ .name | quote }}
+        - {{ tpl .name $ | quote }}
       secretName: {{ .tls.secretName }}
   {{- end }}
   {{- end }}
@@ -64,7 +64,9 @@ spec:
   {{- else if .Values.ingress.web.tls.enabled }}
   tls:
     - hosts:
-        {{- .Values.ingress.web.hosts | default (list .Values.ingress.web.host) | toYaml | nindent 8 }}
+        {{- range .Values.ingress.web.hosts | default (list .Values.ingress.web.host) }}
+        - {{ tpl . $ | quote }}
+        {{- end }}
       secretName: {{ .Values.ingress.web.tls.secretName }}
   {{- end }}
   rules:

--- a/helm-tests/tests/helm_tests/apiserver/test_ingress_apiserver.py
+++ b/helm-tests/tests/helm_tests/apiserver/test_ingress_apiserver.py
@@ -190,8 +190,14 @@ class TestIngressAPIServer:
                     "apiServer": {
                         "enabled": True,
                         "hosts": [
-                            {"name": "*.{{ .Release.Namespace }}.example.com"},
-                            {"name": "{{ .Values.testValues.scalar }}.example.com"},
+                            {
+                                "name": "*.{{ .Release.Namespace }}.example.com",
+                                "tls": {"enabled": True, "secretName": "secret1"},
+                            },
+                            {
+                                "name": "{{ .Values.testValues.scalar }}.example.com",
+                                "tls": {"enabled": True, "secretName": "secret2"},
+                            },
                             {"name": "{{ index .Values.testValues.list 1 }}.example.com"},
                             {"name": "{{ .Values.testValues.dict.key }}.example.com"},
                         ],
@@ -207,6 +213,10 @@ class TestIngressAPIServer:
             "aa.example.com",
             "cc.example.com",
             "dd.example.com",
+        ]
+        assert jmespath.search("spec.tls[*]", docs[0]) == [
+            {"hosts": ["*.airflow.example.com"], "secretName": "secret1"},
+            {"hosts": ["aa.example.com"], "secretName": "secret2"},
         ]
 
     def test_backend_service_name(self):

--- a/helm-tests/tests/helm_tests/webserver/test_ingress_flower.py
+++ b/helm-tests/tests/helm_tests/webserver/test_ingress_flower.py
@@ -198,8 +198,14 @@ class TestIngressFlower:
                     "flower": {
                         "enabled": True,
                         "hosts": [
-                            {"name": "*.{{ .Release.Namespace }}.example.com"},
-                            {"name": "{{ .Values.testValues.scalar }}.example.com"},
+                            {
+                                "name": "*.{{ .Release.Namespace }}.example.com",
+                                "tls": {"enabled": True, "secretName": "secret1"},
+                            },
+                            {
+                                "name": "{{ .Values.testValues.scalar }}.example.com",
+                                "tls": {"enabled": True, "secretName": "secret2"},
+                            },
                             {"name": "{{ index .Values.testValues.list 1 }}.example.com"},
                             {"name": "{{ .Values.testValues.dict.key }}.example.com"},
                         ],
@@ -215,6 +221,10 @@ class TestIngressFlower:
             "aa.example.com",
             "cc.example.com",
             "dd.example.com",
+        ]
+        assert jmespath.search("spec.tls[*]", docs[0]) == [
+            {"hosts": ["*.airflow.example.com"], "secretName": "secret1"},
+            {"hosts": ["aa.example.com"], "secretName": "secret2"},
         ]
 
     def test_backend_service_name(self):

--- a/helm-tests/tests/helm_tests/webserver/test_ingress_web.py
+++ b/helm-tests/tests/helm_tests/webserver/test_ingress_web.py
@@ -190,8 +190,14 @@ class TestIngressWeb:
                     "web": {
                         "enabled": True,
                         "hosts": [
-                            {"name": "*.{{ .Release.Namespace }}.example.com"},
-                            {"name": "{{ .Values.testValues.scalar }}.example.com"},
+                            {
+                                "name": "*.{{ .Release.Namespace }}.example.com",
+                                "tls": {"enabled": True, "secretName": "secret1"},
+                            },
+                            {
+                                "name": "{{ .Values.testValues.scalar }}.example.com",
+                                "tls": {"enabled": True, "secretName": "secret2"},
+                            },
                             {"name": "{{ index .Values.testValues.list 1 }}.example.com"},
                             {"name": "{{ .Values.testValues.dict.key }}.example.com"},
                         ],
@@ -207,6 +213,10 @@ class TestIngressWeb:
             "aa.example.com",
             "cc.example.com",
             "dd.example.com",
+        ]
+        assert jmespath.search("spec.tls[*]", docs[0]) == [
+            {"hosts": ["*.airflow.example.com"], "secretName": "secret1"},
+            {"hosts": ["aa.example.com"], "secretName": "secret2"},
         ]
 
     def test_backend_service_name(self):


### PR DESCRIPTION
Apply `tpl` rendering to TLS hosts in all ingress templates so that Go template expressions are resolved consistently in both `spec.rules[*].host` and `spec.tls[*].hosts`.                                                                                                                             

closes: #62358