### PR TITLE
Fix `airflowctl pools export` ignoring --output table/yaml/plain

### DIFF
--- a/airflow-ctl/src/airflowctl/ctl/commands/pool_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/pool_command.py
@@ -31,6 +31,7 @@ from airflowctl.api.datamodels.generated import (
     BulkCreateActionPoolBody,
     PoolBody,
 )
+from airflowctl.ctl.console_formatting import AirflowConsole
 
 
 @provide_api_client(kind=ClientKind.CLI)
@@ -77,8 +78,7 @@ def export(args, api_client: Client = NEW_API_CLIENT) -> None:
                 json.dump(pools_list, f, indent=4, sort_keys=True)
             rich.print(f"Exported {pools_response.total_entries} pool(s) to {args.file}")
         else:
-            # For non-json formats, print the pools directly to console
-            rich.print(pools_list)
+            AirflowConsole().print_as(pools_list, args.output)
     except Exception as e:
         raise SystemExit(f"Failed to export pools: {e}")
 

--- a/airflow-ctl/src/airflowctl/ctl/commands/pool_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/pool_command.py
@@ -78,7 +78,7 @@ def export(args, api_client: Client = NEW_API_CLIENT) -> None:
                 json.dump(pools_list, f, indent=4, sort_keys=True)
             rich.print(f"Exported {pools_response.total_entries} pool(s) to {args.file}")
         else:
-            AirflowConsole().print_as(pools_list, args.output)
+            AirflowConsole().print_as(data=pools_list, output=args.output)
     except Exception as e:
         raise SystemExit(f"Failed to export pools: {e}")
 

--- a/airflow-ctl/tests/airflow_ctl/ctl/commands/test_pool_command.py
+++ b/airflow-ctl/tests/airflow_ctl/ctl/commands/test_pool_command.py
@@ -149,35 +149,32 @@ class TestPoolExportCommand:
         expected_output = f"Exported {len(exported_data)} pool(s) to {export_file}"
         assert expected_output in captured.out.replace("\n", "")
 
-    def test_export_non_json_output(self, mock_client, tmp_path, capsys):
-        """Test pool export with non-json output format."""
-        # Create a proper dictionary structure
-        mock_pool = {
-            "name": "test_pool",
-            "slots": 1,
-            "description": "Test pool",
-            "include_deferred": True,
-            "occupied_slots": 0,
-            "running_slots": 0,
-            "queued_slots": 0,
-            "scheduled_slots": 0,
-            "open_slots": 1,
-            "deferred_slots": 0,
-        }
-        # Create a mock response with a proper pools attribute
+    def test_export_non_json_uses_airflow_console(self, mock_client, tmp_path):
+        """Test that non-JSON export delegates to AirflowConsole.print_as()."""
+        pool = type(
+            "Pool",
+            (),
+            {
+                "name": "test_pool",
+                "slots": 5,
+                "description": "Test pool",
+                "include_deferred": True,
+                "occupied_slots": 0,
+                "running_slots": 0,
+                "queued_slots": 0,
+                "scheduled_slots": 0,
+                "open_slots": 5,
+                "deferred_slots": 0,
+            },
+        )()
         mock_pools = mock.MagicMock()
-        mock_pools.pools = [mock.MagicMock(**mock_pool)]
+        mock_pools.pools = [pool]
         mock_pools.total_entries = 1
         mock_client.pools.list.return_value = mock_pools
 
-        pool_command.export(mock.MagicMock(file=tmp_path / "unused.json", output="table"))
-
-        # Verify console output contains the raw dict
-        captured = capsys.readouterr()
-        assert "test_pool" in captured.out
-        assert "slots" in captured.out
-        assert "description" in captured.out
-        assert "include_deferred" in captured.out
+        with mock.patch("airflowctl.ctl.commands.pool_command.AirflowConsole") as mock_console_cls:
+            pool_command.export(mock.MagicMock(file=tmp_path / "unused.json", output="table"))
+            mock_console_cls.return_value.print_as.assert_called_once()
 
     def test_export_failure(self, mock_client, tmp_path):
         """Test pool export with API failure."""

