### PR TITLE
Refactor DataTable to handle internal scrolling and fix overflow on narrow viewports

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/DataTable/DataTable.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DataTable/DataTable.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Heading, HStack, Text } from "@chakra-ui/react";
+import { Box, Heading, HStack, Text } from "@chakra-ui/react";
 import {
   getCoreRowModel,
   getExpandedRowModel,
@@ -169,7 +169,7 @@ export const DataTable = <TData,>({
   ) : undefined;
 
   return (
-    <>
+    <Box display="flex" flex={1} flexDirection="column" minH={0}>
       <ProgressBar size="xs" visibility={Boolean(isFetching) && !Boolean(isLoading) ? "visible" : "hidden"} />
       {showDisplayToggle && onDisplayToggleChange ? (
         <ToggleTableDisplay display={display} setDisplay={onDisplayToggleChange} />
@@ -177,17 +177,19 @@ export const DataTable = <TData,>({
       <Toaster />
       {errorMessage}
       {rowCountHeading}
-      {hasRows && display === "table" ? (
-        <TableList allowFiltering={showColumnsFilter} table={table} />
-      ) : undefined}
-      {hasRows && display === "card" && cardDef !== undefined ? (
-        <CardList cardDef={cardDef} isLoading={isLoading} rows={rows} />
-      ) : undefined}
-      {!hasRows && !Boolean(isLoading) && (
-        <Text as="div" pl={4} pt={1}>
-          {noRowsMessage ?? translate("noItemsFound", { modelName: noRowsModelName })}
-        </Text>
-      )}
+      <Box flex={1} minH={0} overflow="auto">
+        {hasRows && display === "table" ? (
+          <TableList allowFiltering={showColumnsFilter} table={table} />
+        ) : undefined}
+        {hasRows && display === "card" && cardDef !== undefined ? (
+          <CardList cardDef={cardDef} isLoading={isLoading} rows={rows} />
+        ) : undefined}
+        {!hasRows && !Boolean(isLoading) && (
+          <Text as="div" pl={4} pt={1}>
+            {noRowsMessage ?? translate("noItemsFound", { modelName: noRowsModelName })}
+          </Text>
+        )}
+      </Box>
       {hasPagination ? (
         <Pagination.Root
           count={rowCount}
@@ -204,6 +206,6 @@ export const DataTable = <TData,>({
           </HStack>
         </Pagination.Root>
       ) : undefined}
-    </>
+    </Box>
   );
 };

--- a/airflow-core/src/airflow/ui/src/pages/AssetsList/AssetsList.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/AssetsList/AssetsList.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Flex, Heading, Link, useDisclosure, VStack } from "@chakra-ui/react";
+import { Flex, Heading, Link, useDisclosure, VStack } from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useTranslation } from "react-i18next";
 import { useSearchParams, Link as RouterLink } from "react-router-dom";
@@ -170,19 +170,17 @@ export const AssetsList = () => {
           />
         </Flex>
       </VStack>
-      <Box overflow="auto">
-        <DataTable
-          columns={columns}
-          data={data?.assets ?? []}
-          errorMessage={<ErrorAlert error={error} />}
-          initialState={tableURLState}
-          isLoading={isLoading}
-          modelName="common:asset"
-          onStateChange={setTableURLState}
-          showRowCountHeading={false}
-          total={data?.total_entries}
-        />
-      </Box>
+      <DataTable
+        columns={columns}
+        data={data?.assets ?? []}
+        errorMessage={<ErrorAlert error={error} />}
+        initialState={tableURLState}
+        isLoading={isLoading}
+        modelName="common:asset"
+        onStateChange={setTableURLState}
+        showRowCountHeading={false}
+        total={data?.total_entries}
+      />
     </>
   );
 };

--- a/airflow-core/src/airflow/ui/src/pages/Connections/Connections.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/Connections.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Flex, HStack, Spacer, VStack } from "@chakra-ui/react";
+import { Flex, HStack, Spacer, VStack } from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
 import type { TFunction } from "i18next";
 import { useState } from "react";
@@ -201,20 +201,18 @@ export const Connections = () => {
         </HStack>
       </VStack>
 
-      <Box overflow="auto">
-        <DataTable
-          columns={columns}
-          data={data?.connections ?? []}
-          errorMessage={<ErrorAlert error={error} />}
-          initialState={tableURLState}
-          isFetching={isFetching}
-          isLoading={isLoading}
-          modelName="admin:connections.connection"
-          noRowsMessage={<NothingFoundInfo />}
-          onStateChange={setTableURLState}
-          total={data?.total_entries ?? 0}
-        />
-      </Box>
+      <DataTable
+        columns={columns}
+        data={data?.connections ?? []}
+        errorMessage={<ErrorAlert error={error} />}
+        initialState={tableURLState}
+        isFetching={isFetching}
+        isLoading={isLoading}
+        modelName="admin:connections.connection"
+        noRowsMessage={<NothingFoundInfo />}
+        onStateChange={setTableURLState}
+        total={data?.total_entries ?? 0}
+      />
       <ActionBar.Root closeOnInteractOutside={false} open={Boolean(selectedRows.size)}>
         <ActionBar.Content>
           <ActionBar.SelectionTrigger>

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -314,7 +314,7 @@ export const DagsList = () => {
           ) : undefined}
         </HStack>
       </VStack>
-      <Box overflow="auto" pb={8}>
+      <Box pb={8}>
         <DataTable
           cardDef={cardDef}
           columns={columns}

--- a/airflow-core/src/airflow/ui/src/pages/Variables/Variables.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/Variables.tsx
@@ -218,20 +218,18 @@ export const Variables = () => {
           <AddVariableButton disabled={selectedRows.size > 0} />
         </HStack>
       </VStack>
-      <Box overflow="auto">
-        <DataTable
-          columns={columns}
-          data={data?.variables ?? []}
-          errorMessage={<ErrorAlert error={error} />}
-          initialState={tableURLState}
-          isFetching={isFetching}
-          isLoading={isLoading}
-          modelName="admin:variables.variable"
-          noRowsMessage={translate("variables.noRowsMessage")}
-          onStateChange={setTableURLState}
-          total={data?.total_entries ?? 0}
-        />
-      </Box>
+      <DataTable
+        columns={columns}
+        data={data?.variables ?? []}
+        errorMessage={<ErrorAlert error={error} />}
+        initialState={tableURLState}
+        isFetching={isFetching}
+        isLoading={isLoading}
+        modelName="admin:variables.variable"
+        noRowsMessage={translate("variables.noRowsMessage")}
+        onStateChange={setTableURLState}
+        total={data?.total_entries ?? 0}
+      />
       <ActionBar.Root closeOnInteractOutside={false} open={Boolean(selectedRows.size)}>
         <ActionBar.Content>
           <ActionBar.SelectionTrigger>


### PR DESCRIPTION

The DataTable component previously rendered a Fragment (`<>`), delegating scroll behavior to individual consuming pages.
Pages like Connections, Variables, AssetsList, and DagsList wrapped DataTable in `<Box overflow="auto">`, which caused two issues.
1. On narrow viewports, horizontal scroll was limited to the table area and content could be clipped.
2. Vertical scroll moved the entire DataTable (including heading and pagination) instead of just the table body.

This PR moves scroll handling into DataTable itself

## Before
https://github.com/user-attachments/assets/5e276cac-f79d-4006-9b33-456a6ff84521

## After
https://github.com/user-attachments/assets/41aceeec-951c-4b4d-8c23-4282db420f5d

https://github.com/user-attachments/assets/edc1152d-3bb2-49fe-9b21-6f6df1d8bea9




 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
claude

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
