### PR TITLE
Exclude yanked grpcio 1.78.1 from 2.11 constraints generation (#62595)

### DIFF
--- a/scripts/in_container/run_generate_constraints.py
+++ b/scripts/in_container/run_generate_constraints.py
@@ -175,9 +175,12 @@ class ConfigParams:
 
     @cached_property
     def eager_upgrade_additional_requirements_list(self) -> list[str]:
+        # grpcio 1.78.1 yanked from PyPI - caused gcloud serverless outage
+        # See https://github.com/grpc/grpc/issues/41725 and Apache Airflow #62595
+        reqs = ["grpcio!=1.78.1"]
         if self.eager_upgrade_additional_requirements:
-            return self.eager_upgrade_additional_requirements.split(" ")
-        return []
+            reqs.extend(self.eager_upgrade_additional_requirements.split(" "))
+        return reqs
 
 
 def install_local_airflow_with_eager_upgrade(config_params: ConfigParams) -> None:


### PR DESCRIPTION
 Closes #62595

grpcio==1.78.1 was yanked from PyPI because it caused a major outage with gcloud serverless environments. Currently, the 2.11.1 constraints are attempting to pull this yanked version for Python 3.11, 3.12, and 3.13, which is throwing warnings and breaking downstream CI workflows.

As an external contributor, I cannot run breeze release-management update-constraints to fix the constraints-2.11.1 tag directly.

To prevent future regressions, this PR adds grpcio!=1.78.1 to the eager_upgrade_additional_requirements_list property in run_generate_constraints.py on the v2-11-test branch.

Note to Maintainers: A release manager will still need to manually run the update-constraints breeze command against the 2.11.1 tag to provide immediate relief for users, but this PR ensures the yanked version won't be picked up in future v2-11-test constraint generations or patch releases.

Testing

Verified PyPI status of grpcio==1.78.1 (Yanked).

Confirmed providers (grpcio-gcp, grpcio-status, etc.) are compatible with patch downgrade to 1.78.0.