### PR TITLE
Fix max_lines_per_page config setting for ElasticsearchRemoteLogIO

### DIFF
--- a/providers/elasticsearch/src/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/providers/elasticsearch/src/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -157,7 +157,6 @@ class ElasticsearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMix
     """
 
     PAGE = 0
-    MAX_LINE_PER_PAGE = conf.getint("elasticsearch", "max_lines_per_page", fallback=1000)
     LOG_NAME = "Elasticsearch"
 
     trigger_should_wrap = True
@@ -578,7 +577,7 @@ class ElasticsearchRemoteLogIO(LoggingMixin):  # noqa: D101
         self.client = elasticsearch.Elasticsearch(self.host, **es_kwargs)
         self.index_patterns_callable = conf.get("elasticsearch", "index_patterns_callable", fallback="")
         self.PAGE = 0
-        self.MAX_LINE_PER_PAGE = 1000
+        self.MAX_LINE_PER_PAGE = conf.getint("elasticsearch", "max_lines_per_page", fallback=1000)
         self.index_patterns: str = conf.get("elasticsearch", "index_patterns")
         self._doc_type_map: dict[Any, Any] = {}
         self._doc_type: list[Any] = []


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

The `max_lines_per_page` config setting was being used to control the `_es_read()` function in the `ElasticsearchTaskHandler`, this PR restores the setting for `ElasticsearchRemoteLogIO._es_read()` after the refactor in #53821

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)
- [X] No

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---


