### PR TITLE
Forbid accessing team secrets with environment variable as global secret

### DIFF
--- a/airflow-core/src/airflow/secrets/environment_variables.py
+++ b/airflow-core/src/airflow/secrets/environment_variables.py
@@ -20,6 +20,7 @@
 from __future__ import annotations
 
 import os
+import re
 
 from airflow.secrets import BaseSecretsBackend
 
@@ -31,6 +32,9 @@ class EnvironmentVariablesBackend(BaseSecretsBackend):
     """Retrieves Connection object and Variable from environment variable."""
 
     def get_conn_value(self, conn_id: str, team_name: str | None = None) -> str | None:
+        if self._is_team_specific_accessed_as_global(conn_id, team_name):
+            return None
+
         if team_name and (
             team_var := os.environ.get(f"{CONN_ENV_PREFIX}_{team_name.upper()}___" + conn_id.upper())
         ):
@@ -47,6 +51,9 @@ class EnvironmentVariablesBackend(BaseSecretsBackend):
         :param team_name: Team name associated to the task trying to access the variable (if any)
         :return: Variable Value
         """
+        if self._is_team_specific_accessed_as_global(key, team_name):
+            return None
+
         if team_name and (
             team_var := os.environ.get(f"{VAR_ENV_PREFIX}_{team_name.upper()}___" + key.upper())
         ):
@@ -54,3 +61,7 @@ class EnvironmentVariablesBackend(BaseSecretsBackend):
             return team_var
 
         return os.environ.get(VAR_ENV_PREFIX + key.upper())
+
+    @staticmethod
+    def _is_team_specific_accessed_as_global(secret_id: str, team_name: str | None = None) -> bool:
+        return team_name is None and bool(re.fullmatch(r"_[^_]+___.+", secret_id))

--- a/airflow-core/tests/unit/always/test_secrets.py
+++ b/airflow-core/tests/unit/always/test_secrets.py
@@ -24,6 +24,7 @@ import pytest
 from airflow.configuration import ensure_secrets_loaded, initialize_secrets_backends
 from airflow.models import Connection, Variable
 from airflow.sdk import SecretCache
+from airflow.sdk.exceptions import AirflowNotFoundException
 
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import clear_db_variables
@@ -119,6 +120,17 @@ class TestConnectionsFromSecrets:
 
         assert conn.get_uri() == "mysql://airflow:airflow@host:5432/airflow"
 
+    @pytest.mark.db_test
+    @mock.patch.dict(
+        "os.environ",
+        {
+            "AIRFLOW_CONN__TEAM___TEST_MYSQL": "mysql://airflow:airflow@host:5432/airflow",
+        },
+    )
+    def test_connection_env_var_do_not_access_team_specific(self):
+        with pytest.raises(AirflowNotFoundException, match=r"The conn_id `_team___test_mysql` isn't defined"):
+            Connection.get_connection_from_secrets(conn_id="_team___test_mysql")
+
 
 @skip_if_force_lowest_dependencies_marker
 @pytest.mark.db_test
@@ -204,3 +216,12 @@ class TestVariableFromSecrets:
 
         mock_secret_get.return_value = "a_secret_value"
         assert Variable.get(key="not_myvar") == "a_secret_value"
+
+    @mock.patch.dict(
+        "os.environ",
+        {
+            "AIRFLOW_VAR__TEAM___MYVAR": "value",
+        },
+    )
+    def test_variable_env_var_do_not_access_team_specific(self):
+        assert Variable.get_variable_from_secrets(key="_team___myvar") is None


### PR DESCRIPTION
This PR fixes an interesting security breach in multi-team. Variables and connections can be defined via environment variables this way:

- Global
  - Connection: `AIRFLOW_CONN_<CONN_ID>`
  - Variable: `AIRFLOW_VAR_<VAR_KEY>`
- Team specific
  - Connection: `AIRFLOW_CONN__<TEAM>___<CONN_ID>`
  - Variable: `AIRFLOW_VAR__<TEAM>___<VAR_KEY>`

The issue is, if a Dag tries to read the variable key `_marketing___myvar`, it will actually read the variable `myvar` from the team `marketing` regardless of whether the Dag belongs to this team. Why? Because when a Dag reads a variable, we always look up for the team specific variables but also for the global ones. Here it will consider the variable `_marketing___myvar` as global, although it should not.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
