### PR TITLE
Don't validate team existence during dag validation

### DIFF
--- a/airflow-core/src/airflow/dag_processing/dagbag.py
+++ b/airflow-core/src/airflow/dag_processing/dagbag.py
@@ -103,14 +103,16 @@ def _executor_exists(executor_name: str, team_name: str | None) -> bool:
     """Check if executor exists, with global fallback for teams."""
     try:
         # First pass check for team-specific executor or a global executor (i.e. team_name=None)
-        ExecutorLoader.lookup_executor_name_by_str(executor_name, team_name=team_name)
+        ExecutorLoader.lookup_executor_name_by_str(executor_name, team_name=team_name, validate_teams=False)
         return True
     except UnknownExecutorException:
         if team_name:
             # If we had a team_name but didn't find an executor, check if there is a global executor that
             # satisfies the request.
             try:
-                ExecutorLoader.lookup_executor_name_by_str(executor_name, team_name=None)
+                ExecutorLoader.lookup_executor_name_by_str(
+                    executor_name, team_name=None, validate_teams=False
+                )
                 return True
             except UnknownExecutorException:
                 pass

--- a/airflow-core/src/airflow/executors/executor_loader.py
+++ b/airflow-core/src/airflow/executors/executor_loader.py
@@ -301,7 +301,7 @@ class ExecutorLoader:
 
     @classmethod
     def lookup_executor_name_by_str(
-        cls, executor_name_str: str, team_name: str | None = None
+        cls, executor_name_str: str, team_name: str | None = None, validate_teams: bool = True
     ) -> ExecutorName:
         # lookup the executor by alias first, if not check if we're given a module path
         if (
@@ -310,7 +310,7 @@ class ExecutorLoader:
             or not _alias_to_executors_per_team
         ):
             # if we haven't loaded the executors yet, such as directly calling load_executor
-            cls._get_executor_names()
+            cls._get_executor_names(validate_teams)
 
         if executor_name := _alias_to_executors_per_team.get(team_name, {}).get(executor_name_str):
             return executor_name


### PR DESCRIPTION
During dag parsing we validate Dags that use Multiple Executor Configuration, to ensure the executor being requested for a task is available in config and for that team. We do that by examining various airflow and bundle config. However, downstream of getting all the currently configured executors, a new multi-team check was asserting the existence of teams in the DB. This check is really only meant to be done at Scheduler startup. We should not perform this check each parse loop.

This will also save on DB queries that were unintentionally happening each validation.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
