### PR TITLE
Set known_pool names on DagBag in processor to enable validation

### DIFF
--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -61,6 +61,7 @@ from airflow.models.dagbundle import DagBundleModel
 from airflow.models.dagwarning import DagWarning
 from airflow.models.db_callback_request import DbCallbackRequest
 from airflow.models.errors import ParseImportError
+from airflow.models.pool import Pool
 from airflow.observability.metrics import stats_utils
 from airflow.sdk import SecretCache
 from airflow.sdk.log import init_log_file, logging_processors
@@ -971,6 +972,9 @@ class DagFileProcessorManager(LoggingMixin):
         callback_to_execute_for_file = self._callback_to_execute.pop(dag_file, [])
         logger, logger_filehandle = self._get_logger_for_dag_file(dag_file)
 
+        # TODO: This is a blocking DB call, we should probably cache this or move it elsewhere
+        known_pools = {p.pool for p in Pool.get_pools()}
+
         return DagFileProcessorProcess.start(
             id=id,
             path=dag_file.absolute_path,
@@ -981,6 +985,7 @@ class DagFileProcessorManager(LoggingMixin):
             logger=logger,
             logger_filehandle=logger_filehandle,
             client=self.client,
+            known_pools=known_pools,
         )
 
     def _start_new_processes(self):

--- a/airflow-core/src/airflow/dag_processing/processor.py
+++ b/airflow-core/src/airflow/dag_processing/processor.py
@@ -101,6 +101,9 @@ class DagFileParseRequest(BaseModel):
     bundle_name: str
     """Bundle name for team-specific executor validation."""
 
+    known_pools: set[str] | None = None
+    """List of known pools to identify invalid pool references in DAGs."""
+
     callback_requests: list[CallbackRequest] = Field(default_factory=list)
     type: Literal["DagFileParseRequest"] = "DagFileParseRequest"
 
@@ -206,8 +209,6 @@ def _parse_file_entrypoint():
 
 
 def _parse_file(msg: DagFileParseRequest, log: FilteringBoundLogger) -> DagFileParsingResult | None:
-    # TODO: Set known_pool names on DagBag!
-
     stability_check_result = check_dag_file_stability(os.fspath(msg.file))
 
     if stability_check_error_dict := stability_check_result.get_error_format_dict(msg.file, msg.bundle_path):
@@ -223,6 +224,7 @@ def _parse_file(msg: DagFileParseRequest, log: FilteringBoundLogger) -> DagFileP
         bundle_path=msg.bundle_path,
         bundle_name=msg.bundle_name,
         load_op_links=False,
+        known_pools=msg.known_pools,
     )
 
     if msg.callback_requests:
@@ -523,6 +525,7 @@ class DagFileProcessorProcess(WatchedSubprocess):
         callbacks: list[CallbackRequest],
         target: Callable[[], None] = _parse_file_entrypoint,
         client: Client,
+        known_pools: set[str] | None = None,
         **kwargs,
     ) -> Self:
         logger = kwargs["logger"]
@@ -531,7 +534,7 @@ class DagFileProcessorProcess(WatchedSubprocess):
 
         proc: Self = super().start(target=target, client=client, **kwargs)
         proc.had_callbacks = bool(callbacks)  # Track if this process had callbacks
-        proc._on_child_started(callbacks, path, bundle_path, bundle_name)
+        proc._on_child_started(callbacks, path, bundle_path, bundle_name, known_pools)
         return proc
 
     def _on_child_started(
@@ -540,12 +543,14 @@ class DagFileProcessorProcess(WatchedSubprocess):
         path: str | os.PathLike[str],
         bundle_path: Path,
         bundle_name: str,
+        known_pools: set[str] | None,
     ) -> None:
         msg = DagFileParseRequest(
             file=os.fspath(path),
             bundle_path=bundle_path,
             bundle_name=bundle_name,
             callback_requests=callbacks,
+            known_pools=known_pools,
         )
         self.send_msg(msg, request_id=0)
 

--- a/airflow-core/tests/unit/dag_processing/test_processor_known_pools.py
+++ b/airflow-core/tests/unit/dag_processing/test_processor_known_pools.py
@@ -1,0 +1,87 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pathlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+import structlog
+
+from airflow.dag_processing.processor import DagFileParseRequest, _parse_file
+
+
+@pytest.fixture
+def mock_logger():
+    return MagicMock(spec=structlog.typing.FilteringBoundLogger)
+
+
+class TestProcessorKnownPools:
+    def test_parse_file_passes_known_pools_to_dagbag(self, mock_logger):
+        """Test that _parse_file passes known_pools to BundleDagBag."""
+        known_pools = {"pool1", "pool2"}
+
+        with patch("airflow.dag_processing.processor.BundleDagBag") as mock_dagbag_class:
+            mock_dagbag_instance = MagicMock()
+            mock_dagbag_instance.dags = {}
+            mock_dagbag_instance.import_errors = {}
+            mock_dagbag_class.return_value = mock_dagbag_instance
+
+            request = DagFileParseRequest(
+                file="/test/dag.py",
+                bundle_path=pathlib.Path("/test"),
+                bundle_name="test_bundle",
+                known_pools=known_pools,
+            )
+
+            _parse_file(request, log=mock_logger)
+
+            mock_dagbag_class.assert_called_once()
+            call_kwargs = mock_dagbag_class.call_args.kwargs
+            assert call_kwargs["known_pools"] == known_pools
+
+    def test_dagbag_generates_warnings_for_unknown_pools(self, tmp_path):
+        """Test that DagBag generates warnings when unknown pools are used."""
+        # This test integration of DagBag logic with known_pools
+        from airflow.dag_processing.dagbag import DagBag
+        from airflow.models.dagwarning import DagWarningType
+
+        dag_file = tmp_path / "test_dag_pool.py"
+        dag_file.write_text("""
+from airflow import DAG
+from airflow.operators.empty import EmptyOperator
+from datetime import datetime
+
+with DAG("test_pool_dag", start_date=datetime(2023, 1, 1), schedule=None):
+    EmptyOperator(task_id="task1", pool="pool_one")
+    EmptyOperator(task_id="task2", pool="pool_two")
+""")
+
+        known_pools = {"pool_one", "default_pool"}
+
+        # We need to set bundle_path because BundleDagBag might be used or we use DagBag directly
+        # Here we test DagBag logic directly as used in processor
+        dagbag = DagBag(dag_folder=dag_file, known_pools=known_pools, include_examples=False)
+
+        assert "test_pool_dag" in dagbag.dags
+        warnings = dagbag.dag_warnings
+        assert len(warnings) == 1
+        warning = next(iter(warnings))
+        assert warning.dag_id == "test_pool_dag"
+        assert warning.warning_type == DagWarningType.NONEXISTENT_POOL
+        assert "pool_two" in warning.message
+        assert "pool_one" not in warning.message


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->
This PR implements the TODO in `processor.py` to set `known_pool` names on `DagBag`.
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
