### PR TITLE
Upgrade Hatch to 1.16.5 and revert virtualenv pin

### DIFF
--- a/.github/workflows/airflow-distributions-tests.yml
+++ b/.github/workflows/airflow-distributions-tests.yml
@@ -115,7 +115,7 @@ jobs:
         # Pin on virtualenv is temporary for pypa/hatch#2193
         run: |
           uv tool uninstall hatch || true
-          uv tool install hatch==1.16.4 --with 'virtualenv<21'
+          uv tool install hatch==1.16.5
           breeze release-management "${DISTRIBUTION_TYPE}" --distribution-format wheel
         if: ${{ matrix.python-version == inputs.default-python-version }}
       - name: "Verify wheel packages with twine"

--- a/dev/breeze/pyproject.toml
+++ b/dev/breeze/pyproject.toml
@@ -52,8 +52,7 @@ dependencies = [
     "google-auth-httplib2>=0.2.0",
     "google-auth-oauthlib>=1.2.0",
     "gitpython>=3.1.40",
-    "hatch>=1.16.4",
-    "virtualenv<21",  # Temporary pin for pypa/hatch#2193
+    "hatch>=1.16.5",
     "inputimeout>=1.0.4",
     "jinja2>=3.1.5",
     "jsonschema>=4.19.1",

--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -265,7 +265,7 @@ AIRFLOW_USE_UV = False
 GITPYTHON_VERSION = "3.1.46"
 RICH_VERSION = "14.3.3"
 PREK_VERSION = "0.3.3"
-HATCH_VERSION = "1.16.4"
+HATCH_VERSION = "1.16.5"
 PYYAML_VERSION = "6.0.3"
 
 # prek environment and this is done with node, no python installation is needed.
@@ -278,8 +278,7 @@ RUN pip install uv=={UV_VERSION}
 RUN --mount=type=cache,id=cache-airflow-build-dockerfile-installation,target=/root/.cache/ \
   uv pip install --system ignore pip=={AIRFLOW_PIP_VERSION} hatch=={HATCH_VERSION} \
   pyyaml=={PYYAML_VERSION} gitpython=={GITPYTHON_VERSION} rich=={RICH_VERSION} \
-  prek=={PREK_VERSION} \
-  'virtualenv<21'
+  prek=={PREK_VERSION}
 COPY . /opt/airflow
 """
 

--- a/scripts/ci/prek/upgrade_important_versions.py
+++ b/scripts/ci/prek/upgrade_important_versions.py
@@ -691,12 +691,12 @@ def sync_breeze_lock_file() -> None:
 
 def resolve_hatchling_build_requires(with_gitpython: bool = False) -> list[str]:
     """
-    Resolve the full transitive dependency list for hatchling (with virtualenv<21) using uv pip compile.
+    Resolve the full transitive dependency list for hatchling using uv pip compile.
 
     When with_gitpython is True, also includes GitPython and its transitive dependencies (gitdb, smmap).
     Returns a sorted list of pinned requirement strings, with tomli carrying its python_version marker.
     """
-    packages = ["hatchling", "virtualenv<21"]
+    packages = ["hatchling"]
     if with_gitpython:
         packages.append("gitpython")
 


### PR DESCRIPTION
Since Hatch fixes its incompatibility, we can upgrade it and revert #62503.