--- a/airflow-ctl/tests/airflow_ctl/ctl/commands/test_pool_command.py
+++ b/airflow-ctl/tests/airflow_ctl/ctl/commands/test_pool_command.py
@@ -172,8 +172,8 @@ class TestPoolExportCommand:
         with mock.patch("airflowctl.ctl.commands.pool_command.AirflowConsole") as mock_console_cls:
             pool_command.export(mock.MagicMock(file=tmp_path / "unused.json", output=output_format))
             mock_console_cls.return_value.print_as.assert_called_once_with(
-                [pool_attrs],
-                output_format,
+                data=[pool_attrs],
+                output=output_format,
             )
 
     def test_export_failure(self, mock_client, tmp_path):

--- a/airflow-ctl/tests/airflow_ctl/ctl/commands/test_pool_command.py
+++ b/airflow-ctl/tests/airflow_ctl/ctl/commands/test_pool_command.py
@@ -149,32 +149,32 @@ class TestPoolExportCommand:
         expected_output = f"Exported {len(exported_data)} pool(s) to {export_file}"
         assert expected_output in captured.out.replace("\n", "")
 
-    def test_export_non_json_uses_airflow_console(self, mock_client, tmp_path):
-        """Test that non-JSON export delegates to AirflowConsole.print_as()."""
-        pool = type(
-            "Pool",
-            (),
-            {
-                "name": "test_pool",
-                "slots": 5,
-                "description": "Test pool",
-                "include_deferred": True,
-                "occupied_slots": 0,
-                "running_slots": 0,
-                "queued_slots": 0,
-                "scheduled_slots": 0,
-                "open_slots": 5,
-                "deferred_slots": 0,
-            },
-        )()
+    @pytest.mark.parametrize("output_format", ["table", "yaml", "plain"])
+    def test_export_non_json_uses_airflow_console(self, mock_client, tmp_path, output_format):
+        """Test that non-JSON export delegates to AirflowConsole.print_as() with correct data and format."""
+        pool_attrs = {
+            "name": "test_pool",
+            "slots": 5,
+            "description": "Test pool",
+            "include_deferred": True,
+            "occupied_slots": 0,
+            "running_slots": 0,
+            "queued_slots": 0,
+            "scheduled_slots": 0,
+            "open_slots": 5,
+            "deferred_slots": 0,
+        }
         mock_pools = mock.MagicMock()
-        mock_pools.pools = [pool]
+        mock_pools.pools = [type("Pool", (), pool_attrs)()]
         mock_pools.total_entries = 1
         mock_client.pools.list.return_value = mock_pools
 
         with mock.patch("airflowctl.ctl.commands.pool_command.AirflowConsole") as mock_console_cls:
-            pool_command.export(mock.MagicMock(file=tmp_path / "unused.json", output="table"))
-            mock_console_cls.return_value.print_as.assert_called_once()
+            pool_command.export(mock.MagicMock(file=tmp_path / "unused.json", output=output_format))
+            mock_console_cls.return_value.print_as.assert_called_once_with(
+                [pool_attrs],
+                output_format,
+            )
 
     def test_export_failure(self, mock_client, tmp_path):
         """Test pool export with API failure."""


### PR DESCRIPTION
`airflowctl pools export` accepts `--output table|yaml|plain` but only handles `json` properly. For all other formats, it falls through to `rich.print(pools_list)` which outputs raw Python list repr instead of formatted output.

This replaces the raw `rich.print()` call with `AirflowConsole().print_as()`, which already supports all 4 output formats and is used by other airflow-ctl commands.

closes: #62651

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (claude-opus-4-6)

Generated-by: Claude Code (claude-opus-4-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)