### PR TITLE
Fix UI e2e test does not clean up containers properly on test failures

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/testing_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/testing_commands.py
@@ -1594,17 +1594,18 @@ def ui_e2e_tests(
         if report_path.exists():
             get_console().print(f"[info]Report: file://{report_path}[/]")
 
-        stop_docker_compose(tmp_dir)
-        shutil.rmtree(tmp_dir, ignore_errors=True)
-
         if result.returncode != 0:
             sys.exit(result.returncode)
 
+    except KeyboardInterrupt:
+        get_console().print("\n[warning]Interrupted by user.[/]")
+        sys.exit(1)
     except Exception as e:
         get_console().print(f"[error]{str(e)}[/]")
+        sys.exit(1)
+    finally:
         stop_docker_compose(tmp_dir)
         shutil.rmtree(tmp_dir, ignore_errors=True)
-        sys.exit(1)
 
 
 class TimeoutHandler:


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

### Why
When running UI end-to-end testing, the containers are not cleaned up properly when the tests failed. It requires manually clean up containers/volumes before running the next test, which introduce a little frustration when iterating on the tests.

When the tests fail, the HTML reporter opens in a browser and keeps the process alive. When the user presses `Ctrl+C` to exit, Python raises `KeyboardInterrupt`. However, `KeyboardInterrupt` inherits from `BaseException`, not `Exception`. The current code only catches `Exception`, so the following clean up process is not triggered.

```python
stop_docker_compose(tmp_dir)
shutil.rmtree(tmp_dir, ignore_errors=True)
```

<img width="1264" height="765" alt="Screenshot from 2026-02-26 23-29-47" src="https://github.com/user-attachments/assets/9602e8bb-f4c7-4e4e-a508-62d983b77fb0" />

### Fix
Replace the `try...except` with `try...except...finally` to guarantee cleanup runs regardless of how the function exits (success, exception, or on keyboard interrupt).

### Tests

After inspecting the HTML report, `Ctrl+C` to exit, cleanup process run.
<img width="1170" height="515" alt="Screenshot from 2026-02-26 23-40-22" src="https://github.com/user-attachments/assets/5989f7d9-4c56-450f-ab68-4221984ebe55" />

`Ctrl+C` to exit while the tests are running, cleanup process run.
<img width="1170" height="515" alt="Screenshot from 2026-02-26 23-43-13" src="https://github.com/user-attachments/assets/f2e19491-1da6-473c-bdbd-247a9d647fa6" />

When all tests passed.
<img width="1023" height="681" alt="Screenshot from 2026-02-27 00-26-01" src="https://github.com/user-attachments/assets/3c7184ad-3463-4504-b6c2-7eedd765a98c" />


---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
