### PR TITLE
Fix PythonVirtualenvOperator cannot run with pendulum<3

### DIFF
--- a/providers/standard/src/airflow/providers/standard/operators/python.py
+++ b/providers/standard/src/airflow/providers/standard/operators/python.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+import datetime as dt
 import inspect
 import json
 import logging
@@ -39,7 +40,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple, cast
 import lazy_object_proxy
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.specifiers import InvalidSpecifier
-from packaging.version import InvalidVersion
+from packaging.version import InvalidVersion, Version
 
 from airflow.exceptions import (
     AirflowConfigException,
@@ -621,6 +622,7 @@ class _BasePythonVirtualenvOperator(PythonOperator, metaclass=ABCMeta):
                 "pickling_library": self.serializer,
                 "python_callable": self.python_callable.__name__,
                 "python_callable_source": self.get_python_source(),
+                **self._get_additional_jinja_context(),
             }
 
             if inspect.getfile(self.python_callable) == self.dag.fileloc:
@@ -677,11 +679,56 @@ class _BasePythonVirtualenvOperator(PythonOperator, metaclass=ABCMeta):
 
             return self._read_result(output_path)
 
+    def _get_additional_jinja_context(self) -> dict:
+        """Return additional Jinja context variables for the virtualenv script template."""
+        return {}
+
     def determine_kwargs(self, context: Mapping[str, Any]) -> Mapping[str, Any]:
         keyword_params = KeywordParameters.determine(self.python_callable, self.op_args, context)
         if AIRFLOW_V_3_0_PLUS:
             return keyword_params.unpacking()
         return keyword_params.serializing()  # type: ignore[attr-defined]
