### PR TITLE
Refactor MetastorePartitionSensor to use explicit arguments

### DIFF
--- a/providers/apache/hive/src/airflow/providers/apache/hive/sensors/metastore_partition.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/sensors/metastore_partition.py
@@ -55,17 +55,11 @@ class MetastorePartitionSensor(SqlSensor):
         mysql_conn_id: str = "metastore_mysql",
         **kwargs: Any,
     ):
+        super().__init__(conn_id=mysql_conn_id, sql="", **kwargs)
         self.partition_name = partition_name
         self.table = table
         self.schema = schema
         self.first_poke = True
-        self.conn_id = mysql_conn_id
-        # TODO(aoen): We shouldn't be using SqlSensor here but MetastorePartitionSensor.
-        # The problem is the way apply_defaults works isn't compatible with inheritance.
-        # The inheritance model needs to be reworked in order to support overriding args/
-        # kwargs with arguments here, then 'conn_id' and 'sql' can be passed into the
-        # constructor below and apply_defaults will no longer throw an exception.
-        super().__init__(**kwargs)
 
     def poke(self, context: Context) -> Any:
         if self.first_poke:

--- a/providers/apache/hive/tests/unit/apache/hive/sensors/test_metastore_partition_refactor.py
+++ b/providers/apache/hive/tests/unit/apache/hive/sensors/test_metastore_partition_refactor.py
@@ -1,0 +1,95 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from unittest import mock
+
+from airflow.providers.apache.hive.sensors.metastore_partition import MetastorePartitionSensor
+
+
+class TestMetastorePartitionSensor:
+    def test_init(self):
+        op = MetastorePartitionSensor(
+            task_id="test_task",
+            table="my_table",
+            partition_name="ds=2023-01-01",
+            schema="my_schema",
+            mysql_conn_id="my_conn",
+        )
+        assert op.table == "my_table"
+        assert op.partition_name == "ds=2023-01-01"
+        assert op.schema == "my_schema"
+        assert op.conn_id == "my_conn"
+        assert op.sql == ""  # Initial dummy value
+
+    @mock.patch("airflow.providers.common.sql.sensors.sql.SqlSensor._get_hook")
+    def test_poke_sql_construction(self, mock_get_hook):
+        op = MetastorePartitionSensor(
+            task_id="test_task", table="my_table", partition_name="ds=2023-01-01", schema="my_schema"
+        )
+
+        # Mock hook behavior
+        hook = mock.MagicMock()
+        mock_get_hook.return_value = hook
+        hook.get_records.return_value = [[1]]  # Return non-empty result
+
+        context = {"ds": "2023-01-01"}  # Dummy context
+        result = op.poke(context)
+
+        assert result is True
+        # Verify SQL construction
+        expected_sql = """
+            SELECT 'X'
+            FROM PARTITIONS A0
+            LEFT OUTER JOIN TBLS B0 ON A0.TBL_ID = B0.TBL_ID
+            LEFT OUTER JOIN DBS C0 ON B0.DB_ID = C0.DB_ID
+            WHERE
+                B0.TBL_NAME = 'my_table' AND
+                C0.NAME = 'my_schema' AND
+                A0.PART_NAME = 'ds=2023-01-01';
+            """
+        # Normalize whitespace for comparison
+        assert " ".join(op.sql.split()) == " ".join(expected_sql.split())
+
+    @mock.patch("airflow.providers.common.sql.sensors.sql.SqlSensor._get_hook")
+    def test_poke_table_split(self, mock_get_hook):
+        op = MetastorePartitionSensor(
+            task_id="test_task", table="other_schema.other_table", partition_name="ds=2023-01-01"
+        )
+
+        hook = mock.MagicMock()
+        mock_get_hook.return_value = hook
+        hook.get_records.return_value = []  # Return empty result
+
+        result = op.poke({})
+
+        assert result is False
+        assert op.schema == "other_schema"
+        assert op.table == "other_table"
+
+        expected_sql = """
+            SELECT 'X'
+            FROM PARTITIONS A0
+            LEFT OUTER JOIN TBLS B0 ON A0.TBL_ID = B0.TBL_ID
+            LEFT OUTER JOIN DBS C0 ON B0.DB_ID = C0.DB_ID
+            WHERE
+                B0.TBL_NAME = 'other_table' AND
+                C0.NAME = 'other_schema' AND
+                A0.PART_NAME = 'ds=2023-01-01';
+            """
+        assert " ".join(op.sql.split()) == " ".join(expected_sql.split())


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->
This PR refactors MetastorePartitionSensor.__init__ to remove the reliance on **kwargs and apply_defaults limitations which are no longer relevant in Airflow 3.0+.
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
