### PR TITLE
Add ObjectStorage support to LLMSQLQueryOperator via DataFusion

### DIFF
--- a/providers/common/ai/pyproject.toml
+++ b/providers/common/ai/pyproject.toml
@@ -89,6 +89,7 @@ dev = [
     "apache-airflow-providers-common-sql",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
     "sqlglot>=26.0.0",
+    "apache-airflow-providers-common-sql[datafusion]"
 ]
 
 # To build docs:

--- a/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_sql.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_sql.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 from airflow.providers.common.ai.operators.llm_sql import LLMSQLQueryOperator
 from airflow.providers.common.compat.sdk import dag, task
+from airflow.providers.common.sql.config import DataSourceConfig
 
 
 # [START howto_operator_llm_sql_basic]
@@ -100,3 +101,26 @@ def example_llm_sql_expand():
 # [END howto_operator_llm_sql_expand]
 
 example_llm_sql_expand()
+
+
+# [START howto_operator_llm_sql_with_object_storage]
+@dag
+def example_llm_sql_with_object_storage():
+    datasource_config = DataSourceConfig(
+        conn_id="aws_default",
+        table_name="sales_data",
+        uri="s3://my-bucket/data/sales/",
+        format="parquet",
+    )
+
+    LLMSQLQueryOperator(
+        task_id="generate_sql",
+        prompt="Find the top 5 products by total sales amount",
+        llm_conn_id="pydantic_ai_default",
+        datasource_config=datasource_config,
+    )
+
+
+# [END howto_operator_llm_sql_with_object_storage]
+
+example_llm_sql_with_object_storage()

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/llm_sql.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/llm_sql.py
@@ -22,6 +22,8 @@ from collections.abc import Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
+from airflow.providers.common.sql.datafusion.engine import DataFusionEngine
+
 try:
     from airflow.providers.common.ai.utils.sql_validation import (
         DEFAULT_ALLOWED_TYPES,
@@ -38,6 +40,7 @@ from airflow.providers.common.compat.sdk import BaseHook
 if TYPE_CHECKING:
     from sqlglot import exp
 
+    from airflow.providers.common.sql.config import DataSourceConfig
     from airflow.providers.common.sql.hooks.sql import DbApiHook
     from airflow.sdk import Context
 
@@ -101,6 +104,7 @@ class LLMSQLQueryOperator(LLMOperator):
         validate_sql: bool = True,
         allowed_sql_types: tuple[type[exp.Expression], ...] = DEFAULT_ALLOWED_TYPES,
         dialect: str | None = None,
+        datasource_config: DataSourceConfig | None = None,
         **kwargs: Any,
     ) -> None:
         kwargs.pop("output_type", None)  # SQL operator always returns str
@@ -111,6 +115,7 @@ class LLMSQLQueryOperator(LLMOperator):
         self.validate_sql = validate_sql
         self.allowed_sql_types = allowed_sql_types
         self.dialect = dialect
+        self.datasource_config = datasource_config
 
     @cached_property
     def db_hook(self) -> DbApiHook | None:
@@ -178,7 +183,18 @@ class LLMSQLQueryOperator(LLMOperator):
                 f"None of the requested tables ({self.table_names}) returned schema information. "
                 "Check that the table names are correct and the database connection has access."
             )
+
+        if self.datasource_config:
+            object_storage_schema = self._introspect_object_storage_schema()
+            parts.append(f"Table: {self.datasource_config.table_name}\nColumns: {object_storage_schema}")
+
         return "\n\n".join(parts)
+
+    def _introspect_object_storage_schema(self):
+        """Use DataFusion Engine to get the schema of object stores."""
+        engine = DataFusionEngine()
+        engine.register_datasource(self.datasource_config)
+        return engine.get_schema(self.datasource_config.table_name)
 
     def _build_system_prompt(self, schema_info: str) -> str:
         """Construct the system prompt for the LLM."""

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/llm_sql.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/llm_sql.py
@@ -133,6 +133,7 @@ class LLMSQLQueryOperator(LLMOperator):
 
     def execute(self, context: Context) -> str:
         schema_info = self._get_schema_context()
+
         full_system_prompt = self._build_system_prompt(schema_info)
 
         agent = self.llm_hook.create_agent(
@@ -163,8 +164,9 @@ class LLMSQLQueryOperator(LLMOperator):
         """Return schema context from manual override or database introspection."""
         if self.schema_context:
             return self.schema_context
-        if self.db_hook and self.table_names:
+        if (self.db_hook and self.table_names) or self.datasource_config:
             return self._introspect_schemas()
+
         return ""
 
     def _introspect_schemas(self) -> str:

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/llm_sql.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/llm_sql.py
@@ -22,13 +22,12 @@ from collections.abc import Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
-from airflow.providers.common.sql.datafusion.engine import DataFusionEngine
-
 try:
     from airflow.providers.common.ai.utils.sql_validation import (
         DEFAULT_ALLOWED_TYPES,
         validate_sql as _validate_sql,
     )
+    from airflow.providers.common.sql.datafusion.engine import DataFusionEngine
 except ImportError as e:
     from airflow.providers.common.compat.sdk import AirflowOptionalProviderFeatureException
 

--- a/providers/common/sql/src/airflow/providers/common/sql/datafusion/engine.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/datafusion/engine.py
@@ -165,3 +165,8 @@ class DataFusionEngine(LoggingMixin):
     def _remove_none_values(params: dict[str, Any]) -> dict[str, Any]:
         """Filter out None values from the dictionary."""
         return {k: v for k, v in params.items() if v is not None}
+
+    def get_schema(self, table_name: str):
+        """Get the schema of a table."""
+        schema = str(self.session_context.table(table_name).schema())
+        return schema


### PR DESCRIPTION
### Summary

This PR extends `LLMSQLQueryOperator` https://github.com/apache/airflow/pull/62599 to support querying data stored in object storage (S3, local filesystem, etc.) by integrating with the DataFusion engine. The operator can now introspect schemas from both traditional databases **and** object storage sources, enabling the LLM to generate SQL that spans across both.

Additionally, the generated SQL can be executed directly against object storage data using `AnalyticsOperator`, creating a complete natural-language-to-results pipeline over data lakes.

### Usage Example

```
from airflow.providers.common.ai.operators.llm_sql import LLMSQLQueryOperator
from airflow.providers.common.sql.config import DataSourceConfig
from airflow.providers.common.sql.operators.analytics import AnalyticsOperator
from airflow.sdk import DAG
datasource_config = DataSourceConfig(
    conn_id="aws_default",
    table_name="trip_data",
    uri="s3://bucket/trip_data/",
    format="parquet",
)

with DAG(
    dag_id="llm_object_storage_analytics",
    schedule=None,
    start_date=None,
    tags=["example"],
    catchup=False,
) as dag:


    # Step 1: Generate SQL from natural language
    generate_sql = LLMSQLQueryOperator(
        task_id="generate_sql",
        prompt="Find total count of records",
        llm_conn_id="pydantic_ai_default",
        datasource_config=datasource_config,
        model_id="google-gla:gemini-2.5-pro"
    )

    # Step 2: Execute the generated SQL against object storage
    run_query = AnalyticsOperator(
        task_id="run_query",
        datasource_configs=[datasource_config],
        queries=["{{ ti.xcom_pull(task_ids='generate_sql') }}"],
    )

    generate_sql >> run_query

```

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