+
+
+def _pendulum_to_native_datetime(obj):
+    """
+    Recursively convert pendulum DateTime objects to native Python datetime.
+
+    When the virtualenv has a different major version of pendulum than the host,
+    pendulum's internal pickle representations are incompatible. This function
+    converts pendulum DateTime objects to stdlib datetime.datetime with
+    zoneinfo.ZoneInfo timezone info, which can be serialized and deserialized
+    without pendulum.
+    """
+    import pendulum
+
+    if isinstance(obj, pendulum.DateTime):
+        tz = None
+        if obj.timezone_name:
+            from zoneinfo import ZoneInfo
+
+            try:
+                tz = ZoneInfo(obj.timezone_name)
+            except KeyError:
+                # Fall back to fixed UTC offset if the timezone name is not recognized
+                utc_offset = obj.utcoffset()
+                tz = dt.timezone(utc_offset) if utc_offset is not None else None
+        return dt.datetime(
+            obj.year,
+            obj.month,
+            obj.day,
+            obj.hour,
+            obj.minute,
+            obj.second,
+            obj.microsecond,
+            tzinfo=tz,
+        )
+    if isinstance(obj, dict):
+        return {k: _pendulum_to_native_datetime(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        converted = [_pendulum_to_native_datetime(v) for v in obj]
+        return type(obj)(converted)
+    return obj
 
 
 class PythonVirtualenvOperator(_BasePythonVirtualenvOperator):
@@ -980,6 +1027,52 @@ class PythonVirtualenvOperator(_BasePythonVirtualenvOperator):
             result = self._execute_python_callable_in_subprocess(python_path)
             self._cleanup_python_pycache_dir(venv_python_cache_dir)
             return result
+
+    def _is_pendulum_version_mismatch(self) -> bool:
+        """
+        Check if the virtualenv pendulum version will differ in major version from the host.
+
+        Compares the host's installed pendulum major version against the version specifier in the requirements.
+        """
+        from importlib.metadata import version as metadata_version
+
+        host_major = Version(metadata_version("pendulum")).major
+
+        for raw_str in chain.from_iterable(req.splitlines() for req in self.requirements):
+            line = raw_str.strip()
+            if not line or line.startswith("#"):
+                continue
+
+            # strip inline comments from a requirement line
+            req_str = re.sub(r"#.*$", "", line).strip()
+
+            try:
+                req = Requirement(req_str)
+            except (InvalidRequirement, InvalidSpecifier, InvalidVersion):
+                continue
+
+            if req.name == "pendulum" and req.specifier:
+                lower_bound = Version(f"{host_major}.0.0")
+                upper_bound = Version(f"{host_major}.999.999")
+                host_major_allowed = req.specifier.contains(lower_bound) or req.specifier.contains(
+                    upper_bound
+                )
+                return not host_major_allowed
+
+        return False
+
+    def _write_args(self, file: Path):
+        if self._is_pendulum_version_mismatch():
+            self.log.info(
+                "pendulum version mismatch detected between host and virtualenv; "
+                "converting pendulum objects to native Python datetime for serialization."
+            )
+            self.op_args = _pendulum_to_native_datetime(self.op_args)
+            self.op_kwargs = _pendulum_to_native_datetime(self.op_kwargs)
+        super()._write_args(file)
+
+    def _get_additional_jinja_context(self) -> dict:
+        return {"pendulum_version_mismatch": self._is_pendulum_version_mismatch()}
 
     def _iter_serializable_context_keys(self):
         yield from self.BASE_SERIALIZABLE_CONTEXT_KEYS

--- a/providers/standard/src/airflow/providers/standard/utils/python_virtualenv_script.jinja2
+++ b/providers/standard/src/airflow/providers/standard/utils/python_virtualenv_script.jinja2
@@ -78,6 +78,52 @@ with open(sys.argv[1], "rb") as file:
 arg_dict = {"args": [], "kwargs": {}}
 {% endif %}
 
+{% if pendulum_version_mismatch | default(false) %}
+# Pendulum version mismatch: the host serialized pendulum objects as native datetime.
+# Convert them back to pendulum DateTime using the virtualenv's pendulum version.
+import datetime as _dt
+
+try:
+    import pendulum as _pendulum
+    _pendulum_available = True
+except ImportError:
+    _pendulum_available = False
+
+def _native_datetime_to_pendulum(obj):
+    """Convert native datetime to pendulum DateTime (using virtualenv's pendulum version)."""
+    if _pendulum_available and isinstance(obj, _dt.datetime) and not isinstance(obj, _pendulum.DateTime):
+        return _pendulum.instance(obj)
+    if isinstance(obj, dict):
+        return {k: _native_datetime_to_pendulum(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return type(obj)(_native_datetime_to_pendulum(v) for v in obj)
+    return obj
+
+def _pendulum_to_native_datetime(obj):
+    """Convert pendulum DateTime to native datetime (using virtualenv's pendulum version)."""
+    if _pendulum_available and isinstance(obj, _pendulum.DateTime):
+        tz = None
+        if obj.timezone_name:
+            from zoneinfo import ZoneInfo
+            try:
+                tz = ZoneInfo(obj.timezone_name)
+            except KeyError:
+                tz = _dt.timezone(obj.utcoffset()) if obj.utcoffset() is not None else None
+        return _dt.datetime(
+            obj.year, obj.month, obj.day,
+            obj.hour, obj.minute, obj.second, obj.microsecond,
+            tzinfo=tz,
+        )
+    if isinstance(obj, dict):
+        return {k: _pendulum_to_native_datetime(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return type(obj)(_pendulum_to_native_datetime(v) for v in obj)
+    return obj
+
+arg_dict["args"] = [_native_datetime_to_pendulum(a) for a in arg_dict["args"]]
+arg_dict["kwargs"] = _native_datetime_to_pendulum(arg_dict["kwargs"])
+{% endif %}
+
 {% if string_args_global | default(true) -%}
 # Read string args
 with open(sys.argv[3], "r") as file:
@@ -94,4 +140,7 @@ except Exception as e:
 # Write output
 with open(sys.argv[2], "wb") as file:
     if res is not None:
+{% if pendulum_version_mismatch | default(false) %}
+        res = _pendulum_to_native_datetime(res)
+{% endif %}
         {{ pickling_library }}.dump(res, file)

--- a/providers/standard/src/airflow/providers/standard/utils/python_virtualenv_script.jinja2
+++ b/providers/standard/src/airflow/providers/standard/utils/python_virtualenv_script.jinja2
@@ -79,8 +79,6 @@ arg_dict = {"args": [], "kwargs": {}}
 {% endif %}
 
 {% if pendulum_version_mismatch | default(false) %}
-# Pendulum version mismatch: the host serialized pendulum objects as native datetime.
-# Convert them back to pendulum DateTime using the virtualenv's pendulum version.
 import datetime as _dt
 
 try:

--- a/providers/standard/tests/unit/standard/operators/test_python.py
+++ b/providers/standard/tests/unit/standard/operators/test_python.py
@@ -1792,23 +1792,14 @@ class TestPythonVirtualenvOperator(BaseTestPythonVirtualenvOperator):
     @pytest.mark.parametrize(
         ("requirements", "expected_mismatch"),
         [
-            # pendulum<3 with host v3 → mismatch
             (["pendulum<3"], True),
-            # pendulum>=3 with host v3 → no mismatch
             (["pendulum>=3"], False),
-            # pendulum==2.1.2 with host v3 → mismatch
             (["pendulum==2.1.2"], True),
-            # pendulum>=3.0.1 with host v3 → no mismatch (still allows 3.x)
             (["pendulum>=3.0.1"], False),
-            # pendulum (bare, no specifier) → no mismatch
             (["pendulum"], False),
-            # pendulum>=2,<4 with host v3 → no mismatch (3.x allowed)
             (["pendulum>=2,<4"], False),
-            # pendulum~=2.1.0 with host v3 → mismatch (only 2.1.x)
             (["pendulum~=2.1.0"], True),
-            # no pendulum at all → no mismatch
             (["requests"], False),
-            # empty requirements → no mismatch
             ([], False),
         ],
     )

--- a/providers/standard/tests/unit/standard/operators/test_python.py
+++ b/providers/standard/tests/unit/standard/operators/test_python.py
@@ -1789,6 +1789,128 @@ class TestPythonVirtualenvOperator(BaseTestPythonVirtualenvOperator):
             # Consume the generator to trigger parsing
             list(op._iter_serializable_context_keys())
 
+    @pytest.mark.parametrize(
+        ("requirements", "expected_mismatch"),
+        [
+            # pendulum<3 with host v3 → mismatch
+            (["pendulum<3"], True),
+            # pendulum>=3 with host v3 → no mismatch
+            (["pendulum>=3"], False),
+            # pendulum==2.1.2 with host v3 → mismatch
+            (["pendulum==2.1.2"], True),
+            # pendulum>=3.0.1 with host v3 → no mismatch (still allows 3.x)
+            (["pendulum>=3.0.1"], False),
+            # pendulum (bare, no specifier) → no mismatch
+            (["pendulum"], False),
+            # pendulum>=2,<4 with host v3 → no mismatch (3.x allowed)
+            (["pendulum>=2,<4"], False),
+            # pendulum~=2.1.0 with host v3 → mismatch (only 2.1.x)
+            (["pendulum~=2.1.0"], True),
+            # no pendulum at all → no mismatch
+            (["requests"], False),
+            # empty requirements → no mismatch
+            ([], False),
+        ],
+    )
+    def test_is_pendulum_version_mismatch(self, requirements, expected_mismatch):
+        def func():
+            return "test_return_value"
+
+        op = PythonVirtualenvOperator(
+            task_id="task",
+            python_callable=func,
+            requirements=requirements,
+            system_site_packages=False,
+        )
+        assert op._is_pendulum_version_mismatch() == expected_mismatch
+
+    def test_pendulum_to_native_datetime(self):
+        import pendulum
+
+        from airflow.providers.standard.operators.python import _pendulum_to_native_datetime
+
+        pdt = pendulum.datetime(2025, 5, 3, 10, 30, 45, tz="America/New_York")
+        result = _pendulum_to_native_datetime(pdt)
+
+        assert type(result) is datetime
+        assert not isinstance(result, pendulum.DateTime)
+        assert result.year == 2025
+        assert result.month == 5
+        assert result.day == 3
+        assert result.hour == 10
+        assert result.minute == 30
+        assert result.second == 45
+        assert result.tzinfo is not None
+        assert str(result.tzinfo) == "America/New_York"
+
+    def test_pendulum_to_native_datetime_nested(self):
+        import pendulum
+
+        from airflow.providers.standard.operators.python import _pendulum_to_native_datetime
+
+        pdt = pendulum.datetime(2025, 1, 1, tz="UTC")
+        nested = {
+            "date": pdt,
+            "list": [pdt, "string", 42],
+            "tuple": (pdt,),
+            "string": "test_value",
+        }
+        result = _pendulum_to_native_datetime(nested)
+
+        assert type(result["date"]) is datetime
+        assert type(result["list"][0]) is datetime
+        assert result["list"][1] == "string"
+        assert result["list"][2] == 42
+        assert type(result["tuple"]) is tuple
+        assert type(result["tuple"][0]) is datetime
+        assert result["string"] == "test_value"
+
+    @pytest.mark.parametrize("serializer", ["pickle", "cloudpickle", "dill"])
+    @mock.patch(
+        "airflow.providers.standard.operators.python.PythonVirtualenvOperator._is_pendulum_version_mismatch"
+    )
+    def test_write_args_converts_pendulum_on_mismatch(self, mock_mismatch, tmp_path, serializer):
+        import importlib
+
+        import pendulum
+
+        mock_mismatch.return_value = True
+
+        pdt = pendulum.datetime(2025, 6, 15, 12, 0, 0, tz="UTC")
+
+        def func(logical_date):
+            return str(logical_date)
+
+        op = PythonVirtualenvOperator(
+            task_id="task",
+            python_callable=func,
+            requirements=["pendulum<3"],
+            system_site_packages=False,
+            op_kwargs={"logical_date": pdt},
+            serializer=serializer,
+        )
+
+        output_file = tmp_path / "script.in"
+        op._write_args(output_file)
+
+        # Deserialize using the same library and check that the pendulum object was converted
+        pickling_library = importlib.import_module(serializer)
+
+        with open(output_file, "rb") as f:
+            arg_dict = pickling_library.load(f)
+
+        result_dt = arg_dict["kwargs"]["logical_date"]
+        assert type(result_dt) is datetime
+        assert not isinstance(result_dt, pendulum.DateTime)
+        assert result_dt.year == 2025
+        assert result_dt.month == 6
+        assert result_dt.day == 15
+        assert result_dt.hour == 12
+        assert result_dt.minute == 0
+        assert result_dt.second == 0
+        assert result_dt.tzinfo is not None
+        assert str(result_dt.tzinfo) == "UTC"
+
     @mock.patch("airflow.providers.standard.operators.python.PythonVirtualenvOperator._prepare_venv")
     @mock.patch(
         "airflow.providers.standard.operators.python.PythonVirtualenvOperator._execute_python_callable_in_subprocess"

--- a/providers/standard/tests/unit/standard/operators/test_python.py
+++ b/providers/standard/tests/unit/standard/operators/test_python.py
@@ -1856,7 +1856,14 @@ class TestPythonVirtualenvOperator(BaseTestPythonVirtualenvOperator):
         assert type(result["tuple"][0]) is datetime
         assert result["string"] == "test_value"
 
-    @pytest.mark.parametrize("serializer", ["pickle", "cloudpickle", "dill"])
+    @pytest.mark.parametrize(
+        "serializer",
+        [
+            pytest.param("pickle", id="pickle"),
+            pytest.param("cloudpickle", marks=CLOUDPICKLE_MARKER, id="cloudpickle"),
+            pytest.param("dill", marks=DILL_MARKER, id="dill"),
+        ],
+    )
     @mock.patch(
         "airflow.providers.standard.operators.python.PythonVirtualenvOperator._is_pendulum_version_mismatch"
     )


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
* closes: #50752 

### Why
The error occurs because pendulum objects are serialized with pendulum v3 (in the Airflow environment) but deserialized with pendulum v2 (in the virtualenv), and the two versions have incompatible internal class structures. The pendulum objects are coming from the `PENDULUM_SERIALIZABLE_CONTEXT_KEYS` 

### Fix

1. check if pendulum is defined in the `requirements` and check the if any version specified
2. evaluate the version string and check if the major version mismatch
3. if the major version mismatch, before serializing in `_write_args`, convert pendulum `DateTime` objects to `datetime.datetime` with `zoneinfo.ZoneInfo` timezone info, which can be serialized and deserialized without pendulum.
4. A flag is passed into Jinja template to render the code to convert the `datetime.datetime` back to `pendulum.Datetime` and vice versa.
5. Before returning to the Airflow environment, convert back to `datetime.datetime` before being serialized in the virtual environment.

### Tests
1. specify `requirements` with `["pendulum<3"]`, and test against `pickle`, `cloudpickle`, and `dill`
2. specify `requirements` with `["pendulum>=3"]`, and test against `pickle`, `cloudpickle`, and `dill`
3. specify `requirements` with `["pendulum"]`, and test against `pickle`, `cloudpickle`, and `dill`
4. do not specify `requirements` (i.e., `requirements=None`), and test against `pickle`, `cloudpickle`, and `dill`

<img width="1348" height="701" alt="Screenshot from 2026-02-28 00-24-07" src="https://github.com/user-attachments/assets/cad37243-9c86-4154-90c8-e6e1d5bcaf81" />

### DAG code
```python
from datetime import datetime, timedelta
import pendulum
from airflow import DAG

from airflow.providers.standard.operators.python import PythonOperator, PythonVirtualenvOperator


# Define the DAG
with DAG(dag_id="example_virtualenv_dag", start_date=datetime(2025, 5, 1), schedule=None, catchup=False) as dag:

    # A simple Python callable to be run in the virtualenv
    def generate_message(*args, **kwargs):
        import pendulum
        return f"Hello from virtualenv! pendulum version {pendulum.__version__}"

    # Task: runs `generate_message` inside a fresh virtual environment
    virtualenv_task = PythonVirtualenvOperator(
        task_id="virtualenv_task",
        python_version="3.9",
        python_callable=generate_message,
        requirements=[
            "pendulum<3"
        ],  # This will cause an error: AttributeError: type object 'Timezone' has no attribute '_unpickle'
        system_site_packages=False,
        expect_airflow=False,
        serializer="dill",
    )


if __name__ == "__main__":
    dag_run = dag.test(
        logical_date=pendulum.datetime(2025, 5, 3)
    )  # Runs all tasks locally without a scheduler :contentReference[oaicite:2]{index=2}
    print("STATE: ", dag_run.state)
```

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

Generated-by: [Antigravity] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

I use it to suggest the way to compare version mismatch. I originally think to check just the major version difference. However, the tool suggest the following:

>we cannot simply compare major versions because a requirement is usually a range, not a single version number. For example, what is the "major version" of a requirement like `pendulum>=2,<4`? It allows any version in the 2.x and 3.x line. Or what about pendulum!=3.0.0? Because `req.specifier` is a `SpecifierSet` containing complex mathematical boundaries (not a single version), the only truly robust way to ask "Does this requirement allow the host's major version?" is to ask the `SpecifierSet` to validate some versions within that major release line.

I am open to learn more if there is a better way to check it.

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
