### PR TITLE
Make CORS allow_credentials configurable instead of hardcoded True

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/app.py
@@ -152,12 +152,18 @@ def init_config(app: FastAPI) -> None:
     allow_origins = conf.getlist("api", "access_control_allow_origins")
     allow_methods = conf.getlist("api", "access_control_allow_methods")
     allow_headers = conf.getlist("api", "access_control_allow_headers")
+    allow_credentials = conf.getboolean("api", "access_control_allow_credentials", fallback=False)
 
     if allow_origins or allow_methods or allow_headers:
+        if allow_credentials and "*" in allow_origins:
+            log.warning(
+                "CORS allow_credentials is True with wildcard (*) in allow_origins. "
+                "This is a security risk. Consider specifying explicit origins."
+            )
         app.add_middleware(
             CORSMiddleware,
             allow_origins=allow_origins,
-            allow_credentials=True,
+            allow_credentials=allow_credentials,
             allow_methods=allow_methods,
             allow_headers=allow_headers,
         )

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1710,6 +1710,16 @@ api:
       version_added: 2.2.0
       example: ~
       default: ""
+    access_control_allow_credentials:
+      description: |
+        Indicates whether the response to the request can be exposed when the credentials flag is true.
+        When used as part of a response to a preflight request, this indicates whether or not the
+        actual request can be made using credentials. Setting this to True with a wildcard (*) in
+        access_control_allow_origins is a security risk.
+      type: boolean
+      version_added: 3.0.0
+      example: ~
+      default: "False"
     grid_view_sorting_order:
       description: |
         Sorting order in grid view. Valid values are: ``topological``, ``hierarchical_alphabetical``


### PR DESCRIPTION
## Summary
- Replace hardcoded `allow_credentials=True` in CORSMiddleware with configurable `[api] access_control_allow_credentials` option (default: `False`)
- Log a warning when `allow_credentials=True` is used with wildcard (`*`) origins, as this creates CSRF risk
- Add config option to `config.yml` template

Co-contributors : @codingrealitylabs @girlcoder-gaming

## Test plan
- [ ] Verify default behavior: `allow_credentials=False` when option not set
- [ ] Verify setting `access_control_allow_credentials = True` enables credentials
- [ ] Verify warning is logged when credentials + wildcard origins are configured
- [ ] Run `pytest tests/api_fastapi/core_api/test_app.py -v`

**Note:** This is a breaking change for deployments that rely on CORS credentials being enabled by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)