### PR TITLE
Handle UnicodeEncodeError during fetch_log in Airflow 3

### DIFF
--- a/providers/docker/src/airflow/providers/docker/operators/docker.py
+++ b/providers/docker/src/airflow/providers/docker/operators/docker.py
@@ -53,7 +53,7 @@ def stringify(line: str | bytes):
     """Make sure string is returned even if bytes are passed. Docker stream can return bytes."""
     decode_method = getattr(line, "decode", None)
     if decode_method:
-        return decode_method(encoding="utf-8", errors="surrogateescape")
+        return decode_method(encoding="utf-8", errors="replace")
     return line
 
 


### PR DESCRIPTION
# Overview

We encountered an issue during log streaming from Docker containers with the Docker provider package:

```
UnicodeEncodeError: 'utf-8' codec can't encode character '\udce2' in position 76: surrogates not allowed
File "/home/airflow/.local/lib/python3.12/site-packages/airflow/sdk/bases/operator.py", line 417 in wrapper
File "/home/airflow/.local/lib/python3.12/site-packages/airflow/providers/docker/operators/docker.py", line 495 in execute
File "/home/airflow/.local/lib/python3.12/site-packages/airflow/providers/docker/operators/docker.py", line 360 in _run_image
File "/home/airflow/.local/lib/python3.12/site-packages/airflow/providers/docker/operators/docker.py", line 422 in _run_image_with_mounts
File "/home/airflow/.local/lib/python3.12/site-packages/airflow/providers/docker/operators/docker.py", line 66 in fetch_logs
File "/home/airflow/.local/lib/python3.12/site-packages/airflow/sdk/_shared/logging/structlog.py", line 100 in meth
File "/home/airflow/.local/lib/python3.12/site-packages/structlog/_base.py", line 222 in _proxy_to_logger
File "/home/airflow/.local/lib/python3.12/site-packages/structlog/_base.py", line 173 in _process_event
File "/home/airflow/.local/lib/python3.12/site-packages/structlog/processors.py", line 353 in __call__
```

The issue was caused by surrogate characters appearing in log streams (likely due to partial character reads during streaming). We resolved this by changing the error handling parameter from surrogateescape to replace, which gracefully handles non-UTF-8 characters instead of raising a UnicodeEncodeError.

# Details of change:

* Changed the errors parameter from surrogateescape to replace in log stream handling