### PR TITLE
Add missing index on task_instance.dag_version_id

### DIFF
--- a/airflow-core/src/airflow/migrations/versions/0107_3_2_0_add_dag_version_id_index_to_ti.py
+++ b/airflow-core/src/airflow/migrations/versions/0107_3_2_0_add_dag_version_id_index_to_ti.py
@@ -1,0 +1,47 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Add index on dag_version_id to task_instance.
+
+Revision ID: a4c2fd67d16b
+Revises: 134de42d3cb0
+Create Date: 2025-03-01 00:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a4c2fd67d16b"
+down_revision = "134de42d3cb0"
+branch_labels = None
+depends_on = None
+airflow_version = "3.2.0"
+
+
+def upgrade():
+    """Add index on dag_version_id to task_instance table."""
+    op.create_index("ti_dag_version_id", "task_instance", ["dag_version_id"], unique=False)
+
+
+def downgrade():
+    """Remove index on dag_version_id from task_instance table."""
+    op.drop_index("ti_dag_version_id", table_name="task_instance")

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -501,6 +501,7 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
         Index("ti_state_lkp", dag_id, task_id, run_id, state),
         Index("ti_pool", pool, state, priority_weight),
         Index("ti_trigger_id", trigger_id),
+        Index("ti_dag_version_id", dag_version_id),
         Index("ti_heartbeat", last_heartbeat_at),
         PrimaryKeyConstraint("id", name="task_instance_pkey"),
         UniqueConstraint("dag_id", "task_id", "run_id", "map_index", name="task_instance_composite_key"),


### PR DESCRIPTION
## Summary
- Add `ti_dag_version_id` index on `task_instance.dag_version_id` column
- This column is queried by the DAG processor but had no index, causing full table scans on large tables (27M+ rows reported in #61894)
- Include Alembic migration `0107_3_2_0_add_dag_version_id_index_to_ti.py`

Co-contributors : @codingrealitylabs @girlcoder-gaming

## Test plan
- [ ] Verify Alembic migration applies cleanly: `airflow db migrate`
- [ ] Verify Alembic migration downgrades cleanly: `airflow db downgrade`
- [ ] Verify index exists after migration: `SELECT * FROM pg_indexes WHERE indexname = 'ti_dag_version_id'`
- [ ] Monitor scheduler performance improvement on large deployments

Closes: #61894

**Note:** On large `task_instance` tables, the index creation may take several minutes during migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)