### PR TITLE
Fix incorrect protocol selection when use_tls is provided as string in VaultHook

### DIFF
--- a/providers/hashicorp/src/airflow/providers/hashicorp/hooks/vault.py
+++ b/providers/hashicorp/src/airflow/providers/hashicorp/hooks/vault.py
@@ -30,6 +30,7 @@ from airflow.providers.hashicorp._internal_client.vault_client import (
     _VaultClient,
 )
 from airflow.utils.helpers import merge_dicts
+from airflow.utils.strings import to_boolean
 
 if TYPE_CHECKING:
     import hvac
@@ -187,11 +188,14 @@ class VaultHook(BaseHook):
             else (None, None)
         )
 
-        if self.connection.extra_dejson.get("use_tls") is not None:
-            if bool(self.connection.extra_dejson.get("use_tls")):
-                conn_protocol = "https"
+        use_tls = self.connection.extra_dejson.get("use_tls")
+
+        if use_tls is not None:
+            if isinstance(use_tls, bool):
+                is_tls = use_tls
             else:
-                conn_protocol = "http"
+                is_tls = to_boolean(use_tls)
+            conn_protocol = "https" if is_tls else "http"
         else:
             if self.connection.conn_type == "vault":
                 conn_protocol = "http"

--- a/providers/hashicorp/tests/unit/hashicorp/hooks/test_vault.py
+++ b/providers/hashicorp/tests/unit/hashicorp/hooks/test_vault.py
@@ -199,6 +199,8 @@ class TestVaultHook:
         [
             (True, "https://localhost:8180"),
             (False, "http://localhost:8180"),
+            ("true", "https://localhost:8180"),
+            ("false", "http://localhost:8180"),
         ],
     )
     @mock.patch("airflow.providers.hashicorp.hooks.vault.VaultHook.get_connection")


### PR DESCRIPTION

**Description**

Fix incorrect handling of the `use_tls` connection extra in `VaultHook`. Previously, protocol selection used `bool(use_tls)`, causing string values like `"false"` to be treated as truthy and incorrectly select HTTPS. This could lead to SSL handshake failures when connections were provisioned with string-based extras.

The fix preserves native boolean values and applies `to_boolean()` only when needed, ensuring correct handling of both boolean and string representations.

**Rationale**

The Vault connection documentation defines `use_tls` as an extra JSON parameter (please refer to [this link](https://airflow.apache.org/docs/apache-airflow-providers-hashicorp/stable/connections/vault.html).) Since connections may be provisioned via environment variables, Helm, Terraform, or other systems that serialize values as strings, the hook must defensively interpret string booleans. This change ensures consistent protocol resolution regardless of how the connection is configured.

**Tests**

Extended the existing `test_protocol_via_use_tls` parametrized test to include `"true"` and `"false"` string inputs.

**Backwards Compatibility**

No behavior changes for valid boolean inputs i.e `True` or `False`. The fix only corrects handling of string-based `use_tls` values.