### PR TITLE
CI: Replace curl-based uv installation with pip install from PyPI

### DIFF
--- a/.github/actions/breeze/action.yml
+++ b/.github/actions/breeze/action.yml
@@ -38,7 +38,7 @@ runs:
         python-version: ${{ inputs.python-version }}
     - name: "Install uv"
       shell: bash
-      run: curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh | sh
+      run: pip install "uv==${UV_VERSION}"
       env:
         UV_VERSION: ${{ inputs.uv-version }}
     # NOTE! Installing Breeze without using cache is FASTER than when using cache - uv is so fast and has

--- a/.github/actions/install-prek/action.yml
+++ b/.github/actions/install-prek/action.yml
@@ -39,7 +39,7 @@ runs:
   steps:
     - name: "Install uv"
       shell: bash
-      run: curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh | sh
+      run: pip install "uv==${UV_VERSION}"
       env:
         UV_VERSION: ${{ inputs.uv-version }}
     - name: Install prek

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -139,7 +139,7 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
       - name: "Install uv"
-        run: curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh | sh
+        run: pip install "uv==${UV_VERSION}"
         env:
           UV_VERSION: ${{ inputs.uv-version }}
       - name: "Run shared ${{ matrix.shared-distribution }} tests"
@@ -427,7 +427,7 @@ jobs:
         with:
           persist-credentials: false
       - name: "Install uv"
-        run: curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh | sh
+        run: pip install "uv==${UV_VERSION}"
         env:
           UV_VERSION: ${{ inputs.uv-version }}
       - name: "Set up Airflow home directory"

--- a/.github/workflows/ci-amd-arm.yml
+++ b/.github/workflows/ci-amd-arm.yml
@@ -40,6 +40,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GITHUB_USERNAME: ${{ github.actor }}
   SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+  UV_VERSION: "0.10.7"  # Keep this comment to allow automatic replacement of uv version
   VERBOSE: "true"
 
 concurrency:
@@ -248,7 +249,7 @@ jobs:
         with:
           persist-credentials: false
       - name: "Install uv"
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+        run: pip install "uv==${UV_VERSION}"
       - name: "Verify release calendar"
         run: uv run dev/verify_release_calendar.py
 


### PR DESCRIPTION
Replace `curl -LsSf https://astral.sh/uv/.../install.sh | sh` with `pip install "uv==${UV_VERSION}"` in all GitHub Actions workflows and composite actions, matching the pattern already used in `scripts/tools/setup_breeze`.

Also pins the previously unpinned uv install in `ci-amd-arm.yml` (verify-release-calendar job) to the repo standard version via a top-level `UV_VERSION` env var.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.6

Generated-by: Claude Opus 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)