### PR TITLE
Improve the log file template for ExecuteCallback

### DIFF
--- a/airflow-core/src/airflow/executors/workloads/callback.py
+++ b/airflow-core/src/airflow/executors/workloads/callback.py
@@ -90,7 +90,7 @@ class ExecuteCallback(BaseDagBundleWorkload):
                 name=dag_run.dag_model.bundle_name,
                 version=dag_run.bundle_version,
             )
-        fname = f"executor_callbacks/{callback.id}"  # TODO: better log file template
+        fname = f"executor_callbacks/{dag_run.dag_id}/{dag_run.run_id}/{callback.id}"
 
         return cls(
             callback=CallbackDTO.model_validate(callback, from_attributes=True),


### PR DESCRIPTION
## Why
Currently, all executor callback logs are stored in a single flat directory `executor_callbacks/`, named only by their callback ID. This makes it difficult to associate logs with specific DAGs or runs without querying the database.

closes: #60464


##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
