### PR TITLE
Clean generated _api folders in prepare-provider-distributions

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -1130,6 +1130,11 @@ def prepare_provider_distributions(
     perform_environment_checks()
     fix_ownership_using_docker()
     cleanup_python_generated_files()
+    get_console().print("\n[info]Cleaning generated _api folders from docs directories")
+    for api_dir in AIRFLOW_ROOT_PATH.rglob("docs/_api"):
+        if api_dir.is_dir():
+            shutil.rmtree(api_dir, ignore_errors=True)
+            get_console().print(f"[info]Removed {api_dir}")
     distributions_list_as_tuple: tuple[str, ...] = ()
     if distributions_list and len(distributions_list):
         get_console().print(


### PR DESCRIPTION
## Summary
- The `prepare-provider-distributions` breeze command now removes all generated `_api` folders from `docs` directories across the repository before building provider packages.
- These folders are generated by Sphinx during documentation builds and can interfere with clean distribution builds.
- The cleanup runs right after the existing `cleanup_python_generated_files()` step.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: Claude Code [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
