### PR TITLE
perf: use deque for cursor row buffers in Google provider

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/bigquery.py
@@ -26,6 +26,7 @@ import re
 import time
 import uuid
 import warnings
+from collections import deque
 from collections.abc import Iterable, Mapping, Sequence
 from copy import deepcopy
 from datetime import datetime, timedelta
@@ -1614,7 +1615,7 @@ class BigQueryCursor(BigQueryBaseCursor):
         self.buffersize: int | None = None
         self.page_token: str | None = None
         self.job_id: str | None = None
-        self.buffer: list = []
+        self.buffer: deque = deque()
         self.all_pages_loaded: bool = False
         self._description: list = []
 
@@ -1669,7 +1670,7 @@ class BigQueryCursor(BigQueryBaseCursor):
         self.page_token = None
         self.job_id = None
         self.all_pages_loaded = False
-        self.buffer = []
+        self.buffer = deque()
 
     def fetchone(self) -> list | None:
         """Fetch the next row of a query result set."""
@@ -1709,7 +1710,7 @@ class BigQueryCursor(BigQueryBaseCursor):
                 self.flush_results()
                 return None
 
-        return self.buffer.pop(0)
+        return self.buffer.popleft()
 
     def fetchmany(self, size: int | None = None) -> list:
         """

--- a/providers/google/src/airflow/providers/google/cloud/transfers/presto_to_gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/presto_to_gcs.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+from collections import deque
 from typing import TYPE_CHECKING, Any
 
 from airflow.providers.google.cloud.transfers.sql_to_gcs import BaseSQLToGCSOperator
@@ -44,7 +45,7 @@ class _PrestoToGCSPrestoCursorAdapter:
 
     def __init__(self, cursor: PrestoCursor):
         self.cursor: PrestoCursor = cursor
-        self.rows: list[Any] = []
+        self.rows: deque[Any] = deque()
         self.initialized: bool = False
 
     @property
@@ -82,7 +83,7 @@ class _PrestoToGCSPrestoCursorAdapter:
     def execute(self, *args, **kwargs) -> PrestoResult:
         """Prepare and execute a database operation (query or command)."""
         self.initialized = False
-        self.rows = []
+        self.rows = deque()
         return self.cursor.execute(*args, **kwargs)
 
     def executemany(self, *args, **kwargs):
@@ -93,20 +94,20 @@ class _PrestoToGCSPrestoCursorAdapter:
         all parameter sequences or mappings found in the sequence seq_of_parameters.
         """
         self.initialized = False
-        self.rows = []
+        self.rows = deque()
         return self.cursor.executemany(*args, **kwargs)
 
     def peekone(self) -> Any:
         """Return the next row without consuming it."""
         self.initialized = True
         element = self.cursor.fetchone()
-        self.rows.insert(0, element)
+        self.rows.appendleft(element)
         return element
 
     def fetchone(self) -> Any:
         """Fetch the next row of a query result set, returning a single sequence, or ``None``."""
         if self.rows:
-            return self.rows.pop(0)
+            return self.rows.popleft()
         return self.cursor.fetchone()
 
     def fetchmany(self, size=None) -> list:

--- a/providers/google/src/airflow/providers/google/cloud/transfers/trino_to_gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/trino_to_gcs.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+from collections import deque
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
@@ -47,7 +48,7 @@ class _TrinoToGCSTrinoCursorAdapter:
 
     def __init__(self, cursor: TrinoCursor):
         self.cursor: TrinoCursor = cursor
-        self.rows: list[Any] = []
+        self.rows: deque[Any] = deque()
         self.initialized: bool = False
 
     @property
@@ -85,7 +86,7 @@ class _TrinoToGCSTrinoCursorAdapter:
     def execute(self, *args, **kwargs) -> TrinoResult:
         """Prepare and execute a database operation (query or command)."""
         self.initialized = False
-        self.rows = []
+        self.rows = deque()
         return self.cursor.execute(*args, **kwargs)
 
     def executemany(self, *args, **kwargs):
@@ -96,20 +97,20 @@ class _TrinoToGCSTrinoCursorAdapter:
         all parameter sequences or mappings found in the sequence seq_of_parameters.
         """
         self.initialized = False
-        self.rows = []
+        self.rows = deque()
         return self.cursor.executemany(*args, **kwargs)
 
     def peekone(self) -> Any:
         """Return the next row without consuming it."""
         self.initialized = True
         element = self.cursor.fetchone()
-        self.rows.insert(0, element)
+        self.rows.appendleft(element)
         return element
 
     def fetchone(self) -> Any:
         """Fetch the next row of a query result set, returning a single sequence, or ``None``."""
         if self.rows:
-            return self.rows.pop(0)
+            return self.rows.popleft()
         return self.cursor.fetchone()
 
     def fetchmany(self, size=None) -> list:


### PR DESCRIPTION
## Problem

Three files in the Google provider use `.pop(0)` and `.insert(0, ...)` for cursor row buffering. Both operations are **O(n)** on Python lists.

## Solution

Switch to `collections.deque` with `.popleft()` and `.appendleft()` for **O(1)** front operations.

## Changes

| File | Pattern |
|------|---------|
| `hooks/bigquery.py` | `BigQueryCursor.buffer` — row fetch buffer |
| `transfers/presto_to_gcs.py` | `_PrestoHTTPCursorAdapter.rows` — row peek/fetch buffer |
| `transfers/trino_to_gcs.py` | `_TrinoCursorAdapter.rows` — row peek/fetch buffer |

All existing `.append()`, truthiness checks, and iteration work identically on deque.