### PR TITLE
Fix `airflowctl connections import` failure when JSON omits `extra` field

### DIFF
--- a/airflow-ctl/src/airflowctl/ctl/commands/connection_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/connection_command.py
@@ -54,7 +54,7 @@ def import_(args, api_client=NEW_API_CLIENT) -> None:
                 login=v.get("login"),
                 password=v.get("password"),
                 port=v.get("port"),
-                extra=v.get("extra", {}),
+                extra=v.get("extra"),
                 description=v.get("description", ""),
             )
             for k, v in connections_json.items()


### PR DESCRIPTION
`airflowctl connections import` fails with a Pydantic `ValidationError` when the input JSON omits the `extra` field.

The default value `v.get("extra", {})` returns `{}` (a dict), but `ConnectionBody.extra` expects `str | None`. Changing it to `v.get("extra")` returns `None` when the key is absent, which matches the model's type.

closes: #62653

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (claude-opus-4-6)

Generated-by: Claude Code (claude-opus-4-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)