### PR TITLE
airflow-ctl: Add tests for helper and import utilities

### DIFF
--- a/airflow-ctl/tests/airflow_ctl/test_exceptions.py
+++ b/airflow-ctl/tests/airflow_ctl/test_exceptions.py
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+
+from airflowctl.exceptions import (
+    AirflowCtlConnectionException,
+    AirflowCtlCredentialNotFoundException,
+    AirflowCtlException,
+    AirflowCtlKeyringException,
+    AirflowCtlNotFoundException,
+)
+
+
+def test_exceptions_follow_expected_hierarchy():
+    assert issubclass(AirflowCtlNotFoundException, AirflowCtlException)
+    assert issubclass(AirflowCtlCredentialNotFoundException, AirflowCtlNotFoundException)
+    assert issubclass(AirflowCtlCredentialNotFoundException, AirflowCtlException)
+    assert issubclass(AirflowCtlConnectionException, AirflowCtlException)
+    assert issubclass(AirflowCtlKeyringException, AirflowCtlException)
+
+
+@pytest.mark.parametrize(
+    "exception_type",
+    [
+        AirflowCtlException,
+        AirflowCtlNotFoundException,
+        AirflowCtlCredentialNotFoundException,
+        AirflowCtlConnectionException,
+        AirflowCtlKeyringException,
+    ],
+)
+def test_exceptions_can_be_raised_and_caught(exception_type):
+    with pytest.raises(exception_type):
+        raise exception_type("failure")

--- a/airflow-ctl/tests/airflow_ctl/utils/__init__.py
+++ b/airflow-ctl/tests/airflow_ctl/utils/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow-ctl/tests/airflow_ctl/utils/test_helpers.py
+++ b/airflow-ctl/tests/airflow_ctl/utils/test_helpers.py
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from airflowctl.utils.helpers import partition
+
+
+def test_partition_splits_even_and_odd_values():
+    false_iter, true_iter = partition(lambda value: value % 2 == 0, [1, 2, 3, 4])
+
+    assert list(false_iter) == [1, 3]
+    assert list(true_iter) == [2, 4]
+
+
+def test_partition_handles_empty_iterable():
+    false_iter, true_iter = partition(lambda _: True, [])
+
+    assert list(false_iter) == []
+    assert list(true_iter) == []
+
+
+def test_partition_works_with_generator_input():
+    data = (value for value in range(5))
+    false_iter, true_iter = partition(lambda value: value > 2, data)
+
+    assert list(false_iter) == [0, 1, 2]
+    assert list(true_iter) == [3, 4]

--- a/airflow-ctl/tests/airflow_ctl/utils/test_module_loading.py
+++ b/airflow-ctl/tests/airflow_ctl/utils/test_module_loading.py
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+
+from airflowctl.utils.module_loading import import_string
+
+
+def test_import_string_imports_attribute_successfully():
+    assert import_string("builtins.str") is str
+
+
+def test_import_string_rejects_invalid_dotted_path():
+    with pytest.raises(ImportError, match="doesn't look like a module path"):
+        import_string("invalid_path")
+
+
+def test_import_string_raises_when_module_is_missing():
+    with pytest.raises(ImportError):
+        import_string("not_a_real_module.SomeClass")
+
+
+def test_import_string_raises_when_attribute_is_missing():
+    with pytest.raises(ImportError, match='does not define a "missing_attr" attribute/class'):
+        import_string("builtins.missing_attr")


### PR DESCRIPTION
Add tests for helper partitioning, import-string resolution, and airflow-ctl exception hierarchy.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex

following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)