### PR TITLE
Add CODEOWNERS for agentic instruction files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -150,5 +150,12 @@ Dockerfile.ci @potiuk @ashb @gopidesupavan @amoghrajesh @jscheffl @bugraoz93 @ka
 # Shared Libraries
 /shared/ @ashb @amoghrajesh @potiuk
 
+# Agentic instructions
+/AGENTS.md @potiuk @kaxil @jscheffl @amoghrajesh @ashb @sjyangkevin
+/.github/instructions/ @potiuk @kaxil @jscheffl @amoghrajesh @ashb @sjyangkevin
+/airflow-core/src/airflow/api_fastapi/execution_api/AGENTS.md @potiuk @kaxil @jscheffl @amoghrajesh @ashb @sjyangkevin
+/providers/AGENTS.md @potiuk @kaxil @jscheffl @amoghrajesh @ashb @sjyangkevin
+/.github/skills/ @potiuk @kaxil @jscheffl @amoghrajesh @ashb @sjyangkevin
+
 # RMs on release documents
 /dev/README_RELEASE_*.md @potiuk @jscheffl @vincbeck @shahar1 @jedcunningham @bugraoz93


### PR DESCRIPTION
Add CODEOWNERS entries for all agentic instruction files in the repository so that
PRs modifying AI agent instructions get reviewed by the people who maintain them.

Covered paths (all owned by @potiuk @kaxil @jscheffl @amoghrajesh @ashb @sjyangkevin):

- `/AGENTS.md`
- `/.github/instructions/`
- `/airflow-core/src/airflow/api_fastapi/execution_api/AGENTS.md`
- `/providers/AGENTS.md`
- `/.github/skills/`

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.6

Generated-by: Claude Opus 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)