### PR TITLE
UI: Translate remaining TODO entries in Polish locale

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/common.json
@@ -173,6 +173,17 @@
     "placeholder": "Dodaj notatkę...",
     "taskInstance": "Notatka instancji zadania"
   },
+  "partitionedDagRun_few": "Partycjonowane wykonania Dagów",
+  "partitionedDagRun_many": "Partycjonowanych wykonań Dagów",
+  "partitionedDagRun_one": "Partycjonowane wykonanie Daga",
+  "partitionedDagRun_other": "Partycjonowane wykonania Dagów",
+  "partitionedDagRunDetail": {
+    "receivedAssetEvents": "Otrzymane zdarzenia zasobów"
+  },
+  "pendingDagRun_few": "{{count}} oczekujące wykonania Dagów",
+  "pendingDagRun_many": "{{count}} oczekujących wykonań Dagów",
+  "pendingDagRun_one": "{{count}} oczekujące wykonanie Daga",
+  "pendingDagRun_other": "{{count}} oczekujących wykonań Dagów",
   "reset": "Resetuj",
   "runId": "Identyfikator wykonania",
   "runTypes": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/components.json
@@ -150,6 +150,7 @@
     "intervalStart": "Początek",
     "loading": "Ładowanie informacji o Dagach...",
     "loadingFailed": "Nie udało się załadować informacji o Dagach. Spróbuj ponownie.",
+    "manualRunDenied": "Ręczne uruchamianie nie jest dozwolone dla tego Daga",
     "runIdHelp": "Opcjonalne - zostanie wygenerowane, jeśli nie podano",
     "selectDescription": "Wyzwól pojedyncze wykonanie",
     "selectLabel": "Pojedyncze wykonanie",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/dag.json
@@ -129,6 +129,15 @@
     "graphDirection": {
       "label": "Kierunek grafu"
     },
+    "showVersionIndicator": {
+      "label": "Pokaż wskaźnik wersji",
+      "options": {
+        "hideAll": "Ukryj wszystkie",
+        "showAll": "Pokaż wszystkie",
+        "showBundleVersion": "Pokaż wersję pakietu",
+        "showDagVersion": "Pokaż wersję Daga"
+      }
+    },
     "taskStreamFilter": {
       "activeFilter": "Aktywny filtr",
       "clearFilter": "Wyczyść filtr",


### PR DESCRIPTION
Translate all remaining "TODO: translate" placeholder entries in the Polish (pl) locale files:

- **dag.json**: Version indicator labels (show/hide all, bundle/dag version)
- **components.json**: Manual run denied message
- **common.json**: Partitioned dag run plurals, pending dag run plurals, received asset events

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.6

Generated-by: Claude Opus 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)