### PR TITLE
Explicitly set extra for connections in generic transfer tests

### DIFF
--- a/providers/common/sql/tests/unit/common/sql/operators/test_generic_transfer.py
+++ b/providers/common/sql/tests/unit/common/sql/operators/test_generic_transfer.py
@@ -89,10 +89,10 @@ class TestMySql:
                 self.init_client = self.connection.extra_dejson.get("client", "mysqlclient")
 
             def __enter__(self):
-                self.connection = f'{{"client": "{self.client}"}}'
+                self.connection.extra = f'{{"client": "{self.client}"}}'
 
             def __exit__(self, exc_type, exc_val, exc_tb):
-                self.connection = f'{{"client": "{self.init_client}"}}'
+                self.connection.extra = f'{{"client": "{self.init_client}"}}'
 
         with MySqlContext(client):
             sql = "SELECT * FROM connection;"

--- a/providers/common/sql/tests/unit/common/sql/operators/test_generic_transfer.py
+++ b/providers/common/sql/tests/unit/common/sql/operators/test_generic_transfer.py
@@ -89,10 +89,10 @@ class TestMySql:
                 self.init_client = self.connection.extra_dejson.get("client", "mysqlclient")
 
             def __enter__(self):
-                self.connection.set_extra(f'{{"client": "{self.client}"}}')
+                self.connection = f'{{"client": "{self.client}"}}'
 
             def __exit__(self, exc_type, exc_val, exc_tb):
-                self.connection.set_extra(f'{{"client": "{self.init_client}"}}')
+                self.connection = f'{{"client": "{self.init_client}"}}'
 
         with MySqlContext(client):
             sql = "SELECT * FROM connection;"

--- a/providers/mysql/tests/unit/mysql/hooks/test_mysql.py
+++ b/providers/mysql/tests/unit/mysql/hooks/test_mysql.py
@@ -619,10 +619,10 @@ class MySqlContext:
         self.init_client = self.connection.extra_dejson.get("client", "mysqlclient")
 
     def __enter__(self):
-        self.connection.set_extra(f'{{"client": "{self.client}"}}')
+        self.connection.extra = f'{{"client": "{self.client}"}}'
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.connection.set_extra(f'{{"client": "{self.init_client}"}}')
+        self.connection.extra = f'{{"client": "{self.init_client}"}}'
 
 
 @pytest.mark.backend("mysql")


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->


Noticed in PR #61523 that we used `set_extra`. Providers are now using Task SDK Connection instead of airflow.models.Connection as per compat layer if task sdk is installed (3.0+ versions). The task sdk Connection doesn't have `set_extra()` method, only the extra attribute. Tests that use set_extra() will fail with the new SDK Connection, so we can just instead set `extra`

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
